### PR TITLE
pillow error improvements

### DIFF
--- a/corehq/ex-submodules/pillow_retry/models.py
+++ b/corehq/ex-submodules/pillow_retry/models.py
@@ -100,7 +100,7 @@ class PillowError(models.Model):
             )
 
             if change.metadata:
-                error.date_created = change.metadata.publish_timestamp
+                error.date_created = change.metadata.original_publication_datetime
                 error.change_metadata = change.metadata.to_json()
 
         return error

--- a/corehq/ex-submodules/pillowtop/feed/interface.py
+++ b/corehq/ex-submodules/pillowtop/feed/interface.py
@@ -37,6 +37,9 @@ class ChangeMeta(jsonobject.JsonObject):
     # track of retry attempts
     attempts = jsonobject.IntegerProperty(default=0)
 
+    # track when first published (will not get updated on retry, unlike publish_timestamp)
+    original_publication_datetime = jsonobject.DateTimeProperty(default=datetime.utcnow)
+
 
 class Change(object):
     """

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -490,6 +490,15 @@ def handle_pillow_error(pillow, change, exception):
         'exception_type': exception_path
     })
 
+    notify_exception(
+        None,
+        'Unexpected error in pillow',
+        details={
+            'pillow_name': pillow.get_name(),
+            'change_id': change['id']
+        }
+        exec_info=(type(exception), exception, traceback)
+    )
     # keep track of error attempt count
     change.increment_attempt_count()
 

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -484,6 +484,7 @@ def handle_pillow_error(pillow, change, exception):
     ))
 
     exception_path = path_from_object(exception)
+    traceback = exception.__traceback__
     metrics_counter('commcare.change_feed.changes.exceptions', tags={
         'pillow_name': pillow.get_name(),
         'exception_type': exception_path
@@ -495,5 +496,5 @@ def handle_pillow_error(pillow, change, exception):
     # always retry document missing errors, because the error is likely with couch
     if pillow.retry_errors or isinstance(exception, DocumentMissingError):
         error = PillowError.get_or_create(change, pillow)
-        error.add_attempt(exception, sys.exc_info()[2], change.metadata)
+        error.add_attempt(exception, traceback, change.metadata)
         error.save()

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -496,7 +496,7 @@ def handle_pillow_error(pillow, change, exception):
         details={
             'pillow_name': pillow.get_name(),
             'change_id': change['id']
-        }
+        },
         exec_info=(type(exception), exception, traceback)
     )
     # keep track of error attempt count

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -495,7 +495,9 @@ def handle_pillow_error(pillow, change, exception):
         'Unexpected error in pillow',
         details={
             'pillow_name': pillow.get_name(),
-            'change_id': change['id']
+            'change_id': change['id'],
+            'domain': change.get('domain'),
+            'doc_type': change.get('document_type'),
         },
         exec_info=(type(exception), exception, traceback)
     )


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Small improvements to our pillow error code, as suggested in https://dimagi-dev.atlassian.net/browse/SAAS-13566

Each commit handles one of the first three suggestions in that ticket
The first commit improves the traceback captured in the `PillowError` model by using the `__traceback__` attribute of the underlying exception.
The second commit sends the error to sentry (this already occurred in some places, but this makes sure it happens every time).
The third commit adds a new property to kafka change metadata that will be set to the timestamp of the initial creation of that change in kafka. While the `publish_timestamp` is updated upon retry to ensure accurate lag calculations, this will not be updated, and so will be visible from the `PillowError` model. It won't be fully accurate for changes that predate this change, but that is a pretty small number of errors, and it is not more wrong than what is currently there. This new property is then used to fill in `date_created`.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This only touches logging in error handling code, using patterns found elsewhere in the codebase. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Pillow retry code has automated tests that cover the change to creation.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
