### PR TITLE
fetch nested toggle dependencies 

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -331,9 +331,15 @@ class PredictablyRandomToggle(StaticToggle):
         randomness,
         help_link=None,
         description=None,
+        relevant_environments=None,
+        notification_emails=None,
+        parent_toggles=None
     ):
         super(PredictablyRandomToggle, self).__init__(slug, label, tag, list(namespaces),
-                                                      help_link=help_link, description=description)
+                                                      help_link=help_link, description=description,
+                                                      relevant_environments=relevant_environments,
+                                                      notification_emails=notification_emails,
+                                                      parent_toggles=parent_toggles)
         _ensure_valid_namespaces(namespaces)
         _ensure_valid_randomness(randomness)
         self.randomness = randomness
@@ -394,11 +400,15 @@ class DynamicallyPredictablyRandomToggle(PredictablyRandomToggle):
         default_randomness=0.0,
         help_link=None,
         description=None,
-        relevant_environments=None
+        relevant_environments=None,
+        notification_emails=None,
+        parent_toggles=None
     ):
         super(PredictablyRandomToggle, self).__init__(slug, label, tag, list(namespaces),
                                                       help_link=help_link, description=description,
-                                                      relevant_environments=relevant_environments)
+                                                      relevant_environments=relevant_environments,
+                                                      notification_emails=notification_emails,
+                                                      parent_toggles=parent_toggles)
         _ensure_valid_namespaces(namespaces)
         _ensure_valid_randomness(default_randomness)
         self.default_randomness = default_randomness
@@ -437,14 +447,18 @@ class FeatureRelease(DynamicallyPredictablyRandomToggle):
         default_randomness=0.0,
         help_link=None,
         description=None,
-        relevant_environments=None
+        relevant_environments=None,
+        notification_emails=None,
+        parent_toggles=None
     ):
         super().__init__(
             slug, label, tag, namespaces,
             default_randomness=default_randomness,
             help_link=help_link,
             description=description,
-            relevant_environments=relevant_environments
+            relevant_environments=relevant_environments,
+            notification_emails=notification_emails,
+            parent_toggles=parent_toggles
         )
         self.owner = owner
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -143,7 +143,12 @@ class StaticToggle(object):
         self.enabled_for_new_users_after = enabled_for_new_users_after
         # pass in a set of environments where this toggle applies
         self.relevant_environments = relevant_environments
-        self.parent_toggles = parent_toggles or []
+
+        parent_toggles = parent_toggles or []
+        for dependency in parent_toggles:
+            parent_toggles.extend(dependency.parent_toggles)
+
+        self.parent_toggles = parent_toggles
 
         if namespaces:
             self.namespaces = [None if n == NAMESPACE_USER else n for n in namespaces]


### PR DESCRIPTION
## Technical Summary
Ideally feature flags should not depend on each other but sometimes they do. Ideally the dependencies should not be more than 1 level deep but on [occasion](https://github.com/dimagi/commcare-hq/pull/31630/files#diff-e795c5340a3b1ebdea3983771b7d0e7912a23023e03e66ed7a613218ba2640e4) they are.

Follow on from https://github.com/dimagi/commcare-hq/pull/31357

This PR recursively collects all dependencies.

## Safety Assurance

### Safety story
Change to feature flags only

### Automated test coverage
None

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
