### PR TITLE
support for multi-select case list with inline search

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -89,7 +89,7 @@ class RemoteRequestFactory(object):
         else:
             if self.module.is_multi_select():
                 # the instance is dynamic and its ID matches the datum ID
-                self.case_session_var = SearchSelectedCasesInstanceXpath.id
+                self.case_session_var = SearchSelectedCasesInstanceXpath.default_id
             else:
                 self.case_session_var = self.module.search_config.case_session_var
 
@@ -125,7 +125,7 @@ class RemoteRequestFactory(object):
         return data
 
     def _get_multi_select_nodeset(self):
-        return SearchSelectedCasesInstanceXpath().instance()
+        return SearchSelectedCasesInstanceXpath(self.case_session_var).instance()
 
     def _get_multi_select_exclude(self):
         return CaseIDXPath(XPath("current()").slash(".")).case().count().eq(1)

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -163,6 +163,32 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             </partial>"""  # noqa: E501
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[2]")
 
+    def test_inline_search_multi_select(self):
+        self.module.case_details.short.multi_select = True
+
+        suite = self.app.create_suite()
+
+        expected_entry_post = """
+        <partial>
+            <post url="http://localhost:8000/a/test_domain/phone/claim-case/"
+                relevant="$case_id != ''">
+             <data key="case_id"
+                nodeset="instance('selected_cases')/results/value" ref="."
+                exclude="count(instance('casedb')/casedb/case[@case_id=current()/.]) = 1"/>
+            </post>
+        </partial>"""  # noqa: E501
+        self.assertXmlPartialEqual(expected_entry_post, suite, "./entry[1]/post")
+
+        expected_entry_datum = """
+                <partial>
+                    <instance-datum id="selected_cases"
+                        nodeset="instance('results')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
+                        value="./@case_id"
+                        detail-confirm="m0_case_long"
+                        detail-select="m0_case_short"/>
+                </partial>"""  # noqa: E501
+        self.assertXmlPartialEqual(expected_entry_datum, suite, "./entry[1]/session/instance-datum")
+
     def test_case_detail_tabs_with_inline_search(self):
         """Test that the detail nodeset uses the correct instance (results not casedb)"""
         self.app.get_module(0).case_details.long.tabs = [

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -405,8 +405,12 @@ class IndicatorXpath(InstanceXpath):
 
 
 class SearchSelectedCasesInstanceXpath(InstanceXpath):
-    id = "search_selected_cases"
+    default_id = "search_selected_cases"
     path = "results/value"
+
+    @property
+    def id(self):
+        return self or self.default_id
 
 
 class CommCareSession(object):


### PR DESCRIPTION
## Technical Summary
Fix interaction between multi-select and 'inline search' that resulted in using the incorrect instance ID in the entry post.

https://dimagi-dev.atlassian.net/browse/QA-4233

## Feature Flag
inline case search

## Safety Assurance

### Safety story
Good test coverage

### Automated test coverage
Existing tests covering existing functionality and new test for the fix

### QA Plan
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
