### PR TITLE
display html for unknown form usernames

### DIFF
--- a/corehq/apps/reports/display.py
+++ b/corehq/apps/reports/display.py
@@ -1,5 +1,6 @@
 from django.utils.translation import gettext as _
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 
 from couchdbkit.exceptions import ResourceNotFound
 
@@ -48,8 +49,12 @@ class FormDisplay(object):
             else:
                 name = ""
         except (ResourceNotFound, IncompatibleDocument):
-            name = "<b>[unregistered]</b>"
-        return (username or _('No data for username')) + (" %s" % name if name else "")
+            name = mark_safe('<b>[unregistered]</b>')  # nosec: no user input
+        username = username or _('No data for username')
+        if name:
+            return format_html('{} {}', username, name)
+        else:
+            return username
 
     @property
     def submission_or_completion_time(self):

--- a/corehq/apps/reports/display.py
+++ b/corehq/apps/reports/display.py
@@ -16,6 +16,9 @@ from corehq.util.timezones.conversions import PhoneTime, ServerTime
 from corehq.util.view_utils import absolute_reverse
 
 
+ONE_WEEK = 7 * 24 * 60 * 60
+
+
 class StringWithAttributes(str):
 
     def replace(self, *args):
@@ -23,7 +26,7 @@ class StringWithAttributes(str):
         return StringWithAttributes(string)
 
 
-class FormDisplay(object):
+class FormDisplay():
 
     def __init__(self, form_doc, report, lang=None):
         self.form = form_doc
@@ -44,7 +47,7 @@ class FormDisplay(object):
         username = self.form["form"]["meta"].get("username")
         try:
             if username not in ['demo_user', 'admin']:
-                full_name = get_cached_property(CouchUser, uid, 'full_name', expiry=7*24*60*60)
+                full_name = get_cached_property(CouchUser, uid, 'full_name', expiry=ONE_WEEK)
                 name = '"%s"' % full_name if full_name else ""
             else:
                 name = ""


### PR DESCRIPTION
## Technical Summary
Associated ticket: https://dimagi-dev.atlassian.net/browse/SAAS-12854.  For unknown users, the raw HTML markup "<b>[unregistered]</b>" was being displayed. Because this HTML isn't coming from a user, this fix aims to show this HTML as valid HTML.

## Safety Assurance

### Safety story
Tested locally.

### Automated test coverage

No tests

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
