### PR TITLE
Respect default answers in GPS questions

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -938,7 +938,12 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.loadMap = function () {
             var token = initialPageData.get("mapbox_access_token");
             if (token) {
-                self.map = L.map(self.entryId).setView([self.DEFAULT.lat, self.DEFAULT.lon], self.DEFAULT.zoom);
+                // if a default answer exists, use that instead
+                let lat = self.rawAnswer().length ? self.rawAnswer()[0] : self.DEFAULT.lat;
+                let lon = self.rawAnswer().length ? self.rawAnswer()[1] : self.DEFAULT.lon;
+                let zoom = self.rawAnswer().length ? self.DEFAULT.anszoom : self.DEFAULT.zoom;
+
+                self.map = L.map(self.entryId).setView([lat, lon], zoom);
                 L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token='
                             + token, {
                     id: 'mapbox/streets-v11',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Default answers for GPS questions are currently ignored, meaning the map always loads at the global default values which makes this question type more difficult to use.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[SAAS-13309](https://dimagi-dev.atlassian.net/browse/SAAS-13309)

The GeoPoint Question type does not check for a default answer when initially loading the map. It looks like this functionality was [accidentally removed when migrating from google maps to mapbox](https://github.com/dimagi/commcare-hq/pull/28059/files#diff-618e6196936ad2bd555542ceb09b87fd592a74f473d0fc6be9fad011c8336a19L701-L703).

This PR essentially adds those 3 lines back, using the specified latitude and longitude, as well as the default zoom when there is already an answer. 

This is what it now looks like if a default answer is specified for a GPS question:
![Screen Shot 2022-04-16 at 5 17 43 PM](https://user-images.githubusercontent.com/15785053/163695114-520f0b39-2fc8-4894-b1e4-eb3a40fc254d.png)

The `anszoom` variable was unused which makes me wonder if we could have caught this sooner with a static checker for unused variables? 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI change.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
