### PR TITLE
Updated case list overwrite logic for multi-select shadow modules

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -58,6 +58,7 @@ from corehq.apps.app_manager.models import (
     CaseSearchProperty,
     DefaultCaseSearchProperty,
     DeleteModuleRecord,
+    Detail,
     DetailColumn,
     DetailTab,
     FixtureSelect,
@@ -950,14 +951,14 @@ def _update_module_short_detail(src_module, dest_module, attrs):
         _update_module_search_config(src_module, dest_module, search_attrs)
 
     attrs = attrs - search_attrs
+    src_detail = Detail.wrap(getattr(src_module.case_details, "short").to_json().copy())
 
     # Shadow modules inherit some attributes from source module, so ignore the detail attr
     if src_module.module_type == "shadow":
         if 'multi_select' in attrs:
-            attrs['multi_select'] = src_module.is_multi_select()
+            src_detail.multi_select = src_module.is_multi_select()
 
     if attrs:
-        src_detail = getattr(src_module.case_details, "short")
         dest_detail = getattr(dest_module.case_details, "short")
         dest_detail.overwrite_attrs(src_detail, attrs)
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -950,6 +950,12 @@ def _update_module_short_detail(src_module, dest_module, attrs):
         _update_module_search_config(src_module, dest_module, search_attrs)
 
     attrs = attrs - search_attrs
+
+    # Shadow modules inherit some attributes from source module, so ignore the detail attr
+    if src_module.module_type == "shadow":
+        if 'multi_select' in attrs:
+            attrs['multi_select'] = src_module.is_multi_select()
+
     if attrs:
         src_detail = getattr(src_module.case_details, "short")
         dest_detail = getattr(dest_module.case_details, "short")


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/QA-4113

Overwriting a case list detail gets funky when dealing with the new multi select property, because shadow modules inherit it. This PR implements this behavior:
* If a shadow menu is being used to overwrite a regular menu, use the multi-select value of the source menu (because the shadow menu detail's actual `multi_select` attr does not indicate whether the menu uses multi select)
* If a shadow menu is having its case list config overwritten, it doesn't matter what the original menu's multi select behavior is. The shadow menu will always inherit its behavior from its source menu.

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
Only affects a feature flag that isn't being used in production yet.

### Automated test coverage

There's test coverage for the model-level overwrite functionality, but not for this view-level code. I didn't push this code deeper because [Detail.overwrite_attrs](https://github.com/dimagi/commcare-hq/blob/1ba6a02046be3b7f1ed5e6c7101ea62ef0681ffd/corehq/apps/app_manager/models.py#L2114) only has access to the source detail, not to the source module.

### QA Plan
Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
