### PR TITLE
Refactor CommCareUser API update method

### DIFF
--- a/corehq/apps/api/exceptions.py
+++ b/corehq/apps/api/exceptions.py
@@ -1,11 +1,14 @@
 class InvalidFormatException(Exception):
 
-    def __init__(self, expected_type):
+    def __init__(self, field, expected_type):
+        self.field = field
         self.expected_type = expected_type
 
 
 class UnknownFieldException(Exception):
-    pass
+
+    def __init__(self, field):
+        self.field = field
 
 
 class UpdateConflictException(Exception):

--- a/corehq/apps/api/exceptions.py
+++ b/corehq/apps/api/exceptions.py
@@ -2,3 +2,7 @@ class InvalidFormatException(Exception):
 
     def __init__(self, expected_type):
         self.expected_type = expected_type
+
+
+class UnknownFieldException(Exception):
+    pass

--- a/corehq/apps/api/exceptions.py
+++ b/corehq/apps/api/exceptions.py
@@ -6,3 +6,9 @@ class InvalidFormatException(Exception):
 
 class UnknownFieldException(Exception):
     pass
+
+
+class UpdateConflictException(Exception):
+
+    def __init__(self, message):
+        self.message = message

--- a/corehq/apps/api/exceptions.py
+++ b/corehq/apps/api/exceptions.py
@@ -1,0 +1,4 @@
+class InvalidFormatException(Exception):
+
+    def __init__(self, expected_type):
+        self.expected_type = expected_type

--- a/corehq/apps/api/exceptions.py
+++ b/corehq/apps/api/exceptions.py
@@ -1,14 +1,14 @@
+class InvalidFieldException(Exception):
+
+    def __init__(self, field):
+        self.field = field
+
+
 class InvalidFormatException(Exception):
 
     def __init__(self, field, expected_type):
         self.field = field
         self.expected_type = expected_type
-
-
-class UnknownFieldException(Exception):
-
-    def __init__(self, field):
-        self.field = field
 
 
 class UpdateConflictException(Exception):

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -103,7 +103,7 @@ from . import (
     v0_4,
 )
 from .pagination import DoesNothingPaginator, NoCountingPaginator
-from ..exceptions import InvalidFormatException, UnknownFieldException, UpdateConflictException
+from ..exceptions import InvalidFormatException, InvalidFieldException, UpdateConflictException
 from ..user_updates import update
 
 MOCK_BULK_USER_ES = None
@@ -276,10 +276,10 @@ class CommCareUserResource(v0_1.CommCareUserResource):
         for key, value in bundle.data.items():
             try:
                 update(bundle.obj, key, value, user_change_logger)
+            except InvalidFieldException as e:
+                errors.append(_("Attempted to update unknown or non-editable field '{}'").format(e.field))
             except InvalidFormatException as e:
                 errors.append(_('{} must be a {}').format(e.field, e.expected_type))
-            except UnknownFieldException as e:
-                errors.append(_("Attempted to update unknown field '{}'").format(e.field))
             except (UpdateConflictException, ValidationError) as e:
                 errors.append(e.message)
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 
 from django.conf.urls import re_path as url
 from django.contrib.auth.models import User
-from django.forms import ValidationError
+from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponse, HttpResponseNotFound
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -18,7 +18,6 @@ from tastypie.http import HttpForbidden, HttpUnauthorized
 from tastypie.resources import ModelResource, Resource, convert_post_to_patch
 from tastypie.utils import dict_strip_unicode_keys
 
-from dimagi.utils.couch.bulk import get_docs
 from phonelog.models import DeviceReportEntry
 
 from corehq import privileges, toggles
@@ -43,7 +42,6 @@ from corehq.apps.api.resources.meta import CustomResourceMeta
 from corehq.apps.api.resources.serializers import ListToSingleObjectSerializer
 from corehq.apps.api.util import get_obj
 from corehq.apps.app_manager.models import Application
