### PR TITLE
centralise suite xml instance handling

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -1,39 +1,3 @@
-"""
-Notes on instances
-==================
-
-Instances are used to reference data beyond the scope of the current XML document.
-Examples are the commcare session, casedb, lookup tables, mobile reports, case search data etc.
-
-When running applications instances are initialized using an instance declaration which ties the
-instance ID to the actual instance model:
-
-    <instance id="my-instance" ref="jr://fixture/my-fixture" />
-
-This allows using the fixture with the specified ID:
-
-    instance('my-instance')path/to/node
-
-From the mobile code point of view the ID is completely user defined and used only to 'register'
-the instance current context.
-
-Instances in CommCare HQ
-------------------------
-In CommCare HQ we allow app builders to reference instance in many places in the application
-but don't require that the app builder define the full instance declaration.
-
-When 'building' the app we rely on instance ID conventions to enable the build process to
-determine what 'ref' to use for the instances used in the app.
-
-For static instances like 'casedb' the instance ID must match a pre-defined name. For example
-* casedb
-* commcaresession
-* groups
-
-Other instances use a namespaced convention: "type:sub-type". For example:
-* commcare-reports:<uuid>
-* item-list:<fixture name>
-"""
 import re
 from collections import defaultdict
 
@@ -52,7 +16,9 @@ from corehq.util.timer import time_method
 
 
 class EntryInstances(PostProcessor):
-    """Adds instance declarations to the suite file"""
+    """Adds instance declarations to the suite file
+
+    See docs/instances.rst"""
 
     IGNORED_INSTANCES = {
         'jr://instance/remote',
@@ -211,6 +177,10 @@ _factory_map = {}
 
 
 def get_instance_factory(instance_name):
+    """Get the instance factory for an instance name (ID).
+    This relies on a naming convention for instances: "scheme:id"
+
+    See docs/instances.rst"""
     try:
         scheme, _ = instance_name.split(':', 1)
     except ValueError:

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -23,7 +23,7 @@ from corehq.util.timer import time_method
 class EntryInstances(PostProcessor):
     """Adds instance declarations to the suite file
 
-    See docs/instances.rst"""
+    See docs/apps/instances.rst"""
 
     IGNORED_INSTANCES = {
         'jr://instance/remote',
@@ -215,7 +215,7 @@ def get_instance_factory(instance_name):
     """Get the instance factory for an instance name (ID).
     This relies on a naming convention for instances: "scheme:id"
 
-    See docs/instances.rst"""
+    See docs/apps/instances.rst"""
     try:
         scheme, _ = instance_name.split(':', 1)
     except ValueError:

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -97,7 +97,6 @@ class RemoteRequestFactory(object):
         return RemoteRequest(
             post=self.build_remote_request_post(),
             command=self.build_command(),
-            instances=self.build_instances(),
             session=self.build_session(),
             stack=self.build_stack(),
         )
@@ -144,20 +143,6 @@ class RemoteRequestFactory(object):
     @cached_property
     def _details_helper(self):
         return DetailsHelper(self.app)
-
-    def build_instances(self):
-        """Add in instance IDs configured in itemsets directly. This is to work around
-        a legacy issue where the instance IDs didn't conform to the
-        ID convention: 'commcare-reports:uuid' and were instead just the 'uuid'.
-        """
-        prompt_select_instances = [
-            Instance(id=prop.itemset.instance_id, src=prop.itemset.instance_uri)
-            for prop in self.module.search_config.properties
-            if prop.itemset.instance_id
-        ]
-
-        # sorted list to prevent intermittent test failures
-        return sorted(set(prompt_select_instances), key=lambda i: i.id)
 
     def build_session(self):
         return RemoteRequestSession(
@@ -372,9 +357,6 @@ class SessionEndpointRemoteRequestFactory(RemoteRequestFactory):
             id=f"claim_command.{self.endpoint_id}.{self.case_session_var}",
             display=Display(text=Text()),   # users never see this, but a Display and Text are required
         )
-
-    def build_instances(self):
-        return []
 
     def build_remote_request_queries(self):
         return []

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -210,14 +210,11 @@ class EntriesHelper(object):
                 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import get_report_context_tile_datum
                 e.datums.append(get_report_context_tile_datum())
 
-            if form.requires_case():
+            if form.requires_case() and using_inline_search:
                 from corehq.apps.app_manager.suite_xml.post_process.remote_requests import RemoteRequestFactory
                 case_session_var = self.get_case_session_var_for_form(form)
                 remote_request_factory = RemoteRequestFactory(None, module, [], case_session_var=case_session_var)
-                if using_inline_search:
-                    e.post = remote_request_factory.build_remote_request_post()
-                if using_inline_search or loads_registry_case:
-                    e.instances = remote_request_factory.build_instances()
+                e.post = remote_request_factory.build_remote_request_post()
 
             # Ideally all of this version check should happen in Command/Display class
             if self.app.enable_localized_menu_media:

--- a/docs/apps/instances.rst
+++ b/docs/apps/instances.rst
@@ -1,0 +1,47 @@
+Instances in suite.xml
+======================
+
+Instances are used to reference data beyond the scope of the current XML document.
+Examples are the commcare session, casedb, lookup tables, mobile reports, case search data etc.
+
+Instances are added into the suite file in `<entry>` elements and directly in the form XML. This is
+done in post processing of the suite file in ``corehq.apps.app_manager.suite_xml.post_process.instances``.
+
+How instances work
+------------------
+When running applications instances are initialized for the current context using an instance declaration
+which ties the instance ID to the actual instance model:
+
+    <instance id="my-instance" ref="jr://fixture/my-fixture" />
+
+This allows using the fixture with the specified ID:
+
+    instance('my-instance')path/to/node
+
+From the mobile code point of view the ID is completely user defined and only used to 'register'
+the instance in current context. The index 'ref' is used to determine which instance is attached
+to the given ID.
+
+Instances in CommCare HQ
+------------------------
+In CommCare HQ we allow app builders to reference instance in many places in the application
+but don't require that the app builder define the full instance declaration.
+
+When 'building' the app we rely on instance ID conventions to enable the build process to
+determine what 'ref' to use for the instances used in the app.
+
+For static instances like 'casedb' the instance ID must match a pre-defined name. For example
+* casedb
+* commcaresession
+* groups
+
+Other instances use a namespaced convention: "type:sub-type". For example:
+* commcare-reports:<uuid>
+* item-list:<fixture name>
+
+Custom instances
+----------------
+There are two places in app builder where users can define custom instances:
+
+* in a form using the 'CUSTOM_INSTANCES' plugin
+* in 'Lookup Table Selection' case search properties under 'Advanced Lookup Table Options'


### PR DESCRIPTION
## Technical Summary
Followup from https://github.com/dimagi/commcare-hq/pull/31702

This centralises the entry instance logic for suite XML generation instead of having special cases spread around the code.

The change treats instances defined in case search itemsets as 'custom instances'. This is possible because the data model defines the instance ID as well as the instance ref. The duplication logic is updated to only raise an exception if the instance ID is reused with a different `ref`. If both `id` and `ref` are the same then we can safely ignore the 'custom instance' since it will already be added via the normal mechanism.

## Safety Assurance

### Safety story
Code is well covered by tests and I've added some additional tests.

### Automated test coverage
Good existing coverage and some new tests added

### QA Plan
None

### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
