### PR TITLE
only write to redis if throttling

### DIFF
--- a/corehq/apps/api/resources/meta.py
+++ b/corehq/apps/api/resources/meta.py
@@ -33,7 +33,11 @@ class HQThrottle(CacheDBThrottle):
         # Do the import here, instead of top-level, so that the model is
         # only required when using this throttling mechanism.
         from tastypie.models import ApiAccess
-        super(CacheDBThrottle, self).accessed(identifier, **kwargs)
+
+        # only record in redis if we need the throttle, otherwise skip
+        # and just leave the db logging
+        if not API_THROTTLE_WHITELIST.enabled(identifier):
+            super(CacheDBThrottle, self).accessed(identifier, **kwargs)
         # Write out the access to the DB for logging purposes.
         url = kwargs.get('url', '')
         if len(url) > 255:


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
API usage tracking is a huge contributor to our redis bandwidth, which we have recently been exceeding the limits of our capacity. This does not track API usage in redis (but continues to log in the audit db) if the user is exempt from rate limits, as they both represent the highest volume users and we don't need to care in that case.

If you are curious about the link between redis usage and API hits by certain projects, I made this notebook https://app.datadoghq.com/notebook/2415859/ny-api-usage-vs-redis-network

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`API_THROTTLE_WHITELIST`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
No behavior change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
