### PR TITLE
[SSO] Implement additional security on Enterprise Admin Edit IdP form

### DIFF
--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -184,6 +184,7 @@ class B3MultiField(LayoutObject):
         self.css_id = kwargs.pop('css_id', '')
         self.field_class = kwargs.pop('field_class', None)
         self.label_class = kwargs.pop('label_class', None)
+        self.show_row_class = kwargs.pop('show_row_class', True)
         self.required = kwargs.pop('required', False)
         self.help_bubble_text = kwargs.pop('help_bubble_text', '')
         self.flat_attrs = flatatt(kwargs)

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/multi_field.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/multi_field.html
@@ -11,9 +11,9 @@
         {% endif %}
     </label>
     <div class="controls {{ field_class }} controls-multiple">
-        <div class="row">
+        {% if show_row_class %}<div class="row">{% endif %}
             {{ field_html }}
-        </div>
+        {% if show_row_class %}</div>{% endif %}
         {% for error in error_list %}
             <span class="help-block">
                 <strong>{{ error }}</strong>

--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -6,7 +6,7 @@ from django.db import transaction
 from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext_lazy, gettext
 from django.utils.translation import gettext as _
 
 from crispy_forms.helper import FormHelper
@@ -791,6 +791,26 @@ class SsoOidcEnterpriseSettingsForm(BaseSsoEnterpriseSettingsForm):
 
         self.fields['entity_id'].label = _("Issuer URL")
 
+        if self.idp.client_secret:
+            client_secret_toggles = crispy.Div(
+                crispy.HTML(
+                    format_html(
+                        '<p class="form-control-text"><a href="#" data-bind="click: showClientSecret, '
+                        'visible: isClientSecretHidden">{}</a></p>',
+                        gettext("Show Secret")
+                    ),
+                ),
+                crispy.HTML(
+                    format_html(
+                        '<p class="form-control-text" data-bind="visible: isClientSecretVisible">'
+                        '<a href="#" data-bind="click: hideClientSecret">{}</a></p>',
+                        gettext("Hide Secret")
+                    ),
+                ),
+            )
+        else:
+            client_secret_toggles = crispy.Div()
+
         self.helper = FormHelper()
         self.helper.label_class = 'col-sm-3 col-md-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
@@ -811,7 +831,17 @@ class SsoOidcEnterpriseSettingsForm(BaseSsoEnterpriseSettingsForm):
                     crispy.Fieldset(
                         _('OpenID Provider Configuration'),
                         'client_id',
-                        'client_secret',
+                        hqcrispy.B3MultiField(
+                            gettext("Client Secret"),
+                            crispy.Div(
+                                hqcrispy.InlineField(
+                                    'client_secret',
+                                    data_bind="visible: isClientSecretVisible"
+                                ),
+                                client_secret_toggles,
+                            ),
+                            show_row_class=False,
+                        ),
                         'entity_id',
                     ),
                     css_class="panel-body"

--- a/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
+++ b/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
@@ -23,5 +23,30 @@ hqDefine('sso/js/enterprise_edit_identity_provider', [
         });
         $('#sso-exempt-user-manager').koApplyBindings(ssoExemptUserManager);
         ssoExemptUserManager.init();
+
+        let oidcClientSecretManager = function () {
+            'use strict';
+            let self = {};
+
+            self.isClientSecretVisible = ko.observable(false);
+            self.isClientSecretHidden = ko.computed(function () {
+                return !self.isClientSecretVisible();
+            });
+
+            self.showClientSecret = function () {
+                self.isClientSecretVisible(true);
+            };
+
+            self.hideClientSecret = function () {
+                self.isClientSecretVisible(false);
+            };
+
+            return self;
+
+        };
+
+        if (initialPageData.get('toggle_client_secret')) {
+            $('#idp').koApplyBindings(oidcClientSecretManager);
+        }
     });
 });

--- a/corehq/apps/sso/templates/sso/enterprise_admin/edit_identity_provider.html
+++ b/corehq/apps/sso/templates/sso/enterprise_admin/edit_identity_provider.html
@@ -7,6 +7,7 @@
 
 {% block page_content %}
   {% initial_page_data 'idp_slug' idp_slug %}
