### PR TITLE
Fix disappearing 'location_id' case property values

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
@@ -132,7 +132,8 @@ class Version2CaseParsingTest(TestCase):
         # quick test for ota restore
         v2response = xml.get_case_xml(case, [const.CASE_ACTION_CREATE, const.CASE_ACTION_UPDATE], V2)
         expected_v2_response = """
-        <case case_id="foo-case-id" user_id="bar-user-id" date_modified="2011-12-07T13:42:50.000000Z" xmlns="http://commcarehq.org/case/transaction/v2">
+        <case case_id="foo-case-id" user_id="bar-user-id" date_modified="2011-12-07T13:42:50.000000Z"
+            xmlns="http://commcarehq.org/case/transaction/v2">
                 <create>
                     <case_type>v2_case_type</case_type>
                     <case_name>test case name</case_name>
@@ -161,7 +162,8 @@ class Version2CaseParsingTest(TestCase):
         case = CommCareCase.objects.get_case("case_id", self.domain)
 
         expected_xml = """
-            <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="case_id" user_id="" date_modified="2011-12-07T13:42:50.000000Z">
+            <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="case_id" user_id=""
+                date_modified="2011-12-07T13:42:50.000000Z">
                 <create>
                     <case_type/>
                     <case_name/>

--- a/corehq/ex-submodules/casexml/apps/case/views.py
+++ b/corehq/ex-submodules/casexml/apps/case/views.py
@@ -54,6 +54,8 @@ class CaseDisplayWrapper(object):
         # so also check and add it here
         if self.case.external_id:
             dynamic_data['external_id'] = self.case.external_id
+        if self.case.location_id:
+            dynamic_data['location_id'] = self.case.location_id
 
         return dynamic_data
 

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -177,6 +177,8 @@ class V2CaseXMLGenerator(CaseXMLGeneratorBase):
     def add_custom_properties(self, element):
         if self.case.external_id:
             element.append(safe_element('external_id', self.case.external_id))
+        if self.case.location_id:
+            element.append(safe_element('location_id', self.case.location_id))
         if self.case.opened_on:
             element.append(safe_element("date_opened", date_to_xml_string(self.case.opened_on)))
         super(V2CaseXMLGenerator, self).add_custom_properties(element)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

If a user defined case property is named `location_id` it currently won't show up as one of its case properties in the case detail view. This PR fixes that.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13503)

Previously, when a case property named `location_id` was saved it was being saved only as a case attribute (`case.location_id`) due to it being a special attribute for case indexing (meant for legitimate location_ids corresponding to organization levels defined in the domain). This PR appends that value to the case properties list before displaying in the case detail view, as well as when downloading the case xml.   

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally and on staging. 

This is a second version of the [same PR](https://github.com/dimagi/commcare-hq/pull/31634) that came out of discussion with @snopoke. I'd originally taken a different approach due to a concern that a backend assigned `location_id` that corresponds to an organization level could be overwritten by a user defined `location_id` case property. However the former scenario could only really happen for supply point cases, which don't have user defined properties. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-4134)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
