### PR TITLE
add new default option

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -128,6 +128,7 @@ class Command(SubCommand):
             'traceback',
             'no_color',
             'force_color',
+            'skip_checks'
         ]:
             options.pop(option, None)
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This command removes all the django default options from the options dict before passing the remaining options on to Reindexer constructor. It looks like django added a new default arg `skip_checks` in one of the versions we just updated to, so this updates the command to pop that one as well. Otherwise we get `__init__ received unexpected keyword argument 'skip_checks'`.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Management command only, no changes to behavior.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
