### PR TITLE
Updated relevant condition for multi-select remote request post

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2237,11 +2237,8 @@ class CaseSearch(DocumentSchema):
         return "search_case_id"
 
     def get_relevant(self, multi_select=False):
-        if multi_select:
-            return self.additional_relevant
-
-        # Single select case lists are irrelevant if the selected case is already in the casedb
-        default_condition = CaseClaimXpath(self.case_session_var).default_relevant()
+        xpath = CaseClaimXpath(self.case_session_var)
+        default_condition = xpath.multi_select_relevant() if multi_select else xpath.default_relevant()
         if self.additional_relevant:
             return f"({default_condition}) and ({self.additional_relevant})"
         return default_condition

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -380,8 +380,10 @@ class SessionEndpointRemoteRequestFactory(RemoteRequestFactory):
         self.case_session_var = case_session_var
 
     def get_post_relevant(self):
-        if not self.module.is_multi_select():
-            return CaseClaimXpath(self.case_session_var).default_relevant()
+        xpath = CaseClaimXpath(self.case_session_var)
+        if self.module.is_multi_select():
+            return xpath.multi_select_relevant()
+        return xpath.default_relevant()
 
     def build_command(self):
         return Command(

--- a/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
@@ -1,6 +1,7 @@
 <partial>
   <remote-request>
-    <post url="https://www.example.com/a/multiple-referrals/phone/claim-case/">
+    <post url="https://www.example.com/a/multiple-referrals/phone/claim-case/"
+          relevant="$case_id != ''">
       <data key="case_id"
             nodeset="instance('selected_cases')/results/value"
             exclude="count(instance('casedb')/casedb/case[@case_id=current()/.]) = 1"

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -198,10 +198,10 @@ class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def test_search_config_relevant_multi_select(self, *args):
         config = CaseSearch()
 
-        self.assertEqual(config.get_relevant(multi_select=True), None)
+        self.assertEqual(config.get_relevant(multi_select=True), "$case_id != ''")
 
         config.additional_relevant = "double(now()) mod 2 = 0"
-        self.assertEqual(config.get_relevant(multi_select=True), "double(now()) mod 2 = 0")
+        self.assertEqual(config.get_relevant(multi_select=True), "($case_id != '') and (double(now()) mod 2 = 0)")
 
     @flag_enabled("USH_CASE_CLAIM_UPDATES")
     def test_remote_request(self, *args):

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -339,6 +339,10 @@ class CaseClaimXpath(object):
         # count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/search_case_id]) = 0
         return CaseIDXPath(session_var(self.session_var_name)).case().count().eq(0)
 
+    def multi_select_relevant(self):
+        # Verifies that there's at least one case that isn't yet owned by the user
+        return XPath("$case_id").neq(XPath.string(""))
+
 
 class LedgerdbXpath(XPath):
 


### PR DESCRIPTION
## Technical Summary
Follows up on https://github.com/dimagi/commcare-hq/pull/31343

From [spec](https://docs.google.com/document/d/1N_Zg1vqRQofSsJo7X0Bj4WHktTroVofkpUIWt8_3Bhc/edit?disco=AAAAXhMAxb4): When all selected cases are already owned by the user, the expression below results in 'case_id' being empty and in turn FP skipping the parameter altogether from the claim request. Putting this relevancy condition will altogether skip the claim request if 'case_id` is empty.

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
Pretty limited change to a feature not being used in prod. Automated tests cover regressions.

### Automated test coverage

In PR.

### QA Plan

No QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
