### PR TITLE
Add support to update mobile worker 'default_phone_number' via API

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -312,6 +312,30 @@ class CommCareUserResource(v0_1.CommCareUserResource):
 
                         if change_messages:
                             user_change_logger.add_change_message({'phone_numbers': change_messages})
+                elif key == 'default_phone_number':
+                    old_phone_numbers = set(bundle.obj.phone_numbers)
+                    phone_number = bundle.data.get('default_phone_number')
+                    if not isinstance(phone_number, str):
+                        errors.append(_('Only a single value, not a list, can be set for default_phone_number.'))
+                        continue
+                    formatted_phone_number = strip_plus(phone_number)
+                    bundle.obj.set_default_phone_number(formatted_phone_number)
+
+                    if user_change_logger:
+                        (numbers_added, numbers_removed) = find_differences_in_list(
+                            target=list(phone_number),
+                            source=list(old_phone_numbers)
+                        )
+
+                        change_messages = {}
+                        if numbers_added:
+                            change_messages.update(
+                                UserChangeMessage.phone_numbers_added(list(numbers_added))["phone_numbers"]
+                            )
+
+                        if change_messages:
+                            user_change_logger.add_change_message({'phone_numbers': change_messages})
+
                 elif key == 'groups':
                     group_ids = bundle.data.get("groups", [])
                     groups_updated = bundle.obj.set_groups(group_ids)

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -316,7 +316,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
                     old_phone_numbers = set(bundle.obj.phone_numbers)
                     phone_number = bundle.data.get('default_phone_number')
                     if not isinstance(phone_number, str):
-                        errors.append(_('Only a single value, not a list, can be set for default_phone_number.'))
+                        errors.append(_('{} must be a string.'.format(key)))
                         continue
                     formatted_phone_number = strip_plus(phone_number)
                     bundle.obj.set_default_phone_number(formatted_phone_number)

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -332,8 +332,6 @@ class CommCareUserResource(v0_1.CommCareUserResource):
                             change_messages.update(
                                 UserChangeMessage.phone_numbers_added(list(numbers_added))["phone_numbers"]
                             )
-
-                        if change_messages:
                             user_change_logger.add_change_message({'phone_numbers': change_messages})
 
                 elif key == 'groups':

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -673,7 +673,6 @@ class TestCommCareUserResourceUpdate(TestCase):
     def test_update_default_phone_number(self):
         self.user.phone_numbers = ['50253311398']
         self.user.save()
-        self.assertEqual(self.user.default_phone_number, "50253311398")
         bundle = Bundle()
         bundle.obj = self.user
         bundle.data = {"default_phone_number": "50253311399"}
@@ -686,9 +685,6 @@ class TestCommCareUserResourceUpdate(TestCase):
         self.assertEqual(modified.default_phone_number, "50253311399")
 
     def test_update_default_phone_number_returns_error_if_multiple_values(self):
-        self.user.phone_numbers = ['50253311398']
-        self.user.save()
-        self.assertEqual(self.user.default_phone_number, "50253311398")
         bundle = Bundle()
         bundle.obj = self.user
         bundle.data = {"default_phone_number": ["50253311399"]}
@@ -700,7 +696,6 @@ class TestCommCareUserResourceUpdate(TestCase):
     def test_update_phone_numbers(self):
         self.user.phone_numbers = ['50253311398']
         self.user.save()
-        self.assertEqual(self.user.default_phone_number, "50253311398")
         bundle = Bundle()
         bundle.obj = self.user
         bundle.data = {"phone_numbers": ["50253311399", "50253311398"]}
@@ -710,13 +705,10 @@ class TestCommCareUserResourceUpdate(TestCase):
         self.assertFalse(errors)
         modified = bundle.obj
         self.assertEqual(modified.phone_numbers, ["50253311399", "50253311398"])
-        # NOTE: the default phone number is the first number provided in the array of numbers
-        self.assertEqual(modified.default_phone_number, "50253311399")
 
     def test_update_phone_numbers_overwrites(self):
         self.user.phone_numbers = ['50253311398']
         self.user.save()
-        self.assertEqual(self.user.default_phone_number, "50253311398")
         bundle = Bundle()
         bundle.obj = self.user
         bundle.data = {"phone_numbers": ["50253311399"]}
