### PR TITLE
remove icds tagging of sms metrics

### DIFF
--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -68,11 +68,7 @@ def remove_from_queue(queued_sms):
 
     sms.publish_change()
 
-    tags = {'backend': sms.backend_api, 'icds_indicator': ''}
-    if isinstance(sms.custom_metadata, dict) and 'icds_indicator' in sms.custom_metadata:
-        tags.update({
-            'icds_indicator': sms.custom_metadata['icds_indicator']
-        })
+    tags = {'backend': sms.backend_api}
     if sms.direction == OUTGOING and sms.processed and not sms.error:
         create_billable_for_sms(sms)
         metrics_counter('commcare.sms.outbound_succeeded', tags=tags)


### PR DESCRIPTION
## Technical Summary
Remove legacy metric tagging

## Safety Assurance

### Safety story
Metrics only change

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
