### PR TITLE
Added OData Enterprise Reports

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -44,10 +44,6 @@ from corehq.apps.api.util import get_obj
 from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import UserES
-from corehq.apps.export.esaccessors import (
-    get_case_export_base_query,
-    get_form_export_base_query,
-)
 from corehq.apps.export.models import CaseExportInstance, FormExportInstance
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.permissions import location_safe
@@ -979,9 +975,8 @@ class ODataCaseResource(BaseODataResource):
                     "You do not have permission to view this feed."
                 ))
             )
-        query = get_case_export_base_query(domain, config.case_type)
-        for filter in config.get_filters():
-            query = query.filter(filter.to_es_filter())
+
+        query = config.get_query()
 
         if not bundle.request.couch_user.has_permission(
             domain, 'access_all_locations'
@@ -1018,9 +1013,7 @@ class ODataFormResource(BaseODataResource):
                 ))
             )
 
-        query = get_form_export_base_query(domain, config.app_id, config.xmlns, include_errors=False)
-        for filter in config.get_filters():
-            query = query.filter(filter.to_es_filter())
+        query = config.get_query()
 
         if not bundle.request.couch_user.has_permission(
             domain, 'access_all_locations'

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -394,7 +394,8 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     auto_case_update_hour = IntegerProperty()
 
     # Allowed number of max OData feeds that this domain can create.
-    # If this value is None, the value in settings.DEFAULT_ODATA_FEED_LIMIT is used
+    # NOTE: This value is generally None. If you want the value the system will use,
+    # please use the `get_odata_feed_limit` method instead
     odata_feed_limit = IntegerProperty()
 
     # exchange/domain copying stuff

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -813,6 +813,9 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
             self.blobs[LOGO_ATTACHMENT].content_type
         )
 
+    def get_odata_feed_limit(self):
+        return self.odata_feed_limit or settings.DEFAULT_ODATA_FEED_LIMIT
+
     def put_attachment(self, *args, **kw):
         return super(Domain, self).put_attachment(domain=self.name, *args, **kw)
 

--- a/corehq/apps/domain/tests/test_models.py
+++ b/corehq/apps/domain/tests/test_models.py
@@ -1,0 +1,13 @@
+from django.test import SimpleTestCase, override_settings
+from corehq.apps.domain.models import Domain
+
+
+class DomainTests(SimpleTestCase):
+    def test_odata_feed_limit_returns_set_value(self):
+        domain = Domain(odata_feed_limit=5)
+        self.assertEqual(domain.get_odata_feed_limit(), 5)
+
+    @override_settings(DEFAULT_ODATA_FEED_LIMIT=10)
+    def test_odata_feed_limit_when_unset_uses_default(self):
+        domain = Domain()
+        self.assertEqual(domain.get_odata_feed_limit(), 10)

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -295,7 +295,7 @@ class EnterpriseODataReport(EnterpriseReport):
         if export_line_counts:
             total_line_count = sum(export_line_counts.values())
         else:
