### PR TITLE
Rc/date range search error

### DIFF
--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -121,9 +121,7 @@ class SearchCriteria:
         pattern = re.compile(r'__range__\d{4}-\d{2}-\d{2}__\d{4}-\d{2}-\d{2}')
         if self.has_multiple_terms:
             # don't validate empty values
-            values = self._value_without_empty()
-            if isinstance(values, str):
-                values = [values]
+            values = [val for val in self.value if val != '']
         else:
             values = [self.value]
         for v in values:

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -120,13 +120,14 @@ class SearchCriteria:
             return
         pattern = re.compile(r'__range__\d{4}-\d{2}-\d{2}__\d{4}-\d{2}-\d{2}')
         if self.has_multiple_terms:
-            for v in self.value:
-                if v:
-                    match = pattern.match(v)
-                    if not match:
-                        raise CaseFilterError(_('Invalid date range format, {}'), self.key)
+            # don't validate empty values
+            values = self._value_without_empty()
+            if isinstance(values, str):
+                values = [values]
         else:
-            match = pattern.match(self.value)
+            values = [self.value]
+        for v in values:
+            match = pattern.match(v)
             if not match:
                 raise CaseFilterError(_('Invalid date range format, {}'), self.key)
 

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -95,12 +95,11 @@ class SearchCriteria:
             'owner_id',
         ]
 
-        if self.is_daterange:
-            if len(self.value) > 2:
-                raise CaseFilterError(
-                    _("Only one blank value plus one date range value are supprted"),
-                    self.key
-                )
+        if self.is_daterange and len(self.value) > 2:
+            raise CaseFilterError(
+                _("Only one blank value plus one date range value are supprted"),
+                self.key
+            )
 
         if self.key in disallowed_parameters:
             raise CaseFilterError(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Previously in case search when a date range was input and "Include results where field is blank" is checked a 500 error was returned. This change is to allow searching for multiple values on a date range field where one is a date range and the other is blank.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-1842](https://dimagi-dev.atlassian.net/browse/USH-1842)
<img width="1189" alt="Screen Shot 2022-04-25 at 4 50 32 PM" src="https://user-images.githubusercontent.com/42388648/165172646-041229aa-5095-4353-858a-72d38bbe2ed8.png">

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
tested locally

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
