### PR TITLE
Updated no-detail condition to handle multi-select

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -121,7 +121,12 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var detailObjects = model.models;
         // If we have no details, just select the entity
         if (detailObjects === null || detailObjects === undefined || detailObjects.length === 0) {
-            FormplayerFrontend.trigger("menu:select", caseId);
+            if (isMultiSelect) {
+                var Constants = hqImport("cloudcare/js/formplayer/constants");
+                FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_ADD, [caseId]);
+            } else {
+                FormplayerFrontend.trigger("menu:select", caseId);
+            }
             return;
         }
         var detailObject = detailObjects[detailTabIndex];


### PR DESCRIPTION
## Product Description
Part of https://dimagi-dev.atlassian.net/browse/QA-4118

When using select parent first, the parent selection doesn't require confirmation, so there's no detail popup. This wasn't handling multi-select properly.

Clicking on a row in a parent case list will now just check the associated checkbox.

![Screen Shot 2022-05-20 at 12 54 00 PM](https://user-images.githubusercontent.com/1486591/169576330-5c4e2ecc-abbc-45b0-ad05-5945718ef72f.png)

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
Change is limited to a flag that no one is using in prod.

### Automated test coverage

None

### QA Plan

This is a qabug, so QA will verify the fix

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
