### PR TITLE
Fixed another bit of weird multi-select datum behavior

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -981,12 +981,15 @@ class EntriesHelper(object):
                     if not parent_datum_meta.requires_selection:
                         # Add parent datums of opened subcases and automatically-selected cases
                         datums.insert(index, attr.evolve(parent_datum_meta, from_parent=True))
-                    elif this_datum_meta and this_datum_meta.case_type == parent_datum_meta.case_type:
-                        append_update(changed_ids_by_case_tag,
-                                      rename_other_id(this_datum_meta, parent_datum_meta, datum_ids))
-                        append_update(changed_ids_by_case_tag,
-                                      get_changed_id(this_datum_meta, parent_datum_meta))
-                        this_datum_meta.datum.id = parent_datum_meta.datum.id
+                    elif this_datum_meta:
+                        same_case_type = this_datum_meta.case_type == parent_datum_meta.case_type
+                        same_datum_type = type(this_datum_meta.datum) == type(parent_datum_meta.datum)
+                        if same_case_type and same_datum_type:
+                            append_update(changed_ids_by_case_tag,
+                                          rename_other_id(this_datum_meta, parent_datum_meta, datum_ids))
+                            append_update(changed_ids_by_case_tag,
+                                          get_changed_id(this_datum_meta, parent_datum_meta))
+                            this_datum_meta.datum.id = parent_datum_meta.datum.id
                 index += 1
 
     @staticmethod

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -983,7 +983,7 @@ class EntriesHelper(object):
                         datums.insert(index, attr.evolve(parent_datum_meta, from_parent=True))
                     elif this_datum_meta:
                         same_case_type = this_datum_meta.case_type == parent_datum_meta.case_type
-                        same_datum_type = type(this_datum_meta.datum) == type(parent_datum_meta.datum)
+                        same_datum_type = this_datum_meta.datum.ROOT_NAME == parent_datum_meta.datum.ROOT_NAME
                         if same_case_type and same_datum_type:
                             append_update(changed_ids_by_case_tag,
                                           rename_other_id(this_datum_meta, parent_datum_meta, datum_ids))

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -333,8 +333,7 @@ class MultiSelectChildModuleDatumIDTests(SimpleTestCase, TestXmlMixin):
     def test_child_of_multiselect(self):
         self.assert_module_datums(self.m0.id, [('instance-datum', 'selected_cases')])
 
-        # datum = selected_cases? Should it be case_id?
-        self.assert_module_datums(self.m1.id, [('datum', 'selected_cases')])
+        self.assert_module_datums(self.m1.id, [('datum', 'case_id')])
         # case_id isn't defined in the session
         self.assert_form_datums(self.m1f0, 'case_id')
 

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -334,7 +334,6 @@ class MultiSelectChildModuleDatumIDTests(SimpleTestCase, TestXmlMixin):
         self.assert_module_datums(self.m0.id, [('instance-datum', 'selected_cases')])
 
         self.assert_module_datums(self.m1.id, [('datum', 'case_id')])
-        # case_id isn't defined in the session
         self.assert_form_datums(self.m1f0, 'case_id')
 
     def test_select_parent_multiselect(self):


### PR DESCRIPTION
## Technical Summary
Fixes a piece of strange behavior identified in https://github.com/dimagi/commcare-hq/pull/31559/

This shouldn't have a user-facing effect, but for consistency, let's only use `selected_cases` for multi-select datums.

@esoergel I think this rename logic is where most of the remaining weirdness is. I originally added a check for matching datum ids instead of matching classes, which seemed like the right things to do, since it's duplicate ids that are a problem for CommCare, and that fixed some of it but broke other legitimate behavior.

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
Should only affect a feature flag that isn't being used in prod.

### Automated test coverage

In PR.

### QA Plan

No

### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
