### PR TITLE
[SSO] Update IdP Enterprise Admin Views to support OIDC

### DIFF
--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -779,12 +779,11 @@ class SsoOidcEnterpriseSettingsForm(BaseSsoEnterpriseSettingsForm):
     )
 
     def __init__(self, identity_provider, *args, **kwargs):
-        kwargs['initial'] = {
-            'is_active': identity_provider.is_active,
-            'entity_id': identity_provider.entity_id,
-            'client_id': identity_provider.client_id,
-            'client_secret': identity_provider.client_secret,
-        }
+        initial = kwargs['initial'] = kwargs.get('initial', {}).copy()
+        initial.setdefault('is_active', identity_provider.is_active)
+        initial.setdefault('entity_id': identity_provider.entity_id)
+        initial.setdefault('client_id': identity_provider.client_id)
+        initial.setdefault('client_secret': identity_provider.client_secret)
         super().__init__(identity_provider, *args, **kwargs)
 
         rp_details_form = RelyingPartyDetailsForm(identity_provider)

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -261,9 +261,9 @@ class ServiceProviderDetailsForm(forms.Form):
     def token_encryption_help_block(self):
         if self.idp.idp_type == IdentityProviderType.AZURE_AD:
             help_text = _(
-                'This is a high security feature  that ensures Assertions are '
+                'This is a high security feature that ensures Assertions are '
                 'fully encrypted. This feature requires a Premium Azure AD '
-                'subscription. '
+                'subscription.'
             )
         else:
             help_text = _(

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -542,6 +542,10 @@ class BaseSsoEnterpriseSettingsForm(forms.Form):
         label=gettext_lazy("Linked Email Domains"),
         required=False,
     )
+    entity_id = forms.CharField(
+        label=gettext_lazy("Entity ID"),
+        required=False,
+    )
 
     def __init__(self, identity_provider, *args, **kwargs):
         self.idp = identity_provider
@@ -582,12 +586,14 @@ class BaseSsoEnterpriseSettingsForm(forms.Form):
             _check_is_editable_requirements(self.idp)
         return is_active
 
+    def clean_entity_id(self):
+        is_active = bool(self.data.get('is_active'))
+        entity_id = self.cleaned_data['entity_id']
+        _check_required_when_active(is_active, entity_id)
+        return entity_id
+
 
 class SsoSamlEnterpriseSettingsForm(BaseSsoEnterpriseSettingsForm):
-    entity_id = forms.CharField(
-        label=gettext_lazy("Azure AD Identifier"),
-        required=False,
-    )
     login_url = forms.CharField(
         label=gettext_lazy("Login URL"),
         required=False,
@@ -692,12 +698,6 @@ class SsoSamlEnterpriseSettingsForm(BaseSsoEnterpriseSettingsForm):
             ),
             crispy.Div(*self.get_primary_fields()),
         )
-
-    def clean_entity_id(self):
-        is_active = bool(self.data.get('is_active'))
-        entity_id = self.cleaned_data['entity_id']
-        _check_required_when_active(is_active, entity_id)
-        return entity_id
 
     def clean_login_url(self):
         is_active = bool(self.data.get('is_active'))

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -603,6 +603,9 @@ class BaseSsoEnterpriseSettingsForm(forms.Form):
         _check_required_when_active(is_active, entity_id)
         return entity_id
 