-from corehq.apps.domain.forms import clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import UserES
 from corehq.apps.export.esaccessors import (
@@ -60,8 +58,6 @@ from corehq.apps.reports.standard.cases.utils import (
     query_location_restricted_cases,
     query_location_restricted_forms,
 )
-from corehq.apps.sms.util import strip_plus
-from corehq.apps.user_importer.helpers import find_differences_in_list
 from corehq.apps.userreports.columns import UCRExpandDatabaseSubcolumn
 from corehq.apps.userreports.dbaccessors import get_datasources_for_domain
 from corehq.apps.userreports.exceptions import BadSpecError
@@ -82,7 +78,6 @@ from corehq.apps.userreports.util import (
     get_configurable_and_static_reports,
     get_report_config_or_not_found,
 )
-from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.dbaccessors import (
     get_all_user_id_username_pairs_by_domain,
 )
@@ -108,6 +103,8 @@ from . import (
     v0_4,
 )
 from .pagination import DoesNothingPaginator, NoCountingPaginator
+from ..exceptions import InvalidFormatException, UnknownFieldException
+from ..user_updates import update
 
 MOCK_BULK_USER_ES = None
 
@@ -200,7 +197,6 @@ class BulkUserResource(HqBaseResource, DomainSpecificResourceMixin):
 
 
 class CommCareUserResource(v0_1.CommCareUserResource):
-    immutable_fields = ['id', 'username']
 
     class Meta(v0_1.CommCareUserResource.Meta):
         detail_allowed_methods = ['get', 'put', 'delete']
@@ -278,100 +274,14 @@ class CommCareUserResource(v0_1.CommCareUserResource):
     def _update(cls, bundle, user_change_logger=None):
         errors = []
         for key, value in bundle.data.items():
-            if key in cls.immutable_fields:
-                errors.append(_('Cannot update a mobile user\'s {}.').format(key))
-                continue
-            if getattr(bundle.obj, key, None) != value:
-                if key == 'phone_numbers':
-                    old_phone_numbers = set(bundle.obj.phone_numbers)
-                    new_phone_numbers = set()
-                    bundle.obj.phone_numbers = []
-                    for idx, phone_number in enumerate(bundle.data.get('phone_numbers', [])):
-                        formatted_phone_number = strip_plus(phone_number)
-                        new_phone_numbers.add(formatted_phone_number)
-                        bundle.obj.add_phone_number(formatted_phone_number)
-                        if idx == 0:
-                            bundle.obj.set_default_phone_number(formatted_phone_number)
-
-                    if user_change_logger:
-                        (numbers_added, numbers_removed) = find_differences_in_list(
-                            target=list(new_phone_numbers),
-                            source=list(old_phone_numbers)
-                        )
-
-                        change_messages = {}
-                        if numbers_removed:
-                            change_messages.update(
-                                UserChangeMessage.phone_numbers_removed(list(numbers_removed))["phone_numbers"]
-                            )
-
-                        if numbers_added:
-                            change_messages.update(
-                                UserChangeMessage.phone_numbers_added(list(numbers_added))["phone_numbers"]
-                            )
-
-                        if change_messages:
-                            user_change_logger.add_change_message({'phone_numbers': change_messages})
-                elif key == 'default_phone_number':
-                    old_phone_numbers = set(bundle.obj.phone_numbers)
-                    phone_number = bundle.data.get('default_phone_number')
-                    if not isinstance(phone_number, str):
-                        errors.append(_('{} must be a string.'.format(key)))
-                        continue
-                    formatted_phone_number = strip_plus(phone_number)
-                    bundle.obj.set_default_phone_number(formatted_phone_number)
-
-                    if user_change_logger:
-                        (numbers_added, numbers_removed) = find_differences_in_list(
-                            target=list(phone_number),
-                            source=list(old_phone_numbers)
-                        )
-
-                        change_messages = {}
-                        if numbers_added:
-                            change_messages.update(
-                                UserChangeMessage.phone_numbers_added(list(numbers_added))["phone_numbers"]
-                            )
-                            user_change_logger.add_change_message({'phone_numbers': change_messages})
-
-                elif key == 'groups':
-                    group_ids = bundle.data.get("groups", [])
-                    groups_updated = bundle.obj.set_groups(group_ids)
-                    if user_change_logger and groups_updated:
-                        groups = []
-                        if group_ids:
-                            groups = [Group.wrap(doc) for doc in get_docs(Group.get_db(), group_ids)]
-                        user_change_logger.add_info(UserChangeMessage.groups_info(groups))
-                elif key == 'email':
-                    lowercase_value = value.lower()
-                    if user_change_logger and getattr(bundle.obj, key) != lowercase_value:
-                        user_change_logger.add_changes({key: lowercase_value})
-                    setattr(bundle.obj, key, lowercase_value)
-                elif key == 'password':
-                    domain = Domain.get_by_name(bundle.obj.domain)
-                    if domain.strong_mobile_passwords:
-                        try:
-                            clean_password(bundle.data.get("password"))
-                        except ValidationError as e:
-                            errors.append(e.message)
-                    bundle.obj.set_password(bundle.data.get("password"))
-                    if user_change_logger:
-                        user_change_logger.add_change_message(UserChangeMessage.password_reset())
-                elif key == 'user_data':
-                    try:
-                        original_user_data = bundle.obj.metadata.copy()
-                        bundle.obj.update_metadata(value)
-                        # check changes post update to account for any changes in update_metadata
-                        if user_change_logger and original_user_data != bundle.obj.user_data:
-                            user_change_logger.add_changes({'user_data': bundle.obj.user_data})
-                    except ValueError as e:
-                        raise BadRequest(str(e))
-                elif key in ['first_name', 'last_name', 'language']:
-                    if user_change_logger and getattr(bundle.obj, key) != value:
-                        user_change_logger.add_changes({key: value})
-                    setattr(bundle.obj, key, value)
-                else:
-                    errors.append(_('Attempted to update unknown field {}.').format(key))
+            try:
+                update(bundle.obj, key, value, user_change_logger)
+            except InvalidFormatException as e:
+                errors.append(_('{} must be a {}.'.format(key, e.expected_type)))
+            except UnknownFieldException:
+                errors.append(_('Attempted to update unknown field {}.').format(key))
+            except ValidationError as e:
+                errors.append(e.message)
 
         return errors
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -103,7 +103,7 @@ from . import (
     v0_4,
 )
 from .pagination import DoesNothingPaginator, NoCountingPaginator
-from ..exceptions import InvalidFormatException, UnknownFieldException
+from ..exceptions import InvalidFormatException, UnknownFieldException, UpdateConflictException
 from ..user_updates import update
 
 MOCK_BULK_USER_ES = None
@@ -280,7 +280,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
                 errors.append(_('{} must be a {}.'.format(key, e.expected_type)))
             except UnknownFieldException:
                 errors.append(_("Attempted to update unknown field '{}'.").format(key))
-            except ValidationError as e:
+            except (UpdateConflictException, ValidationError) as e:
                 errors.append(e.message)
 
         return errors

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -256,7 +256,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
         user_change_logger = self._get_user_change_logger(bundle)
         errors = self._update(bundle, user_change_logger)
         if errors:
-            formatted_errors = ' '.join(errors)
+            formatted_errors = ', '.join(errors)
             raise BadRequest(_('The request resulted in the following errors: {}').format(formatted_errors))
         assert bundle.obj.domain == kwargs['domain']
         bundle.obj.save()
@@ -277,9 +277,9 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             try:
                 update(bundle.obj, key, value, user_change_logger)
             except InvalidFormatException as e:
-                errors.append(_('{} must be a {}.'.format(key, e.expected_type)))
+                errors.append(_('{} must be a {}'.format(key, e.expected_type)))
             except UnknownFieldException:
-                errors.append(_("Attempted to update unknown field '{}'.").format(key))
+                errors.append(_("Attempted to update unknown field '{}'").format(key))
             except (UpdateConflictException, ValidationError) as e:
                 errors.append(e.message)
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -277,9 +277,9 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             try:
                 update(bundle.obj, key, value, user_change_logger)
             except InvalidFormatException as e:
-                errors.append(_('{} must be a {}'.format(key, e.expected_type)))
-            except UnknownFieldException:
-                errors.append(_("Attempted to update unknown field '{}'").format(key))
+                errors.append(_('{} must be a {}').format(e.field, e.expected_type))
+            except UnknownFieldException as e:
+                errors.append(_("Attempted to update unknown field '{}'").format(e.field))
             except (UpdateConflictException, ValidationError) as e:
                 errors.append(e.message)
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -279,7 +279,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             except InvalidFormatException as e:
                 errors.append(_('{} must be a {}.'.format(key, e.expected_type)))
             except UnknownFieldException:
-                errors.append(_('Attempted to update unknown field {}.').format(key))
+                errors.append(_("Attempted to update unknown field '{}'.").format(key))
             except ValidationError as e:
                 errors.append(e.message)
 

--- a/corehq/apps/api/tests/test_user_updates.py
+++ b/corehq/apps/api/tests/test_user_updates.py
@@ -1,7 +1,10 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from corehq.apps.api.exceptions import InvalidFormatException
+from corehq.apps.api.exceptions import (
+    InvalidFormatException,
+    UnknownFieldException,
+)
 from corehq.apps.api.user_updates import update
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.groups.models import Group
@@ -109,6 +112,10 @@ class TestUpdateUserMethods(TestCase):
         self.addCleanup(group.delete)
         update(self.user, 'groups', [group._id])
         self.assertEqual(self.user.get_group_ids()[0], group._id)
+
+    def test_update_unknown_field_raises_exception(self):
+        with self.assertRaises(UnknownFieldException):
+            update(self.user, 'username', 'new-username')
 
 
 class TestUpdateUserMethodsLogChanges(TestCase):

--- a/corehq/apps/api/tests/test_user_updates.py
+++ b/corehq/apps/api/tests/test_user_updates.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 
 from corehq.apps.api.exceptions import (
     InvalidFormatException,
-    UnknownFieldException,
+    InvalidFieldException,
     UpdateConflictException,
 )
 from corehq.apps.api.user_updates import update
@@ -127,7 +127,7 @@ class TestUpdateUserMethods(TestCase):
         self.assertEqual(self.user.get_group_ids()[0], group._id)
 
     def test_update_unknown_field_raises_exception(self):
-        with self.assertRaises(UnknownFieldException):
+        with self.assertRaises(InvalidFieldException):
             update(self.user, 'username', 'new-username')
 
     def _setup_profile(self):

--- a/corehq/apps/api/tests/test_user_updates.py
+++ b/corehq/apps/api/tests/test_user_updates.py
@@ -1,0 +1,237 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from corehq.apps.api.exceptions import InvalidFormatException
+from corehq.apps.api.user_updates import update
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.groups.models import Group
+from corehq.apps.user_importer.helpers import UserChangeLogger
+from corehq.apps.users.audit.change_messages import (
+    GROUPS_FIELD,
+    PASSWORD_FIELD,
+)
+from corehq.apps.users.models import CommCareUser
+from corehq.const import USER_CHANGE_VIA_API
+
+
+class TestUpdateUserMethods(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-domain'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = CommCareUser.create('test-domain', 'test-username', 'qwer1234', None, None)
+        self.addCleanup(self.user.delete, self.domain, deleted_by=None)
+
+    def test_update_password_without_strong_passwords_succeeds(self):
+        self.domain_obj.strong_mobile_passwords = False
+        self.domain_obj.save()
+
+        try:
+            update(self.user, 'password', 'abc123')
+        except ValidationError:
+            self.fail('Unexpected ValidationError raised.')
+
+    def test_update_password_with_strong_passwords_raises_exception(self):
+        self.domain_obj.strong_mobile_passwords = True
+        self.domain_obj.save()
+
+        with self.assertRaises(ValidationError):
+            update(self.user, 'password', 'abc123')
+
+    def test_update_password_with_strong_passwords_succeeds(self):
+        self.domain_obj.strong_mobile_passwords = True
+        self.domain_obj.save()
+
+        try:
+            update(self.user, 'password', 'a7d8fhjkdf8d')
+        except ValidationError:
+            self.fail('Unexpected ValidationError raised.')
+
+    def test_update_email_succeeds(self):
+        self.user.email = 'initial@dimagi.com'
+        update(self.user, 'email', 'updated@dimagi.com')
+        self.assertEqual(self.user.email, 'updated@dimagi.com')
+
+    def test_update_first_name_succeeds(self):
+        self.user.first_name = 'Initial'
+        update(self.user, 'first_name', 'Updated')
+        self.assertEqual(self.user.first_name, 'Updated')
+
+    def test_update_last_name_succeeds(self):
+        self.user.last_name = 'Initial'
+        update(self.user, 'last_name', 'Updated')
+        self.assertEqual(self.user.last_name, 'Updated')
+
+    def test_update_language_succeeds(self):
+        self.user.language = 'in'
+        update(self.user, 'language', 'up')
+        self.assertEqual(self.user.language, 'up')
+
+    def test_update_default_phone_number_succeeds(self):
+        self.user.set_default_phone_number('50253311398')
+        update(self.user, 'default_phone_number', '50253311399')
+        self.assertEqual(self.user.default_phone_number, '50253311399')
+
+    def test_update_default_phone_number_preserves_previous_number(self):
+        self.user.set_default_phone_number('50253311398')
+        update(self.user, 'default_phone_number', '50253311399')
+        self.assertIn('50253311398', self.user.phone_numbers)
+
+    def test_update_default_phone_number_raises_exception_if_not_string(self):
+        self.user.set_default_phone_number('50253311398')
+        with self.assertRaises(InvalidFormatException):
+            update(self.user, 'default_phone_number', 50253311399)
+
+    def test_update_phone_numbers_succeeds(self):
+        self.user.phone_numbers = ['50253311398']
+        update(self.user, 'phone_numbers', ['50253311399', '50253311398'])
+        self.assertEqual(self.user.phone_numbers, ['50253311399', '50253311398'])
+
+    def test_update_phone_numbers_updates_default(self):
+        self.user.set_default_phone_number('50253311398')
+        update(self.user, 'phone_numbers', ['50253311399', '50253311398'])
+        self.assertEqual(self.user.default_phone_number, '50253311399')
+
+    def test_update_user_data_succeeds(self):
+        self.user.update_metadata({'custom_data': "initial custom data"})
+        update(self.user, 'user_data', {'custom_data': 'updated custom data'})
+        self.assertEqual(self.user.metadata["custom_data"], "updated custom data")
+
+    def test_update_groups_succeeds(self):
+        group = Group({"name": "test"})
+        group.save()
+        self.addCleanup(group.delete)
+        update(self.user, 'groups', [group._id])
+        self.assertEqual(self.user.get_group_ids()[0], group._id)
+
+
+class TestUpdateUserMethodsLogChanges(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-domain'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = CommCareUser.create('test-domain', 'test-username', 'qwer1234', None, None)
+        self.addCleanup(self.user.delete, self.domain, deleted_by=None)
+
+        self.user_change_logger = UserChangeLogger(
+            upload_domain=self.domain,
+            user_domain=self.domain,
+            user=self.user,
+            is_new_user=False,
+            changed_by_user=self.user,
+            changed_via=USER_CHANGE_VIA_API,
+            upload_record_id=None,
+            user_domain_required_for_log=True
+        )
+
+    def test_update_password_logs_change(self):
+        update(self.user, 'password', 'a7d8fhjkdf8d', user_change_logger=self.user_change_logger)
+        self.assertIn(PASSWORD_FIELD, self.user_change_logger.change_messages.keys())
+
+    def test_update_email_logs_change(self):
+        self.user.email = 'initial@dimagi.com'
+        update(self.user, 'email', 'updated@dimagi.com', user_change_logger=self.user_change_logger)
+        self.assertIn('email', self.user_change_logger.fields_changed.keys())
+
+    def test_update_email_with_no_change_does_not_log_change(self):
+        self.user.email = 'unchanged@dimagi.com'
+        update(self.user, 'email', 'unchanged@dimagi.com', user_change_logger=self.user_change_logger)
+        self.assertNotIn('email', self.user_change_logger.fields_changed.keys())
+
+    def test_update_first_name_logs_change(self):
+        self.user.first_name = 'Initial'
+        self.user.save()
+        update(self.user, 'first_name', 'Updated', user_change_logger=self.user_change_logger)
+        self.assertIn('first_name', self.user_change_logger.fields_changed.keys())
+
+    def test_update_first_name_does_not_log_no_change(self):
+        self.user.first_name = 'Unchanged'
+        update(self.user, 'first_name', 'Unchanged', user_change_logger=self.user_change_logger)
+        self.assertNotIn('first_name', self.user_change_logger.fields_changed.keys())
+
+    def test_update_last_name_logs_change(self):
+        self.user.last_name = 'Initial'
+        update(self.user, 'last_name', 'Updated', user_change_logger=self.user_change_logger)
+        self.assertIn('last_name', self.user_change_logger.fields_changed.keys())
+
+    def test_update_last_name_does_not_log_no_change(self):
+        self.user.last_name = 'Unchanged'
+        update(self.user, 'last_name', 'Unchanged', user_change_logger=self.user_change_logger)
+        self.assertNotIn('last_name', self.user_change_logger.fields_changed.keys())
+
+    def test_update_language_logs_change(self):
+        self.user.language = 'in'
+        update(self.user, 'language', 'up', user_change_logger=self.user_change_logger)
+        self.assertIn('language', self.user_change_logger.fields_changed.keys())
+
+    def test_update_language_does_not_log_no_change(self):
+        self.user.language = 'un'
+        update(self.user, 'language', 'un', user_change_logger=self.user_change_logger)
+        self.assertNotIn('language', self.user_change_logger.fields_changed.keys())
+
+    def test_update_default_phone_number_logs_change(self):
+        self.user.set_default_phone_number('50253311398')
+        update(self.user, 'default_phone_number', '50253311399', user_change_logger=self.user_change_logger)
+        self.assertIn('phone_numbers', self.user_change_logger.change_messages.keys())
+
+    def test_update_default_phone_number_does_not_log_no_change(self):
+        self.user.set_default_phone_number('50253311399')
+        update(self.user, 'default_phone_number', '50253311399', user_change_logger=self.user_change_logger)
+        self.assertNotIn('phone_numbers', self.user_change_logger.change_messages.keys())
+
+    def test_update_phone_numbers_logs_changes(self):
+        self.user.phone_numbers = ['50253311398']
+        update(self.user, 'phone_numbers', ['50253311399'], user_change_logger=self.user_change_logger)
+        self.assertIn('phone_numbers', self.user_change_logger.change_messages.keys())
+
+    def test_update_phone_numbers_does_not_log_no_change(self):
+        self.user.phone_numbers = ['50253311399', '50253311398']
+
+        update(self.user,
+               'phone_numbers',
+               ['50253311399', '50253311398'],
+               user_change_logger=self.user_change_logger)
+
+        self.assertNotIn('phone_numbers', self.user_change_logger.change_messages.keys())
+
+    def test_update_user_data_logs_change(self):
+        self.user.update_metadata({'custom_data': "initial custom data"})
+
+        update(self.user,
+               'user_data',
+               {'custom_data': 'updated custom data'},
+               user_change_logger=self.user_change_logger)
+
+        self.assertIn('user_data', self.user_change_logger.fields_changed.keys())
+
+    def test_update_user_data_does_not_log_no_change(self):
+        self.user.update_metadata({'custom_data': "unchanged custom data"})
+        update(self.user, 'user_data', {'custom_data': 'unchanged custom data'})
+        self.assertNotIn('user_data', self.user_change_logger.fields_changed.keys())
+
+    def test_update_groups_logs_change(self):
+        group = Group({"name": "test"})
+        group.save()
+        self.addCleanup(group.delete)
+        update(self.user, 'groups', [group._id], user_change_logger=self.user_change_logger)
+        self.assertIn(GROUPS_FIELD, self.user_change_logger.change_messages.keys())
+
+    def test_update_groups_does_not_log_no_change(self):
+        group = Group({"name": "test"})
+        group.save()
+        self.user.set_groups([group._id])
+        self.addCleanup(group.delete)
+        update(self.user, 'groups', [group._id], user_change_logger=self.user_change_logger)
+        self.assertNotIn(GROUPS_FIELD, self.user_change_logger.change_messages.keys())

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -300,8 +300,8 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.content.decode('utf-8'),
-            '{"error": "The request resulted in the following errors: Attempted to update unknown field username. '
-            'default_phone_number must be a string."}'
+            "{\"error\": \"The request resulted in the following errors: Attempted to update unknown field "
+            "'username'. default_phone_number must be a string.\"}"
         )
 
 
@@ -563,7 +563,7 @@ class TestCommCareUserResourceUpdate(TestCase):
         bundle.data = {"id": 'updated-id'}
 
         errors = CommCareUserResource._update(bundle)
-        self.assertIn('Attempted to update unknown field id.', errors)
+        self.assertIn("Attempted to update unknown field 'id'.", errors)
 
     def test_update_password_with_weak_passwords_returns_error_if_strong_option_on(self):
         self.domain_obj.strong_mobile_passwords = True

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -272,8 +272,8 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.content.decode('utf-8'),
-            "{\"error\": \"The request resulted in the following errors: Attempted to update unknown field "
-            "'username', default_phone_number must be a string\"}"
+            "{\"error\": \"The request resulted in the following errors: Attempted to update unknown or "
+            "non-editable field 'username', default_phone_number must be a string\"}"
         )
 
 
@@ -553,7 +553,7 @@ class TestCommCareUserResourceUpdate(TestCase):
         bundle.data = {"id": 'updated-id'}
 
         errors = CommCareUserResource._update(bundle)
-        self.assertIn("Attempted to update unknown field 'id'", errors)
+        self.assertIn("Attempted to update unknown or non-editable field 'id'", errors)
 
     def test_update_password_with_weak_passwords_returns_error_if_strong_option_on(self):
         self.domain_obj.strong_mobile_passwords = True

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -273,7 +273,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(
             response.content.decode('utf-8'),
             "{\"error\": \"The request resulted in the following errors: Attempted to update unknown field "
-            "'username'. default_phone_number must be a string.\"}"
+            "'username', default_phone_number must be a string\"}"
         )
 
 
@@ -553,7 +553,7 @@ class TestCommCareUserResourceUpdate(TestCase):
         bundle.data = {"id": 'updated-id'}
 
         errors = CommCareUserResource._update(bundle)
-        self.assertIn("Attempted to update unknown field 'id'.", errors)
+        self.assertIn("Attempted to update unknown field 'id'", errors)
 
     def test_update_password_with_weak_passwords_returns_error_if_strong_option_on(self):
         self.domain_obj.strong_mobile_passwords = True
@@ -575,7 +575,7 @@ class TestCommCareUserResourceUpdate(TestCase):
 
         errors = CommCareUserResource._update(bundle)
 
-        self.assertIn('default_phone_number must be a string.', errors)
+        self.assertIn('default_phone_number must be a string', errors)
 
     def test_update_user_data_returns_error_if_profile_conflict(self):
         bundle = Bundle()

--- a/corehq/apps/api/user_updates.py
+++ b/corehq/apps/api/user_updates.py
@@ -35,7 +35,7 @@ def update(user, field, value, user_change_logger=None):
     }.get(field)
 
     if not update_fn:
