### PR TITLE
remove old enterprise count

### DIFF
--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -8,7 +8,6 @@ from corehq.project_limits.rate_limiter import RateLimiter, RateDefinition, \
 
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
-@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_rate_limit_interface():
     """
@@ -25,7 +24,6 @@ def test_rate_limit_interface():
 
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
-@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit():
     per_user_rate_def = RateDefinition(per_second=10)
@@ -40,7 +38,6 @@ def test_get_window_of_first_exceeded_limit():
 
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
-@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit_none():
     per_user_rate_def = RateDefinition(per_second=10)
@@ -55,7 +52,6 @@ def test_get_window_of_first_exceeded_limit_none():
 
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
-@patch('corehq.project_limits.rate_limiter.get_n_users_old_enterprise_count', lambda domain: 10)
 @patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'test')
 def test_get_window_of_first_exceeded_limit_priority():
     per_user_rate_def = RateDefinition(per_second=10, per_week=10)


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This removes the old enterprise rate limiting so that we exclusively use the new calculation.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Very simple change and errors are swallowed if they are introduced so no functionality, beyond the rate limiting itself, will be broken if there is an error here.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Rate limiter is tested.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
