### PR TITLE
Minor fixes for finding already claimed cases

### DIFF
--- a/corehq/apps/ota/tests/test_claim.py
+++ b/corehq/apps/ota/tests/test_claim.py
@@ -130,6 +130,24 @@ class CaseClaimTests(TestCase):
         first_claim = get_first_claims(DOMAIN, self.user.user_id, [self.host_case_id])
         self.assertEqual(first_claim, {self.host_case_id})
 
+    def test_claim_index_deleted(self):
+        """
+        get_first_claim should return None if claim case is closed
+        """
+        claim_id = claim_case(DOMAIN, self.restore_user, self.host_case_id,
+                              host_type=self.host_case_type, host_name=self.host_case_name)
+
+        # delete the case index
+        case_block = CaseBlock(
+            create=False,
+            case_id=claim_id,
+            index={"host": (self.host_case_type, "")}
+        ).as_xml()
+        post_case_blocks([case_block], {'domain': DOMAIN})
+
+        first_claim = get_first_claims(DOMAIN, self.user.user_id, [self.host_case_id])
+        self.assertEqual(len(first_claim), 0)
+
     def test_claim_case_other_domain(self):
         malicious_domain = 'malicious_domain'
         domain_obj = create_domain(malicious_domain)

--- a/corehq/ex-submodules/casexml/apps/case/cleanup.py
+++ b/corehq/ex-submodules/casexml/apps/case/cleanup.py
@@ -147,19 +147,18 @@ def get_first_claims(domain, user_id, case_ids):
     if len(cases_not_found) != 0:
         raise CaseNotFound(", ".join(cases_not_found))
 
-    potential_cases = CommCareCase.objects.get_reverse_indexed_cases(
+    potential_claim_cases = CommCareCase.objects.get_reverse_indexed_cases(
         domain, case_ids_found, case_types=[CLAIM_CASE_TYPE], is_closed=False)
-    # creates set of claimed case_ids where owner_id = user_id
 
     def _get_host_case_id(case):
-        """The actual index identifier is irrelevant so return the referenced case ID from the first
-        extension index."""
+        """The actual index identifier is irrelevant so return the referenced case ID
+        from the first live extension index"""
         for index in case.live_indices:
             if index.relationship == CASE_INDEX_EXTENSION:
                 return index.referenced_id
 
     previously_claimed_ids = {
-        _get_host_case_id(case) for case in potential_cases
+        _get_host_case_id(case) for case in potential_claim_cases
         if case.owner_id == user_id
     }
 


### PR DESCRIPTION
## Technical Summary
Using the save-to-case feature it is possible to create 'claim' cases that do not use the 'host' index identifier. Regardless of this they still serve the same purpose since index identifiers are not a considering in determining what cases are considered part of a user restore.

This makes two changes to the code that looks for existing claims:
1. ignore the index ID return the first extension index
2. only consider 'live' indexes. It is unlikely we would come across this edge case but it is more compliant with the index contract.

## Feature Flag
case search and claim

## Safety Assurance

### Safety story
Feature is covered by existing tests. Tests added for changes.

### Automated test coverage
Covered by existing tests

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
