### PR TITLE
[couch-to-sql] [Repeaters] Add missing field in FormRepeater

### DIFF
--- a/corehq/motech/repeaters/management/commands/migrate_formrepeater.py
+++ b/corehq/motech/repeaters/management/commands/migrate_formrepeater.py
@@ -18,13 +18,14 @@ class Command(RepeaterMigrationHelper):
 
     @classmethod
     def _get_list_props(cls):
-        return ['white_listed_form_xmlns']
+        return ['white_listed_form_xmlns', 'user_blocklist']
 
     @classmethod
     def get_sql_options_obj(cls, doc):
         return {
             "options": {
                 "white_listed_form_xmlns": doc.get("white_listed_form_xmlns"),
-                "include_app_id_param": doc.get("include_app_id_param")
+                "include_app_id_param": doc.get("include_app_id_param"),
+                "user_blocklist": doc.get("user_blocklist")
             }
         }

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -398,6 +398,7 @@ class SQLFormRepeater(SQLRepeater):
 
     include_app_id_param = OptionValue(default=True)
     white_listed_form_xmlns = OptionValue(default=list)
+    user_blocklist = OptionValue(default=list)
 
     class Meta:
         proxy = True

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -100,7 +100,7 @@ from dimagi.utils.couch.migration import (
     SyncSQLToCouchMixin,
 )
 from dimagi.utils.couch.undo import DELETED_SUFFIX
-from dimagi.utils.logging import notify_exception
+from dimagi.utils.logging import notify_error, notify_exception
 from dimagi.utils.modules import to_function
 from dimagi.utils.parsing import json_format_datetime
 
@@ -218,7 +218,13 @@ class RepeaterSuperProxy(models.Model):
             else:
                 repeater_class = REPEATER_CLASS_MAP.get(proxy_class_name)
                 if repeater_class is None:
-                    raise UnknownRepeater(proxy_class_name)
+                    details = {
+                        'args': args,
+                        'kwargs': kwargs
+                    }
+                    notify_error(UnknownRepeater(proxy_class_name), details=details)
+                    # Fallback to creating SQLRepeater if repeater class is not found
+                    repeater_class = cls
 
         return super().__new__(repeater_class)
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -455,7 +455,11 @@ class SQLFormRepeater(SQLRepeater):
 
     @classmethod
     def _migration_get_fields(cls):
-        return super()._migration_get_fields() + ["include_app_id_param", "white_listed_form_xmlns"]
+        return super()._migration_get_fields() + [
+            "include_app_id_param",
+            "white_listed_form_xmlns",
+            "user_blocklist"
+        ]
 
 
 class SQLCaseRepeater(SQLRepeater):
@@ -1156,7 +1160,11 @@ class FormRepeater(Repeater):
 
     @classmethod
     def _migration_get_fields(cls):
-        return super()._migration_get_fields() + ["include_app_id_param", "white_listed_form_xmlns"]
+        return super()._migration_get_fields() + [
+            "include_app_id_param",
+            "white_listed_form_xmlns",
+            "user_blocklist"
+        ]
 
     @classmethod
     def _migration_get_sql_model_class(cls):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
While writing tests for the `to_json` method of SQLRepeater, I noticed that some fields were more in Couch Repeaters. On investigating I found out that I have missed adding this field in `SQLFormRepeater` before. 

Since we are still reading from Couch so I will run the migrations for `FormRepeater` based classes again. This should fix any disparity in data.

This also adds a check that we have discussed in the Couch-Derisking meeting about not failing hard on invalid repeater types but rather having the error notification sent and falling back to SQLRepeater. See 808c96839d5162e265ad74a0427dd133faa0b03d
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12155
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
Tested locally and would be testing it out on staging.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There are numerous tests that verify that the change is safe. 
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA
<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
