### PR TITLE
Revert "setup django app registry prior to building docs"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,10 +23,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 settings.LOGGING = {}
 init_hq_python_path()
 
-# Must setup django app registry prior to building docs with sphinx
-import django  # noqa: E402
-django.setup()
-
 # -- Custom configuration -----------------------------------------------------
 
 # mock out stubborn modules that are hard to pip install


### PR DESCRIPTION
Reverts dimagi/commcare-hq#31571

Reverting because it seems better to have a docs build that passes with a few bugs rather than a docs build that fails. Still need some time to figure out a better solution to the dependency issue.