### PR TITLE
Remove old UserPillow

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1730,11 +1730,6 @@ PILLOWTOPS = {
             }
         },
         {
-            'name': 'UserPillow',
-            'class': 'pillowtop.pillow.interface.ConstructedPillow',
-            'instance': 'corehq.pillows.user.get_user_pillow_old',
-        },
-        {
             'name': 'user-pillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.pillows.user.get_user_pillow',

--- a/testapps/test_pillowtop/tests/test_user_pillow.py
+++ b/testapps/test_pillowtop/tests/test_user_pillow.py
@@ -23,70 +23,85 @@ from pillowtop.es_utils import initialize_index_and_mapping
 from .base import BasePillowTestCase
 
 
-TEST_DOMAIN = 'user-pillow-test'
-
-
 @es_test
 class UserPillowTestBase(BasePillowTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'user-pillow-test'
+        domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(domain_obj.delete)
+
     def setUp(self):
-        super(UserPillowTestBase, self).setUp()
+        super().setUp()
         self.index_info = USER_INDEX_INFO
         self.elasticsearch = get_es_new()
         delete_all_users()
         ensure_index_deleted(self.index_info.index)
         initialize_index_and_mapping(self.elasticsearch, self.index_info)
-
-    @classmethod
-    def setUpClass(cls):
-        super(UserPillowTestBase, cls).setUpClass()
-        create_domain(TEST_DOMAIN)
-
-    def tearDown(self):
-        ensure_index_deleted(self.index_info.index)
-        super(UserPillowTestBase, self).tearDown()
+        self.addCleanup(ensure_index_deleted, self.index_info.index)
 
 
 @es_test
 class UserPillowTest(UserPillowTestBase):
 
-    def test_kafka_user_pillow(self):
-        self._make_and_test_user_kafka_pillow('user-pillow-test-kafka')
+    def setUp(self):
+        super().setUp()
+        self.user = CommCareUser.create(self.domain, 'test-user', 'secret', None, None)
+        self.user_pillow = get_user_pillow_old(skip_ucr=True)
+        self.addCleanup(self.user.delete, self.domain, deleted_by=None)
 
-    def test_kafka_user_pillow_deletion(self):
-        user = self._make_and_test_user_kafka_pillow('test-kafka-user_deletion')
-        # soft delete
-        user.retire(TEST_DOMAIN, deleted_by=None)
-
-        # send to kafka
+    def test_created_user_sent_to_elasticsearch(self):
         since = get_topic_offset(topics.COMMCARE_USER)
-        producer.send_change(topics.COMMCARE_USER, _user_to_change_meta(user))
+        producer.send_change(topics.COMMCARE_USER, _user_to_change_meta(self.user))
 
-        # send to elasticsearch
-        pillow = get_user_pillow_old(skip_ucr=True)
-        pillow.process_changes(since=since, forever=False)
+        self.user_pillow.process_changes(since=since, forever=False)
+
+        self.elasticsearch.indices.refresh(self.index_info.index)
+        hits = UserES().run().hits
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]['username'], 'test-user')
+
+    def test_edited_user_sent_to_elasticsearch(self):
+        since = get_topic_offset(topics.COMMCARE_USER)
+        producer.send_change(topics.COMMCARE_USER, _user_to_change_meta(self.user))
+        self.user_pillow.process_changes(since=since, forever=False)
+        self.user.first_name = 'edited'
+        self.user.save()
+        since = get_topic_offset(topics.COMMCARE_USER)
+        producer.send_change(topics.COMMCARE_USER, _user_to_change_meta(self.user))
+
+        self.user_pillow.process_changes(since=since, forever=False)
+
+        self.elasticsearch.indices.refresh(self.index_info.index)
+        user_doc = UserES().run().hits[0]
+        self.assertEqual(user_doc['first_name'], 'edited')
+
+    def test_deleted_user_sent_to_elasticsearch(self):
+        since = get_topic_offset(topics.COMMCARE_USER)
+        producer.send_change(topics.COMMCARE_USER, _user_to_change_meta(self.user))
+        self.user.retire(self.domain, deleted_by=None)
+        producer.send_change(topics.COMMCARE_USER, _user_to_change_meta(self.user))
+
+        self.user_pillow.process_changes(since=since, forever=False)
+
         self.elasticsearch.indices.refresh(self.index_info.index)
         self.assertEqual(0, UserES().run().total)
 
