### PR TITLE
Case Search subcase queries: switch from ES aggregation to python

### DIFF
--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from dataclasses import dataclass
 
 from django.utils.translation import gettext as _
@@ -10,7 +11,7 @@ from eulxml.xpath.ast import (
 )
 
 from corehq.apps.case_search.exceptions import XPathFunctionException
-from corehq.apps.es import CaseSearchES, aggregations, filters, queries
+from corehq.apps.es import CaseSearchES, filters, queries
 
 
 @dataclass
@@ -82,37 +83,28 @@ def _get_parent_case_ids_matching_subcase_query(subcase_query, context):
     else:
         subcase_filter = filters.match_all()
 
-    index_identifier_filter = filters.term('indices.identifier', subcase_query.index_identifier)
-    index_query = queries.nested(
-        'indices',
-        queries.filtered(
-            queries.match_all(),
-            filters.AND(
-                index_identifier_filter,
-                filters.NOT(filters.term('indices.referenced_id', ''))  # exclude deleted indices
-            )
-        )
-    )
     es_query = (
         CaseSearchES().domain(context.domain)
-        .filter(index_query)
-        .filter(subcase_filter)
-        .aggregation(
-            aggregations.NestedAggregation(
-                'indices', 'indices',
-            ).aggregation(
-                aggregations.FilterAggregation(
-                    'matching_indices', index_identifier_filter
-                ).aggregation(
-                    aggregations.TermsAggregation(
-                        'referenced_id', 'indices.referenced_id'
-                    )
+        .nested(
+            'indices',
+            queries.filtered(
+                queries.match_all(),
+                filters.AND(
+                    filters.term('indices.identifier', subcase_query.index_identifier),
+                    filters.NOT(filters.term('indices.referenced_id', ''))  # exclude deleted indices
                 )
             )
         )
+        .filter(subcase_filter)
+        .source(['indices.referenced_id', 'indices.identifier'])
     )
 
-    counts_by_parent_id = es_query.run().aggregations.indices.matching_indices.referenced_id.counts_by_bucket()
+    counts_by_parent_id = Counter(
+        index['referenced_id']
+        for subcase in es_query.run().hits
+        for index in subcase['indices']
+        if index['identifier'] == subcase_query.index_identifier
+    )
     if len(counts_by_parent_id) > MAX_RELATED_CASES:
         from ..exceptions import TooManyRelatedCasesError
         raise TooManyRelatedCasesError(


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-1997

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Followup from https://github.com/dimagi/commcare-hq/pull/31637
For reasons unknown to me, the aggregation is very slow, regardless of the number of docs matching the filters.  This implementation is substantially faster, by comparison (0.3s vs 3s).  My hunch is that this is somehow analogous to the performance issues we've had sorting by case properties in this index.  Like, when operating on nested docs, ES isn't able to pre-filter to those contained in top-level docs matching the query.  Hopefully a more modern version of ES will fix that.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

has automated test suite

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change