### PR TITLE
Fix UPDATE_TRANSLATIONS_SKIP_GIT bug

### DIFF
--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -33,7 +33,7 @@ while getopts ":h-:" option; do
     esac
 done
 
-if [ -z "${UPDATE_TRANSLATIONS_SKIP_GIT}" ]
+if [ -z "${UPDATE_TRANSLATIONS_SKIP_GIT-}" ]
 then
     has_local_changes=`git diff-index HEAD` && true
     if [[ $has_local_changes ]]
@@ -93,7 +93,7 @@ set -e
 echo "Pushing updates to transifex."
 tx push -s -t
 
-if [ -z "${UPDATE_TRANSLATIONS_SKIP_GIT}" ]
+if [ -z "${UPDATE_TRANSLATIONS_SKIP_GIT-}" ]
 then
     has_local_changes=`git diff-index HEAD` && true
     if [[ ! $has_local_changes ]]


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

update-translations.sh was failing to run due to the unset variable `UPDATE_TRANSLATIONS_SKIP_GIT`. This fix will default that to an empty string instead of an undefined. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

This is a bug fix so it'd have to be rolled back with [this commit](https://github.com/dimagi/commcare-hq/commit/7adb92ba5b91d1c7634a3e50d7323a1719368858) that introduced this line. 

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
