### PR TITLE
Only run subcase queries once

### DIFF
--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -112,14 +112,14 @@ def _get_parent_case_ids_matching_subcase_query(subcase_query, context):
         )
     )
 
-    if es_query.count() > MAX_RELATED_CASES:
+    counts_by_parent_id = es_query.run().aggregations.indices.matching_indices.referenced_id.counts_by_bucket()
+    if len(counts_by_parent_id) > MAX_RELATED_CASES:
         from ..exceptions import TooManyRelatedCasesError
         raise TooManyRelatedCasesError(
             _("The related case lookup you are trying to perform would return too many cases"),
             serialize(subcase_query.subcase_filter)
         )
 
-    counts_by_parent_id = es_query.run().aggregations.indices.matching_indices.referenced_id.counts_by_bucket()
     if subcase_query.op == '>' and subcase_query.count <= 0:
         return list(counts_by_parent_id)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
I found in testing that even the `count` query is slow (3 seconds).  This just skips it.  It does mean we might accidentally do larger queries than otherwise if it _is_ over the limit, but this seems like the better of those two options.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

This is covered by automated tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