+    def update_identity_provider(self, admin_user):
+        raise NotImplementedError("please implement update_identity_provider")
+
 
 class SsoSamlEnterpriseSettingsForm(BaseSsoEnterpriseSettingsForm):
     login_url = forms.CharField(

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -781,9 +781,9 @@ class SsoOidcEnterpriseSettingsForm(BaseSsoEnterpriseSettingsForm):
     def __init__(self, identity_provider, *args, **kwargs):
         initial = kwargs['initial'] = kwargs.get('initial', {}).copy()
         initial.setdefault('is_active', identity_provider.is_active)
-        initial.setdefault('entity_id': identity_provider.entity_id)
-        initial.setdefault('client_id': identity_provider.client_id)
-        initial.setdefault('client_secret': identity_provider.client_secret)
+        initial.setdefault('entity_id', identity_provider.entity_id)
+        initial.setdefault('client_id', identity_provider.client_id)
+        initial.setdefault('client_secret', identity_provider.client_secret)
         super().__init__(identity_provider, *args, **kwargs)
 
         rp_details_form = RelyingPartyDetailsForm(identity_provider)

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -130,6 +130,10 @@ class IdentityProvider(models.Model):
     def __str__(self):
         return f"{self.name} IdP [{self.idp_type}]"
 
+    @property
+    def service_name(self):
+        return dict(IdentityProviderType.CHOICES)[self.idp_type]
+
     def create_service_provider_certificate(self):
         sp_cert = ServiceProviderCertificate()
         self.sp_cert_public = sp_cert.public_key

--- a/corehq/apps/sso/templates/sso/partials/manage_sso_exempt_users.html
+++ b/corehq/apps/sso/templates/sso/partials/manage_sso_exempt_users.html
@@ -26,7 +26,7 @@
         <!-- /ko -->
         <ul data-bind="foreach: linkedObjects">
           <li>
-            @ <strong data-bind="text: $data"
+            <strong data-bind="text: $data"
                       style="padding-right: 10px;"></strong>
             (<button type="button"
                      class="btn-link"

--- a/corehq/apps/sso/tests/test_forms.py
+++ b/corehq/apps/sso/tests/test_forms.py
@@ -651,7 +651,7 @@ class TestSsoOidcEnterpriseSettingsForm(BaseSSOFormTest):
             email_domain=email_domain,
         )
         post_data = self._get_post_data()
-        edit_sso_idp_form = SsoSamlEnterpriseSettingsForm(self.idp, post_data)
+        edit_sso_idp_form = SsoOidcEnterpriseSettingsForm(self.idp, post_data)
         self.assertTrue(edit_sso_idp_form.is_valid())
         edit_sso_idp_form.update_identity_provider(self.accounting_admin)
 

--- a/corehq/apps/sso/tests/test_forms.py
+++ b/corehq/apps/sso/tests/test_forms.py
@@ -8,7 +8,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.sso.forms import (
     CreateIdentityProviderForm,
     EditIdentityProviderAdminForm,
-    SSOEnterpriseSettingsForm,
+    SsoSamlEnterpriseSettingsForm,
 )
 from corehq.apps.sso.models import (
     IdentityProvider,
@@ -334,7 +334,7 @@ class TestEditIdentityProviderAdminForm(BaseSSOFormTest):
         self.assertTrue(idp.is_active)
 
 
-class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
+class TestSsoSamlEnterpriseSettingsForm(BaseSSOFormTest):
 
     def setUp(self):
         super().setUp()
@@ -377,7 +377,7 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
         """
         Test that if `is_active` is set to true, then related required fields
         raise ValidationErrors if left blank. Once the requirements are met and
-        SSOEnterpriseSettingsForm validates, ensure that
+        SsoSamlEnterpriseSettingsForm validates, ensure that
         update_identity_provider() updates the `is_active` field on
         the IdentityProvider as expected.
         """
@@ -387,7 +387,7 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
             no_login_url=True,
             no_logout_url=True,
         )
-        edit_sso_idp_form = SSOEnterpriseSettingsForm(self.idp, post_data)
+        edit_sso_idp_form = SsoSamlEnterpriseSettingsForm(self.idp, post_data)
         edit_sso_idp_form.cleaned_data = post_data
 
         with self.assertRaises(forms.ValidationError):
@@ -438,7 +438,7 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
         )
 
         self.assertFalse(self.idp.is_active)