-        raise UnknownFieldException
+        raise UnknownFieldException(field)
 
     update_fn(user, value, user_change_logger)
 
@@ -70,7 +70,7 @@ def _update_default_phone_number(user, phone_number, user_change_logger):
     old_phone_numbers = set(user.phone_numbers)
     new_phone_numbers = set(user.phone_numbers)
     if not isinstance(phone_number, str):
-        raise InvalidFormatException('string')
+        raise InvalidFormatException('default_phone_number', 'string')
     formatted_phone_number = strip_plus(phone_number)
     new_phone_numbers.add(formatted_phone_number)
     user.set_default_phone_number(formatted_phone_number)

--- a/corehq/apps/api/user_updates.py
+++ b/corehq/apps/api/user_updates.py
@@ -1,6 +1,9 @@
 from dimagi.utils.couch.bulk import get_docs
 
-from corehq.apps.api.exceptions import InvalidFormatException
+from corehq.apps.api.exceptions import (
+    InvalidFormatException,
+    UnknownFieldException,
+)
 from corehq.apps.domain.forms import clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.groups.models import Group
@@ -29,6 +32,9 @@ def update(user, field, value, user_change_logger=None):
         'phone_numbers': _update_phone_numbers,
         'user_data': _update_user_data,
     }.get(field)
