### PR TITLE
Fix parameter order

### DIFF
--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -213,7 +213,7 @@ def create_metrics_event(title: str, text: str, alert_type: str = ALERT_INFO,
     """
     tags = COMMON_TAGS.update(tags or {})
     try:
-        _get_metrics_provider().create_event(title, text, tags, alert_type, aggregation_key)
+        _get_metrics_provider().create_event(title, text, alert_type, tags, aggregation_key)
     except Exception as e:
         metrics_logger.exception('Error creating metrics event', e)
 


### PR DESCRIPTION
## Technical Summary

Fixes a bug where `create_event()` is called with two parameters swapped around.

## Safety Assurance

### Safety story

You can find the definition of [`create_event()` here](https://github.com/dimagi/commcare-hq/blob/cb15e8c3594a6f325fb3dd5a6cd741fadece88a7/corehq/util/metrics/metrics.py#L72).

### Automated test coverage

Bug discovered using type checking. Type checking not included.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
