### PR TITLE
Added build errors for multiple referrals used with data registries

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -39,6 +39,7 @@ from corehq.apps.app_manager.exceptions import (
 from corehq.apps.app_manager.util import (
     app_callout_templates,
     module_case_hierarchy_has_circular_reference,
+    module_loads_registry_case,
     module_uses_smart_links,
     split_path,
     xpath_references_case,
@@ -382,6 +383,18 @@ class ModuleBaseValidator(object):
             if self.module.parent_select.active:
                 errors.append({
                     'type': 'smart links select parent first',
+                    'module': self.get_module_info(),
+                })
+            if self.module.is_multi_select():
+                errors.append({
+                    'type': 'smart links multi select',
+                    'module': self.get_module_info(),
+                })
+
+        if module_loads_registry_case(self.module):
+            if self.module.is_multi_select():
+                errors.append({
+                    'type': 'data registry multi select',
                     'module': self.get_module_info(),
                 })
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -161,6 +161,18 @@
                 uses both smart links and Parent Child Selection. These two
                 features are not compatible.
               {% endblocktrans %}
+            {% case "smart links multi select" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                uses both smart links and a multi-select case list. These two
+                features are not compatible.
+              {% endblocktrans %}
+            {% case "data registry multi select" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                loads a case from a data registry and uses a multi-select case list.
+                These two features are not compatible.
+              {% endblocktrans %}
             {% case "circular case hierarchy" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -5,8 +5,17 @@ from django.test import SimpleTestCase
 
 from unittest.mock import patch
 
-from corehq.apps.app_manager.models import Application, CaseList, Module
+from corehq.apps.app_manager.const import REGISTRY_WORKFLOW_LOAD_CASE, REGISTRY_WORKFLOW_SMART_LINK
+from corehq.apps.app_manager.models import (
+    Application,
+    CaseList,
+    CaseSearch,
+    CaseSearchLabel,
+    CaseSearchProperty,
+    Module,
+)
 from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.util.test_utils import flag_enabled
 
 
 @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
@@ -184,3 +193,29 @@ class BuildErrorsTest(SimpleTestCase):
             'type': 'training module child',
             'module': {'id': 1, 'unique_id': 'training_module', 'name': {'en': 'training module'}}
         }, app.validate_app())
+
+    @flag_enabled('DATA_REGISTRY')
+    @patch.object(Application, 'supports_data_registry', lambda: True)
+    def test_multi_select_module_errors(self, *args):
+        factory = AppFactory()
+        module, form = factory.new_basic_module('basic', 'person')
+        factory.form_requires_case(form, 'person')
+
+        module.case_details.short.multi_select = True
+        module.search_config = CaseSearch(
+            search_label=CaseSearchLabel(label={'en': 'Search'}),
+            properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
+            data_registry="so_many_cases",
+            data_registry_workflow=REGISTRY_WORKFLOW_LOAD_CASE,
+        )
+
+        self.assertIn({
+            'type': 'data registry multi select',
+            'module': {'id': 0, 'unique_id': 'basic_module', 'name': {'en': 'basic module'}}
+        }, factory.app.validate_app())
+
+        module.search_config.data_registry_workflow = REGISTRY_WORKFLOW_SMART_LINK
+        self.assertIn({
+            'type': 'smart links multi select',
+            'module': {'id': 0, 'unique_id': 'basic_module', 'name': {'en': 'basic module'}}
+        }, factory.app.validate_app())


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-1762

Multi-select case lists are definitely not compatible with smart links. I'm less sure if/how they would work with data registries, but we don't currently have a use case.

## Feature Flag
USH: Allow selecting multiple cases from the case list
USH: Enable Data Registries for sharing data between project spaces

## Safety Assurance

### Safety story
Small change of flagged, low-usage functionality.

### Automated test coverage

In PR.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