@@ -726,7 +718,17 @@ class TestCommCareUserResourceUpdate(TestCase):
         self.assertFalse(errors)
         modified = bundle.obj
         self.assertEqual(modified.phone_numbers, ["50253311399"])
-        # NOTE: the default phone number is the first number provided in the array of numbers
+
+    def test_update_phone_numbers_updates_default_number(self):
+        self.user.set_default_phone_number('50253311398')
+        bundle = Bundle()
+        bundle.obj = self.user
+        bundle.data = {"phone_numbers": ["50253311399"]}
+
+        errors = CommCareUserResource._update(bundle)
+
+        self.assertFalse(errors)
+        modified = bundle.obj
         self.assertEqual(modified.default_phone_number, "50253311399")
 
     def test_update_user_data(self):

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -670,6 +670,33 @@ class TestCommCareUserResourceUpdate(TestCase):
         modified = bundle.obj
         self.assertEqual(modified.language, 'up')
 
+    def test_update_default_phone_number(self):
+        self.user.phone_numbers = ['50253311398']
+        self.user.save()
+        self.assertEqual(self.user.default_phone_number, "50253311398")
+        bundle = Bundle()
+        bundle.obj = self.user
+        bundle.data = {"default_phone_number": "50253311399"}
+
+        errors = CommCareUserResource._update(bundle)
+
+        self.assertFalse(errors)
+        modified = bundle.obj
+        self.assertEqual(modified.phone_numbers, ["50253311399", "50253311398"])
+        self.assertEqual(modified.default_phone_number, "50253311399")
+
+    def test_update_default_phone_number_returns_error_if_multiple_values(self):
+        self.user.phone_numbers = ['50253311398']
+        self.user.save()
+        self.assertEqual(self.user.default_phone_number, "50253311398")
+        bundle = Bundle()
+        bundle.obj = self.user
+        bundle.data = {"default_phone_number": ["50253311399"]}
+
+        errors = CommCareUserResource._update(bundle)
+
+        self.assertIn('Only a single value, not a list, can be set for default_phone_number.', errors)
+
     def test_update_phone_numbers(self):
         self.user.phone_numbers = ['50253311398']
         self.user.save()
@@ -683,6 +710,22 @@ class TestCommCareUserResourceUpdate(TestCase):
         self.assertFalse(errors)
         modified = bundle.obj
         self.assertEqual(modified.phone_numbers, ["50253311399", "50253311398"])
+        # NOTE: the default phone number is the first number provided in the array of numbers
+        self.assertEqual(modified.default_phone_number, "50253311399")
+
+    def test_update_phone_numbers_overwrites(self):
+        self.user.phone_numbers = ['50253311398']
+        self.user.save()
+        self.assertEqual(self.user.default_phone_number, "50253311398")
+        bundle = Bundle()
+        bundle.obj = self.user
+        bundle.data = {"phone_numbers": ["50253311399"]}
+
+        errors = CommCareUserResource._update(bundle)
+
+        self.assertFalse(errors)
+        modified = bundle.obj
+        self.assertEqual(modified.phone_numbers, ["50253311399"])
         # NOTE: the default phone number is the first number provided in the array of numbers
         self.assertEqual(modified.default_phone_number, "50253311399")
 

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -691,7 +691,16 @@ class TestCommCareUserResourceUpdate(TestCase):
 
         errors = CommCareUserResource._update(bundle)
 
-        self.assertIn('Only a single value, not a list, can be set for default_phone_number.', errors)
+        self.assertIn('default_phone_number must be a string.', errors)
+
+    def test_update_default_phone_number_returns_error_if_integer(self):
+        bundle = Bundle()
+        bundle.obj = self.user
+        bundle.data = {"default_phone_number": 50253311399}
+
+        errors = CommCareUserResource._update(bundle)
+
+        self.assertIn('default_phone_number must be a string.', errors)
 
     def test_update_phone_numbers(self):
         self.user.phone_numbers = ['50253311398']


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12962

Currently, an API user would need to update `phone_numbers` to properly update the default phone number. Given that this has the potential to be destructive by replacing the current list with a new list, it is less error prone to add support for providing a `default_phone_number` as well. 

I see this as fixing the immediate issue, and getting tests in place to know it works properly, which sets the foundation to refactor this area of code to be less redundant/easier to read in the future.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Between automated tests and locally testing this, I feel confident this works correctly.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
