### PR TITLE
Enable saving Linked Project Space History reports

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -47,6 +47,7 @@ from corehq.apps.reports.daterange import (
 from corehq.apps.reports.dispatcher import (
     CustomProjectReportDispatcher,
     ProjectReportDispatcher,
+    ReleaseManagementReportDispatcher,
 )
 from corehq.apps.reports.exceptions import InvalidDaterangeException
 from corehq.apps.reports.tasks import export_all_rows_task
@@ -197,7 +198,8 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
         dispatchers = [
             ProjectReportDispatcher,
             CustomProjectReportDispatcher,
-            EnterpriseReportDispatcher
+            EnterpriseReportDispatcher,
+            ReleaseManagementReportDispatcher,
         ]
 
         for dispatcher in dispatchers:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[SAAS-12370](https://dimagi-dev.atlassian.net/browse/SAAS-12370)

When creating the ReleaseManagementReportDispatcher, I did not add it to the list of dispatchers checked when attempting to save a report. This prevented it from saving successfully with the error (local error):
> 2022-04-16 17:42:07,991 ERROR [notify] Notify Exception: This saved-report (id: 64fe4042764f90f4340bacb81200e3a9) is unknown (report_type: release_management_report) and so we have archived it

This is a straightforward change that adds the dispatcher to the list of dispatchers checked upon saving.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is a standard, straightforward change. I tested it locally.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
