### PR TITLE
clear local storage after successful selection

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -58,6 +58,7 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
                 var urlObject = Util.currentUrlToObject();
                 urlObject.setSelections(response.selections);
                 Util.setUrlToObject(urlObject, true);
+                sessionStorage.removeItem('selectedValues');
             }
 
             if (response.commands) {


### PR DESCRIPTION
## Technical Summary
Multi-select bugfix when both parent and child module use multi-select lists.

https://dimagi-dev.atlassian.net/browse/QA-4118

After the first selection the local storage was not getting cleared and so the next selection included the IDs from the parent module's case list.

I'm not sure if this is the best place to remove them but it is also where we replace the 'use_selected_values' placeholder in the selections array with the UUID so it seemed like a reasonable place.

## Feature Flag
mutli-select case lists

## Safety Assurance

### Safety story
Fix for an as yet unreleased feature.

### Automated test coverage
None

### QA Plan
https://dimagi-dev.atlassian.net/browse/QA-4118


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
