### PR TITLE
Resolve some deprecation warnings

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -669,7 +669,7 @@ def _email_is_valid(email):
     try:
         validate_email(email)
     except EmailNotValidError as e:
-        logger.warn(str(e))
+        logger.warning(str(e))
         return False
 
     return True

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -48,7 +48,7 @@ class TestSendToHubspot(TestCase):
         _send_hubspot_form_request.assert_called_once()
         hubspot_id, form_id, data = _send_hubspot_form_request.call_args[0]
         self.assertEqual(form_id, HUBSPOT_SIGNUP_FORM_ID)
-        self.assertDictContainsSubset(buyer_props, data)
+        self.assertEqual(data['buyer_persona'], 'Old-Timey Prospector')
 
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -98,7 +98,7 @@ class XPathEnum(TextXPath):
         if type == "display" and format == "enum":
             parts.insert(0, "replace(join(' ', ")
             parts[-1] = parts[-1][:-2] # removes extra comma from last string
-            parts.append("), '\s+', ' ')")
+            parts.append("), '\\s+', ' ')")
         else:
             parts.append("''")
             parts.append(")" * len(enum))

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -11,6 +11,7 @@ from lxml import etree
 
 from corehq.apps.app_manager.exceptions import UnknownInstanceError
 
+
 class XPathField(StringField):
     """
     A string field that is supposed to contain an arbitrary xpath expression
@@ -97,7 +98,7 @@ class XPathEnum(TextXPath):
             parts.append(template.format(**template_context))
         if type == "display" and format == "enum":
             parts.insert(0, "replace(join(' ', ")
-            parts[-1] = parts[-1][:-2] # removes extra comma from last string
+            parts[-1] = parts[-1][:-2]  # removes extra comma from last string
             parts.append("), '\\s+', ' ')")
         else:
             parts.append("''")
@@ -128,7 +129,7 @@ class Text(XmlObject):
             <argument key=""/> <!------------ 0 or More. Arguments for the localized string. Key is optional. Arguments can support any child elements that <body> can. -->
         </locale>
     </text>
-    """
+    """  # noqa: E501
 
     ROOT_NAME = 'text'
 

--- a/corehq/apps/app_manager/tests/test_suite_formats.py
+++ b/corehq/apps/app_manager/tests/test_suite_formats.py
@@ -92,7 +92,7 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
             </text>
           </template>
         </partial>
-        """.format(
+        """.format(  # noqa: #501
             key1_varname=key1_varname,
             key2_varname=key2_varname,
             key3_varname=key3_varname,
@@ -157,7 +157,7 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
             </text>
           </template>
         </partial>
-        """
+        """  # noqa: #501
         # check correct suite is generated
         self.assertXmlPartialEqual(
             icon_mapping_spec,
@@ -217,7 +217,7 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
                 </text>
               </template>
             </partial>
-        """.format(
+        """.format(  # noqa: #501
             key1_varname=key1_varname,
             key2_varname=key2_varname,
             key3_varname=key3_varname,

--- a/corehq/apps/app_manager/tests/test_suite_formats.py
+++ b/corehq/apps/app_manager/tests/test_suite_formats.py
@@ -146,7 +146,7 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
         <partial>
           <template>
             <text>
-              <xpath function="replace(join(' ', if(selected(if(gender = 'male', 'boy', 'girl'), 'boy'), $kboy, ''), if(selected(if(gender = 'male', 'boy', 'girl'), 'girl'), $kgirl, '')), '\s+', ' ')">
+              <xpath function="replace(join(' ', if(selected(if(gender = 'male', 'boy', 'girl'), 'boy'), $kboy, ''), if(selected(if(gender = 'male', 'boy', 'girl'), 'girl'), $kgirl, '')), '\\s+', ' ')">
                 <variable name="kboy">
                   <locale id="m0.case_short.case_if(gender  'male', 'boy', 'girl')_1.enum.kboy"/>
                 </variable>

--- a/corehq/apps/domain_migration_flags/api.py
+++ b/corehq/apps/domain_migration_flags/api.py
@@ -86,7 +86,7 @@ def get_uncompleted_migrations(slug):
     for progress in progs:
         if progress.completed_on is not None:
             assert progress.migration_status != MigrationStatus.COMPLETE, progress
-            log.warn("uncompleted migation (status=%s) has a completed-on date: %s",
+            log.warning("uncompleted migation (status=%s) has a completed-on date: %s",
                 progress.migration_status, progress.domain)
         result[progress.migration_status].append(progress)
     return result

--- a/corehq/apps/export/tests/test_export_form_subcases.py
+++ b/corehq/apps/export/tests/test_export_form_subcases.py
@@ -170,7 +170,8 @@ class TestFormExportSubcases(TestCase, TestXmlMixin):
                 for row in export_data[table]['rows']
             ]
 
-        self.assertDictContainsSubset({
+        form_data = get_form_data('Forms')[0]
+        for key, value in {
             # normal form questions
             "form.add_a_prescription": "yes_then_close",
             "form.how_are_you_today": "fine_thanks",
@@ -202,7 +203,8 @@ class TestFormExportSubcases(TestCase, TestXmlMixin):
             "form.subcase_0.case.index.parent.#text": "71626d9c-2d05-491f-81d9-becf8566618a",
             "form.subcase_0.case.index.parent.@case_type": "mom",
 
-        }, get_form_data('Forms')[0])
+        }.items():
+            self.assertEqual(form_data[key], value, f"key: {key!r}")
 
         self.assertDictEqual({
             "number": "0.0",

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -934,7 +934,7 @@ class ExportTest(SimpleTestCase):
 
             with export_file as export:
                 wb = load_workbook(export)
-                self.assertEqual(wb.get_sheet_names(), ["Export1-My table", "Export2-My table"])
+                self.assertEqual(wb.sheetnames, ["Export1-My table", "Export2-My table"])
 
                 for sheet in expected.keys():
                     for cell in expected[sheet].keys():

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -214,14 +214,14 @@ class AdminRestoreView(TemplateView):
         cases = xml_payload.findall('{http://commcarehq.org/case/transaction/v2}case')
         num_cases = len(cases)
 
-        create_case_type = filter(None, [case.find(
+        create_case_type = [case.find(
             '{http://commcarehq.org/case/transaction/v2}create/'
             '{http://commcarehq.org/case/transaction/v2}case_type'
-        ) for case in cases])
-        update_case_type = filter(None, [case.find(
+        ) for case in cases if len(case) and hasattr(case, "type")]
+        update_case_type = [case.find(
             '{http://commcarehq.org/case/transaction/v2}update/'
             '{http://commcarehq.org/case/transaction/v2}case_type'
-        ) for case in cases])
+        ) for case in cases if len(case) and hasattr(case, "type")]
         case_type_counts = dict(Counter([
             case.type for case in itertools.chain(create_case_type, update_case_type)
         ]))

--- a/corehq/apps/hqwebapp/tests/test_compress_command.py
+++ b/corehq/apps/hqwebapp/tests/test_compress_command.py
@@ -29,7 +29,7 @@ class TestDjangoCompressOffline(SimpleTestCase):
         if not line.strip():
             return
         for tag in DISALLOWED_REGEXES:
-            self.assertNotRegexpMatches(line.strip(), tag[0], '{}: {}'.format(tag[1], filename))
+            self.assertNotRegex(line.strip(), tag[0], '{}: {}'.format(tag[1], filename))
 
     @attr("slow")
     def test_compress_offline(self):

--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -95,7 +95,7 @@ class NotificationsServiceRMIView(JSONResponseMixin, View):
         }
 
     def get_domain(self):
-        domain_match_regex = '(?<=a\/)(.*?)(?=\s*\/)'
+        domain_match_regex = r'(?<=a/)(.*?)(?=\s*/)'
         domain = re.search(domain_match_regex, self.request.META['HTTP_REFERER'])
         if domain:
             return domain.group(0)

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -155,13 +155,13 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
 
     def test_submit_bad_xml(self):
         log_output = self._test_submit_bad_data(b'\xad\xac\xab\xd36\xe1\xab\xd6\x9dR\x9b')
-        self.assertRegexpMatches(log_output, r"Problem receiving submission.*")
+        self.assertRegex(log_output, r"Problem receiving submission.*")
 
     def test_submit_bad_device_log(self):
         log_output = self._test_submit_bad_data(
             "malformed xml dvice log</log></log_subreport></device_report>".encode('utf8')
         )
-        self.assertRegexpMatches(log_output, r"Badly formed device log.*")
+        self.assertRegex(log_output, r"Badly formed device log.*")
 
     def test_missing_xmlns(self):
         file, res = self._submit('missing_xmlns.xml')

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -194,7 +194,7 @@ class ExportWriter(object):
             elif isinstance(name, Promise):
                 # noinspection PyCompatibility
                 name = str(name)
-            return re.sub(r"[\n]", '', re.sub(r"[[\\?*/:\]]", "-", name))
+            return re.sub(r"[\n]", '', re.sub(r"[\[\\?*/:\]]", "-", name))
 
         table_title_truncated = self.table_name_generator.next_unique(
             _clean_name(table_title or table_index)

--- a/corehq/ex-submodules/dimagi/utils/decorators/profile.py
+++ b/corehq/ex-submodules/dimagi/utils/decorators/profile.py
@@ -93,7 +93,7 @@ def profile_dump(log_file, probability=1, limit=None):
         base, ext = os.path.splitext(log_file)
 
         header = '=' * 100
-        logger.warn("""
+        logger.warning("""
         %(header)s
         Profiling enabled for %(module)s.%(name)s with probability %(prob)s and limit %(limit)s.
         Output will be written to %(base)s-[datetime]%(ext)s

--- a/corehq/ex-submodules/dimagi/utils/system.py
+++ b/corehq/ex-submodules/dimagi/utils/system.py
@@ -34,7 +34,7 @@ def shell_exec_checked(cmd, cwd=None):
         raise ShellCommandError(**locals())
 
     if err:
-        logging.warn('command [%s] returned error output %s (return code OK)' % (cmd, str(err)))
+        logging.warning('command [%s] returned error output %s (return code OK)' % (cmd, str(err)))
     return out
 
 

--- a/corehq/motech/openmrs/tests/test_tasks.py
+++ b/corehq/motech/openmrs/tests/test_tasks.py
@@ -8,7 +8,7 @@ from django.test import SimpleTestCase
 
 import pytz
 from unittest.mock import patch
-from nose.tools import assert_raises_regexp
+from nose.tools import assert_raises_regex
 from requests.exceptions import ConnectTimeout, ReadTimeout
 
 from corehq.apps.groups.models import Group
@@ -193,7 +193,7 @@ def test_bad_data_type():
         'property': 'data_proxima_consulta'
     }
     with get_importer(bad_column_mapping) as importer:
-        with assert_raises_regexp(
+        with assert_raises_regex(
             ConfigurationError,
             'Errors importing from <OpenmrsImporter None admin@http://www.example.com/openmrs>:\n'
             'Unable to deserialize value 1551564000000 '

--- a/corehq/sql_db/tests/test_checks.py
+++ b/corehq/sql_db/tests/test_checks.py
@@ -3,6 +3,8 @@ from nose.tools import assert_equal, assert_in
 
 from corehq.sql_db import check_standby_configs
 
+from .utils import ignore_databases_override_warning
+
 
 def test_check_standby_configs():
     databases = {
@@ -23,6 +25,7 @@ def test_check_standby_configs():
         }
     }
 
+    @ignore_databases_override_warning
     def _check_settings(config, is_error):
         settings = {
             'DATABASES': databases,

--- a/corehq/sql_db/tests/test_connections.py
+++ b/corehq/sql_db/tests/test_connections.py
@@ -18,6 +18,7 @@ from corehq.sql_db.util import (
     get_replication_delay_for_shard_standbys,
     get_standbys_with_acceptible_delay,
 )
+from .utils import ignore_databases_override_warning
 
 
 def _get_db_config(db_name, master=None, delay=None):
@@ -49,6 +50,7 @@ REPORTING_DATABASES = {
 }
 
 
+@ignore_databases_override_warning
 @override_settings(DATABASES=DATABASES, REPORTING_DATABASES=REPORTING_DATABASES)
 class ConnectionManagerTests(SimpleTestCase):
     def setUp(self):
@@ -173,6 +175,7 @@ class ConnectionManagerTests(SimpleTestCase):
         )
 
 
+@ignore_databases_override_warning
 @override_settings(DATABASES=PARTITION_CONFIG_WITH_STANDBYS)
 class TestReadsFromShardStandbys(SimpleTestCase):
     def setUp(self):

--- a/corehq/sql_db/tests/test_partition_config.py
+++ b/corehq/sql_db/tests/test_partition_config.py
@@ -24,6 +24,7 @@ from ..exceptions import (
     NotPowerOf2Error,
     NotZeroStartError,
 )
+from .utils import ignore_databases_override_warning
 
 db_dict = {'NAME': 'commcarehq', 'USER': 'commcarehq', 'HOST': 'hqdb0', 'PORT': 5432}
 TEST_DATABASES = {
@@ -101,6 +102,7 @@ PARTITION_CONFIG_WITH_STANDBYS.update({
 })
 
 
+@ignore_databases_override_warning
 @override_settings(DATABASES=TEST_DATABASES, USE_PARTITIONED_DATABASE=True)
 class TestPartitionConfig(SimpleTestCase):
 
@@ -185,6 +187,7 @@ class TestPartitionConfig(SimpleTestCase):
             _get_standby_plproxy_config(config)
 
 
+@ignore_databases_override_warning
 def test_partition_config_validation():
     def _run_test(config, exception, message):
         settings = {
@@ -202,6 +205,7 @@ def test_partition_config_validation():
         yield _run_test, config, exception, message
 
 
+@ignore_databases_override_warning
 @override_settings(DATABASES=TEST_DATABASES)
 class PlProxyTests(SimpleTestCase):
 

--- a/corehq/sql_db/tests/test_routers.py
+++ b/corehq/sql_db/tests/test_routers.py
@@ -22,7 +22,10 @@ from corehq.sql_db.tests.test_partition_config import (
 )
 from corehq.sql_db.util import select_plproxy_db_for_read
 
+from .utils import ignore_databases_override_warning
 
+
+@ignore_databases_override_warning
 class AllowMigrateTest(SimpleTestCase):
 
     @override_settings(
@@ -64,6 +67,7 @@ class AllowMigrateTest(SimpleTestCase):
         self.assertIs(True, allow_migrate(DEFAULT_DB_ALIAS, 'accounting'))
 
 
+@ignore_databases_override_warning
 @patch('corehq.sql_db.util.get_standby_databases', return_value=set())
 @patch('corehq.sql_db.util.get_standbys_with_acceptible_delay', return_value=set())
 def test_load_balanced_read_apps(_, __):
@@ -85,6 +89,7 @@ def test_load_balanced_read_apps(_, __):
     assert_equal(get_load_balanced_app_db('users', default='default_option'), 'default_option')
 
 
+@ignore_databases_override_warning
 @override_settings(DATABASES=PARTITION_CONFIG_WITH_STANDBYS)
 def test_load_balanced_plproxy():
     primary_config = PlProxyConfig.from_dict(PARTITION_CONFIG_WITH_STANDBYS)

--- a/corehq/sql_db/tests/utils.py
+++ b/corehq/sql_db/tests/utils.py
@@ -8,7 +8,15 @@ from sqlalchemy.exc import ProgrammingError
 from corehq.sql_db.config import plproxy_config
 from corehq.sql_db.connections import connection_manager, DEFAULT_ENGINE_ID
 from corehq.sql_db.util import get_db_alias_for_partitioned_doc
+from corehq.tests.util.warnings import filter_warnings
 from corehq.util.decorators import ContextDecorator
+
+
+ignore_databases_override_warning = filter_warnings(
+    "ignore",
+    "Overriding setting DATABASES can lead to unexpected behavior.",
+    UserWarning,
+)
 
 
 class temporary_database(ContextDecorator):

--- a/corehq/tests/util/tests/test_warnings.py
+++ b/corehq/tests/util/tests/test_warnings.py
@@ -1,0 +1,186 @@
+import warnings
+from difflib import unified_diff
+from functools import wraps
+from unittest import TestCase, TestResult, TestSuite
+
+from testil import Regex, assert_raises, eq
+
+from ..warnings import filter_warnings
+
+
+def verify_same_filters_before_and_after(test):
+    @wraps(test)
+    def check():
+        old_filters = list(warnings.filters)
+        with filter_warnings("error"):
+            test()
+            done = True
+        assert done, "test did not return"
+        if warnings.filters != old_filters:
+            assert False, "warnings.filters changed\n" + "\n".join(unified_diff(
+                [str(f) for f in old_filters],
+                [str(f) for f in warnings.filters],
+                "filters removed",
+                "filters added",
+                n=1,
+            ))
+    return check
+
+
+def test_repr():
+    eq(
+        str(filter_warnings("default")),
+        "filter_warnings('default', '', <class 'Warning'>, '', 0, False)",
+    )
+
+
+@verify_same_filters_before_and_after
+def test_context_manager():
+    with filter_warnings("default", "expected") as log:
+        warnings.warn("expected", DeprecationWarning)
+    eq([str(r.message) for r in log], ["expected"])
+
+
+@verify_same_filters_before_and_after
+def test_reentrant_context_manager():
+    context = filter_warnings("default", "expected")
+    with context as log1:
+        warnings.warn("expected", DeprecationWarning)
+    with context as log2:
+        warnings.warn("expected too", DeprecationWarning)
+    eq([str(r.message) for r in log1], ["expected"])
+    eq([str(r.message) for r in log2], ["expected too"])
+
+
+@verify_same_filters_before_and_after
+def test_context_manager_with_ignored_warning():
+    with filter_warnings("ignore", "fake") as log:
+        warnings.warn("fake deprecation", DeprecationWarning)
+    eq(log, [])
+
+
+@verify_same_filters_before_and_after
+def test_context_manager_with_unexpected_warning():
+    with assert_raises(DeprecationWarning, msg="unexpected"):
+        with filter_warnings("default", "nomatch") as log:
+            warnings.warn("unexpected", DeprecationWarning)
+    eq(log, [])
+
+
+@verify_same_filters_before_and_after
+def test_function_decorator():
+    @filter_warnings("default", "expected")
+    def func():
+        warnings.warn("expected", DeprecationWarning)
+        calls.append(1)
+    calls = []
+    func()
+    eq(calls, [1])
+
+
+@verify_same_filters_before_and_after
+def test_function_decorator_with_unexpected_warning():
+    @filter_warnings("default", "nomatch")
+    def func():
+        warnings.warn("unexpected", DeprecationWarning)
+    with assert_raises(DeprecationWarning, msg="unexpected"):
+        func()
+
+
+@verify_same_filters_before_and_after
+def test_class_decorator():
+    @filter_warnings("default", "expected")
+    class Test(TestCase):
+        @classmethod
+        def setUpClass(cls):
+            warnings.warn("expected", DeprecationWarning)
+            log.append("setup")
+            super().setUpClass()
+
+        @classmethod
+        def tearDownClass(cls):
+            warnings.warn("expected", DeprecationWarning)
+            super().tearDownClass()
+            log.append("teardown")
+
+        def runTest(self):
+            warnings.warn("expected", DeprecationWarning)
+            log.append("test")
+
+    log = []
+    TestSuite([Test()]).debug()
+    eq(log, ["setup", "test", "teardown"])
+
+
+@verify_same_filters_before_and_after
+def test_class_decorator_should_not_catch_unfiltered_setup_warning():
+    @filter_warnings("default", "message", DeprecationWarning)
+    class Test(TestCase):
+        @classmethod
+        def setUpClass(cls):
+            log.append("setup")
+            warnings.warn("fail")
+            log.append("setup end")  # should not get here
+
+        @classmethod
+        def tearDownClass(cls):
+            super().tearDownClass()
+            log.append("teardown")
+
+        def runTest(self):
+            log.append("test")
+
+    log = []
+    result = TestResult()
+    TestSuite([Test()]).run(result)
+    eq(str(result.errors), Regex(r" in setUpClass\\n .*Warning: fail"), result)
+    eq(log, ["setup"])
+
+
+@verify_same_filters_before_and_after
+def test_class_decorator_should_not_catch_unfiltered_test_warning():
+    @filter_warnings("default", "message", DeprecationWarning)
+    class Test(TestCase):
+        @classmethod
+        def setUpClass(cls):
+            log.append("setup")
+            super().setUpClass()
+
+        @classmethod
+        def tearDownClass(cls):
+            super().tearDownClass()
+            log.append("teardown")
+
+        def runTest(self):
+            warnings.warn("fail")
+            log.append("test")  # should not get here
+
+    log = []
+    result = TestResult()
+    TestSuite([Test()]).run(result)
+    eq(str(result.errors), Regex(r" in runTest\\n .*Warning: fail"), result)
+    eq(log, ["setup", "teardown"])
+
+
+@verify_same_filters_before_and_after
+def test_class_decorator_should_not_catch_unfiltered_teardown_warning():
+    @filter_warnings("default", "message", DeprecationWarning)
+    class Test(TestCase):
+        @classmethod
+        def setUpClass(cls):
+            log.append("setup")
+            super().setUpClass()
+
+        @classmethod
+        def tearDownClass(cls):
+            warnings.warn("fail")
+            log.append("teardown")
+
+        def runTest(self):
+            log.append("test")  # should not get here
+
+    log = []
+    result = TestResult()
+    TestSuite([Test()]).run(result)
+    eq(str(result.errors), Regex(r" in tearDownClass\\n .*Warning: fail"), result)
+    eq(log, ["setup", "test"])

--- a/corehq/tests/util/warnings.py
+++ b/corehq/tests/util/warnings.py
@@ -1,0 +1,107 @@
+"""warnings test utilities"""
+import warnings
+from functools import wraps
+from unittest import TestCase
+
+from nose.tools import nottest
+
+
+@nottest
+class TestContextDecorator:
+    """Context manager/decorator for wrapping tests
+
+    Initialize with a single context manager argument or override
+    `__init__`, `__repr__`, `__enter__` and `__exit__`.
+    """
+
+    def __init__(self, context):
+        self.context = context
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self.context})"
+
+    def __enter__(self):
+        return self.context.__enter__()
+
+    def __exit__(self, *exc_info):
+        self.context.__exit__(*exc_info)
+
+    def start(self):
+        self.__enter__()
+
+    def stop(self):
+        self.__exit__(None, None, None)
+
+    def __call__(self, func):
+        if isinstance(func, type):
+            assert issubclass(func, TestCase), func
+            return self.decorate_class(func)
+        return self.decorate_callable(func)
+
+    def decorate_class(self, class_):
+        @classmethod
+        def setUpClass(cls):
+            self.start()
+            cls.addClassCleanup(self.stop)
+            original_setup()
+
+        original_setup, class_.setUpClass = class_.setUpClass, setUpClass
+        return class_
+
+    def decorate_callable(self, func):
+        @wraps(func)
+        def filtered(*args, **kw):
+            with self:
+                return func(*args, **kw)
+        return filtered
+
+
+class filter_warnings(TestContextDecorator):
+    """Context manager/test decorator for temporarily filtering warnings
+
+    A thin wrapper around `warnings.catch_warnings()` and
+    `warnings.filterwarnings()`. Accepts the same arguments as
+    `warnings.filterwarnings()`.
+
+    Usage:
+
+        with filter_warnings("default", "heya") as log:
+            warnings.warn("heya")  # warning will be captured
+            warnings.warn("yow")   # warning will not be captured
+        assert len(log) == 1  # log is a list of filtered warnings
+
+
+        @filter_warnings("default", "heya")
+        def func(arg):
+            warnings.warn("heya")  # warning will be captured
+            warnings.warn("yow")   # warning will not be captured
+
+
+        @filter_warnings("default", "heya")
+        class TestSomething(TestCase):
+            def test_thing():
+                warnings.warn("heya")  # warning will be captured
+                warnings.warn("yow")   # warning will not be captured
+    """
+
+    def __init__(self, action, message="", category=Warning, module="", lineno=0, append=False):
+        self.filter = (action, message, category, module, lineno, append)
+
+    def __repr__(self):
+        return f"{type(self).__name__}{self.filter}"
+
+    def __enter__(self):
+        """Start filtering warnings
+
+        Returns a list that will be populated with captured warnings.
+        """
+        if not hasattr(self, "context"):
+            self.context = warnings.catch_warnings(record=True)
+        log = self.context.__enter__()
+        warnings.filterwarnings(*self.filter)
+        return log
+
+    def __exit__(self, *exc_info):
+        """Stop filtering warnings."""
+        self.context.__exit__(*exc_info)
+        del self.context

--- a/corehq/util/tests/test_argparse_types.py
+++ b/corehq/util/tests/test_argparse_types.py
@@ -43,7 +43,7 @@ class TestValidateInteger(SimpleTestCase):
             with wrap_system_exit() as stderr:
                 self.parser.parse_args(argv)
         err_msg = stderr.getvalue().strip().split("\n")[-1]
-        self.assertRegexpMatches(err_msg, f": {re.escape(err_suffix)}$")
+        self.assertRegex(err_msg, f": {re.escape(err_suffix)}$")
 
     def test_validate_range_int_gt5(self):
         self.add_validated_arg(int, gt=5)

--- a/corehq/util/tests/test_couchdb_management.py
+++ b/corehq/util/tests/test_couchdb_management.py
@@ -34,15 +34,13 @@ class CouchConfigTest(SimpleTestCase):
 
     def test_all_db_uris_by_slug(self):
         config = CouchConfig(config=self._config)
-        self.assertDictContainsSubset(
-            {
-                None: self.remote_db_uri,
-                'users': '{}__users'.format(self.remote_db_uri),
-                'fixtures': '{}__fixtures'.format(self.remote_db_uri),
-                'meta': '{}__meta'.format(self.remote_db_uri),
-            },
-            config.all_db_uris_by_slug
-        )
+        for key, value in {
+            None: self.remote_db_uri,
+            'users': '{}__users'.format(self.remote_db_uri),
+            'fixtures': '{}__fixtures'.format(self.remote_db_uri),
+            'meta': '{}__meta'.format(self.remote_db_uri),
+        }.items():
+            self.assertEqual(config.all_db_uris_by_slug[key], value, f"key: {key!r}")
 
     def test_get_db_for_doc_type(self):
         config = CouchConfig(config=self._config)


### PR DESCRIPTION
Fix assorted deprecation warnings found while running tests locally. Most commit messages contain details about the specific ~error~ warning being resolved.

## Safety Assurance

### Safety story

These were all straightforward changes, most of them with recommended fixes in the error message.

### Automated test coverage

Yes. All errors were found by running tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
