### PR TITLE
Add force_web_user_password_reset management command

### DIFF
--- a/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
+++ b/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
@@ -1,4 +1,3 @@
-import uuid
 
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError

--- a/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
+++ b/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
@@ -1,0 +1,62 @@
+import uuid
+
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+from django.urls import reverse
+
+from corehq.apps.hqwebapp.tasks import send_html_email_async
+from corehq.apps.users.models import WebUser
+from dimagi.utils.web import get_url_base
+
+
+class Command(BaseCommand):
+    """
+    For each user in newline-separated `web_users_file`, log the user out and force them to reset their password.
+    It also sends them an email with some context and a link to where they can initiate the password reset.
+
+    Usage:
+        $ ./manage.py force_web_user_password_reset web_users_file
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('web_users_file')
+
+    def handle(self, web_users_file, **options):
+        web_user_usernames = get_lines_from_file(web_users_file)
+        errors = []
+        web_users = []
+        for web_user_username in web_user_usernames:
+            web_user = WebUser.get_by_username(web_user_username)
+            if web_user is None:
+                errors.append(f'No user named {web_user_username}')
+            elif not web_user.is_web_user():
+                errors.append(f'{web_user_username} is not a WebUser')
+            else:
+                web_users.append(web_user)
+
+        if errors:
+            raise CommandError(f'The following errors were found in your input file:\n{errors}')
+
+        django_users = [web_user.get_django_user() for web_user in web_users]
+
+        for user in django_users:
+            force_password_reset(user)
+
+
+def get_lines_from_file(filename):
+    with open(filename) as f:
+        return [line.strip() for line in f.readlines()]
+
+
+def force_password_reset(user):
+    user.set_password(uuid.uuid4().hex)
+    user.save()
+    url = f"{get_url_base()}{reverse('password_reset_email')}"
+    send_html_email_async.delay(
+        'Reset Password on CommCare HQ',
+        user.get_email(),
+        (f'Your system administrator has forced a password reset. '
+         f'Before you will be able to continue to use CommCare, '
+         f'you must reset your password by navigating to {url} and following the instructions.'),
+        email_from=settings.DEFAULT_FROM_EMAIL
+    )

--- a/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
+++ b/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
@@ -43,7 +43,8 @@ class Command(BaseCommand):
                 web_users_to_reset.append(web_user)
 
         if errors:
-            raise CommandError(f'The following errors were found in your input file:\n{errors}')
+            errors_string = '\n'.join(f'  - {error}' for error in errors)
+            raise CommandError(f'The following errors were found in your input file:\n{errors_string}')
 
         if web_users_to_skip_due_to_recent_reset:
             self.stdout.write("The following users will be skipped "

--- a/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
+++ b/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
@@ -37,10 +37,20 @@ class Command(BaseCommand):
         if errors:
             raise CommandError(f'The following errors were found in your input file:\n{errors}')
 
+        self.stdout.write("The following users will be logged out and have their passwords force reset.")
+        self.stdout.write("Additionally, they will receive an email directing them to reset their password.")
+        for web_user_username in web_user_usernames:
+            self.stdout.write(f"  - {web_user_username}")
+
+        if 'y' != input('Do you want to proceed? [y/N]'):
+            raise CommandError('You have aborted the command and no action was taken.')
+
         django_users = [web_user.get_django_user() for web_user in web_users]
 
         for user in django_users:
+            self.stdout.write(f"Force resetting password for {user.username}", ending='')
             force_password_reset(user)
+            self.stdout.write(" - Done")
 
 
 def get_lines_from_file(filename):

--- a/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
+++ b/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 from django.urls import reverse
 
+from corehq.apps.hqadmin.utils import unset_password
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.users.models import WebUser
 from corehq.util.argparse_types import utc_timestamp
@@ -78,7 +79,7 @@ def get_lines_from_file(filename):
 
 def force_password_reset(web_user):
     user = web_user.get_django_user()
-    user.set_password(uuid.uuid4().hex)
+    unset_password(user)
     user.save()
     url = f"{get_url_base()}{reverse('password_reset_email')}"
     send_html_email_async.delay(

--- a/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
+++ b/corehq/apps/hqadmin/management/commands/force_web_user_password_reset.py
@@ -47,8 +47,8 @@ class Command(BaseCommand):
             raise CommandError(f'The following errors were found in your input file:\n{errors_string}')
 
         if web_users_to_skip_due_to_recent_reset:
-            self.stdout.write("The following users will be skipped "
-                              "because they have reset their passwords since {skip_if_reset_since}")
+            self.stdout.write(f"The following users will be skipped "
+                              f"because they have reset their passwords since {skip_if_reset_since}")
 
             for web_user in web_users_to_skip_due_to_recent_reset:
                 self.stdout.write(f"  - {web_user.username} (password last set on {web_user.last_password_set})")

--- a/corehq/apps/hqadmin/utils.py
+++ b/corehq/apps/hqadmin/utils.py
@@ -1,3 +1,4 @@
+import os
 from importlib import import_module
 from itertools import groupby
 
@@ -149,3 +150,28 @@ def get_session(session_key):
         return None
 
     return session
+
+
+def unset_password(user):
+    """
+    "Clear" or "force reset" a user's password, preventing them from working until they have reset their password.
+
+    This is done by setting the user's password to a strong random value
+    that is discarded without ever being recorded.
+
+    This has the effect of
+    - Logging them out immediately
+    - Requiring the use of the reset-password workflow
+    - *Not* updating the user's `last_password_set` value
+      (conceptually we are treating this as not a password setting operation, but an "unsetting" of the password)
+
+    It is the caller's responsibility to save. Usage:
+
+      unset_password(user)
+      user.save()
+
+    """
+    # os.urandom is suitable for generating randomness for cryptographic use
+    # 128 bits / 8 (bits/byte) = 16 bytes
+    random_key = os.urandom(16).hex()
+    user.set_password(random_key)

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -35,6 +35,7 @@ from two_factor.utils import default_device
 
 from casexml.apps.phone.xml import SYNC_XMLNS
 from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
+from corehq.apps.hqadmin.utils import unset_password
 from couchexport.models import Format
 from couchforms.openrosa_response import RESPONSE_XMLNS
 from dimagi.utils.django.email import send_HTML_email
@@ -398,7 +399,7 @@ class DisableUserView(FormView):
 
         reset_password = form.cleaned_data['reset_password']
         if reset_password:
-            self.user.set_password(uuid.uuid4().hex)
+            unset_password(self.user)
             change_messages.update(UserChangeMessage.password_reset())
 
         # toggle active state


### PR DESCRIPTION
## Product Description
There is no user-facing entrypoint being added here, but it allows a system administrator to run a management command to log out and force reset the passwords of a given set of Web Users.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-13598

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
