### PR TITLE
Add gettext (translation dependency) to base Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update \
      wget \
      libxml2-dev \
      libxmlsec1-dev \
-     libxmlsec1-openssl
+     libxmlsec1-openssl \
+     gettext
 
 # Install latest chrome dev package and fonts to support major
 # charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12685

Companion to https://github.com/dimagi/commcare-hq/pull/31635. Needs to be a separate PR, so we can let the centralized docker container rebuild, and then run that PR against it.

## Safety Assurance
The Dockerfile only affects the docker container, which is used in tests and locally.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
