### PR TITLE
Use new Django 3 enum type for choices

### DIFF
--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -9,24 +9,6 @@ from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 from corehq.apps.case_importer import exceptions
 
-property_type = namedtuple('property_type', 'slug display')
-
-
-class PROPERTY_TYPES:
-    DATE = property_type('date', _('Date'))
-    PLAIN = property_type('plain', _('Plain'))
-    NUMBER = property_type('number', _('Number'))
-    SELECT = property_type('select', _('Multiple Choice'))
-    BARCODE = property_type('barcode', _('Barcode'))
-    GPS = property_type('gps', _('GPS'))
-    PHONE_NUMBER = property_type('phone_number', _('Phone Number'))
-    PASSWORD = property_type('password', _('Password'))
-    UNDEFINED = property_type('', _('No Type Currently Selected'))
-
-    @classmethod
-    def get_all(cls):
-        return [t for t in cls.__dict__.values() if isinstance(t, property_type)]
-
 
 class CaseType(models.Model):
     domain = models.CharField(max_length=255, default=None)
@@ -59,6 +41,18 @@ class CaseType(models.Model):
 
 
 class CaseProperty(models.Model):
+
+    class DataType(models.TextChoices):
+        DATE = 'date', _('Date')
+        PLAIN = 'plain', _('Plain')
+        NUMBER = 'number', _('Number')
+        SELECT = 'select', _('Multiple Choice')
+        BARCODE = 'barcode', _('Barcode')
+        GPS = 'gps', _('GPS')
+        PHONE_NUMBER = 'phone_number', _('Phone Number')
+        PASSWORD = 'password', _('Password')
+        UNDEFINED = '', _('No Type Currently Selected')
+
     case_type = models.ForeignKey(
         CaseType,
         on_delete=models.CASCADE,
@@ -69,10 +63,10 @@ class CaseProperty(models.Model):
     description = models.TextField(default='', blank=True)
     deprecated = models.BooleanField(default=False)
     data_type = models.CharField(
-        choices=[(t.slug, t.display) for t in PROPERTY_TYPES.get_all()],
+        choices=DataType.choices,
         max_length=20,
-        default='',
-        blank=True
+        default=DataType.UNDEFINED,
+        blank=True,
     )
     group = models.TextField(default='', blank=True)
 

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -10,7 +10,6 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
 )
 from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
 from corehq.apps.data_dictionary.models import (
-    PROPERTY_TYPES,
     CaseProperty,
     CasePropertyAllowedValue,
     CaseType,
@@ -242,5 +241,5 @@ def get_gps_properties(domain, case_type):
     return set(CaseProperty.objects.filter(
         case_type__domain=domain,
         case_type__name=case_type,
-        data_type=PROPERTY_TYPES.GPS.slug,
+        data_type=CaseProperty.DataType.GPS,
     ).values_list('name', flat=True))

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -21,7 +21,6 @@ from corehq import toggles
 from corehq.apps.case_importer.tracking.filestorage import make_temp_file
 from corehq.apps.data_dictionary import util
 from corehq.apps.data_dictionary.models import (
-    PROPERTY_TYPES,
     CaseProperty,
     CasePropertyAllowedValue,
     CaseType,
@@ -345,9 +344,9 @@ class DataDictionaryView(BaseProjectDataView):
                 'fhir_resource_types': SUPPORTED_FHIR_RESOURCE_TYPES,
             })
         main_context.update({
-            'question_types': [{'value': t.slug, 'display': t.display}
-                               for t in PROPERTY_TYPES.get_all()
-                               if t != PROPERTY_TYPES.UNDEFINED],
+            'question_types': [{'value': t.value, 'display': t.label}
+                               for t in CaseProperty.DataType
+                               if t != CaseProperty.DataType.UNDEFINED],
             'fhir_integration_enabled': fhir_integration_enabled,
         })
         return main_context
@@ -405,7 +404,7 @@ def _process_bulk_upload(bulk_file, domain):
     import_fhir_data = toggles.FHIR_INTEGRATION.enabled(domain)
     fhir_resource_type_by_case_type = {}
     expected_columns_in_prop_sheet = 5
-    data_type_map = {t.display: t.slug for t in PROPERTY_TYPES.get_all()}
+    data_type_map = {t.label: t.value for t in CaseProperty.DataType}
 
     if import_fhir_data:
         expected_columns_in_prop_sheet = 7


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary

From https://github.com/dimagi/commcare-hq/pull/31402/files#r844983856
This switches DD case property choices from an ad-hoc constant class to the new Django 3 enum type for "choices"

Thanks Farid for pointing it out to me.  We merged the Django 3 upgrade shortly after that PR, so I took the excuse to rework this portion of that.

This is pretty rad, it does just what I wanted.  https://docs.djangoproject.com/en/4.0/ref/models/fields/#enumeration-types

The docs also have suggestions for more involved variations when needed, such as storing an int or other type in the DB, or including more information along with the slug and label

Here it is in practice:

```python
In [1]: from corehq.apps.data_dictionary.models import *

In [2]: CaseProperty.DataType
Out[2]: <enum 'DataType'>

In [3]: list(CaseProperty.DataType)
Out[3]:
[<DataType.DATE: 'date'>,
 <DataType.PLAIN: 'plain'>,
 <DataType.NUMBER: 'number'>,
 <DataType.SELECT: 'select'>,
 <DataType.BARCODE: 'barcode'>,
 <DataType.GPS: 'gps'>,
 <DataType.PHONE_NUMBER: 'phone_number'>,
 <DataType.PASSWORD: 'password'>,
 <DataType.UNDEFINED: ''>]

In [4]: CaseProperty.DataType.choices
Out[4]:
[('date', 'Date'),
 ('plain', 'Plain'),
 ('number', 'Number'),
 ('select', 'Multiple Choice'),
 ('barcode', 'Barcode'),
 ('gps', 'GPS'),
 ('phone_number', 'Phone Number'),
 ('password', 'Password'),
 ('', 'No Type Currently Selected')]

In [5]: CaseProperty.DataType.DATE
Out[5]: <DataType.DATE: 'date'>

In [6]: str(CaseProperty.DataType.DATE)
Out[6]: 'date'

In [7]: isinstance(CaseProperty.DataType.DATE, str)
Out[7]: True

In [8]: CaseProperty.DataType.DATE.value
Out[8]: 'date'

In [9]: CaseProperty.DataType.DATE.label
Out[9]: 'Date'

In [10]: CaseProperty.DataType.DATE.name
Out[10]: 'DATE'
```
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