+
+    if not update_fn:
+        raise UnknownFieldException
 
     update_fn(user, value, user_change_logger)
 

--- a/corehq/apps/api/user_updates.py
+++ b/corehq/apps/api/user_updates.py
@@ -115,9 +115,10 @@ def _update_user_data(user, user_data, user_change_logger):
 
 
 def _simple_update(user, key, value, user_change_logger):
-    if user_change_logger and getattr(user, key) != value:
-        user_change_logger.add_changes({key: value})
-    setattr(user, key, value)
+    if getattr(user, key) != value:
+        setattr(user, key, value)
+        if user_change_logger:
+            user_change_logger.add_changes({key: value})
 
 
 def _log_phone_number_change(new_phone_numbers, old_phone_numbers, user_change_logger):

--- a/corehq/apps/api/user_updates.py
+++ b/corehq/apps/api/user_updates.py
@@ -2,7 +2,7 @@ from dimagi.utils.couch.bulk import get_docs
 
 from corehq.apps.api.exceptions import (
     InvalidFormatException,
-    UnknownFieldException,
+    InvalidFieldException,
     UpdateConflictException,
 )
 from corehq.apps.domain.forms import clean_password
@@ -35,7 +35,7 @@ def update(user, field, value, user_change_logger=None):
     }.get(field)
 
     if not update_fn:
