### PR TITLE
Upgrade attrs to 21.4.0

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -1,6 +1,6 @@
 alembic
 architect
-attrs<22
+attrs>=21.4
 boto3
 # celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737	celery==4.4.7
 # upgrade when https://github.com/celery/celery/issues/4980 is fixed

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -16,7 +16,7 @@ asgiref==3.5.0
     # via django
 asttokens==2.0.5
     # via stack-data
-attrs==18.2.0
+attrs==21.4.0
     # via
     #   -r base-requirements.in
     #   jsonschema

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -14,7 +14,7 @@ architect==0.6.0
     # via -r base-requirements.in
 asgiref==3.5.0
     # via django
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   -r base-requirements.in
     #   jsonschema

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -14,7 +14,7 @@ asgiref==3.5.0
     # via django
 asttokens==2.0.5
     # via stack-data
-attrs==18.2.0
+attrs==21.4.0
     # via
     #   -r base-requirements.in
     #   jsonschema

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,7 @@ architect==0.6.0
     # via -r base-requirements.in
 asgiref==3.5.0
     # via django
-attrs==18.2.0
+attrs==21.4.0
     # via
     #   -r base-requirements.in
     #   jsonschema

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -12,7 +12,7 @@ architect==0.6.0
     # via -r base-requirements.in
 asgiref==3.5.0
     # via django
-attrs==18.2.0
+attrs==21.4.0
     # via
     #   -r base-requirements.in
     #   jsonschema


### PR DESCRIPTION
Preparation for use of attrs on the Lookup Tables Couch to SQL migration. A [lot of nice things](https://www.attrs.org/en/latest/names.html#tl-dr) have been added to attrs since 18.2. Going forward the recommended usage pattern is
```py
from attrs import define, field

@define
class Point:
    x = field()
    y = field()
```

The new names have some different and better defaults, but the old `@attr.s` and `x = attr.ib()` way still works.

## Safety Assurance

### Safety story

The change logs have detailed explanations of backward-incompatible changes, none of which appear to be problematic for us. Attrs has a very strong backward compatibility guarantee.

### Automated test coverage

Some of our uses of attrs are covered by tests. Unknown if all are.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
