### PR TITLE
handle web user in ucr group expression

### DIFF
--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -28,7 +28,7 @@ from corehq.apps.userreports.expressions.getters import (
 from corehq.apps.userreports.mixins import NoPropertyTypeCoercionMixIn
 from corehq.apps.userreports.specs import EvaluationContext, TypeProperty
 from corehq.apps.userreports.util import add_tabbed_text
-from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.util.couch import get_db_by_doc_type
@@ -816,7 +816,10 @@ class _GroupsExpressionSpec(JsonObject):
     @ucr_context_cache(vary_on=('user_id',))
     def _get_groups(self, user_id, context):
         domain = context.root_doc['domain']
-        user = CommCareUser.get_by_user_id(user_id, domain)
+        try:
+            user = CommCareUser.get_by_user_id(user_id, domain)
+        except CouchUser.AccountTypeError:
+            user = None
         if not user:
             return []
 

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1300,7 +1300,7 @@ class TestGetCaseSharingGroupsExpression(TestCase):
         self.assertEqual(len(case_sharing_groups), 0)
 
     def test_web_user(self):
-        user = WebUser.create(domain=self.domain, username='web', password='123',
+        user = WebUser.create(domain=None, username='web', password='123',
                               created_by=None, created_via=None)
         case_sharing_groups = self.expression({'user_id': user._id}, self.context)
         self.assertEqual(len(case_sharing_groups), 0)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -23,7 +23,7 @@ from corehq.apps.userreports.expressions.specs import (
     eval_statements,
 )
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
-from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.util.test_utils import (
@@ -1296,6 +1296,12 @@ class TestGetCaseSharingGroupsExpression(TestCase):
         group = Group(domain=self.second_domain, name='group_wrong_domain', users=[user._id], case_sharing=True)
         group.save()
 
+        case_sharing_groups = self.expression({'user_id': user._id}, self.context)
+        self.assertEqual(len(case_sharing_groups), 0)
+
+    def test_web_user(self):
+        user = WebUser.create(domain=self.domain, username='web', password='123',
+                              created_by=None, created_via=None)
         case_sharing_groups = self.expression({'user_id': user._id}, self.context)
         self.assertEqual(len(case_sharing_groups), 0)
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
These expressions only work with mobile users. The change prevents an exception when the given id is a web user, instead returning an empty set of groups.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Change is small and very specific while not altering any existing behavior, except to catch a single known exception.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Existing automated tests cover the functioning mobile user case here, so any regression will be caught. New test added for web user case.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
