### PR TITLE
implement fuzzy-match case search query function

### DIFF
--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -8,8 +8,15 @@ from couchforms.geopoint import GeoPoint
 from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.case_search.exceptions import CaseFilterError
-from corehq.apps.case_search.filter_dsl import build_filter_from_ast, SearchFilterContext
-from corehq.apps.es.case_search import CaseSearchES, case_property_geo_distance
+from corehq.apps.case_search.filter_dsl import (
+    SearchFilterContext,
+    build_filter_from_ast,
+)
+from corehq.apps.es.case_search import (
+    CaseSearchES,
+    case_property_geo_distance,
+    case_property_query,
+)
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
@@ -643,11 +650,22 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         self.checkQuery(expected_filter, built_filter, is_raw_query=True)
 
     def test_within_distance_filter(self):
-        parsed = parse_xpath("within-distance(coords, '42.4402967 -71.1453275', 1, 'miles')")
-        expected_filter = case_property_geo_distance('coords', GeoPoint(42.4402967, -71.1453275), miles=1.0)
-        built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
-        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
+        self._test_xpath_query(
+            "within-distance(coords, '42.4402967 -71.1453275', 1, 'miles')",
+            case_property_geo_distance('coords', GeoPoint(42.4402967, -71.1453275), miles=1.0)
+        )
 
+    def test_fuzzy_match(self):
+        self._test_xpath_query(
+            "fuzzy-match(name, 'jimmy')",
+            case_property_query("name", "jimmy", fuzzy=True)
+        )
+
+    def _test_xpath_query(self, query_string, expected_filter, context=None):
+        parsed = parse_xpath(query_string)
+        context = context or SearchFilterContext("domain")
+        built_filter = build_filter_from_ast(parsed, context)
+        self.checkQuery(expected_filter, built_filter, is_raw_query=True)
 
 @es_test
 class TestFilterDslLookups(ElasticTestMixin, TestCase):

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -1,4 +1,10 @@
-from .query_functions import not_, selected_all, selected_any, within_distance
+from .query_functions import (
+    fuzzy_match,
+    not_,
+    selected_all,
+    selected_any,
+    within_distance,
+)
 from .subcase_functions import subcase
 from .value_functions import date, date_add, today
 
@@ -18,4 +24,5 @@ XPATH_QUERY_FUNCTIONS = {
     'selected-any': selected_any,
     'selected-all': selected_all,
     'within-distance': within_distance,
+    'fuzzy-match': fuzzy_match,
 }

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -69,6 +69,17 @@ def within_distance(node, context):
     return case_property_geo_distance(property_name, geo_point, **{unit: distance})
 
 
+def fuzzy_match(node, context):
+    """fuzzy-match(alias, 'pinky')"""
+    from corehq.apps.case_search.dsl_utils import unwrap_value
+
+    confirm_args_count(node, 2)
+    property_name = _property_name_to_string(node.args[0], node)
+    value = unwrap_value(node.args[1], context)
+
+    return case_property_query(property_name, value, fuzzy=True)
+
+
 def _property_name_to_string(value, node):
     if isinstance(value, Step):
         return serialize(value)


### PR DESCRIPTION
## Product Description
Alternative approach to https://github.com/dimagi/commcare-hq/pull/31506 for making it possible to do fuzzy searches via Case Search Query expressions.

This PR adds a `fuzzy-match` function for applying fuzzy filtering to a field query:
```
fuzzy-match(name, 'john')
```

Jira: https://dimagi-dev.atlassian.net/browse/USH-1851

## Technical Summary
New case search query function

## Feature Flag
Case Search

## Safety Assurance

### Safety story
New case search query function. Code is isolated to the new function.

### Automated test coverage
New tests added for this function

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
