### PR TITLE
Quick fix for loading hubspot demo/trial forms

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/hubspot.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.js
@@ -34,10 +34,10 @@ hqDefine('analytix/js/hubspot', [
         _logger = logging.getLoggerForApi('Hubspot');
         _ready = utils.initApi(_ready, apiId, scriptUrl, _logger);
 
+        // these forms get processed on the backend, so they don't need the hubspot js to be loaded
+        _utils.loadTrialForm();
         if (_get('isDemoVisible')) {
-            // these forms get processed on the backend, so they don't need the hubspot js to be loaded
             _utils.loadDemoForm();
-            _utils.loadTrialForm();
         }
 
     });

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -259,10 +259,10 @@ def banners(request):
 
 
 def get_demo(request):
-    is_user_not_logged_in = getattr(request, 'user', None) and not request.user.is_authenticated
+    is_user_logged_in = getattr(request, 'user', None) and request.user.is_authenticated
     is_hubspot_enabled = settings.ANALYTICS_IDS.get('HUBSPOT_API_ID')
     context = {}
-    if settings.IS_SAAS_ENVIRONMENT and is_hubspot_enabled and is_user_not_logged_in:
+    if settings.IS_SAAS_ENVIRONMENT and is_hubspot_enabled and not is_user_logged_in:
         context.update({
             'is_demo_visible': True,
         })


### PR DESCRIPTION
## Product Description
The trial form should always load regardless if the demo form is loading. Also fixes the logic for when to show the Schedule a Demo button.

followup to a recent issue reported here:
https://dimagi-dev.atlassian.net/browse/SAAS-11157

## Safety Assurance

### Safety story
Small frontend change. Tested locally and on staging. Fixes a currently broken workflow on production.

### Automated test coverage
no

### QA Plan
no

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
