### PR TITLE
Data Registry repeater compatibility between Couch and SQL

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -615,7 +615,15 @@ class SQLDataRegistryCaseUpdateRepeater(SQLCreateCaseRepeater):
         # Exclude extension cases where the host is also a case type that this repeater
         # would act on since they get forwarded along with their host
         host_index = payload.get_index(CASE_INDEX_IDENTIFIER_HOST)
-        return not host_index or host_index.referenced_type not in self.white_listed_case_types
+        if host_index and host_index.referenced_type in self.white_listed_case_types:
+            return False
+
+        transaction = CaseTransaction.objects.get_most_recent_form_transaction(payload.case_id)
+        if transaction:
+            # prevent chaining updates
+            return transaction.xmlns != DataRegistryCaseUpdatePayloadGenerator.XMLNS
+
+        return True
 
     @classmethod
     def _migration_get_couch_model_class(cls):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -487,7 +487,7 @@ class SQLCaseRepeater(SQLRepeater):
         return not self.white_listed_case_types or payload.type in self.white_listed_case_types
 
     def _allowed_user(self, payload):
-        return self.payload_user_id(payload) not in self.black_listed_users
+        return not self.black_listed_users or self.payload_user_id(payload) not in self.black_listed_users
 
     def payload_user_id(self, payload):
         # get the user_id who submitted the payload, note, it's not the owner_id
@@ -1174,7 +1174,7 @@ class CaseRepeater(Repeater):
         return not self.white_listed_case_types or payload.type in self.white_listed_case_types
 
     def _allowed_user(self, payload):
-        return self.payload_user_id(payload) not in self.black_listed_users
+        return not self.black_listed_users or self.payload_user_id(payload) not in self.black_listed_users
 
     def payload_user_id(self, payload):
         # get the user_id who submitted the payload, note, it's not the owner_id

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
@@ -114,10 +114,15 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
             )]
         )
         cases = factory.create_or_update_case(extension, user_id=self.mobile_user.get_id)
+        extension_case, host_case = cases
+
+        # test that the extension case doesn't match the 'allow' criteria
+        self.assertFalse(self.repeater.allowed_to_forward(extension_case))
+        self.assertFalse(self.sql_repeater.allowed_to_forward(extension_case))
+
         repeat_records = self.repeat_records(self.domain).all()
         self.assertEqual(len(repeat_records), 1)
         payload = repeat_records[0].get_payload()
-        host_case = cases[1]
         form = DataRegistryUpdateForm(payload, host_case)
         form.assert_case_updates({
             self.target_case_id_1: {"new_prop": "new_val_case1"},

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
@@ -46,6 +46,7 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
             white_listed_case_types=[IntentCaseBuilder.CASE_TYPE]
         )
         cls.repeater.save()
+        cls.sql_repeater = cls.repeater._migration_get_sql_object()
 
         cls.user = create_user("admin", "123")
         cls.registry_slug = create_registry_for_test(
@@ -135,13 +136,17 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
             .target_case(self.target_domain, self.target_case_id_1)
             .case_properties(new_prop="new_val_case1")
         )
-        case = CaseStructure(
+        case_struct = CaseStructure(
             attrs={"create": True, "case_type": "registry_case_update", "update": builder.props},
         )
-        CaseFactory(self.domain).create_or_update_case(case, user_id=self.mobile_user.get_id, form_extras={
+        [case] = CaseFactory(self.domain).create_or_update_case(case_struct, user_id=self.mobile_user.get_id, form_extras={
             # pretend this form came from a repeater in another domain
             'xmlns': DataRegistryCaseUpdatePayloadGenerator.XMLNS
         })
+
+        self.assertFalse(self.repeater.allowed_to_forward(case))
+        self.assertFalse(self.sql_repeater.allowed_to_forward(case))
+
         repeat_records = self.repeat_records(self.domain).all()
         self.assertEqual(len(repeat_records), 0)
 


### PR DESCRIPTION
## Technical Summary
2nd commit is the reach change which brings the `SQLDataRegistryCaseUpdateRepeater` in line with `DataRegistryCaseUpdateRepeater`.

1st commit is a small performance improvement

@AmitPhulera FYI

## Safety Assurance

### Safety story
only affects repeaters, specifically the data registry case update repeater

### Automated test coverage
Updated tests

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
