### PR TITLE
Fixed get_multimedia_sizes_for_build params

### DIFF
--- a/corehq/apps/app_manager/views/multimedia.py
+++ b/corehq/apps/app_manager/views/multimedia.py
@@ -72,7 +72,7 @@ def get_multimedia_sizes(request, domain, app_id, build_profile_id=None):
         return JsonResponse({
             "message": _("Multimedia size comparison is only available for app builds")
         }, status=400)
-    mm_sizes = get_multimedia_sizes_for_build(domain, build, build_profile_id=build_profile_id)
+    mm_sizes = get_multimedia_sizes_for_build(build, build_profile_id=build_profile_id)
     if mm_sizes:
         mm_sizes = _update_mm_sizes(mm_sizes)
     return JsonResponse(mm_sizes)


### PR DESCRIPTION
## Product Description
Stop popup error on view source files page.

## Technical Summary
https://github.com/dimagi/commcare-hq/pull/31394/ removed `domain` from the function definition but not the function call.

## Feature Flag
Support

## Safety Assurance

### Safety story
Minor bugfix to internal feature

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
