### PR TITLE
Updated datum ids for multi-select datums in entries

### DIFF
--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -15,7 +15,12 @@ def get_select_chain(app, module, include_self=True):
 
 
 def get_select_chain_with_sessions(app, module, include_self=True):
-    select_chain = [(module, 'case_id')] if include_self else []
+    select_chain = []
+    if include_self:
+        if module.is_multi_select():
+            select_chain.append((module, 'selected_cases'))
+        else:
+            select_chain.append((module, 'case_id'))
     current_module = module
     case_type = module.case_type
     i = len(select_chain)
@@ -29,7 +34,10 @@ def get_select_chain_with_sessions(app, module, include_self=True):
         if is_other_relation and case_type == parent_module.case_type:
             session_var = 'case_id_' + case_type
         else:
-            session_var = ('parent_' * i or 'case_') + 'id'
+            if current_module.is_multi_select():
+                session_var = ('parent_' * i) + 'selected_cases'
+            else:
+                session_var = ('parent_' * i or 'case_') + 'id'
         if parent_module in [m for (m, _) in select_chain]:
             raise SuiteValidationError("Circular reference in case hierarchy")
         select_chain.append((parent_module, session_var))

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -54,7 +54,7 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
                 </command>
                 <instance id="casedb" src="jr://instance/casedb"/>
                 <session>
-                  <instance-datum id="case_id"
+                  <instance-datum id="selected_cases"
                                   nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open']"
                                   value="./@case_id"
                                   detail-select="m0_case_short"
@@ -168,7 +168,7 @@ class MultiSelectSelectParentFirstTests(SimpleTestCase, TestXmlMixin):
                 </command>
                 <instance id="casedb" src="jr://instance/casedb"/>
                 <session>
-                  <instance-datum id="case_id"
+                  <instance-datum id="selected_cases"
                                   nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open']"
                                   value="./@case_id"
                                   detail-select="m1_case_short"
@@ -231,7 +231,7 @@ class MultiSelectSelectParentFirstTests(SimpleTestCase, TestXmlMixin):
                          nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open']"
                          value="./@case_id"
                          detail-select="m0_case_short"/>
-                  <instance-datum id="case_id"
+                  <instance-datum id="selected_cases"
                                   nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open']"
                                   value="./@case_id"
                                   detail-select="m1_case_short"


### PR DESCRIPTION
## Technical Summary
https://github.com/dimagi/commcare-hq/pull/31435#discussion_r850351902

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
Bugfix in feature not being used on prod. Automated suite generation tests mitigate the risk of regressions.

### Automated test coverage
Yes

### QA Plan
No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