-    def _make_and_test_user_kafka_pillow(self, username):
-        # make a user
-        user = CommCareUser.create(TEST_DOMAIN, username, 'secret', None, None)
-
-        # send to kafka
+    def test_multiple_published_changes_sent_to_elasticsearch(self):
         since = get_topic_offset(topics.COMMCARE_USER)
-        producer.send_change(topics.COMMCARE_USER, _user_to_change_meta(user))
+        producer.send_change(topics.COMMCARE_USER, _user_to_change_meta(self.user))
+        self.user.first_name = 'multiple'
+        self.user.save()
+        producer.send_change(topics.COMMCARE_USER, _user_to_change_meta(self.user))
+        self.user.retire(self.domain, deleted_by=None)
+        producer.send_change(topics.COMMCARE_USER, _user_to_change_meta(self.user))
 
-        # send to elasticsearch
-        pillow = get_user_pillow_old()
-        pillow.process_changes(since=since, forever=False)
+        self.user_pillow.process_changes(since=since, forever=False)
+
         self.elasticsearch.indices.refresh(self.index_info.index)
-        self._verify_user_in_es(username)
-        return user
-
-    def _verify_user_in_es(self, username):
-        results = UserES().run()
-        self.assertEqual(1, results.total)
-        user_doc = results.hits[0]
-        self.assertEqual(username, user_doc['username'])
+        self.assertEqual(0, UserES().run().total)
 
 
 @es_test
@@ -95,9 +110,9 @@ class UnknownUserPillowTest(UserPillowTestBase):
     def test_unknown_user_pillow(self):
         FormProcessorTestUtils.delete_all_xforms()
         user_id = 'test-unknown-user'
-        metadata = TestFormMetadata(domain=TEST_DOMAIN, user_id='test-unknown-user')
+        metadata = TestFormMetadata(domain=self.domain, user_id='test-unknown-user')
         form = get_form_ready_to_save(metadata)
-        FormProcessorInterface(domain=TEST_DOMAIN).save_processed_models([form])
+        FormProcessorInterface(domain=self.domain).save_processed_models([form])
 
         # send to kafka
         topic = topics.FORM_SQL
@@ -116,7 +131,7 @@ class UnknownUserPillowTest(UserPillowTestBase):
         results = user_es.run()
         self.assertEqual(1, results.total)
         user_doc = results.hits[0]
-        self.assertEqual(TEST_DOMAIN, user_doc['domain'])
+        self.assertEqual(self.domain, user_doc['domain'])
         self.assertEqual(user_id, user_doc['_id'])
         self.assertEqual('UnknownUser', user_doc['doc_type'])
 

--- a/testapps/test_pillowtop/tests/test_user_pillow.py
+++ b/testapps/test_pillowtop/tests/test_user_pillow.py
@@ -14,7 +14,7 @@ from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
-from corehq.pillows.user import get_user_pillow_old
+from corehq.pillows.user import get_user_pillow
 from corehq.pillows.xform import get_xform_pillow
 from corehq.util.elastic import ensure_index_deleted
 from corehq.util.test_utils import get_form_ready_to_save
@@ -49,7 +49,7 @@ class UserPillowTest(UserPillowTestBase):
     def setUp(self):
         super().setUp()
         self.user = CommCareUser.create(self.domain, 'test-user', 'secret', None, None)
-        self.user_pillow = get_user_pillow_old(skip_ucr=True)
+        self.user_pillow = get_user_pillow(skip_ucr=True)
         self.addCleanup(self.user.delete, self.domain, deleted_by=None)
 
     def test_created_user_sent_to_elasticsearch(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I was poking around in this code, noticed we have quite a few old pillows hanging around that claim they could be removed after https://github.com/dimagi/commcare-hq/pull/21329 was rolled out, but they have remained.

I figure there might be a good reason for this, but after viewing datadog and confirming the old `UserPillow` is not in use, but the new `user-pillow` is, it felt a bit safer to at least start with removing the old user pillow. Additionally, the user pillow tests were still using the old pillow which didn't seem right. I added some test cases there and made it look more like tests we write these days while I was at it.

If it turns out we can't yet remove this, I'd at least want the test changes to go out.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
From what I can tell, the old UserPillow is not in use and safe to remove, which is all this PR does.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
