### PR TITLE
Multiple referrals: block default case management

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
@@ -115,6 +115,8 @@
           {% trans "Registration: This form opens a new case" as registers_case %}
           {% if module_loads_registry_case %}
             {% trans "Followup: This form loads a case from a data registry" as updates_case %}
+          {% elif module_is_multi_select %}
+            {% trans "Followup: This form loads a set of cases" as updates_case %}
           {% else %}
             {% trans "Followup: This form loads a case and may then update or close it" as updates_case %}
           {% endif %}
@@ -151,6 +153,14 @@
           {% endblocktrans %}</p>
         </div>
       </div>
+      {% elif module_is_multi_select %}
+      <div class="panel panel-appmanager">
+        <div class="panel-body">
+          <p>{% blocktrans trimmed %}
+            Updating cases directly is not supported for multi-select menus.
+          {% endblocktrans %}</p>
+        </div>
+      </div>
       {% else %}
       <div data-bind="template: {
                         name: 'case-config:case-transaction',
@@ -165,8 +175,8 @@
                       }"></div>
       <!--/ko-->
       {% if add_ons.subcases %}
-        {% if module_loads_registry_case %}
-        {# only allow subcases when also opening a case since we can't attach subcases to a case in another domain #}
+        {% if module_loads_registry_case or module_is_multi_select %}
+        {# only allow subcases updating a single case in the same domain #}
         <!--ko if: actionType() === 'open'-->
         {% else %}
         <!--ko if: actionType() !== 'none'-->

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2/multi_no_actions.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2/multi_no_actions.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>New Form</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/A22A5D53-037A-48DE-979B-BAA54734194E" uiVersion="1" version="5" name="New Form">
+                    <question1/>
+                    <orx:meta xmlns:cc="http://commcarehq.org/xforms">
+                        <orx:deviceID/>
+                        <orx:timeStart/>
+                        <orx:timeEnd/>
+                        <orx:username/>
+                        <orx:userID/>
+                        <orx:instanceID/>
+                        <cc:appVersion/>
+                        <orx:drift/>
+                    </orx:meta>
+                </data>
+            </instance>
+            <instance src="jr://instance/session" id="commcaresession"/>
+            <instance src="jr://instance/selected_cases" id="selected_cases"/>
+            <bind nodeset="/data/question1" type="xsd:string"/>
+            <itext>
+                <translation lang="en" default="">
+                    <text id="question1-label">
+                        <value>question1</value>
+                    </text>
+                </translation>
+            </itext>
+            <setvalue ref="/data/meta/deviceID" event="xforms-ready" value="instance('commcaresession')/session/context/deviceid"/>
+            <setvalue ref="/data/meta/timeStart" event="xforms-ready" value="now()"/>
+            <bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/>
+            <setvalue ref="/data/meta/timeEnd" event="xforms-revalidate" value="now()"/>
+            <bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/>
+            <setvalue ref="/data/meta/username" event="xforms-ready" value="instance('commcaresession')/session/context/username"/>
+            <setvalue ref="/data/meta/userID" event="xforms-ready" value="instance('commcaresession')/session/context/userid"/>
+            <setvalue ref="/data/meta/instanceID" event="xforms-ready" value="uuid()"/>
+            <setvalue ref="/data/meta/appVersion" event="xforms-ready" value="instance('commcaresession')/session/context/appversion"/>
+            <setvalue event="xforms-revalidate" ref="/data/meta/drift" value="if(count(instance('commcaresession')/session/context/drift) = 1, instance('commcaresession')/session/context/drift, '')"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/question1">
+            <label ref="jr:itext('question1-label')"/>
+        </input>
+    </h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2/multi_open_update_case.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2/multi_open_update_case.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>New Form</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/A22A5D53-037A-48DE-979B-BAA54734194E" uiVersion="1" version="5" name="New Form">
+                    <question1/>
+                    <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" user_id="" date_modified="">
+                        <create>
+                            <case_name/>
+                            <owner_id/>
+                            <case_type>person</case_type>
+                        </create>
+                        <update>
+                            <question1/>
+                        </update>
+                    </case>
+                    <orx:meta xmlns:cc="http://commcarehq.org/xforms">
+                        <orx:deviceID/>
+                        <orx:timeStart/>
+                        <orx:timeEnd/>
+                        <orx:username/>
+                        <orx:userID/>
+                        <orx:instanceID/>
+                        <cc:appVersion/>
+                        <orx:drift/>
+                    </orx:meta>
+                </data>
+            </instance>
+            <instance src="jr://instance/session" id="commcaresession"/>
+            <instance src="jr://instance/selected_cases" id="selected_cases"/>
+            <bind nodeset="/data/question1" type="xsd:string" required="true()"/>
+            <itext>
+                <translation lang="en" default="">
+                    <text id="question1-label">
+                        <value>question1</value>
+                    </text>
+                </translation>
+            </itext>
+
+            <bind nodeset="/data/case/@date_modified" type="xsd:dateTime" calculate="/data/meta/timeEnd"/>
+            <bind nodeset="/data/case/@user_id" calculate="/data/meta/userID"/>
+            <setvalue ref="/data/case/@case_id" event="xforms-ready" value="instance('commcaresession')/session/data/case_id_new_person_0"/>
+            <bind nodeset="/data/case/create/case_name" calculate="/data/question1"/>
+            <bind nodeset="/data/case/create/owner_id" calculate="/data/meta/userID"/>
+            <bind nodeset="/data/case/update/question1" relevant="count(/data/question1) &gt; 0" calculate="/data/question1"/>
+            <setvalue ref="/data/meta/deviceID" event="xforms-ready" value="instance('commcaresession')/session/context/deviceid"/>
+            <setvalue ref="/data/meta/timeStart" event="xforms-ready" value="now()"/>
+            <bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/>
+            <setvalue ref="/data/meta/timeEnd" event="xforms-revalidate" value="now()"/>
+            <bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/>
+            <setvalue ref="/data/meta/username" event="xforms-ready" value="instance('commcaresession')/session/context/username"/>
+            <setvalue ref="/data/meta/userID" event="xforms-ready" value="instance('commcaresession')/session/context/userid"/>
+            <setvalue ref="/data/meta/instanceID" event="xforms-ready" value="uuid()"/>
+            <setvalue ref="/data/meta/appVersion" event="xforms-ready" value="instance('commcaresession')/session/context/appversion"/>
+            <setvalue event="xforms-revalidate" ref="/data/meta/drift" value="if(count(instance('commcaresession')/session/context/drift) = 1, instance('commcaresession')/session/context/drift, '')"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/question1">
+            <label ref="jr:itext('question1-label')"/>
+        </input>
+    </h:body>
+</h:html>

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -797,6 +797,7 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
         ],
         'form_icon': None,
         'session_endpoints_enabled': toggles.SESSION_ENDPOINTS.enabled(domain),
+        'module_is_multi_select': module.is_multi_select(),
         'module_loads_registry_case': module_loads_registry_case(module),
     }
 

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1626,7 +1626,15 @@ class XForm(WrappedNode):
             raise CaseError("To update a case you must either open a case or require a case to begin with")
 
         module = form.get_module()
