### PR TITLE
Updated multi select select parent first logic

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -374,7 +374,7 @@ class ModuleBaseValidator(object):
                 'module': self.get_module_info(),
             })
 
-        if self.module.parent_select.active and self.module.parent_select.relationship == 'parent':
+        if hasattr(self.module, 'parent_select') and self.module.parent_select.active:
             if self.module.parent_select.relationship == 'parent':
                 from corehq.apps.app_manager.views.modules import get_modules_with_parent_case_type
                 valid_modules = get_modules_with_parent_case_type(app, self.module)

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -374,10 +374,17 @@ class ModuleBaseValidator(object):
                 'module': self.get_module_info(),
             })
 
-        if self.module.is_multi_select():
-            if self.module.parent_select.active and self.module.parent_select.relationship == 'parent':
+        if self.module.parent_select.active and self.module.parent_select.relationship == 'parent':
+            if self.module.parent_select.relationship == 'parent':
+                from corehq.apps.app_manager.views.modules import get_modules_with_parent_case_type
+                valid_modules = get_modules_with_parent_case_type(app, self.module)
+            else:
+                from corehq.apps.app_manager.views.modules import get_all_case_modules
+                valid_modules = get_all_case_modules(app, self.module)
+            valid_module_ids = [info['unique_id'] for info in valid_modules]
+            if self.module.parent_select.module_id not in valid_module_ids:
                 errors.append({
-                    'type': 'multi select select parent first',
+                    'type': 'invalid parent select id',
                     'module': self.get_module_info(),
                 })
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -295,21 +295,11 @@
                 <a href="{{ module_url }}">{{ module_name }}</a>
                 doesn't have a source module specified.
               {% endblocktrans %}
-            {% case "no parent select id" %}
+            {% case "invalid parent select id" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 <a href="{{ module_url }}">{{ module_name }}</a>
                 uses parent case selection but doesn't have a parent case list specified.
               {% endblocktrans %}
-            {% case "multi select select parent first" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses parent case selection and a multi-select case list.
-              {% endblocktrans %}
-              {% if "NON_PARENT_MENU_SELECTION" in toggles %}
-                {% trans "Multi-select case lists can only use 'other' parent child selection." %}
-              {% else %}
-                {% trans "These two features are not compatible." %}
-              {% endif %}
             {% case "parent cycle" %}
               {% blocktrans %}
                 The app's parent child case selection graph contains a cycle.

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -202,13 +202,13 @@ class MultiSelectSelectParentFirstTests(SimpleTestCase, TestXmlMixin):
     @patch('corehq.apps.app_manager.helpers.validators.domain_has_privilege', return_value=True)
     @patch('corehq.apps.builds.models.BuildSpec.supports_j2me', return_value=False)
     def test_select_parent_first_parent_not_allowed(self, *args):
-        self.other_module.parent_select.active = True
-        self.other_module.parent_select.module_id = self.module.unique_id
-        self.other_module.parent_select.relationship = 'parent'
+        self.module.parent_select.active = True
+        self.module.parent_select.module_id = self.other_module.unique_id
+        self.module.parent_select.relationship = 'parent'
 
         self.assertIn({
-            'type': 'multi select select parent first',
-            'module': {'id': 1, 'unique_id': 'another_module', 'name': {'en': 'another module'}}
+            'type': 'invalid parent select id',
+            'module': {'id': 0, 'unique_id': 'basic_module', 'name': {'en': 'basic module'}}
         }, self.factory.app.validate_app())
 
     @flag_enabled('NON_PARENT_MENU_SELECTION')

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -292,8 +292,8 @@ def _get_advanced_module_view_context(app, module):
 
 def _get_basic_module_view_context(request, app, module, case_property_builder):
     return {
-        'parent_case_modules': _get_modules_with_parent_case_type(app, module, case_property_builder),
-        'all_case_modules': _get_all_case_modules(app, module),
+        'parent_case_modules': get_modules_with_parent_case_type(app, module, case_property_builder),
+        'all_case_modules': get_all_case_modules(app, module),
         'case_list_form_not_allowed_reasons': _case_list_form_not_allowed_reasons(module),
         'child_module_enabled': (
             add_ons.show("submenus", request, app, module=module) and not module.is_training_module
@@ -395,22 +395,29 @@ def _setup_case_property_builder(app):
 
 
 # Parent case selection in case list: get modules whose case type is the parent of the given module's case type
-def _get_modules_with_parent_case_type(app, module, case_property_builder):
+def get_modules_with_parent_case_type(app, module, case_property_builder=None):
+    if case_property_builder is None:
+        case_property_builder = _setup_case_property_builder(app)
 
     parent_types = case_property_builder.get_parent_types(module.case_type)
     modules = app.modules
     parent_module_ids = [
         mod.unique_id for mod in modules
-        if mod.case_type in parent_types]
+        if mod.case_type in parent_types
+    ]
 
     return [{
         'unique_id': mod.unique_id,
         'name': mod.name,
-        'is_parent': mod.unique_id in parent_module_ids,
-    } for mod in app.modules if mod.case_type != module.case_type and mod.unique_id != module.unique_id]
+        'is_parent': mod.unique_id in parent_module_ids
+    } for mod in app.modules
+        if mod.case_type != module.case_type
+        and mod.unique_id != module.unique_id
+        and not mod.is_multi_select()
+    ]
 
 
-def _get_all_case_modules(app, module):
+def get_all_case_modules(app, module):
     # return all case modules except the given module
     return [{
         'unique_id': mod.unique_id,


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/QA-4118

Followup for https://github.com/dimagi/commcare-hq/pull/31457

Rethought the requirements on this one. It's fine for a multi-select menu to **use** select parent first. What doesn't make sense if for a multi-select menu to **be** a parent case list for some other menu's select parent first config, because that adds a `[index/parent=instance('commcaresession')/session/data/parent_id]` filter that isn't compatible with a parent that's an instance, not a single id.

This PR updates the UI to filter multi-select menus out of the select parent first dropdown. It also expands the build error to trigger if a select parent first config's parent menu is invalid for any reason (either it's a multi-select or it's been deleted).

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
Most of this is behind a feature flag, and the remainder is a fairly small refactor.

### Automated test coverage

There's some in the PR.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
