### PR TITLE
fix bad escape sequences

### DIFF
--- a/corehq/apps/fixtures/tests/test_field_names.py
+++ b/corehq/apps/fixtures/tests/test_field_names.py
@@ -152,7 +152,7 @@ class FieldNameValidationTest(SimpleTestCase):
         self.assertTrue(is_identifier_invalid(bad_name))
 
     def test_combo(self):
-        bad_name = "<space>\<dadgg sd"
+        bad_name = "<space>\\<dadgg sd"
         self.assertTrue(is_identifier_invalid(bad_name))
 
     def test_starts_with_number(self):
@@ -160,7 +160,7 @@ class FieldNameValidationTest(SimpleTestCase):
         self.assertTrue(is_identifier_invalid(bad_name))
 
     def test_punctuation(self):
-        bad_name = "ﾉｲ丂 ﾑ ｲ尺ﾑｱ! \_(ツ)_/¯"
+        bad_name = "ﾉｲ丂 ﾑ ｲ尺ﾑｱ! \\_(ツ)_/¯"
         self.assertTrue(is_identifier_invalid(bad_name))
 
     def test_alphanumeric_nonascii(self):

--- a/corehq/blobs/tests/test_s3db.py
+++ b/corehq/blobs/tests/test_s3db.py
@@ -1,4 +1,4 @@
-"""Test S3 Blob DB
+r"""Test S3 Blob DB
 
 Commands to setup Docker with minio for development/testing
 


### PR DESCRIPTION
SyntaxError: invalid escape sequence

## Safety Assurance

### Safety story

Docstring and test update to fix escaping.

### Automated test coverage

No new tests.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
