### PR TITLE
Remove UsersMiddlewhere app check

### DIFF
--- a/corehq/apps/users/middleware.py
+++ b/corehq/apps/users/middleware.py
@@ -1,9 +1,5 @@
-import django.core.exceptions
-from django.conf import settings
-from django.template.response import TemplateResponse
 from django.utils.deprecation import MiddlewareMixin
 
-from corehq import toggles
 from corehq.apps.users.models import AnonymousCouchUser, CouchUser, InvalidUser
 from corehq.apps.users.util import username_to_user_id
 from corehq.toggles import PUBLISH_CUSTOM_REPORTS
@@ -21,18 +17,6 @@ def is_public_reports(view_kwargs, request):
 
 
 class UsersMiddleware(MiddlewareMixin):
-
-    def __init__(self, get_response):
-        super(UsersMiddleware, self).__init__(get_response)
-        # Normally we'd expect this class to be pulled out of the middleware list, too,
-        # but in case someone forgets, this will stop this class from being used.
-        found_domain_app = False
-        for app_name in settings.INSTALLED_APPS:
-            if app_name == "users" or app_name.endswith(".users"):
-                found_domain_app = True
-                break
-        if not found_domain_app:
-            raise django.core.exceptions.MiddlewareNotUsed
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         request.analytics_enabled = True


### PR DESCRIPTION
## Technical Summary

Removes fragile app name check (there's a [better way](https://docs.djangoproject.com/en/3.2/ref/applications/#django.apps.apps.get_app_configs) if you need to do this).

- HQ now unconditionally depends on this middlewhere, so the logic for enabling/disabling it is no longer relevant.
- See [discussion](https://dimagi.slack.com/archives/C02QG63MU/p1646843508965369?thread_ts=1646843276.759419&cid=C02QG63MU):

  > It seems like you could probably remove this check all together

## Safety Assurance

### Safety story

Safe (removes unused middleware exception condition).

### Automated test coverage

No tests.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
