### PR TITLE
Refactor access methods for linked domains feature

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -18,7 +18,7 @@ from .dbaccessors import get_all_built_app_ids_and_versions
 from .models import LATEST_APK_VALUE, LATEST_APP_VALUE
 from .util import get_commcare_builds
 from ..hqwebapp.widgets import BootstrapCheckboxInput
-from ..linked_domain.util import can_domain_access_release_management
+from ..linked_domain.util import can_domain_access_linked_domains
 
 
 class CopyApplicationForm(forms.Form):
@@ -57,7 +57,7 @@ class CopyApplicationForm(forms.Form):
         self.from_domain = from_domain
         if app:
             self.fields['name'].initial = app.name
-        if can_domain_access_release_management(self.from_domain) and not is_linked_app(app):
+        if can_domain_access_linked_domains(self.from_domain) and not is_linked_app(app):
             fields.append(PrependedText('linked', ''))
 
         self.helper = FormHelper()
@@ -84,7 +84,7 @@ class CopyApplicationForm(forms.Form):
     def clean(self):
         domain = self.cleaned_data.get('domain')
         if self.cleaned_data.get('linked'):
-            if not can_domain_access_release_management(domain):
+            if not can_domain_access_linked_domains(domain):
                 raise forms.ValidationError("The target project space does not have this feature enabled.")
             link = DomainLink.objects.filter(linked_domain=domain)
             if link and link[0].master_domain != self.from_domain:

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -48,7 +48,7 @@ from corehq.apps.linked_domain.dbaccessors import (
     get_upstream_domain_link,
     is_active_downstream_domain,
 )
-from corehq.apps.linked_domain.util import can_domain_access_release_management
+from corehq.apps.linked_domain.util import can_domain_access_linked_domains
 from corehq.util.soft_assert import soft_assert
 
 
@@ -274,7 +274,7 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
     # NOTE: The CopyApplicationForm checks for access to linked domains before displaying
     linkable_domains = []
     limit_to_linked_domains = True