+  {% initial_page_data 'toggle_client_secret' toggle_client_secret %}
 
   <ul class="nav nav-tabs sticky-tabs" id="user-settings-tabs">
     <li><a href="#idp" data-toggle="tab">{% trans "Identity Provider" %}</a></li>

--- a/corehq/apps/sso/tests/test_forms.py
+++ b/corehq/apps/sso/tests/test_forms.py
@@ -542,6 +542,8 @@ class TestSsoOidcEnterpriseSettingsForm(BaseSSOFormTest):
         super().setUp()
         self.idp = IdentityProvider.objects.create(
             owner=self.account,
+            idp_type=IdentityProviderType.ONE_LOGIN,
+            protocol=IdentityProviderProtocol.OIDC,
             name='OneLogin for Vault Wax',
             slug='vaultwax',
             created_by='otheradmin@dimagi.com',
@@ -560,7 +562,7 @@ class TestSsoOidcEnterpriseSettingsForm(BaseSSOFormTest):
                        is_active=False):
         return {
             'is_active': is_active,
-            'entity_id': '' if no_entity_id else 'https://test.org/oic',
+            'entity_id': '' if no_entity_id else 'https://test1-dev.onelogin.com/oidc',
             'client_id': '' if no_client_id else 'vaultwax',
             'client_secret': '' if no_client_secret else 'secret',
         }
@@ -603,6 +605,19 @@ class TestSsoOidcEnterpriseSettingsForm(BaseSSOFormTest):
         with self.assertRaises(forms.ValidationError):
             edit_form.clean_client_secret()
         self.assertFalse(edit_form.is_valid())
+
+    def test_that_entity_id_raises_error_when_url_is_not_one_login(self):
+        """
+        This ensures that the Entity ID / Issuer URL matches a pattern that is expected for
+        the given Identity Provider Type of One Login.
+        """
+        post_data = self._get_post_data()
+        post_data['entity_id'] = 'http://localhost:8000/oidc'
+        edit_form = SsoOidcEnterpriseSettingsForm(self.idp, post_data)
+        edit_form.cleaned_data = post_data
+
+        with self.assertRaises(forms.ValidationError):
+            edit_form.clean_entity_id()
 
     def test_that_is_active_updates_successfully_when_requirements_are_met(self):
         """

--- a/corehq/apps/sso/views/enterprise_admin.py
+++ b/corehq/apps/sso/views/enterprise_admin.py
@@ -63,6 +63,10 @@ class EditIdentityProviderEnterpriseView(BaseEnterpriseAdminView, AsyncHandlerMi
         return {
             'edit_idp_form': self.edit_enterprise_idp_form,
             'idp_slug': self.idp_slug,
+            'toggle_client_secret': (
+                self.identity_provider.protocol == IdentityProviderProtocol.OIDC
+                and self.identity_provider.client_secret
+            ),
         }
 
     @property


### PR DESCRIPTION
## Product Description
This makes the following changes to the Edit Identity Provider form for enterprise admins:
- the client secret is obfuscated by default in the UI if there is a value present
- sanity checks are made on the Issuer ID to ensure that a valid One Login URL is entered


![Screen Shot 2022-05-17 at 8 10 27 PM](https://user-images.githubusercontent.com/716573/168899735-49dea286-52d3-45c9-94a2-d59eb3791bdc.png)
![Screen Shot 2022-05-17 at 8 10 40 PM](https://user-images.githubusercontent.com/716573/168899737-9059b230-6fc1-4468-afc5-d9687699ed00.png)
![Screen Shot 2022-05-17 at 9 56 48 PM](https://user-images.githubusercontent.com/716573/168899739-e774cc06-fbc8-4af4-9b4e-ea1789d68ada.png)



## Safety Assurance

### Safety story
Very safe and well-tested changes to a workflow that is currently unused in production

### Automated test coverage
Yes

### QA Plan
QA will happen at a later stage for the entire SSO feature, but not needed to merge this PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
