### PR TITLE
Web Apps handle "back" with multi-select case lists

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -152,6 +152,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
     FormplayerFrontend.getChannel().reply("app:select:menus", function (options) {
         if (sessionStorage.selectedValues !== undefined) {
             options.selectedValues = sessionStorage.selectedValues.split(',');
+            sessionStorage.removeItem("selectedValues");
         }
         if (!options.endpointId) {
             return API.queryFormplayer(options, options.isInitial ? "navigate_menu_start" : "navigate_menu");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -153,6 +153,10 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
         if (sessionStorage.selectedValues !== undefined) {
             options.selectedValues = sessionStorage.selectedValues.split(',');
             sessionStorage.removeItem("selectedValues");
+        } else if (
+            // handle missing selectedValue (when user presses 'back')
+            options.selections !== undefined && options.selections.at(-1) === "use_selected_values") {
+            options.selections.pop();
         }
         if (!options.endpointId) {
             return API.queryFormplayer(options, options.isInitial ? "navigate_menu_start" : "navigate_menu");


### PR DESCRIPTION
## Technical Summary
Two commits to better handle the workflow edge case where the user presses the back button in the browser.

The alternative implementation option was to replace the URL in the history instead of 'append' it so that when the user presses 'back' the previous URL already does not contain the selections. This would be done here:
https://github.com/dimagi/commcare-hq/blob/fc0d5d02ac5f8b9f53131a9d0525250cfeca2ec5/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js#L60

My only concern with doing this is whether it would impact other workflows.

## Feature Flag
USH: Allow selecting multiple cases from the case list (`ush_case_list_multi_select`)

## Safety Assurance

### Safety story
Only impacts toggled feature

### Automated test coverage
None

### QA Plan
Staging: https://dimagi-dev.atlassian.net/browse/QA-4085

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
