### PR TITLE
Gregorian to Ethiopian: Keep date strings marked as constants as strings

### DIFF
--- a/corehq/apps/userreports/expressions/date_specs.py
+++ b/corehq/apps/userreports/expressions/date_specs.py
@@ -255,6 +255,11 @@ class GregorianDateToEthiopianDateSpec(JsonObject):
         }
 
     """
+
+    class Meta(object):
+        # prevent JsonObject from auto-converting dates etc.
+        string_conversions = ()
+
     type = TypeProperty("gregorian_date_to_ethiopian_date")
     date_expression = DefaultProperty(required=True)
 

--- a/corehq/apps/userreports/tests/test_date_expressions.py
+++ b/corehq/apps/userreports/tests/test_date_expressions.py
@@ -201,3 +201,18 @@ def test_gregorian_to_ethiopian_expression(self, source_doc, expected_value):
         'date_expression': date_expression,
     })
     self.assertEqual(expected_value, expression(source_doc))
+
+
+@generate_cases([
+    ({"type": "constant", "constant": '2021-10-11'}, '2014-02-01'),
+    ({"type": "constant", "constant": '2021-10-9'}, '2014-01-29'),
+])
+def test_gregorian_to_ethiopian_expression_constant(self, expression, expected_value):
+    """
+        Used to fail with BadValueError: datetime.date(2020, 9, 9) is not a date-formatted string
+    """
+    wrapped_expression = ExpressionFactory.from_spec({
+        'type': 'gregorian_date_to_ethiopian_date',
+        'date_expression': expression,
+    })
+    self.assertEqual(expected_value, wrapped_expression({"foo": "bar"}))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Builds on https://github.com/dimagi/commcare-hq/pull/31582/files 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-2101
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
UCR
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests that used to fail, but now pass
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
