### PR TITLE
Bump PyGithub from 1.45.1 to 1.55 in /requirements

### DIFF
--- a/corehq/apps/builds/management/commands/add_commcare_build.py
+++ b/corehq/apps/builds/management/commands/add_commcare_build.py
@@ -58,6 +58,21 @@ class Command(BaseCommand):
 
 
 def _get_latest_commcare_build_version():
+    """Get the latest commcare build version from the github tags.
+
+    FIXME: create a custom test API token for this test?
+    NOTE: this doctest is _not_ executed because GitHub rate-limits
+    unauthenticated API requests _very_ fast.
+    See also: corehq/apps/builds/tests.py
+
+    >>> repo = Github().get_organization('dimagi')
+    >>> tag = repo.get_repo("commcare-android").get_latest_release().tag_name
+    >>> tag.startswith("commcare_")
+    True
+    >>> version = tag.split('commcare_')[1]
+    >>> _get_latest_commcare_build_version() == version
+    True
+    """
     repo = Github().get_organization('dimagi').get_repo("commcare-android")
     latest_release_tag = repo.get_latest_release().tag_name
 

--- a/corehq/apps/builds/tests.py
+++ b/corehq/apps/builds/tests.py
@@ -1,5 +1,24 @@
 from corehq.apps.builds.utils import extract_build_info_from_filename
 
+# FIXME: does this do anything?
+# $ ./manage.py test -v corehq/apps/builds/tests.py
+# nosetests corehq/apps/builds/tests.py --verbosity=2
+#
+# ----------------------------------------------------------------------
+# Ran 0 tests in 0.000s
+#
+# OK
 __test__ = {
     'extract_build_info_from_filename': extract_build_info_from_filename
 }
+
+# NOTE: Don't run the test below because GitHub rate-limits unauthenticated API
+# request _very_ fast.
+#
+# See doctest in: corehq/apps/builds/management/commands/add_commcare_build.py
+#
+# def test_doctests():
+#     import doctest
+#     from .management.commands import add_commcare_build
+#     results = doctest.testmod(add_commcare_build, optionflags=doctest.ELLIPSIS)
+#     assert results.failed == 0, results

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -50,6 +50,7 @@ cffi==1.14.3
     # via
     #   cryptography
     #   csiphash
+    #   pynacl
 chardet==3.0.4
     # via
     #   ghdiff
@@ -418,7 +419,7 @@ pycryptodome==3.10.1
     # via -r base-requirements.in
 pyflakes==2.3.1
     # via flake8
-pygithub==1.54.1
+pygithub==1.55
     # via -r base-requirements.in
 pygments==2.11.2
     # via
@@ -426,10 +427,12 @@ pygments==2.11.2
     #   sphinx
 pygooglechart==0.4.0
     # via -r base-requirements.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   pygithub
     #   twilio
+pynacl==1.5.0
+    # via pygithub
 pyopenssl==20.0.1
     # via -r sso-requirements.in
 pyparsing==2.4.7

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -43,6 +43,7 @@ cffi==1.14.3
     # via
     #   cryptography
     #   csiphash
+    #   pynacl
 chardet==3.0.4
     # via
     #   ghdiff
@@ -331,16 +332,18 @@ pycparser==2.20
     # via cffi
 pycryptodome==3.10.1
     # via -r base-requirements.in
-pygithub==1.54.1
+pygithub==1.55
     # via -r base-requirements.in
 pygments==2.11.2
     # via sphinx
 pygooglechart==0.4.0
     # via -r base-requirements.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   pygithub
     #   twilio
+pynacl==1.5.0
+    # via pygithub
 pyparsing==2.4.7
     # via
     #   httplib2

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -46,6 +46,7 @@ cffi==1.14.3
     # via
     #   cryptography
     #   csiphash
+    #   pynacl
 chardet==3.0.4
     # via
     #   ghdiff
@@ -345,16 +346,18 @@ pycparser==2.20
     # via cffi
 pycryptodome==3.10.1
     # via -r base-requirements.in
-pygithub==1.54.1
+pygithub==1.55
     # via -r base-requirements.in
 pygments==2.11.2
     # via ipython
 pygooglechart==0.4.0
     # via -r base-requirements.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   pygithub
     #   twilio
+pynacl==1.5.0
+    # via pygithub
 pyopenssl==20.0.1
     # via
     #   -r prod-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -38,6 +38,7 @@ cffi==1.14.3
     # via
     #   cryptography
     #   csiphash
+    #   pynacl
 chardet==3.0.4
     # via
     #   ghdiff
@@ -308,14 +309,16 @@ pycparser==2.20
     # via cffi
 pycryptodome==3.10.1
     # via -r base-requirements.in
-pygithub==1.54.1
+pygithub==1.55
     # via -r base-requirements.in
 pygooglechart==0.4.0
     # via -r base-requirements.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   pygithub
     #   twilio
+pynacl==1.5.0
+    # via pygithub
 pyopenssl==20.0.1
     # via -r sso-requirements.in
 pyparsing==3.0.7

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -40,6 +40,7 @@ cffi==1.14.3
     # via
     #   cryptography
     #   csiphash
+    #   pynacl
 chardet==3.0.4
     # via
     #   ghdiff
@@ -341,14 +342,16 @@ pycparser==2.20
     # via cffi
 pycryptodome==3.10.1
     # via -r base-requirements.in
-pygithub==1.54.1
+pygithub==1.55
     # via -r base-requirements.in
 pygooglechart==0.4.0
     # via -r base-requirements.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   pygithub
     #   twilio
+pynacl==1.5.0
+    # via pygithub
 pyopenssl==20.0.1
     # via -r sso-requirements.in
 pyparsing==3.0.7


### PR DESCRIPTION
## Technical Summary

Upgrade PyGithub.

Ticket: [SAAS-13582](https://dimagi-dev.atlassian.net/browse/SAAS-13582)

## Safety Assurance

### Safety story

Tested manually.

### Automated test coverage

Wrote new tests and promptly got rate-limited by Github. Used a personal access token to perform manual tests without rate-limiting. New version does not break existing usage.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