-        is_registry_case = _module_loads_registry_case(module) and not form_opens_case
+        if form.get_module().is_multi_select():
+            self.add_instance(
+                'selected_cases',
+                'jr://instance/selected_cases'
+            )
+            default_case_management = False
+        else:
+            default_case_management = not _module_loads_registry_case(module)
+        default_case_management = default_case_management or form_opens_case
         delegation_case_block = None
         if not actions or (form.requires == 'none' and not form_opens_case):
             case_block = None
@@ -1675,10 +1683,10 @@ class XForm(WrappedNode):
                         {'external_id': actions['open_case'].external_id},
                         save_only_if_edited=self.save_only_if_edited
                     )
-            elif not is_registry_case:
+            elif default_case_management:
                 case_block.bind_case_id(case_id_xpath)
 
-            if 'update_case' in actions and not is_registry_case:
+            if 'update_case' in actions and default_case_management:
                 self._add_case_updates(
                     case_block,
                     getattr(actions.get('update_case'), 'update', {}),
@@ -1687,7 +1695,7 @@ class XForm(WrappedNode):
                     case_id_xpath=case_id_xpath
                 )
 
-            if 'close_case' in actions and not is_registry_case:
+            if 'close_case' in actions and default_case_management:
                 case_block.add_close_block(self.action_relevance(actions['close_case'].condition))
 
             if 'case_preload' in actions:
@@ -1698,7 +1706,7 @@ class XForm(WrappedNode):
                     case_id_xpath=case_id_xpath
                 )
 
-        if 'subcases' in actions and not is_registry_case:
+        if 'subcases' in actions and default_case_management:
             subcases = actions['subcases']
 
             repeat_context_count = form.actions.count_subcases_per_repeat_context()


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-1894

Piggybacks on https://github.com/dimagi/commcare-hq/pull/30519/

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
Changes a flag not being used in production. `xform.py` changes have regression tests.

### Automated test coverage

In PR.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
