### PR TITLE
Add DOCS_BUILD flag to sphinx command to setup django before builds

### DIFF
--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -46,5 +46,7 @@ object.__setattr__(_state.current_app, "_Proxy__local", _get_current_app)
 _state.get_current_app = _get_current_app
 
 if os.environ.get('DOCS_BUILD'):
+    # Before building docs, django.setup() needs to be run, specifically to register apps so that imports succeed.
+    # Adding this in docs/conf.py would be too early because autodoc_mock_imports have not yet been applied.
     import django
     django.setup()

--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -44,3 +44,7 @@ assert _state._tls.current_app is None, "Current app already created"
 assert hasattr(_state.current_app, "_Proxy__local")
 object.__setattr__(_state.current_app, "_Proxy__local", _get_current_app)
 _state.get_current_app = _get_current_app
+
+if os.environ.get('DOCS_BUILD'):
+    import django
+    django.setup()

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,4 +22,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@DOCS_BUILD=1 $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Take 2 on #31571.

Due to a recent refactor where celery is no longer initialized any time `corehq/__init__.py` is executed, `django.setup()` was not being called for doc builds which resulted in imports failing due to apps not being registered yet. We unfortunately cannot add `django.setup()` to `docs/conf.py` because the mock_imports specified in that config are not yet applied, which causes `django.setup()` to fail when only running with docs-requirements.txt.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally with only docs-requirements.txt installed.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
