### PR TITLE
use unique datum ID for remote requests when using multi-select

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -135,6 +135,7 @@ INSTANCE_KWARGS_BY_ID = {
     'registry': dict(id='registry', src='jr://instance/remote'),
     'results': dict(id='results', src='jr://instance/remote'),
     'selected_cases': dict(id='selected_cases', src='jr://instance/selected_cases'),
+    'search_selected_cases': dict(id='search_selected_cases', src='jr://instance/selected_cases'),
 }
 
 

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -84,7 +84,8 @@ class RemoteRequestFactory(object):
         self.module = module
         self.detail_section_elements = detail_section_elements
         if self.module.is_multi_select():
-            self.case_session_var = "search_selected_cases"
+            # the instance is dynamic and its ID matches the datum ID
+            self.case_session_var = SearchSelectedCasesInstanceXpath.id
         else:
             self.case_session_var = self.module.search_config.case_session_var
 

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -43,7 +43,7 @@ from corehq.apps.app_manager.util import (
 from corehq.apps.app_manager.xpath import (
     CaseClaimXpath,
     CaseIDXPath,
-    SelectedCasesInstanceXpath,
+    SearchSelectedCasesInstanceXpath,
     CaseTypeXpath,
     InstanceXpath,
     interpolate_xpath,
@@ -84,7 +84,7 @@ class RemoteRequestFactory(object):
         self.module = module
         self.detail_section_elements = detail_section_elements
         if self.module.is_multi_select():
-            self.case_session_var = "selected_cases"
+            self.case_session_var = "search_selected_cases"
         else:
             self.case_session_var = self.module.search_config.case_session_var
 
@@ -128,7 +128,7 @@ class RemoteRequestFactory(object):
         }
 
     def _get_multi_select_nodeset(self):
-        return SelectedCasesInstanceXpath().instance()
+        return SearchSelectedCasesInstanceXpath().instance()
 
     def _get_multi_select_exclude(self):
         return CaseIDXPath(XPath("current()").slash(".")).case().count().eq(1)

--- a/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
@@ -3,7 +3,7 @@
     <post url="https://www.example.com/a/multiple-referrals/phone/claim-case/"
           relevant="$case_id != ''">
       <data key="case_id"
-            nodeset="instance('selected_cases')/results/value"
+            nodeset="instance('search_selected_cases')/results/value"
             exclude="count(instance('casedb')/casedb/case[@case_id=current()/.]) = 1"
             ref="."/>
     </post>
@@ -16,7 +16,7 @@
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
-    <instance id="selected_cases" src="jr://instance/selected_cases"/>
+    <instance id="search_selected_cases" src="jr://instance/selected_cases"/>
     <session>
       <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/multiple-referrals/phone/search/{app_id}/">
         <data key="case_type" ref="'person'"/>
@@ -35,11 +35,11 @@
           </display>
         </prompt>
       </query>
-      <instance-datum detail-confirm="m0_search_long" detail-select="m0_search_short" id="selected_cases" nodeset="instance('results')/results/case[@case_type='person'][not(commcare_is_related_case=true())]" value="./@case_id"/>
+      <instance-datum detail-confirm="m0_search_long" detail-select="m0_search_short" id="search_selected_cases" nodeset="instance('results')/results/case[@case_type='person'][not(commcare_is_related_case=true())]" value="./@case_id"/>
     </session>
     <stack>
       <push>
-        <rewind value="instance('commcaresession')/session/data/selected_cases"/>
+        <rewind value="instance('commcaresession')/session/data/search_selected_cases"/>
       </push>
     </stack>
   </remote-request>

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -404,8 +404,8 @@ class IndicatorXpath(InstanceXpath):
         return self
 
 
-class SelectedCasesInstanceXpath(InstanceXpath):
-    id = "selected_cases"
+class SearchSelectedCasesInstanceXpath(InstanceXpath):
+    id = "search_selected_cases"
     path = "results/value"
 
 


### PR DESCRIPTION
## Technical Summary
Fix issue with parent child modules using multi-select case lists.

Because the datum ID in the parent entry matched the entry ID in the child remote request entry, Formplayer won't prompt for selecting the child datum in the remote request entry.

For normal case lists we use `search_case_id` in remote request entries. Following the same pattern this PR uses `search_selected_value` instead of `selected_values`.

Jira: https://dimagi-dev.atlassian.net/browse/QA-4104

## Feature Flag
USH: Allow selecting multiple cases from the case list (ush_case_list_multi_select)

## Safety Assurance

### Safety story
Feature flagged feature fix for QA.

### Automated test coverage
Updated

### QA Plan
https://dimagi-dev.atlassian.net/browse/QA-4104

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
