### PR TITLE
Upgrade pip (22.0.4) and pip-tools (6.6.0)

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -373,7 +373,7 @@ pillow==9.0.1
     # via
     #   -r base-requirements.in
     #   reportlab
-pip-tools==6.5.1
+pip-tools==6.6.0
     # via -r test-requirements.in
 platformdirs==2.4.1
     # via black

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -567,7 +567,7 @@ zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.3.1
+pip==22.0.4
     # via -r prod-requirements.in
 setuptools==50.3.0
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -310,7 +310,7 @@ pillow==9.0.1
     # via
     #   -r base-requirements.in
     #   reportlab
-pip-tools==6.5.1
+pip-tools==6.6.0
     # via -r test-requirements.in
 ply==3.11
     # via


### PR DESCRIPTION
## Technical Summary

Bump the versions on these two dependencies

## Safety Assurance

### Safety story
Simple upgrade of these fairly reliable tools (whose code isn't called directly by the production process anyway)


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
