### PR TITLE
Added multi-select option to case list overwrite

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
@@ -73,6 +73,12 @@
                     {% trans "Search and claim options" %}
                   </label><br>
                 {% endif %}
+                {% if request|toggle_enabled:'USH_CASE_LIST_MULTI_SELECT' %}
+                  <label for="multi_select">
+                    <input type="checkbox" name="multi_select" id="multi_select"/>
+                    {% trans "Multi-Select Case List Options" %}
+                  </label><br>
+                {% endif %}
             </div>
           </div>
           {% endif %}

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -163,7 +163,7 @@ class OverwriteModuleDetailTests(SimpleTestCase):
 
     def setUp(self):
         self.all_attrs = ['columns', 'filter', 'sort_elements', 'custom_variables', 'custom_xml',
-                          'case_tile_configuration', 'print_template']
+                          'case_tile_configuration', 'multi_select', 'print_template']
         self.cols_and_filter = ['columns', 'filter']
         self.case_tile = ['case_tile_configuration']
 
@@ -175,6 +175,7 @@ class OverwriteModuleDetailTests(SimpleTestCase):
         self.filter_ = setattr(self.src_detail, 'filter', 'a > b')
         self.custom_variables = setattr(self.src_detail, 'custom_variables', 'def')
         self.custom_xml = setattr(self.src_detail, 'custom_xml', 'ghi')
+        self.multi_select = getattr(self.src_detail, 'multi_select')
         self.print_template = getattr(self.src_detail, 'print_template')
         self.print_template['name'] = 'test'
         self.case_tile_configuration = setattr(self.src_detail, 'persist_tile_on_forms', True)


### PR DESCRIPTION
## Product Description
Adds multi select option here:
![Screen Shot 2022-04-21 at 5 31 28 PM](https://user-images.githubusercontent.com/1486591/164555622-4e782750-f56e-4f62-8d72-28b7987d57dd.png)

## Technical Summary
I added the option to the overwrite view [here](https://github.com/dimagi/commcare-hq/commit/6dbb59113c9c91a5196c6102ee46a8d65fa0e44c#diff-459608d873f6082b7d5217076b8e09a044aaaea60ffc9a34538741217baddbb8R897) but forgot to add the checkbox to the UI.

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
Pretty minor change to a flagged feature not being used in production.

### Automated test coverage

Some in PR.

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
