### PR TITLE
[SSO] Update Accounting Admin UIs to support OIDC and OneLogin

### DIFF
--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -20,6 +20,7 @@ from corehq.apps.sso import certificates
 from corehq.apps.sso.models import (
     IdentityProvider,
     IdentityProviderProtocol,
+    IdentityProviderType,
 )
 from corehq.apps.sso.utils import url_helpers
 from corehq.apps.sso.utils.url_helpers import get_documentation_url
@@ -319,6 +320,14 @@ class EditIdentityProviderAdminForm(forms.Form):
         label=gettext_lazy("Billing Account Owner"),
         required=False,
     )
+    protocol = forms.CharField(
+        label=gettext_lazy("Protocol"),
+        required=False,
+    )
+    idp_type = forms.CharField(
+        label=gettext_lazy("Service"),
+        required=False,
+    )
     slug = forms.CharField(
         label=gettext_lazy("Slug"),
         required=False,
@@ -415,6 +424,14 @@ class EditIdentityProviderAdminForm(forms.Form):
                                 account_link,
                                 identity_provider.owner.name
                             )
+                        ),
+                        hqcrispy.B3TextField(
+                            'protocol',
+                            dict(IdentityProviderProtocol.CHOICES)[self.idp.protocol]
+                        ),
+                        hqcrispy.B3TextField(
+                            'idp_type',
+                            dict(IdentityProviderType.CHOICES)[self.idp.idp_type]
                         ),
                         'name',
                         twbscrispy.PrependedText('is_editable', ''),

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -375,6 +375,8 @@ class EditIdentityProviderAdminForm(forms.Form):
         }
         super().__init__(*args, **kwargs)
 
+        current_protocol_name = dict(IdentityProviderProtocol.CHOICES)[self.idp.protocol]
+
         if self.idp.protocol == IdentityProviderProtocol.SAML:
             sp_details_form = ServiceProviderDetailsForm(
                 identity_provider, show_help_block=False
@@ -386,6 +388,7 @@ class EditIdentityProviderAdminForm(forms.Form):
                 crispy.Div(*sp_details_form.service_provider_fields),
                 crispy.Div(*sp_details_form.token_encryption_fields),
             )
+            protocol_notice = current_protocol_name
         else:
             rp_details_form = RelyingPartyDetailsForm(identity_provider)
             self.fields.update(rp_details_form.fields)
@@ -393,6 +396,13 @@ class EditIdentityProviderAdminForm(forms.Form):
                 _('Relying Party Settings'),
                 'slug',
                 crispy.Div(*rp_details_form.application_details_fields),
+            )
+            # todo remove when OIDC is active
+            protocol_notice = format_html(
+                "{}<p class='alert alert-warning'>"
+                "<strong>Please Note that OIDC support is still in development!</strong><br/> "
+                "Do not make any Identity Providers live on production.</p>",
+                current_protocol_name
             )
 
         from corehq.apps.accounting.views import ManageBillingAccountView
