### PR TITLE
Auto Update Rules: Add AND/OR text dependent on whether ALL/ANY is selected

### DIFF
--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_criteria.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_criteria.html
@@ -65,7 +65,12 @@
         <button type="button" class="btn btn-danger" data-bind="click: $parent.removeFilter"><i class="fa fa-close"></i></button>
       </div>
       <div class="col-xs-6 text-center">
-        <label class="control-label">{% trans "AND" %}</label>
+        <!-- ko if: $parent.criteriaOperator() == 'ALL' -->
+          <label class="control-label">{% trans "AND"%}</label>
+        <!-- /ko -->
+        <!-- ko if: $parent.criteriaOperator() == 'ANY' -->
+          <label class="control-label">{% trans "OR"%}</label>
+        <!-- /ko -->
       </div>
     </div>
   </div>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_criteria.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_criteria.html
@@ -65,11 +65,11 @@
         <button type="button" class="btn btn-danger" data-bind="click: $parent.removeFilter"><i class="fa fa-close"></i></button>
       </div>
       <div class="col-xs-6 text-center">
-        <!-- ko if: $parent.criteriaOperator() == 'ALL' -->
-          <label class="control-label">{% trans "AND"%}</label>
+        <!-- ko if: $index() > 0 && $parent.criteriaOperator() == 'ALL' -->
+          <label class="control-label">{% trans "AND" %}</label>
         <!-- /ko -->
-        <!-- ko if: $parent.criteriaOperator() == 'ANY' -->
-          <label class="control-label">{% trans "OR"%}</label>
+        <!-- ko if: $index() > 0 && $parent.criteriaOperator() == 'ANY' -->
+          <label class="control-label">{% trans "OR" %}</label>
         <!-- /ko -->
       </div>
     </div>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Context: [new ANY option for automatic update rules](https://github.com/dimagi/commcare-hq/pull/31540).

A picture is worth a thousand words so _two_ is worth _two_ thousand.

![Screen Shot 2022-05-13 at 3 18 24 PM](https://user-images.githubusercontent.com/6729291/168375016-4cd8be62-43f8-4875-bed4-24e66998f151.png)
![Screen Shot 2022-05-13 at 3 19 06 PM](https://user-images.githubusercontent.com/6729291/168375105-da9754d7-e3a5-480b-9db3-ab4c292cf794.png)


Per Farid's suggestion, this updates the "AND" text next to criteria on auto update rules to say "OR" if the user selects the new ANY option for auto update rules. The text will change instantly as a user switches the toggle.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I originally tried doing this all within one line with a `data-bind` but couldn't figure out how to add translations. There is probably a way to do that, and maybe this text is better off without translations anyways?

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

No.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Local testing. This is just a UI change, so very low risk. Should be ok to proceed without a staging deploy or QA.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
