### PR TITLE
don't 500 if owner_id is empty

### DIFF
--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -99,6 +99,8 @@ class CaseDisplay:
     @property
     @quickcache(['self.owner_id', 'self.user_id'])
     def owner(self):
+        if not self.owner_id:
+            return 'user', {'id': self.owner_id, 'name': self.owner_id}
         if self.owning_group and self.owning_group.name:
             return ('group', {'id': self.owning_group._id, 'name': self.owning_group.name})
         elif self.location:

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -102,12 +102,12 @@ class CaseDisplay:
         if not self.owner_id:
             return 'user', {'id': self.owner_id, 'name': self.owner_id}
         if self.owning_group and self.owning_group.name:
-            return ('group', {'id': self.owning_group._id, 'name': self.owning_group.name})
+            return 'group', {'id': self.owning_group._id, 'name': self.owning_group.name}
         elif self.location:
             return ('location', {'id': self.location.location_id,
                                  'name': self.location.display_name})
         else:
-            return ('user', self._user_meta(self.user_id))
+            return 'user', self._user_meta(self.user_id)
 
     @property
     def owner_type(self):

--- a/corehq/apps/reports/tests/test_case_display.py
+++ b/corehq/apps/reports/tests/test_case_display.py
@@ -55,3 +55,17 @@ def test_parse_date_none():
 def test_parse_date_int():
     parsed = CaseDisplay({}).parse_date(4)
     assert_equal(parsed, 4)
+
+
+def test_blank_owner_id():
+    # previously this would error
+    owner_type, meta = CaseDisplay({}).owner
+    assert_equal(owner_type, 'user')
+    assert_equal(meta, {'id': '', 'name': ''})
+
+
+def test_null_owner_id():
+    # previously this would error
+    owner_type, meta = CaseDisplay({'owner_id': None}).owner
+    assert_equal(owner_type, 'user')
+    assert_equal(meta, {'id': None, 'name': None})


### PR DESCRIPTION
## Product Description
Edge case I came across in local testing on the Case List report.

It is rare but has occurred at least once in the last 30 day on prod: https://sentry.io/share/issue/75b649fb6d7041289f2caeb5a84fc33e/

## Safety Assurance

### Safety story
Short circuit DB lookups if the ID is blank or null

### Automated test coverage
Added basic tests.

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
