### PR TITLE
Avoid error on null subscription

### DIFF
--- a/corehq/apps/notifications/tests/test_views.py
+++ b/corehq/apps/notifications/tests/test_views.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from corehq.apps.accounting.models import Subscription
+from corehq.apps.accounting.models import Subscription, SubscriptionType
 from corehq.apps.groups.models import Group
 
 from ..views import NotificationsServiceRMIView
@@ -13,21 +13,21 @@ def test_should_hide_feature_notifs_for_pro_with_groups():
 
 
 def test_should_hide_feature_notifs_for_pro_without_groups():
-    with case_sharing_groups_patch([]), active_service_type_patch("not_IMPLEMENTATION_or_SANDBOX"):
+    with case_sharing_groups_patch([]), active_service_type_patch(TRIAL):
         hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "pro")
         assert not hide, "notifications should not be hidden for pro domain without groups"
 
 
 def test_should_hide_feature_notifs_for_implementation_subscription():
-    with active_service_type_patch("IMPLEMENTATION"):
+    with active_service_type_patch(IMPLEMENTATION):
         hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "basic")
-        assert hide, "notifications should be hidden for IMPLEMENTATION subscription"
+        assert hide, f"notifications should be hidden for {IMPLEMENTATION} subscription"
 
 
 def test_should_hide_feature_notifs_for_sandbox_subscription():
-    with active_service_type_patch("SANDBOX"):
+    with active_service_type_patch(SANDBOX):
         hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "basic")
-        assert hide, "notifications should be hidden for SANDBOX subscription"
+        assert hide, f"notifications should be hidden for {SANDBOX} subscription"
 
 
 def test_should_hide_feature_notifs_bug():
@@ -49,3 +49,8 @@ def case_sharing_groups_patch(groups):
         assert not wrap, "expected wrap to be false"
         return groups
     return patch.object(Group, "get_case_sharing_groups", getter)
+
+
+IMPLEMENTATION = SubscriptionType.IMPLEMENTATION
+SANDBOX = SubscriptionType.SANDBOX
+TRIAL = SubscriptionType.TRIAL

--- a/corehq/apps/notifications/tests/test_views.py
+++ b/corehq/apps/notifications/tests/test_views.py
@@ -18,12 +18,6 @@ def test_should_hide_feature_notifs_for_pro_without_groups():
         assert not hide, "notifications should not be hidden for pro domain without groups"
 
 
-def test_should_hide_feature_notifs_for_non_pro_with_groups():
-    with case_sharing_groups_patch(['agroupid']), active_service_type_patch("not_IMPLEMENTATION_or_SANDBOX"):
-        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", None)
-        assert not hide, "notifications should not be hidden for pro domain without groups"
-
-
 def test_should_hide_feature_notifs_for_implementation_subscription():
     with case_sharing_groups_patch([]), active_service_type_patch("IMPLEMENTATION"):
         hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "pro")

--- a/corehq/apps/notifications/tests/test_views.py
+++ b/corehq/apps/notifications/tests/test_views.py
@@ -19,20 +19,20 @@ def test_should_hide_feature_notifs_for_pro_without_groups():
 
 
 def test_should_hide_feature_notifs_for_implementation_subscription():
-    with case_sharing_groups_patch([]), active_service_type_patch("IMPLEMENTATION"):
-        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "pro")
+    with active_service_type_patch("IMPLEMENTATION"):
+        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "basic")
         assert hide, "notifications should be hidden for IMPLEMENTATION subscription"
 
 
 def test_should_hide_feature_notifs_for_sandbox_subscription():
-    with case_sharing_groups_patch([]), active_service_type_patch("SANDBOX"):
-        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "pro")
+    with active_service_type_patch("SANDBOX"):
+        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "basic")
         assert hide, "notifications should be hidden for SANDBOX subscription"
 
 
 def test_should_hide_feature_notifs_bug():
-    with case_sharing_groups_patch([]), active_service_type_patch():
-        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", None)
+    with active_service_type_patch():
+        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "basic")
         assert not hide, "notifications should not be hidden for null subscription"
 
 

--- a/corehq/apps/notifications/tests/test_views.py
+++ b/corehq/apps/notifications/tests/test_views.py
@@ -7,7 +7,7 @@ from ..views import NotificationsServiceRMIView
 
 
 def test_should_hide_feature_notifs_for_pro_with_groups():
-    with case_sharing_groups_patch(['agroupid']), active_service_type_patch("not_IMPLEMENTATION_or_SANDBOX"):
+    with case_sharing_groups_patch(['agroupid']):
         hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "pro")
         assert hide, "notifications should be hidden for pro domain with groups"
 
@@ -34,6 +34,12 @@ def test_should_hide_feature_notifs_for_sandbox_subscription():
     with case_sharing_groups_patch([]), active_service_type_patch("SANDBOX"):
         hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "pro")
         assert hide, "notifications should be hidden for SANDBOX subscription"
+
+
+def test_should_hide_feature_notifs_bug():
+    with case_sharing_groups_patch([]), active_service_type_patch():
+        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", None)
+        assert not hide, "notifications should not be hidden for null subscription"
 
 
 def active_service_type_patch(service_type=None):

