### PR TITLE
Updated get_apps_modules

### DIFF
--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -638,7 +638,7 @@ def get_apps_modules(domain, current_app_id=None, current_module_id=None, app_do
                 'module_id': module.id,
                 'name': clean_trans(module.name, app.langs),
                 'is_current': module.unique_id == current_module_id,
-            } for module in app.modules]
+            } for module in app.get_modules()]
         }
         for app in get_apps_in_domain(domain)
         # No linked, deleted or remote apps. (Use app.doc_type not


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/SUPPORT-13219 and https://dimagi-dev.atlassian.net/browse/SAAS-12620

Users with the "Allow copying a form from one app to another" intermittently get 500s in their apps.

## Technical Summary
See https://github.com/dimagi/commcare-hq/pull/24375 for background.

I did not find a way to test this but figured I might as well fix the bug.

## Feature Flag
Allow copying a form from one app to another

## Safety Assurance

### Safety story
Minor, low-risk change to a feature flag.

### Automated test coverage

This function has tests, `test_get_apps_modules`

### QA Plan

No


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
