### PR TITLE
Multi select checkbox clearing bug fix

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -366,6 +366,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 this.updateCheckboxes();
                 this.selectedCaseIdsLength = this.selectedCaseIds.length;
                 sessionStorage.selectedValues = [];
+                this.ui.continueButton.prop("disabled", this.selectedCaseIds.length === 0);
             }
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -457,9 +457,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         updateCheckboxes: function () {
+            var self = this;
             if (this.isMultiSelect) {
                 this.children.each(function (childView) {
-                    if (childView.parentView.selectedCaseIds.indexOf(childView.model.id) !== -1) {
+                    if (self.selectedCaseIds.indexOf(childView.model.id) !== -1) {
                         let checkbox = childView.ui.selectRow[0];
                         checkbox.checked = true;
                     }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -364,7 +364,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             if (sessionStorage.selectedValues && sessionStorage.selectedValues.length !== 0) {
                 this.selectedCaseIds = sessionStorage.selectedValues.split(',');
                 this.updateCheckboxes();
-                this.selectedCaseIdsLength = this.selectedCaseIds.length;
                 sessionStorage.selectedValues = [];
                 this.ui.continueButton.prop("disabled", this.selectedCaseIds.length === 0);
             }
@@ -491,7 +490,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 hasNoItems: this.hasNoItems,
                 sortIndices: this.options.sortIndices,
                 isMultiSelect: isMultiSelectCaseList,
-                selectedCaseIdsLength: this.selectedCaseIds.length,
+                selectedCaseIds: this.selectedCaseIds,
                 columnSortable: function (index) {
                     return this.sortIndices.indexOf(index) > -1;
                 },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -327,7 +327,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             this.styles = options.styles;
             this.hasNoItems = options.collection.length === 0;
             this.redoLast = options.redoLast;
-            this.selectedCaseIds = [];
+            this.selectedCaseIds = sessionStorage.selectedValues === undefined || sessionStorage.selectedValues.length === 0 ?  [] : sessionStorage.selectedValues.split(',');
         },
 
         ui: {
@@ -358,6 +358,15 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             'keypress @ui.selectAllCheckbox': 'selectAllAction',
             'click @ui.continueButton': 'continueAction',
             'keypress @ui.continueButton': 'continueAction',
+        },
+
+        onRender: function () {
+            if (sessionStorage.selectedValues && sessionStorage.selectedValues.length !== 0) {
+                this.selectedCaseIds = sessionStorage.selectedValues.split(',');
+                this.updateCheckboxes();
+                this.selectedCaseIdsLength = this.selectedCaseIds.length;
+                sessionStorage.selectedValues = [];
+            }
         },
 
         caseListAction: function (e) {
@@ -392,6 +401,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             e.preventDefault();
             var casesPerPage = this.ui.casesPerPageLimit.val();
             FormplayerFrontend.trigger("menu:perPageLimit", casesPerPage);
+            sessionStorage.selectedValues = this.selectedCaseIds;
         },
 
         paginationGoAction: function (e) {
@@ -442,6 +452,17 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 this.ui.continueButton.prop("disabled", true);
             } else {
                 this.ui.continueButton.prop("disabled", false);
+            }
+        },
+
+        updateCheckboxes: function () {
+            if (this.isMultiSelect) {
+                this.children.each(function (childView) {
+                    if (childView.parentView.selectedCaseIds.indexOf(childView.model.id) !== -1) {
+                        let checkbox = childView.ui.selectRow[0];
+                        checkbox.checked = true;
+                    }
+                });
             }
         },
 

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -58,7 +58,7 @@
     <% if (actions || isMultiSelect) { %>
     <div class="case-list-actions">
       <% if (isMultiSelect) { %>
-      <button type="button" class="btn btn-success btn-lg formplayer-request" disabled="true" id="multi-select-continue-btn">{% trans "Continue" %} (<span id="multi-select-btn-text"><%- selectedCaseIdsLength %></span>)</button>
+      <button type="button" class="btn btn-success btn-lg formplayer-request" disabled="true" id="multi-select-continue-btn">{% trans "Continue" %} (<span id="multi-select-btn-text"><%- selectedCaseIds.length %></span>)</button>
       <% } %>
       <% if (actions) { %>
         <% _.each(actions, function(action, index) { %>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The checkbox selection clears when you select a new number-per-page limit, so this updates the checkboxes and continue button to represent what was selected prior to the changes. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
`selectedCaseIds` was cleared on render so the first solution I tried for putting the `updateCheckboxes` function within the page limit function was not successful. Instead, I added the `onRender` function that checks if anything is stored in the sessionStorage for the selectedCaseIds and then reassigns that var and then clears the sessionStorage for that variable again. The session storage is updated in the page limit update function so this is saved during that, but not during other renders like navigating away from the page and/or manually pressing the refresh button

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
USE_CASE_LIST_MULTI_SELECT

## Safety Assurance
This is behind a flag not being used on my production domains and will go through QA and use testing

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
This will go through QA along with the rest of the multi-select feature

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