@@ -417,6 +427,7 @@ class EditIdentityProviderAdminForm(forms.Form):
                 crispy.Div(
                     crispy.Fieldset(
                         _('Primary Configuration'),
+                        protocol_notice,
                         hqcrispy.B3TextField(
                             'owner',
                             format_html(
@@ -427,7 +438,7 @@ class EditIdentityProviderAdminForm(forms.Form):
                         ),
                         hqcrispy.B3TextField(
                             'protocol',
-                            dict(IdentityProviderProtocol.CHOICES)[self.idp.protocol]
+                            protocol_notice
                         ),
                         hqcrispy.B3TextField(
                             'idp_type',

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -323,7 +323,7 @@ class EditIdentityProviderAdminForm(forms.Form):
         label=gettext_lazy("Slug"),
         required=False,
         help_text=gettext_lazy(
-            "CAUTION: Changing this value will alter the SAML endpoint URLs "
+            "CAUTION: Changing this value will alter SSO endpoint URLs "
             "below and affect active SSO setups for the client!"
         ),
     )

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -27,6 +27,17 @@ class IdentityProviderProtocol:
         (OIDC, "OpenID Connect (OIDC)"),
     )
 
+    @classmethod
+    def get_supported_types(cls):
+        return {
+            cls.SAML: (
+                (IdentityProviderType.AZURE_AD, "Azure AD"),
+            ),
+            cls.OIDC: (
+                (IdentityProviderType.ONE_LOGIN, "One Login"),
+            )
+        }
+
 
 class ServiceProviderCertificate:
 

--- a/corehq/apps/sso/static/sso/js/new_identity_provider.js
+++ b/corehq/apps/sso/static/sso/js/new_identity_provider.js
@@ -1,9 +1,13 @@
 hqDefine('sso/js/new_identity_provider', [
     'jquery',
+    'knockout',
     'accounting/js/widgets',
+    'hqwebapp/js/initial_page_data',
 ], function (
     $,
-    widgets
+    ko,
+    widgets,
+    initialPageData
 ) {
 
     var identityProviderModel = function () {
@@ -11,6 +15,12 @@ hqDefine('sso/js/new_identity_provider', [
         var self = {};
 
         self.owner = widgets.asyncSelect2Handler('owner', false, 'select2_identity_provider');
+        self.protocol = ko.observable('saml');
+        self.idpTypesByProtocol = initialPageData.get('idp_types_by_protocol');
+        self.availableIdpTypes = ko.computed(function () {
+            return self.idpTypesByProtocol[self.protocol()];
+        });
+        self.idpType = ko.observable('azure_ad');
 
         self.init = function () {
             self.owner.init();
@@ -22,5 +32,6 @@ hqDefine('sso/js/new_identity_provider', [
     $(function () {
         var identityProviderHandler = identityProviderModel();
         identityProviderHandler.init();
+        $('#ko-new-idp-form').koApplyBindings(identityProviderHandler);
     });
 });

--- a/corehq/apps/sso/tasks.py
+++ b/corehq/apps/sso/tasks.py
@@ -5,7 +5,7 @@ from celery.schedules import crontab
 from celery.task import periodic_task
 
 from corehq.apps.hqwebapp.tasks import send_html_email_async
-from corehq.apps.sso.models import IdentityProvider
+from corehq.apps.sso.models import IdentityProvider, IdentityProviderProtocol
 from corehq.apps.sso.utils.context_helpers import get_idp_cert_expiration_email_context
 
 
@@ -23,6 +23,7 @@ def renew_service_provider_x509_certificates():
     """
     in_one_week = datetime.datetime.utcnow() + datetime.timedelta(days=7)
     for idp in IdentityProvider.objects.filter(
+        protocol=IdentityProviderProtocol.SAML,
         sp_rollover_cert_public__isnull=False,
         date_sp_cert_expiration__lte=in_one_week
     ).all():
@@ -37,6 +38,7 @@ def create_rollover_service_provider_x509_certificates():
     """
     in_two_weeks = datetime.datetime.utcnow() + datetime.timedelta(days=14)
     for idp in IdentityProvider.objects.filter(
+        protocol=IdentityProviderProtocol.SAML,
         sp_rollover_cert_public__isnull=True,
         date_sp_cert_expiration__lte=in_two_weeks
     ).all():
@@ -64,6 +66,7 @@ def send_idp_cert_expires_reminder_emails(num_days):
     date_in_n_days = today + datetime.timedelta(days=num_days)
     day_after_that = date_in_n_days + datetime.timedelta(days=1)
     queryset = IdentityProvider.objects.filter(
+        protocol=IdentityProviderProtocol.SAML,
         is_active=True,
         date_idp_cert_expiration__gte=date_in_n_days,
         date_idp_cert_expiration__lt=day_after_that,

--- a/corehq/apps/sso/templates/sso/accounting_admin/new_identity_provider.html
+++ b/corehq/apps/sso/templates/sso/accounting_admin/new_identity_provider.html
@@ -6,7 +6,9 @@
 {% requirejs_main 'sso/js/new_identity_provider' %}
 
 {% block page_content %}
-  <form class="form form-horizontal" method="post">
+  {% initial_page_data 'idp_types_by_protocol' idp_types_by_protocol|JSON %}
+
+  <form class="form form-horizontal" method="post" id="ko-new-idp-form">
     {% crispy create_idp_form %}
   </form>
 {% endblock %}

--- a/corehq/apps/sso/urls.py
+++ b/corehq/apps/sso/urls.py
@@ -1,5 +1,10 @@
 from django.conf.urls import include, re_path as url
 
+from corehq.apps.sso.views.oidc import (
+    sso_oidc_login,
+    sso_oidc_auth,
+    sso_oidc_logout,
+)
 from corehq.apps.sso.views.saml import (
     sso_saml_metadata,
     sso_saml_acs,
@@ -12,6 +17,13 @@ saml_urls = [
     url(r'^login/$', sso_saml_login, name='sso_saml_login'),
 ]
 
+oidc_urls = [
+    url(r'^login/$', sso_oidc_login, name='sso_oidc_login'),
+    url(r'^auth/$', sso_oidc_auth, name='sso_oidc_auth'),
+    url(r'^logout/$', sso_oidc_logout, name='sso_oidc_logout'),
+]
+
 urlpatterns = [
     url(r'^saml2/', include(saml_urls)),
+    url(r'^oidc/', include(oidc_urls)),
 ]

--- a/corehq/apps/sso/utils/url_helpers.py
+++ b/corehq/apps/sso/utils/url_helpers.py
@@ -15,6 +15,18 @@ def get_saml_login_url(identity_provider):
     return _get_full_sso_url("sso_saml_login", identity_provider)
 
 
+def get_oidc_login_url(identity_provider):
+    return _get_full_sso_url("sso_oidc_login", identity_provider)
+
+
+def get_oidc_auth_url(identity_provider):
+    return _get_full_sso_url("sso_oidc_auth", identity_provider)
+
+
+def get_oidc_logout_url(identity_provider):
+    return _get_full_sso_url("sso_oidc_logout", identity_provider)
+
+
 def get_documentation_url(identity_provider):
     # todo we are only supporting docs for Azure AD here. OneLogin, etc to come later
     return 'https://confluence.dimagi.com/display/commcarepublic/Set+up+SSO+for+CommCare+HQ'

--- a/corehq/apps/sso/views/accounting_admin.py
+++ b/corehq/apps/sso/views/accounting_admin.py
@@ -27,7 +27,7 @@ from corehq.apps.sso.async_handlers import (
     IdentityProviderAdminAsyncHandler,
     SSOExemptUsersAdminAsyncHandler,
 )
-from corehq.apps.sso.models import IdentityProvider
+from corehq.apps.sso.models import IdentityProvider, IdentityProviderProtocol
 
 
 class IdentityProviderInterface(AddItemInterface):
@@ -119,6 +119,7 @@ class NewIdentityProviderAdminView(BaseIdentityProviderAdminView, AsyncHandlerMi
     def page_context(self):
         return {
             'create_idp_form': self.create_idp_form,
+            'idp_types_by_protocol': IdentityProviderProtocol.get_supported_types(),
         }
 
     @property

--- a/corehq/apps/sso/views/oidc.py
+++ b/corehq/apps/sso/views/oidc.py
@@ -1,0 +1,21 @@
+from django.http import Http404
+
+from corehq.apps.sso.decorators import identity_provider_required
+
+
+@identity_provider_required
+def sso_oidc_login(request, idp_slug):
+    # todo this is a temporary placeholder view
+    raise Http404()
+
+
+@identity_provider_required
+def sso_oidc_auth(request, idp_slug):
+    # todo this is a temporary placeholder view
+    raise Http404()
+
+
+@identity_provider_required
+def sso_oidc_logout(request, idp_slug):
+    # todo this is a temporary placeholder view
+    raise Http404()


### PR DESCRIPTION
## Product Description
This updates the accounting admin UIs to allow a choice of protocol and service when creating an IdP:
![Screen Shot 2022-04-11 at 9 00 32 PM](https://user-images.githubusercontent.com/716573/162811073-e0c089d3-0776-4481-937a-4ea7e8dcbef6.png)

This also ensures that the information displayed on the accounting admin edit Identity Provider is also updated to reflect the choice of OIDC as the protocol (vs the default of SAML v2)
![Screen Shot 2022-04-11 at 9 01 00 PM](https://user-images.githubusercontent.com/716573/162811479-c4b4d95a-0238-4079-8541-ccc853f53d44.png)

Just to be safe, I've added a note for OIDC when the Identity Provider is edited.
![Screen Shot 2022-04-11 at 9 12 43 PM](https://user-images.githubusercontent.com/716573/162812904-b7b99dd4-e3d8-45d9-bff2-7c4db5bac24d.png)


## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-13410

## Feature Flag
Since this is a backend UI, I'm not hiding the changes behind a feature flag. It's safe to merge into master as this is a workflow limited to a very small set of users.

## Safety Assurance

### Safety story
Safe change. Only modifies the accounting admin UIs which a very small subset of users have access to

### Automated test coverage
Yes

### QA Plan
Not needed yet. Will come later

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