-            total_line_count = _('ERROR: Unsupported number of exports')
+            total_line_count = _('ERROR: Too many exports. Please contact customer service')
 
         return [
             export_count,

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -2,7 +2,9 @@ import re
 from datetime import datetime, timedelta
 
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _lazy
 
+from itertools import chain
 from memoized import memoized
 
 from couchforms.analytics import get_last_form_submission_received
@@ -15,6 +17,8 @@ from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
 from corehq.apps.domain.calculations import sms_in_last
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import forms as form_es
+from corehq.apps.export.models.new import FormExportInstance, CaseExportInstance
+from corehq.apps.export.dbaccessors import get_brief_exports
 from corehq.apps.reports.filters.users import \
     ExpandedMobileWorkerFilter as EMWF
 from corehq.apps.users.dbaccessors import (
@@ -31,6 +35,7 @@ class EnterpriseReport(object):
     WEB_USERS = 'web_users'
     MOBILE_USERS = 'mobile_users'
     FORM_SUBMISSIONS = 'form_submissions'
+    ODATA_FEEDS = 'odata_feeds'
 
     title = _('Enterprise Report')
     subtitle = ''
@@ -60,6 +65,8 @@ class EnterpriseReport(object):
             report = EnterpriseMobileWorkerReport(account_id, couch_user)
         elif slug == cls.FORM_SUBMISSIONS:
             report = EnterpriseFormReport(account_id, couch_user)
+        elif slug == cls.ODATA_FEEDS:
+            report = EnterpriseODataReport(account_id, couch_user)
 
         if report:
             report.slug = slug
@@ -257,3 +264,78 @@ class EnterpriseFormReport(EnterpriseReport):
 
     def total_for_domain(self, domain_obj):
         return len(self.hits(domain_obj.name))
+
+
+class EnterpriseODataReport(EnterpriseReport):
+    title = _lazy('OData Reports')
+    MAXIMUM_EXPECTED_EXPORTS = 150
+
+    def __init__(self, account_id, couch_user):
+        super().__init__(account_id, couch_user)
+
+    @property
+    def headers(self):
+        headers = super().headers
+        return [_('Odata feeds used'), _('Odata feeds available'), _('Export Name'), _('Lines Used')] + headers
+
+    def total_for_domain(self, domain_obj):
+        return len(self._get_odata_exports(domain_obj))
+
+    def rows_for_domain(self, domain_obj):
+        export_docs = self._get_odata_exports(domain_obj)
+        if len(export_docs) > self.MAXIMUM_EXPECTED_EXPORTS:
+            return [self._get_domain_summary_line(domain_obj, export_docs, None)]
+
+        export_line_counts = self._get_export_line_counts(export_docs)
+
+        domain_summary_line = self._get_domain_summary_line(domain_obj, export_docs, export_line_counts)
+        individual_export_rows = self._get_individual_export_rows(export_docs, export_line_counts)
+
+        rows = [domain_summary_line]
+        rows.extend(individual_export_rows)
+        return rows
+
+    def _get_odata_exports(self, domain_obj):
+        all_domain_exports = get_brief_exports(domain_obj.name)
+        return [export for export in all_domain_exports if export['is_odata_config']]
+
+    def _get_export_line_counts(self, export_docs):
+        exports = self._get_export_objects(export_docs)
+        return {export._id: export.get_count() for export in exports}
+
+    def _get_export_objects(self, export_docs):
+        case_export_ids = [export['_id'] for export in export_docs
+            if export['doc_type'] == CaseExportInstance.__name__]
+        form_export_ids = [export['_id'] for export in export_docs
+            if export['doc_type'] == FormExportInstance.__name__]
+
+        case_exports = CaseExportInstance.view('_all_docs', keys=case_export_ids, include_docs=True)
+        form_exports = FormExportInstance.view('_all_docs', keys=form_export_ids, include_docs=True)
+        return chain(case_exports, form_exports)
+
+    def _get_domain_summary_line(self, domain_obj, export_docs, export_line_counts):
+        if export_line_counts:
+            total_line_count = sum(export_line_counts.values())
+        else:
+            total_line_count = 'ERROR: Unsupported number of exports'
+
+        return [
+            len(export_docs),
+            domain_obj.get_odata_feed_limit(),
+            None,  # Export Name
+            total_line_count
+        ] + self.domain_properties(domain_obj)
+
+    def _get_individual_export_rows(self, exports, export_line_counts):
+        rows = []
+
+        for export in exports:
+            count = export_line_counts[export['_id']]
+            rows.append([
+                None,  # OData feeds used
+                None,  # OData feeds available
+                export['name'],
+                count]
+            )
+
+        return rows

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -28,7 +28,7 @@ from corehq.apps.users.models import CouchUser, Invitation
 from corehq.util.quickcache import quickcache
 
 
-class EnterpriseReport(object):
+class EnterpriseReport:
     DOMAINS = 'domains'
     WEB_USERS = 'web_users'
     MOBILE_USERS = 'mobile_users'
@@ -38,9 +38,8 @@ class EnterpriseReport(object):
     title = _('Enterprise Report')
     subtitle = ''
 
-    def __init__(self, account_id, couch_user):
-        super(EnterpriseReport, self).__init__()
-        self.account = BillingAccount.objects.get(id=account_id)
+    def __init__(self, account, couch_user):
+        self.account = account
         self.couch_user = couch_user
         self.slug = None
 
@@ -54,17 +53,18 @@ class EnterpriseReport(object):
 
     @classmethod
     def create(cls, slug, account_id, couch_user):
+        account = BillingAccount.objects.get(id=account_id)
         report = None
         if slug == cls.DOMAINS:
-            report = EnterpriseDomainReport(account_id, couch_user)
+            report = EnterpriseDomainReport(account, couch_user)
         elif slug == cls.WEB_USERS:
-            report = EnterpriseWebUserReport(account_id, couch_user)
+            report = EnterpriseWebUserReport(account, couch_user)
         elif slug == cls.MOBILE_USERS:
-            report = EnterpriseMobileWorkerReport(account_id, couch_user)
+            report = EnterpriseMobileWorkerReport(account, couch_user)
         elif slug == cls.FORM_SUBMISSIONS:
-            report = EnterpriseFormReport(account_id, couch_user)
+            report = EnterpriseFormReport(account, couch_user)
         elif slug == cls.ODATA_FEEDS:
-            report = EnterpriseODataReport(account_id, couch_user)
+            report = EnterpriseODataReport(account, couch_user)
 
         if report:
             report.slug = slug
@@ -110,12 +110,9 @@ class EnterpriseReport(object):
 class EnterpriseDomainReport(EnterpriseReport):
     title = _('Project Spaces')
 
-    def __init__(self, account_id, couch_user):
-        super(EnterpriseDomainReport, self).__init__(account_id, couch_user)
-
     @property
     def headers(self):
-        headers = super(EnterpriseDomainReport, self).headers
+        headers = super().headers
         return [_('Created On [UTC]'), _('# of Apps'), _('# of Mobile Users'), _('# of Web Users'),
                 _('# of SMS (last 30 days)'), _('Last Form Submission [UTC]')] + headers
 
@@ -136,12 +133,9 @@ class EnterpriseDomainReport(EnterpriseReport):
 class EnterpriseWebUserReport(EnterpriseReport):
     title = _('Web Users')
 
-    def __init__(self, account_id, couch_user):
-        super(EnterpriseWebUserReport, self).__init__(account_id, couch_user)
-
     @property
     def headers(self):
-        headers = super(EnterpriseWebUserReport, self).headers
+        headers = super().headers
         return [_('Email Address'), _('Name'), _('Role'), _('Last Login [UTC]'),
                 _('Last Access Date [UTC]'), _('Status')] + headers
 
@@ -185,12 +179,9 @@ class EnterpriseWebUserReport(EnterpriseReport):
 class EnterpriseMobileWorkerReport(EnterpriseReport):
     title = _('Mobile Workers')
 
-    def __init__(self, account_id, couch_user):
-        super(EnterpriseMobileWorkerReport, self).__init__(account_id, couch_user)
-
     @property
     def headers(self):
-        headers = super(EnterpriseMobileWorkerReport, self).headers
+        headers = super().headers
         return [_('Username'), _('Name'), _('Email Address'), _('Role'), _('Created Date [UTC]'),
                 _('Last Sync [UTC]'), _('Last Submission [UTC]'), _('CommCare Version'), _('User ID')] + headers
 
@@ -219,14 +210,14 @@ class EnterpriseMobileWorkerReport(EnterpriseReport):
 class EnterpriseFormReport(EnterpriseReport):
     title = _('Mobile Form Submissions')
 
-    def __init__(self, account_id, couch_user):
-        super(EnterpriseFormReport, self).__init__(account_id, couch_user)
+    def __init__(self, account, couch_user):
+        super().__init__(account, couch_user)
         self.window = 30
         self.subtitle = _("past {} days").format(self.window)
 
     @property
     def headers(self):
-        headers = super(EnterpriseFormReport, self).headers
+        headers = super().headers
         return [_('Form Name'), _('Submitted [UTC]'), _('App Name'), _('Mobile User')] + headers
 
     @quickcache(['self.account.id', 'domain_name'], timeout=60)
@@ -268,8 +259,8 @@ class EnterpriseODataReport(EnterpriseReport):
     title = _lazy('OData Reports')
     MAXIMUM_EXPECTED_EXPORTS = 150
 
-    def __init__(self, account_id, couch_user):
-        super().__init__(account_id, couch_user)
+    def __init__(self, account, couch_user):
+        super().__init__(account, couch_user)
         self.export_fetcher = ODataExportFetcher()
 
     @property

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -1,4 +1,4 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 from unittest.mock import patch, MagicMock
 
 from corehq.apps.export.models.new import FormExportInstance
@@ -8,6 +8,7 @@ from corehq.apps.export.dbaccessors import ODataExportFetcher
 from corehq.apps.enterprise.enterprise import EnterpriseODataReport
 
 
+@override_settings(BASE_ADDRESS='localhost:8000')
 class EnterpriseODataReportTests(SimpleTestCase):
     def test_headers(self):
         report = self._create_report_for_domains()
@@ -71,7 +72,7 @@ class EnterpriseODataReportTests(SimpleTestCase):
 
         self.assertEqual(report.rows, [
             [151, 200, None,
-            'ERROR: Unsupported number of exports',
+            'ERROR: Too many exports. Please contact customer service',
             'domain_one', None, 'http://localhost:8000/a/domain_one/settings/project/']
         ])
 

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -1,0 +1,113 @@
+from django.test import SimpleTestCase
+from unittest.mock import patch, MagicMock
+
+from corehq.apps.export.models.new import FormExportInstance
+from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.domain.models import Domain
+from corehq.apps.export.dbaccessors import ODataExportFetcher
+from corehq.apps.enterprise.enterprise import EnterpriseODataReport
+
+
+class EnterpriseODataReportTests(SimpleTestCase):
+    def test_total_number_display_odata_reports_across_enterprise(self):
+        domain_one = self._create_domain(name='domain_one')
+        domain_two = self._create_domain(name='domain_two')
+        self.domain_to_export_map['domain_one'] = [
+            self._create_export()
+        ]
+        self.domain_to_export_map['domain_two'] = [
+            self._create_export(),
+            self._create_export()
+        ]
+
+        report = self._create_report_for_domains(domain_one, domain_two)
+        self.assertEqual(report.total_for_domain(domain_one), 1)
+        self.assertEqual(report.total_for_domain(domain_two), 2)
+        self.assertEqual(report.total, 3)
+
+    def test_full_report_for_single_domain(self):
+        domain_one = self._create_domain(name='domain_one', max_exports=10)
+        self.domain_to_export_map['domain_one'] = [
+            self._create_export(name='ExportOne', row_count=5),
+            self._create_export(name='ExportTwo', row_count=7)
+        ]
+
+        report = self._create_report_for_domains(domain_one)
+        self.assertEqual(report.rows, [
+            [2, 10, None, 12, 'domain_one', None, 'http://localhost:8000/a/domain_one/settings/project/'],
+            [None, None, 'ExportOne', 5],
+            [None, None, 'ExportTwo', 7]
+        ])
+
+    def test_full_report_for_multiple_domains(self):
+        domain_one = self._create_domain(name='domain_one', max_exports=25)
+        domain_two = self._create_domain(name='domain_two', max_exports=50)
+
+        self.domain_to_export_map['domain_one'] = [self._create_export(name='ExportOne', row_count=9)]
+        self.domain_to_export_map['domain_two'] = [self._create_export(name='ExportTwo', row_count=15)]
+
+        report = self._create_report_for_domains(domain_one, domain_two)
+
+        self.assertEqual(report.rows, [
+            [1, 25, None, 9, 'domain_one', None, 'http://localhost:8000/a/domain_one/settings/project/'],
+            [None, None, 'ExportOne', 9],
+            [1, 50, None, 15, 'domain_two', None, 'http://localhost:8000/a/domain_two/settings/project/'],
+            [None, None, 'ExportTwo', 15]
+        ])
+
+    @patch.object(ODataExportFetcher, 'get_export_count')
+    def test_report_replaces_row_count_with_error_when_too_many_exports(self, mock_export_count):
+        mock_export_count.return_value = 151
+        domain_one = self._create_domain(name='domain_one', max_exports=200)
+
+        report = self._create_report_for_domains(domain_one)
+
+        self.assertEqual(report.rows, [
+            [151, 200, None,
+            'ERROR: Unsupported number of exports',
+            'domain_one', None, 'http://localhost:8000/a/domain_one/settings/project/']
+        ])
+
+# setup / helpers
+
+    def setUp(self):
+        super().setUp()
+
+        # NOTE: This convoluted patching is because JSON Object doesn't allow
+        #  child properties/methods to be mocked out. This is a workaround, where
+        #  the class method is getting mocked out instead
+        form_patcher = patch.object(FormExportInstance, 'get_count',
+            lambda self: self.mock_count if hasattr(self, 'mock_count') else 0)
+        form_patcher.start()
+        self.addCleanup(form_patcher.stop)
+
+        self.domain_to_export_map = {}
+        fetcher_patcher = patch.object(ODataExportFetcher, 'get_exports',
+            lambda _, domain: self.domain_to_export_map[domain])
+        fetcher_patcher.start()
+        self.addCleanup(fetcher_patcher.stop)
+        count_patcher = patch.object(ODataExportFetcher, 'get_export_count',
+            lambda _, domain: len(self.domain_to_export_map[domain]))
+        count_patcher.start()
+        self.addCleanup(count_patcher.stop)
+
+        self.billing_account = BillingAccount()
+        billing_account_patcher = patch.object(BillingAccount.objects, 'get', return_value=self.billing_account)
+        billing_account_patcher.start()
+        self.addCleanup(billing_account_patcher.stop)
+
+        self.next_id = 1
+
+    def _create_export(self, name='TestExport', domain='TestDomain', row_count=10):
+        export = FormExportInstance(_id=str(self.next_id), name=name, domain=domain, is_odata_config=True)
+        self.next_id += 1
+        export.mock_count = row_count
+        return export
+
+    def _create_domain(self, name='TestDomain', max_exports=10):
+        return Domain(name=name, odata_feed_limit=max_exports)
+
+    def _create_report_for_domains(self, *domains):
+        report = EnterpriseODataReport(self.billing_account, None)
+        report.domains = MagicMock(return_value=domains)
+        return report

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -9,6 +9,13 @@ from corehq.apps.enterprise.enterprise import EnterpriseODataReport
 
 
 class EnterpriseODataReportTests(SimpleTestCase):
+    def test_headers(self):
+        report = self._create_report_for_domains()
+        self.assertEqual(report.headers, [
+            'Odata feeds used', 'Odata feeds available', 'Report Names', 'Number of rows',
+            'Project Space Name', 'Project Name', 'Project URL'
+        ])
+
     def test_total_number_display_odata_reports_across_enterprise(self):
         domain_one = self._create_domain(name='domain_one')
         domain_two = self._create_domain(name='domain_two')

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -99,10 +99,6 @@ class EnterpriseODataReportTests(SimpleTestCase):
         self.addCleanup(count_patcher.stop)
 
         self.billing_account = BillingAccount()
-        billing_account_patcher = patch.object(BillingAccount.objects, 'get', return_value=self.billing_account)
-        billing_account_patcher.start()
-        self.addCleanup(billing_account_patcher.stop)
-
         self.next_id = 1
 
     def _create_export(self, name='TestExport', domain='TestDomain', row_count=10):

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -77,6 +77,7 @@ def enterprise_dashboard(request, domain):
             EnterpriseReport.WEB_USERS,
             EnterpriseReport.MOBILE_USERS,
             EnterpriseReport.FORM_SUBMISSIONS,
+            EnterpriseReport.ODATA_FEEDS,
         )],
         'current_page': {
             'page_name': _('Enterprise Dashboard'),

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -14,11 +14,6 @@ from soil import DownloadBase
 
 from corehq.apps.export.const import MAX_EXPORTABLE_ROWS
 from corehq.apps.export.dbaccessors import get_properly_wrapped_export_instance
-from corehq.apps.export.esaccessors import (
-    get_case_export_base_query,
-    get_form_export_base_query,
-    get_sms_export_base_query,
-)
 from corehq.apps.export.models.new import (
     CaseExportInstance,
     FormExportInstance,
@@ -424,19 +419,10 @@ def _get_base_query(export_instance):
     Return an ESQuery object for the given export instance.
     Includes filters for domain, doc_type, and xmlns/case_type.
     """
-    if isinstance(export_instance, FormExportInstance):
-        return get_form_export_base_query(
-            export_instance.domain,
-            export_instance.app_id,
-            export_instance.xmlns,
-            export_instance.include_errors
-        )
-    if isinstance(export_instance, CaseExportInstance):
-        return get_case_export_base_query(
-            export_instance.domain, export_instance.case_type
-        )
-    if isinstance(export_instance, SMSExportInstance):
-        return get_sms_export_base_query(export_instance.domain)
+    if (isinstance(export_instance, FormExportInstance)
+            or isinstance(export_instance, CaseExportInstance)
+            or isinstance(export_instance, SMSExportInstance)):
+        return export_instance.get_query(include_filters=False)
     else:
         raise Exception(
             "Unknown base query for export instance type {}".format(type(export_instance))

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -89,6 +89,11 @@ from corehq.apps.export.dbaccessors import (
     get_latest_case_export_schema,
     get_latest_form_export_schema,
 )
+from corehq.apps.export.esaccessors import (
+    get_case_export_base_query,
+    get_form_export_base_query,
+    get_sms_export_base_query
+)
 from corehq.apps.export.utils import is_occurrence_deleted
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.products.models import SQLProduct
@@ -1175,11 +1180,11 @@ class CaseExportInstance(ExportInstance):
             for column in table.columns
         )
 
-    def get_query(self):
-        from corehq.apps.export.esaccessors import get_case_export_base_query
+    def get_query(self, include_filters=True):
         query = get_case_export_base_query(self.domain, self.case_type)
-        for filter in self.get_filters():
-            query = query.filter(filter.to_es_filter())
+        if include_filters:
+            for filter in self.get_filters():
+                query = query.filter(filter.to_es_filter())
 
         return query
 
@@ -1258,11 +1263,11 @@ class FormExportInstance(ExportInstance):
             )
         return []
 
-    def get_query(self):
-        from corehq.apps.export.esaccessors import get_form_export_base_query
-        query = get_form_export_base_query(self.domain, self.app_id, self.xmlns, include_errors=False)
-        for filter in self.get_filters():
-            query = query.filter(filter.to_es_filter())
+    def get_query(self, include_filters=True):
+        query = get_form_export_base_query(self.domain, self.app_id, self.xmlns, self.include_errors)
+        if include_filters:
+            for filter in self.get_filters():
+                query = query.filter(filter.to_es_filter())
 
         return query
 
@@ -1298,6 +1303,14 @@ class SMSExportInstance(ExportInstance):
         instance = cls(domain=schema.domain, tables=[main_table])
         instance._insert_system_properties(instance.domain, schema.type, instance.tables[0])
         return instance
+
+    def get_query(self, include_filters=True):
+        query = get_sms_export_base_query(self.domain)
+        if include_filters:
+            for filter in self.get_filters():
+                query = query.filter(filter.to_es_filter())
+
+        return query
 
 
 class ExportInstanceDefaults(object):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1175,6 +1175,20 @@ class CaseExportInstance(ExportInstance):
             for column in table.columns
         )
 
+    def get_query(self):
+        from corehq.apps.export.esaccessors import get_case_export_base_query
+        query = get_case_export_base_query(self.domain, self.case_type)
+        for filter in self.get_filters():
+            query = query.filter(filter.to_es_filter())
+
+        return query
+
+    def get_rows(self):
+        return self.get_query().values()
+
+    def get_count(self):
+        return self.get_query().count()
+
 
 class FormExportInstance(ExportInstance):
     xmlns = StringProperty()
@@ -1243,6 +1257,20 @@ class FormExportInstance(ExportInstance):
                 self.filters.date_period,
             )
         return []
+
+    def get_query(self):
+        from corehq.apps.export.esaccessors import get_form_export_base_query
+        query = get_form_export_base_query(self.domain, self.app_id, self.xmlns, include_errors=False)
+        for filter in self.get_filters():
+            query = query.filter(filter.to_es_filter())
+
+        return query
+
+    def get_rows(self):
+        return self.get_query().values()
+
+    def get_count(self):
+        return self.get_query().count()
 
 
 class SMSExportInstance(ExportInstance):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -980,7 +980,7 @@ class ODataFeedListHelper(ExportListHelper):
     @memoized
     def odata_feed_limit(self):
         domain_object = Domain.get_by_name(self.domain)
-        return domain_object.odata_feed_limit or settings.DEFAULT_ODATA_FEED_LIMIT
+        return domain_object.get_odata_feed_limit()
 
     @property
     def create_export_form_title(self):


### PR DESCRIPTION
## Product Description
Adds OData report functionality to the enterprise portal

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-13397

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
The report has been tested locally. There is a new test suite for the report output in _enterprise.tests.test_enterprise:EnterpriseODataReportTests_
The main concern with how this might be unsafe is how it could affect our celery worker load. I've attempted to mitigate this by displaying an error on the report rather than query the database for domains containing an excessive (> 150) amount of exports. Note that this does not prevent the scenario where a single enterprise account contains many exports across all domains.

### Automated test coverage

See the new test suite mentioned above. Tests may be added later to ensure database functionality is working as expected. In the interrim, local testing sufficed.

### QA Plan

No QA necessary

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
