### PR TITLE
@generate_cases([...]) as class method decorator

### DIFF
--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -364,12 +364,20 @@ def unregistered_django_model(model_class):
     return model_class
 
 
-def generate_cases(argsets, cls=None):
-    """Make a decorator to generate a set of parameterized test cases
+class generate_cases:
+    """A decorator to generate parameterized test cases
 
-    Until we have nose generator tests...
+    Usage as test method decorator:
 
-    Usage:
+        class TestThing(TestCase):
+            @generate_cases([
+                ("foo", "bar"),
+                ("bar", "foo"),
+            ])
+            def test_foo(self, foo, bar)
+                self.assertEqual(self.thing[foo], bar)
+
+    Deprecated: two-argument decorator on module level test function:
 
         @generate_cases([
             ("foo", "bar"),
@@ -382,39 +390,63 @@ def generate_cases(argsets, cls=None):
     their parameterized names are not valid function names. This was a
     tradeoff with making parameterized tests identifiable on failure.
 
+    Another alternative is nose test generators.
+    https://nose.readthedocs.io/en/latest/writing_tests.html#test-generators
+
     :param argsets: A sequence of argument tuples or dicts, one for each
     test case to be generated.
     :param cls: Optional test case class to which tests should be added.
     """
-    def add_cases(test_func):
-        if cls is None:
-            class Test(TestCase):
+
+    def __init__(self, argsets, cls=None):
+        self.argsets = argsets
+        self.test_class = cls
+
+    def __call__(self, test_func):
+        def assign(owner, test):
+            assert not hasattr(owner, test.__name__), \
+                "duplicate test case: {}.{}".format(owner, test.__name__)
+            setattr(owner, test.__name__, test)
+
+        tests = []
+
+        if self.test_class is None:
+            class DecoratedMethodMeta(type):
+                def __set_name__(self, owner, name):
+                    # Delete Test class, which has replaced decorated method
+                    delattr(owner, name)
+                    # Assign parameterized tests to class of decorated method
+                    for test in tests:
+                        assign(owner, test)
+
+            class Test(TestCase, metaclass=DecoratedMethodMeta):
+                # Test case for top-level module @generate_cases([...])
                 pass
             Test.__name__ = test_func.__name__
         else:
-            Test = cls
+            Test = self.test_class
 
-        for args in argsets:
+        for args in self.argsets:
             def test(self, args=args):
                 if isinstance(args, dict):
                     return test_func(self, **args)
                 return test_func(self, *args)
 
             test.__name__ = test_func.__name__ + repr(args)
-            assert not hasattr(Test, test.__name__), \
-                "duplicate test case: {} {}".format(Test, test.__name__)
+            assign(Test, test)
+            tests.append(test)
 
-            setattr(Test, test.__name__, test)
-
-        if cls is None:
+        if self.test_class is None:
             # Only return newly created test class; otherwise the test
             # runner will run tests on cls twice. Explanation: the
             # returned value will be bound to the name of the decorated
             # test_func; if cls is provided then there will be two names
-            # bound to the same test class
+            # bound to the same test class. This is happens when the
+            # decorated test is a module-level function.
+            #
+            # In the case of a decorated test method, DecoratedMethodMeta
+            # will delete this and assign tests to the owning test class.
             return Test
-
-    return add_cases
 
 
 def timelimit(limit):

--- a/corehq/util/tests/test_utils.py
+++ b/corehq/util/tests/test_utils.py
@@ -1,9 +1,11 @@
 import re
 import time
 
+from unittest import TestCase
+
 from testil import assert_raises, eq
 
-from ..test_utils import disable_quickcache, timelimit
+from ..test_utils import disable_quickcache, generate_cases, timelimit
 
 
 def test_timelimit_pass():
@@ -52,3 +54,55 @@ def test_disable_quickcache():
     finally:
         foo.clear(1)
         foo.clear(2)
+
+
+def test_generate_cases_for_test_method():
+    # Preferred usage pattern
+    class Test(TestCase):
+        @generate_cases([
+            (1,),
+            (2,),
+        ])
+        def test(self, arg):
+            return str(arg)
+
+    assert not hasattr(Test, "test"), Test.test
+    check_case(Test)
+
+
+def test_generate_cases_for_class():
+    # Deprecated usage pattern
+    class Test(TestCase):
+        pass
+
+    @generate_cases([
+        (1,),
+        (2,),
+    ], Test)
+    def test(self, arg):
+        return str(arg)
+
+    eq(test, None)
+    check_case(Test)
+
+
+def test_generate_cases_for_function():
+    # Deprecated usage pattern
+    @generate_cases([
+        (1,),
+        (2,),
+    ])
+    def test(self, arg):
+        return str(arg)
+
+    assert issubclass(test, TestCase), test.__mro__
+    check_case(test)
+
+
+def check_case(Test):
+    test_case = Test()
+    for arg in [1, 2]:
+        name = f"test({arg},)"
+        test = getattr(test_case, name, None)
+        assert test is not None, (name, dir(test_case))
+        eq(test(), str(arg))


### PR DESCRIPTION
Adds a more natural usage pattern for `@generate_cases`. Previously it only worked at the module level, now, with a bit of metaclass magic, it can be used to decorate test methods.

```py
class TestSomeThing(TestCase):
    @generate_cases([
        ("one", 1),
        ("two", 2),
    ])
    def test_the_thing(self, name, number):
        ...
```

FYI @dimagi/team-commcare-hq 

## Safety Assurance

### Safety story

Change affects tests only.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