-        edit_sso_idp_form = SSOEnterpriseSettingsForm(
+        edit_sso_idp_form = SsoSamlEnterpriseSettingsForm(
             self.idp, post_data, self._get_request_files(certificate_file)
         )
         edit_sso_idp_form.cleaned_data = post_data
@@ -458,13 +458,13 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
 
     def test_that_validation_error_is_raised_when_certificate_file_is_bad(self):
         """
-        Ensure that SSOEnterpriseSettingsForm raises a validation error
+        Ensure that SsoSamlEnterpriseSettingsForm raises a validation error
         when the certificate file contains bad data.
         """
         certificate_file = generator.get_bad_cert_file(b"bad cert")
         post_data = self._get_post_data(certificate=certificate_file)
 
-        edit_sso_idp_form = SSOEnterpriseSettingsForm(
+        edit_sso_idp_form = SsoSamlEnterpriseSettingsForm(
             self.idp, post_data, self._get_request_files(certificate_file)
         )
         edit_sso_idp_form.cleaned_data = post_data
@@ -474,13 +474,13 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
 
     def test_that_validation_error_is_raised_when_certificate_is_expired(self):
         """
-        Ensure that SSOEnterpriseSettingsForm raises a validation error
+        Ensure that SsoSamlEnterpriseSettingsForm raises a validation error
         when the certificate file contains an expired certificate.
         """
         certificate_file = generator.get_public_cert_file(expiration_in_seconds=0)
         post_data = self._get_post_data(certificate=certificate_file)
 
-        edit_sso_idp_form = SSOEnterpriseSettingsForm(
+        edit_sso_idp_form = SsoSamlEnterpriseSettingsForm(
             self.idp, post_data, self._get_request_files(certificate_file)
         )
 
@@ -492,7 +492,7 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
     def test_last_modified_by_and_fields_update_when_not_active(self):
         """
         Ensure that fields properly update and that `last_modified_by` updates
-        as expected when SSOEnterpriseSettingsForm validates and
+        as expected when SsoSamlEnterpriseSettingsForm validates and
         update_identity_provider() is called.
         """
         email_domain = AuthenticatedEmailDomain.objects.create(
@@ -504,7 +504,7 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
             email_domain=email_domain,
         )
         post_data = self._get_post_data()
-        edit_sso_idp_form = SSOEnterpriseSettingsForm(self.idp, post_data)
+        edit_sso_idp_form = SsoSamlEnterpriseSettingsForm(self.idp, post_data)
         self.assertTrue(edit_sso_idp_form.is_valid())
         edit_sso_idp_form.update_identity_provider(self.accounting_admin)
 
@@ -521,14 +521,14 @@ class TestSSOEnterpriseSettingsForm(BaseSSOFormTest):
 
     def test_require_encrypted_assertions_is_saved(self):
         """
-        Ensure that SSOEnterpriseSettingsForm updates the
+        Ensure that SsoSamlEnterpriseSettingsForm updates the
         `require_encrypted_assertions property` on the IdentityProvider.
         """
         post_data = self._get_post_data(
             require_encrypted_assertions=True,
         )
         self.assertFalse(self.idp.require_encrypted_assertions)
-        edit_sso_idp_form = SSOEnterpriseSettingsForm(self.idp, post_data)
+        edit_sso_idp_form = SsoSamlEnterpriseSettingsForm(self.idp, post_data)
         self.assertTrue(edit_sso_idp_form.is_valid())
         edit_sso_idp_form.update_identity_provider(self.accounting_admin)
         self.idp.refresh_from_db()

--- a/corehq/apps/sso/views/enterprise_admin.py
+++ b/corehq/apps/sso/views/enterprise_admin.py
@@ -10,7 +10,9 @@ from corehq.apps.enterprise.views import BaseEnterpriseAdminView
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.sso.async_handlers import SSOExemptUsersAdminAsyncHandler
 from corehq.apps.sso.certificates import get_certificate_response
-from corehq.apps.sso.forms import SSOEnterpriseSettingsForm
+from corehq.apps.sso.forms import (
+    SsoSamlEnterpriseSettingsForm,
+)
 from corehq.apps.sso.models import IdentityProvider
 
 
@@ -94,10 +96,10 @@ class EditIdentityProviderEnterpriseView(BaseEnterpriseAdminView, AsyncHandlerMi
     @memoized
     def edit_enterprise_idp_form(self):
         if self.request.method == 'POST':
-            return SSOEnterpriseSettingsForm(
+            return SsoSamlEnterpriseSettingsForm(
                 self.identity_provider, self.request.POST, self.request.FILES
             )
-        return SSOEnterpriseSettingsForm(self.identity_provider)
+        return SsoSamlEnterpriseSettingsForm(self.identity_provider)
 
     def post(self, request, *args, **kwargs):
         if self.async_response is not None:

--- a/corehq/apps/sso/views/enterprise_admin.py
+++ b/corehq/apps/sso/views/enterprise_admin.py
@@ -12,8 +12,9 @@ from corehq.apps.sso.async_handlers import SSOExemptUsersAdminAsyncHandler
 from corehq.apps.sso.certificates import get_certificate_response
 from corehq.apps.sso.forms import (
     SsoSamlEnterpriseSettingsForm,
+    SsoOidcEnterpriseSettingsForm,
 )
-from corehq.apps.sso.models import IdentityProvider
+from corehq.apps.sso.models import IdentityProvider, IdentityProviderProtocol
 
 
 class ManageSSOEnterpriseView(BaseEnterpriseAdminView):
@@ -95,11 +96,15 @@ class EditIdentityProviderEnterpriseView(BaseEnterpriseAdminView, AsyncHandlerMi
     @property
     @memoized
     def edit_enterprise_idp_form(self):
+        form_class = (
+            SsoSamlEnterpriseSettingsForm if self.identity_provider.protocol == IdentityProviderProtocol.SAML
+            else SsoOidcEnterpriseSettingsForm
+        )
         if self.request.method == 'POST':
-            return SsoSamlEnterpriseSettingsForm(
+            return form_class(
                 self.identity_provider, self.request.POST, self.request.FILES
             )
-        return SsoSamlEnterpriseSettingsForm(self.identity_provider)
+        return form_class(self.identity_provider)
 
     def post(self, request, *args, **kwargs):
         if self.async_response is not None:


### PR DESCRIPTION
## Product Description
This adds support for OIDC in the Edit Identity Provider forms accessible through the enterprise console.

![Screen Shot 2022-04-22 at 7 39 11 PM](https://user-images.githubusercontent.com/716573/164769314-fdd7a4d2-096b-46f0-86ae-cf6830403d95.png)


## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-13411

## Feature Flag
Not needed. This code is extremely well tested and users will only see the OIDC updates if an accounting admin has created a IdP that supports OIDC.

## Safety Assurance

### Safety story
Does not impact any active workflows. Code touched is very well tested

### Automated test coverage
Yes

### QA Plan
Not yet needed. QA will test everything once all the SSO work is complete.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
