### PR TITLE
Ethiopian Dates: Keep date strings marked as constants as strings

### DIFF
--- a/corehq/apps/userreports/expressions/date_specs.py
+++ b/corehq/apps/userreports/expressions/date_specs.py
@@ -295,4 +295,7 @@ class EthiopianDateToGregorianDateSpec(JsonObject):
         self._date_expression = date_expression
 
     def __call__(self, item, context=None):
-        return transform_date(get_ethiopian_to_gregorian(self._date_expression(item, context)))
+        unwrapped_date = self._date_expression(item, context)
+        if isinstance(unwrapped_date, (datetime.datetime, datetime.date)):
+            unwrapped_date = unwrapped_date.isoformat()
+        return transform_date(get_ethiopian_to_gregorian(unwrapped_date))

--- a/corehq/apps/userreports/expressions/date_specs.py
+++ b/corehq/apps/userreports/expressions/date_specs.py
@@ -297,5 +297,5 @@ class EthiopianDateToGregorianDateSpec(JsonObject):
     def __call__(self, item, context=None):
         unwrapped_date = self._date_expression(item, context)
         if isinstance(unwrapped_date, (datetime.datetime, datetime.date)):
-            unwrapped_date = unwrapped_date.isoformat()
+            unwrapped_date = unwrapped_date.strftime('%Y-%m-%d')
         return transform_date(get_ethiopian_to_gregorian(unwrapped_date))

--- a/corehq/apps/userreports/expressions/date_specs.py
+++ b/corehq/apps/userreports/expressions/date_specs.py
@@ -283,6 +283,11 @@ class EthiopianDateToGregorianDateSpec(JsonObject):
         }
 
     """
+
+    class Meta(object):
+        # prevent JsonObject from auto-converting dates etc.
+        string_conversions = ()
+
     type = TypeProperty("ethiopian_date_to_gregorian_date")
     date_expression = DefaultProperty(required=True)
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -82,10 +82,6 @@ class ConstantGetterSpec(JsonObject):
            "constant": "hello"
        }
     """
-    class Meta(object):
-        # prevent JsonObject from auto-converting dates etc.
-        string_conversions = ()
-
     type = TypeProperty('constant')
     constant = DefaultProperty()
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -82,6 +82,10 @@ class ConstantGetterSpec(JsonObject):
            "constant": "hello"
        }
     """
+    class Meta(object):
+        # prevent JsonObject from auto-converting dates etc.
+        string_conversions = ()
+
     type = TypeProperty('constant')
     constant = DefaultProperty()
 

--- a/corehq/apps/userreports/tests/test_date_expressions.py
+++ b/corehq/apps/userreports/tests/test_date_expressions.py
@@ -155,8 +155,9 @@ def test_add_hours_to_datetime_expression(self, source_doc, count_expression, ex
 
 @generate_cases([
     ({'dob': '2015-01-20'}, date(2022, 9, 30)),
-    ({'dob': date(2015, 1, 20)}, None),  # Cannot convert a native date
-    ({'dob': datetime(2015, 1, 20)}, None),
+    ({'dob': '2014-13-05'}, date(2022, 9, 10)),
+    ({'dob': date(2015, 1, 20)}, date(2022, 9, 30)),
+    ({'dob': datetime(2015, 1, 20)}, date(2022, 9, 30)),
 ])
 def test_ethiopian_to_gregorian_expression(self, source_doc, expected_value):
     date_expression = {

--- a/corehq/apps/userreports/tests/test_date_expressions.py
+++ b/corehq/apps/userreports/tests/test_date_expressions.py
@@ -171,7 +171,8 @@ def test_ethiopian_to_gregorian_expression(self, source_doc, expected_value):
 
 
 @generate_cases([
-    ({"type": "constant", "constant": '2015-01-20'}, date(2022, 9, 30)),
+    ({"type": "constant", "constant": '2015-01-20'}, date(2022, 9, 30)),  # Date that looks like gregorian dates
+    ({"type": "constant", "constant": '2014-13-05'}, date(2022, 9, 10)),  # Invalid gregorian date, valid ethiopian
 ])
 def test_ethiopian_to_gregorian_expression_constant(self, expression, expected_value):
     """

--- a/corehq/apps/userreports/tests/test_date_expressions.py
+++ b/corehq/apps/userreports/tests/test_date_expressions.py
@@ -171,6 +171,20 @@ def test_ethiopian_to_gregorian_expression(self, source_doc, expected_value):
 
 
 @generate_cases([
+    ({"type": "constant", "constant": '2015-01-20'}, date(2022, 9, 30)),
+])
+def test_ethiopian_to_gregorian_expression_constant(self, expression, expected_value):
+    """
+        Used to fail with BadValueError: datetime.date(2020, 9, 9) is not a date-formatted string
+    """
+    wrapped_expression = ExpressionFactory.from_spec({
+        'type': 'ethiopian_date_to_gregorian_date',
+        'date_expression': expression,
+    })
+    self.assertEqual(expected_value, wrapped_expression({"foo": "bar"}))
+
+
+@generate_cases([
     ({'dob': '2022-09-30'}, '2015-01-20'),
     ({'dob': date(2022, 9, 30)}, '2015-01-20'),
     ({'dob': datetime(2022, 9, 30)}, '2015-01-20'),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When using the ethiopian date conversion with a constant, we were facing a "not a date-formatted string" error due to `jsonobject`'s auto-conversion of constants that look like dates to dates. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-2077

Similar issue to: https://github.com/dimagi/commcare-hq/pull/29592 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
This is a well tested area of code, and I've added tests covering the new functionality

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
