### PR TITLE
Remove ERM_DEVELOPMENT toggle

### DIFF
--- a/corehq/apps/linked_domain/tests/test_release_manager.py
+++ b/corehq/apps/linked_domain/tests/test_release_manager.py
@@ -179,7 +179,7 @@ class TestReleaseManager(BaseReleaseManagerTest):
 
 class TestReleaseApp(BaseReleaseManagerTest):
 
-    def test_app_not_pushed_if_not_found_with_toggle_disabled(self):
+    def test_app_not_pushed_if_not_found(self):
         unpushed_app = Application.new_app(self.domain, "Not Yet Pushed App")
         unpushed_app.save()
         self.addCleanup(unpushed_app.delete)
@@ -188,17 +188,6 @@ class TestReleaseApp(BaseReleaseManagerTest):
 
         errors = manager._release_app(self.domain_link, model, manager.user)
 
-        self.assertTrue("Could not find app" in errors)
-
-    @flag_enabled('ERM_DEVELOPMENT')
-    def test_app_not_pushed_if_not_found_with_toggle_enabled(self):
-        unpushed_app = Application.new_app(self.domain, "Not Yet Pushed App")
-        unpushed_app.save()
-        self.addCleanup(unpushed_app.delete)
-        model = self._linked_data_view_model(MODEL_APP, detail=AppLinkDetail(app_id=unpushed_app._id).to_json())
-        manager = ReleaseManager(self.domain, self.user.username)
-
-        errors = manager._release_app(self.domain_link, model, manager.user)
         self.assertTrue("Could not find app" in errors)
 
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2079,13 +2079,6 @@ FHIR_INTEGRATION = StaticToggle(
     help_link="https://confluence.dimagi.com/display/GS/FHIR+API+Documentation",
 )
 
-ERM_DEVELOPMENT = StaticToggle(
-    'erm_development',
-    'General purpose "enterprise release management" development flag',
-    TAG_PRODUCT,
-    namespaces=[NAMESPACE_DOMAIN],
-)
-
 AUTO_DEACTIVATE_MOBILE_WORKERS = StaticToggle(
     'auto_deactivate_mobile_workers',
     'Development flag for auto-deactivation of mobile workers. To be replaced '


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Easy one! [Flagged by QA](https://dimagi-dev.atlassian.net/browse/QA-4030?focusedCommentId=201957&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-201957), I don't think it's worth keeping this in the codebase for now. Maybe someday in the future it might be useful, but it's easy enough to roll out another feature flag then. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ERM_DEVELOPMENT`
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Just removing an unused feature flag. Definitely unused. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
