### PR TITLE
Remove myself as SMS owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 /corehq/elastic.py @proteusvacuum @joxl
 /corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py @millerdev
 /corehq/form_processor/ @snopoke
-/corehq/messaging/ @millerdev @orangejenny @mkangia
+/corehq/messaging/ @orangejenny @mkangia
 /corehq/motech/ @kaapstorm
 /corehq/pillows/ @calellowitz @joxl
 /corehq/sql_accessors/ @snopoke
@@ -48,7 +48,7 @@
 /corehq/apps/ota/ @snopoke
 /corehq/apps/reports/standard/cases/ @proteusvacuum @esoergel
 /corehq/apps/receiverwrapper/ @snopoke
-/corehq/apps/sms*/ @millerdev @orangejenny @mkangia
+/corehq/apps/sms*/ @orangejenny @mkangia
 /corehq/apps/smsbillables/ @dannyroberts @biyeun
 /corehq/apps/styleguide/ @orangejenny
 /corehq/apps/translations/app_translations/ @orangejenny


### PR DESCRIPTION
The PR notifications I get because of those ownership tags are not useful to me.

## Safety Assurance

### Safety story

Not a code change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
