### PR TITLE
Cs/sc 1789 webusers domain memberships assigned location ids

### DIFF
--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -68,7 +68,7 @@ class UserES(HQESQuery):
 
 class ElasticUser(ElasticDocumentAdapter):
 
-    _index_name = "hqusers_2017-09-07"
+    _index_name = "hqusers_2022-05-09"
     type = "user"
 
     @property

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -163,17 +163,20 @@ def primary_location(location_id):
     )
 
 
-def location(location_id):
+def location(location_id, include_web_users=False):
     # by any assigned-location primary or not
-    return filters.OR(
-        filters.AND(mobile_users(), filters.term('assigned_location_ids', location_id)),
-        # todo; this actually doesn't get applied since the below field is not indexed
-        filters.AND(
-            web_users(),
-            filters.term('domain_memberships.assigned_location_ids', location_id)
-        ),
-    )
+    users_locations_filter = filters.AND(mobile_users(), filters.term('assigned_location_ids', location_id))
 
+    if include_web_users:
+        users_locations_filter = filters.OR(
+            users_locations_filter,
+            filters.AND(
+                web_users(),
+                filters.term('domain_memberships.assigned_location_ids', location_id)
+            ),
+        )
+
+    return users_locations_filter
 
 def is_practice_user(practice_mode=True):
     return filters.term('is_demo_user', practice_mode)

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -163,20 +163,16 @@ def primary_location(location_id):
     )
 
 
-def location(location_id, include_web_users=False):
+def location(location_id):
     # by any assigned-location primary or not
-    users_locations_filter = filters.AND(mobile_users(), filters.term('assigned_location_ids', location_id))
+    return filters.OR(
+        filters.AND(mobile_users(), filters.term('assigned_location_ids', location_id)),
+        filters.AND(
+            web_users(),
+            filters.term('domain_memberships.assigned_location_ids', location_id)
+        ),
+    )
 
-    if include_web_users:
-        users_locations_filter = filters.OR(
-            users_locations_filter,
-            filters.AND(
-                web_users(),
-                filters.term('domain_memberships.assigned_location_ids', location_id)
-            ),
-        )
-
-    return users_locations_filter
 
 def is_practice_user(practice_mode=True):
     return filters.term('is_demo_user', practice_mode)

--- a/corehq/apps/locations/dbaccessors.py
+++ b/corehq/apps/locations/dbaccessors.py
@@ -90,6 +90,10 @@ def get_users_location_ids(domain, user_ids):
     return list(chain(*location_ids))
 
 
+def user_ids_at_locations(location_ids):
+    return UserES().location(location_ids, include_web_users=True).get_ids()
+
+
 def mobile_user_ids_at_locations(location_ids):
     # this doesn't include web users
     return UserES().location(location_ids).get_ids()

--- a/corehq/apps/locations/dbaccessors.py
+++ b/corehq/apps/locations/dbaccessors.py
@@ -91,12 +91,11 @@ def get_users_location_ids(domain, user_ids):
 
 
 def user_ids_at_locations(location_ids):
-    return UserES().location(location_ids, include_web_users=True).get_ids()
+    return UserES().location(location_ids).get_ids()
 
 
 def mobile_user_ids_at_locations(location_ids):
-    # this doesn't include web users
-    return UserES().location(location_ids).get_ids()
+    return UserES().location(location_ids).mobile_users().get_ids()
 
 
 def user_ids_at_locations_and_descendants(location_ids):

