### PR TITLE
Show proper XMLNS on form_data page

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1710,7 +1710,7 @@ def _get_cases_changed_context(domain, form, case_id=None):
 def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
     from corehq.apps.hqwebapp.templatetags.proptable_tags import get_default_definition, get_tables_as_columns
 
-    meta = _top_level_tags(form).get('meta', None) or {}
+    meta = form.form_data.get('meta', None) or {}
 
     meta['received_on'] = json_format_datetime(form.received_on)
     meta['server_modified_on'] = json_format_datetime(form.server_modified_on) if form.server_modified_on else ''
@@ -1755,28 +1755,6 @@ def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
         "auth_user_info": auth_user_info,
         "user_info": user_info,
     }
-
-
-def _top_level_tags(form):
-    """
-    Returns a OrderedDict of the top level tags found in the xml, in the
-    order they are found.
-
-    The actual values are taken from the form JSON data and not from the XML
-    """
-    to_return = OrderedDict()
-
-    element = form.get_xml_element()
-    if element is None:
-        return OrderedDict(sorted(form.form_data.items()))
-
-    for child in element:
-        # fix {namespace}tag format forced by ElementTree in certain cases (eg, <reg> instead of <n0:reg>)
-        key = child.tag.split('}')[1] if child.tag.startswith("{") else child.tag
-        if key == "Meta":
-            key = "meta"
-        to_return[key] = form.get_data('form/' + key)
-    return to_return
 
 
 def _sorted_form_metadata_keys(keys):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1711,7 +1711,7 @@ def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
     from corehq.apps.hqwebapp.templatetags.proptable_tags import get_default_definition, get_tables_as_columns
 
     meta = form.form_data.get('meta', None) or {}
-
+    meta['@xmlns'] = form.xmlns
     meta['received_on'] = json_format_datetime(form.received_on)
     meta['server_modified_on'] = json_format_datetime(form.server_modified_on) if form.server_modified_on else ''
     if support_enabled:

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1710,7 +1710,7 @@ def _get_cases_changed_context(domain, form, case_id=None):
 def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
     from corehq.apps.hqwebapp.templatetags.proptable_tags import get_default_definition, get_tables_as_columns
 
-    meta = form.form_data.get('meta', None) or {}
+    meta = form.metadata.to_json()
     meta['@xmlns'] = form.xmlns
     meta['received_on'] = json_format_datetime(form.received_on)
     meta['server_modified_on'] = json_format_datetime(form.server_modified_on) if form.server_modified_on else ''


### PR DESCRIPTION
## Product Description
Currently, the form data page doesn't show the actual XMLNS that's used in filtering forms, but the one on the `<meta />` block.  This means that given a form with an XML like this:

![image](https://user-images.githubusercontent.com/2367539/166715472-c7e68dfe-4543-4ca6-a654-1e6462ff0987.png)

The metadata tab shows
> **@xmlns**
> http://openrosa.org/jr/xforms 

This PR switches that to
> **@xmlns**
> http://openrosa.org/formdesigner/7BC5123F-E2B3-4F02-A780-91912478092E

That latter one is the actual XMLNS used to identify particular forms in reports.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Bonus clean-up commit

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
