### PR TITLE
Standardize @dimagi.com email checks

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -64,7 +64,8 @@ from corehq.apps.accounting.utils import (
 from corehq.apps.domain import UNKNOWN_DOMAIN
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.tasks import send_html_email_async
-from corehq.apps.users.models import CouchUser, WebUser
+from corehq.apps.users.models import WebUser
+from corehq.apps.users.util import is_dimagi_email
 from corehq.blobs.mixin import CODES, BlobMixin
 from corehq.const import USER_DATE_FORMAT
 from corehq.privileges import REPORT_BUILDER_ADD_ON_PRIVS
@@ -2126,7 +2127,7 @@ class Invoice(InvoiceBase):
 
         if filter_out_dimagi:
             emails_with_dimagi = contact_emails
-            contact_emails = [e for e in contact_emails if not CouchUser.is_dimagi_email(e)]
+            contact_emails = [e for e in contact_emails if not is_dimagi_email(e)]
             if not contact_emails:
                 # make sure at least someone (even if it's dimagi)
                 # gets this communication. Also helpful with QA when the only

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -64,7 +64,7 @@ from corehq.apps.accounting.utils import (
 from corehq.apps.domain import UNKNOWN_DOMAIN
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.tasks import send_html_email_async
-from corehq.apps.users.models import WebUser
+from corehq.apps.users.models import CouchUser, WebUser
 from corehq.blobs.mixin import CODES, BlobMixin
 from corehq.const import USER_DATE_FORMAT
 from corehq.privileges import REPORT_BUILDER_ADD_ON_PRIVS
@@ -2126,7 +2126,7 @@ class Invoice(InvoiceBase):
 
         if filter_out_dimagi:
             emails_with_dimagi = contact_emails
-            contact_emails = [e for e in contact_emails if not e.endswith('@dimagi.com')]
+            contact_emails = [e for e in contact_emails if not CouchUser.is_dimagi_email(e)]
             if not contact_emails:
                 # make sure at least someone (even if it's dimagi)
                 # gets this communication. Also helpful with QA when the only

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -12,7 +12,7 @@ from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.api.cors import add_cors_headers_to_response
 from corehq.apps.api.util import get_obj
-from corehq.apps.users.models import CouchUser
+from corehq.apps.users.util import is_dimagi_email
 
 
 class DictObject(object):
@@ -105,7 +105,7 @@ class HqBaseResource(CorsResourceMixin, JsonResourceMixin, Resource):
             if isinstance(self, DomainSpecificResourceMixin):
                 track_workflow(request.user.username, "API Request", properties={
                     'domain': request.domain,
-                    'is_dimagi': CouchUser.is_dimagi_email(request.user.username),
+                    'is_dimagi': is_dimagi_email(request.user.username),
                 })
             return super(HqBaseResource, self).dispatch(request_type, request, **kwargs)
         else:

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -12,6 +12,7 @@ from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.api.cors import add_cors_headers_to_response
 from corehq.apps.api.util import get_obj
+from corehq.apps.users.models import CouchUser
 
 
 class DictObject(object):
@@ -104,7 +105,7 @@ class HqBaseResource(CorsResourceMixin, JsonResourceMixin, Resource):
             if isinstance(self, DomainSpecificResourceMixin):
                 track_workflow(request.user.username, "API Request", properties={
                     'domain': request.domain,
-                    'is_dimagi': request.user.username.endswith('@dimagi.com'),
+                    'is_dimagi': CouchUser.is_dimagi_email(request.user.username),
                 })
             return super(HqBaseResource, self).dispatch(request_type, request, **kwargs)
         else:

--- a/corehq/apps/hqadmin/forms.py
+++ b/corehq/apps/hqadmin/forms.py
@@ -1,5 +1,3 @@
-import re
-
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -10,7 +8,7 @@ from crispy_forms.helper import FormHelper
 
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.crispy import FieldWithHelpBubble, FormActions
-from corehq.apps.users.models import CouchUser
+from corehq.apps.users.util import is_dimagi_email
 
 
 class EmailForm(forms.Form):
@@ -80,7 +78,7 @@ class SuperuserManagementForm(forms.Form):
 
         users = []
         for username in csv_email_list:
-            if settings.IS_DIMAGI_ENVIRONMENT and not CouchUser.is_dimagi_email(username):
+            if settings.IS_DIMAGI_ENVIRONMENT and not is_dimagi_email(username):
                 raise forms.ValidationError("Email address '{}' is not a dimagi email address".format(username))
             try:
                 users.append(User.objects.get(username=username))

--- a/corehq/apps/hqadmin/forms.py
+++ b/corehq/apps/hqadmin/forms.py
@@ -7,11 +7,10 @@ from django.utils.translation import gettext as _
 
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
-from memoized import memoized
 
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.crispy import FieldWithHelpBubble, FormActions
-from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.models import CouchUser
 
 
 class EmailForm(forms.Form):
@@ -81,7 +80,7 @@ class SuperuserManagementForm(forms.Form):
 
         users = []
         for username in csv_email_list:
-            if settings.IS_DIMAGI_ENVIRONMENT and "@dimagi.com" not in username:
+            if settings.IS_DIMAGI_ENVIRONMENT and not CouchUser.is_dimagi_email(username):
                 raise forms.ValidationError("Email address '{}' is not a dimagi email address".format(username))
             try:
                 users.append(User.objects.get(username=username))

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -97,7 +97,7 @@ from corehq.apps.sms.event_handlers import handle_email_messaging_subevent
 from corehq.apps.users.event_handlers import handle_email_invite_message
 from corehq.apps.users.landing_pages import get_redirect_url
 from corehq.apps.users.models import CouchUser, Invitation
-from corehq.apps.users.util import format_username
+from corehq.apps.users.util import format_username, is_dimagi_email
 from corehq.toggles import CLOUDCARE_LATEST_BUILD
 from corehq.util.context_processors import commcare_hq_names
 from corehq.util.email_event_utils import handle_email_sns_event
@@ -831,7 +831,7 @@ class BugReportView(View):
 
         # only fake the from email if it's an @dimagi.com account
         is_icds_env = settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS
-        if CouchUser.is_dimagi_email(report['username']) and not is_icds_env:
+        if is_dimagi_email(report['username']) and not is_icds_env:
             email.from_email = report['username']
         else:
             email.from_email = settings.SUPPORT_EMAIL

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -831,7 +831,7 @@ class BugReportView(View):
 
         # only fake the from email if it's an @dimagi.com account
         is_icds_env = settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS
-        if re.search(r'@dimagi\.com$', report['username']) and not is_icds_env:
+        if CouchUser.is_dimagi_email(report['username']) and not is_icds_env:
             email.from_email = report['username']
         else:
             email.from_email = settings.SUPPORT_EMAIL

--- a/corehq/apps/toggle_ui/tasks.py
+++ b/corehq/apps/toggle_ui/tasks.py
@@ -211,7 +211,7 @@ def _get_user_info(username):
         return {"error": "User not found"}
 
     return {
-        "user_is_dimagi": "@dimagi.com" in username,
+        "user_is_dimagi": CouchUser.is_dimagi_email(username),
         "user_is_mobile": "commcarehq.org" in username,
         "user_is_active": user.is_active,
         "user_last_login": user.last_login,

--- a/corehq/apps/toggle_ui/tasks.py
+++ b/corehq/apps/toggle_ui/tasks.py
@@ -12,6 +12,7 @@ from corehq.apps.domain.calculations import last_form_submission
 from corehq.apps.domain.models import Domain
 from corehq.apps.toggle_ui.utils import has_dimagi_user, get_subscription_info
 from corehq.apps.users.models import CouchUser
+from corehq.apps.users.util import is_dimagi_email
 from corehq.blobs import get_blob_db, CODES
 from corehq.const import USER_DATETIME_FORMAT
 from corehq.toggles import (
@@ -211,7 +212,7 @@ def _get_user_info(username):
         return {"error": "User not found"}
 
     return {
-        "user_is_dimagi": CouchUser.is_dimagi_email(username),
+        "user_is_dimagi": is_dimagi_email(username),
         "user_is_mobile": "commcarehq.org" in username,
         "user_is_active": user.is_active,
         "user_last_login": user.last_login,

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -990,7 +990,11 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
     @property
     def is_dimagi(self):
-        return self.username.endswith('@dimagi.com')
+        return self.is_dimagi_email(self.username)
+
+    @staticmethod
+    def is_dimagi_email(email):
+        return email.endswith('@dimagi.com')
 
     def is_locked_out(self):
         return self.supports_lockout() and self.should_be_locked_out()
@@ -2427,7 +2431,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     def get_dimagi_emails_by_domain(cls, domain):
         user_ids = cls.ids_by_domain(domain)
         for user_doc in iter_docs(cls.get_db(), user_ids):
-            if user_doc['email'].endswith('@dimagi.com'):
+            if CouchUser.is_dimagi_email(user_doc['email']):
                 yield user_doc['email']
 
     def save(self, fire_signals=True, **params):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -81,6 +81,7 @@ from corehq.apps.users.util import (
     user_location_data,
     username_to_user_id,
     bulk_auto_deactivate_commcare_users,
+    is_dimagi_email,
 )
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.supply import SupplyInterface
@@ -990,11 +991,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
     @property
     def is_dimagi(self):
-        return self.is_dimagi_email(self.username)
-
-    @staticmethod
-    def is_dimagi_email(email):
-        return email.endswith('@dimagi.com')
+        return is_dimagi_email(self.username)
 
     def is_locked_out(self):
         return self.supports_lockout() and self.should_be_locked_out()
@@ -2431,7 +2428,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     def get_dimagi_emails_by_domain(cls, domain):
         user_ids = cls.ids_by_domain(domain)
         for user_doc in iter_docs(cls.get_db(), user_ids):
-            if CouchUser.is_dimagi_email(user_doc['email']):
+            if is_dimagi_email(user_doc['email']):
                 yield user_doc['email']
 
     def save(self, fire_signals=True, **params):

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -451,3 +451,7 @@ def bulk_auto_deactivate_commcare_users(user_ids, domain):
         # FYI we don't call the save() method individually because
         # it is ridiculously inefficient! Unfortunately, it's harder to get
         # around caches and signals in a bulk way.
+
+
+def is_dimagi_email(email):
+    return email.endswith('@dimagi.com')


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Based on a comment left by @mjriley on [this PR](https://github.com/dimagi/commcare-hq/pull/31465#discussion_r866885545).

As Matt explains in his comment, there's a lot of places that check whether a given email ends with `@dimagi.com` so standardizing it would be best, for readability and if there's ever a need to tweak this check a little. 

Matt mentions ~9 or so places where this check occurs but I was only able to find 6 so if you know of a place that has this please let me know!

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally. Most of these places were something along the lines of `email.endwith('@dimagi.com')` so it's just replacing that with a call to a method that does the same thing. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