--- a/corehq/apps/locations/tasks.py
+++ b/corehq/apps/locations/tasks.py
@@ -99,7 +99,7 @@ def update_users_at_locations(domain, location_ids, supply_point_ids, ancestor_i
     Update location fixtures for users given locations
     """
     from corehq.apps.users.models import CouchUser, update_fixture_status_for_users
-    from corehq.apps.locations.dbaccessors import mobile_user_ids_at_locations
+    from corehq.apps.locations.dbaccessors import user_ids_at_locations
     from corehq.apps.fixtures.models import UserLookupTableType
     from dimagi.utils.couch.database import iter_docs
 
@@ -108,7 +108,7 @@ def update_users_at_locations(domain, location_ids, supply_point_ids, ancestor_i
         close_supply_point_case(domain, supply_point_id)
 
     # unassign users from locations
-    unassign_user_ids = mobile_user_ids_at_locations(location_ids)
+    unassign_user_ids = user_ids_at_locations(location_ids)
     for doc in iter_docs(CouchUser.get_db(), unassign_user_ids):
         user = CouchUser.wrap_correctly(doc)
         for location_id in location_ids:
@@ -120,7 +120,7 @@ def update_users_at_locations(domain, location_ids, supply_point_ids, ancestor_i
                 user.unset_location_by_id(location_id, fall_back_to_next=True)
 
     # update fixtures for users at ancestor locations
-    user_ids = mobile_user_ids_at_locations(ancestor_ids)
+    user_ids = user_ids_at_locations(ancestor_ids)
     update_fixture_status_for_users(user_ids, UserLookupTableType.LOCATION)
 
 

--- a/corehq/apps/locations/tests/test_dbaccessors.py
+++ b/corehq/apps/locations/tests/test_dbaccessors.py
@@ -145,7 +145,7 @@ class TestUsersByLocation(TestCase):
             [self.meereen._id, self.pentos._id]
         )
 
-    def test_user_ids_at_locations(self):
+    def test_mobile_user_ids_at_locations(self):
         self.assertItemsEqual(
             mobile_user_ids_at_locations([self.meereen._id]),
             [self.daenerys._id, self.tyrion._id]

--- a/corehq/apps/locations/tests/test_dbaccessors.py
+++ b/corehq/apps/locations/tests/test_dbaccessors.py
@@ -23,6 +23,7 @@ from ..dbaccessors import (
     get_users_by_location_id,
     get_users_location_ids,
     mobile_user_ids_at_locations,
+    user_ids_at_locations,
     get_user_ids_from_assigned_location_ids,
     get_user_ids_from_primary_location_ids
 )
@@ -148,6 +149,12 @@ class TestUsersByLocation(TestCase):
         self.assertItemsEqual(
             mobile_user_ids_at_locations([self.meereen._id]),
             [self.daenerys._id, self.tyrion._id]
+        )
+
+    def test_user_ids_at_locations(self):
+        self.assertItemsEqual(
+            user_ids_at_locations([self.meereen._id]),
+            [self.daenerys._id, self.tyrion._id, self.george._id]
         )
 
 

--- a/corehq/pillows/mappings/user_mapping.py
+++ b/corehq/pillows/mappings/user_mapping.py
@@ -216,7 +216,10 @@ USER_MAPPING = {
                 },
                 "timezone": {
                     "type": "string"
-                }
+                },
+                'assigned_location_ids': {
+                    'type': 'string'
+                },
             }
         },
         "eulas": {

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -188,7 +188,7 @@ EXPECTED_PROD_INDICES = [
     {
         "alias": "test_hqusers",
         "hq_index_name": "hqusers",
-        "index": "test_hqusers_2017-09-07",
+        "index": "test_hqusers_2022-05-09",
         "type": "user",
         "meta": {
             "settings": {


### PR DESCRIPTION
## Product Description
No visible changes

## Technical Summary
This PR addresses [this](https://github.com/dimagi/commcare-hq/blob/02ef417fa33e0dcc9c81bb1b1c997c1d41d44bb6/corehq/apps/es/users.py#L170) comment by adding the `assigned_location_ids` to user_mapping.py, which is necessary to make the result of the UserES().location filter more accurate, i.e. to include web users and not just the mobile users at that location. This is important for tasks such as [update_users_at_locations](https://github.com/dimagi/commcare-hq/blob/b80d7781672d399962375fba689173b68438ade4/corehq/apps/locations/tasks.py#L97) (which is executed when a location is removed and updates the users assigned to that location accordingly).

Because [mobile_user_ids_at_locations(...)](https://github.com/dimagi/commcare-hq/blob/4ca04a02a7c61e6d3a4970f119a537ce571a94b2/corehq/apps/locations/dbaccessors.py#L93) relies on this "bug" that existed (and is called from a bunch of places), I'm ensuring that the UserES().location filter still returns the expected results by simply allowing an argument to the location filter function in order to include the web users in the filter results.   
 
## Feature Flag
Not FF specific

## Safety Assurance

### Safety story
Unit test + local testing

### Automated test coverage
Unit test added which specifically shows that web users are also included in the location filter result.

### Rollback instructions
- [ ] This PR can be reverted after deploy with no further considerations

This PR updates the ES user index.


### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
