### PR TITLE
Sk/case search refactor

### DIFF
--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -142,7 +142,7 @@ def test_case_list_queries(self, querystring, expected):
     ("date_opened.start=2020-01-30", "'start' is not a valid type of date range."),
     ('xpath=gibberish',
      "Bad XPath: Your search query is required to have at least one boolean "
-     "operator (>, >=, <, <=, =, !=)"),
+     "operator (=, !=, >, >=, <, <=)"),
 ], TestCaseListAPI)
 def test_bad_requests(self, querystring, error_msg):
     with self.assertRaises(UserError) as e:


### PR DESCRIPTION
## Technical Summary
Smallish refactor of the case search DSL execution function that avoids a recursive call.

When I was going over this code it didn't make a lot of sense to me that we needed to format an expression and then run it through the full filter execution.

This also centralises more of the validation.

## Feature Flag
Case search

## Safety Assurance

### Safety story
Non-functional refactor that's well covered by tests

### Automated test coverage
Existing test coverage

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
