### PR TITLE
Update requirements to ipython==8.2.0

### DIFF
--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -24,8 +24,6 @@ backcall==0.2.0
     # via ipython
 billiard==3.5.0.4
     # via -r base-requirements.in
-black==22.1.0
-    # via ipython
 boto3==1.17.85
     # via -r base-requirements.in
 botocore==1.20.85
@@ -52,8 +50,6 @@ chardet==3.0.4
     # via
     #   ghdiff
     #   requests
-click==8.0.3
-    # via black
 cloudant==2.14.0
     # via jsonobject-couchdbkit
 commcaretranslationchecker==0.9.7
@@ -234,7 +230,7 @@ importlib-metadata==4.11.3
     # via markdown
 intervaltree==3.1.0
     # via ddtrace
-ipython==8.0.1
+ipython==8.2.0
     # via -r prod-requirements.in
 iso8601==0.1.13
     # via -r base-requirements.in
@@ -290,8 +286,6 @@ markupsafe==1.1.1
     #   mako
 matplotlib-inline==0.1.3
     # via ipython
-mypy-extensions==0.4.3
-    # via black
 ndg-httpsclient==0.5.1
     # via -r prod-requirements.in
 oauthlib==3.1.0
@@ -304,8 +298,6 @@ openpyxl==3.0.6
     #   commcaretranslationchecker
 parso==0.8.3
     # via jedi
-pathspec==0.9.0
-    # via black
 pexpect==4.8.0
     # via ipython
 phonenumberslite==8.12.10
@@ -318,8 +310,6 @@ pillow==9.0.1
     # via
     #   -r base-requirements.in
     #   reportlab
-platformdirs==2.4.1
-    # via black
 ply==3.11
     # via
     #   eulxml
@@ -521,8 +511,6 @@ text-unidecode==1.3
     #   faker
 tinys3==0.1.12
     # via -r base-requirements.in
-tomli==2.0.1
-    # via black
 toposort==1.7
     # via -r base-requirements.in
 tornado==4.5.3
@@ -538,9 +526,7 @@ turn-python==0.0.1
 twilio==6.5.1
     # via -r base-requirements.in
 typing-extensions==4.1.1
-    # via
-    #   black
-    #   django-countries
+    # via django-countries
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0


### PR DESCRIPTION
which also removes a number of requirements

## Technical Summary

Facing a number of INFO level log message we didn't used to get, referencing `blib2to3/Grammar.txt` and `.cache/black`, I decided to try upgrading ipython to the latest version since that's the only thing that uses `black`. Turns out doing so removes `black` and a number of other libraries as a dependency for us.
## Safety Assurance

### Safety story
Ipython is used for administrative functions only and not involved directly in production services.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
