### PR TITLE
improvements to the UCR expression debugger to make it useful for other contexts

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/expression_debugger.js
+++ b/corehq/apps/userreports/static/userreports/js/expression_debugger.js
@@ -18,6 +18,7 @@ hqDefine('userreports/js/expression_debugger', function () {
             documentType: initial_page_data('document_type'),
             documentId: initial_page_data('document_id'),
             dataSourceId: initial_page_data('data_source_id'),
+            ucrExpressionId: initial_page_data('ucr_expression_id'),
         };
         $('#expression-debugger').koApplyBindings(
             expressionModel(expressionEditor, docEditor, submitUrl, initialData),

--- a/corehq/apps/userreports/static/userreports/js/expression_debugger.js
+++ b/corehq/apps/userreports/static/userreports/js/expression_debugger.js
@@ -3,7 +3,9 @@ hqDefine('userreports/js/expression_debugger', function () {
     $(function () {
         var expressionModel = hqImport('userreports/js/expression_evaluator').expressionModel;
         var submitUrl = hqImport("hqwebapp/js/initial_page_data").reverse("expression_evaluator");
-        var expressionEditor = ace.edit($('.jsonwidget ~pre')[0]);
+        var expressionEditor = ace.edit($('#expression ~pre')[0]);
+        var docEditor = ace.edit($('#raw_document ~pre')[0]);
+        docEditor.getSession().setValue("{}");
         var sampleExpression = {
             "type": "property_name",
             "property_name": "name",
@@ -12,12 +14,13 @@ hqDefine('userreports/js/expression_debugger', function () {
         var initial_page_data = hqImport("hqwebapp/js/initial_page_data").get;
         expressionEditor.getSession().setValue(sampleText);
         var initialData = {
+            inputType: initial_page_data('input_type'),
             documentType: initial_page_data('document_type'),
             documentId: initial_page_data('document_id'),
             dataSourceId: initial_page_data('data_source_id'),
         };
         $('#expression-debugger').koApplyBindings(
-            expressionModel(expressionEditor, submitUrl, initialData),
+            expressionModel(expressionEditor, docEditor, submitUrl, initialData),
         );
     });
 });

--- a/corehq/apps/userreports/static/userreports/js/expression_evaluator.js
+++ b/corehq/apps/userreports/static/userreports/js/expression_evaluator.js
@@ -10,6 +10,7 @@ hqDefine('userreports/js/expression_evaluator', function () {
         self.documentType = ko.observable(initialData.documentType);
         self.documentId = ko.observable(initialData.documentId);
         self.dataSourceId = ko.observable(initialData.dataSourceId);
+        self.ucrExpressionId = ko.observable(initialData.ucrExpressionId);
         self.expressionText = ko.observable(expressionEditor.getSession().getValue());
         self.docText = ko.observable(docEditor.getSession().getValue());
         self.error = ko.observable();
@@ -68,6 +69,9 @@ hqDefine('userreports/js/expression_evaluator', function () {
             if (self.dataSourceId()) {
                 newParams['data_source'] = self.dataSourceId();
             }
+            if (self.ucrExpressionId()) {
+                newParams['ucr_expression_id'] = self.ucrExpressionId();
+            }
             newParams = $.param(newParams);
             if (currentParams !== newParams) {
                 var newUrl = document.location.pathname + "?" + newParams;
@@ -89,8 +93,12 @@ hqDefine('userreports/js/expression_evaluator', function () {
                 let data = {
                     input_type: self.inputType(),
                     data_source: self.dataSourceId(),
-                    expression: self.expressionText(),
                 };
+                if (self.ucrExpressionId()) {
+                    data.ucr_expression_id = self.ucrExpressionId();
+                } else {
+                    data.expression = self.expressionText();
+                }
                 if (self.inputType() === 'doc') {
                     data.doc_type = self.documentType();
                     data.doc_id = self.documentId();

--- a/corehq/apps/userreports/static/userreports/js/expression_evaluator.js
+++ b/corehq/apps/userreports/static/userreports/js/expression_evaluator.js
@@ -1,14 +1,17 @@
 /* globals hqDefine */
 hqDefine('userreports/js/expression_evaluator', function () {
-    var expressionModel = function (editor, submitUrl, initialData) {
+    var expressionModel = function (expressionEditor, docEditor, submitUrl, initialData) {
         var self = {};
         initialData = initialData || {};
-        self.editor = editor;
+        self.expressionEditor = expressionEditor;
+        self.docEditor = docEditor;
         self.submitUrl = submitUrl;
+        self.inputType = ko.observable(initialData.inputType);
         self.documentType = ko.observable(initialData.documentType);
         self.documentId = ko.observable(initialData.documentId);
         self.dataSourceId = ko.observable(initialData.dataSourceId);
-        self.expressionText = ko.observable(editor.getSession().getValue());
+        self.expressionText = ko.observable(expressionEditor.getSession().getValue());
+        self.docText = ko.observable(docEditor.getSession().getValue());
         self.error = ko.observable();
         self.result = ko.observable();
         self.isEvaluating = ko.observable(false);
@@ -20,18 +23,34 @@ hqDefine('userreports/js/expression_evaluator', function () {
                 return null;
             }
         };
-        self.editor.getSession().on('change', function () {
-            self.expressionText(self.editor.getSession().getValue());
+        self.expressionEditor.getSession().on('change', function () {
+            self.expressionText(self.expressionEditor.getSession().getValue());
+        });
+
+        self.getDocJSON = function () {
+            try {
+                return JSON.parse(self.docText());
+            } catch (err) {
+                return null;
+            }
+        };
+        self.docEditor.getSession().on('change', function () {
+            self.docText(self.docEditor.getSession().getValue());
         });
 
         self.hasParseError = ko.computed(function () {
             return self.getExpressionJSON() === null;
         }, self);
 
+        self.hasDocParseError = ko.computed(function () {
+            return self.getDocJSON() === null;
+        }, self);
+
         self.updateUrl = function () {
             var currentParams = document.location.search.substring(1);
             var newParams = {
                 'id': self.documentId(),
+                'input_type': self.inputType(),
                 'type': self.documentType(),
             };
             if (self.dataSourceId()) {
@@ -49,21 +68,26 @@ hqDefine('userreports/js/expression_evaluator', function () {
         self.evaluateExpression = function () {
             self.error("");
             self.result("");
-            if (self.hasParseError()) {
+            if (self.hasParseError() || self.hasDocParseError()) {
                 return;
-            } else if (!self.documentId()) {
-                self.error("Please enter a document ID.");
-            }
-            else {
+            } else if (!self.documentId() && !self.docText()) {
+                self.error("Please enter a document ID or document JSON");
+            } else {
                 self.isEvaluating(true);
+                let data = {
+                    input_type: self.inputType(),
+                    data_source: self.dataSourceId(),
+                    expression: self.expressionText(),
+                };
+                if (self.inputType() === 'doc') {
+                    data.doc_type = self.documentType();
+                    data.doc_id = self.documentId();
+                } else {
+                    data.raw_doc = self.docText();
+                }
                 $.post({
                     url: self.submitUrl,
-                    data: {
-                        doc_type: self.documentType(),
-                        doc_id: self.documentId(),
-                        data_source: self.dataSourceId(),
-                        expression: self.expressionText(),
-                    },
+                    data: data,
                     success: function (data) {
                         self.result(JSON.stringify(data.result, null, 4));
                         self.updateUrl();

--- a/corehq/apps/userreports/static/userreports/js/expression_evaluator.js
+++ b/corehq/apps/userreports/static/userreports/js/expression_evaluator.js
@@ -46,6 +46,18 @@ hqDefine('userreports/js/expression_evaluator', function () {
             return self.getDocJSON() === null;
         }, self);
 
+        self.formatJson = function () {
+            let expr = self.getExpressionJSON();
+            if (expr !== null) {
+                self.expressionEditor.getSession().setValue(JSON.stringify(expr, null, 2));
+            }
+
+            let doc = self.getDocJSON();
+            if (doc !== null) {
+                self.docEditor.getSession().setValue(JSON.stringify(doc, null, 2));
+            }
+        };
+
         self.updateUrl = function () {
             var currentParams = document.location.search.substring(1);
             var newParams = {

--- a/corehq/apps/userreports/templates/userreports/expression_debugger.html
+++ b/corehq/apps/userreports/templates/userreports/expression_debugger.html
@@ -7,6 +7,7 @@
 {% endblock %}
 {% block page_content %}
   {% registerurl "expression_evaluator" domain %}
+  {% initial_page_data "input_type" request.GET.input_type %}
   {% initial_page_data "document_type" request.GET.type %}
   {% initial_page_data "document_id" request.GET.id %}
   {% initial_page_data "data_source_id" request.GET.data_source %}
@@ -21,6 +22,27 @@
   <p>{% trans "Paste an expression and document information below to see the result of that expression evaluated on the document." %}</p>
   <form id="expression-debugger" class="form-horizontal ko-template" data-bind="submit: evaluateExpression">
     <div class="form-group">
+      <label for="doc_type" class="col-sm-2 control-label">{% trans "Input Type" %}</label>
+      <div class="col-sm-3">
+        <select-toggle data-apply-bindings="false"
+                       params="
+                         options: [
+                           {
+                             'id': 'raw',
+                             'text': '{% trans_html_attr "Raw" %}',
+                           },
+                           {
+                             'id': 'doc',
+                             'text': '{% trans_html_attr "Document" %}',
+                           },
+                         ],
+                         name: 'input_type',
+                         id: 'input_type',
+                         value: inputType,
+                       "></select-toggle>
+      </div>
+    </div>
+    <div class="form-group" data-bind="visible: inputType() === 'doc'">
       <label for="doc_type" class="col-sm-2 control-label">{% trans "Document Type" %}</label>
       <div class="col-sm-3">
         <select-toggle data-apply-bindings="false"
@@ -41,10 +63,22 @@
                        "></select-toggle>
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" data-bind="visible: inputType() === 'doc'">
       <label for="doc_id" class="col-sm-2 control-label">{% trans "Document ID" %}</label>
       <div class="col-sm-6">
-        <input type="doc_id" class="form-control" id="doc_id" data-bind="value: documentId">
+        <input type="text" class="form-control" id="doc_id" data-bind="value: documentId">
+      </div>
+    </div>
+     <div class="form-group" data-bind="visible: inputType() === 'raw', css: {'has-error': hasDocParseError}">
+      <label for="" class="col-sm-2 control-label">{% trans "Document JSON" %}</label>
+      <div class="col-sm-10">
+        <textarea id="raw_document" class="form-control jsonwidget" ></textarea>
+        <div class="help-block" data-bind="visible: hasDocParseError">
+          {% blocktrans %}
+            Your document JSON has parse errors!
+            For more details, try pasting into a <a href="http://jsonlint.com/" target="_blank">JSON Validator</a>.
+          {% endblocktrans %}
+        </div>
       </div>
     </div>
     {% if data_sources %}

--- a/corehq/apps/userreports/templates/userreports/expression_debugger.html
+++ b/corehq/apps/userreports/templates/userreports/expression_debugger.html
@@ -121,6 +121,9 @@
           <i class="fa fa-spin fa-refresh" data-bind="visible: isEvaluating"></i>
           {% trans "Evaluate!" %}
         </button>
+        <button class="btn btn-primary" data-bind="click: formatJson, disable: isEvaluating">
+          {% trans "Format JSON" %}
+        </button>
       </div>
     </div>
     <div class="col-sm-offset-2 col-sm-10">

--- a/corehq/apps/userreports/templates/userreports/expression_debugger.html
+++ b/corehq/apps/userreports/templates/userreports/expression_debugger.html
@@ -11,6 +11,7 @@
   {% initial_page_data "document_type" request.GET.type %}
   {% initial_page_data "document_id" request.GET.id %}
   {% initial_page_data "data_source_id" request.GET.data_source %}
+  {% initial_page_data "ucr_expression_id" request.GET.ucr_expression_id %}
 
   <h1>
     {% if use_updated_ucr_naming %}
@@ -103,10 +104,31 @@
         </div>
       </div>
     {% endif %}
-    <div class="form-group" data-bind="css: {'has-error': hasParseError}">
+    {% if ucr_expressions %}
+      <div class="form-group">
+        <label for="ucr_exrepssion_id" class="col-sm-2 control-label">
+          {% trans "Saved expression" %}
+        </label>
+        <div class="col-sm-6">
+          <select class="hqwebapp-select2" data-bind="value: ucrExpressionId">
+            <option></option>
+            {% for expression in ucr_expressions %}
+              <option value="{{ expression.id }}">{{ expression.name }}</option>
+            {% endfor %}
+          </select>
+          <p class="help-block">
+            {% url 'ucr_expressions' domain as expressions_url %}
+            {% blocktrans %}
+              Use a saved expression from the <a href="{{ expressions_url }}">expression library</a>
+            {% endblocktrans %}
+          </p>
+        </div>
+      </div>
+    {% endif %}
+    <div class="form-group" data-bind="hidden: ucrExpressionId, css: {'has-error': hasParseError}">
       <label for="" class="col-sm-2 control-label">{% trans "Expression JSON" %}</label>
       <div class="col-sm-10">
-        <textarea id="expression" class="form-control jsonwidget" ></textarea>
+        <textarea id="expression" class="form-control jsonwidget"></textarea>
         <div class="help-block" data-bind="visible: hasParseError">
           {% blocktrans %}
             Your expression has parse errors!

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -958,15 +958,19 @@ class DataSourceDebuggerView(BaseUserConfigReportsView):
 @login_and_domain_required
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 def evaluate_expression(request, domain):
-    doc_type = request.POST['doc_type']
-    doc_id = request.POST['doc_id']
+    input_type = request.POST['input_type']
     data_source_id = request.POST['data_source']
     expression_text = request.POST['expression']
 
     try:
         factory_context = _get_factory_context(domain, data_source_id)
         parsed_expression = _get_parsed_expression(factory_context, expression_text)
-        doc = _get_document(domain, doc_type, doc_id)
+        if input_type == 'doc':
+            doc_type = request.POST['doc_type']
+            doc_id = request.POST['doc_id']
+            doc = _get_document(domain, doc_type, doc_id)
+        else:
+            doc = json.loads(request.POST['raw_doc'])
         result = parsed_expression(doc, EvaluationContext(doc))
         return JsonResponse({"result": result})
     except HttpException as e:

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -39,6 +39,7 @@ from dimagi.utils.couch.undo import (
 )
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import json_response
+from no_exceptions.exceptions import HttpException
 from pillowtop.dao.exceptions import DocumentNotFoundError
 
 from corehq import toggles
@@ -960,53 +961,54 @@ def evaluate_expression(request, domain):
     doc_type = request.POST['doc_type']
     doc_id = request.POST['doc_id']
     data_source_id = request.POST['data_source']
+    expression_text = request.POST['expression']
+
     try:
-        if data_source_id:
+        factory_context = _get_factory_context(domain, data_source_id)
+        parsed_expression = _get_parsed_expression(factory_context, expression_text)
+        doc = _get_document(domain, doc_type, doc_id)
+        result = parsed_expression(doc, EvaluationContext(doc))
+        return JsonResponse({"result": result})
+    except HttpException as e:
+        return JsonResponse({'message': e.message}, status=e.status)
+    except Exception as e:
+        return JsonResponse({"error": str(e)}, status=500)
+
+
+def _get_factory_context(domain, data_source_id):
+    if data_source_id:
+        try:
             data_source = get_datasource_config(data_source_id, domain)[0]
-            factory_context = data_source.get_factory_context()
-        else:
-            factory_context = FactoryContext.empty(domain=domain)
+            return data_source.get_factory_context()
+        except DataSourceConfigurationNotFoundError:
+            raise HttpException(
+                404, _("Data source with id {} not found in domain {}.").format(data_source_id, domain)
+            )
+    return FactoryContext.empty(domain=domain)
+
+
+def _get_parsed_expression(factory_context, expression_text):
+    try:
+        expression_json = json.loads(expression_text)
+        return ExpressionFactory.from_spec(
+            expression_json,
+            context=factory_context
+        )
+    except BadSpecError as e:
+        raise HttpException(400, _("Problem with expression: {}").format(e))
+
+
+def _get_document(domain, doc_type, doc_id):
+    try:
         usable_type = {
             'form': 'XFormInstance',
             'case': 'CommCareCase',
         }.get(doc_type, 'Unknown')
         document_store = get_document_store_for_doc_type(
             domain, usable_type, load_source="eval_expression")
-        doc = document_store.get_document(doc_id)
-        expression_text = request.POST['expression']
-        expression_json = json.loads(expression_text)
-        parsed_expression = ExpressionFactory.from_spec(
-            expression_json,
-            context=factory_context
-        )
-        result = parsed_expression(doc, EvaluationContext(doc))
-        return json_response({
-            "result": result,
-        })
-    except DataSourceConfigurationNotFoundError:
-        return json_response(
-            {"error": _("Data source with id {} not found in domain {}.").format(
-                data_source_id, domain
-            )},
-            status_code=404,
-        )
+        return document_store.get_document(doc_id)
     except DocumentNotFoundError:
-        return json_response(
-            {"error": _("{} with id {} not found in domain {}.").format(
-                doc_type, doc_id, domain
-            )},
-            status_code=404,
-        )
-    except BadSpecError as e:
-        return json_response(
-            {"error": _("Problem with expression: {}").format(e)},
-            status_code=400,
-        )
-    except Exception as e:
-        return json_response(
-            {"error": str(e)},
-            status_code=500,
-        )
+        raise HttpException(404, _("{} with id {} not found in domain {}.").format(doc_type, doc_id, domain))
 
 
 @login_and_domain_required


### PR DESCRIPTION
## Product Description
This adds some features to the UCR Expression debugger to make it more useful with expressions that are used with Expression Repeaters etc.

* Allow user to specify raw JSON input instead of a document ID
* Format JSON button
* Allow user to select a saved expression

![Peek 2022-05-19 10-10](https://user-images.githubusercontent.com/249606/169248135-36040838-5bac-4a74-9a8e-d000cd27ca0b.gif)

In the long run I'd like to build this out as a test framework that allow you to save and run test cases and links to the saved expressions. It could also be used as an editor for the saved expressions.

## Feature Flag
USER_CONFIGURABLE_REPORTS

## Safety Assurance

### Safety story
Changes limited to an advanced view.

### Automated test coverage
None

### QA Plan
None - tested locally and not a critical or highly used feature


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
