### PR TITLE
Move geopoint functionality under general USH flag

### DIFF
--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -237,7 +237,6 @@ def fields_to_validate(domain, case_type_name):
 
 @quickcache(['domain', 'case_type'], timeout=24 * 60 * 60)
 def get_gps_properties(domain, case_type):
-    # Used for CASE_SEARCH_SMART_TYPES
     return set(CaseProperty.objects.filter(
         case_type__domain=domain,
         case_type__name=case_type,

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -568,7 +568,7 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             )
         )
 
-    @flag_enabled('CASE_SEARCH_SMART_TYPES')
+    @flag_enabled('USH_CASE_CLAIM_UPDATES')
     @patch('corehq.pillows.case_search.get_gps_properties', return_value={'coords'})
     def test_geopoint_query(self, _):
         self._bootstrap_cases_in_es_for_domain(self.domain, [

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -30,9 +30,9 @@ from corehq.pillows.mappings.case_search_mapping import (
 from corehq.toggles import (
     CASE_API_V0_6,
     CASE_LIST_EXPLORER,
-    CASE_SEARCH_SMART_TYPES,
     ECD_MIGRATED_DOMAINS,
     EXPLORE_CASE_DATA,
+    USH_CASE_CLAIM_UPDATES,
 )
 from corehq.util.doc_processor.sql import SqlDocumentProvider
 from corehq.util.es.interface import ElasticsearchInterface
@@ -107,7 +107,7 @@ def _get_case_properties(doc_dict):
     dynamic_properties = [_format_property(key, value, case_id)
                           for key, value in doc_dict['case_json'].items()]
 
-    if CASE_SEARCH_SMART_TYPES.enabled(domain):
+    if USH_CASE_CLAIM_UPDATES.enabled(domain):
         _add_smart_types(dynamic_properties, domain, doc_dict['type'])
 
     return base_case_properties + dynamic_properties

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -945,13 +945,6 @@ ECD_MIGRATED_DOMAINS = StaticToggle(
     'NOTE: enabling this Feature Flag will NOT enable the CaseSearch index.'
 )
 
-CASE_SEARCH_SMART_TYPES = StaticToggle(
-    'case_search_smart_types',
-    'USH: Intelligently index specific case properties using the data dictionary',
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-)
-
 WEB_USER_ACTIVITY_REPORT = StaticToggle(
     'web_user_activity_report',
     'USH: Enable Web User Activity Report',

--- a/testapps/test_pillowtop/tests/test_case_search_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_search_pillow.py
@@ -120,7 +120,7 @@ class CaseSearchPillowTest(TestCase):
     def _get_kafka_seq(self):
         return get_topic_offset(topics.CASE_SQL)
 
-    @flag_enabled('CASE_SEARCH_SMART_TYPES')
+    @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_geopoint_property(self):
         CaseSearchConfig.objects.get_or_create(pk=self.domain, enabled=True)
         domains_needing_search_index.clear()


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-1907

This moves the geopoint functionality previously covered by `CASE_SEARCH_SMART_TYPES` under `USH_CASE_CLAIM_UPDATES`

I also added some docs [here](https://confluence.dimagi.com/display/USH/Storing+GPS+Case+Properties+as+GeoPoints)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
> USH Specific toggle to support several different case search/claim workflows in web apps

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
