### PR TITLE
[SSO] implement simple sanity checks on getting email domain from username

### DIFF
--- a/corehq/apps/sso/tests/test_user_helpers.py
+++ b/corehq/apps/sso/tests/test_user_helpers.py
@@ -1,0 +1,31 @@
+from testil import eq
+
+from corehq.apps.sso.utils.user_helpers import get_email_domain_from_username
+
+
+def test_get_email_domain_with_bad_username():
+    eq(get_email_domain_from_username('brian@securitytest.io @test.com'), None)
+
+
+def test_get_email_domain_with_bad_username_strange_characters():
+    eq(get_email_domain_from_username('brian@securitytest.com %0a%0c{<@test.com'), None)
+
+
+def test_get_email_domain_with_bad_username_no_user():
+    eq(get_email_domain_from_username('@test.com'), None)
+
+
+def test_get_email_domain_with_bad_username_multiple_ats():
+    eq(get_email_domain_from_username('brian@test.com@bar.com@test.com'), None)
+
+
+def test_get_email_domain_with_bad_username_spaces():
+    eq(get_email_domain_from_username('brian test@test.com'), None)
+
+
+def test_get_email_domain_with_bad_username_space_at_end():
+    eq(get_email_domain_from_username('brian @test.com'), None)
+
+
+def test_get_email_domain_with_good_username():
+    eq(get_email_domain_from_username('foobar123+test@test.com'), 'test.com')

--- a/corehq/apps/sso/utils/user_helpers.py
+++ b/corehq/apps/sso/utils/user_helpers.py
@@ -1,15 +1,18 @@
+import re
+
+
 def get_email_domain_from_username(username):
     """
     A quick utility for getting an Email Domain from a username
     (the last part of the email after the '@' sign)
     :param username: String
-    :return: Domain name string. `None` if there is no domain name.
+    :return: Domain name string. `None` if there is no domain name (or username is otherwise invalid).
     """
     split_username = username.split('@')
-    if len(split_username) < 2:
+    if len(split_username) != 2:
         # Not a real email address with an expected email domain.
-        return None
-    # we take the last split because `@` is technically an allowed character if
-    # inside a quoted string.
-    # See https://en.wikipedia.org/wiki/Email_address#Local-part
+        return
+    if not re.match(r"^[a-z0-9!#$%&'*+=?^_‘{|}~-]+(?:\.[a-z0-9!#$%&'*+=?^_‘{|}~-]+)*$", split_username[0]):
+        # not a real email address as the username contains invalid characters
+        return
     return split_username[-1]


### PR DESCRIPTION
## Technical Summary
As recommended by our pentest findings, we are doing some simple sanity checks against getting the email domain from a username. This includes test cases that were mentioned in the pentest to handle.

## Safety Assurance

### Safety story
Simple change. Well tested.

### Automated test coverage
Yes

### QA Plan
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
