### PR TITLE
Upgrade Kafka+Zookeeper Docker Containers

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -110,14 +110,14 @@ services:
       - ./files/elasticsearch_5.yml:/usr/share/elasticsearch/config/elasticsearch.yml:rw
 
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: zookeeper:3.7
     ports:
       - "2181:2181"
     volumes:
-      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/opt/zookeeper-3.4.13/data
+      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/opt/zookeeper-3.7/data
 
   kafka:
-      image: wurstmeister/kafka:2.13-2.6.0
+      image: bitnami/kafka:3.2
       ports:
         - "9092:9092"
       environment:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -133,6 +133,7 @@ services:
               echo "Wait script download failed"
             fi
           KAFKA_ADVERTISED_HOST_NAME: "kafka"
+          ALLOW_PLAINTEXT_LISTENER: "yes"
       volumes:
         - ${DOCKER_SOCK}:${DOCKER_SOCK}
         - ${VOLUME_PREFIX}${BLANK_IF_TESTS-kafka:}/kafka/kafka-logs-1


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13370

- targeting Kafka v3.2
- targeting Zookeeper v3.7 with the hope to remove the need for this container entirely in the near future in favor of kraft

I was concerned about [compatibility with kafka-python](https://kafka-python.readthedocs.io/en/master/compatibility.html), but it sounds like kafka has backwards compatibility:
> Because the kafka server protocol is backwards compatible, kafka-python is expected to work with newer broker releases as well.
>
> Although kafka-python is tested and expected to work on recent broker versions, not all features are supported. Specifically, authentication codecs, and transactional producer/consumer support are not fully implemented. PRs welcome!

`corehq.form_processor.tests.test_kafka` and `corehq.apps.change_feed.tests.test_kafka_change_feed` exercise the kafka broker, and still pass after these changes.

We definitely need to run through QA on staging when the Server Infrastructure pod rolls this out.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
