### PR TITLE
case v6 rate limits

### DIFF
--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -36,6 +36,13 @@ def wrap_4xx_errors_for_apis(view_func):
     return _inner
 
 
+def get_rate_limit_identifier(request):
+    username = request.couch_user.username
+    if API_THROTTLE_WHITELIST.enabled(username):
+        return username
+    return f"{getattr(request, 'domain', '')}_{username}"
+
+
 class HQAuthenticationMixin:
     decorator_map = {}  # should be set by subclasses
 
@@ -43,10 +50,7 @@ class HQAuthenticationMixin:
         return self.decorator_map[determine_authtype_from_header(request)]
 
     def get_identifier(self, request):
-        username = request.couch_user.username
-        if API_THROTTLE_WHITELIST.enabled(username):
-            return username
-        return f"{getattr(request, 'domain', '')}_{username}"
+        return get_rate_limit_identifier(request)
 
 
 class LoginAuthentication(HQAuthenticationMixin, Authentication):

--- a/corehq/apps/api/resources/meta.py
+++ b/corehq/apps/api/resources/meta.py
@@ -7,6 +7,12 @@ from corehq.apps.api.resources.auth import LoginAndDomainAuthentication
 from corehq.apps.api.serializers import CustomXMLSerializer
 from corehq.toggles import API_THROTTLE_WHITELIST
 
+def get_hq_throttle():
+    return HQThrottle(
+        throttle_at=getattr(settings, 'CCHQ_API_THROTTLE_REQUESTS', 25),
+        timeframe=getattr(settings, 'CCHQ_API_THROTTLE_TIMEFRAME', 15)
+    )
+
 
 class HQThrottle(CacheDBThrottle):
 
@@ -43,7 +49,4 @@ class CustomResourceMeta(object):
     authentication = LoginAndDomainAuthentication()
     serializer = CustomXMLSerializer()
     default_format = 'application/json'
-    throttle = HQThrottle(
-        throttle_at=getattr(settings, 'CCHQ_API_THROTTLE_REQUESTS', 25),
-        timeframe=getattr(settings, 'CCHQ_API_THROTTLE_TIMEFRAME', 15)
-    )
+    throttle = get_hq_throttle()

--- a/corehq/apps/api/resources/meta.py
+++ b/corehq/apps/api/resources/meta.py
@@ -7,6 +7,7 @@ from corehq.apps.api.resources.auth import LoginAndDomainAuthentication
 from corehq.apps.api.serializers import CustomXMLSerializer
 from corehq.toggles import API_THROTTLE_WHITELIST
 
+
 def get_hq_throttle():
     return HQThrottle(
         throttle_at=getattr(settings, 'CCHQ_API_THROTTLE_REQUESTS', 25),

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -188,4 +188,5 @@ def _submit_case_updates(updates, domain, user, device_id):
         user_id=user.user_id,
         xmlns='http://commcarehq.org/case_api',
         device_id=device_id,
+        max_wait=15
     )

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -24,6 +24,7 @@ from ..utils import submit_case_blocks
 @disable_quickcache
 @privilege_enabled(privileges.API_ACCESS)
 @flag_enabled('CASE_API_V0_6')
+@flag_enabled('API_THROTTLE_WHITELIST')
 class TestCaseAPI(TestCase):
     domain = 'test-update-cases'
     maxDiff = None

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -11,7 +11,7 @@ from soil import DownloadBase
 
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
-from corehq.apps.api.decorators import allow_cors
+from corehq.apps.api.decorators import allow_cors, api_throttle
 from corehq.apps.domain.decorators import (
     api_auth,
     require_superuser_or_contractor,
@@ -86,6 +86,7 @@ class ExplodeCasesView(BaseProjectSettingsView, TemplateView):
 @require_permission(Permissions.access_api)
 @CASE_API_V0_6.required_decorator()
 @requires_privilege_with_fallback(privileges.API_ACCESS)
+@api_throttle
 def case_api(request, domain, case_id=None):
     if request.method == 'GET' and case_id:
         return _handle_individual_get(request, case_id)


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This does two semi related things. It applies the standard system form rate limiting to the case api updates (adding a wait when the domain is over the limit), and it creates a decorator that can be applied to any api view that applies the same api throttling we apply to tastypie views. This PR only applies it to the v6 case api, but I plan to look for other non tastypie api views to apply it to.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
The v6 case api is behind a feature flag `case_api_v0_6`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This is tested locally and only applies to a single API behind a feature flag.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
This API is tested in automated tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
