### PR TITLE
apply rate limiting delay to auto update rules and condtional alerts

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -875,7 +875,7 @@ class UpdateCaseDefinition(BaseUpdateCaseDefinition):
             if case_id == case.case_id:
                 continue
             result = update_case(case.domain, case_id, case_properties=properties, close=False,
-                xmlns=AUTO_UPDATE_XMLNS)
+                                 xmlns=AUTO_UPDATE_XMLNS, max_wait=15)
             rule.log_submission(result[0].form_id)
             num_related_updates += 1
 
@@ -888,7 +888,7 @@ class UpdateCaseDefinition(BaseUpdateCaseDefinition):
 
         if close_case or properties:
             result = update_case(case.domain, case.case_id, case_properties=properties, close=close_case,
-                xmlns=AUTO_UPDATE_XMLNS)
+                                 xmlns=AUTO_UPDATE_XMLNS, max_wait=15)
 
             rule.log_submission(result[0].form_id)
 

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -132,7 +132,7 @@ def _get_update_or_close_case_block(case_id, case_properties=None, close=False, 
 
 
 def update_case(domain, case_id, case_properties=None, close=False,
-                xmlns=None, device_id=None, owner_id=None):
+                xmlns=None, device_id=None, owner_id=None, max_wait=...):
     """
     Updates or closes a case (or both) by submitting a form.
     domain - the case's domain
@@ -142,6 +142,9 @@ def update_case(domain, case_id, case_properties=None, close=False,
     close - True to close the case, False otherwise
     xmlns - pass in an xmlns to use it instead of the default
     device_id - see submit_case_blocks device_id docs
+    max_wait - Maximum time (in seconds) to allow the process to be delayed if
+               the project is over its submission rate limit.
+               See the docstring for submit_form_locally for meaning of values
     """
     caseblock = _get_update_or_close_case_block(case_id, case_properties, close, owner_id)
     return submit_case_blocks(
@@ -150,6 +153,7 @@ def update_case(domain, case_id, case_properties=None, close=False,
         user_id=SYSTEM_USER_ID,
         xmlns=xmlns,
         device_id=device_id,
+        max_wait=max_wait
     )
 
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This causes case updates from auto update rules and conditional alerts to be delayed by up to 15 seconds if rate limits are exceeded. This could make auto update rules process slower for everyone (the delayed rules will take up places in the queue), but will make sure that no rules overwhelm the system, a tradeoff that seems reasonable, at least on first pass, and especially given that we don't have a lot of guarantees about how long it takes a rule to run.

This is mainly protection against large case migrations that a number of projects have run, both in USH and solutions, but adding Simon in case USH has concerns about this approach.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
All of these mechanisms are already in use, this just adds an optional argument at one of the call sites.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There is automated testing for auto update rules, which will catch if this breaks the basic functionality.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
