### PR TITLE
OpenMRS Importer must handle empty names

### DIFF
--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -199,6 +199,12 @@ def import_patients_of_owner(requests, importer, domain_name, owner_id, location
         elif error == LookupErrors.NotFound:
             case_block = get_addpatient_caseblock(patient, importer, owner_id)
             case_blocks.append(RowAndCase(i, case_block))
+        elif error == LookupErrors.MultipleResults:
+            raise ConfigurationError(
+                f'Error importing patients for project space "{importer.domain}" '
+                f'from OpenMRS Importer "{importer}": {importer.case_type}'
+                f'.{EXTERNAL_ID} "{patient_id}" is not unique.'
+            )
 
     submit_case_blocks(
         [cb.case.as_text() for cb in case_blocks],

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -179,9 +179,17 @@ def import_patients_of_owner(requests, importer, domain_name, owner_id, location
         return
     case_blocks = []
     for i, patient in enumerate(openmrs_patients):
+        try:
+            patient_id = str(patient[importer.external_id_column])
+        except KeyError:
+            raise ConfigurationError(
+                f'Error importing patients for project space "{importer.domain}" '
+                f'from OpenMRS Importer "{importer}": External ID column '
+                f'"{importer.external_id_column}" not found in patient data.'
+            )
         case, error = importer_util.lookup_case(
             EXTERNAL_ID,
-            str(patient[importer.external_id_column]),
+            patient_id,
             domain_name,
             importer.case_type
         )

--- a/corehq/motech/openmrs/tests/test_tasks.py
+++ b/corehq/motech/openmrs/tests/test_tasks.py
@@ -1,4 +1,5 @@
 import datetime
+import doctest
 import json
 import logging
 from contextlib import contextmanager
@@ -460,3 +461,10 @@ class OwnerTests(LocationHierarchyTestCase):
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=['admin@example.com'],
             )
+
+
+def test_doctests():
+    import corehq.motech.openmrs.tasks
+
+    results = doctest.testmod(corehq.motech.openmrs.tasks)
+    assert results.failed == 0


### PR DESCRIPTION
## Technical Summary

Context: [SUPPORT-12921](https://dimagi-dev.atlassian.net/servicedesk/customer/portal/1/SUPPORT-12921)

If a patient has a `null` value in one of their name fields in an OpenMRS report, the OpenMRS Importer is failing.

This change substitutes `None` with `''`, and cleans up the spacing in the name.

Also adds a bit more error handling.


## Feature Flag
OpenMRS Integration

## Safety Assurance

### Automated test coverage

Test included

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
