### PR TITLE
Use username instead of user object

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -811,7 +811,7 @@ class UserDomainsResource(CorsResourceMixin, Resource):
             if not domain_has_privilege(domain, privileges.ZAPIER_INTEGRATION):
                 continue
             domain_object = Domain.get_by_name(domain)
-            if feature_flag and feature_flag not in toggles.toggles_dict(username=request.user, domain=domain):
+            if feature_flag and feature_flag not in toggles.toggles_dict(username=request.user.username, domain=domain):
                 continue
             results.append(UserDomain(
                 domain_name=domain_object.name,

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -806,12 +806,13 @@ class UserDomainsResource(CorsResourceMixin, Resource):
         if feature_flag and feature_flag not in toggles.all_toggle_slugs():
             raise BadRequest(f"{feature_flag!r} is not a valid feature flag")
         couch_user = CouchUser.from_django_user(request.user)
+        username = request.user.username
         results = []
         for domain in couch_user.get_domains():
             if not domain_has_privilege(domain, privileges.ZAPIER_INTEGRATION):
                 continue
             domain_object = Domain.get_by_name(domain)
-            if feature_flag and feature_flag not in toggles.toggles_dict(username=request.user.username, domain=domain):
+            if feature_flag and feature_flag not in toggles.toggles_dict(username=username, domain=domain):
                 continue
             results.append(UserDomain(
                 domain_name=domain_object.name,

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -631,7 +631,7 @@ class TestUserDomainsResource(TestCase):
 
     @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
     @patch('corehq.apps.api.resources.v0_5.toggles.toggles_dict', return_value={"superset-analytics": True})
-    def test_domain_returned_when_valid_flag_sent(self, _, __):
+    def test_domain_returned_when_valid_flag_sent(self, *args):
         bundle = Bundle()
         bundle.obj = self.user
         bundle.request = Mock()
@@ -641,8 +641,7 @@ class TestUserDomainsResource(TestCase):
         self.assertListEqual([self.domain], [d.domain_name for d in resp])
 
     @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
-    @patch('corehq.apps.api.resources.v0_5.toggles.toggles_dict', return_value={"normalset-analytics": True})
-    def test_domain_not_returned_when_invalid_flag_sent(self, _, __):
+    def test_domain_not_returned_when_flag_not_enabled(self, *args):
         bundle = Bundle()
         bundle.obj = self.user
         bundle.request = Mock()


### PR DESCRIPTION
## Product Description
Server error when user api is queried with feature flag argument

## Technical Summary
Passing user object instead of username throws error

## Feature Flag
No

## Safety Assurance

### Safety story
Manual testing

### Automated test coverage
Unit test

### QA Plan
No

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
