### PR TITLE
Add post-make-requirements script to purge appnope

### DIFF
--- a/requirements/Makefile
+++ b/requirements/Makefile
@@ -7,6 +7,7 @@ requirements:
 	pip-compile -o test-requirements.txt test-requirements.in --allow-unsafe
 	pip-compile -o dev-requirements.txt dev-requirements.in --allow-unsafe
 	pip-compile -o docs-requirements.txt docs-requirements.in --allow-unsafe
+	python ../scripts/purge-platform-pkgs.py ./*requirements.txt
 
 upgrade-requirements: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 upgrade-requirements:
@@ -15,3 +16,4 @@ upgrade-requirements:
 	pip-compile --upgrade -o test-requirements.txt test-requirements.in --allow-unsafe
 	pip-compile --upgrade -o dev-requirements.txt dev-requirements.in --allow-unsafe
 	pip-compile --upgrade -o docs-requirements.txt docs-requirements.in --allow-unsafe
+	python ../scripts/purge-platform-pkgs.py ./*requirements.txt

--- a/scripts/purge-platform-pkgs.py
+++ b/scripts/purge-platform-pkgs.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+import argparse
+import sys
+from collections import deque
+
+
+PACKAGES_TO_PURGE = {
+    # package, via
+    "appnope": "ipython",
+}
+
+
+def main(files, packages=PACKAGES_TO_PURGE):
+    for file in files:
+        # Ideally these things are less than GiB's in size, because we're gonna
+        # have a few copies in memory :)
+        lines = list(file)
+        purged = list(purge_packages(lines, packages))
+        if file.fileno() == 0:  # stdin
+            # always write these lines to stdout, regardless of purge
+            rewrite_lines(sys.stdout, purged)
+        elif lines != purged:
+            file.close()
+            with open(file.name, "w") as outfile:
+                rewrite_lines(outfile, purged)
+
+
+def purge_packages(lines, packages):
+    """Iterates over a collection of requirements `lines`, yielding all lines
+    except those provided by `packages`.
+
+    :param lines: iterable of requirement file lines
+    :param packages: dictionary of packages to purge
+
+    To run tests:
+    $ ./scripts/purge-platform-pkgs.py --test
+
+    >>> unwanted = {'dep': 'parent'}
+    >>> list(purge_packages([], unwanted))
+    []
+    >>> list(purge_packages(['django==3.2.1', ' # via -r base.in'], unwanted))
+    ['django==3.2.1', ' # via -r base.in']
+    >>> list(purge_packages(['dep==1.2.3', ' # via parent'], unwanted))
+    []
+    >>> list(purge_packages(['dep==1.2.3', ' # via django'], unwanted))
+    ['dep==1.2.3', ' # via django']
+    >>> list(purge_packages(['django', ' # via -r base.in', 'dep==1.2.3', ' # via parent'], unwanted))
+    ['django', ' # via -r base.in']
+    >>> list(purge_packages(['dep==1.2.3', ' # via parent', 'django', ' # via -r base.in'], unwanted))
+    ['django', ' # via -r base.in']
+    """
+    stack = deque(lines)
+    while stack:
+        line = stack.popleft()
+        name, delim, tail = line.partition("=")
+        if delim and name in packages and stack:
+            next_line = stack.popleft()  # pop the "via" line
+            if next_line.strip().startswith(f"# via {packages[name]}"):
+                continue  # skip both lines
+            stack.insert(0, next_line)  # nope, put it back
+        yield line
+
+
+def rewrite_lines(file, lines):
+    sys.stderr.write(f"re-writing {file.name!r}\n")
+    file.writelines(lines)
+
+
+if __name__ == "__main__":
+    if "--test" in sys.argv:
+        # pre-argparse because that requires at least one valid file arg
+        import doctest
+        doctest.testmod()
+    else:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("files", metavar="FILE", nargs="+", type=argparse.FileType("r"),
+            help="purge packages from compiled python requirements %(metavar)s(s)")
+        main(parser.parse_args().files)

--- a/scripts/purge-platform-pkgs.py
+++ b/scripts/purge-platform-pkgs.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python
+"""Strip unwanted packages out of pip-compiled requirements txt files.
+
+TODO:
+- support packages with multiple via's
+- accept purge package details via --package argument instead of global dict
+"""
 import argparse
 import sys
 from collections import deque
@@ -27,7 +33,7 @@ def main(files, packages=PACKAGES_TO_PURGE):
 
 def purge_packages(lines, packages):
     """Iterates over a collection of requirements `lines`, yielding all lines
-    except those provided by `packages`.
+    except those matching `packages`.
 
     :param lines: iterable of requirement file lines
     :param packages: dictionary of packages to purge

--- a/scripts/purge-platform-pkgs.py
+++ b/scripts/purge-platform-pkgs.py
@@ -42,6 +42,8 @@ def purge_packages(lines, packages):
     ['django==3.2.1', ' # via -r base.in']
     >>> list(purge_packages(['dep==1.2.3', ' # via parent'], unwanted))
     []
+    >>> list(purge_packages(['dep==1.2.3', ' # via parent-sub'], unwanted))
+    ['dep==1.2.3', ' # via parent-sub']
     >>> list(purge_packages(['dep==1.2.3', ' # via django'], unwanted))
     ['dep==1.2.3', ' # via django']
     >>> list(purge_packages(['django', ' # via -r base.in', 'dep==1.2.3', ' # via parent'], unwanted))
@@ -55,7 +57,7 @@ def purge_packages(lines, packages):
         name, delim, tail = line.partition("=")
         if delim and name in packages and stack:
             next_line = stack.popleft()  # pop the "via" line
-            if next_line.strip().startswith(f"# via {packages[name]}"):
+            if next_line.strip() == f"# via {packages[name]}":
                 continue  # skip both lines
             stack.insert(0, next_line)  # nope, put it back
         yield line


### PR DESCRIPTION
## Technical Summary

Python script to replace platform-specific issues encountered on #31400.

Adds a new script `purge-platform-pkgs.py` which gets called at the end of `make requirements` commands to clean up platform-specific packages that are not product dependencies.  The script is configurable to add more packages, currently the only package purged is `appnope` (required by `ipython` on macOS).

## Safety Assurance

### Safety story

Safe due to strict requirements file line matching.

### Automated test coverage

Includes tests (via `doctest`).

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
