### PR TITLE
pass query data to Formplayer debugger endpoints

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -172,6 +172,7 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
             this.options.baseUrl,
             {
                 selections: this.options.selections,
+                query_data: self.options.queryData,
                 username: this.options.username,
                 restoreAs: this.options.restoreAs,
                 domain: this.options.domain,
@@ -196,6 +197,7 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
             baseUrl: null,
             formSessionId: null,
             selections: null,
+            queryData: null,
             username: null,
             restoreAs: null,
             domain: null,
@@ -352,6 +354,7 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
                     xpath: xpath,
                     app_id: self.options.appId,
                     selections: self.options.selections,
+                    query_data: self.options.queryData,
                     debugOutput: self.selectedDebugOption().key,
                 },
                 self.options.sessionType

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -378,6 +378,7 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         cloudCareDebugger = new CloudCareDebugger({
             baseUrl: user.formplayer_url,
             selections: urlObject.selections,
+            queryData:  urlObject.queryData,
             username: user.username,
             restoreAs: user.restoreAs,
             domain: user.domain,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -378,7 +378,7 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         cloudCareDebugger = new CloudCareDebugger({
             baseUrl: user.formplayer_url,
             selections: urlObject.selections,
-            queryData:  urlObject.queryData,
+            queryData: urlObject.queryData,
             username: user.username,
             restoreAs: user.restoreAs,
             domain: user.domain,


### PR DESCRIPTION
## Product Description
Improvement to the web apps / app preview debugger when used in conjunction with case search.

## Technical Summary
Pass the query data to the debugger endpoints to allow correct session replay.

## Safety Assurance

### Safety story
Only impacts the web apps / app preview debugger. Formplayer endpoints already accept the param but don't do anything with it (yet)

### Automated test coverage
None

### QA Plan
I've tested this locally and found no issues.

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
