### PR TITLE
case query endpoint

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -773,7 +773,7 @@ class WorkflowQueryMeta(WorkflowSessionMeta):
         url = self.query.url
         if self.is_case_search:
             # we don't need the full search results, just the case that's been selected
-            url = url.replace('/phone/search/', '/phone/registry_case/')
+            url = url.replace('/phone/search/', '/phone/case_fixture/')
         return StackQuery(id=self.query.storage_instance, value=url, data=data)
 
     def __repr__(self):

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -614,7 +614,7 @@ class EntriesHelper(object):
 
         return FormDatumMeta(
             datum=RemoteRequestQuery(
-                url=absolute_reverse('registry_case', args=[self.app.domain, self.app.get_id]),
+                url=absolute_reverse('case_fixture', args=[self.app.domain, self.app.get_id]),
                 storage_instance=REGISTRY_INSTANCE,
                 template='case',
                 data=data,

--- a/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
@@ -33,7 +33,7 @@
             </prompt>
           </query>
           <datum detail-confirm="m0_case_long" detail-select="m0_case_short" id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]" value="./@case_id"/>
-          <query default_search="true" storage-instance="registry" template="case" url="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+          <query default_search="true" storage-instance="registry" template="case" url="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
             <data key="x_commcare_data_registry" ref="'myregistry'"/>
             <data key="case_type" ref="'case'"/>
             <data key="case_id" ref="'another case ID'"/>

--- a/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_entry.xml
@@ -33,7 +33,7 @@
         </prompt>
       </query>
       <datum detail-confirm="m1_case_long" detail-select="m1_case_short" id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]" value="./@case_id"/>
-      <query default_search="true" storage-instance="registry" template="case" url="https://www.example.com/a/test_domain/phone/registry_case/456/">
+      <query default_search="true" storage-instance="registry" template="case" url="https://www.example.com/a/test_domain/phone/case_fixture/456/">
         <data key="x_commcare_data_registry" ref="'myregistry'"/>
         <data key="case_type" ref="'case'"/>
         <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -149,7 +149,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         <partial>
           <create>
             <command value="'m0'"/>
-            <query id="results" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+            <query id="results" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
               <data key="case_type" ref="'case'"/>
               <data key="case_type" ref="'other_case'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_new_case_0"/>
@@ -201,7 +201,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             <partial>
               <create>
                 <command value="'m1'"/>
-                <query id="results" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+                <query id="results" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
                   <data key="case_type" ref="'case'"/>
                   <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
                 </query>
@@ -343,7 +343,7 @@ class InlineSearchFormLinkChildModuleTest(SimpleTestCase, SuiteMixin):
             <command value="'m0'"/>
             <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
             <command value="'m1'"/>
-            <query id="results" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+            <query id="results" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
               <data key="case_type" ref="'case'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_case"/>
             </query>

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -125,7 +125,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             </query>
             <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                 value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
-            <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/"
+            <query url="http://localhost:8000/a/test_domain/phone/case_fixture/123/"
                 storage-instance="registry" template="case" default_search="true">
               <data key="{CASE_SEARCH_REGISTRY_ID_KEY}" ref="'myregistry'"/>
               <data key="case_type" ref="'case'"/>
