### PR TITLE
Updated get_add_case_preloads_case_id_xpath to check for multi-select

### DIFF
--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -346,8 +346,7 @@ class MultiSelectChildModuleDatumIDTests(SimpleTestCase, TestXmlMixin):
             ('instance-datum', 'selected_cases'),
             ('datum', 'case_id'),
         ])
-        # This should just be `case_id`
-        self.assert_form_datums(self.m1f0, 'case_id_beneficiary')
+        self.assert_form_datums(self.m1f0, 'case_id')
 
     def test_parent_selects_parent_same_type(self):
         self.set_parent_select(self.m0, self.m2)
@@ -392,8 +391,7 @@ class MultiSelectChildModuleDatumIDTests(SimpleTestCase, TestXmlMixin):
             ('instance-datum', 'selected_cases'),
             ('datum', 'case_id'),
         ])
-        # This should just be `case_id`
-        self.assert_form_datums(self.m1f0, 'case_id_beneficiary')
+        self.assert_form_datums(self.m1f0, 'case_id')
 
     def test_select_parent_that_selects_other_different_case_type(self):
         self.set_parent_select(self.m0, self.m3)
@@ -403,11 +401,9 @@ class MultiSelectChildModuleDatumIDTests(SimpleTestCase, TestXmlMixin):
             ('datum', 'parent_selected_cases'),
             ('instance-datum', 'selected_cases')
         ])
-        # This looks correct
         self.assert_module_datums(self.m1.id, [
             ('datum', 'parent_selected_cases'),
             ('instance-datum', 'selected_cases'),
             ('datum', 'case_id'),
         ])
-        # This should just be `case_id`
-        self.assert_form_datums(self.m1f0, 'case_id_beneficiary')
+        self.assert_form_datums(self.m1f0, 'case_id')

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -116,17 +116,16 @@ def get_case_parent_id_xpath(parent_path, case_id_xpath=None):
 
 
 def get_add_case_preloads_case_id_xpath(module, form):
-    xpath = None
     if 'open_case' in form.active_actions():
-        xpath = CaseIDXPath(session_var(form.session_var_for_action('open_case')))
+        return CaseIDXPath(session_var(form.session_var_for_action('open_case')))
     elif module.root_module_id and module.parent_select.active:
-        # This is a submodule. case_id will have changed to avoid a clash with the parent case.
-        # Case type is enough to ensure uniqueness for normal forms. No need to worry about a suffix.
-        case_id = '_'.join((CASE_ID, form.get_case_type()))
-        xpath = CaseIDXPath(session_var(case_id))
-    else:
-        xpath = SESSION_CASE_ID
-    return xpath
+        parent_module = module.get_app().get_module_by_unique_id(module.parent_select.module_id)
+        if not parent_module.is_multi_select():
+            # This is a submodule. case_id will have changed to avoid a clash with the parent case.
+            # Case type is enough to ensure uniqueness for normal forms. No need to worry about a suffix.
+            case_id = '_'.join((CASE_ID, form.get_case_type()))
+            return CaseIDXPath(session_var(case_id))
+    return SESSION_CASE_ID
 
 
 def relative_path(from_path, to_path):


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/QA-4117

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
This should only affect a flagged feature that isn't being used in prod.

### Automated test coverage

In PR.

### QA Plan

This is a qabug and will be verified.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
