### PR TITLE
improve report filtering related to system forms

### DIFF
--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -204,11 +204,15 @@ class TermsAggregation(Aggregation):
     :param name: aggregation name
     :param field: name of the field to bucket on
     :param size:
+    :param missing: define how documents that are missing a value should be treated.
+                    By default, they will be ignored. If a value is supplied here it will be used where
+                    the value is missing.
+
     """
     type = "terms"
     result_class = BucketResult
 
-    def __init__(self, name, field, size=None):
+    def __init__(self, name, field, size=None, missing=None):
         assert re.match(r'\w+$', name), \
             "Names must be valid python variable names, was {}".format(name)
         self.name = name
@@ -216,6 +220,8 @@ class TermsAggregation(Aggregation):
             "field": field,
             "size": size if size is not None else SIZE_LIMIT,
         }
+        if missing:
+            self.body["missing"] = missing
 
     def order(self, field, order="asc", reset=True):
         query = deepcopy(self)

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -3,19 +3,17 @@ import uuid
 from xml.etree import cElementTree as ElementTree
 
 from django.template.loader import render_to_string
+from django.utils.translation import gettext_lazy
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.util import property_changed_in_action
-from corehq.apps.es.cases import CaseES
-from corehq.apps.es import filters
 from dimagi.utils.parsing import json_format_datetime
 
+from corehq.apps.es import filters
+from corehq.apps.es.cases import CaseES
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.util import SYSTEM_USER_ID
-from corehq.form_processor.exceptions import (
-    CaseNotFound,
-    MissingFormXml,
-)
+from corehq.form_processor.exceptions import CaseNotFound, MissingFormXml
 from corehq.form_processor.models import CommCareCase
 
 CASEBLOCK_CHUNKSIZE = 100
@@ -23,8 +21,8 @@ SYSTEM_FORM_XMLNS = 'http://commcarehq.org/case'
 EDIT_FORM_XMLNS = 'http://commcarehq.org/case/edit'
 
 SYSTEM_FORM_XMLNS_MAP = {
-    SYSTEM_FORM_XMLNS: 'System Form',
-    EDIT_FORM_XMLNS: 'Data Cleaning Form',
+    SYSTEM_FORM_XMLNS: gettext_lazy('System Form'),
+    EDIT_FORM_XMLNS: gettext_lazy('Data Cleaning Form'),
 }
 
 ALLOWED_CASE_IDENTIFIER_TYPES = [

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy, gettext_noop
 from couchdbkit.exceptions import ResourceNotFound
 from memoized import memoized
 
+from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS_MAP
 from couchforms.analytics import (
     get_all_xmlns_app_id_pairs_submitted_to_in_domain,
 )
@@ -404,7 +405,13 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
                             return list(form['name'].values())[0]
 
         guessed_name = guess_form_name_from_submissions_using_xmlns(self.domain, xmlns)
-        return guessed_name or (None if none_if_not_found else _("Name Unknown"))
+        if guessed_name:
+            return guessed_name
+
+        if xmlns in SYSTEM_FORM_XMLNS_MAP:
+            return SYSTEM_FORM_XMLNS_MAP[xmlns]
+
+        return None if none_if_not_found else _("Name Unknown")
 
     @staticmethod
     def get_translated_value(display_lang, app_langs, obj):

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -119,6 +119,8 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
             form_values = list(self.all_relevant_forms.values())
             if form_values:
                 query = query.OR(*[self._form_filter(f) for f in form_values])
+        else:
+            query = query.NOT(es_filters.missing("app_id"))
 
         return query
 

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -120,11 +120,6 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
             if form_values:
                 query = query.OR(*[self._form_filter(f) for f in form_values])
 
-        # Exclude system forms unless they selected "Unknown User"
-        if HQUserType.UNKNOWN not in EMWF.selected_user_types(mobile_user_and_group_slugs):
-            query = query.NOT(form_es.xmlns(
-                list(SYSTEM_FORM_XMLNS_MAP.keys())
-            ))
         return query
 
     @property

--- a/corehq/apps/reports/templates/reports/filters/form_app_module_drilldown.html
+++ b/corehq/apps/reports/templates/reports/filters/form_app_module_drilldown.html
@@ -15,8 +15,11 @@
           {% trans 'Known Forms' %}
           <span class="hq-help-template"
                 data-title="{% trans "What are Known Forms?" %}"
-                data-content="{% trans "Known Forms are forms that have IDs which can be matched to existing or deleted CommCare Applications in your Project." %}"
-          ></span>
+                data-content="{% blocktrans %}
+                  These are forms that can be matched to an existing or deleted CommCare Application
+                  in your project.
+                {% endblocktrans %}">
+          </span>
         </label>
       </div>
       <div class="radio">
@@ -27,11 +30,15 @@
                  name="{{ slug }}_{{ unknown.slug }}"
                  id="{{ css_id }}_{{ unknown.slug }}_show"
                  value="yes">
-          {% trans 'Unknown Forms (Possibly Deleted)' %}
+          {% trans 'Unknown Forms' %}
           <span class="hq-help-template"
                 data-title="{% trans "What are Unknown Forms?" %}"
-                data-content="{% trans "We tried and tried, but these form IDs did not belong to any CommCare Applications (existing or deleted) in your Project. It might mean that these forms once belonged to an application, were deleted from it, and then replaced by a different form." %}"
-          ></span>
+                data-content="{% blocktrans %}
+                  These forms do not belong to a CommCare Application (existing or deleted) in your project.
+                  It might mean that these forms once belonged to an application but the application form
+                  has since been removed. They may also be 'system forms' or forms from an integration or API.
+                  {% endblocktrans %}">
+          </span>
         </label>
       </div>
     </div>

--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -2,6 +2,7 @@ import datetime
 
 from corehq.apps.es import FormES
 from corehq.apps.es.aggregations import TermsAggregation
+from corehq.const import MISSING_APP_ID
 from corehq.util.quickcache import quickcache
 
 from corehq.util.couch import stale_ok
@@ -74,7 +75,7 @@ def get_all_xmlns_app_id_pairs_submitted_to_in_domain(domain):
     query = (FormES()
              .domain(domain)
              .aggregation(
-                 TermsAggregation("app_id", "app_id").aggregation(
+                 TermsAggregation("app_id", "app_id", missing=MISSING_APP_ID).aggregation(
                      TermsAggregation("xmlns", "xmlns.exact")))
              .remove_default_filter("has_xmlns")
              .remove_default_filter("has_user")


### PR DESCRIPTION
## Product Description
Changes to the way we filter forms by application and user.

### User filter changes
Change made to allow 'system' forms to be displayed which don't usually have a user associated with them:

* When no filters are applied
    * *Previous behaviour*
        * filter the data by all user IDs in the project (active and inactive).
    * *New behaviour*
        * do not filter by user ID at all.

### App filter changes
* Dropdown options for 'unknown forms'
    * *Previous behaviour*
        * Only include forms that were submitted from an application (have an `app_id` field
    * *New behaviour*
        * Include all 'unknown' forms including those that don't have an `app_id` field

* When the default options are selected ("Show Forms in all Applications")
    * *Previous behaviour*
        * Don't apply app filtering at all. This would include forms that don't come from an app e.g. system forms
    * *New behaviour*
        * Filter out forms that do not have an app ID

* Unknown user system form filter
    * *Previous behaviour*
        * If 'unknown users' was NOT selected as a filter option then filter out specific system forms
            * This would only filter on some system XMLNS
    * *New behaviour*
        * Removed completely - do not change XMLNS filtering based on user types

Spec: https://docs.google.com/document/d/1t97k35y9juT7Wl_suOiWi-NYP3cpiaV4hUmZ0j2e-e4/edit#heading=h.lqyt6iorkjwv
Jira: https://dimagi-dev.atlassian.net/browse/USH-1844

## Technical Summary
The biggest change was to make the app / xml ES aggregation include forms with no `app_id`: 54c51aa078e8113aaefd47f0b6f0db8fb3c413e2

A few other filter changes.

## Safety Assurance

### Safety story
I consider this quite safe. It does alter a system report but only minor logic changes have been done.

### Automated test coverage
None

### QA Plan
[Will be QA'd on staging.](https://dimagi-dev.atlassian.net/browse/QA-4190)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
