### PR TITLE
Remove ReportFormESView 

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -6,9 +6,8 @@ import logging
 from django.utils.decorators import classonlymethod, method_decorator
 from django.views.generic import View
 
-from corehq.util.es.elasticsearch import ElasticsearchException, NotFoundError
+from no_exceptions.exceptions import Http400
 
-from corehq.util.es.interface import ElasticsearchInterface
 from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 from corehq.apps.api.models import ESCase, ESXFormInstance
@@ -16,8 +15,8 @@ from corehq.apps.api.resources.v0_1 import TASTYPIE_RESERVED_GET_PARAMS
 from corehq.apps.api.util import object_does_not_exist
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.es import filters
-from corehq.apps.es.forms import FormES
 from corehq.apps.es.cases import CaseES
+from corehq.apps.es.forms import FormES
 from corehq.apps.es.utils import flatten_field_dict
 from corehq.apps.reports.filters.forms import FormsByApplicationFilter
 from corehq.elastic import (
@@ -25,11 +24,11 @@ from corehq.elastic import (
     get_es_new,
     report_and_fail_on_shard_failures,
 )
-from corehq.pillows.base import VALUE_TAG
 from corehq.pillows.mappings.case_mapping import CASE_ES_ALIAS
 from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_ES_ALIAS
 from corehq.pillows.mappings.xform_mapping import XFORM_ALIAS
-from no_exceptions.exceptions import Http400
+from corehq.util.es.elasticsearch import ElasticsearchException, NotFoundError
+from corehq.util.es.interface import ElasticsearchInterface
 
 logger = logging.getLogger('es')
 

--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -242,29 +242,6 @@ class FormESView(ESView):
         return es_results
 
 
-def report_term_filter(terms, mapping):
-    """convert terms to correct #value term queries based upon the mapping
-    does it match up with pre-defined stuff in the mapping?
-    """
-
-    ret_terms = []
-    for orig_term in terms:
-        curr_mapping = mapping.get('properties')
-        split_term = orig_term.split('.')
-        for ix, sub_term in enumerate(split_term, start=1):
-            is_property = sub_term in curr_mapping
-            if ix == len(split_term):
-                #it's the last one, and if it's still not in it, then append a value
-                if is_property:
-                    ret_term = orig_term
-                else:
-                    ret_term = '%s.%s' % (orig_term, VALUE_TAG)
-                ret_terms.append(ret_term)
-            if is_property and 'properties' in curr_mapping[sub_term]:
-                curr_mapping = curr_mapping[sub_term]['properties']
-    return ret_terms
-
-
 class ElasticAPIQuerySet(object):
     """
     An abstract representation of an elastic search query,

--- a/corehq/pillows/base.py
+++ b/corehq/pillows/base.py
@@ -34,29 +34,6 @@ def convert_property_dict(sub_dict, mapping, override_root_keys=None):
     return sub_dict
 
 
-def restore_property_dict(report_dict_item):
-    """
-    Revert a converted/retrieved document from Report<index> and deconvert all its properties
-    back from {#value: <val>} to just <val>
-    """
-    restored = {}
-    if not isinstance(report_dict_item, dict):
-        return report_dict_item
-
-    for k, v in report_dict_item.items():
-        if isinstance(v, list):
-            restored[k] = [restore_property_dict(x) for x in v]
-        elif isinstance(v, dict):
-            if VALUE_TAG in v:
-                restored[k] = v[VALUE_TAG]
-            else:
-                restored[k] = restore_property_dict(v)
-        else:
-            restored[k] = v
-
-    return restored
-
-
 def is_couch_change_for_sql_domain(change):
     if not change.metadata or not change.metadata.domain:
         return False

--- a/testapps/test_pillowtop/tests/test_pillows_cases.py
+++ b/testapps/test_pillowtop/tests/test_pillows_cases.py
@@ -1,13 +1,11 @@
 from django.conf import settings
 from django.test import TestCase
 from casexml.apps.case.xform import extract_case_blocks
-from corehq.apps.api.es import report_term_filter
 from corehq.pillows.base import VALUE_TAG
 from corehq.pillows.case import transform_case_for_elasticsearch
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
 from corehq.pillows.reportcase import transform_case_to_report_es
 from corehq.pillows.reportxform import transform_xform_for_report_forms_index
-from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_MAPPING
 from corehq.pillows.xform import transform_xform_for_elasticsearch
 from corehq.util.test_utils import softer_assert
 
@@ -533,21 +531,3 @@ class testReportCaseProcessing(TestCase):
             self.assertTrue(VALUE_TAG in diaper)
 
         self.assertEqual(case['prior_diapers'], [x[VALUE_TAG] for x in processed_case['prior_diapers']])
-
-    def testReportCaseQuery(self):
-
-        unknown_terms = ['gender', 'notes', 'sms_reminder', 'hamlet_name', 'actions.dob',
-                         'actions.dots', 'actions.hp']
-        unknown_terms_query = report_term_filter(unknown_terms, REPORT_CASE_MAPPING)
-
-        manually_set = ['%s.%s' % (x, VALUE_TAG) for x in unknown_terms]
-        self.assertEqual(manually_set, unknown_terms_query)
-
-        known_terms = ['owner_id', 'domain', 'opened_on', 'actions.action_type', 'actions.date',
-                       'actions.indices.doc_type']
-        known_terms_query = report_term_filter(known_terms, REPORT_CASE_MAPPING)
-
-        self.assertEqual(known_terms_query, known_terms)
-
-
-

--- a/testapps/test_pillowtop/tests/test_pillows_xforms.py
+++ b/testapps/test_pillowtop/tests/test_pillows_xforms.py
@@ -2,9 +2,7 @@ import copy
 from unittest import mock
 from django.test import SimpleTestCase
 from django.conf import settings
-from corehq.apps.api.es import report_term_filter
-from corehq.pillows.base import restore_property_dict, VALUE_TAG
-from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_MAPPING
+from corehq.pillows.base import restore_property_dict
 from corehq.pillows.reportxform import transform_xform_for_report_forms_index
 from corehq.pillows.utils import UNKNOWN_USER_TYPE
 
@@ -347,37 +345,6 @@ class TestReportXFormProcessing(SimpleTestCase):
 
         self.assertNotEqual(orig['computed_'], for_indexing['computed_'])
         self.assertEqual(orig['computed_'], restored['computed_'])
-
-    def testReporXFormtQuery(self):
-
-        unknown_terms = ['form.num_using_fp.#text', 'form.num_using_fp.@concept_id',
-                         'form.counseling.sanitation_counseling.handwashing_importance',
-                         'form.counseling.bednet_counseling.wash_bednet',
-                         'form.prev_location_code',
-                         'member_available.#text',
-                         'location_code_1']
-        unknown_terms_query = report_term_filter(unknown_terms, REPORT_XFORM_MAPPING)
-
-        manually_set = ['%s.%s' % (x, VALUE_TAG) for x in unknown_terms]
-        self.assertEqual(manually_set, unknown_terms_query)
-
-        known_terms = [
-            'initial_processing_complete',
-            'doc_type',
-            'app_id',
-            'xmlns',
-            '@uiVersion',
-            '@version',
-            'form.#type',
-            'form.@name',
-            'form.meta.timeStart',
-            'form.meta.timeEnd',
-            'form.meta.appVersion',
-            ]
-
-        # shoot, TODO, cases are difficult to escape the VALUE_TAG term due to dynamic templates
-        known_terms_query = report_term_filter(known_terms, REPORT_XFORM_MAPPING)
-        self.assertEqual(known_terms_query, known_terms)
 
     def testConceptReportConversion(self):
         orig = CONCEPT_XFORM


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
As you may have noticed, I'm deleting pieces rather piecemeal so each change can be reviewed and merged without too much fuss, versus a single massive, scary deletion.  Though I expect the eventual deletion of the report pillows will be a pretty big one, just getting a bunch of other stuff out of the way first.

This piece is dead code last used in pact, as shown in this rename commit https://github.com/dimagi/commcare-hq/commit/9dbeb2c9f85
When we removed the pact custom module, we removed the last remaining reference to this.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
