### PR TITLE
Revert bad depickle if add_inferred_export_properties

### DIFF
--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -151,7 +151,7 @@ def get_saved_export_task_status(export_instance_id):
     return get_task_status(download_data.task)
 
 
-@serial_task('{domain}-{case_type}', queue='background_queue')
+@serial_task('{domain}-{case_type}', queue='background_queue', serializer='pickle')
 def add_inferred_export_properties(sender, domain, case_type, properties):
     _cached_add_inferred_export_properties(sender, domain, case_type, properties)
 

--- a/serializer-pickle-files.lock
+++ b/serializer-pickle-files.lock
@@ -7,6 +7,7 @@
   8 corehq/apps/data_interfaces/tasks.py
   1 corehq/apps/dropbox/tasks.py
   1 corehq/apps/enterprise/tasks.py
+  1 corehq/apps/export/tasks.py
   2 corehq/apps/hqadmin/tasks.py
   2 corehq/apps/hqmedia/tasks.py
   3 corehq/apps/hqwebapp/tasks.py


### PR DESCRIPTION
## Technical Summary
Reverts one commit in https://github.com/dimagi/commcare-hq/pull/31422 that came up with issues in QA (https://dimagi-dev.atlassian.net/browse/QA-4049). Re-scrutinized the other commits in that PR and I believe none of them are susceptible to a similar issue.

The issue here was that "Object of type set is not JSON serializable" i.e. one of the arguments here is a set, not a list or a dict as I had thought when making the change.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

~This PR can be reverted after deploy with no further considerations~

I don't think you can roll back this PR by itself, since it's fixing a bug in a recent PR. If you need to roll back this PR, then also roll back https://github.com/dimagi/commcare-hq/pull/31422. Other than that it's revertible.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
