### PR TITLE
Mark closed cases as duplicates during backfill

### DIFF
--- a/corehq/apps/data_interfaces/deduplication.py
+++ b/corehq/apps/data_interfaces/deduplication.py
@@ -80,6 +80,7 @@ def reset_deduplicate_rule(rule):
 def backfill_deduplicate_rule(domain, rule):
     from corehq.apps.data_interfaces.models import (
         AutomaticUpdateRule,
+        CaseDeduplicationActionDefinition,
         DomainCaseRuleRun,
     )
 
@@ -94,7 +95,10 @@ def backfill_deduplicate_rule(domain, rule):
             status=DomainCaseRuleRun.STATUS_RUNNING,
             case_type=rule.case_type,
         )
-        case_iterator = AutomaticUpdateRule.iter_cases(domain, rule.case_type)
+        action = CaseDeduplicationActionDefinition.from_rule(rule)
+        case_iterator = AutomaticUpdateRule.iter_cases(
+            domain, rule.case_type, include_closed=action.include_closed
+        )
         iter_cases_and_run_rules(
             domain,
             case_iterator,

--- a/corehq/apps/data_interfaces/deduplication.py
+++ b/corehq/apps/data_interfaces/deduplication.py
@@ -84,7 +84,7 @@ def backfill_deduplicate_rule(domain, rule):
     )
 
     progress_helper = MessagingRuleProgressHelper(rule.pk)
-    total_cases_count = CaseES().domain(domain).case_type(rule.case_type).count()
+    total_cases_count = CaseSearchES().domain(domain).case_type(rule.case_type).count()
     progress_helper.set_total_cases_to_be_processed(total_cases_count)
     now = datetime.utcnow()
     try:

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -210,17 +210,20 @@ class AutomaticUpdateRule(models.Model):
         return date
 
     @classmethod
-    def iter_cases(cls, domain, case_type, boundary_date=None, db=None):
-        return cls._iter_cases_from_postgres(domain, case_type, boundary_date=boundary_date, db=db)
+    def iter_cases(cls, domain, case_type, boundary_date=None, db=None, include_closed=False):
+        return cls._iter_cases_from_postgres(
+            domain, case_type, boundary_date=boundary_date, db=db, include_closed=include_closed
+        )
 
     @classmethod
-    def _iter_cases_from_postgres(cls, domain, case_type, boundary_date=None, db=None):
+    def _iter_cases_from_postgres(cls, domain, case_type, boundary_date=None, db=None, include_closed=False):
         q_expression = Q(
             domain=domain,
             type=case_type,
-            closed=False,
             deleted=False,
         )
+        if not include_closed:
+            q_expression = q_expression & Q(closed=False)
 
         if boundary_date:
             q_expression = q_expression & Q(server_modified_on__lte=boundary_date)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When a deduplication rule uses the "include closed" parameter, we weren't including these when backfilling for duplicates. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Changes the case iterator to include closed cases when necessary
https://dimagi-dev.atlassian.net/browse/SC-2048

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CASE_DEDUPE

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Added tests

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
