### PR TITLE
test to validate case block ordering in a form does not impact index creation

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -166,6 +166,22 @@ class CaseBugTest(TestCase, TestFileMixin):
         self.assertEqual(cases[0].get_case_property('p'), '2')
         self.assertEqual(cases[1].get_case_property('p'), '2')
 
+    def test_case_block_ordering_with_indices(self):
+        # creating a case that indexes another new case in the same form
+        # where the child case block appears before the parent case block in the form
+        case_id1 = "child-" + uuid.uuid4().hex
+        case_id2 = "parent-" + uuid.uuid4().hex
+        blocks = [
+            CaseBlock(create=True, case_id=case_id1, case_type="child", index={
+                "parent": ("parent", case_id2)
+            }).as_xml(),
+            CaseBlock(create=True, case_id=case_id2, case_type="parent").as_xml()
+        ]
+
+        xform, cases = post_case_blocks(blocks)
+        child_case = [case for case in cases if case.type == "child"][0]
+        self.assertEqual(child_case.get_index("parent").referenced_id, case_id2)
+
 
 @sharded
 class TestCaseHierarchy(TestCase):


### PR DESCRIPTION
## Technical Summary
I couldn't find another test to answer this specific question so added one.

## Safety Assurance

### Safety story
Tests only 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
