### PR TITLE
Pin minimum Django version to 3.2.13

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -37,7 +37,7 @@ django-transfer
 django-two-factor-auth
 django-user-agents
 django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
-django>=2.2.27,<4.0
+django>=3.2.13,<4.0
 djangorestframework
 dnspython
 dropbox

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -97,7 +97,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==3.2.12
+django==3.2.13
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -74,7 +74,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==3.2.12
+django==3.2.13
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -81,7 +81,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==3.2.12
+django==3.2.13
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -71,7 +71,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==3.2.12
+django==3.2.13
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -79,7 +79,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==3.2.12
+django==3.2.13
     # via
     #   -r base-requirements.in
     #   django-appconf


### PR DESCRIPTION
Security update, and update pin to force Django to upgrade when running `pip-compile -o requirements/local.txt requirements/local.in`

## Safety Assurance

### Safety story

Patch update. No major changes.

### Automated test coverage

No new tests.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
