### PR TITLE
allow specifying the index identifier for the DR repeater

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -382,6 +382,7 @@ class CaseUpdateConfig:
         "index_create_case_id": "target_index_create_case_id",
         "index_create_case_type": "target_index_create_case_type",
         "index_create_relationship": "target_index_create_relationship",
+        "index_create_identifier": "target_index_create_identifier",
         # index remove
         "index_remove_case_id": "target_index_remove_case_id",
         "index_remove_identifier": "target_index_remove_identifier",
@@ -412,6 +413,7 @@ class CaseUpdateConfig:
     index_create_case_id = attr.ib()
     index_create_case_type = attr.ib()
     index_create_relationship = attr.ib()
+    index_create_identifier = attr.ib()
     index_remove_case_id = attr.ib()
     index_remove_identifier = attr.ib()
     index_remove_relationship = attr.ib()
@@ -432,13 +434,14 @@ class CaseUpdateConfig:
             kwargs["index_create_relationship"] = "child"
         if "index_remove_relationship" not in kwargs:
             kwargs["index_remove_relationship"] = "child"
+        if kwargs.get("index_create_identifier") is None:
+            kwargs["index_create_identifier"] = (
+                "parent" if kwargs["index_create_relationship"] == "child" else "host"
+            )
+
         config = CaseUpdateConfig(**kwargs)
         config.validate()
         return config
-
-    @property
-    def index_create_identifier(self):
-        return "parent" if self.index_create_relationship == "child" else "host"
 
     def validate(self):
         missing = [

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -430,9 +430,10 @@ class CaseUpdateConfig:
             for attr, prop_name in cls.PROPS.items()
         }
         kwargs["intent_case"] = payload_doc
-        if "index_create_relationship" not in kwargs:
+
+        if kwargs.get("index_create_relationship") is None:
             kwargs["index_create_relationship"] = "child"
-        if "index_remove_relationship" not in kwargs:
+        if kwargs.get("index_remove_relationship") is None:
             kwargs["index_remove_relationship"] = "child"
         if kwargs.get("index_create_identifier") is None:
             kwargs["index_create_identifier"] = (

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -433,8 +433,6 @@ class CaseUpdateConfig:
 
         if kwargs.get("index_create_relationship") is None:
             kwargs["index_create_relationship"] = "child"
-        if kwargs.get("index_remove_relationship") is None:
-            kwargs["index_remove_relationship"] = "child"
         if kwargs.get("index_create_identifier") is None:
             kwargs["index_create_identifier"] = (
                 "parent" if kwargs["index_create_relationship"] == "child" else "host"

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -147,6 +147,18 @@ def test_generator_update_create_index_to_host():
             "1": {"host": IndexAttrs("parent_type", "case2", "extension")}})
 
 
+def test_generator_update_create_index_custom_identifier():
+    builder = IntentCaseBuilder().create_index("case2", "parent_type", "extension", "parent")
+
+    def _get_case(case_id, domain=None):
+        assert case_id == "case2"
+        return Mock(domain=TARGET_DOMAIN, type="parent_type")
+
+    with patch.object(CommCareCase.objects, 'get_case', new=_get_case):
+        _test_payload_generator(intent_case=builder.get_case(), expected_indices={
+            "1": {"parent": IndexAttrs("parent_type", "case2", "extension")}})
+
+
 def test_generator_update_create_index_not_found():
     builder = IntentCaseBuilder().create_index("case2", "parent_type", "child")
 
@@ -475,12 +487,14 @@ class IntentCaseBuilder:
         })
         return self
 
-    def create_index(self, case_id, case_type, relationship="child"):
+    def create_index(self, case_id, case_type, relationship="child", identifier=None):
         self.props.update({
             "target_index_create_case_id": case_id,
             "target_index_create_case_type": case_type,
             "target_index_create_relationship": relationship,
         })
+        if identifier is not None:
+            self.props["target_index_create_identifier"] = identifier
         return self
 
     def remove_index(self, case_id, identifier, relationship=None):

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_payload_generator.py
@@ -501,8 +501,9 @@ class IntentCaseBuilder:
         self.props.update({
             "target_index_remove_case_id": case_id,
             "target_index_remove_identifier": identifier,
-            "target_index_remove_relationship": relationship,
         })
+        if relationship is not None:
+            self.props["target_index_remove_relationship"] = relationship
         return self
 
     def include_props(self, include):


### PR DESCRIPTION
## Product Description
Allow specifying the index identifier when creating case indexes via the Data Registry Case Update repeater

## Feature Flag
DATA REGISTRY
DATA REGISTRY CASE UPDATE REPEATER

## Safety Assurance

### Safety story
Tested and only affects this one repeater type

### Automated test coverage
Added tests for the changes.

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
