### PR TITLE
Fix syntax error

### DIFF
--- a/corehq/tests/noseplugins/uniformresult.py
+++ b/corehq/tests/noseplugins/uniformresult.py
@@ -1,4 +1,4 @@
-"""A plugin to format test names uniformly for easy comparison
+r"""A plugin to format test names uniformly for easy comparison
 
 Usage:
 


### PR DESCRIPTION
SyntaxError: invalid escape sequence '\ '

## Safety Assurance

### Safety story

Trivial docstring update to fix escaping.

### Automated test coverage

No new tests.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
