### PR TITLE
Whitelist error with ipython in pyenv virtualenv

### DIFF
--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -45,6 +45,7 @@ WHITELIST = [
     ("corehq.util.validation", "metaschema specified by $schema was not found"),
 
     # other, resolution not obvious
+    ("IPython.core.interactiveshell", "install IPython inside the virtualenv.", UserWarning),
     ("sqlalchemy.", re.compile(r"^Predicate of partial index .* ignored during reflection"), SAWarning),
     ("sqlalchemy.",
         "Skipped unsupported reflection of expression-based index form_processor_xformattachmentsql_blobmeta_key",


### PR DESCRIPTION
Resolving this probably requires an IPython fix, possibly pyenv. Related issue: https://github.com/ipython/ipython/issues/10955

Relevant state in IPython initialization logic. 

```py
> site-packages/IPython/core/interactiveshell.py (821) in init_virtualenv
 821  ->         if any(p_venv == p.parents[1] for p in paths):
 822                 # Our exe is inside or has access to the virtualenv, don't need to do anything.
 823                 return
++> p_venv
PosixPath('/home/user/.pyenv/versions/3.9.7/envs/hq')
++> [p.parents[1] for p in paths]
[
  PosixPath('/home/user/.pyenv/versions/hq'),
  PosixPath('/home/user/.pyenv/versions/hq'),
  PosixPath('/home/user/.pyenv/versions/3.9.7'),
]
```

`any(p_venv == p.parents[1] for p in paths)` should return true, but it does not.

UserWarning: Attempting to work in a virtualenv. If you encounter problems, please install IPython inside the virtualenv.

## Safety Assurance

### Safety story

Warnings whiltelist update only.

### Automated test coverage

No.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
