### PR TITLE
sanitize datadog tag values

### DIFF
--- a/corehq/util/metrics/datadog.py
+++ b/corehq/util/metrics/datadog.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import List, Dict
 
 from datadog import api
@@ -12,12 +13,17 @@ from datadog.dogstatsd.base import DogStatsd
 datadog_logger = logging.getLogger('datadog')
 
 
+def _sanitize_value(tag_value: str):
+    # valid characters for tag values from https://docs.datadoghq.com/getting_started/tagging/#defining-tags
+    return re.sub(r'[^a-zA-Z0-9_:./-]+', '_', tag_value.lower())
+
+
 def _format_tags(tag_values: Dict[str, str]):
     if not tag_values:
         return None
 
     return [
-        f'{name}:{value}' for name, value in tag_values.items()
+        f'{name}:{_sanitize_value(value)}' for name, value in tag_values.items()
     ]
 
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This enforces datadog restrictions on tag values, as defined in https://docs.datadoghq.com/getting_started/tagging/#defining-tags
We noticed this in https://github.com/dimagi/commcare-hq/blob/master/corehq/project_limits/rate_limiter.py#L58 as some scope names do not conform to datadog rules, but it is likely that other metrics are also not making it to datadog at this time.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
I tested the regular expression locally on a variety of inputs

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
