### PR TITLE
Add CCHQ_STRICT_WARNINGS for developers

### DIFF
--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -29,7 +29,6 @@ WHITELIST = [
         "two_factor",
     ]) + ")' defines default_app_config"), RemovedInDjango41Warning),
     ("django_celery_results", "ugettext_lazy() is deprecated"),
-    ("django_digest", "The 'warn' method is deprecated"),
     ("django_otp.plugins", "django.conf.urls.url() is deprecated"),
     ("kombu.utils.functional", "'collections.abc'"),
     ("logentry_admin.admin", "ugettext_lazy() is deprecated"),

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -20,6 +20,8 @@ WHITELIST = [
     # warnings that may be resolved with a library upgrade
     ("captcha.fields", "ugettext_lazy() is deprecated"),
     ("celery", "'collections.abc'"),
+    ("compressor.filters.base", "smart_text() is deprecated"),
+    ("compressor.signals", "The providing_args argument is deprecated."),
     ("couchdbkit.schema.properties", "'collections.abc'"),
     ("django.apps", re.compile(r"'(" + "|".join(re.escape(app) for app in [
         "captcha",

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -52,11 +52,12 @@ WHITELIST = [
 
 
 def configure_warnings(is_testing):
-    if is_testing:
+    strict = is_testing or os.environ.get("CCHQ_STRICT_WARNINGS")
+    if strict:
         augment_warning_messages(is_testing)
         if 'PYTHONWARNINGS' not in os.environ:
             warnings.simplefilter("error")
-    if is_testing or "CCHQ_WHITELISTED_WARNINGS" in os.environ:
+    if strict or "CCHQ_WHITELISTED_WARNINGS" in os.environ:
         for args in WHITELIST:
             whitelist(*args)
 

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -56,7 +56,7 @@ WHITELIST = [
 def configure_warnings(is_testing):
     strict = is_testing or os.environ.get("CCHQ_STRICT_WARNINGS")
     if strict:
-        augment_warning_messages(is_testing)
+        augment_warning_messages()
         if 'PYTHONWARNINGS' not in os.environ:
             warnings.simplefilter("error")
     if strict or "CCHQ_WHITELISTED_WARNINGS" in os.environ:
@@ -88,7 +88,7 @@ def whitelist(module, message, category=DeprecationWarning):
     warnings.filterwarnings(action, message, category, re.escape(module))
 
 
-def augment_warning_messages(is_testing):
+def augment_warning_messages():
     """Make it easier to find the module that triggered the warning
 
     Adds additional context to each warning message, which is useful
@@ -129,9 +129,7 @@ def augment_warning_messages(is_testing):
         else:
             module = filename
         message += f"\nmodule: {module} line {lineno}"
-
-        if is_testing:
-            message += POSSIBLE_RESOLUTIONS
+        message += POSSIBLE_RESOLUTIONS
 
         stacklevel += 1
         return real_warn(message, category, stacklevel, source)


### PR DESCRIPTION
@dimagi/team-commcare-hq You can add `export CCHQ_STRICT_WARNINGS=1` to your bash profile to have warnings raised as errors when running any management command.

:blowfish: Review by commit. A few other msic. things were done as well.

## Safety Assurance

### Safety story

Adds a developer-only feature that does not affect production run modes. Also updates the `django-digest` submodule to eliminate a deprecated code path.

### Automated test coverage

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
