### PR TITLE
Setup Celery as part of Django setup

### DIFF
--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -18,7 +18,8 @@ def _get_current_app():
     # raise an error if the current app is accessed before it is set,
     # but not thereafter?
     #
-    # Note no distinction between current and default app. They are the same.
+    # Eliminating the thread-local current app hooey should be fine.
+    # https://github.com/celery/celery/blob/ab3231dea14501c0159d3caa1fcf83689eb6db2d/celery/app/trace.py#L673-L680
     app = _state.default_app
     if app is None:
         raise RuntimeError("""Celery is not initialized.
@@ -34,7 +35,11 @@ def _get_current_app():
 # corehq.apps.celery._init_celery_app during Django setup.
 os.environ.setdefault("C_STRICT_APP", "1")
 from celery import _state  # noqa: E402
-assert _state.default_app is None, "Default app already created"
+if _state.default_app is not None:
+    # Reset default app, which can be initialized by gevent monkey
+    # patching, which traverses gc.get_objects() and calls
+    # isinstance(...) on each object.
+    _state.set_default_app(None)
 assert _state._tls.current_app is None, "Current app already created"
 assert hasattr(_state.current_app, "_Proxy__local")
 object.__setattr__(_state.current_app, "_Proxy__local", _get_current_app)

--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -30,7 +30,7 @@ def _get_current_app():
     return app
 
 
-# Monkey patch Celery. The app is initialized in
+# Monkey patch Celery. The app will be initialized in
 # corehq.apps.celery._init_celery_app during Django setup.
 os.environ.setdefault("C_STRICT_APP", "1")
 from celery import _state  # noqa: E402

--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -5,3 +5,37 @@
 # Startup logic should be invoked in a Django `AppConfig`, in the
 # `main()` method of manage.py, and/or in `corehq.celery` for
 # celery processes.
+import os
+
+
+def _get_current_app():
+    # HACK Celery 4.1 default/current app mechanism is broken when app
+    # initilaization is not done as an import side-effect. It either
+    # creates a new app when the current app is first requested (which
+    # is broken because then tasks get hooked to the wrong app), or
+    # (with C_STRICT_APP) it unconditionally raises an error when the
+    # current app is accessed. Why is there no way to configure it to
+    # raise an error if the current app is accessed before it is set,
+    # but not thereafter?
+    #
+    # Note no distinction between current and default app. They are the same.
+    app = _state.default_app
+    if app is None:
+        raise RuntimeError("""Celery is not initialized.
+
+        If you are seeing this error it probably means you have imported
+        something that depends on the Celery app before initializing it.
+        Adjust imports and/or INSTALLED_APPS (see corehq.apps.celery).
+        """)
+    return app
+
+
+# Monkey patch Celery. The app is initialized in
+# corehq.apps.celery._init_celery_app during Django setup.
+os.environ.setdefault("C_STRICT_APP", "1")
+from celery import _state  # noqa: E402
+assert _state.default_app is None, "Default app already created"
+assert _state._tls.current_app is None, "Current app already created"
+assert hasattr(_state.current_app, "_Proxy__local")
+object.__setattr__(_state.current_app, "_Proxy__local", _get_current_app)
+_state.get_current_app = _get_current_app

--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -1,3 +1,7 @@
-from .celery import app as celery_app  # noqa
-
-__all__ = ['celery_app']
+# This must not import any module that performs app initialization on
+# import since it is loaded by manage.py very early during startup as
+# a side effect of importing other modules in the package.
+#
+# Startup logic should be invoked in a Django `AppConfig`, in the
+# `main()` method of manage.py, and/or in `corehq.celery` for
+# celery processes.

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -24,6 +24,9 @@ auditcare
     A couch-based set of auditing tools. All page views in CommCare HQ are recorded in auditcare.
     This backs the User Audit Log report, which allows admins to view a given user's historical actions.
     Doing non-user-based queries is prohibitively slow.
+celery
+   A Django app that initializes the default/current Celery app during Django
+   setup.
 cloudcare
    Web Apps, a web-based interface for data entry, with essentially the same functionality
    as CommCare Mobile, but available via HQ to both web and mobile users. This app contains the HQ

--- a/corehq/apps/celery/__init__.py
+++ b/corehq/apps/celery/__init__.py
@@ -6,8 +6,9 @@ class Config(AppConfig):
     """Configure global Celery app as part of Django setup"""
     name = 'corehq.apps.celery'
 
-    def ready(self):
+    def __init__(self, *args, **kw):
         _init_celery_app()
+        super().__init__(*args, **kw)
 
 
 def _init_celery_app():
@@ -16,3 +17,4 @@ def _init_celery_app():
     app = Celery()
     app.config_from_object('django.conf:settings', namespace='CELERY')
     app.autodiscover_tasks()
+    app.set_default()

--- a/corehq/apps/celery/__init__.py
+++ b/corehq/apps/celery/__init__.py
@@ -1,0 +1,18 @@
+from celery import Celery
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    """Configure global Celery app as part of Django setup"""
+    name = 'corehq.apps.celery'
+
+    def ready(self):
+        _init_celery_app()
+
+
+def _init_celery_app():
+    assert "app" not in globals(), "Celery is already initialized"
+    global app
+    app = Celery()
+    app.config_from_object('django.conf:settings', namespace='CELERY')
+    app.autodiscover_tasks()

--- a/corehq/apps/celery/tests/test_celery_app.py
+++ b/corehq/apps/celery/tests/test_celery_app.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+from celery import current_app
+from testil import assert_raises
+
+from corehq.apps import celery as celery_app
+
+
+def test_init_celery_app():
+    app = getattr(celery_app, "app", None)
+    assert app is not None, "Celery is not initialized"
+
+
+def test_celery_always_eager():
+    conf = celery_app.app.conf
+    assert conf.task_always_eager, "task_always_eager is required for tests"
+
+
+def test_celery_current_app():
+    current = current_app._get_current_object()
+    assert celery_app.app is current, (celery_app.app, current)
+
+
+def test_current_app_pre_init_error():
+    with patch("celery._state.default_app", None):
+        with assert_raises(RuntimeError):
+            current_app._get_current_object()

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -23,8 +23,8 @@ from ..models import CommCareUser, WebUser
 # already been called.  It's easier to patch something that the handler calls.
 
 
-
 @mock_out_couch()
+@patch('corehq.apps.sms.tasks.sync_user_phone_numbers', new=MagicMock())
 @patch('corehq.apps.users.models.CouchUser.sync_to_django_user', new=MagicMock())
 @patch('corehq.apps.users.models.CommCareUser.project', new=MagicMock())
 @es_test

--- a/corehq/celery.py
+++ b/corehq/celery.py
@@ -1,10 +1,11 @@
+# When celery is launched with `celery -A corehq ...` it automatically
+# finds the app at `corehq.celery.app`. This module is for that purpose
+# alone, and should not be imported elsewhere.
 import os
 
 import django
 from django.core.checks import run_checks
 from django.core.exceptions import AppRegistryNotReady
-
-from celery import Celery
 
 from manage import init_hq_python_path, run_patches
 
@@ -13,12 +14,10 @@ run_patches()
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
 
-app = Celery()
-app.config_from_object('django.conf:settings', namespace='CELERY')
-app.autodiscover_tasks()
-
-django.setup()
+django.setup()  # calls corehq.apps.celery.Config.ready()
 try:
     run_checks()
 except AppRegistryNotReady:
     pass
+
+from corehq.apps.celery import app  # noqa: E402, F401

--- a/corehq/celery.py
+++ b/corehq/celery.py
@@ -13,7 +13,7 @@ run_patches()
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
 
-django.setup()  # calls corehq.apps.celery.Config.ready()
+django.setup()  # corehq.apps.celery.Config creates the app
 run_checks()
 
 from corehq.apps.celery import app  # noqa: E402, F401

--- a/corehq/celery.py
+++ b/corehq/celery.py
@@ -5,7 +5,6 @@ import os
 
 import django
 from django.core.checks import run_checks
-from django.core.exceptions import AppRegistryNotReady
 
 from manage import init_hq_python_path, run_patches
 
@@ -15,9 +14,6 @@ run_patches()
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
 
 django.setup()  # calls corehq.apps.celery.Config.ready()
-try:
-    run_checks()
-except AppRegistryNotReady:
-    pass
+run_checks()
 
 from corehq.apps.celery import app  # noqa: E402, F401

--- a/deployment/gunicorn/commcarehq_wsgi.py
+++ b/deployment/gunicorn/commcarehq_wsgi.py
@@ -11,9 +11,7 @@ _set_source_root(os.path.join('custom', '_legacy'))
 # patch gevent
 from gevent.monkey import patch_all
 from psycogreen.gevent import patch_psycopg
-from manage import patch_pickle
 
-patch_pickle()  # should happen before gevent patch, which imports pickle
 patch_all(subprocess=True)
 patch_psycopg()
 

--- a/manage.py
+++ b/manage.py
@@ -115,10 +115,6 @@ def run_patches():
 
     patch_jsonfield()
 
-    import django
-    _setup_once.setup = django.setup
-    django.setup = _setup_once
-
 
 def patch_jsonfield():
     """Patch the ``to_python`` method of JSONField
@@ -145,13 +141,6 @@ def patch_jsonfield():
         from django.contrib.postgres.fields.jsonb import JSONField
         import django.db.models
         django.db.models.JSONField = JSONField
-
-
-# HACK monkey-patch django setup to prevent second setup by django_nose
-def _setup_once(*args, **kw):
-    if not hasattr(_setup_once, "done"):
-        _setup_once.done = True
-        _setup_once.setup(*args, **kw)
 
 
 def set_default_settings_path(argv):

--- a/manage.py
+++ b/manage.py
@@ -8,8 +8,6 @@ from psycogreen.gevent import patch_psycopg
 
 
 def main():
-    patch_pickle()  # should happen before gevent patch, which imports pickle
-
     # important to apply gevent monkey patches before running any other code
     # applying this later can lead to inconsistencies and threading issues
     # but compressor doesn't like it
@@ -115,23 +113,11 @@ def run_patches():
     import mimetypes
     mimetypes.init()
 
-    patch_pickle()
     patch_jsonfield()
 
     import django
     _setup_once.setup = django.setup
     django.setup = _setup_once
-
-
-def patch_pickle():
-    """Patch pickle to support protocol 5
-
-    Remove after upgrading to Python 3.8+
-    """
-    import pickle
-    if pickle.HIGHEST_PROTOCOL < 5:
-        import pickle5
-        sys.modules["pickle"] = pickle5
 
 
 def patch_jsonfield():

--- a/settings.py
+++ b/settings.py
@@ -204,6 +204,7 @@ ROOT_URLCONF = "urls"
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 DEFAULT_APPS = (
+    'corehq.apps.celery.Config',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',


### PR DESCRIPTION
In addition to a bit of cleanup, this allows `manage.py` to import things from `corehq` without triggering Celery initialization as a side effect.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Tested on staging. Web workers and celery processes appear to be working normally.

### Automated test coverage

No new test coverage.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
