### PR TITLE
Checks OptionValue object

### DIFF
--- a/corehq/motech/repeaters/optionvalue.py
+++ b/corehq/motech/repeaters/optionvalue.py
@@ -36,6 +36,7 @@ class OptionValue(property):
     def __get__(self, obj, objtype=None):
         if obj is None:
             return self
+        _assert_options(obj)
         if self.schema:
             return self.schema(obj.options.setdefault(self.name, {}))
         if self.name in obj.options:
@@ -51,6 +52,7 @@ class OptionValue(property):
     def __set__(self, obj, value):
         if self.choices and value not in self.choices:
             raise ValueError(f"{value!r} not in {self.choices!r}")
+        _assert_options(obj)
         if self.schema:
             if not isinstance(value, self.schema):
                 raise TypeError(
@@ -65,3 +67,8 @@ class OptionValue(property):
 @attr.s
 class OptionSchema:
     options = attr.ib()
+
+
+def _assert_options(obj):
+    assert hasattr(obj, 'options') and isinstance(obj.options, dict), \
+        f"{obj!r} needs an 'options' dict to use OptionValue"

--- a/corehq/motech/repeaters/tests/test_optionvalue.py
+++ b/corehq/motech/repeaters/tests/test_optionvalue.py
@@ -85,6 +85,18 @@ def test_raises_on_invalid_schema():
         order.packaged_water = {"somedict": "hola"}
 
 
+def test_raises_on_no_options():
+    order = BadFoodOptions()
+    with assert_raises(AssertionError):
+        order.dish = 'Rhino'
+
+
+def test_raises_on_bad_options_type():
+    order = AlsoBadFoodOptions()
+    with assert_raises(AssertionError):
+        order.dish = 'Albatross'
+
+
 class WaterBottle(OptionSchema):
     qty = OptionValue(default="1")
 
@@ -96,3 +108,16 @@ class FoodOptions:
     food_option = OptionValue(default="veg", choices=["veg", "non-veg"])
     condiments = OptionValue(default=list)
     packaged_water = OptionValue(schema=WaterBottle)
+
+
+class BadFoodOptions:
+    dish = OptionValue()
+
+
+class AlsoBadFoodOptions:
+    options = (
+        ('ALB', 'Albatross'),
+        ('BON', 'Bonobo'),
+        ('DOL', 'Dolphin'),
+    )
+    dish = OptionValue()


### PR DESCRIPTION
## Technical Summary

While I was reviewing a Repeaters PR I realized there is an OptionValue-shaped hole in my knowledge about SQLRepeaters, so I read its code and its tests.

I made this small change because it represented a discovery for me -- that an "OptionValue" is used for managing an "options" property of the class it belongs to. (In hindsight, it's obvious! The clue is in the name!) But it doesn't explicitly say that anywhere, so I'm hoping this `assert` will make it clearer to the next person.

The `optionvalue` module could benefit from some documentation, and I'm willing to write it, but I'll need to learn a bit more about `OptionSchema` first. The word "schema" makes me think it's just a dictionary with a static set of keys. But I feel like I must be missing something.

## Safety Assurance

### Safety story

### Automated test coverage

Includes tests

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
