### PR TITLE
fix js error when trying to load the trial form that doesn't exist on the page

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/hubspot.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.js
@@ -136,6 +136,10 @@ hqDefine('analytix/js/hubspot', [
             hasInteractedWithForm = false,
             trialForm;
 
+        if ($form.length === 0) {
+            return;
+        }
+
         trialForm = ctaForms.hubspotCtaForm({
             hubspotFormId: '9c8ecc33-b088-474e-8f4c-1b10fae50c2f',
             showContactMethod: true,


### PR DESCRIPTION
## Technical Summary
quick fix for an annoying js error when the trial form doesn't exist on the page.

## Safety Assurance

### Safety story
Small, very safe change

### Automated test coverage
no

### QA Plan
none


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
