### PR TITLE
Case claim request: Return 204 based on user's sync token

### DIFF
--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -102,7 +102,6 @@ class CaseClaimEndpointTests(TestCase):
         ensure_index_deleted(CASE_SEARCH_INDEX)
         self.user.delete(self.domain.name, deleted_by=None)
         self.domain.delete()
-        SyncLogSQL.objects.all().delete()
         cache = get_redis_default_cache()
         cache.clear()
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -163,9 +163,9 @@ def claim(request, domain):
         try:
             synclog = get_properly_wrapped_sync_log(request.last_sync_token)
             missing_case_ids_on_phone = set(case_ids) - synclog.case_ids_on_phone
-            return not(bool(missing_case_ids_on_phone))
-        except MissingSyncLog as err:
-            print(err)
+            return not missing_case_ids_on_phone
+        except MissingSyncLog:
+            return False
 
     if not case_ids_to_claim and phone_holds_all_cases(request):
         return HttpResponse(status=204)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Invisible.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Came out of the PR discussion [here](https://github.com/dimagi/formplayer/pull/1117). Currently, if a user has already claimed a case but tries to claim that case again, HQ will return a 204 code to tell formplayer/commcare that the user's device doesn't need to sync.

This PR changes that 204 code to be returned based on whether the case is already on the user's phone or not, instead of based on whether the user has previously claimed this case. This way, if a user happens to claim the case on device A and then do it again on device B without syncing, the sync will still (as expected) be triggered instead of HQ assuming that case is already on device B.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

SEARCH_CLAIM

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Local testing w/ the web app. 204 is returned when a case has already been claimed, 201 when it is being newly claimed (as expected). I tried testing using the CLI too to test the potential multiple-devices issue described above but the CLI's case search workflow doesn't work w/ a restore file.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
