### PR TITLE
Form metadata context fix

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1710,7 +1710,7 @@ def _get_cases_changed_context(domain, form, case_id=None):
 def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
     from corehq.apps.hqwebapp.templatetags.proptable_tags import get_default_definition, get_tables_as_columns
 
-    meta = form.metadata.to_json()
+    meta = form.metadata.to_json() or {}
     meta['@xmlns'] = form.xmlns
     meta['received_on'] = json_format_datetime(form.received_on)
     meta['server_modified_on'] = json_format_datetime(form.server_modified_on) if form.server_modified_on else ''

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1710,7 +1710,7 @@ def _get_cases_changed_context(domain, form, case_id=None):
 def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
     from corehq.apps.hqwebapp.templatetags.proptable_tags import get_default_definition, get_tables_as_columns
 
-    meta = form.metadata.to_json() or {}
+    meta = form.metadata.to_json() if form.metadata else {}
     meta['@xmlns'] = form.xmlns
     meta['received_on'] = json_format_datetime(form.received_on)
     meta['server_modified_on'] = json_format_datetime(form.server_modified_on) if form.server_modified_on else ''


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This handles a `None` value returned by `form.metadata.to_json()`. There are some cases in HQ that do not have the expected form data structure that is expected by the `form.metadata` class property. This is meant as a hot fix to handle this issue before addressing the case structure issue. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is in response to this interrupt ticket: [Jira](https://dimagi-dev.atlassian.net/browse/USH-2052)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
