### PR TITLE
Bump jsonobject to 2.0.0 and make requirements

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -61,7 +61,7 @@ Jinja2
 json-delta
 jsonfield
 jsonobject-couchdbkit
-jsonobject
+jsonobject>=2.0.0
 # jsonpath-ng with support for "wherenot" operator, and building documents
 # Upgrade when changes merged upstream
 jsonpath-ng @ https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_or_create/wheel/jsonpath_ng-1.5.2.2-py3-none-any.whl

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -294,7 +294,7 @@ jsonfield==2.1.1
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   -r base-requirements.in
     #   git-build-branch

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -246,7 +246,7 @@ jsonfield==2.1.1
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -254,7 +254,7 @@ jsonfield==2.1.1
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -231,7 +231,7 @@ jsonfield==2.1.1
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -249,7 +249,7 @@ jsonfield==2.1.1
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==0.9.10
+jsonobject==2.0.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit


### PR DESCRIPTION
Preparation for Django 3.2 upgrade.
https://github.com/dimagi/jsonobject/pull/201

## Safety Assurance

### Safety story

Django 3.2 QA has passed with all changes included in [this version of jsonobject](https://github.com/dimagi/commcare-hq/commit/09ab3dce188fa4fc9d5c8be976e57e6dcd1b44d3) (the version bump and new release was created after QA passed).

### Automated test coverage

No new tests added in this PR. Automated tests [uncovered an issue](https://github.com/dimagi/jsonobject/pull/200) with jsonobject 0.9.10 and Django 3.2.

### QA Plan

Done.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
