### PR TITLE
case search report instance fix

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -1,3 +1,39 @@
+"""
+Notes on instances
+==================
+
+Instances are used to reference data beyond the scope of the current XML document.
+Examples are the commcare session, casedb, lookup tables, mobile reports, case search data etc.
+
+When running applications instances are initialized using an instance declaration which ties the
+instance ID to the actual instance model:
+
+    <instance id="my-instance" ref="jr://fixture/my-fixture" />
+
+This allows using the fixture with the specified ID:
+
+    instance('my-instance')path/to/node
+
+From the mobile code point of view the ID is completely user defined and used only to 'register'
+the instance current context.
+
+Instances in CommCare HQ
+------------------------
+In CommCare HQ we allow app builders to reference instance in many places in the application
+but don't require that the app builder define the full instance declaration.
+
+When 'building' the app we rely on instance ID conventions to enable the build process to
+determine what 'ref' to use for the instances used in the app.
+
+For static instances like 'casedb' the instance ID must match a pre-defined name. For example
+* casedb
+* commcaresession
+* groups
+
+Other instances use a namespaced convention: "type:sub-type". For example:
+* commcare-reports:<uuid>
+* item-list:<fixture name>
+"""
 import re
 from collections import defaultdict
 

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -374,13 +374,7 @@ class SessionEndpointRemoteRequestFactory(RemoteRequestFactory):
         )
 
     def build_instances(self):
-        query_xpaths = [QuerySessionXPath(self.case_session_var).instance()]
-        query_xpaths.extend([datum.ref for datum in self._remote_request_query_datums])
-        query_xpaths.append(self.get_post_relevant())
-        instances, unknown_instances = get_all_instances_referenced_in_xpaths(self.app, query_xpaths)
-
-        # sorted list to prevent intermittent test failures
-        return sorted(instances, key=lambda i: i.id)
+        return []
 
     def build_remote_request_queries(self):
         return []

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -200,7 +200,8 @@ class EntriesHelper(object):
         # avoid circular dependency
         from corehq.apps.app_manager.models import Module, AdvancedModule
         results = []
-        using_inline_search = module_uses_inline_search(module) and not module_loads_registry_case(module)
+        loads_registry_case = module_loads_registry_case(module)
+        using_inline_search = module_uses_inline_search(module) and not loads_registry_case
         for form in module.get_suite_forms():
             e = Entry()
             e.form = form.xmlns
@@ -209,12 +210,14 @@ class EntriesHelper(object):
                 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import get_report_context_tile_datum
                 e.datums.append(get_report_context_tile_datum())
 
-            if form.requires_case() and using_inline_search:
+            if form.requires_case():
                 from corehq.apps.app_manager.suite_xml.post_process.remote_requests import RemoteRequestFactory
                 case_session_var = self.get_case_session_var_for_form(form)
-                factory = RemoteRequestFactory(None, module, [], case_session_var=case_session_var)
-                e.post = factory.build_remote_request_post()
-                e.instances = factory.build_instances()
+                remote_request_factory = RemoteRequestFactory(None, module, [], case_session_var=case_session_var)
+                if using_inline_search:
+                    e.post = remote_request_factory.build_remote_request_post()
+                if using_inline_search or loads_registry_case:
+                    e.instances = remote_request_factory.build_instances()
 
             # Ideally all of this version check should happen in Command/Display class
             if self.app.enable_localized_menu_media:

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -214,6 +214,7 @@ class EntriesHelper(object):
                 case_session_var = self.get_case_session_var_for_form(form)
                 factory = RemoteRequestFactory(None, module, [], case_session_var=case_session_var)
                 e.post = factory.build_remote_request_post()
