### PR TITLE
Multi-select case detail "continue" flow

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -15,5 +15,8 @@ hqDefine("cloudcare/js/formplayer/constants", function () {
             LIST: 'list',
         },
         DEFAULT_INCOMPLETE_FORMS_PAGE_SIZE: 20,
+
+        MULTI_SELECT_ADD: 'add',
+        MULTI_SELECT_REMOVE: 'remove',
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -152,6 +152,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
     FormplayerFrontend.getChannel().reply("app:select:menus", function (options) {
         if (sessionStorage.selectedValues !== undefined) {
             options.selectedValues = sessionStorage.selectedValues.split(',');
+            sessionStorage.selectedValues = '';
         }
         if (!options.endpointId) {
             return API.queryFormplayer(options, options.isInitial ? "navigate_menu_start" : "navigate_menu");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -152,7 +152,6 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
     FormplayerFrontend.getChannel().reply("app:select:menus", function (options) {
         if (sessionStorage.selectedValues !== undefined) {
             options.selectedValues = sessionStorage.selectedValues.split(',');
-            sessionStorage.removeItem('selectedValues');
         }
         if (!options.endpointId) {
             return API.queryFormplayer(options, options.isInitial ? "navigate_menu_start" : "navigate_menu");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -152,7 +152,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
     FormplayerFrontend.getChannel().reply("app:select:menus", function (options) {
         if (sessionStorage.selectedValues !== undefined) {
             options.selectedValues = sessionStorage.selectedValues.split(',');
-            sessionStorage.selectedValues = '';
+            sessionStorage.removeItem('selectedValues');
         }
         if (!options.endpointId) {
             return API.queryFormplayer(options, options.isInitial ? "navigate_menu_start" : "navigate_menu");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -57,7 +57,7 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
             if (response.selections) {
                 var urlObject = Util.currentUrlToObject();
                 urlObject.setSelections(response.selections);
-                Util.setUrlToObject(urlObject);
+                Util.setUrlToObject(urlObject, true);
             }
 
             if (response.commands) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -141,6 +141,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         });
         var detailFooterView = hqImport("cloudcare/js/formplayer/menus/views").CaseDetailFooterView({
             model: model,
+            caseId: caseId,
             isMultiSelect: isMultiSelect,
         });
         $('#case-detail-modal').find('.js-detail-tabs').html(tabListView.render().el);
@@ -148,9 +149,6 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         $('#case-detail-modal').find('.js-detail-footer-content').html(detailFooterView.render().el);
         $('#case-detail-modal').modal('show');
 
-        $('#select-case').off('click').click(function () {
-            FormplayerFrontend.trigger("menu:select", caseId);
-        });
         $('#select-case-for-multi-select').off('click').click(function () {
             // todo: add logic to select case id via checkbox
         });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -72,14 +72,14 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         });
     };
 
-    var selectDetail = function (caseId, detailIndex, isPersistent) {
+    var selectDetail = function (caseId, detailIndex, isPersistent, isMultiSelect) {
         var urlObject = Util.currentUrlToObject();
         if (!isPersistent) {
             urlObject.addSelection(caseId);
         }
         var fetchingDetails = FormplayerFrontend.getChannel().request("entity:get:details", urlObject, isPersistent);
         $.when(fetchingDetails).done(function (detailResponse) {
-            showDetail(detailResponse, detailIndex, caseId);
+            showDetail(detailResponse, detailIndex, caseId, isMultiSelect);
         }).fail(function () {
             FormplayerFrontend.trigger('navigateHome');
         });
@@ -117,8 +117,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         FormplayerFrontend.regions.getRegion('persistentCaseTile').show(detailView.render());
     };
 
-    var showDetail = function (model, detailTabIndex, caseId) {
-        var isMultiSelect = false; // TODO: add logic
+    var showDetail = function (model, detailTabIndex, caseId, isMultiSelect) {
         var detailObjects = model.models;
         // If we have no details, just select the entity
         if (detailObjects === null || detailObjects === undefined || detailObjects.length === 0) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -149,9 +149,6 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         $('#case-detail-modal').find('.js-detail-footer-content').html(detailFooterView.render().el);
         $('#case-detail-modal').modal('show');
 
-        $('#select-case-for-multi-select').off('click').click(function () {
-            // todo: add logic to select case id via checkbox
-        });
     };
 
     var getDetailList = function (detailObject) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -333,16 +333,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             this.redoLast = options.redoLast;
             this.selectedCaseIds = sessionStorage.selectedValues === undefined || sessionStorage.selectedValues.length === 0 ?  [] : sessionStorage.selectedValues.split(',');
             this.isMultiSelect = options.isMultiSelect;
-
-            var self = this;
-            FormplayerFrontend.on("multiSelect:updateCases", function (action, caseIds) {
-                if (action === Constants.MULTI_SELECT_ADD) {
-                    self.selectedCaseIds = _.union(self.selectedCaseIds, caseIds);
-                } else {
-                    self.selectedCaseIds = _.difference(self.selectedCaseIds, caseIds);
-                }
-                self.reconcileMultiSelectUI();
-            });
         },
 
         ui: {
@@ -377,11 +367,17 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         onRender: function () {
-            if (sessionStorage.selectedValues && sessionStorage.selectedValues.length !== 0) {
-                this.selectedCaseIds = sessionStorage.selectedValues.split(',');
-                this.reconcileMultiSelectUI();
-                sessionStorage.selectedValues = [];
-            }
+            var self = this;
+            FormplayerFrontend.off("multiSelect:updateCases").on("multiSelect:updateCases", function (action, caseIds) {
+                if (action === Constants.MULTI_SELECT_ADD) {
+                    self.selectedCaseIds = _.union(self.selectedCaseIds, caseIds);
+                } else {
+                    self.selectedCaseIds = _.difference(self.selectedCaseIds, caseIds);
+                }
+                sessionStorage.selectedValues = self.selectedCaseIds.join(",");
+                self.reconcileMultiSelectUI();
+            });
+            this.reconcileMultiSelectUI();
         },
 
         caseListAction: function (e) {
@@ -417,7 +413,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             e.preventDefault();
             var casesPerPage = this.ui.casesPerPageLimit.val();
             FormplayerFrontend.trigger("menu:perPageLimit", casesPerPage);
-            sessionStorage.selectedValues = this.selectedCaseIds;
         },
 
         paginationGoAction: function (e) {
@@ -463,7 +458,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         continueAction: function () {
-            sessionStorage.selectedValues = this.selectedCaseIds;
             FormplayerFrontend.trigger("menu:select", this.selectedCaseIds);
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -250,7 +250,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         rowClick: function (e) {
             if (!(e.target.className === 'module-case-list-column-checkbox' || e.target.id === 'select-row-checkbox')) {
                 e.preventDefault();
-                FormplayerFrontend.trigger("menu:show:detail", this.model.get('id'), 0, false);
+                FormplayerFrontend.trigger("menu:show:detail", this.model.get('id'), 0, this.parentView.options.isMultiSelect);
             }
         },
 
@@ -304,7 +304,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         rowClick: function (e) {
             e.preventDefault();
             if (this.options.hasInlineTile) {
-                FormplayerFrontend.trigger("menu:show:detail", this.options.model.get('id'), 0, true);
+                FormplayerFrontend.trigger("menu:show:detail", this.options.model.get('id'), 0, false, true);
             }
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -263,12 +263,14 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         selectRowAction: function (e) {
             if (e.target.checked) {
                 this.parentView.selectedCaseIds.push(this.model.get('id'));
+                FormplayerFrontend.trigger("multiSelect:addCases", [this.model.get('id')]);
             } else {
                 const index = this.parentView.selectedCaseIds.indexOf(this.model.get('id'));
                 if (index > -1) {
                     this.parentView.selectedCaseIds.splice(index, 1);
                 }
                 this.parentView.ui.selectAllCheckbox[0].checked = false;
+                FormplayerFrontend.trigger("multiSelect:removeCases", [this.model.get('id')]);
             }
             this.parentView.updateContinueButtonText(this.parentView.selectedCaseIds.length);
             this.parentView.reconcileSelectAll();
@@ -318,7 +320,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
     var CaseListView = Marionette.CollectionView.extend({
         tagName: "div",
         template: _.template($("#case-view-list-template").html() || ""),
-
 
         childViewContainer: ".js-case-container",
         childView: CaseView,
@@ -449,6 +450,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     for (const value of childView.model.collection.models) {
                         if (self.selectedCaseIds.indexOf(value.id) === -1) {
                             self.selectedCaseIds.push(value.id);
+                            FormplayerFrontend.trigger("multiSelect:addCases", [value.id]);
                         }
                     }
                 } else {
@@ -456,6 +458,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                         let index = self.selectedCaseIds.indexOf(value.id);
                         if (index !== -1) {
                             self.selectedCaseIds.splice(index, 1);
+                            FormplayerFrontend.trigger("multiSelect:removeCases", [value.id]);
                         }
                     }
                 }
@@ -796,7 +799,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             this.caseId = options.caseId;
         },
         selectCase: function () {
-            FormplayerFrontend.trigger("menu:select", this.caseId);
+            if (this.isMultiSelect) {
+                FormplayerFrontend.trigger("multiSelect:addCases", [this.caseId]);
+            } else {
+                FormplayerFrontend.trigger("menu:select", this.caseId);
+            }
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -341,13 +341,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 } else {
                     self.selectedCaseIds = _.difference(self.selectedCaseIds, caseIds);
                 }
-
-                // Update state of Continue button
-                self.ui.continueButtonText[0].innerText = self.selectedCaseIds.length;
-                self.ui.continueButton.prop("disabled", !self.selectedCaseIds.length);
-
-                // Reconcile state of "select all" checkbox
-                self.ui.selectAllCheckbox[0].checked = !_.difference(self._allCaseIds(), self.selectedCaseIds).length;
+                self.reconcileMultiSelectUI();
             });
         },
 
@@ -385,9 +379,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         onRender: function () {
             if (sessionStorage.selectedValues && sessionStorage.selectedValues.length !== 0) {
                 this.selectedCaseIds = sessionStorage.selectedValues.split(',');
-                this.updateCheckboxes();
+                this.reconcileMultiSelectUI();
                 sessionStorage.selectedValues = [];
-                this.ui.continueButton.prop("disabled", this.selectedCaseIds.length === 0);
             }
         },
 
@@ -474,16 +467,26 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             FormplayerFrontend.trigger("menu:select", this.selectedCaseIds);
         },
 
-        updateCheckboxes: function () {
+        reconcileMultiSelectUI: function () {
             var self = this;
-            if (this.isMultiSelect) {
-                this.children.each(function (childView) {
-                    if (self.selectedCaseIds.indexOf(childView.model.id) !== -1) {
-                        let checkbox = childView.ui.selectRow[0];
-                        checkbox.checked = true;
-                    }
-                });
+            if (!self.isMultiSelect) {
+                return;
             }
+
+            // Update states of row checkboxes
+            self.children.each(function (childView) {
+                if (self.selectedCaseIds.indexOf(childView.model.id) !== -1) {
+                    let checkbox = childView.ui.selectRow[0];
+                    checkbox.checked = true;
+                }
+            });
+
+            // Update state of Continue button
+            self.ui.continueButtonText[0].innerText = self.selectedCaseIds.length;
+            self.ui.continueButton.prop("disabled", !self.selectedCaseIds.length);
+
+            // Reconcile state of "select all" checkbox
+            self.ui.selectAllCheckbox[0].checked = !_.difference(self._allCaseIds(), self.selectedCaseIds).length;
         },
 
         templateContext: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -351,7 +351,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 } else {
                     self.selectedCaseIds = _.difference(self.selectedCaseIds, caseIds);
                 }
-                self.reconcileSelectAll();
+
+                // Reconcile state of "select all" checkbox
+                self.ui.selectAllCheckbox[0].checked = !_.difference(self._allCaseIds(), self.selectedCaseIds).length;
             });
         },
 
@@ -460,35 +462,17 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         selectAllAction: function (e) {
-            var self = this;
-            this.children.each(function (childView) {
-                childView.ui.selectRow[0].checked = e.target.checked;
-                if (e.target.checked) {
-                    for (const value of childView.model.collection.models) {
-                        if (self.selectedCaseIds.indexOf(value.id) === -1) {
-                            self.selectedCaseIds.push(value.id);
-                            FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_ADD, [value.id]);
-                        }
-                    }
-                } else {
-                    for (const value of childView.model.collection.models) {
-                        let index = self.selectedCaseIds.indexOf(value.id);
-                        if (index !== -1) {
-                            self.selectedCaseIds.splice(index, 1);
-                            FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_REMOVE, [value.id]);
-                        }
-                    }
-                }
-            });
+            var action = e.target.checked ? Constants.MULTI_SELECT_ADD : Constants.MULTI_SELECT_REMOVE;
+            FormplayerFrontend.trigger("multiSelect:updateCases", action, this._allCaseIds());
             this.updateContinueButtonText(this.selectedCaseIds.length);
         },
 
-        reconcileSelectAll: function () {
-            var allSelected = true;
+        _allCaseIds: function () {
+            var caseIds = [];
             this.children.each(function (childView) {
-                allSelected = allSelected && childView.isChecked();
+                caseIds.push(childView.model.get('id'));
             });
-            this.ui.selectAllCheckbox[0].checked = allSelected;
+            return caseIds;
         },
 
         continueAction: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -328,6 +328,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             this.hasNoItems = options.collection.length === 0;
             this.redoLast = options.redoLast;
             this.selectedCaseIds = sessionStorage.selectedValues === undefined || sessionStorage.selectedValues.length === 0 ?  [] : sessionStorage.selectedValues.split(',');
+            this.isMultiSelect = options.isMultiSelect,
         },
 
         ui: {
@@ -485,16 +486,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         templateContext: function () {
             var paginateItems = paginateOptions(this.options.currentPage, this.options.pageCount);
             var casesPerPage = parseInt($.cookie("cases-per-page-limit")) || 10;
-
-            $(function ()  {
-                var goButton = $("#pagination-go-button");
-                if (goButton.length) {
-                    kissmetrics.track.event("Accessibility Tracking - Pagination Page Loaded");
-                }
-            });
-
-            var isMultiSelectCaseList = this.options.isMultiSelect;
-
             return {
                 startPage: paginateItems.startPage,
                 title: this.options.title,
@@ -513,7 +504,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 useTiles: false,
                 hasNoItems: this.hasNoItems,
                 sortIndices: this.options.sortIndices,
-                isMultiSelect: isMultiSelectCaseList,
+                isMultiSelect: this.isMultiSelect,
                 selectedCaseIds: this.selectedCaseIds,
                 columnSortable: function (index) {
                     return this.sortIndices.indexOf(index) > -1;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -242,7 +242,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             self.isMultiSelect = this.options.isMultiSelect;
             FormplayerFrontend.on("multiSelect:updateCases", function (action, caseIds) {
                 if (_.contains(caseIds, self.model.get('id'))) {
-                    self.ui.selectRow[0].checked = action === Constants.MULTI_SELECT_ADD;
+                    self.ui.selectRow.prop("checked", action === Constants.MULTI_SELECT_ADD);
                 }
             });
         },
@@ -274,7 +274,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         isChecked: function () {
-            return this.ui.selectRow[0].checked;
+            return this.ui.selectRow.prop("checked");
         },
 
         templateContext: function () {
@@ -469,18 +469,15 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
             // Update states of row checkboxes
             self.children.each(function (childView) {
-                if (self.selectedCaseIds.indexOf(childView.model.id) !== -1) {
-                    let checkbox = childView.ui.selectRow[0];
-                    checkbox.checked = true;
-                }
+                childView.ui.selectRow.prop("checked", self.selectedCaseIds.indexOf(childView.model.id) !== -1);
             });
 
             // Update state of Continue button
-            self.ui.continueButtonText[0].innerText = self.selectedCaseIds.length;
+            self.ui.continueButtonText.text(self.selectedCaseIds.length);
             self.ui.continueButton.prop("disabled", !self.selectedCaseIds.length);
 
             // Reconcile state of "select all" checkbox
-            self.ui.selectAllCheckbox[0].checked = !_.difference(self._allCaseIds(), self.selectedCaseIds).length;
+            self.ui.selectAllCheckbox.prop("checked", !_.difference(self._allCaseIds(), self.selectedCaseIds).length);
         },
 
         templateContext: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -778,9 +778,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
     var CaseDetailFooterView = Marionette.View.extend({
         tagName: "div",
         className: "",
-        events: {
-            "click": "tabClick",
-        },
         getTemplate: function () {
             var id = "#module-case-detail";
             if (this.isPersistentDetail) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -2,7 +2,8 @@
 
 hqDefine("cloudcare/js/formplayer/menus/views", function () {
     var kissmetrics = hqImport("analytix/js/kissmetrix");
-    var FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
+    var Constants = hqImport("cloudcare/js/formplayer/constants"),
+        FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
         Util = hqImport("cloudcare/js/formplayer/utils/util");
     var MenuView = Marionette.View.extend({
         tagName: function () {
@@ -34,7 +35,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         getTemplate: function () {
             var id = "#menu-view-row-template";
-            if (this.model.collection.layoutStyle === hqImport("cloudcare/js/formplayer/constants").LayoutStyles.GRID) {
+            if (this.model.collection.layoutStyle === Constants.LayoutStyles.GRID) {
                 id = "#menu-view-grid-item-template";
             } else if (this.model.get('audioUri')) {
                 id = "#menu-view-row-audio-template";
@@ -101,7 +102,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         childViewContainer: ".menus-container",
         getTemplate: function () {
             var id = "#menu-view-list-template";
-            if (this.collection.layoutStyle === hqImport("cloudcare/js/formplayer/constants").LayoutStyles.GRID) {
+            if (this.collection.layoutStyle === Constants.LayoutStyles.GRID) {
                 id = "#menu-view-grid-template";
             }
             return _.template($(id).html() || "");
@@ -263,14 +264,14 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         selectRowAction: function (e) {
             if (e.target.checked) {
                 this.parentView.selectedCaseIds.push(this.model.get('id'));
-                FormplayerFrontend.trigger("multiSelect:addCases", [this.model.get('id')]);
+                FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_ADD, [this.model.get('id')]);
             } else {
                 const index = this.parentView.selectedCaseIds.indexOf(this.model.get('id'));
                 if (index > -1) {
                     this.parentView.selectedCaseIds.splice(index, 1);
                 }
                 this.parentView.ui.selectAllCheckbox[0].checked = false;
-                FormplayerFrontend.trigger("multiSelect:removeCases", [this.model.get('id')]);
+                FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_REMOVE, [this.model.get('id')]);
             }
             this.parentView.updateContinueButtonText(this.parentView.selectedCaseIds.length);
             this.parentView.reconcileSelectAll();
@@ -450,7 +451,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     for (const value of childView.model.collection.models) {
                         if (self.selectedCaseIds.indexOf(value.id) === -1) {
                             self.selectedCaseIds.push(value.id);
-                            FormplayerFrontend.trigger("multiSelect:addCases", [value.id]);
+                            FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_ADD, [value.id]);
                         }
                     }
                 } else {
@@ -458,7 +459,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                         let index = self.selectedCaseIds.indexOf(value.id);
                         if (index !== -1) {
                             self.selectedCaseIds.splice(index, 1);
-                            FormplayerFrontend.trigger("multiSelect:removeCases", [value.id]);
+                            FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_REMOVE, [value.id]);
                         }
                     }
                 }
@@ -800,7 +801,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
         selectCase: function () {
             if (this.isMultiSelect) {
-                FormplayerFrontend.trigger("multiSelect:addCases", [this.caseId]);
+                FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_ADD, [this.caseId]);
             } else {
                 FormplayerFrontend.trigger("menu:select", this.caseId);
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -346,6 +346,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
             var self = this;
             FormplayerFrontend.on("multiSelect:updateCases", function (action, caseIds) {
+                if (action === Constants.MULTI_SELECT_ADD) {
+                    self.selectedCaseIds = _.union(self.selectedCaseIds, caseIds);
+                } else {
+                    self.selectedCaseIds = _.difference(self.selectedCaseIds, caseIds);
+                }
                 self.reconcileSelectAll();
             });
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -778,6 +778,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
     var CaseDetailFooterView = Marionette.View.extend({
         tagName: "div",
         className: "",
+        events: {
+            "click #select-case": "selectCase",
+        },
         getTemplate: function () {
             var id = "#module-case-detail";
             if (this.isPersistentDetail) {
@@ -790,6 +793,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         initialize: function (options) {
             this.isPersistentDetail = options.model.get('isPersistentDetail');
             this.isMultiSelect = options.isMultiSelect;
+            this.caseId = options.caseId;
+        },
+        selectCase: function () {
+            FormplayerFrontend.trigger("menu:select", this.caseId);
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -236,8 +236,15 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             'click @ui.selectRow': 'selectRowAction',
             'keypress @ui.selectRow': 'selectRowAction',
         },
+
         initialize: function () {
+            var self = this;
             this.parentView = this.options.parentView;
+            FormplayerFrontend.on("multiSelect:updateCases", function (action, caseIds) {
+                if (_.contains(caseIds, self.model.get('id'))) {
+                    self.ui.selectRow[0].checked = action === Constants.MULTI_SELECT_ADD;
+                }
+            });
         },
 
         className: "formplayer-request",

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -280,7 +280,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 this.parentView.ui.selectAllCheckbox[0].checked = false;
                 FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_REMOVE, [this.model.get('id')]);
             }
-            this.parentView.updateContinueButtonText(this.parentView.selectedCaseIds.length);
         },
 
         isChecked: function () {
@@ -352,6 +351,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     self.selectedCaseIds = _.difference(self.selectedCaseIds, caseIds);
                 }
 
+                // Update state of Continue button
+                self.ui.continueButtonText[0].innerText = self.selectedCaseIds.length;
+                self.ui.continueButton.prop("disabled", !self.selectedCaseIds.length);
+
                 // Reconcile state of "select all" checkbox
                 self.ui.selectAllCheckbox[0].checked = !_.difference(self._allCaseIds(), self.selectedCaseIds).length;
             });
@@ -369,6 +372,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             casesPerPageLimit: '.per-page-limit',
             selectAllCheckbox: "#select-all-checkbox",
             continueButton: "#multi-select-continue-btn",
+            continueButtonText: "#multi-select-btn-text",
         },
 
         events: {
@@ -464,7 +468,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         selectAllAction: function (e) {
             var action = e.target.checked ? Constants.MULTI_SELECT_ADD : Constants.MULTI_SELECT_REMOVE;
             FormplayerFrontend.trigger("multiSelect:updateCases", action, this._allCaseIds());
-            this.updateContinueButtonText(this.selectedCaseIds.length);
         },
 
         _allCaseIds: function () {
@@ -478,15 +481,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         continueAction: function () {
             sessionStorage.selectedValues = this.selectedCaseIds;
             FormplayerFrontend.trigger("menu:select", this.selectedCaseIds);
-        },
-
-        updateContinueButtonText: function (newValue) {
-            document.getElementById('multi-select-btn-text').innerText = String(newValue);
-            if (this.selectedCaseIds.length === 0) {
-                this.ui.continueButton.prop("disabled", true);
-            } else {
-                this.ui.continueButton.prop("disabled", false);
-            }
         },
 
         updateCheckboxes: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -239,7 +239,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         initialize: function () {
             var self = this;
-            this.parentView = this.options.parentView;
+            self.isMultiSelect = this.options.isMultiSelect;
             FormplayerFrontend.on("multiSelect:updateCases", function (action, caseIds) {
                 if (_.contains(caseIds, self.model.get('id'))) {
                     self.ui.selectRow[0].checked = action === Constants.MULTI_SELECT_ADD;
@@ -258,7 +258,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         rowClick: function (e) {
             if (!(e.target.classList.contains('module-case-list-column-checkbox') || e.target.classList.contains("select-row-checkbox"))) {
                 e.preventDefault();
-                FormplayerFrontend.trigger("menu:show:detail", this.model.get('id'), 0, this.parentView.options.isMultiSelect);
+                FormplayerFrontend.trigger("menu:show:detail", this.model.get('id'), 0, this.isMultiSelect);
             }
         },
 
@@ -282,7 +282,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             return {
                 data: this.options.model.get('data'),
                 styles: this.options.styles,
-                isMultiSelect: this.options.parentView.options.isMultiSelect,
+                isMultiSelect: this.options.isMultiSelect,
                 resolveUri: function (uri) {
                     return FormplayerFrontend.getChannel().request('resourceMap', uri, appId);
                 },
@@ -322,8 +322,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         childView: CaseView,
         childViewOptions: function () {
             return {
+                isMultiSelect: this.options.isMultiSelect,
                 styles: this.options.styles,
-                parentView: this,
             };
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -281,7 +281,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_REMOVE, [this.model.get('id')]);
             }
             this.parentView.updateContinueButtonText(this.parentView.selectedCaseIds.length);
-            this.parentView.reconcileSelectAll();
         },
 
         isChecked: function () {
@@ -344,6 +343,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             this.redoLast = options.redoLast;
             this.selectedCaseIds = sessionStorage.selectedValues === undefined || sessionStorage.selectedValues.length === 0 ?  [] : sessionStorage.selectedValues.split(',');
             this.isMultiSelect = options.isMultiSelect;
+
+            var self = this;
+            FormplayerFrontend.on("multiSelect:updateCases", function (action, caseIds) {
+                self.reconcileSelectAll();
+            });
         },
 
         ui: {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -268,6 +268,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 if (index > -1) {
                     this.parentView.selectedCaseIds.splice(index, 1);
                 }
+                this.parentView.ui.selectAllCheckbox[0].checked = false;
             }
             this.parentView.updateContinueButtonText(this.parentView.selectedCaseIds.length);
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -269,17 +269,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         selectRowAction: function (e) {
-            if (e.target.checked) {
-                this.parentView.selectedCaseIds.push(this.model.get('id'));
-                FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_ADD, [this.model.get('id')]);
-            } else {
-                const index = this.parentView.selectedCaseIds.indexOf(this.model.get('id'));
-                if (index > -1) {
-                    this.parentView.selectedCaseIds.splice(index, 1);
-                }
-                this.parentView.ui.selectAllCheckbox[0].checked = false;
-                FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_REMOVE, [this.model.get('id')]);
-            }
+            var action = e.target.checked ? Constants.MULTI_SELECT_ADD : Constants.MULTI_SELECT_REMOVE;
+            FormplayerFrontend.trigger("multiSelect:updateCases", action, [this.model.get('id')]);
         },
 
         isChecked: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -328,7 +328,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             this.hasNoItems = options.collection.length === 0;
             this.redoLast = options.redoLast;
             this.selectedCaseIds = sessionStorage.selectedValues === undefined || sessionStorage.selectedValues.length === 0 ?  [] : sessionStorage.selectedValues.split(',');
-            this.isMultiSelect = options.isMultiSelect,
+            this.isMultiSelect = options.isMultiSelect;
         },
 
         ui: {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -65,8 +65,8 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         listSettings: function () {
             appsController.listSettings();
         },
-        showDetail: function (caseId, detailTabIndex, isPersistent) {
-            menusController.selectDetail(caseId, detailTabIndex, isPersistent);
+        showDetail: function (caseId, detailTabIndex, isPersistent, isMultiSelect) {
+            menusController.selectDetail(caseId, detailTabIndex, isPersistent, isMultiSelect);
         },
         listSessions: function (pageNumber, pageSize) {
             sessionsController.listSessions(pageNumber, pageSize);
@@ -204,8 +204,8 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         API.listSettings();
     });
 
-    FormplayerFrontend.on("menu:show:detail", function (caseId, detailTabIndex, isPersistent) {
-        API.showDetail(caseId, detailTabIndex, isPersistent);
+    FormplayerFrontend.on("menu:show:detail", function (caseId, detailTabIndex, isMultiSelect, isPersistent) {
+        API.showDetail(caseId, detailTabIndex, isPersistent, isMultiSelect);
     });
 
     FormplayerFrontend.on("sessions", function (pageNumber, pageSize) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -226,11 +226,13 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             delete this.endpointId;
             delete this.endpointArgs;
             this.selections = selections || [];
+            sessionStorage.removeItem('selectedValues');
         };
 
         this.clearExceptApp = function () {
             this.sessionId = null;
             this.selections = null;
+            sessionStorage.removeItem('selectedValues');
             this.page = null;
             this.sortIndex = null;
             this.search = null;
@@ -263,6 +265,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.search = null;
             this.sortIndex = null;
             this.queryData = null;
+            sessionStorage.removeItem('selectedValues');
         };
     };
 

--- a/corehq/apps/cloudcare/templates/formplayer/case_detail.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_detail.html
@@ -33,7 +33,7 @@
 <script type="text/template" id="module-case-detail-multi-select">
   <button type="button"
       class="btn btn-success btn-lg module-case-detail-btn"
-      id="select-case-for-multi-select"
+      id="select-case"
       data-dismiss="modal">{% trans "Select" %}</button>
   <button type="button"
       class="btn btn-default btn-lg module-case-detail-btn"

--- a/corehq/apps/cloudcare/templates/formplayer/case_detail.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_detail.html
@@ -37,7 +37,6 @@
       data-dismiss="modal">{% trans "Select" %}</button>
   <button type="button"
       class="btn btn-default btn-lg module-case-detail-btn"
-      id="cancel-case-select"
       data-dismiss="modal">{% trans "Cancel" %}</button>
 </script>
 


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/QA-4122, and hopefully also https://dimagi-dev.atlassian.net/browse/QA-4110

First few commits are from @stephherbers 

Review by commit. I ended up moving around a good deal of code to make the logic more event-based, because the detail popup footer view doesn't have access to the case and case list views.

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
This should largely affect a feature that isn't being used in prod yet.

### Automated test coverage

None

### QA Plan

Will wait for QA to verify this before merging.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