-        raise UnknownFieldException(field)
+        raise InvalidFieldException(field)
 
     update_fn(user, value, user_change_logger)
 

--- a/corehq/apps/api/user_updates.py
+++ b/corehq/apps/api/user_updates.py
@@ -67,23 +67,15 @@ def _update_password(user, password, user_change_logger):
 
 def _update_default_phone_number(user, phone_number, user_change_logger):
     old_phone_numbers = set(user.phone_numbers)
+    new_phone_numbers = set(user.phone_numbers)
     if not isinstance(phone_number, str):
         raise InvalidFormatException('string')
     formatted_phone_number = strip_plus(phone_number)
+    new_phone_numbers.add(formatted_phone_number)
     user.set_default_phone_number(formatted_phone_number)
 
     if user_change_logger:
-        numbers_added, numbers_removed = find_differences_in_list(
-            target=[phone_number],
-            source=list(old_phone_numbers)
-        )
-
-        change_messages = {}
-        if numbers_added:
-            change_messages.update(
-                UserChangeMessage.phone_numbers_added(list(numbers_added))["phone_numbers"]
-            )
-            user_change_logger.add_change_message({'phone_numbers': change_messages})
+        _log_phone_number_change(new_phone_numbers, old_phone_numbers, user_change_logger)
 
 
 def _update_phone_numbers(user, phone_numbers, user_change_logger):