+                e.instances = factory.build_instances()
 
             # Ideally all of this version check should happen in Command/Display class
             if self.app.enable_localized_menu_media:

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -9,6 +9,7 @@ from corehq.apps.app_manager.models import (
     DetailColumn,
     DetailTab,
     FormLink,
+    Itemset,
     Module,
     OpenCaseAction,
     ParentSelect,
@@ -211,6 +212,48 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             """,
             suite,
             "./entry[2]/stack/create"
+        )
+
+    @flag_enabled('MOBILE_UCR')
+    def test_prompt_itemset_mobile_report(self):
+        self.module.search_config.properties[0].input_ = 'select1'
+        instance_id = "123abc"
+        self.module.search_config.properties[0].itemset = Itemset(
+            instance_id=instance_id,
+            instance_uri="jr://fixture/commcare-reports:abcdef",
+            nodeset=f"instance('{instance_id}')/rows/row",
+            label='name',
+            value='id',
+            sort='id',
+        )
+        suite = self.app.create_suite()
+        expected = f"""
+            <partial>
+              <prompt key="name" input="select1">
+                <display>
+                  <text>
+                    <locale id="search_property.m0.name"/>
+                  </text>
+                </display>
+                <itemset nodeset="instance('{instance_id}')/rows/row">
+                  <label ref="name"/>
+                  <value ref="id"/>
+                  <sort ref="id"/>
+                </itemset>
+              </prompt>
+            </partial>
+            """
+        self.assertXmlPartialEqual(expected, suite, "./entry[1]/session/query/prompt[@key='name']")
+
+        expected_instance = f"""
+            <partial>
+              <instance id="{instance_id}" src="jr://fixture/commcare-reports:abcdef"/>
+            </partial>
+            """
+        self.assertXmlPartialEqual(
+            expected_instance,
+            suite,
+            f"./entry[1]/instance[@id='{instance_id}']",
         )
 
 

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -283,6 +283,48 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             "./entry[2]/stack/create"
         )
 
+    @flag_enabled('MOBILE_UCR')
+    def test_prompt_itemset_mobile_report(self):
+        self.module.search_config.properties[0].input_ = 'select1'
+        instance_id = "123abc"
+        self.module.search_config.properties[0].itemset = Itemset(
+            instance_id=instance_id,
+            instance_uri="jr://fixture/commcare-reports:abcdef",
+            nodeset=f"instance('{instance_id}')/rows/row",
+            label='name',
+            value='id',
+            sort='id',
+        )
+        suite = self.app.create_suite()
+        expected = f"""
+                <partial>
+                  <prompt key="name" input="select1">
+                    <display>
+                      <text>
+                        <locale id="search_property.m0.name"/>
+                      </text>
+                    </display>
+                    <itemset nodeset="instance('{instance_id}')/rows/row">
+                      <label ref="name"/>
+                      <value ref="id"/>
+                      <sort ref="id"/>
+                    </itemset>
+                  </prompt>
+                </partial>
+                """
+        self.assertXmlPartialEqual(expected, suite, "./entry[1]/session/query/prompt[@key='name']")
+
+        expected_instance = f"""
+                <partial>
+                  <instance id="{instance_id}" src="jr://fixture/commcare-reports:abcdef"/>
+                </partial>
+                """
+        self.assertXmlPartialEqual(
+            expected_instance,
+            suite,
+            f"./entry[1]/instance[@id='{instance_id}']",
+        )
+
 
 @patch('corehq.util.view_utils.get_url_base', new=lambda: "https://www.example.com")
 @patch_get_xform_resource_overrides()

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -711,6 +711,53 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             "./remote-request[1]/instance[@id='item-list:states']",
         )
 
+    def test_prompt_itemset_mobile_report_legacy(self):
+        self._test_prompt_itemset_mobile_report('abcdef')
+
+    def test_prompt_itemset_mobile_report(self):
+        self._test_prompt_itemset_mobile_report('commcare-reports:abcdef')
+
+    @flag_enabled('MOBILE_UCR')
+    def _test_prompt_itemset_mobile_report(self, instance_id):
+        self.module.search_config.properties[0].input_ = 'select1'
+        self.module.search_config.properties[0].itemset = Itemset(
+            instance_id=instance_id,
+            instance_uri="jr://fixture/commcare-reports:abcdef",
+            nodeset=f"instance('{instance_id}')/rows/row",
+            label='name',
+            value='id',
+            sort='id',
+        )
+        suite = self.app.create_suite()
+        expected = f"""
+        <partial>
+          <prompt key="name" input="select1">
+            <display>
+              <text>
+                <locale id="search_property.m0.name"/>
+              </text>
+            </display>
+            <itemset nodeset="instance('{instance_id}')/rows/row">
+              <label ref="name"/>
+              <value ref="id"/>
+              <sort ref="id"/>
+            </itemset>
+          </prompt>
+        </partial>
+        """
+        self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
+
+        expected_instance = f"""
+        <partial>
+          <instance id="{instance_id}" src="jr://fixture/commcare-reports:abcdef"/>
+        </partial>
+        """
+        self.assertXmlPartialEqual(
+            expected_instance,
+            suite,
+            f"./remote-request[1]/instance[@id='{instance_id}']",
+        )
+
     @flag_enabled("USH_CASE_CLAIM_UPDATES")
     def test_prompt_default_value(self, *args):
         """Setting the default to "default_value"

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -64,9 +64,10 @@ def item_lists_by_app(app):
     ]
     ret = list()
     for config in report_configs:
-        uri = 'jr://fixture/commcare-reports:%s' % (config.uuid)
+        instance_id = f'commcare-reports:{config.uuid}'  # follow HQ instance ID convention
+        uri = f'jr://fixture/{instance_id}'
         ret.append({
-            'id': config.uuid,
+            'id': instance_id,
             'uri': uri,
             'path': "/rows/row",
             'name': config.header.get(app.default_language),


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SUPPORT-13580

## Technical Summary
Fixes an issue where case search report instances 

The [UCR based dropdowns in case-search screen](https://github.com/dimagi/commcare-hq/pull/29435) feature used non-conventional instance IDs for the reports instances. While these worked on mobile they break the instance ID convention used in app builder which makes it impossible to validate them using the same process as other instances.

[This PR](https://github.com/dimagi/commcare-hq/pull/31630) combined the instance processing for remote request entries with normal entries. As a result apps using the non-conventional instance IDs can't be built.

This PR fixes the issue in 2 ways:
1. add the case search itemset instances directly to the entry as was done previously
2. update the auto-generation of the report instance IDs to follow the normal convention

This also fixes the issue for 'inline search' and 'data registry search'.

## Feature Flag
* USH case claim updates
* data registry
* inline search

## Safety Assurance

### Safety story
I think this is a well understood issue (both in therms of how it was working and what the fix should be). The app builder code is well covered by tests and additional tests have been added for this specific issue.

### Automated test coverage
Tests added for normal case search, inline search and data registry search.

### QA Plan
None


### Migrations
NA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
