### PR TITLE
Apply stricter validation to GPS case properties

### DIFF
--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -238,6 +238,7 @@ def fields_to_validate(domain, case_type_name):
 @quickcache(['domain', 'case_type'], timeout=24 * 60 * 60)
 def get_gps_properties(domain, case_type):
     return set(CaseProperty.objects.filter(
+        deprecated=False,
         case_type__domain=domain,
         case_type__name=case_type,
         data_type=CaseProperty.DataType.GPS,

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -238,7 +238,6 @@ def fields_to_validate(domain, case_type_name):
 @quickcache(['domain', 'case_type'], timeout=24 * 60 * 60)
 def get_gps_properties(domain, case_type):
     return set(CaseProperty.objects.filter(
-        deprecated=False,
         case_type__domain=domain,
         case_type__name=case_type,
         data_type=CaseProperty.DataType.GPS,

--- a/corehq/ex-submodules/couchforms/geopoint.py
+++ b/corehq/ex-submodules/couchforms/geopoint.py
@@ -30,8 +30,8 @@ class GeoPoint:
         try:
             latitude, longitude, altitude, accuracy = _extract_elements(input_string, flexible)
             return cls(
-                _to_decimal(latitude),
-                _to_decimal(longitude),
+                _validate_range(_to_decimal(latitude), -90, 90),
+                _validate_range(_to_decimal(longitude), -180, 180),
                 _to_decimal(altitude),
                 _to_decimal(accuracy),
             )
@@ -63,6 +63,12 @@ def _to_decimal(n):
     if uses_sci_notation and abs(ret) < Decimal("0.001"):
         return Decimal("0")
     return ret
+
+
+def _validate_range(d, lower, upper):
+    if (d.is_nan() or not lower <= d <= upper):
+        raise _GeoPointGenerationError(f"{d} is out of range")
+    return d
 
 
 class _GeoPointGenerationError(Exception):

--- a/corehq/ex-submodules/couchforms/tests/test_geopoint.py
+++ b/corehq/ex-submodules/couchforms/tests/test_geopoint.py
@@ -36,6 +36,9 @@ def test_invalid_geopoint_properties():
             '42.3739063 -71.1109113 0.0 whoops',
             '42.3739063 -71.1109113 0.0',  # only three elements
             3,  # wrong type
+            '24.85676533097921 240.27256620218806 0.0 0.0',  # out of bounds
+            '-11.683438999546881 -184.6692769950829 0.0 0.0',  # out of bounds
+            'NaN -71.669 0.0 0.0',
     ]:
         yield _is_invalid_input, input_string
 


### PR DESCRIPTION
## Technical Summary
@calellowitz found a case that was erroring when being sent to elasticsearch, due to the attempt to index it as a geo_point property.  This was because that property was set to an invalid GPS, I think from a pre-geocoder version of formplayer, though I'm not certain about how/why it used such odd values.  Normally, they're signed decimals between +/- 90 and +/- 180, respectively, but I found some here that exceeded that range.  The test cases in this PR are representative.  Some testing confirmed that formplayer does now use standard values for lat and lon.

Unrelatedly...
In investigating to convince myself this couldn't hurt the use of `GeoPoint` in xforms, I discovered that we might not actually be using that correctly.  We extract the location value here:
https://github.com/dimagi/commcare-hq/blob/479e5795245a01d38283d50dc079c79c31986b46/corehq/pillows/xform.py#L98-L99
This test demonstrates the expectation there:
https://github.com/dimagi/commcare-hq/blob/479e5795245a01d38283d50dc079c79c31986b46/testapps/test_pillowtop/tests/test_xform_pillow.py#L258-L258
Based on the real form submissions I checked, it looks like that should actually test a location in this format (which fails)
```python
'location': {
    '#text': '42.7 -21 0 0',
    "@xmlns": "http://commcarehq.org/xforms",
}
```
We do clean and extract that here: https://github.com/dimagi/commcare-hq/blob/479e5795245a01d38283d50dc079c79c31986b46/corehq/form_processor/models/forms.py#L609-L609
but I didn't find any usages of that outside of tests.  At any rate, I checked out a few real form submissions with location info and saw that their `geo_point` fields are `null` in ES.

I don't intend to fix this at this time - it sounds like we'd just need to add `['#text']` to the chain above, but we should probably further investigate the implications of such a correction.

## Feature Flag
USH_CASE_CLAIM_UPDATES
> USH Specific toggle to support several different case search/claim workflows in web apps

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change