### PR TITLE
[Accounting] Fix multi-page invoice rendering

### DIFF
--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -188,7 +188,6 @@ class InvoiceTemplate(object):
             self.draw_table_with_header_and_footer(self.items)
 
         # should only call save once to avoid reportlab exception
-        self.canvas.showPage()
         self.canvas.save()
 
     def draw_customer_invoice(self, items, items_to_draw):
@@ -197,6 +196,7 @@ class InvoiceTemplate(object):
         else:
             self.draw_header()
             self.draw_table(items)
+            self.canvas.showPage()
             if len(items_to_draw) == 0:
                 self.draw_totals_on_new_page()
 
@@ -580,9 +580,9 @@ class InvoiceTemplate(object):
             self.draw_table(items)
         self.draw_totals(totals_x=inches(5.85), line_height=inches(0.25), subtotal_y=inches(3.5))
         self.draw_footer()
+        self.canvas.showPage()
 
     def draw_totals_on_new_page(self):
-        self.canvas.showPage()
         self.canvas.setStrokeColor(STROKE_COLOR)
         self.draw_logo()
         self.draw_from_address()
@@ -595,6 +595,7 @@ class InvoiceTemplate(object):
 
         self.draw_totals(totals_x=inches(5.85), line_height=inches(0.25), subtotal_y=inches(7.0))
         self.draw_footer()
+        self.canvas.showPage()
 
     def draw_totals(self, totals_x, line_height, subtotal_y):
         tax_y = subtotal_y - line_height

--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -582,6 +582,7 @@ class InvoiceTemplate(object):
         self.draw_footer()
 
     def draw_totals_on_new_page(self):
+        self.canvas.showPage()
         self.canvas.setStrokeColor(STROKE_COLOR)
         self.draw_logo()
         self.draw_from_address()

