### PR TITLE
Updated multiple referrals to not use AUTO_LAUNCH_EXPRESSION

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -390,11 +390,11 @@ class DetailContributor(SectionContributor):
     def _get_auto_launch_expression(module, in_search):
         allow_auto_launch = toggles.USH_CASE_CLAIM_UPDATES.enabled(module.get_app().domain) and not in_search
         auto_launch_expression = "false()"
-        if allow_auto_launch:
+        if allow_auto_launch and module.search_config.auto_launch:
             if module.is_multi_select():
                 # AUTO_LAUNCH_EXPRESSION is incompatible with multi select case lists - See USH-1870
                 auto_launch_expression = "true()"
-            elif module.search_config.auto_launch:
+            else:
                 auto_launch_expression = XPath(AUTO_LAUNCH_EXPRESSION)
         return auto_launch_expression
 

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -390,8 +390,12 @@ class DetailContributor(SectionContributor):
     def _get_auto_launch_expression(module, in_search):
         allow_auto_launch = toggles.USH_CASE_CLAIM_UPDATES.enabled(module.get_app().domain) and not in_search
         auto_launch_expression = "false()"
-        if allow_auto_launch and module.search_config.auto_launch:
-            auto_launch_expression = XPath(AUTO_LAUNCH_EXPRESSION)
+        if allow_auto_launch:
+            if module.is_multi_select():
+                # AUTO_LAUNCH_EXPRESSION is incompatible with multi select case lists - See USH-1870
+                auto_launch_expression = "true()"
+            elif module.search_config.auto_launch:
+                auto_launch_expression = XPath(AUTO_LAUNCH_EXPRESSION)
         return auto_launch_expression
 
     def _get_custom_xml_detail(self, module, detail, detail_type):

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -120,5 +120,3 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
             suite,
             "./detail[@id='m0_search_short']/action",
         )
-
-        self.module.search_config.auto_launch = False

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -29,16 +29,16 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
         self.factory = AppFactory(domain="multiple-referrals")
         self.app_id = uuid4().hex
         self.factory.app._id = self.app_id
-        module, form = self.factory.new_basic_module('basic', 'person')
+        self.module, form = self.factory.new_basic_module('basic', 'person')
         self.factory.form_requires_case(form, 'person')
         form.xmlns = "some-xmlns"
 
-        module.case_details.short.multi_select = True
-        module.search_config = CaseSearch(
+        self.module.case_details.short.multi_select = True
+        self.module.search_config = CaseSearch(
             search_label=CaseSearchLabel(label={'en': 'Search'}),
             properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
         )
-        module.assign_references()
+        self.module.assign_references()
 
     def test_multi_select_case_list(self):
         suite = self.factory.app.create_suite()
@@ -71,3 +71,54 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
             suite,
             "./remote-request",
         )
+
+    @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    def test_multi_select_case_list_auto_launch(self):
+        self.module.search_config.auto_launch = True
+        suite = self.factory.app.create_suite()
+
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+              <action auto_launch="true()" redo_last="false">
+                <display>
+                  <text>
+                    <locale id="case_search.m0"/>
+                  </text>
+                </display>
+                <stack>
+                  <push>
+                    <mark/>
+                    <command value="'search_command.m0'"/>
+                  </push>
+                </stack>
+              </action>
+            </partial>
+            """,
+            suite,
+            "./detail[@id='m0_case_short']/action",
+        )
+
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+              <action auto_launch="false()" redo_last="true">
+                <display>
+                  <text>
+                    <locale id="case_search.m0.again"/>
+                  </text>
+                </display>
+                <stack>
+                  <push>
+                    <mark/>
+                    <command value="'search_command.m0'"/>
+                  </push>
+                </stack>
+              </action>
+            </partial>
+            """,
+            suite,
+            "./detail[@id='m0_search_short']/action",
+        )
+
+        self.module.search_config.auto_launch = False


### PR DESCRIPTION
## Technical Summary
See discussion in https://dimagi-dev.atlassian.net/browse/USH-1870

The current expression doesn't apply when selecting multiple cases. Temporarily avoid it until we get a different solution figured out.

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
This change is limited to an app config that isn't used in production, and it has test coverage.

### Automated test coverage

In PR.

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
