### PR TITLE
Rc/case search accessibility

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -4,7 +4,7 @@
 <script type="text/template" id="case-view-list-template">
   <div class="module-case-list-container">
 
-    <div class="page-header menu-header"><h1 class="page-title"><%- title %></h1></div>
+    <div arialabel="<%- title %>" tabindex="0" class="page-header menu-header"><h1 class="page-title"><%- title %></h1></div>
 
     <div class="module-search-container">
       <div class="input-group input-group-lg">

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -3,7 +3,7 @@
 
 <script type="text/template" id="query-view-list-template">
   <form>
-    <p><h2><%- title %></h2></p>
+    <p><h2 tabindex="0"><%- title %></h2></p>
     <table class="table table-hover table-striped table-bordered">
       <tbody>
       </tbody>
@@ -21,7 +21,7 @@
 
 <script type="text/template" id="query-view-item-template">
   <td class="col-sm-6">
-    <div>
+    <div tabindex="0">
       <%- text ? text : "" %>
       <% if (typeof hint !== "undefined" && hint !== null) { %>
       <div class="hq-help pull-right">
@@ -53,14 +53,14 @@
     <select>
 
     <% } else if (input == "daterange") { %>
-    <input type="text" class="daterange query-field form-control" value="<%- value %>">
+    <input aria-label="<%- text ? text : "" %> daterange" type="text" class="daterange query-field form-control" value="<%- value %>">
 
     <% } else if (input == "address") { %>
     <div class="query-field" value="<%- value %>" id="<%- id %>_mapbox" data-address="<%- id %>">
     </div>
 
     <% } else { %>
-    <input type="text" class="query-field form-control" value="<%- value %>" data-receive="<%- receive %>">
+    <input aria-label="<%- text ? text : "" %> text entry" type="text" class="query-field form-control" value="<%- value %>" data-receive="<%- receive %>">
     <% } %>
 
     <% if (allow_blank_value) { %>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Previously, in case search, there was no indication that screenreader users had landed on the case search page. Search field labels were skipped if the user was tabbing, as opposed to stepping incrementally, through the page, and text input fields were read out as generically as "text entry".

Now the case search heading and search field labels will be read when tabbing and the text inputs will be read with a more specific description, e.g. "last name text entry".

https://user-images.githubusercontent.com/42388648/166567392-bf789716-f763-4e20-b4de-7d0fde190076.mov

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-1929

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally and on staging.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