@@ -162,7 +162,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
         expected_entry_query = f"""
         <partial>
-          <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/" storage-instance="registry"
+          <query url="http://localhost:8000/a/test_domain/phone/case_fixture/123/" storage-instance="registry"
                 template="case" default_search="true">
             <data key="{CASE_SEARCH_REGISTRY_ID_KEY}" ref="'myregistry'"/>
             <data key="case_type" ref="'case'"/>
@@ -205,14 +205,14 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         <partial>
           <create>
             <command value="'m0'"/>
-            <query id="results" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+            <query id="results" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
               <data key="case_type" ref="'case'"/>
               <data key="case_type" ref="'other_case'"/>
               <data key="{CASE_SEARCH_REGISTRY_ID_KEY}" ref="'myregistry'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_new_case_0"/>
             </query>
             <datum id="case_id" value="instance('commcaresession')/session/data/case_id_new_case_0"/>
-            <query id="registry" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+            <query id="registry" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
               <data key="{CASE_SEARCH_REGISTRY_ID_KEY}" ref="'myregistry'"/>
               <data key="case_type" ref="'case'"/>
               <data key="case_type" ref="'other_case'"/>
@@ -265,13 +265,13 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             <partial>
               <create>
                 <command value="'m1'"/>
-                <query id="results" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+                <query id="results" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
                   <data key="case_type" ref="'case'"/>
                   <data key="x_commcare_data_registry" ref="'myregistry'"/>
                   <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
                 </query>
                 <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
-                <query id="registry" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+                <query id="registry" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
                   <data key="x_commcare_data_registry" ref="'myregistry'"/>
                   <data key="case_type" ref="'case'"/>
                   <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
@@ -438,13 +438,13 @@ class RemoteRequestSuiteFormLinkChildModuleTest(SimpleTestCase, SuiteMixin):
             <command value="'m0'"/>
             <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
             <command value="'m1'"/>
-            <query id="results" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+            <query id="results" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
               <data key="case_type" ref="'case'"/>
               <data key="{CASE_SEARCH_REGISTRY_ID_KEY}" ref="'myregistry'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_case"/>
             </query>
             <datum id="case_id_case" value="instance('commcaresession')/session/data/case_id_case"/>
-            <query id="registry" value="http://localhost:8000/a/test_domain/phone/registry_case/123/">
+            <query id="registry" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
               <data key="{CASE_SEARCH_REGISTRY_ID_KEY}" ref="'myregistry'"/>
               <data key="case_type" ref="'case'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_case"/>
@@ -512,7 +512,7 @@ class InlineSearchDataRegistryModuleTest(SimpleTestCase, SuiteMixin):
                 </query>
                 <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                     value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
-                <query url="http://localhost:8000/a/test_domain/phone/registry_case/123/"
+                <query url="http://localhost:8000/a/test_domain/phone/case_fixture/123/"
                 storage-instance="registry" template="case" default_search="true">
                   <data key="{CASE_SEARCH_REGISTRY_ID_KEY}" ref="'myregistry'"/>
                   <data key="case_type" ref="'case'"/>

--- a/corehq/apps/ota/tests/test_case_fixture_view.py
+++ b/corehq/apps/ota/tests/test_case_fixture_view.py
@@ -20,7 +20,7 @@ from corehq.util.test_utils import generate_cases, flag_enabled
 
 @flag_enabled("DATA_REGISTRY")
 @flag_enabled("SYNC_SEARCH_CASE_CLAIM")
-class RegistryCaseDetailsTests(TestCase):
+class RegistryCaseFixtureViewTests(TestCase):
     domain = 'registry-case-details'
 
     @classmethod
@@ -169,7 +169,7 @@ class _FixtureCase:
     ({}, f"'case_id', 'case_type', '{CASE_SEARCH_REGISTRY_ID_KEY}' are required parameters"),
     ({"case_id": "a"}, f"'case_type', '{CASE_SEARCH_REGISTRY_ID_KEY}' are required parameters"),
     ({"case_id": "a", "case_type": "b"}, f"'{CASE_SEARCH_REGISTRY_ID_KEY}' is a required parameter"),
-], RegistryCaseDetailsTests)
+], RegistryCaseFixtureViewTests)
 @flag_enabled("SYNC_SEARCH_CASE_CLAIM")
 @flag_enabled("DATA_REGISTRY")
 def test_required_params(self, params, message):

--- a/corehq/apps/ota/tests/test_case_fixture_view.py
+++ b/corehq/apps/ota/tests/test_case_fixture_view.py
@@ -1,3 +1,4 @@
+from unittest import skip
 from unittest.mock import patch
 
 from defusedxml import ElementTree
@@ -112,6 +113,11 @@ class CaseFixtureViewTests(TestCase):
     def test_get_case_details_missing_case(self):
         self._make_request({"case_id": "missing", "case_type": "parent"}, 404)
 
+    def test_get_registry_case_details_feature_flag_not_active(self):
+        self._make_request({
+            CASE_SEARCH_REGISTRY_ID_KEY: "any-registry", "case_id": "missing", "case_type": "parent"
+        }, 404)
+
     @generate_cases([
         ({}, "'case_id', 'case_type' are required parameters"),
         ({"case_id": "a"}, "'case_type' is a required parameter"),
@@ -161,6 +167,10 @@ class RegistryCaseFixtureViewTests(CaseFixtureViewTests):
         super()._make_request({
             CASE_SEARCH_REGISTRY_ID_KEY: "not-a-registry", "case_id": self.parent_case_id, "case_type": "parent",
         }, 404)
+
+    @skip("Does not apply in this suite")
+    def test_get_registry_case_details_feature_flag_not_active(self):
+        pass
 
     def _make_request(self, params, expected_response_code, method="get"):
         params[CASE_SEARCH_REGISTRY_ID_KEY] = self.registry.slug

--- a/corehq/apps/ota/tests/test_case_fixture_view.py
+++ b/corehq/apps/ota/tests/test_case_fixture_view.py
@@ -134,6 +134,14 @@ class RegistryCaseFixtureViewTests(TestCase):
             CASE_SEARCH_REGISTRY_ID_KEY: "not-a-registry", "case_id": self.parent_case_id, "case_type": "parent",
         }, 404)
 
+    @generate_cases([
+        ({}, "'case_id', 'case_type' are required parameters"),
+        ({"case_id": "a"}, "'case_type' is a required parameters"),
+    ])
+    def test_required_params(self, params, message):
+        content = self._make_request(params, 400)
+        self.assertEqual(content, message)
+
     def _make_request(self, params, expected_response_code, method="get"):
         request_method = {
             "get": self.client.get,
@@ -163,15 +171,3 @@ class _FixtureCase:
 
     def get_property(self, name):
         return self.xml_element.findtext(name)
-
-
-@generate_cases([
-    ({}, f"'case_id', 'case_type', '{CASE_SEARCH_REGISTRY_ID_KEY}' are required parameters"),
-    ({"case_id": "a"}, f"'case_type', '{CASE_SEARCH_REGISTRY_ID_KEY}' are required parameters"),
-    ({"case_id": "a", "case_type": "b"}, f"'{CASE_SEARCH_REGISTRY_ID_KEY}' is a required parameter"),
-], RegistryCaseFixtureViewTests)
-@flag_enabled("SYNC_SEARCH_CASE_CLAIM")
-@flag_enabled("DATA_REGISTRY")
-def test_required_params(self, params, message):
-    content = self._make_request(params, 400)
-    self.assertEqual(content, message)

--- a/corehq/apps/ota/urls.py
+++ b/corehq/apps/ota/urls.py
@@ -9,7 +9,6 @@ from corehq.apps.ota.views import (
     recovery_measures,
     restore,
     search,
-    registry_case,
     case_fixture,
     case_restore,
 )
@@ -25,7 +24,7 @@ urlpatterns = [
     url(r'^heartbeat/(?P<app_build_id>[\w-]+)/$', heartbeat, name='phone_heartbeat'),
     url(r'^get_next_id/$', get_next_id, name='get_next_id'),
     url(r'^recovery_measures/(?P<build_id>[\w-]+)/$', recovery_measures, name='recovery_measures'),
-    url(r'^registry_case/(?P<app_id>[\w-]+)/$', registry_case, name='registry_case'),
+    url(r'^registry_case/(?P<app_id>[\w-]+)/$', case_fixture),
     url(r'^case_fixture/(?P<app_id>[\w-]+)/$', case_fixture, name='case_fixture'),
     url(r'^case_restore/(?P<case_id>[\w\-]+)/$', case_restore, name='case_restore'),
 ]

--- a/corehq/apps/ota/urls.py
+++ b/corehq/apps/ota/urls.py
@@ -10,6 +10,7 @@ from corehq.apps.ota.views import (
     restore,
     search,
     registry_case,
+    case_fixture,
     case_restore,
 )
 
@@ -25,5 +26,6 @@ urlpatterns = [
     url(r'^get_next_id/$', get_next_id, name='get_next_id'),
     url(r'^recovery_measures/(?P<build_id>[\w-]+)/$', recovery_measures, name='recovery_measures'),
     url(r'^registry_case/(?P<app_id>[\w-]+)/$', registry_case, name='registry_case'),
+    url(r'^case_fixture/(?P<app_id>[\w-]+)/$', case_fixture, name='case_fixture'),
     url(r'^case_restore/(?P<case_id>[\w\-]+)/$', case_restore, name='case_restore'),
 ]

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -478,6 +478,10 @@ def _single_domain_case_fixture(request, domain, case_types, case_ids):
     for case in cases:
         if case.domain != domain or case.type not in case_types:
             raise Http404(f"Case '{case.case_id}' not found")
+    case_ids_found = {case.case_id for case in cases}
+    missing = set(case_ids) - case_ids_found
+    if missing:
+        raise Http404(f"Cases '{','.join(missing)}' not found")
 
     return get_case_hierarchy(domain, cases)
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -427,20 +427,7 @@ def recovery_measures(request, domain, build_id):
 @csrf_exempt
 @mobile_auth
 @toggles.SYNC_SEARCH_CASE_CLAIM.required_decorator()
-def registry_case(request, domain, app_id):
-    """Legacy endpoint name. Can be removed once no active apps are using it."""
-    return _case_fixture(request, domain, app_id)
-
-
-@location_safe_bypass
-@csrf_exempt
-@mobile_auth
-@toggles.SYNC_SEARCH_CASE_CLAIM.required_decorator()
 def case_fixture(request, domain, app_id):
-    return _case_fixture(request, domain, app_id)
-
-
-def _case_fixture(request, domain, app_id):
     request_dict = request.GET if request.method == 'GET' else request.POST
     case_ids = request_dict.getlist("case_id")
     case_types = request_dict.getlist("case_type")

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -21,6 +21,7 @@ from tastypie.http import HttpTooManyRequests
 
 from casexml.apps.case.cleanup import claim_case, get_first_claims
 from casexml.apps.case.fixtures import CaseDBFixture
+from casexml.apps.phone.data_providers.case.livequery import get_case_hierarchy
 from casexml.apps.phone.exceptions import MissingSyncLog
 from casexml.apps.phone.models import get_properly_wrapped_sync_log
 from casexml.apps.phone.restore import (
@@ -478,7 +479,7 @@ def _single_domain_case_query(request, domain, app_id, case_types, case_ids, reg
         if case.domain != domain or case.type not in case_types:
             raise Http404(f"Case '{case.case_id}' not found")
 
-    return cases
+    return get_case_hierarchy(domain, cases)
 
 
 @toggles.DATA_REGISTRY.required_decorator()


### PR DESCRIPTION
## Technical Summary
Similar to 'registry search', when doing 'inline search' ie. case search directly as part of a form entry, and combining that with form linking it is necessary for the form linking stack operations to have query datums.

With data registries we introduced a 'registry_case' view that allowed us to do a query for only the selected cases. 

This PR generalises that to a `case_fixture` view which can be used with or without data registries.

The original 'registry_case' URL mapping is kept for backwards compatibility with existing apps.

Easiest review by commit.

## Feature Flag
inline search / data registry

## Safety Assurance

### Safety story
Limited to feature flagged features and covered by tests.

### Automated test coverage
Good coverage and new tests added

### QA Plan
None

### Migrations
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