--- a/corehq/apps/notifications/tests/test_views.py
+++ b/corehq/apps/notifications/tests/test_views.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+from corehq.apps.accounting.models import Subscription
+from corehq.apps.groups.models import Group
+
+from ..views import NotificationsServiceRMIView
+
+
+def test_should_hide_feature_notifs_for_pro_with_groups():
+    with case_sharing_groups_patch(['agroupid']), active_service_type_patch("not_IMPLEMENTATION_or_SANDBOX"):
+        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "pro")
+        assert hide, "notifications should be hidden for pro domain with groups"
+
+
+def test_should_hide_feature_notifs_for_pro_without_groups():
+    with case_sharing_groups_patch([]), active_service_type_patch("not_IMPLEMENTATION_or_SANDBOX"):
+        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "pro")
+        assert not hide, "notifications should not be hidden for pro domain without groups"
+
+
+def test_should_hide_feature_notifs_for_non_pro_with_groups():
+    with case_sharing_groups_patch(['agroupid']), active_service_type_patch("not_IMPLEMENTATION_or_SANDBOX"):
+        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", None)
+        assert not hide, "notifications should not be hidden for pro domain without groups"
+
+
+def test_should_hide_feature_notifs_for_implementation_subscription():
+    with case_sharing_groups_patch([]), active_service_type_patch("IMPLEMENTATION"):
+        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "pro")
+        assert hide, "notifications should be hidden for IMPLEMENTATION subscription"
+
+
+def test_should_hide_feature_notifs_for_sandbox_subscription():
+    with case_sharing_groups_patch([]), active_service_type_patch("SANDBOX"):
+        hide = NotificationsServiceRMIView._should_hide_feature_notifs("test", "pro")
+        assert hide, "notifications should be hidden for SANDBOX subscription"
+
+
+def active_service_type_patch(service_type=None):
+    def getter(domain):
+        return sub
+    sub = None if service_type is None else Subscription(service_type=service_type)
+    return patch.object(Subscription, "get_active_subscription_by_domain", getter)
+
+
+def case_sharing_groups_patch(groups):
+    # patch because quickcache makes this hard to test
+    def getter(domain, wrap):
+        assert not wrap, "expected wrap to be false"
+        return groups
+    return patch.object(Group, "get_case_sharing_groups", getter)

--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -9,7 +9,7 @@ from django.views.generic import View
 
 from memoized import memoized
 
-from corehq.apps.accounting.models import Subscription, SoftwarePlanEdition
+from corehq.apps.accounting.models import Subscription, SoftwarePlanEdition, SubscriptionType
 from corehq.apps.domain.decorators import login_required, require_superuser
 from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.views import BasePageView
@@ -67,7 +67,10 @@ class NotificationsServiceRMIView(JSONResponseMixin, View):
         if plan == 'pro' and Group.get_case_sharing_groups(domain, wrap=False):
             return True
         sub = Subscription.get_active_subscription_by_domain(domain)
-        return sub is not None and sub.service_type in ['IMPLEMENTATION', 'SANDBOX']
+        return sub is not None and sub.service_type in [
+            SubscriptionType.IMPLEMENTATION,
+            SubscriptionType.SANDBOX,
+        ]
 
     @allow_remote_invocation
     def mark_as_read(self, in_data):

--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -64,8 +64,7 @@ class NotificationsServiceRMIView(JSONResponseMixin, View):
 
     @staticmethod
     def _should_hide_feature_notifs(domain, plan):
-        groups = Group.get_case_sharing_groups(domain, wrap=False)
-        if plan == 'pro' and groups:
+        if plan == 'pro' and Group.get_case_sharing_groups(domain, wrap=False):
             return True
         sub = Subscription.get_active_subscription_by_domain(domain)
         return sub is not None and sub.service_type in ['IMPLEMENTATION', 'SANDBOX']

--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -65,12 +65,10 @@ class NotificationsServiceRMIView(JSONResponseMixin, View):
     @staticmethod
     def _should_hide_feature_notifs(domain, plan):
         groups = Group.get_case_sharing_groups(domain, wrap=False)
-        subscription_type = Subscription.get_active_subscription_by_domain(domain).service_type
-        if plan == 'pro' and groups != []:
+        if plan == 'pro' and groups:
             return True
-        if subscription_type == 'IMPLEMENTATION' or subscription_type == 'SANDBOX':
-            return True
-        return False
+        sub = Subscription.get_active_subscription_by_domain(domain)
+        return sub is not None and sub.service_type in ['IMPLEMENTATION', 'SANDBOX']
 
     @allow_remote_invocation
     def mark_as_read(self, in_data):


### PR DESCRIPTION
The context of the reported error was a third-party hosting environment. It is unclear whether notifications should be hidden in that context, so I opted took the conservative route of not hiding them.

```
corehq/apps/notifications/views.py", line 52, in should_hide_feature_notifs
  subscription_type = Subscription.get_active_subscription_by_domain(domain).service_type
AttributeError: 'NoneType' object has no attribute 'service_type'
```

:blowfish: Review by commit. The first puts the function in a testable location and adds tests. The second fixes the bug.

## Safety Assurance

### Safety story

Minor change to fix a bug.

### Automated test coverage

Unit tests added.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
