### PR TITLE
Allow gettext_lazy with the SelectToggle

### DIFF
--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -9,6 +9,8 @@ from django.utils.safestring import mark_safe
 from django.utils.html import format_html, conditional_escape
 from django.utils.translation import gettext_noop
 
+from corehq.util.json import CommCareJSONEncoder
+
 from dimagi.utils.dates import DateSpan
 
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import html_attr
@@ -149,15 +151,20 @@ class SelectToggle(forms.Select):
     def render(self, name, value, attrs=None, renderer=None):
         return '''
             <select-toggle data-apply-bindings="{apply_bindings}"
-                           params="name: '{name}',
-                                   id: '{id}',
-                                   value: {value},
-                                   options: {options}"></select-toggle>
-        '''.format(apply_bindings="true" if self.apply_bindings else "false",
-                   name=name,
-                   id=html_attr(attrs.get('id', '')),
-                   value=html_attr(self.params['value'] or '"{}"'.format(html_attr(value))),
-                   options=html_attr(json.dumps([{'id': c[0], 'text': c[1]} for c in self.choices])))
+                            params="name: '{name}',
+                                    id: '{id}',
+                                    value: {value},
+                                    options: {options}"></select-toggle>
+        '''.format(
+            apply_bindings="true" if self.apply_bindings else "false",
+            name=name,
+            id=html_attr(attrs.get('id', '')),
+            value=html_attr(self.params['value'] or '"{}"'.format(html_attr(value))),
+            options=html_attr(json.dumps(
+                [{'id': c[0], 'text': c[1]} for c in self.choices],
+                cls=CommCareJSONEncoder
+            ))
+        )
 
 
 class GeoCoderInput(Input):

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -561,9 +561,9 @@ class LocationFilterForm(forms.Form):
     SHOW_ALL = 'show_all'
 
     LOCATION_ACTIVE_STATUS = (
-        (SHOW_ALL, _('Show All')),
-        (ACTIVE, _('Only Active')),
-        (ARCHIVED, _('Only Archived'))
+        (SHOW_ALL, gettext_lazy('Show All')),
+        (ACTIVE, gettext_lazy('Only Active')),
+        (ARCHIVED, gettext_lazy('Only Archived'))
     )
 
     location_id = forms.CharField(

--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -105,9 +105,9 @@ class SavedReportConfigForm(forms.Form):
 
 class ScheduledReportForm(forms.Form):
     INTERVAL_CHOICES = [
-        ("daily", gettext("Daily")),
-        ("weekly", gettext("Weekly")),
-        ("monthly", gettext("Monthly"))
+        ("daily", _("Daily")),
+        ("weekly", _("Weekly")),
+        ("monthly", _("Monthly"))
     ]
 
     config_ids = forms.MultipleChoiceField(

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1411,9 +1411,9 @@ class UserFilterForm(forms.Form):
     INACTIVE = 'inactive'
 
     USER_ACTIVE_STATUS = [
-        ('show_all', _('Show All')),
-        (ACTIVE, _('Only Active')),
-        (INACTIVE, _('Only Deactivated'))
+        ('show_all', gettext_lazy('Show All')),
+        (ACTIVE, gettext_lazy('Only Active')),
+        (INACTIVE, gettext_lazy('Only Deactivated'))
     ]
 
     role_id = forms.ChoiceField(label=gettext_lazy('Role'), choices=(), required=False)


### PR DESCRIPTION
## Product Description

No user-facing effects

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

As discovered in [this PR](https://github.com/dimagi/commcare-hq/pull/31540), you can't use `ugettext_lazy` with our [SelectToggle widget](https://www.commcarehq.org/styleguide/molecules/#molecules-selections). So users of the SelectToggle have had to use regular `gettext` for the choices they pass into it. This means these choices probably aren't getting translated properly.

To fix this I've updated the SelectToggle as per `https://commcare-hq.readthedocs.io/translations.html#gettext-lazy-a-cautionary-tale` to allow the use of `gettext_lazy`, and updated the translations that are passed into this toggle.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested the SelectToggle locally on each page that is being updated here (locations download, users download, scheduled reports). It's purely text/UI so risk should be low. 

### Automated test coverage

Nope.

### QA Plan

None.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
