### PR TITLE
Improve error messaging around app linking

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -36,8 +36,8 @@ class CopyApplicationForm(forms.Form):
                 "<!-- ko ifnot: shouldEnableLinkedAppOption -->"
                 "The selected project space is either not yet linked to the current project space, or you do not"
                 " have the correct permissions in the selected project space. "
-                "<a href=\"https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces\" target=\"_blank\">Learn more</a> "
-                "about Linked Project Spaces."
+                "<a href=\"https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces\" "
+                "target=\"_blank\">Learn more</a> about Linked Project Spaces."
                 "<!-- /ko -->"
             )),  # nosec: no user input
             attrs={"data-bind": "enable: shouldEnableLinkedAppOption, checked: isChecked"},

--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -34,7 +34,10 @@ class CopyApplicationForm(forms.Form):
         widget=BootstrapCheckboxInput(
             inline_label=mark_safe(_(
                 "<!-- ko ifnot: shouldEnableLinkedAppOption -->"
-                "The selected project space must first be linked to the current project space."
+                "The selected project space is either not yet linked to the current project space, or you do not"
+                " have the correct permissions in the selected project space. "
+                "<a href=\"https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces\" target=\"_blank\">Learn more</a> "
+                "about Linked Project Spaces."
                 "<!-- /ko -->"
             )),  # nosec: no user input
             attrs={"data-bind": "enable: shouldEnableLinkedAppOption, checked: isChecked"},


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13556

Rather than complicate this and try to figure out exactly why the user is unable to link (is it a user permissions error or a not yet linked project space error?), I figured at least providing an explanation that one of these two reasons is the culprit is way more helpful than what this was, and keeps it simple. I'll admit this is a bit of a mouthful though.

![Screen Shot 2022-05-11 at 7 36 45 PM](https://user-images.githubusercontent.com/15785053/167981044-b0ed31a4-ffdf-4857-be89-c8ca31f19637.png)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Text change.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Just changing some text.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
