### PR TITLE
Removed unused "no forms" build error

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -125,11 +125,6 @@
               {% if error.message %}
                 {% trans "Details:" %}
               {% endif %}
-            {% case "no forms" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                has no forms.
-              {% endblocktrans %}
             {% case "no forms or case list" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 <a href="{{ module_url }}">{{ module_name }}</a>


### PR DESCRIPTION
## Technical Summary
We only use ever raise the "no forms or case list" build error.

## Safety Assurance

### Safety story
Small dead code removal.

### Automated test coverage

Probably none.

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