-    if can_domain_access_release_management(request.domain):
+    if can_domain_access_linked_domains(request.domain):
         linkable_domains = get_accessible_downstream_domains(domain, request.couch_user)
         limit_to_linked_domains = not request.couch_user.is_superuser
     context.update({

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -7,7 +7,7 @@ from corehq.apps.linked_domain.util import (
     is_available_upstream_domain,
     is_domain_available_to_link,
     user_has_admin_access_in_all_domains,
-    can_domain_access_release_management,
+    can_domain_access_linked_domains,
 )
 from corehq.privileges import RELEASE_MANAGEMENT, LITE_RELEASE_MANAGEMENT
 from corehq.util.quickcache import quickcache
@@ -102,7 +102,7 @@ def get_accessible_downstream_domains(upstream_domain_name, user):
     NOTE: if the RELEASE_MANAGEMENT privilege is enabled, ensure user has admin access
     """
     downstream_domains = [d.linked_domain for d in get_linked_domains(upstream_domain_name)]
-    if can_domain_access_release_management(upstream_domain_name):
+    if can_domain_access_linked_domains(upstream_domain_name):
         return [domain for domain in downstream_domains
                 if user_has_admin_access_in_all_domains(user, [upstream_domain_name, domain])]
     return downstream_domains

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -3,7 +3,7 @@ from functools import wraps
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, Http404
 
 from corehq.apps.linked_domain.dbaccessors import get_upstream_domain_link
-from corehq.apps.linked_domain.util import can_user_access_release_management
+from corehq.apps.linked_domain.util import can_user_access_linked_domains
 
 REMOTE_REQUESTER_HEADER = 'HTTP_HQ_REMOTE_REQUESTER'
 
@@ -18,7 +18,7 @@ def require_access_to_linked_domains(view_func):
 
         def call_view():
             return view_func(request, domain, *args, **kwargs)
-        if can_user_access_release_management(couch_user, domain):
+        if can_user_access_linked_domains(couch_user, domain):
             return call_view()
         else:
             return HttpResponseForbidden()

--- a/corehq/apps/linked_domain/tests/test_decorators.py
+++ b/corehq/apps/linked_domain/tests/test_decorators.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from corehq.apps.linked_domain.util import can_user_access_linked_domains, can_domain_access_release_management
+from corehq.apps.linked_domain.util import can_user_access_linked_domains, can_domain_access_linked_domains
 from corehq.privileges import LITE_RELEASE_MANAGEMENT, RELEASE_MANAGEMENT
 
 
@@ -61,10 +61,10 @@ class TestCanUserAccessLinkedDomains(SimpleTestCase):
         self.assertTrue(result)
 
 
-class TestCanDomainAccessReleaseManagement(SimpleTestCase):
+class TestCanDomainAccessLinkedDomains(SimpleTestCase):
 
     def test_returns_false_if_no_domain(self):
-        result = can_domain_access_release_management(None)
+        result = can_domain_access_linked_domains(None)
         self.assertFalse(result)
 
     def test_returns_true_if_domain_has_release_management_privilege(self):
@@ -73,14 +73,14 @@ class TestCanDomainAccessReleaseManagement(SimpleTestCase):
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.side_effect = mock_handler
-            result = can_domain_access_release_management('test')
+            result = can_domain_access_linked_domains('test')
 
         self.assertTrue(result)
 
     def test_returns_false_if_domain_does_not_have_release_management_privilege(self):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
-            result = can_domain_access_release_management('test')
+            result = can_domain_access_linked_domains('test')
 
         self.assertFalse(result)
 
@@ -91,7 +91,7 @@ class TestCanDomainAccessReleaseManagement(SimpleTestCase):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.side_effect = mock_handler
             # include_lite_version is True by default
-            result = can_domain_access_release_management('test')
+            result = can_domain_access_linked_domains('test')
 
         self.assertTrue(result)
 
@@ -99,7 +99,7 @@ class TestCanDomainAccessReleaseManagement(SimpleTestCase):
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = False
             # include_lite_version is True by default
-            result = can_domain_access_release_management('test')
+            result = can_domain_access_linked_domains('test')
 
         self.assertFalse(result)
 
@@ -108,6 +108,6 @@ class TestCanDomainAccessReleaseManagement(SimpleTestCase):
             return privilege == LITE_RELEASE_MANAGEMENT
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.side_effect = mock_handler
-            result = can_domain_access_release_management('test', include_lite_version=False)
+            result = can_domain_access_linked_domains('test', include_lite_version=False)
 
         self.assertFalse(result)

--- a/corehq/apps/linked_domain/tests/test_decorators.py
+++ b/corehq/apps/linked_domain/tests/test_decorators.py
@@ -2,47 +2,53 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from corehq.apps.linked_domain.util import can_user_access_release_management, can_domain_access_release_management
+from corehq.apps.linked_domain.util import can_user_access_linked_domains, can_domain_access_release_management
 from corehq.privileges import LITE_RELEASE_MANAGEMENT, RELEASE_MANAGEMENT
 
 
-class TestCanUserAccessReleaseManagement(SimpleTestCase):
+class TestCanUserAccessLinkedDomains(SimpleTestCase):
 
     def test_returns_false_if_no_user(self):
-        result = can_user_access_release_management(None, 'test')
+        result = can_user_access_linked_domains(None, 'test')
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_returns_false_if_no_domain(self, mock_user):
-        result = can_user_access_release_management(mock_user, None)
+        result = can_user_access_linked_domains(mock_user, None)
         self.assertFalse(result)
 
     def test_returns_false_if_no_user_and_no_domain(self):
-        result = can_user_access_release_management(None, None)
+        result = can_user_access_linked_domains(None, None)
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
-    def test_returns_false_if_domain_has_privilege_but_user_is_not_admin(self, mock_user):
+    def test_returns_false_if_has_privilege_but_is_not_admin(self, mock_user):
+        """
+        Regardless of privilege, if not admin, this method should always return false
+        """
         mock_user.is_domain_admin.return_value = False
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.return_value = True
-            result = can_user_access_release_management(mock_user, 'test')
+            result = can_user_access_linked_domains(mock_user, 'test')
 
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
-    def test_returns_true_if_domain_has_privilege_and_user_is_admin(self, mock_user):
+    def test_returns_true_if_has_release_management_and_is_admin(self, mock_user):
         mock_user.is_domain_admin.return_value = True
 
+        def mock_handler(domain, privilege):
+            return privilege == RELEASE_MANAGEMENT
+
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.return_value = True
-            result = can_user_access_release_management(mock_user, 'test')
+            mock_domain_has_privilege.side_effect = mock_handler
+            result = can_user_access_linked_domains(mock_user, 'test')
 
         self.assertTrue(result)
 
     @patch('corehq.apps.users.models.CouchUser')
-    def test_returns_true_if_domain_has_lite_privilege_and_user_is_admin(self, mock_user):
+    def test_returns_true_if_has_lite_release_management_and_is_admin(self, mock_user):
         mock_user.is_domain_admin.return_value = True
 
         def mock_handler(domain, privilege):
@@ -50,22 +56,9 @@ class TestCanUserAccessReleaseManagement(SimpleTestCase):
 
         with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
             mock_domain_has_privilege.side_effect = mock_handler
-            result = can_user_access_release_management(mock_user, 'test')
+            result = can_user_access_linked_domains(mock_user, 'test')
 
         self.assertTrue(result)
-
-    @patch('corehq.apps.users.models.CouchUser')
-    def test_false_if_domain_has_lite_privilege_and_user_is_admin_but_include_lite_is_false(self, mock_user):
-        mock_user.is_domain_admin.return_value = True
-
-        def mock_handler(domain, privilege):
-            return privilege == LITE_RELEASE_MANAGEMENT
-
-        with patch('corehq.apps.linked_domain.util.domain_has_privilege') as mock_domain_has_privilege:
-            mock_domain_has_privilege.side_effect = mock_handler
-            result = can_user_access_release_management(mock_user, 'test', include_lite_version=False)
-
-        self.assertFalse(result)
 
 
 class TestCanDomainAccessReleaseManagement(SimpleTestCase):

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -28,7 +28,7 @@ def can_user_access_linked_domains(user, domain):
     return any(domain_has_privilege(domain, priv) for priv in privileges_with_linked_domain_access) and is_admin
 
 
-def can_domain_access_release_management(domain, include_lite_version=True):
+def can_domain_access_linked_domains(domain, include_lite_version=True):
     """
     :param include_lite_version: set to True if the LITE_RELEASE_MANAGEMENT privilege should be checked
     Checks if the current domain has any of the following enabled:

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -13,24 +13,19 @@ from corehq.privileges import RELEASE_MANAGEMENT, LITE_RELEASE_MANAGEMENT
 from corehq.util.timezones.conversions import ServerTime
 
 
-def can_user_access_release_management(user, domain, include_lite_version=True):
+def can_user_access_linked_domains(user, domain):
     """
-    :param include_lite_version: set to True if the LITE_RELEASE_MANAGEMENT privilege should be checked
     Checks if the current domain has any of the following enabled:
     - privileges.RELEASE_MANAGEMENT
     - privileges.LITE_RELEASE_MANAGEMENT
-    If yes, and the user meets the criteria needed, returns True
+    If yes, and the user is an admin, returns True
     """
     if not user or not domain:
         return False
 
+    privileges_with_linked_domain_access = [RELEASE_MANAGEMENT, LITE_RELEASE_MANAGEMENT]
     is_admin = user.is_domain_admin(domain)
-
-    if domain_has_privilege(domain, RELEASE_MANAGEMENT) and is_admin:
-        return True
-    if include_lite_version and domain_has_privilege(domain, LITE_RELEASE_MANAGEMENT) and is_admin:
-        return True
-    return False
+    return any(domain_has_privilege(domain, priv) for priv in privileges_with_linked_domain_access) and is_admin
 
 
 def can_domain_access_release_management(domain, include_lite_version=True):

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -93,7 +93,7 @@ from corehq.apps.linked_domain.util import (
     pull_missing_multimedia_for_app,
     server_to_user_time,
     user_has_admin_access_in_all_domains,
-    can_domain_access_release_management,
+    can_domain_access_linked_domains,
 )
 from corehq.apps.linked_domain.view_helpers import (
     build_domain_link_view_model,
@@ -328,7 +328,7 @@ class DomainLinkView(BaseAdminProjectSettingsView):
                 'view_models_to_push': sorted(view_models_to_push, key=lambda m: m['name']),
                 'linked_domains': sorted(linked_domains, key=lambda d: d['downstream_domain']),
                 'linkable_ucr': remote_linkable_ucr,
-                'has_full_access': can_domain_access_release_management(self.domain, include_lite_version=False),
+                'has_full_access': can_domain_access_linked_domains(self.domain, include_lite_version=False),
             },
         }
 

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -341,5 +341,5 @@ class ReleaseManagementReportDispatcher(ReportDispatcher):
     map_name = 'RELEASE_MANAGEMENT_REPORTS'
 
     def permissions_check(self, report, request, domain=None, is_navigation_check=False):
-        from corehq.apps.linked_domain.util import can_user_access_release_management
-        return can_user_access_release_management(request.couch_user, domain)
+        from corehq.apps.linked_domain.util import can_user_access_linked_domains
+        return can_user_access_linked_domains(request.couch_user, domain)

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -52,7 +52,7 @@ from corehq.apps.integration.views import (
     GaenOtpServerSettingsView,
     HmacCalloutSettingsView,
 )
-from corehq.apps.linked_domain.util import can_user_access_release_management
+from corehq.apps.linked_domain.util import can_user_access_linked_domains
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.receiverwrapper.rate_limiter import (
     SHOULD_RATE_LIMIT_SUBMISSIONS,
@@ -2055,7 +2055,7 @@ def _get_feature_flag_items(domain, couch_user):
 def _get_release_management_items(user, domain):
     items = []
     title = None
-    if not can_user_access_release_management(user, domain):
+    if not can_user_access_linked_domains(user, domain):
         return title, items
 
     if domain_has_privilege(domain, privileges.RELEASE_MANAGEMENT):

--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -22,7 +22,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
     def setUp(self):
         super().setUp()
 
-        access_patcher = patch('corehq.tabs.tabclasses.can_user_access_release_management')
+        access_patcher = patch('corehq.tabs.tabclasses.can_user_access_linked_domains')
         self.mock_can_access = access_patcher.start()
         self.addCleanup(access_patcher.stop)
 
@@ -35,7 +35,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
         self.mock_reverse.return_value = 'dummy_url'
         self.addCleanup(reverse_patcher.stop)
 
-    def test_returns_none_if_cannot_user_access_release_management(self):
+    def test_returns_none_if_user_does_not_have_access(self):
         self.mock_can_access.return_value = False
 
         title, items = _get_release_management_items(self.user, "domain")
@@ -43,7 +43,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
         self.assertFalse(title)
         self.assertFalse(items)
 
-    def test_returns_erm_if_can_access_full_release_management(self):
+    def test_returns_erm_if_user_has_full_access(self):
         self.mock_can_access.return_value = True
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == RELEASE_MANAGEMENT
 
@@ -53,7 +53,7 @@ class TestAccessToReleaseManagementTab(SimpleTestCase):
         self.assertEqual(items[0]['title'], 'Linked Project Spaces')
         self.assertEqual(items[1]['title'], 'Linked Project Space History')
 
-    def test_returns_mrm_if_has_privilege_but_not_admin(self):
+    def test_returns_mrm_if_user_has_lite_access(self):
         self.mock_can_access.return_value = True
         self.mock_domain_has_privilege.side_effect = lambda domain, privilege: privilege == LITE_RELEASE_MANAGEMENT
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Want to get weigh in from across divisions for those familiar with this feature. Feel free to veto, but here's how I look at it.

ERM/MRM are types of the Release Management feature, which is really just an umbrella term to house multiple features within, linked domains being one of those.

Reasons I'm in favor of this change:
- we get to _continue_ to refer to this feature as linked domains/linked projects/linked project spaces, especially considering the app this code lives in is still `linked_domain`
- if/when we add more features under the release management umbrella, we avoid confusion since this is just another feature under that umbrella

Reasons I'm opposed:
- one of the reasons to make this change is based on a _potential future_ change which isn't great, but I still think this is less confusing than the alternative which is calling this feature release management.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Will test on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated test coverage for these methods is good.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
