### PR TITLE
setup django app registry prior to building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ settings.LOGGING = {}
 init_hq_python_path()
 
 # Must setup django app registry prior to building docs with sphinx
-import django
+import django  # noqa: E402
 django.setup()
 
 # -- Custom configuration -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,10 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 settings.LOGGING = {}
 init_hq_python_path()
 
+# Must setup django app registry prior to building docs with sphinx
+import django
+django.setup()
+
 # -- Custom configuration -----------------------------------------------------
 
 # mock out stubborn modules that are hard to pip install


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[SAAS-13529](https://dimagi-dev.atlassian.net/browse/SAAS-13529)


When building docs, I ran into this warning `WARNING: autodoc: failed to import class 'specs.NamedExpressionSpec' from module 'corehq.apps.userreports.expressions'; the following exception was raised: django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.` for many different UCR spec classes. I couldn't find explicit information on why this recently changed, but my best guess is a difference between Django 2 and 3. We don't know at what point these doc references broke so it is tough to say with any confidence.

Regardless, it appears we need to explicitly call `django.setup()` prior to building docs to ensure the app registry is loaded and imports succeed.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Locally tested with cleaned `docs/_build` directory and no longer encounter these errors. My local docs build displays these class references as expected.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Just docs.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