@@ -98,24 +90,7 @@ def _update_phone_numbers(user, phone_numbers, user_change_logger):
             user.set_default_phone_number(formatted_phone_number)
 
     if user_change_logger:
-        (numbers_added, numbers_removed) = find_differences_in_list(
-            target=list(new_phone_numbers),
-            source=list(old_phone_numbers)
-        )
-
-        change_messages = {}
-        if numbers_removed:
-            change_messages.update(
-                UserChangeMessage.phone_numbers_removed(list(numbers_removed))["phone_numbers"]
-            )
-
-        if numbers_added:
-            change_messages.update(
-                UserChangeMessage.phone_numbers_added(list(numbers_added))["phone_numbers"]
-            )
-
-        if change_messages:
-            user_change_logger.add_change_message({'phone_numbers': change_messages})
+        _log_phone_number_change(new_phone_numbers, old_phone_numbers, user_change_logger)
 
 
 def _update_groups(user, group_ids, user_change_logger):
@@ -139,3 +114,24 @@ def _simple_update(user, key, value, user_change_logger):
     if user_change_logger and getattr(user, key) != value:
         user_change_logger.add_changes({key: value})
     setattr(user, key, value)
+
+
+def _log_phone_number_change(new_phone_numbers, old_phone_numbers, user_change_logger):
+    numbers_added, numbers_removed = find_differences_in_list(
+        target=list(new_phone_numbers),
+        source=list(old_phone_numbers)
+    )
+
+    change_messages = {}
+    if numbers_removed:
+        change_messages.update(
+            UserChangeMessage.phone_numbers_removed(list(numbers_removed))["phone_numbers"]
+        )
+
+    if numbers_added:
+        change_messages.update(
+            UserChangeMessage.phone_numbers_added(list(numbers_added))["phone_numbers"]
+        )
+
+    if change_messages:
+        user_change_logger.add_change_message({'phone_numbers': change_messages})

