### PR TITLE
refactor "get indices"

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -840,7 +840,7 @@ class BaseUpdateCaseDefinition(CaseRuleActionDefinition):
                 if name.lower().startswith('parent/'):
                     name = name[7:]
                     # uses first parent if there are multiple
-                    parent_cases = current_case.get_parent(identifier=DEFAULT_PARENT_IDENTIFIER)
+                    parent_cases = current_case.get_parents(identifier=DEFAULT_PARENT_IDENTIFIER)
                     if parent_cases:
                         current_case = parent_cases[0]
                     else:

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -666,7 +666,7 @@ class ClosedParentDefinition(CaseRuleCriteriaDefinition):
     def matches(self, case, now):
         relationship = self.relationship_id
 
-        for parent in case.get_parent(identifier=self.identifier, relationship=relationship):
+        for parent in case.get_parents(identifier=self.identifier, relationship=relationship):
             if parent.closed:
                 return True
 

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -664,7 +664,7 @@ class ClosedParentDefinition(CaseRuleCriteriaDefinition):
     relationship_id = models.PositiveSmallIntegerField(default=CommCareCaseIndex.CHILD)
 
     def matches(self, case, now):
-        relationship = self.relationship_id
+        relationship = CommCareCaseIndex.relationship_id_to_name(self.relationship_id)
 
         for parent in case.get_parents(identifier=self.identifier, relationship=relationship):
             if parent.closed:

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -620,7 +620,7 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
         CasePropertyResult = namedtuple('CasePropertyResult', 'case value')
 
         if property_name.lower().startswith('parent/'):
-            parents = self.get_parent(identifier=DEFAULT_PARENT_IDENTIFIER)
+            parents = self.get_parents(identifier=DEFAULT_PARENT_IDENTIFIER)
             for parent in parents:
                 parent._resolve_case_property(property_name[7:], result)
             return
@@ -692,7 +692,7 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
         return cls.objects.get_case(case_id)
 
     @memoized
-    def get_parent(self, identifier=None, relationship=None):
+    def get_parents(self, identifier=None, relationship=None):
         return [index.referenced_case for index in self.get_indices(identifier, relationship)]
 
     def get_indices(self, identifier=None, relationship=None):
@@ -721,7 +721,7 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
         of indices. If for some reason your use case creates more than one,
         please write/use a different property.
         """
-        result = self.get_parent(
+        result = self.get_parents(
             identifier=DEFAULT_PARENT_IDENTIFIER,
             relationship=CASE_INDEX_CHILD
         )
@@ -729,7 +729,7 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
 
     @property
     def host(self):
-        result = self.get_parent(relationship=CASE_INDEX_EXTENSION)
+        result = self.get_parents(relationship=CASE_INDEX_EXTENSION)
         return result[0] if result else None
 
     def save(self, *args, with_tracked_models=False, **kw):

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -694,7 +694,7 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
         return [index.referenced_case for index in self.get_indices(identifier, relationship)]
 
     def get_indices(self, identifier=None, relationship=None):
-        indices = self.indices
+        indices = self.live_indices
 
         if identifier:
             indices = [index for index in indices if index.identifier == identifier]
@@ -702,7 +702,7 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
         if relationship:
             indices = [index for index in indices if index.relationship_id == relationship]
 
-        return [index for index in indices if index.referenced_id]
+        return indices
 
     @property
     def parent(self):

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -691,6 +691,9 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
 
     @memoized
     def get_parent(self, identifier=None, relationship=None):
+        return [index.referenced_case for index in self.get_indices(identifier, relationship)]
+
+    def get_indices(self, identifier=None, relationship=None):
         indices = self.indices
 
         if identifier:
@@ -699,7 +702,7 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
         if relationship:
             indices = [index for index in indices if index.relationship_id == relationship]
 
-        return [index.referenced_case for index in indices if index.referenced_id]
+        return [index for index in indices if index.referenced_id]
 
     @property
     def parent(self):

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -1107,11 +1107,15 @@ class CommCareCaseIndex(PartitionedModel, models.Model, SaveStateMixin):
 
     @property
     def relationship(self):
-        return self.RELATIONSHIP_INVERSE_MAP[self.relationship_id]
+        return CommCareCaseIndex.relationship_id_to_name(self.relationship_id)
 
     @relationship.setter
     def relationship(self, relationship):
         self.relationship_id = self.RELATIONSHIP_MAP[relationship]
+
+    @staticmethod
+    def relationship_id_to_name(relationship_id):
+        return CommCareCaseIndex.RELATIONSHIP_INVERSE_MAP[relationship_id]
 
     def __eq__(self, other):
         return isinstance(other, CommCareCaseIndex) and (

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -15,7 +15,7 @@ from jsonobject import JsonObject, StringProperty
 from jsonobject.properties import BooleanProperty
 from memoized import memoized
 
-from casexml.apps.case.const import CASE_INDEX_EXTENSION, CASE_INDEX_CHILD
+from casexml.apps.case.const import CASE_INDEX_CHILD, CASE_INDEX_EXTENSION
 from dimagi.utils.chunked import chunked
 from dimagi.utils.couch import RedisLockableMixIn
 from dimagi.utils.couch.undo import DELETED_SUFFIX
@@ -25,15 +25,27 @@ from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.exceptions import BadName, NotFound
 from corehq.blobs.util import get_content_md5
 from corehq.sql_db.models import PartitionedModel, RequireDBManager
-from corehq.sql_db.util import get_db_aliases_for_partitioned_query, split_list_by_db_partition
+from corehq.sql_db.util import (
+    get_db_aliases_for_partitioned_query,
+    split_list_by_db_partition,
+)
 from corehq.util.json import CommCareJSONEncoder
 
-from ..exceptions import AttachmentNotFound, CaseNotFound, CaseSaveError, UnknownActionType
+from ..exceptions import (
+    AttachmentNotFound,
+    CaseNotFound,
+    CaseSaveError,
+    UnknownActionType,
+)
 from ..track_related import TrackRelatedChanges
 from .attachment import AttachmentContent, AttachmentMixin
 from .forms import XFormInstance
 from .mixin import CaseToXMLMixin, IsImageMixin, SaveStateMixin
-from .util import attach_prefetch_models, fetchall_as_namedtuple, sort_with_id_list
+from .util import (
+    attach_prefetch_models,
+    fetchall_as_namedtuple,
+    sort_with_id_list,
+)
 
 DEFAULT_PARENT_IDENTIFIER = 'parent'
 
@@ -656,6 +668,7 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
 
     def to_xml(self, version, include_case_on_closed=False):
         from lxml import etree as ElementTree
+
         from casexml.apps.phone.xml import get_case_element
         if self.closed:
             if include_case_on_closed:
@@ -671,8 +684,9 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
         A server specific URL for remote clients to access case attachment resources async.
         """
         if name in self.case_attachments:
-            from dimagi.utils import web
             from django.urls import reverse
+
+            from dimagi.utils import web
             return "%s%s" % (
                 web.get_url_base(),
                 reverse("api_case_attachment", kwargs={


### PR DESCRIPTION
## Technical Summary
Minor refactor to `CommCareCase` to expose `get_indices` function.

## Safety Assurance

### Safety story
Refactor only + small change to data registry repeaters.

### Automated test coverage
Covered by existing tests

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
