### PR TITLE
add context to instance error message

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -871,10 +871,11 @@ class XForm(WrappedNode):
 
         if missing_unknown_instances:
             instance_ids = "', '".join(missing_unknown_instances)
+            module = form.get_module()
             raise XFormValidationError(_(
-                "The form is missing some instance declarations "
-                "that can't be automatically added: '%(instance_ids)s'"
-            ) % {'instance_ids': instance_ids})
+                "The form '{form}' in '{module}' is missing some instance declarations "
+                "that can't be automatically added: '{instance_ids}'"
+            ).format(form=form.default_name(), module=module.default_name(app), instance_ids=instance_ids))
 
         for instance in instances:
             if instance.id not in instance_declarations:


### PR DESCRIPTION
## Product Description
Improve error message when build fails due to missing instances. Add form name and module name to the message:

![image](https://user-images.githubusercontent.com/249606/170714081-bfa5158a-dc61-44be-9e30-3fa7aea4e929.png)

## Safety Assurance

### Safety story
Tested locally, only impacts if the error is triggered which should be very rare.

### Automated test coverage
None

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
