### PR TITLE
Don't set custom xmlns in bulk case util

### DIFF
--- a/corehq/apps/hqcase/bulk.py
+++ b/corehq/apps/hqcase/bulk.py
@@ -4,7 +4,7 @@ from xml.etree import cElementTree as ElementTree
 from corehq.apps.users.util import SYSTEM_USER_ID, username_to_user_id
 from corehq.form_processor.models import CommCareCase
 
-from .utils import CASEBLOCK_CHUNKSIZE, SYSTEM_FORM_XMLNS, submit_case_blocks
+from .utils import CASEBLOCK_CHUNKSIZE, submit_case_blocks
 
 
 @dataclass(frozen=True)
@@ -12,7 +12,6 @@ class SystemFormMeta:
     user_id: str = SYSTEM_USER_ID
     username: str = SYSTEM_USER_ID
     device_id: str = SYSTEM_USER_ID
-    xmlns: str = SYSTEM_FORM_XMLNS
 
     @classmethod
     def for_script(cls, name, username=None):
@@ -28,7 +27,6 @@ class SystemFormMeta:
 
         return cls(
             device_id=name,
-            xmlns=f"http://commcarehq.org/script/{name.split('.')[-1]}",
             **user_kwargs,
         )
 
@@ -64,7 +62,6 @@ class CaseBulkDB:
                 case_blocks,
                 self.domain,
                 device_id=self.form_meta.device_id,
-                xmlns=self.form_meta.xmlns,
                 user_id=self.form_meta.user_id,
                 username=self.form_meta.username,
             )

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -113,8 +113,9 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
 
         # Exclude system forms unless they selected "Unknown User"
         if HQUserType.UNKNOWN not in EMWF.selected_user_types(mobile_user_and_group_slugs):
-            for xmlns in SYSTEM_FORM_XMLNS_MAP.keys():
-                query = query.NOT(form_es.xmlns(xmlns))
+            query = query.NOT(form_es.xmlns(
+                list(SYSTEM_FORM_XMLNS_MAP.keys())
+            ))
         return query
 
     @property


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://docs.google.com/document/d/1t97k35y9juT7Wl_suOiWi-NYP3cpiaV4hUmZ0j2e-e4/edit#
We are not consistent in how we use these meta properties with system forms, but this is more in line with the docstring on submit_case_blocks.

https://github.com/dimagi/commcare-hq/blob/0f98c6a80a2cf57d247d145bf42c16dac378227a/corehq/apps/hqcase/utils.py#L42-L47

As of this writing, this only affects a once-off covid script.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
The util has its own tests as does the script that uses it

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
