### PR TITLE
Remove compatibility fixes for Django 2.2 and 3.1

### DIFF
--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -369,12 +369,7 @@ class TestDownloadCaseSummaryViewByAPIKey(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        try:
-            content_type = response.headers['content-type']
-        except AttributeError:
-            # TODO remove after upgrading to Django 3.2
-            content_type = response._headers['content-type'][1]
-        self.assertEqual(content_type, "application/vnd.ms-excel")
+        self.assertEqual(response.headers['content-type'], "application/vnd.ms-excel")
 
     def test_incorrect_api_key(self):
         """Sending an incorrect (or missing) API key returns a 401 response."""
@@ -409,12 +404,7 @@ class TestDownloadCaseSummaryViewByAPIKey(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        try:
-            content_type = response.headers['content-type']
-        except AttributeError:
-            # TODO remove after upgrading to Django 3.2
-            content_type = response._headers['content-type'][1]
-        self.assertEqual(content_type, "application/vnd.ms-excel")
+        self.assertEqual(response.headers['content-type'], "application/vnd.ms-excel")
 
     def test_unsupported_request_methods(self):
         """Test sending requests by unsupported HTTP methods to the view."""

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -11,7 +11,6 @@ from unittest.mock import patch
 
 from pillowtop.es_utils import initialize_index_and_mapping
 
-from corehq import toggles
 from corehq.apps.app_manager.exceptions import XFormValidationError
 from corehq.apps.app_manager.models import (
     AdvancedModule,
@@ -24,7 +23,6 @@ from corehq.apps.app_manager.tests.util import add_build, get_simple_form
 from corehq.apps.app_manager.views import (
     AppCaseSummaryView,
     AppFormSummaryView,
-    DownloadCaseSummaryView,
 )
 from corehq.apps.app_manager.views.forms import get_apps_modules
 from corehq.apps.builds.models import BuildSpec

--- a/corehq/apps/auditcare/tests/testutils.py
+++ b/corehq/apps/auditcare/tests/testutils.py
@@ -2,11 +2,7 @@ from uuid import uuid4
 
 from django.db import router
 from django.test import TestCase
-try:
-    from django.utils.functional import classproperty
-except ImportError:
-    # Django < 3.1 compatibility
-    from django.utils.decorators import classproperty
+from django.utils.functional import classproperty
 
 from couchdbkit.ext.django.loading import get_db
 

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -37,7 +37,6 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._fix_username_max_length()
         if settings.ENFORCE_SSO_LOGIN:
             self.fields['username'].widget = forms.TextInput(attrs={
                 'class': 'form-control',
@@ -48,14 +47,6 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
                 'class': 'form-control',
                 'placeholder': _("Enter password"),
             })
-
-    def _fix_username_max_length(self):
-        # TODO remove when Django 2 is no longer supported
-        # Django overwrites username max length with
-        # UserModel._meta.get_field(UserModel.USERNAME_FIELD).max_length
-        # This was done incompletely prior to Django 3.1
-        # https://github.com/django/django/commit/6c9778a58e4f680db180d4cc9dc5639d2ec1b40c
-        self.fields['username'].widget.attrs["maxlength"] = self.fields['username'].max_length
 
     def clean_username(self):
         username = self.cleaned_data.get('username', '').lower()

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -236,7 +236,6 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
             cookies = []
             headers = {}
             _resource_closers = []
-            _closable_objects = []  # TODO remove when Django 2 is no longer supported
 
             def has_header(self, name):
                 return False
@@ -247,10 +246,6 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
             def close(self):
                 for close in self._resource_closers:
                     close()
-
-                # TODO remove when Django 2 is no longer supported
-                for obj in self._closable_objects:
-                    obj.close()
 
         def process_device_log(self_, xform):
             result = FormProcessingResult(xform)

--- a/corehq/apps/reports/tests/test_export_response.py
+++ b/corehq/apps/reports/tests/test_export_response.py
@@ -63,13 +63,7 @@ class ExportResponseTest(TestCase):
         res = report.export_response
 
         self.assertEqual(res.status_code, 200)
-
-        try:
-            content_type = res.headers['content-type']
-        except AttributeError:
-            # TODO remove after upgrading to Django 3.2
-            content_type = res._headers['content-type'][1]
-        self.assertEqual(content_type, 'application/vnd.ms-excel')
+        self.assertEqual(res.headers['content-type'], 'application/vnd.ms-excel')
 
     @patch('corehq.apps.reports.standard.monitoring.WorkerActivityReport.export_table', return_value=[])
     @patch('corehq.apps.reports.generic.export_from_tables')

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -5,11 +5,7 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.test import TestCase, TransactionTestCase
-try:
-    from django.utils.functional import classproperty
-except ImportError:
-    # Django < 3.1 compatibility
-    from django.utils.decorators import classproperty
+from django.utils.functional import classproperty
 
 from nose.plugins.attrib import attr
 from nose.tools import nottest

--- a/manage.py
+++ b/manage.py
@@ -138,13 +138,6 @@ def patch_jsonfield():
 
     JSONField.to_python = to_python
 
-    import django
-    if django.VERSION < (3, 1):
-        # TODO remove after upgrading to Django 3.2
-        from django.contrib.postgres.fields.jsonb import JSONField
-        import django.db.models
-        django.db.models.JSONField = JSONField
-
 
 def set_default_settings_path(argv):
     if is_testing(argv):


### PR DESCRIPTION
### Safety story

All changes except for one are changes to tests. The other was a workaround for an issue that was surfaced by tests, and if tests pass all should be well.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
