### PR TITLE
rename proximity to within-distance

### DIFF
--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -642,8 +642,8 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, built_filter, is_raw_query=True)
 
-    def test_proximity_filter(self):
-        parsed = parse_xpath("proximity('coords', '42.4402967 -71.1453275', 1, 'miles')")
+    def test_within_distance_filter(self):
+        parsed = parse_xpath("within-distance(coords, '42.4402967 -71.1453275', 1, 'miles')")
         expected_filter = case_property_geo_distance('coords', GeoPoint(42.4402967, -71.1453275), miles=1.0)
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, built_filter, is_raw_query=True)

--- a/corehq/apps/case_search/tests/test_xpath_functions.py
+++ b/corehq/apps/case_search/tests/test_xpath_functions.py
@@ -11,23 +11,23 @@ INVALID_TEST_CASES = [(
     'not(1 < 3, 2 < 4)',
     "The 'not' function accepts exactly 1 arguments, got 2"
 ), (
-    'proximity(7)',
-    "The 'proximity' function accepts exactly 4 arguments, got 1"
+    'within-distance(7)',
+    "The 'within-distance' function accepts exactly 4 arguments, got 1"
 ), (
-    'proximity(7, "42.4402967 -71.1453275", 1, "miles")',
-    "The first argument to 'proximity' must be a valid case property name"
+    'within-distance(7, "42.4402967 -71.1453275", 1, "miles")',
+    "The first argument to 'within-distance' must be a valid case property name"
 ), (
-    'proximity("coords", 42.4402967, 1, "miles")',
-    "The second argument to 'proximity' must be valid coordinates"
+    'within-distance("coords", 42.4402967, 1, "miles")',
+    "The second argument to 'within-distance' must be valid coordinates"
 ), (
-    'proximity("coords", "42.4402967", 1, "miles")',
-    "The second argument to 'proximity' must be valid coordinates"
+    'within-distance("coords", "42.4402967", 1, "miles")',
+    "The second argument to 'within-distance' must be valid coordinates"
 ), (
-    'proximity("coords", "42.4402967 -71.1453275", 7, "smoots")',
+    'within-distance("coords", "42.4402967 -71.1453275", 7, "smoots")',
     "is not a valid distance unit"
 ), (
-    'proximity("coords", "42.4402967 -71.1453275", "eight", "miles")',
-    "The third argument to 'proximity' must be a number, got 'eight'"
+    'within-distance("coords", "42.4402967 -71.1453275", "eight", "miles")',
+    "The third argument to 'within-distance' must be a number, got 'eight'"
 )]
 
 

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -1,4 +1,4 @@
-from .query_functions import proximity, not_, selected_all, selected_any
+from .query_functions import not_, selected_all, selected_any, within_distance
 from .subcase_functions import subcase
 from .value_functions import date, date_add, today
 
@@ -17,5 +17,5 @@ XPATH_QUERY_FUNCTIONS = {
     'selected': selected_any,  # selected and selected_any function identically.
     'selected-any': selected_any,
     'selected-all': selected_all,
-    'proximity': proximity,
+    'within-distance': within_distance,
 }

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -39,7 +39,7 @@ def _selected_query(node, context, operator):
     return case_property_query(property_name, search_values, fuzzy=context.fuzzy, multivalue_mode=operator)
 
 
-def proximity(node, context):
+def within_distance(node, context):
     confirm_args_count(node, 4)
     property_name, coords, distance, unit = node.args
     property_name = _property_name_to_string(property_name, node)


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-1791
Rename the [newly added](https://github.com/dimagi/commcare-hq/pull/31460) `proximity` function `within-distance`

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
simple rename

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Though not specifically gated, it's useless without the CASE_SEARCH_SMART_TYPES flag:

> USH: Intelligently index specific case properties using the data dictionary


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
