### PR TITLE
Modify exception raised and error shown to user when case import cache issue encountered

### DIFF
--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -22,10 +22,6 @@ class ImporterFileNotFound(ImporterError):
     """Raised when a referenced file can't be found"""
 
 
-class ImporterCacheError(ImporterError):
-    """Raised when a referenced file can't be found in cache"""
-
-
 class ImporterExcelError(ImporterError, xlrd.XLRDError):
     """
     Generic error raised for any error parsing an Excel file

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -22,8 +22,8 @@ class ImporterFileNotFound(ImporterError):
     """Raised when a referenced file can't be found"""
 
 
-class ImporterRefError(ImporterError):
-    """Raised when a Soil download ref is None"""
+class ImporterCacheError(ImporterError):
+    """Raised when a referenced file can't be found in cache"""
 
 
 class ImporterExcelError(ImporterError, xlrd.XLRDError):

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -99,7 +99,8 @@ class ImporterTest(TestCase):
         self.assertIsInstance(res.result, Ignore)
         update_state.assert_called_with(
             state=states.FAILURE,
-            meta=get_interned_exception('Sorry, your session has expired. Please start over and try again.'))
+            meta=get_interned_exception('There was an unexpected error retrieving the file you uploaded. '
+                                        'Please try again and contact support if the problem persists.'))
         self.assertEqual(0, len(CommCareCase.objects.get_case_ids_in_domain(self.domain)))
 
     def testImportBasic(self):

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -4,7 +4,7 @@ from django.db import transaction
 
 from memoized import memoized
 
-from corehq.apps.case_importer.exceptions import ImporterRefError
+from corehq.apps.case_importer.exceptions import ImporterCacheError
 from corehq.apps.case_importer.tracking.exceptions import TimedOutWaitingForCaseUploadRecord
 from corehq.apps.case_importer.tracking.filestorage import (
     persistent_file_store,
@@ -59,7 +59,7 @@ class CaseUpload(object):
         """
         tempfile = self.get_tempfile()
         if not tempfile:
-            raise ImporterRefError('file not found in cache')
+            raise ImporterCacheError('file not found in cache')
         open_spreadsheet_download_ref(tempfile)
 
     def get_spreadsheet(self):

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -4,7 +4,7 @@ from django.db import transaction
 
 from memoized import memoized
 
-from corehq.apps.case_importer.exceptions import ImporterCacheError
+from corehq.apps.case_importer.exceptions import ImporterFileNotFound
 from corehq.apps.case_importer.tracking.exceptions import TimedOutWaitingForCaseUploadRecord
 from corehq.apps.case_importer.tracking.filestorage import (
     persistent_file_store,
@@ -59,7 +59,7 @@ class CaseUpload(object):
         """
         tempfile = self.get_tempfile()
         if not tempfile:
-            raise ImporterCacheError('file not found in cache')
+            raise ImporterFileNotFound('file not found in cache')
         open_spreadsheet_download_ref(tempfile)
 
     def get_spreadsheet(self):

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -10,7 +10,6 @@ from memoized import memoized
 
 from corehq.apps.case_importer.const import LookupErrors
 from corehq.apps.case_importer.exceptions import (
-    ImporterCacheError,
     ImporterExcelError,
     ImporterExcelFileEncrypted,
     ImporterFileNotFound,
@@ -184,12 +183,9 @@ def get_spreadsheet(filename):
 
 
 def get_importer_error_message(e):
-    if isinstance(e, ImporterCacheError):
-        return _('The file you uploaded cannot be read successfully. '
-                 'Please try again and reach out to support if the problem persists.')
-    elif isinstance(e, ImporterFileNotFound):
-        return _('The session containing the file you uploaded has expired. '
-                 'Please upload a new one.')
+    if isinstance(e, ImporterFileNotFound):
+        return _('There was an unexpected error retrieving the file you uploaded. '
+                 'Please try again and contact support if the problem persists.')
     elif isinstance(e, ImporterExcelFileEncrypted):
         return _('The file you want to import is password protected. '
                  'Please choose a file that is not password protected.')

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -10,11 +10,11 @@ from memoized import memoized
 
 from corehq.apps.case_importer.const import LookupErrors
 from corehq.apps.case_importer.exceptions import (
-    ImporterRawError,
+    ImporterCacheError,
     ImporterExcelError,
     ImporterExcelFileEncrypted,
     ImporterFileNotFound,
-    ImporterRefError,
+    ImporterRawError,
 )
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase
@@ -184,12 +184,9 @@ def get_spreadsheet(filename):
 
 
 def get_importer_error_message(e):
-    if isinstance(e, ImporterRefError):
-        # I'm not totally sure this is the right error, but it's what was being
-        # used before. (I think people were just calling _spreadsheet_expired
-        # or otherwise blaming expired sessions whenever anything unexpected
-        # happened though...)
-        return _('Sorry, your session has expired. Please start over and try again.')
+    if isinstance(e, ImporterCacheError):
+        return _('The file you uploaded cannot be read successfully. '
+                 'Please try again and reach out to support if the problem persists.')
     elif isinstance(e, ImporterFileNotFound):
         return _('The session containing the file you uploaded has expired. '
                  'Please upload a new one.')

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -9,7 +9,6 @@ from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from corehq.apps.hqwebapp.decorators import waf_allow
 from dimagi.utils.logging import notify_error
 from dimagi.utils.web import json_response
 
@@ -34,15 +33,20 @@ from corehq.apps.case_importer.suggested_fields import (
 from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
 from corehq.apps.case_importer.util import get_importer_error_message
 from corehq.apps.domain.decorators import api_auth
+from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.apps.reports.analytics.esaccessors import (
     get_case_types_for_domain_es,
 )
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
-from corehq.util.view_utils import absolute_reverse
-from corehq.util.workbook_reading import valid_extensions, SpreadsheetFileExtError, SpreadsheetFileInvalidError
 from corehq.toggles import DOMAIN_PERMISSIONS_MIRROR
+from corehq.util.view_utils import absolute_reverse
+from corehq.util.workbook_reading import (
+    SpreadsheetFileExtError,
+    SpreadsheetFileInvalidError,
+    valid_extensions,
+)
 
 require_can_edit_data = require_permission(Permissions.edit_data)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This came up in the issue uncovered in https://dimagi-dev.atlassian.net/browse/QA-4142.  Since the only place `ImporterRefError` was being used was when there was an unexpected cache miss, I modified that exception to be more specific to this use case. Additionally, I changed the error message displayed to the user to describe the problem slightly better, though still without including unnecessary details.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Minor refactor.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