--- a/corehq/apps/accounting/tests/data/invoice_008.pdf
+++ b/corehq/apps/accounting/tests/data/invoice_008.pdf
@@ -1,0 +1,119 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /DCTDecode ] /Height 8 /Length 312 /Subtype /Image 
+  /Type /XObject /Width 8
+>>
+stream
+s4IA0!"_al8O`[\!<<*#!!*'"s4[N@!!<9(!WiE*!WiE*!s8W."p>&3"9\u7"pG2;#RUnF#RLeE$kEaR$P!ON#n7IU%M'*^&J,9X&eblh'+YWc&HCJb6NI8k!sA]/#Qt89&.8dP&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.nlW!"fJ:#QP,4!>,;5&HMtG!WU(<'EA.6zzz!!!6'_uLJ_!<<*"zzz!<9t;'`e=9zzz!!!92s24mO&HMk3zzz!!*&Q!"8r1!!3`7&HG#q"E5dTs4I~>endstream
+endobj
+4 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 11 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.b50b63cd220923af8626be850a69ead1 3 0 R
+>>
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://wl.flywire.com/?destination=DMG)
+>> /Border [ 0 0 0 ] /Rect [ 191.05 212.4 369.16 224.4 ] /Subtype /Link /Type /Annot
+>>
+endobj
+7 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/billing/statements/)
+>> /Border [ 0 0 0 ] /Rect [ 36 172.8 338.35 184.8 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/Annots [ 6 0 R 7 0 R ] /Contents 13 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 11 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.b50b63cd220923af8626be850a69ead1 3 0 R
+>>
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/PageMode /UseNone /Pages 11 0 R /Type /Catalog
+>>
+endobj
+10 0 obj
+<<
+/Author (anonymous) /CreationDate () /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate () /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+11 0 obj
+<<
+/Count 2 /Kids [ 4 0 R 8 0 R ] /Type /Pages
+>>
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1239
+>>
+stream
+Gau1-D0+Dj&BE]".J?3n-LDLIc^*H/:VG^6KhE!Eod'a=D'l\)&+*W:rCO;s#dB5U:+$/im@W4b:TMG;Yk]O3r?_adCO#H:!26'(JT/On?c#JIg3%eMNg,(fs8&q8j$7SHbBtuMM3,aCi6C#^b5X'&BIiRQZC;l232LG4X!Etb9F8@oBsu\,R$N@T)iFi5l.f(:92:SUCDXQ5^:sf!#Po0?&GT@lHW]\6MQSkV:%fJp@pg/Nj\]$,/U"AuSABud]&0oMHB14/M8DR:]a=ULp>73H\BiMrR0P?r7&?]6P1b7l<eb=?-jWFr&;:ft)6=#jL&+etE['iQe:o^OnZ)\6MoOJt=/Ui%Q`q4XO>c"dr:1Kmno1LtVg6;@Ya-2oJ!WSAY[81-h="h!0Kf\iB0r5aDg2qs4F9RT7!jg*eg/S<:FMA_9QDtX/Ct:.F3'V/f][!QI`pX[(h_aL@b8:fQ6LOj:@VVkp7$JrB>ko5ZKb)nKA3EM@J!@s-Ehu0_dd&b3Q(M0Fi5,c8fe>'PA7te:!epgE,\g?Uq%uH`V\bE15k)KO5"W<BbTt1R$]lV`dnJH89S!9#Y44[nEPpCXb6t$+l)V>MhE@RMcM9i[SG*i4\q.pBr*7Vos%4]HIcBS6sugh$FC6`==d>D=#`\O3(:4*le1sC<M+?=O[KE5l$<Q3adakJ7T%;N+c&\Ngt9ad@UX.R:LKTbP_\/SZs+uX'bZ6h,@l3TH"rNKP][W00F;*]<%30H0hQ#(l0DY:UltXlY:Y8Me<HT3jit_(\p$S0WI2#&PL-=K@!.[Kb,"FHNO>>\<mJA&%_^tO&PD<a:YYC=\R&%_'AWaL8Wb]\dYb6ZUP5<*O54QnCcsql?8(FZ-HfDMF5*d]HBPJ_A%gBeb9"'c#RAX&f<a^HpCoTR*8.LOMEC`Zf(PlB'8N'5\mmoFo_59Gl'r!=W-*1Omd'iNbOAs3.0C4$]K1FD+m)iI[kV]ZU^*oFPb;``H_D#>\I4?-`+-2I+AP?J*koDqMgh>>Slr"oIi*%ukKRkL@p>'c9UVoQFIpaASnI=t6nn;F#c:JQQDk\@0F^1;1?HAYElZ[h4.&XHSR5jKc80St,+*[^"Oec9bLDG[R"h2.R7^,b@HtiQ9\$=H.6gU-7Fe>oY0[Gcb>Q;\Vtr\rVNu8?d>^4I&hNA3ZY-$I&P^aYM<Ua@(t1sL`4h:YF]9RpI@lZK`##?m>-8*+fj$72=""LV#CR1[#Q~>endstream
+endobj
+13 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1661
+>>
+stream
+Gau0BD0+Dj&H9tYfFPM3g'PWZhjM$c"-U%U1lrL9HC`.o@>i('D%YGHjknt<2NA**[!0t*J[)lAIJ2?,V57SX+"b7F'OVV?s,7"j&1i?8`.HnlS-C"nfs(;Pr2t+uZ)r$Wrg42*[Y)1RrA1G$J)m-DD.E"$@DnPl1QsISLH0G7f`lYJ_'9:7ZLb&JZ"PY8O>`0RV+$69f=HOWeo)\@KA\>'.=BBN!OJM'#o(]PE=B_sR"j!>&!^C2&JV\U^.=MWRhqI8iOIAn>(I%ir0R3(dq'^o.+=K?(/W%[a:`*WiC_F?#m6YOT[Y2--ipXanY,fXS'oA+%@@WXmmh:X7_+=nC\GGSjM([s)sNG&n*']07gQ!HR?lA[Ia2B*1.@NOA0tO9:G[:jX11(t[MAWK6bgK%nkBRsiP&j0:$jS+Q&YZJfr'cgX:920*`&sd_9Z!H3Eq=MkOLpSmk>AiR77#%1jr8FfIhU.=htK.MQD?):pGseTk"MJV#l8j"#H%"6C,rp;*C++0m]eZSrK,M3fHgc4[0,(<9RA&h7?V3-\"q<a/;/;6W7m`dIHOIcc]j.JP6H=h%WGaHCBM"lV6oL`mScS[BUmtnlLa6]"<mSdWRQ1H+ij990@mhqo#PXFtsJ$pC!JE#4\)4ZE<ABacu/L@TgVRM\0"C#H+1IAqumd,-KBM5.N_.>qiI=ct('R_52fG?Kjp0UM&63;$R.a54PcK%ZB_`[$`hJ-F%>Ro8lVgf-"7_'aSFk`03Z5mi;t!71Dr>U:R/Mdbj3$#&adf!rrjHUS;_9RMW9fal#F,8n6&Fmj%fPY.G/uN8Leq]Y(#bC90f;(GD8HXM4%-JDltLbX\T3irH?LjTb2d,PH[deV5s,h@VPMo3(*9@b-Rgf/fj&e1g4S._+Tn2d"6</>Rkt*bRDcQ>&DB=LRsraH,S2?dS]DrQK)TeT/E+#'^Vk/1p$Yqrh>r^L!F*!gm9ukL7PS?'%k4jK]TJG$nJa#5?jaBj&1l1/02#O*/PC)6<^QE8n-b'gcKELh4R>=Rrj`k48r(;uA7Qn8G%H%<87:<KP95GD.QD6l)ra+m(K1N#-_Qk6mtA3>i`'(J>=*151gj#j,p(8s77c?'XD-c68%NDZ_CH<LINR[mdRG#Q=X365I]>0imC9h>]8DGnF-!s#@Q6fBb!YC(\!F(j0!3fm=#e9[gM*]4'[0HSmmqI^?pla>91k89lIGAseg5>G4GRC.1WS3Qs&kl9Qgrdb3g^)]Wa]4e-@'?`rp1JVi7ErM>[$+tWT^3'jH$rHrZ<kPZLHT'_jPF'd.@3.;B?]J&e%M0?>jMmC1IQ9\%cZo/p,%Tkh0Pu594k/2I1Uc_DD'XFE#B:&'\APZ\VQ`([+^nW<G:3dH.<cZuK04['[L(\VH(9#dh)2FsNp?lLG-I0J='o;s]<sC@@j;9L"Q=75_HLBis;fRVTDlnHT]L5PaP4$\6kqgD&p9<quU,>YM*H?l$lg@XWCb1eqi(0b2pHsR/+**k%gYf`5D/PFjob#e-Fp.XXL/Fa7Se'bBo*:-1V@T1MEVbFWW>c=AgYJ^_fIdpJ_[pYmR&n`H:]nqjK[4\8'jRqV<=DC8!EceZ!.,oaqk]S+Erpen-Mjf#b>[\UV;uqdbT>e5Z$l2&V3Y8ff6aY:kkkh#X1O\~>endstream
+endobj
+xref
+0 14
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000717 00000 n 
+0000000985 00000 n 
+0000001097 00000 n 
+0000001278 00000 n 
+0000001488 00000 n 
+0000001780 00000 n 
+0000001849 00000 n 
+0000002100 00000 n 
+0000002166 00000 n 
+0000003497 00000 n 
+trailer
+<<
+/ID 
+/Info 10 0 R
+/Root 9 0 R
+/Size 14
+>>
+startxref
+5250
+%%EOF

--- a/corehq/apps/accounting/tests/data/invoice_009.pdf
+++ b/corehq/apps/accounting/tests/data/invoice_009.pdf
@@ -2,7 +2,7 @@
 %“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
 1 0 obj
 <<
-/F1 2 0 R /F2 5 0 R
+/F1 2 0 R /F2 6 0 R
 >>
 endobj
 2 0 obj
@@ -20,7 +20,7 @@ s4IA0!"_al8O`[\!<<*#!!*'"s4[N@!!<9(!WiE*!WiE*!s8W."p>&3"9\u7"pG2;#RUnF#RLeE$kEaR
 endobj
 4 0 obj
 <<
-/Contents 12 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 11 0 R /Resources <<
+/Contents 13 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 12 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.b50b63cd220923af8626be850a69ead1 3 0 R
 >>
@@ -32,26 +32,38 @@ endobj
 endobj
 5 0 obj
 <<
-/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+/Contents 14 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.b50b63cd220923af8626be850a69ead1 3 0 R
+>>
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 6 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (https://wl.flywire.com/?destination=DMG)
 >> /Border [ 0 0 0 ] /Rect [ 191.05 212.4 369.16 224.4 ] /Subtype /Link /Type /Annot
 >>
 endobj
-7 0 obj
+8 0 obj
 <<
 /A <<
 /S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/billing/statements/)
 >> /Border [ 0 0 0 ] /Rect [ 36 172.8 338.35 184.8 ] /Subtype /Link /Type /Annot
 >>
 endobj
-8 0 obj
+9 0 obj
 <<
-/Annots [ 6 0 R 7 0 R ] /Contents 13 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 11 0 R /Resources <<
+/Annots [ 7 0 R 8 0 R ] /Contents 15 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 12 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.b50b63cd220923af8626be850a69ead1 3 0 R
 >>
@@ -61,30 +73,37 @@ endobj
 >> /Type /Page
 >>
 endobj
-9 0 obj
+10 0 obj
 <<
-/PageMode /UseNone /Pages 11 0 R /Type /Catalog
+/PageMode /UseNone /Pages 12 0 R /Type /Catalog
 >>
 endobj
-10 0 obj
+11 0 obj
 <<
 /Author (anonymous) /CreationDate () /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate () /Producer (ReportLab PDF Library - www.reportlab.com) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
-11 0 obj
-<<
-/Count 2 /Kids [ 4 0 R 8 0 R ] /Type /Pages
->>
-endobj
 12 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1764
+/Count 3 /Kids [ 4 0 R 5 0 R 9 0 R ] /Type /Pages
 >>
-stream
-Gb"/hgN)%,&;KZH'RPu,\=!W=JHWg$b(k)oENRrlg?);!kenO#Zt1P#hS(t*+D?>$Ff3ft;b[lp!.HSeqZ0eqbCJkBbl4+a!"KB]s+(42:tu%D8-6aJS.pUQT0DQg.Y[$Bjc>&76(1n[qEH,H9;T'XGlOID/q1"-a`U4ZV3oLfV`>RB)^W&-/lbNA1,#PH#06Dp_T]t#[u,lX)NtIPde"OoFnP-K..3aQ$O7)(<qQg&<kbJ6:9.On%Ru3r..uDkAc8Ho_s2:L^X^O)Gr+BMZ"IC?BJAsK:]*TUkB-65?]nR*#YYA]9$)4?o[?mQB:*=b6cqDCVMKh8$!.4lKDW:YA4=uT\=#gI+2/algSm]pd8uf6qA_C;1SsX9nFZ&UMK/A^UGTFs*'1&Wq,:SL60uWlIJ6pM(R0-@^=-#!M8#!/UWUX67PkP@B'>d4qn(6gS4F\^3BB2>:X4lbKj;aFK9!,#Y9eQ$LZQ"VR`?LKjM^Jjc0u`YXer.>;-#2l.$qF9*,_)8!_*\nT^3\<WoL@aD-Kig-BU<CH6j)#m?:^L@ig4l:5@+qag1S?3BdCbI!TmdLkEaMj!aNlI*XMR%7hb[;\."B.MIJJr>qQb=D!f&<,W&#hfU]?D0?h/RPjDA48L3I9"UAO6of)(UZ*Q5YZXSTi[W<X_ZT(3'*"4B+Xn\,E2P?a/q:V#1ThfFPC`LREWV`UCg2REP?^Am#a<E"0e6a);n\rP-C-[6POLLD*`o5o#alh"=t'5@-Fn+?:c]t7f*T2]\Pd#E;j,=9e%;r.W:Ppra;:GV'sNY_"_bpllc.Z.]j3$kJ+hp*d2c:F(q5LM\<,ih?B;]fB06cTe9h\E[P(0#m9.pYrkD]uO!dFd:S>%aUjCEFietqB]JqK,`mn=][FL_;S=^R91qr60D@UQ\>5?_0YS\1OZQ?O6KEfGW/l.L'Mk7nZaFooo^(Em%7b@I2?SaV$4EIF`A*9q3%oR!u;IG>#3sTD@oa1&)WtORVdqj=,Ye$s;-^`FkF@r">+1J;s53:VPX!aiai)ZJh:V[#R0=j(_VJcaIn]<m,l[b_4+Zp9WD`A?'-`2ib"KPNO8U)/0LMnT7Bg7.2QFR@02Q7%)N%`s][%GSMI`A%k-1-Wlhp0%6KOE_\#R2\o_n_0b$pr.,$tO7:&U,.^cOgBTEk4mJ@QT4Tg"T^JGTDA:9%u&h@LRn9ng4H.bn7=;i#3179^EN]Z5nO:$,N9s+V8%W%=q!,!>*nC`*Zl8\W=LB`8WGH]63P#5`-[lS\d)M64=$^fQ6Os'T(1[KLOJ[KIj\F3+Y0Hb7]r'.7<6/0>o,JPh9V\Y=>ANd.Sdk:0!dR>pI?Ua;q2A%)KeAKjiqo(`"O)BAqAh(8:+$MaXpDg,3=joIJL11PA*!YYLn[WskW!ET6]3b$L10416@b1=bN%f8-XBFLNVs^7Bps$,N<t+Xg`o%>.-.+V<:c]JJc\I\3ZH,8U<4mPn9l^3Sp0@(jEBn3RNfPh:WXC(uQPG3fAbG^kVu#a(sqIYUD*6p%S++M86f![[O_]G^qtZlK1@Gjm2")\EnnUH?cP%.Q7C]L'DIKa8MTE<Dt9@pjCpDo,%Ieu!670JGOpR3tUo06tfdf_Z$/^-]93OR4Q/SZT3$OR4Q/s,%/O]41db'sdPA*j:ZJ`Zl5(E'./E$cel@aP*nIKrhi-r$O"*Lsj)Q7/#=G&>ar+NU4%r+K>P@,2'"q5h$#3<O14FJ1(`jb@J3bJZ/nP:[2IR?hV:n0-GW@A,~>endstream
 endobj
 13 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1614
+>>
+stream
+GauI7D0$US&BE]".J?3-j(<n;LHD'p>lg-!*S8g'BUb>*c3YP5B4K@JhnFEpK[/e9F_AiBEKKheC:-9?=+UJ'J!g2Fg].`jq"T[Hj&"M591T-''o\&Wdna?D'9toUn+Pr$F"^7h/cD<'OJPiZm="n3D`<0sGN:BQG>]tnSC=!d`P%F>hN]Re$^m?>'na]@G@TcEJQp+52iYq4&S_(oMRrZ`,8:Yb]S?k!T<!8CZ^pP6[Ynm'IXo6G"JrhZYcYZ?/(f8%iK&<^\7u6')E[(mM?Xa_oY`tZs"$'(O!Rr[S%qGMW0COW8[#kV4oIJf*)b(50gudm9:5BC%drfZM\T)>i+<lj5()7_[Sr7TUT]]OF?+/*AkM+PE,p()`O*>,.*WD0qbF.cr_cg?&Gp0A5Q"ln(R2D+IaD#cLq\m.UWUX67PkP@ETir?qleC[S4F\^3>daQoBYCQ+]ktWd(s#d<s_+,Yl%g/X8"G=:@&9K%c>6A\(Ht8ZJ*,n\R!f;\DPjV(d)YdZ4FaMNlS<2D*_Hs7-<_!S_R#K:MN+R=TjdrLXo>EZMdXg>lR!YN5gZ5Ghb??1>gFP)O&Nu6ioLDOA)i56$UrKiOOSP7N"klJ["oT-Y(hLVbs<oZVO>k:GSZO>Bru._fe$g`po&5;G%X)JT`+V\=SlYY9XEG+lS)9I5/J7Fk1,/0-la4pi8QQ@qSPR6GZ5G+Cg'rA^-U5dANs-;&p=nSE*9:)[VQU;f77^OE<,i>pbcj3"[R0'=."YhkOF*F+Pj_ATR'@0(&!$U)3XFCg-q`\DDaZCpS'H9g.3i_Y%P+mMbJ47>#U7BT3C6Eq=b82-T$sn>#,U0Qqb08ni?DPPfpBSR0T377X#WS>:J[1ub##i4>9iTAsZ=bhbCJSmP8#(enW``_GGnl6)_DLW-V;>]lt[-T!M@\fG-QMN5rQaFoohhhWM#U\juBmhm'bT"44`grf;F7*=j^$7p1,kMiME^;/d?.Uc>k/@XrCh7Baq?s/!.-#!O4YBO?%aa:+502UQD>3Fl]@"F@tm@+U72[%k0ACe[[+R!SHcNDub:5%he.:XX>C/mk=Sd+3R4%a2?%H+X*Xob^WWktS%NB<!jZe<0u(c8^tZSCC9)-ELB%(m(d!2XNLGVOq=B_e$Hb\\8<g!G,,0X-nmF#"<))<B&q5/G&#&.DChL4L.N(ke39)),f'clRdS6msa/?3nYe#f\.nK1:S\J<;_m)D).Y?oJ^JI8/ifrjEDs^Qe0;Gr>^QJq.tN_nZX7'Mr8b_5gEY6JE(fg#42ed<!)P4*+PjLpB\lZ7^JIVD+d`^+t$mW\fL>O#_0Z%`R*Y@P!0pF*Z%B/?Dbe(1)f*JJ*;F?B&D+g5`C.`1]`67Z<%M@\'tp-j0qD'^EETn:_c.5298n)bP7rG(`;]%^k"J+tNj[DhcD1P;"U43&EAn"cTfsctG-:!kXRRK7<Lj>4!65pa>^X[CZ%U6Pfgi'aB7+@PFIn*e[Ui:kZ8e&%LQr(+g(A9@*Qk7QdE9<u;KTL]N&>HOsMC!YO.HJ5A@Q9%uf<7`+AWX#38WVO^co(^D2c##<sh32ePc>.0K#,V2$ACY(6o>$m[F8sh8W2%/XH$PZ;CpA~>endstream
+endobj
+14 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1346
+>>
+stream
+GauI6gN)%,&;KZH'RPta\=!W=JHWg$lBI;iWYAZ:gKa#/-h:Am9f$MTp'!\o![Y.(4&_,UR/h[g(Af[!&-8k]M##gI!/:f-pdfp38FD$3."Gh4PGEt%#kd*20>6OT(moNs5K4iR\U(m^iM4U-J'&5SKQtDfG"4!A.9k[;:AH4O+^Xb"?1/&XAad(*js&+Cah]mCaabM:qed%7rV-\^#>!^f%=uin/7;W5Sg7ZUg[mW;L;5LOh1Js]bB?^0:#QVN5ORe;[?g6+M87ETKpqf"o^DJ3kqPV2H#QG:NcIlpPgntSe^KR(6m8??#SBTmT#.dg@OQ`t01LVSJEgjuq!_Q"RnbhE7:2Pfs'Hbs,!DdrG;u/<+B^O&C1uVY)=3\fAb&oj8LO4i9KrA]Z"KF^VLD???\lFR2o3ANhF,j&m<Rng:%Vef:FP5PF`K/S/QVK(FWhR6Z-^<VIS\oS%+?:RgU/\u`Q7DMoC1QeMfk.'d]@ts1uHIsgun5.K;T\CGn1UiGSJT5)(s[BAWFLIjF4%T'%Jgb&bNF;\=q8R-&S_)17eHZR#WL7ENlrQ*-kf6GD_5+5V)mR>"H5+kTHDf>Bo8Ld\DJKC-rj9ALAYKH)F\t;4T)$d0C6rb,mWmU;Sr2,a7r?-6Yj1$:e<S#NcEDr^m`p&-@`&WD=jb^Fd'VX+`ss&W^!,3-XL_&i,>R"qa.S$Y)Y=7N[D#7s.ML@h]19)ZaeWL/\Ne6X_9O>pb2+45hS\-[=)HS"ipg]n8%sH+iIc>2!W3#(:?rc%&2]-(l,;</o&MUIc.lq/O&`1rfcC`_E3_cFC%%eTfb\N!IRel:5LRE^FeaC/J:75M[p2X&7:WkU8oo8t&q2],JnWC%Af?9ps;/UZp<VR_WUAlnGRM[h)(*E]$N+a^E\n()12tpulTNSgGK"*q00o$=A]qm'c'PZcs@$EZ14no=7`aO+igcNT=39g<Rr:AmaJ9T;Abb?afe0WS#D\"h*uk3g+[Uf=q#pO1[tc]R[YM]rK%).\e"3DjsfKU94d3G"OEFFAPg.&/mXA2\\!t&QD(ni2[S9$>AXZqen1*@5ia9b>^H)F/h!$`t-^$eB^10:E\0=V!C;P/jh<fGsJSp%gZLq)M/_$5]A<I6f>3u,R/jGDLl2uVcSQ`?A9$Cg\V$TX7Ll"V6(nCYn$uhni6i)FVUo)P`6FeKO'uI^J$rjj8ks?Gqe`Med-#m%fs^g$NP<LVA=\rZiT*t]Qmfo60*U4Gi]%D$@OUQM(K"6p-R`lDLiB?pHmB@'.>3Z5+BN&&>`GlLU.`lSBbGMHTYN?fD4de4pOBY31eK.6c3Sbq[3PUhcCL"kktT+:\q0~>endstream
+endobj
+15 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1661
 >>
@@ -92,28 +111,30 @@ stream
 Gau0BD0+Dj&H9tYfFPM3g'PWZhjM$c"-U%U1lrL9HC`.o@>i('D%YGHjknt<2NA**[!0t*J[)lAIJ2?,V57SX+"b7F'OVV?s,7"j&1i?8`.HnlS-C"nfs(;Pr2t+uZ)r$Wrg42*[Y)1RrA1G$J)m-DD.E"$@DnPl1QsISLH0G7f`lYJ_'9:7ZLb&JZ"PY8O>`0RV+$69f=HOWeo)\@KA\>'.=BBN!OJM'#o(]PE=B_sR"j!>&!^C2&JV\U^.=MWRhqI8iOIAn>(I%ir0R3(dq'^o.+=K?(/W%[a:`*WiC_F?#m6YOT[Y2--ipXanY,fXS'oA+%@@WXmmh:X7_+=nC\GGSjM([s)sNG&n*']07gQ!HR?lA[Ia2B*1.@NOA0tO9:G[:jX11(t[MAWK6bgK%nkBRsiP&j0:$jS+Q&YZJfr'cgX:920*`&sd_9Z!H3Eq=MkOLpSmk>AiR77#%1jr8FfIhU.=htK.MQD?):pGseTk"MJV#l8j"#H%"6C,rp;*C++0m]eZSrK,M3fHgc4[0,(<9RA&h7?V3-\"q<a/;/;6W7m`dIHOIcc]j.JP6H=h%WGaHCBM"lV6oL`mScS[BUmtnlLa6]"<mSdWRQ1H+ij990@mhqo#PXFtsJ$pC!JE#4\)4ZE<ABacu/L@TgVRM\0"C#H+1IAqumd,-KBM5.N_.>qiI=ct('R_52fG?Kjp0UM&63;$R.a54PcK%ZB_`[$`hJ-F%>Ro8lVgf-"7_'aSFk`03Z5mi;t!71Dr>U:R/Mdbj3$#&adf!rrjHUS;_9RMW9fal#F,8n6&Fmj%fPY.G/uN8Leq]Y(#bC90f;(GD8HXM4%-JDltLbX\T3irH?LjTb2d,PH[deV5s,h@VPMo3(*9@b-Rgf/fj&e1g4S._+Tn2d"6</>Rkt*bRDcQ>&DB=LRsraH,S2?dS]DrQK)TeT/E+#'^Vk/1p$Yqrh>r^L!F*!gm9ukL7PS?'%k4jK]TJG$nJa#5?jaBj&1l1/02#O*/PC)6<^QE8n-b'gcKELh4R>=Rrj`k48r(;uA7Qn8G%H%<87:<KP95GD.QD6l)ra+m(K1N#-_Qk6mtA3>i`'(J>=*151gj#j,p(8s77c?'XD-c68%NDZ_CH<LINR[mdRG#Q=X365I]>0imC9h>]8DGnF-!s#@Q6fBb!YC(\!F(j0!3fm=#e9[gM*]4'[0HSmmqI^?pla>91k89lIGAseg5>G4GRC.1WS3Qs&kl9Qgrdb3g^)]Wa]4e-@'?`rp1JVi7ErM>[$+tWT^3'jH$rHrZ<kPZLHT'_jPF'd.@3.;B?]J&e%M0?>jMmC1IQ9\%cZo/p,%Tkh0Pu594k/2I1Uc_DD'XFE#B:&'\APZ\VQ`([+^nW<G:3dH.<cZuK04['[L(\VH(9#dh)2FsNp?lLG-I0J='o;s]<sC@@j;9L"Q=75_HLBis;fRVTDlnHT]L5PaP4$\6kqgD&p9<quU,>YM*H?l$lg@XWCb1eqi(0b2pHsR/+**k%gYf`5D/PFjob#e-Fp.XXL/Fa7Se'bBo*:-1V@T1MEVbFWW>c=AgYJ^_fIdpJ_[pYmR&n`H:]nqjK[4\8'jRqV<=DC8!EceZ!.,oaqk]S+Erpen-Mjf#b>[\UV;uqdbT>e5Z$l2&V3Y8ff6aY:kkkh#X1O\~>endstream
 endobj
 xref
-0 14
+0 16
 0000000000 65535 f 
 0000000073 00000 n 
 0000000114 00000 n 
 0000000221 00000 n 
 0000000717 00000 n 
 0000000985 00000 n 
-0000001097 00000 n 
-0000001278 00000 n 
-0000001488 00000 n 
-0000001780 00000 n 
-0000001849 00000 n 
-0000002100 00000 n 
-0000002166 00000 n 
-0000004022 00000 n 
+0000001253 00000 n 
+0000001365 00000 n 
+0000001546 00000 n 
+0000001756 00000 n 
+0000002048 00000 n 
+0000002118 00000 n 
+0000002369 00000 n 
+0000002441 00000 n 
+0000004147 00000 n 
+0000005585 00000 n 
 trailer
 <<
 /ID 
-/Info 10 0 R
-/Root 9 0 R
-/Size 14
+/Info 11 0 R
+/Root 10 0 R
+/Size 16
 >>
 startxref
-5775
+7338
 %%EOF

--- a/corehq/apps/accounting/tests/data/invoice_009.pdf
+++ b/corehq/apps/accounting/tests/data/invoice_009.pdf
@@ -1,0 +1,119 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /DCTDecode ] /Height 8 /Length 312 /Subtype /Image 
+  /Type /XObject /Width 8
+>>
+stream
+s4IA0!"_al8O`[\!<<*#!!*'"s4[N@!!<9(!WiE*!WiE*!s8W."p>&3"9\u7"pG2;#RUnF#RLeE$kEaR$P!ON#n7IU%M'*^&J,9X&eblh'+YWc&HCJb6NI8k!sA]/#Qt89&.8dP&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.fBa&.nlW!"fJ:#QP,4!>,;5&HMtG!WU(<'EA.6zzz!!!6'_uLJ_!<<*"zzz!<9t;'`e=9zzz!!!92s24mO&HMk3zzz!!*&Q!"8r1!!3`7&HG#q"E5dTs4I~>endstream
+endobj
+4 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 11 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.b50b63cd220923af8626be850a69ead1 3 0 R
+>>
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://wl.flywire.com/?destination=DMG)
+>> /Border [ 0 0 0 ] /Rect [ 191.05 212.4 369.16 224.4 ] /Subtype /Link /Type /Annot
+>>
+endobj
+7 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/billing/statements/)
+>> /Border [ 0 0 0 ] /Rect [ 36 172.8 338.35 184.8 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/Annots [ 6 0 R 7 0 R ] /Contents 13 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 11 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.b50b63cd220923af8626be850a69ead1 3 0 R
+>>
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/PageMode /UseNone /Pages 11 0 R /Type /Catalog
+>>
+endobj
+10 0 obj
+<<
+/Author (anonymous) /CreationDate () /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate () /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+11 0 obj
+<<
+/Count 2 /Kids [ 4 0 R 8 0 R ] /Type /Pages
+>>
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1764
+>>
+stream
+Gb"/hgN)%,&;KZH'RPu,\=!W=JHWg$b(k)oENRrlg?);!kenO#Zt1P#hS(t*+D?>$Ff3ft;b[lp!.HSeqZ0eqbCJkBbl4+a!"KB]s+(42:tu%D8-6aJS.pUQT0DQg.Y[$Bjc>&76(1n[qEH,H9;T'XGlOID/q1"-a`U4ZV3oLfV`>RB)^W&-/lbNA1,#PH#06Dp_T]t#[u,lX)NtIPde"OoFnP-K..3aQ$O7)(<qQg&<kbJ6:9.On%Ru3r..uDkAc8Ho_s2:L^X^O)Gr+BMZ"IC?BJAsK:]*TUkB-65?]nR*#YYA]9$)4?o[?mQB:*=b6cqDCVMKh8$!.4lKDW:YA4=uT\=#gI+2/algSm]pd8uf6qA_C;1SsX9nFZ&UMK/A^UGTFs*'1&Wq,:SL60uWlIJ6pM(R0-@^=-#!M8#!/UWUX67PkP@B'>d4qn(6gS4F\^3BB2>:X4lbKj;aFK9!,#Y9eQ$LZQ"VR`?LKjM^Jjc0u`YXer.>;-#2l.$qF9*,_)8!_*\nT^3\<WoL@aD-Kig-BU<CH6j)#m?:^L@ig4l:5@+qag1S?3BdCbI!TmdLkEaMj!aNlI*XMR%7hb[;\."B.MIJJr>qQb=D!f&<,W&#hfU]?D0?h/RPjDA48L3I9"UAO6of)(UZ*Q5YZXSTi[W<X_ZT(3'*"4B+Xn\,E2P?a/q:V#1ThfFPC`LREWV`UCg2REP?^Am#a<E"0e6a);n\rP-C-[6POLLD*`o5o#alh"=t'5@-Fn+?:c]t7f*T2]\Pd#E;j,=9e%;r.W:Ppra;:GV'sNY_"_bpllc.Z.]j3$kJ+hp*d2c:F(q5LM\<,ih?B;]fB06cTe9h\E[P(0#m9.pYrkD]uO!dFd:S>%aUjCEFietqB]JqK,`mn=][FL_;S=^R91qr60D@UQ\>5?_0YS\1OZQ?O6KEfGW/l.L'Mk7nZaFooo^(Em%7b@I2?SaV$4EIF`A*9q3%oR!u;IG>#3sTD@oa1&)WtORVdqj=,Ye$s;-^`FkF@r">+1J;s53:VPX!aiai)ZJh:V[#R0=j(_VJcaIn]<m,l[b_4+Zp9WD`A?'-`2ib"KPNO8U)/0LMnT7Bg7.2QFR@02Q7%)N%`s][%GSMI`A%k-1-Wlhp0%6KOE_\#R2\o_n_0b$pr.,$tO7:&U,.^cOgBTEk4mJ@QT4Tg"T^JGTDA:9%u&h@LRn9ng4H.bn7=;i#3179^EN]Z5nO:$,N9s+V8%W%=q!,!>*nC`*Zl8\W=LB`8WGH]63P#5`-[lS\d)M64=$^fQ6Os'T(1[KLOJ[KIj\F3+Y0Hb7]r'.7<6/0>o,JPh9V\Y=>ANd.Sdk:0!dR>pI?Ua;q2A%)KeAKjiqo(`"O)BAqAh(8:+$MaXpDg,3=joIJL11PA*!YYLn[WskW!ET6]3b$L10416@b1=bN%f8-XBFLNVs^7Bps$,N<t+Xg`o%>.-.+V<:c]JJc\I\3ZH,8U<4mPn9l^3Sp0@(jEBn3RNfPh:WXC(uQPG3fAbG^kVu#a(sqIYUD*6p%S++M86f![[O_]G^qtZlK1@Gjm2")\EnnUH?cP%.Q7C]L'DIKa8MTE<Dt9@pjCpDo,%Ieu!670JGOpR3tUo06tfdf_Z$/^-]93OR4Q/SZT3$OR4Q/s,%/O]41db'sdPA*j:ZJ`Zl5(E'./E$cel@aP*nIKrhi-r$O"*Lsj)Q7/#=G&>ar+NU4%r+K>P@,2'"q5h$#3<O14FJ1(`jb@J3bJZ/nP:[2IR?hV:n0-GW@A,~>endstream
+endobj
+13 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1661
+>>
+stream
+Gau0BD0+Dj&H9tYfFPM3g'PWZhjM$c"-U%U1lrL9HC`.o@>i('D%YGHjknt<2NA**[!0t*J[)lAIJ2?,V57SX+"b7F'OVV?s,7"j&1i?8`.HnlS-C"nfs(;Pr2t+uZ)r$Wrg42*[Y)1RrA1G$J)m-DD.E"$@DnPl1QsISLH0G7f`lYJ_'9:7ZLb&JZ"PY8O>`0RV+$69f=HOWeo)\@KA\>'.=BBN!OJM'#o(]PE=B_sR"j!>&!^C2&JV\U^.=MWRhqI8iOIAn>(I%ir0R3(dq'^o.+=K?(/W%[a:`*WiC_F?#m6YOT[Y2--ipXanY,fXS'oA+%@@WXmmh:X7_+=nC\GGSjM([s)sNG&n*']07gQ!HR?lA[Ia2B*1.@NOA0tO9:G[:jX11(t[MAWK6bgK%nkBRsiP&j0:$jS+Q&YZJfr'cgX:920*`&sd_9Z!H3Eq=MkOLpSmk>AiR77#%1jr8FfIhU.=htK.MQD?):pGseTk"MJV#l8j"#H%"6C,rp;*C++0m]eZSrK,M3fHgc4[0,(<9RA&h7?V3-\"q<a/;/;6W7m`dIHOIcc]j.JP6H=h%WGaHCBM"lV6oL`mScS[BUmtnlLa6]"<mSdWRQ1H+ij990@mhqo#PXFtsJ$pC!JE#4\)4ZE<ABacu/L@TgVRM\0"C#H+1IAqumd,-KBM5.N_.>qiI=ct('R_52fG?Kjp0UM&63;$R.a54PcK%ZB_`[$`hJ-F%>Ro8lVgf-"7_'aSFk`03Z5mi;t!71Dr>U:R/Mdbj3$#&adf!rrjHUS;_9RMW9fal#F,8n6&Fmj%fPY.G/uN8Leq]Y(#bC90f;(GD8HXM4%-JDltLbX\T3irH?LjTb2d,PH[deV5s,h@VPMo3(*9@b-Rgf/fj&e1g4S._+Tn2d"6</>Rkt*bRDcQ>&DB=LRsraH,S2?dS]DrQK)TeT/E+#'^Vk/1p$Yqrh>r^L!F*!gm9ukL7PS?'%k4jK]TJG$nJa#5?jaBj&1l1/02#O*/PC)6<^QE8n-b'gcKELh4R>=Rrj`k48r(;uA7Qn8G%H%<87:<KP95GD.QD6l)ra+m(K1N#-_Qk6mtA3>i`'(J>=*151gj#j,p(8s77c?'XD-c68%NDZ_CH<LINR[mdRG#Q=X365I]>0imC9h>]8DGnF-!s#@Q6fBb!YC(\!F(j0!3fm=#e9[gM*]4'[0HSmmqI^?pla>91k89lIGAseg5>G4GRC.1WS3Qs&kl9Qgrdb3g^)]Wa]4e-@'?`rp1JVi7ErM>[$+tWT^3'jH$rHrZ<kPZLHT'_jPF'd.@3.;B?]J&e%M0?>jMmC1IQ9\%cZo/p,%Tkh0Pu594k/2I1Uc_DD'XFE#B:&'\APZ\VQ`([+^nW<G:3dH.<cZuK04['[L(\VH(9#dh)2FsNp?lLG-I0J='o;s]<sC@@j;9L"Q=75_HLBis;fRVTDlnHT]L5PaP4$\6kqgD&p9<quU,>YM*H?l$lg@XWCb1eqi(0b2pHsR/+**k%gYf`5D/PFjob#e-Fp.XXL/Fa7Se'bBo*:-1V@T1MEVbFWW>c=AgYJ^_fIdpJ_[pYmR&n`H:]nqjK[4\8'jRqV<=DC8!EceZ!.,oaqk]S+Erpen-Mjf#b>[\UV;uqdbT>e5Z$l2&V3Y8ff6aY:kkkh#X1O\~>endstream
+endobj
+xref
+0 14
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000717 00000 n 
+0000000985 00000 n 
+0000001097 00000 n 
+0000001278 00000 n 
+0000001488 00000 n 
+0000001780 00000 n 
+0000001849 00000 n 
+0000002100 00000 n 
+0000002166 00000 n 
+0000004022 00000 n 
+trailer
+<<
+/ID 
+/Info 10 0 R
+/Root 9 0 R
+/Size 14
+>>
+startxref
+5775
+%%EOF


### PR DESCRIPTION
## Technical Summary
As noted in the following ticket:
https://dimagi-dev.atlassian.net/browse/SAAS-13327

Invoices that end up spanning more than one page currently have overlapping text. This is due to the fact that we only call `canvas.showPage()` once. While this makes sense for most invoices, if the invoice is too long, we do need to call `showPage()` again in order to advance to the next page.

## Safety Assurance

### Safety story
Simple change. Tested locally on a normal invoice and a long invoice (both customer and domain-level invoices)

### Automated test coverage
Yes

### QA Plan
No


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
