### PR TITLE
Fix trial signup form when ad blocker is enabled

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/cta_forms.js
+++ b/corehq/apps/analytics/static/analytix/js/cta_forms.js
@@ -1,0 +1,206 @@
+hqDefine('analytix/js/cta_forms', [
+    'jquery',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/assert_properties',
+    'hqwebapp/js/validators.ko',        // needed for validation of startDate and endDate
+    'intl-tel-input/build/js/intlTelInput.min',
+], function (
+    $,
+    ko,
+    _,
+    initialPageData,
+    assertProperties
+) {
+    'use strict';
+
+    let hubspotCtaForm = function (config) {
+        let self = {};
+        assertProperties.assertRequired(config, [
+            'hubspotFormId',
+            'showContactMethod',
+            'showPreferredLanguage',
+            'useWhatsApp',
+            'useGoogleHangouts',
+            'nextButtonText',
+            'phoneNumberSelector',
+            'submitCallbackFn',
+        ]);
+
+        self.showContactMethod = ko.observable(config.showContactMethod);
+        self.showPreferredLanguage = ko.observable(config.showPreferredLanguage);
+
+        self.useWhatsApp = ko.observable(config.useWhatsApp);
+        self.useGoogleHangouts = ko.observable(config.useGoogleHangouts);
+        self.nextButtonText = ko.observable(config.nextButtonText);
+
+        self.firstname = ko.observable()
+            .extend({
+                required: {
+                    message: gettext("Please enter your first name."),
+                    params: true,
+                },
+            });
+        self.lastname = ko.observable()
+            .extend({
+                required: {
+                    message: gettext("Please enter your last name."),
+                    params: true,
+                },
+            });
+        self.company = ko.observable()
+            .extend({
+                required: {
+                    message: gettext("Please enter your organization."),
+                    params: true,
+                },
+            });
+        self.email = ko.observable()
+            .extend({
+                required: {
+                    message: gettext("Please enter your email address."),
+                    params: true,
+                },
+            })
+            .extend({
+                emailRFC2822: true,
+            });
+
+        self.preferred_method_of_contact = ko.observable();
+
+        self.phone = ko.observable();
+
+        self.skype__c = ko.observable();
+        self.preferred_whatsapp_number = ko.observable();
+
+        self.showPhoneNumber = ko.computed(function () {
+            return self.preferred_method_of_contact() === "Phone";
+        });
+        self.showSkype = ko.computed(function () {
+            return self.preferred_method_of_contact() === "Skype";
+        });
+        self.showWhatsApp = ko.computed(function () {
+            return self.preferred_method_of_contact() === "WhatsApp";
+        });
+
+        self.language__c = ko.observable();
+
+        self.areMainFieldsValid = ko.computed(function () {
+            return _.every([
+                self.firstname,
+                self.lastname,
+                self.company,
+                self.email,
+            ], function (prop) {
+                return prop() !== undefined && prop.isValid();
+            });
+        });
+
+        self.areContactFieldsValid = ko.computed(function () {
+            if (!self.showContactMethod()) {
+                return true;
+            }
+            if (!self.preferred_method_of_contact()) {
+                return false;
+            }
+            let isWhatsAppValid = self.showWhatsApp() && !!self.preferred_whatsapp_number(),
+                isPhoneValid = self.showPhoneNumber() && !!self.phone(),
+                isSkypeValid = self.showSkype() && !!self.skype__c();
+            return isWhatsAppValid || isPhoneValid || isSkypeValid;
+        });
+
+        self.isLanguageFieldValid = ko.computed(function () {
+            return !self.showPreferredLanguage() || !!self.language__c();
+        });
+
+        self.isFormReadyToSubmit = ko.computed(function () {
+            return self.areContactFieldsValid() && self.areMainFieldsValid() && self.isLanguageFieldValid();
+        });
+
+        self.isSubmitDisabled = ko.computed(function () {
+            return !self.isFormReadyToSubmit();
+        });
+
+        self.errorMessage = ko.observable();
+        self.showErrorMessage = ko.computed(function () {
+            return !!self.errorMessage();
+        });
+
+        config.phoneNumberSelector.intlTelInput({
+            separateDialCode: true,
+            utilsScript: initialPageData.get('number_utils_script'),
+            initialCountry: "auto",
+            geoIpLookup: function (success) {
+                $.get("https://ipinfo.io", function () {}, "jsonp").always(function (resp) {
+                    var countryCode = (resp && resp.country) ? resp.country : "";
+                    if (!countryCode) {
+                        countryCode = "us";
+                    }
+                    success(countryCode);
+                });
+            },
+        });
+
+        self.getFullPhoneNumber = function () {
+            return config.phoneNumberSelector.intlTelInput("getNumber");
+        };
+
+        self.submitForm = function () {
+            let submitData = {
+                hubspot_form_id: config.hubspotFormId,
+                firstname: self.firstname(),
+                lastname: self.lastname(),
+                company: self.company(),
+                email: self.email(),
+
+                // needed for hubspot context
+                page_url: window.location.href,
+                page_name: document.title,
+            };
+            if (self.showContactMethod()) {
+                submitData.preferred_method_of_contact = self.preferred_method_of_contact();
+            }
+            if (self.showPhoneNumber()) {
+                submitData.phone = self.phone();
+            }
+            if (self.showWhatsApp()) {
+                submitData.preferred_whatsapp_number = self.preferred_whatsapp_number();
+            }
+            if (self.showSkype()) {
+                submitData.skype__c = self.skype__c();
+            }
+            if (self.showPreferredLanguage()) {
+                submitData.language__c = self.language__c();
+            }
+            $.ajax({
+                method: 'post',
+                url: initialPageData.reverse("submit_hubspot_cta_form"),
+                data: submitData,
+                dataType: 'json',
+                success: function (data) {
+                    if (data.success) {
+                        let newUrl = document.location.origin + document.location.pathname + '?email=' + self.email() + '&name=' + self.firstname() + '%20' + self.lastname();
+
+                        // This nastiness is required for Schedule Once to auto-fill
+                        // required fields. Sending snark the way of the S.O. devs...
+                        window.history.pushState({}, document.title, newUrl);
+
+                        config.submitCallbackFn();
+                    } else {
+                        self.errorMessage(data.message);
+                    }
+                },
+            }).fail(function () {
+                self.errorMessage(gettext("We are sorry, but something unexpected has occurred."));
+            });
+        };
+        return self;
+
+
+    };
+
+    return {
+        hubspotCtaForm: hubspotCtaForm,
+    };
+});

