### PR TITLE
Remove obsolete docker compose links

### DIFF
--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -13,6 +13,15 @@ services:
       DOCKER_HQ_OVERLAYFS_METACOPY: "${DOCKER_HQ_OVERLAYFS_METACOPY}"
     privileged: true  # allows mount inside container
     command: [runserver]
+    depends_on:
+      - postgres
+      - couch
+      - redis
+      - elasticsearch2
+      - elasticsearch5
+      - kafka
+      - zookeeper
+      - minio
     expose:
       - 8000
     ports:
@@ -27,6 +36,9 @@ services:
       service: formplayer
     environment:
         COMMCARE_HOST: "http://web:8000"
+    depends_on:
+      - postgres
+      - redis
     ports:
       - "8080:8080"
       - "8081:8081"

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -13,15 +13,6 @@ services:
       DOCKER_HQ_OVERLAYFS_METACOPY: "${DOCKER_HQ_OVERLAYFS_METACOPY}"
     privileged: true  # allows mount inside container
     command: [runserver]
-    links:
-      - postgres
-      - couch
-      - redis
-      - elasticsearch2
-      - elasticsearch5
-      - kafka
-      - zookeeper
-      - minio
     expose:
       - 8000
     ports:
@@ -36,9 +27,6 @@ services:
       service: formplayer
     environment:
         COMMCARE_HOST: "http://web:8000"
-    links:
-      - postgres
-      - redis
     ports:
       - "8080:8080"
       - "8081:8081"

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -5,6 +5,9 @@ services:
     extends:
       file: hq-compose.yml
       service: formplayer
+    depends_on:
+      - postgres
+      - redis
     expose:
       - 8080
     ports:

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -5,9 +5,6 @@ services:
     extends:
       file: hq-compose.yml
       service: formplayer
-    links:
-      - postgres
-      - redis
     expose:
       - 8080
     ports:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -32,6 +32,15 @@ services:
       TRAVIS_PULL_REQUEST_SHA: "${TRAVIS_PULL_REQUEST_SHA}"
       TRAVIS_REPO_SLUG: "${TRAVIS_REPO_SLUG}"
     privileged: true  # allows mount inside container
+    depends_on:
+      - postgres
+      - couch
+      - redis
+      - elasticsearch2
+      - elasticsearch5
+      - kafka
+      - zookeeper
+      - minio
     volumes:
       - ..:/mnt/commcare-hq-ro${RO}
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-lib:}/mnt/lib

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -32,15 +32,6 @@ services:
       TRAVIS_PULL_REQUEST_SHA: "${TRAVIS_PULL_REQUEST_SHA}"
       TRAVIS_REPO_SLUG: "${TRAVIS_REPO_SLUG}"
     privileged: true  # allows mount inside container
-    links:
-      - postgres
-      - couch
-      - redis
-      - elasticsearch2
-      - elasticsearch5
-      - kafka
-      - zookeeper
-      - minio
     volumes:
       - ..:/mnt/commcare-hq-ro${RO}
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-lib:}/mnt/lib


### PR DESCRIPTION
I believe we were using these to allow services to communicate on the network, but the [docker-compose docs](https://docs.docker.com/compose/compose-file/#links) state that

> Links are not required to enable services to communicate...

Resolves error with podman:
```sh
$ ./scripts/docker bash
Creating hqservice_web_run ... error

ERROR: for hqservice_web_run  Cannot create container for service web: bad parameter: Link is not supported

ERROR: for web  Cannot create container for service web: bad parameter: Link is not supported
ERROR: Encountered errors while bringing up the project.
```

## Safety Assurance

### Safety story

Should only affect tests and development environments using docker. The `links` directive should not be needed.

### Automated test coverage

Tests run on docker, so indirectly yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