--- a/corehq/apps/api/user_updates.py
+++ b/corehq/apps/api/user_updates.py
@@ -1,0 +1,135 @@
+from dimagi.utils.couch.bulk import get_docs
+
+from corehq.apps.api.exceptions import InvalidFormatException
+from corehq.apps.domain.forms import clean_password
+from corehq.apps.domain.models import Domain
+from corehq.apps.groups.models import Group
+from corehq.apps.sms.util import strip_plus
+from corehq.apps.user_importer.helpers import find_differences_in_list
+from corehq.apps.users.audit.change_messages import UserChangeMessage
+
+
+def update(user, field, value, user_change_logger=None):
+    """
+    Used to update user fields via the API
+    Raises exceptions if errors are encountered, otherwise the update is successful
+    :param user: CommCareUser object
+    :param field: the attribute on the user to update
+    :param value: the value to update the attribute to
+    :param user_change_logger: optional UserChangeLogger obj to log changes
+    """
+    update_fn = {
+        'default_phone_number': _update_default_phone_number,
+        'email': _update_email,
+        'first_name': _update_first_name,
+        'groups': _update_groups,
+        'language': _update_language,
+        'last_name': _update_last_name,
+        'password': _update_password,
+        'phone_numbers': _update_phone_numbers,
+        'user_data': _update_user_data,
+    }.get(field)
+
+    update_fn(user, value, user_change_logger)
+
+
+def _update_email(user, email, user_change_logger):
+    _simple_update(user, 'email', email.lower(), user_change_logger)
+
+
+def _update_first_name(user, first_name, user_change_logger):
+    _simple_update(user, 'first_name', first_name, user_change_logger)
+
+
+def _update_last_name(user, last_name, user_change_logger):
+    _simple_update(user, 'last_name', last_name, user_change_logger)
+
+
+def _update_language(user, language, user_change_logger):
+    _simple_update(user, 'language', language, user_change_logger)
+
+
+def _update_password(user, password, user_change_logger):
+    domain = Domain.get_by_name(user.domain)
+    if domain.strong_mobile_passwords:
+        clean_password(password)
+    user.set_password(password)
+
+    if user_change_logger:
+        user_change_logger.add_change_message(UserChangeMessage.password_reset())
+
+
+def _update_default_phone_number(user, phone_number, user_change_logger):
+    old_phone_numbers = set(user.phone_numbers)
+    if not isinstance(phone_number, str):
+        raise InvalidFormatException('string')
+    formatted_phone_number = strip_plus(phone_number)
+    user.set_default_phone_number(formatted_phone_number)
+
+    if user_change_logger:
+        numbers_added, numbers_removed = find_differences_in_list(
+            target=[phone_number],
+            source=list(old_phone_numbers)
+        )
+
+        change_messages = {}
+        if numbers_added:
+            change_messages.update(
+                UserChangeMessage.phone_numbers_added(list(numbers_added))["phone_numbers"]
+            )
+            user_change_logger.add_change_message({'phone_numbers': change_messages})
+
+
+def _update_phone_numbers(user, phone_numbers, user_change_logger):
+    old_phone_numbers = set(user.phone_numbers)
+    new_phone_numbers = set()
+    user.phone_numbers = []
+    for idx, phone_number in enumerate(phone_numbers):
+        formatted_phone_number = strip_plus(phone_number)
+        new_phone_numbers.add(formatted_phone_number)
+        user.add_phone_number(formatted_phone_number)
+        if idx == 0:
+            user.set_default_phone_number(formatted_phone_number)
+
+    if user_change_logger:
+        (numbers_added, numbers_removed) = find_differences_in_list(
+            target=list(new_phone_numbers),
+            source=list(old_phone_numbers)
+        )
+
+        change_messages = {}
+        if numbers_removed:
+            change_messages.update(
+                UserChangeMessage.phone_numbers_removed(list(numbers_removed))["phone_numbers"]
+            )
+
+        if numbers_added:
+            change_messages.update(
+                UserChangeMessage.phone_numbers_added(list(numbers_added))["phone_numbers"]
+            )
+
+        if change_messages:
+            user_change_logger.add_change_message({'phone_numbers': change_messages})
+
+
+def _update_groups(user, group_ids, user_change_logger):
+    groups_updated = user.set_groups(group_ids)
+    if user_change_logger and groups_updated:
+        groups = []
+        if group_ids:
+            groups = [Group.wrap(doc) for doc in get_docs(Group.get_db(), group_ids)]
+        user_change_logger.add_info(UserChangeMessage.groups_info(groups))
+
+
+def _update_user_data(user, user_data, user_change_logger):
+    original_user_data = user.metadata.copy()
+    user.update_metadata(user_data)
+
+    if user_change_logger and original_user_data != user.user_data:
+        user_change_logger.add_changes({'user_data': user.user_data})
+
+
+def _simple_update(user, key, value, user_change_logger):
+    if user_change_logger and getattr(user, key) != value:
+        user_change_logger.add_changes({key: value})
+    setattr(user, key, value)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup to [this comment](https://github.com/dimagi/commcare-hq/pull/31529#pullrequestreview-951983194). The `_update` method was already too large and needed to be cut down a bit, so this handles that refactor.

Review commit by commit.

Rather than have the `immutable_fields` list that we would also have to maintain, it seems easy enough to combine unknown fields with immutable fields, which makes it easy to raise an error when encountered. See d8c8dd2207b4c5898f7b764984d56a6e766153c2.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tests. Lots of code remained the same. Tested on staging.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests for each field that is eligible to be updated.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