--- a/corehq/apps/analytics/static/analytix/js/hubspot.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.js
@@ -3,17 +3,21 @@
  * Instatiates the Hubspot analytics platform.
  */
 hqDefine('analytix/js/hubspot', [
+    'jquery',
     'underscore',
     'analytix/js/initial',
     'analytix/js/logging',
     'analytix/js/utils',
     'analytix/js/kissmetrix',
+    'analytix/js/cta_forms',
 ], function (
+    $,
     _,
     initialAnalytics,
     logging,
     utils,
-    kissmetrics
+    kissmetrics,
+    ctaForms
 ) {
     'use strict';
     var _get = initialAnalytics.getFn('hubspot'),
@@ -30,84 +34,51 @@ hqDefine('analytix/js/hubspot', [
         _logger = logging.getLoggerForApi('Hubspot');
         _ready = utils.initApi(_ready, apiId, scriptUrl, _logger);
 
-
-        // load demo request forms
         if (_get('isDemoVisible')) {
-            _ready.done(function () {
-                var formScriptUrls = ['//js.hsforms.net/forms/v2.js'];
-                if ($('html').hasClass('lt-ie9')) {
-                    formScriptUrls = _.union(['//js.hsforms.net/forms/v2-legacy.js'], formScriptUrls);
-                }
-
-                $.when.apply($, _.map(formScriptUrls, function (url) { return $.getScript(url); }))
-                    .done(function () {
-                        var isTrial = _get('isDemoTrial'),
-                            isVariant = _get('demoABv2').version === 'variant',
-                            formId;
-
-                        if (isTrial) {
-                            formId = isVariant ? "c2381f55-9bd9-4f27-8476-82900e58bfd6" : "4474515e-fea6-4154-b3cf-1fe42b1c1333";
-                        } else {
-                            formId = isVariant ? "f6ebf161-fccf-4083-9a72-5839a0c8ac8c" : "d1897875-a5bb-4b63-9b9c-3d8fdbbe8274";
-                        }
-
-                        _utils.loadDemoForm(apiId, formId);
-                        _utils.loadTrialForm(apiId, '9c8ecc33-b088-474e-8f4c-1b10fae50c2f');
-                    });
-            });
+            // these forms get processed on the backend, so they don't need the hubspot js to be loaded
+            _utils.loadDemoForm();
+            _utils.loadTrialForm();
         }
 
     });
 
     /**
-     * Loads the Hubspot Request Demo form and loads a Schedule Once Calendar
+     * Activates the Hubspot Request Demo form and loads a Schedule Once Calendar
      * Widget for auto-booking an appointment as soon as the form is submitted.
-     * @param {string} apiId
-     * @param {string} formId
      */
-    _utils.loadDemoForm = function (apiId, formId) {
-        hbspt.forms.create({
-            portalId: apiId,
-            formId: formId,
-            target: "#get-demo-cta-form-content",
-            css: "",
-            onFormReady: function () {
-                var $hubspotFormModal = $('#cta-form-get-demo'),
-                    hasInteractedWithForm = false;
+    _utils.loadDemoForm = function () {
+        let isTrial = _get('isDemoTrial'),
+            isVariant = _get('demoABv2').version === 'variant',
+            $modal = $('#cta-form-get-demo'),
+            $form = $('#get-demo-cta-form-content'),
+            hasInteractedWithForm = false,
+            formId,
+            demoForm;
 
-                $hubspotFormModal.on('shown.bs.modal', function () {
-                    kissmetrics.track.event("Demo Workflow - Viewed Form");
-                });
+        if (isTrial) {
+            formId = isVariant ? "c2381f55-9bd9-4f27-8476-82900e58bfd6" : "4474515e-fea6-4154-b3cf-1fe42b1c1333";
+        } else {
+            formId = isVariant ? "f6ebf161-fccf-4083-9a72-5839a0c8ac8c" : "d1897875-a5bb-4b63-9b9c-3d8fdbbe8274";
+        }
 
-                $hubspotFormModal.on('hide.bs.modal', function () {
-                    kissmetrics.track.event("Demo Workflow - Dismissed Form");
-                });
-
-                $('#get-demo-cta-form-content').find('input').click(function () {
-                    if (!hasInteractedWithForm) {
-                        kissmetrics.track.event("Demo Workflow - Interacted With Form");
-                        hasInteractedWithForm = true;
-                    }
-                });
-            },
-            onFormSubmit: function ($form) {
+        demoForm = ctaForms.hubspotCtaForm({
+            hubspotFormId: formId,
+            showContactMethod: isVariant,
+            showPreferredLanguage: false,
+            useWhatsApp: false,
+            useGoogleHangouts: true,
+            nextButtonText: gettext("Book a Time"),
+            phoneNumberSelector: $form.find('input[name="phone"]'),
+            submitCallbackFn: function () {
                 $('#get-demo-cta-calendar-content').fadeIn();
                 $('#get-demo-cta-form-content').addClass('hidden');
 
-                var email = $form.find('[name="email"]').val(),
-                    firstname = $form.find('[name="firstname"]').val(),
-                    lastname = $form.find('[name="lastname"]').val(),
-                    newUrl = document.location.href + '?email=' + email + '&name=' + firstname + '%20' + lastname;
-
                 kissmetrics.track.event("Demo Workflow - Contact Info Received");
-
-                // This nastiness is required for Schedule Once to auto-fill
-                // required fields. Sending snark the way of the S.O. devs...
-                window.history.pushState({}, document.title, newUrl);
 
                 // Causes the Schedule Once form to populate the element
                 // #SOIDIV_commcaredemoform as soon as it loads. Once it's
                 // loaded this does not leave the page.
+
                 $.getScript('//cdn.scheduleonce.com/mergedjs/so.js')
                     .done(function () {
                         kissmetrics.track.event("Demo Workflow - Loaded Booking Options");
@@ -116,7 +87,7 @@ hqDefine('analytix/js/hubspot', [
                             // the Schedule Once Form was submitted on our side.
                             // The style attribute changes when the form is successfully
                             // submitted.
-                            var lastKnownHeight = 0,
+                            let lastKnownHeight = 0,
                                 observer = new MutationObserver(function (mutations) {
                                     mutations.forEach(function () {
                                         var newHeight = $('#SOI_commcaredemoform').height();
@@ -127,65 +98,75 @@ hqDefine('analytix/js/hubspot', [
                                             window.history.pushState({}, document.title, coreUrl);
                                         }
                                         lastKnownHeight = newHeight;
-
                                     });
-                            });
+                                });
                             // target is the the iframe containing the schedule once form
-                            var target = document.getElementById('SOI_commcaredemoform');
+                            let target = document.getElementById('SOI_commcaredemoform');
                             observer.observe(target, { attributes: true, attributeFilter: ['style'] });
                         }, 3000);
                     });
             },
         });
+        $form.koApplyBindings(demoForm);
+
+        $modal.on('shown.bs.modal', function () {
+            kissmetrics.track.event("Demo Workflow - Viewed Form");
+        });
+        $modal.on('hide.bs.modal', function () {
+            kissmetrics.track.event("Demo Workflow - Dismissed Form");
+        });
+
+        $form.find('input').click(function () {
+            if (!hasInteractedWithForm) {
+                kissmetrics.track.event("Demo Workflow - Interacted With Form");
+                hasInteractedWithForm = true;
+            }
+        });
     };
 
     /**
-     * Loads the Hubspot Request Trial form and loads a Schedule Once Calendar
+     * Activates the Hubspot Request Trial form and loads a Schedule Once Calendar
      * Widget for auto-booking an appointment as soon as the form is submitted.
-     * @param {string} apiId
-     * @param {string} formId
      */
-    _utils.loadTrialForm = function (apiId, formId) {
-        hbspt.forms.create({
-            portalId: apiId,
-            formId: formId,
-            target: "#get-trial-cta-form-content",
-            css: "",
-            onFormReady: function () {
-                var $hubspotFormModal = $('#cta-form-start-trial'),
-                    hasInteractedWithForm = false;
+    _utils.loadTrialForm = function () {
+        let $modal = $('#cta-form-start-trial'),
+            $form = $('#get-trial-cta-form-content'),
+            hasInteractedWithForm = false,
+            trialForm;
 
-                $hubspotFormModal.on('shown.bs.modal', function () {
-                    kissmetrics.track.event("Get Trial Workflow - Viewed Form");
-                });
-
-                $hubspotFormModal.on('hide.bs.modal', function () {
-                    kissmetrics.track.event("Get Trial Workflow - Dismissed Form");
-                });
-
-                $('#get-trial-cta-form-content').find('input').click(function () {
-                    if (!hasInteractedWithForm) {
-                        kissmetrics.track.event("Get Trial Workflow - Interacted With Form");
-                        hasInteractedWithForm = true;
-                    }
-                });
-            },
-            onFormSubmit: function ($form) {
-                var email = $form.find('[name="email"]').val(),
-                    firstname = $form.find('[name="firstname"]').val(),
-                    lastname = $form.find('[name="lastname"]').val(),
-                    newUrl = document.location.origin + document.location.pathname + '?email=' + email + '&name=' + firstname + '%20' + lastname;
-
+        trialForm = ctaForms.hubspotCtaForm({
+            hubspotFormId: '9c8ecc33-b088-474e-8f4c-1b10fae50c2f',
+            showContactMethod: true,
+            showPreferredLanguage: true,
+            useWhatsApp: true,
+            useGoogleHangouts: false,
+            nextButtonText: gettext("Next"),
+            phoneNumberSelector: $form.find('input[name="phone"]'),
+            submitCallbackFn: function () {
                 kissmetrics.track.event("Get Trial Workflow - Contact Info Received");
                 // This nastiness is required for Schedule Once to auto-fill
                 // required fields. Sending snark++ the way of the S.O. devs...
-                window.history.pushState({}, document.title, newUrl);
-            },
-            onFormSubmitted: function () {
+
+                // on form submitted?
                 $('#choose-callback-options').toggleClass('hidden');
                 $('#get-trial-cta-form-content').addClass('hidden');
                 $('#start-trial-modal-header').text(gettext("Your trial request has been received!"));
             },
+        });
+        $form.koApplyBindings(trialForm);
+
+        $modal.on('shown.bs.modal', function () {
+            kissmetrics.track.event("Get Trial Workflow - Viewed Form");
+        });
+        $modal.on('hide.bs.modal', function () {
+            kissmetrics.track.event("Get Trial Workflow - Dismissed Form");
+        });
+
+        $form.find('input').click(function () {
+            if (!hasInteractedWithForm) {
+                kissmetrics.track.event("Get Trial Workflow - Interacted With Form");
+                hasInteractedWithForm = true;
+            }
         });
     };
 

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -42,6 +42,7 @@ from corehq.apps.analytics.utils import (
     analytics_enabled_for_email,
     get_instance_string,
     get_meta,
+    get_client_ip_from_meta,
 )
 from corehq.apps.analytics.utils.hubspot import (
     get_blocked_hubspot_domains,
@@ -237,15 +238,6 @@ def _get_user_hubspot_id(web_user, retry_num=0):
     return None
 
 
-def _get_client_ip(meta):
-    x_forwarded_for = meta.get('HTTP_X_FORWARDED_FOR')
-    if x_forwarded_for:
-        ip = x_forwarded_for.split(',')[0]
-    else:
-        ip = meta.get('REMOTE_ADDR')
-    return ip
-
-
 def _send_form_to_hubspot(form_id, webuser, hubspot_cookie, meta, extra_fields=None, email=False):
     """
     This sends hubspot the user's first and last names and tracks everything they did
@@ -263,7 +255,7 @@ def _send_form_to_hubspot(form_id, webuser, hubspot_cookie, meta, extra_fields=N
     if hubspot_id and hubspot_cookie:
         data = {
             'email': email if email else webuser.username,
-            'hs_context': json.dumps({"hutk": hubspot_cookie, "ipAddress": _get_client_ip(meta)}),
+            'hs_context': json.dumps({"hutk": hubspot_cookie, "ipAddress": get_client_ip_from_meta(meta)}),
         }
         if webuser:
             data.update({

--- a/corehq/apps/analytics/templates/analytics/forms/hubspot_cta_form.html
+++ b/corehq/apps/analytics/templates/analytics/forms/hubspot_cta_form.html
@@ -1,0 +1,147 @@
+{% load i18n %}
+
+<form class="form form-ko-validation" method="post">
+  {% csrf_token %}
+  <div class="modal-body">
+    <!-- ko if: showErrorMessage -->
+      <div class="alert alert-warning">
+        <p data-bind="text: errorMessage"></p>
+      </div>
+    <!-- /ko -->
+    <div class="row">
+      <div class="col-sm-6">
+        <div class="form-group">
+          <label class="control-label">
+            {% trans "First name" %}<span class="asteriskField">*</span>
+          </label>
+          <div class="controls">
+            <input type="text"
+                   name="firstname"
+                   data-bind="textInput: firstname"
+                   class="form-control">
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6">
+        <div class="form-group">
+          <label class="control-label">
+            {% trans "Last name" %}<span class="asteriskField">*</span>
+          </label>
+          <div class="controls">
+            <input type="text"
+                   name="lastname"
+                   data-bind="textInput: lastname"
+                   class="form-control">
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="control-label">
+        {% trans "Organization" %}<span class="asteriskField">*</span>
+      </label>
+      <div class="controls">
+        <input type="text"
+               name="company"
+               data-bind="textInput: company"
+               class="form-control">
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="control-label">
+        {% trans "Professional email address" %}<span class="asteriskField">*</span>
+      </label>
+      <div class="controls">
+        <input type="email"
+               name="email"
+               data-bind="textInput: email"
+               class="form-control">
+      </div>
+    </div>
+    <div class="form-group"
+         data-bind="visible: showContactMethod">
+      <label class="control-label">
+          {% trans "How should we contact you?" %}<span class="asteriskField">*</span>
+      </label>
+      <div class="controls">
+        <select name="preferred_method_of_contact"
+                data-bind="value: preferred_method_of_contact"
+                class="select form-control">
+          <option value="">{% trans "Please Select" %}</option>
+          <option value="Phone">{% trans "Phone" %}</option>
+          <option value="Skype">{% trans "Skype" %}</option>
+          <!-- ko if: useWhatsApp -->
+            <option value="WhatsApp">{% trans "WhatsApp" %}</option>
+          <!-- /ko -->
+          <!-- ko if: useGoogleHangouts -->
+            <option value="Google hangouts">{% trans "Google hangouts" %}</option>
+          <!-- /ko -->
+        </select>
+      </div>
+    </div>
+    <div class="form-group"
+         data-bind="visible: showPhoneNumber">
+      <label class="control-label">
+          {% trans "Preferred phone number" %}<span class="asteriskField">*</span>
+      </label>
+      <div class="controls">
+        <input type="text"
+               name="phone"
+               data-bind="textInput: phone"
+               class="form-control">
+      </div>
+    </div>
+    <div class="form-group"
+         data-bind="visible: showSkype">
+      <label class="control-label">
+          {% trans "Skype username" %}<span class="asteriskField">*</span>
+      </label>
+      <div class="controls">
+        <input type="text"
+               name="skype__c"
+               data-bind="textInput: skype__c"
+               class="form-control">
+      </div>
+    </div>
+    <div class="form-group"
+         data-bind="visible: showWhatsApp">
+      <label class="control-label">
+          {% trans "Preferred WhatsApp number" %}<span class="asteriskField">*</span>
+      </label>
+      <div class="controls">
+        <input type="text"
+               name="preferred_whatsapp_number"
+               data-bind="textInput: preferred_whatsapp_number"
+               class="form-control">
+      </div>
+    </div>
+    <div class="form-group"
+         data-bind="visible: showPreferredLanguage">
+      <label class="control-label">
+        {% trans "Preferred Language" %}<span class="asteriskField">*</span>
+      </label>
+      <div class="controls">
+        <select name="language__c"
+                data-bind="value: language__c"
+                class="form-control">
+          <option value="">{% trans "Please Select" %}</option>
+          <option value="English">{% trans "English" %}</option>
+          <option value="French">{% trans "French" %}</option>
+          <option value="Spanish">{% trans "Spanish" %}</option>
+        </select>
+      </div>
+    </div>
+    {% blocktrans %}
+      By clicking this button, you agree to Dimagi's
+      <a href="http://www.dimagi.com/terms/latest/tos/" target="_blank">Terms of Service</a> and
+      <a href="http://www.dimagi.com/terms/latest/privacy/" target="_blank">Privacy Policy</a>.
+    {% endblocktrans %}
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn btn-primary"
+            data-bind="click: submitForm, disable: isSubmitDisabled"
+            type="button">
+      <!-- ko text: nextButtonText --><!-- /ko -->
+    </button>
+  </div>
+</form>

--- a/corehq/apps/analytics/urls.py
+++ b/corehq/apps/analytics/urls.py
@@ -3,9 +3,11 @@ from django.conf.urls import re_path as url
 from corehq.apps.analytics.views import (
     GreenhouseCandidateView,
     HubspotClickDeployView,
+    submit_hubspot_cta_form,
 )
 
 urlpatterns = [
     url(r'^hubspot/click-deploy/$', HubspotClickDeployView.as_view(), name=HubspotClickDeployView.urlname),
-    url(r'^greenhouse/candidate/$', GreenhouseCandidateView.as_view(), name=GreenhouseCandidateView.urlname)
+    url(r'^greenhouse/candidate/$', GreenhouseCandidateView.as_view(), name=GreenhouseCandidateView.urlname),
+    url(r'^hubspot/submit-cta/$', submit_hubspot_cta_form, name="submit_hubspot_cta_form"),
 ]

--- a/corehq/apps/analytics/utils/__init__.py
+++ b/corehq/apps/analytics/utils/__init__.py
@@ -18,3 +18,12 @@ def get_instance_string():
     instance = settings.ANALYTICS_CONFIG.get('HQ_INSTANCE', '')
     env = '' if instance == 'www' else instance + '_'
     return env
+
+
+def get_client_ip_from_meta(meta):
+    x_forwarded_for = meta.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(',')[0]
+    else:
+        ip = meta.get('REMOTE_ADDR')
+    return ip

--- a/corehq/apps/analytics/utils/__init__.py
+++ b/corehq/apps/analytics/utils/__init__.py
@@ -20,6 +20,11 @@ def get_instance_string():
     return env
 
 
+def get_client_ip_from_request(request):
+    meta = get_meta(request)
+    return get_client_ip_from_meta(meta)
+
+
 def get_client_ip_from_meta(meta):
     x_forwarded_for = meta.get('HTTP_X_FORWARDED_FOR')
     if x_forwarded_for:

--- a/corehq/apps/analytics/views.py
+++ b/corehq/apps/analytics/views.py
@@ -19,6 +19,7 @@ from corehq.apps.analytics.tasks import (
 from corehq.apps.analytics.utils import (
     get_meta,
     get_client_ip_from_request,
+    log_response,
 )
 
 
@@ -97,6 +98,7 @@ def submit_hubspot_cta_form(request):
         form_id=form_id
     )
     response = requests.post(url, data=form_data)
+    log_response('HS', form_data, response)
     response.raise_for_status()
 
     return JsonResponse({

--- a/corehq/apps/analytics/views.py
+++ b/corehq/apps/analytics/views.py
@@ -3,8 +3,9 @@ import hmac
 import json
 
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from django.views.generic import View
 
 from corehq.apps.analytics.tasks import (
@@ -57,3 +58,10 @@ class GreenhouseCandidateView(View):
                 pass
 
         return HttpResponse()
+
+
+@require_POST
+def submit_hubspot_cta_form(request):
+    return JsonResponse({
+        "success": True,
+    })

--- a/corehq/apps/analytics/views.py
+++ b/corehq/apps/analytics/views.py
@@ -70,13 +70,9 @@ class GreenhouseCandidateView(View):
 @require_POST
 def submit_hubspot_cta_form(request):
     form_data = {data: value[0] for data, value in dict(request.POST).items()}
-    form_id = form_data['hubspot_form_id']
-    page_url = form_data['page_url']
-    page_name = form_data['page_name']
-
-    del form_data['hubspot_form_id']
-    del form_data['page_url']
-    del form_data['page_name']
+    form_id = form_data.pop('hubspot_form_id')
+    page_url = form_data.pop('page_url')
+    page_name = form_data.pop('page_name')
 
     hubspot_cookie = request.COOKIES.get(HUBSPOT_COOKIE)
     form_data['hs_context'] = json.dumps({

--- a/corehq/apps/analytics/views.py
+++ b/corehq/apps/analytics/views.py
@@ -89,10 +89,7 @@ def submit_hubspot_cta_form(request):
             "message": gettext("No hubspot API ID is present."),
         })
 
-    url = "https://forms.hubspot.com/uploads/form/v2/{hubspot_id}/{form_id}".format(
-        hubspot_id=hubspot_id,
-        form_id=form_id
-    )
+    url = f"https://forms.hubspot.com/uploads/form/v2/{hubspot_id}/{form_id}"
     response = requests.post(url, data=form_data)
     log_response('HS', form_data, response)
     response.raise_for_status()

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -215,6 +215,7 @@
       {% include 'hqwebapp/includes/inactivity_modal_data.html' %}
     {% endif %}
     {% registerurl 'login_new_window' %}
+    {% registerurl 'submit_hubspot_cta_form' %}
 
     {# 30 Day Trial #}
     {% include 'hqwebapp/includes/modal_30_day_trial.html' %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -233,6 +233,9 @@
     {% initial_page_data 'secure_cookies' secure_cookies %}
     {% initial_page_data 'minimumZxcvbnScore' MINIMUM_ZXCVBN_SCORE %}
 
+    {# for get demo and get trial forms #}
+    {% initial_page_data 'number_utils_script' 'intl-tel-input/build/js/utils.js'|static %}
+
     {% if demo_workflow_ab_v2 %}
       {% analytics_ab_test 'kissmetrics.demo_workflow_ab_v2' demo_workflow_ab_v2 %}
       {% initial_analytics_data 'hubspot.demoABv2' demo_workflow_ab_v2 %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/get_demo_modals.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/get_demo_modals.html
@@ -14,27 +14,28 @@
           {% endif %}
         </h4>
       </div>
-      <div class="modal-body form-horizontal">
 
-        {# Hubspot Form #}
-        <div class="form form-horizontal"
-             id="get-demo-cta-form-content"></div>
-
-        {# Schedule Once Demo #}
-        <div id="get-demo-cta-calendar-content" style="display: none;">
-          <p>
-            {% blocktrans %}
-              Select a time to see CommCare in action and review
-              questions with our team.
-            {% endblocktrans %}
-          </p>
-          <div id="SOIDIV_commcaredemoform"
-               data-so-page="commcaredemoform"
-               data-style="border: 1px solid #d8d8d8; min-width: 290px; max-width: 900px;"
-               data-psz="11"></div>
-        </div>
-
+      {# Hubspot Form #}
+      <div id="get-demo-cta-form-content">
+        {% include "analytics/forms/hubspot_cta_form.html" %}
       </div>
+
+      {# Schedule Once Demo #}
+      <div id="get-demo-cta-calendar-content"
+           class="modal-body form-horizontal"
+           style="display: none;">
+        <p>
+          {% blocktrans %}
+            Select a time to see CommCare in action and review
+            questions with our team.
+          {% endblocktrans %}
+        </p>
+        <div id="SOIDIV_commcaredemoform"
+             data-so-page="commcaredemoform"
+             data-style="border: 1px solid #d8d8d8; min-width: 290px; max-width: 900px;"
+             data-psz="11"></div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/corehq/apps/registration/templates/registration/partials/start_trial_modal.html
+++ b/corehq/apps/registration/templates/registration/partials/start_trial_modal.html
@@ -12,34 +12,33 @@
           </strong>
         </h4>
       </div>
-      <div class="modal-body form-horizontal">
 
-        {# Hubspot Form #}
-        <div class="form form-horizontal"
-             id="get-trial-cta-form-content"></div>
-        
-        {# Schedule Call Choices #}
-        <div id="choose-callback-options" class="fadeIn hidden">
-          {% blocktrans %}
-            <p> A member of our team will call you soon to complete the setup of your CommCare trial account. </p>
-            <p> Prefer to schedule your call instead? You can do that, too! </p>
-          {% endblocktrans %}
-          
-          <div class="modal-footer">
-            <button type="button" id="book-a-time-btn" class="btn btn-primary">Book a time</button>
-            <a href="https://sites.dimagi.com/commcare-trial-callback"><button type="button btn-default"  class="btn btn-default">Done</button></a>
-          </div>
-        </div>
-
-        {# Schedule Once Demo #}
-        <div id="get-trial-cta-calendar-content" class="hidden fadeIn">
-          <div id="SOIDIV_CommCareTrial"
-               data-so-page="CommCareTrial"
-               data-style="border: 1px solid #d8d8d8; min-width: 290px; max-width: 900px;"
-               data-psz="11"></div>
-        </div>
-
+      {# Hubspot Form #}
+      <div id="get-trial-cta-form-content">
+        {% include "analytics/forms/hubspot_cta_form.html" %}
       </div>
+
+      {# Schedule Call Choices #}
+      <div id="choose-callback-options" class="fadeIn hidden modal-body">
+        {% blocktrans %}
+          <p> A member of our team will call you soon to complete the setup of your CommCare trial account. </p>
+          <p> Prefer to schedule your call instead? You can do that, too! </p>
+        {% endblocktrans %}
+
+        <div class="modal-footer">
+          <button type="button" id="book-a-time-btn" class="btn btn-primary">Book a time</button>
+          <a href="https://sites.dimagi.com/commcare-trial-callback"><button type="button btn-default"  class="btn btn-default">Done</button></a>
+        </div>
+      </div>
+
+      {# Schedule Once Demo #}
+      <div id="get-trial-cta-calendar-content" class="hidden fadeIn modal-body">
+        <div id="SOIDIV_CommCareTrial"
+             data-so-page="CommCareTrial"
+             data-style="border: 1px solid #d8d8d8; min-width: 290px; max-width: 900px;"
+             data-psz="11"></div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -67,7 +67,6 @@
 
 {% block content %}
   {% initial_page_data 'hide_password_feedback' hide_password_feedback %}
-  {% initial_page_data 'number_utils_script' 'intl-tel-input/build/js/utils.js'|static %}
   {% initial_page_data 'reg_form_defaults' reg_form_defaults %}
 
   {% registerurl 'process_registration' %}


### PR DESCRIPTION
## Product Description
When ad blockers are enabled for a browser, the hubspot scripts fail to load. This means that a very critical part of our signup workflow (the get trial workflow) also fails to load since this relies on hubspot loading. Since adblockers are so common place now, and sometimes built into certain browsers from the start, this has a huge impact on the user experience.

This ticket fixes this workflow by ensuring that we load a native form instead of a hubspot from and the data is then submitted on the backend, which can directly POST to hubspot's API.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-11157

## Safety Assurance

### Safety story
QA will be needed, as this impacts a critical workflow on HQ

### Automated test coverage
No

### QA Plan
Please test the user sign up process with ad blockers enabled. Both the community sign up and the get trial and get demo forms please. Thanks!


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
