### PR TITLE
improvements to sms test view

### DIFF
--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -636,18 +636,22 @@ def load_and_call(sms_handler_names, phone_number, text, sms):
     return handled
 
 
-def get_inbound_phone_entry(msg):
-    if msg.backend_id:
-        backend = SQLMobileBackend.load(msg.backend_id, is_couch_id=True)
+def get_inbound_phone_entry_from_sms(msg):
+    return get_inbound_phone_entry(msg.phone_number, msg.backend_id)
+
+
+def get_inbound_phone_entry(phone_number, backend_id=None):
+    if backend_id:
+        backend = SQLMobileBackend.load(backend_id, is_couch_id=True)
         if toggles.INBOUND_SMS_LENIENCY.enabled(backend.domain):
             p = None
             if toggles.ONE_PHONE_NUMBER_MULTIPLE_CONTACTS.enabled(backend.domain):
                 running_session_info = XFormsSessionSynchronization.get_running_session_info_for_channel(
-                    SMSChannel(backend_id=msg.backend_id, phone_number=msg.phone_number)
+                    SMSChannel(backend_id=backend_id, phone_number=phone_number)
                 )
                 contact_id = running_session_info.contact_id
                 if contact_id:
-                    p = PhoneNumber.get_phone_number_for_owner(contact_id, msg.phone_number)
+                    p = PhoneNumber.get_phone_number_for_owner(contact_id, phone_number)
                 if p is not None:
                     return (
                         p,
@@ -669,14 +673,14 @@ def get_inbound_phone_entry(msg):
             # NOTE: I don't think the backend could ever be global here since global backends
             # don't have a 'domain' and so the toggles would never be activated
             if not backend.is_global:
-                p = PhoneNumber.get_two_way_number_with_domain_scope(msg.phone_number, backend.domains_with_access)
+                p = PhoneNumber.get_two_way_number_with_domain_scope(phone_number, backend.domains_with_access)
                 return (
                     p,
                     p is not None
                 )
 
     return (
-        PhoneNumber.get_reserved_number(msg.phone_number),
+        PhoneNumber.get_reserved_number(phone_number),
         False
     )
 
@@ -713,7 +717,7 @@ def _domain_accepts_inbound(msg):
 
 def _process_incoming(msg):
     sms_load_counter("inbound", msg.domain)()
-    verified_number, has_domain_two_way_scope = get_inbound_phone_entry(msg)
+    verified_number, has_domain_two_way_scope = get_inbound_phone_entry_from_sms(msg)
     is_two_way = verified_number is not None and verified_number.is_two_way
 
     if verified_number:

--- a/corehq/apps/sms/templates/sms/message_tester.html
+++ b/corehq/apps/sms/templates/sms/message_tester.html
@@ -1,24 +1,10 @@
 {% extends 'hqwebapp/base_section.html' %}
 {% load i18n %}
+{% load crispy_forms_tags %}
+
 
 {% block page_content %}
-  <form class="form form-horizontal" action="{% url "message_test" domain phone_number %}" method="post">
-    {% csrf_token %}
-    <fieldset>
-      <legend>{% trans "Simulate Inbound Message from" %} +{{ phone_number }}</legend>
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="sms-message">{% trans "Message:" %}</label>
-        <div class="col-sm-9">
-          <div>
-            <textarea id="sms-message" name="message" class="form-control"></textarea>
-          </div>
-        </div>
-      </div>
-    </fieldset>
-    <div class="form-actions">
-      <div class="col-sm-offset-2">
-        <button type="submit" name="send_sms_button" class="btn btn-primary">{% trans "Send Message" %}</button>
-      </div>
-    </div>
-  </form>
+  <div id="test-message-form">
+    {% crispy form %}
+  </div>
 {% endblock %}

--- a/corehq/apps/sms/tests/test_inbound_sms_phone_entry_assignment.py
+++ b/corehq/apps/sms/tests/test_inbound_sms_phone_entry_assignment.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import TestCase
 
-from corehq.apps.sms.api import get_inbound_phone_entry
+from corehq.apps.sms.api import get_inbound_phone_entry_from_sms
 from corehq.apps.sms.models import PhoneNumber, MobileBackendInvitation, SMS, SQLMobileBackend
 from corehq.apps.smsforms.models import XFormsSessionSynchronization, SMSChannel, RunningSessionInfo
 from corehq.messaging.smsbackends.test.models import SQLTestSMSBackend
@@ -104,14 +104,14 @@ class TestGetInboundPhoneEntry(TestCase):
 
     def test_get_inbound_phone_entry__no_backend_id(self):
         sms = SMS(phone_number=self.phone_number)
-        phone_number, has_domain_two_way_scope = get_inbound_phone_entry(sms)
+        phone_number, has_domain_two_way_scope = get_inbound_phone_entry_from_sms(sms)
 
         self.assertEqual(phone_number.owner_id, "fake-owner-1")
         self.assertFalse(has_domain_two_way_scope)
 
     def test_get_inbound_phone_entry__global_backend(self):
         sms = SMS(phone_number=self.phone_number, backend_id=self.global_backend.couch_id)
-        phone_number, has_domain_two_way_scope = get_inbound_phone_entry(sms)
+        phone_number, has_domain_two_way_scope = get_inbound_phone_entry_from_sms(sms)
 
         self.assertEqual(phone_number.owner_id, "fake-owner-1")
         self.assertFalse(has_domain_two_way_scope)
@@ -122,7 +122,7 @@ class TestGetInboundPhoneEntry(TestCase):
         test methods that are testing `get_inbound_phone_entry` under different conditions
         """
         sms = SMS(phone_number=self.phone_number, backend_id=self.domain2_backend.couch_id)
-        return get_inbound_phone_entry(sms)
+        return get_inbound_phone_entry_from_sms(sms)
 
     def test_get_inbound_phone_entry__domain_backend(self):
         """Should return the only 'two way' number.

--- a/corehq/apps/sms/urls.py
+++ b/corehq/apps/sms/urls.py
@@ -34,8 +34,7 @@ urlpatterns = [
     url(r'^$', default, name='sms_default'),
     url(r'^send_to_recipients/$', send_to_recipients, name='send_to_recipients'),
     url(r'^compose/$', ComposeMessageView.as_view(), name=ComposeMessageView.urlname),
-    url(r'^message_test/(?P<phone_number>\d+)/$',
-        TestSMSMessageView.as_view(), name=TestSMSMessageView.urlname),
+    url(r'^message_test/$', TestSMSMessageView.as_view(), name=TestSMSMessageView.urlname),
     url(r'^api/send_sms/$', api_send_sms, name='api_send_sms'),
     url(r'^add_gateway/(?P<hq_api_id>[\w-]+)/$',
         AddDomainGatewayView.as_view(), name=AddDomainGatewayView.urlname

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -430,7 +430,8 @@ class TestSMSMessageView(BaseDomainView):
             backend = SQLMobileBackend.load(backend_id, is_couch_id=True)
             incoming(
                 phone_number, message, backend.get_api_id(),
-                domain_scope=self.domain, backend_id=backend.couch_id
+                domain_scope=self.domain, backend_id=backend.couch_id,
+                backend_message_id="message_test"
             )
             messages.success(
                 request,

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -420,11 +420,14 @@ class TestSMSMessageView(BaseDomainView):
 
             phone_entry, has_domain_two_way_scope = get_inbound_phone_entry(phone_number, backend_id)
             if not phone_entry or phone_entry.domain != self.domain:
-                messages.error(
-                    request,
-                    _("Invalid phone number being simulated. Please choose a "
-                      "two-way phone number belonging to a contact in your project.")
-                )
+                msg = _("Invalid phone number. Please choose a "
+                        "two-way phone number belonging to a contact in your project.")
+                if toggles.ONE_PHONE_NUMBER_MULTIPLE_CONTACTS.enabled(self.domain):
+                    msg = _("Invalid phone number. Either this number is not assigned to a contact in your "
+                            "project or there is an active session for this number in another project space. "
+                            "To 'claim' this number start a new SMS survey with this number and wait for the "
+                            "first message to be sent.")
+                messages.error(request, msg)
                 return self.get(request, *args, **kwargs)
 
             backend = SQLMobileBackend.load(backend_id, is_couch_id=True)

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -370,6 +370,21 @@ class XFormsSessionSynchronization:
                 cls._release_running_session_info_for_channel(running_session_info, channel)
 
     @classmethod
+    def set_channel_for_affinity(cls, session):
+        """
+        Set the channel affinity for the session. This is used for manually setting the affinity.
+
+        Returns True if the affinity was set
+        """
+        channel = session.get_channel()
+        with cls._critical_section(channel):
+            if cls._channel_is_available_for_session(session):
+                session_info = RunningSessionInfo(None, session.connection_id)
+                cls._release_running_session_info_for_channel(session_info, channel)
+                return True
+        return False
+
+    @classmethod
     def clear_stale_channel_claim(cls, channel):
         with cls._critical_section(channel):
             return cls._clear_stale_channel_claim(channel)

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1108,6 +1108,12 @@ class MessagingTab(UITab):
                 ],
             })
 
+            if self.couch_user.is_superuser or toggles.SUPPORT.enabled_for_request(self._request):
+                reminders_urls.append({
+                    'title': _("Test Inbound SMS"),
+                    'url': reverse("message_test", args=[self.domain]),
+                })
+
         return reminders_urls
 
     @property


### PR DESCRIPTION
## Product Description
This view is 'hidden' and requires accessing the URL directly. It is also not documented anywhere public.

The changes in this PR:

* allow specifying phone number via form instead of the URL
* allow simulating which gateway the message came from
* support feature flags like 'inbound leniency'

With these changes it is possible to test more complex SMS workflows without needing a real gateway:
1. Create a gateway for the domain using the 'Test' gateway type
    - This prevents messages actually going out
    - It also means that any feature flags enabled for the domain will be activated during message processing since the gateway is owned by the domain. This is not true when using a global gateway.
2. (optional) Share the gateway with other domains
3. Either
    - Set the new gateway to the default for the domain(s)
    - OR create a new `SQLMobileBackendMapping` via the Django admin to selectively use the backend
4. Trigger an SMS workflow and use the 'Test SMS' view to simulate incoming messages

## Safety Assurance

### Safety story
Changes to a hidden view.

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
