### PR TITLE
Fix bug in Lookup Tables download: indexes missing on multi-table downloads

### DIFF
--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -105,7 +105,7 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
     excel_sheets = {}
 
     def empty_padding_list(length):
-        return ["" for x in range(0, length)]
+        return [""] * length
 
     max_fields = 0
     max_item_attributes = 0
@@ -312,7 +312,7 @@ def get_indexed_field_numbers(tables):
 
 
 def iter_types_headers(max_fields, indexed_field_numbers):
-    for x in range(1, max_fields + 1):
-        yield "field %d" % x
-        if x - 1 in indexed_field_numbers:
-            yield "field %d: is_indexed?" % x
+    for i in range(max_fields):
+        yield f"field {i + 1}"
+        if i in indexed_field_numbers:
+            yield f"field {i + 1}: is_indexed?"

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -104,6 +104,9 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
     """
     excel_sheets = {}
 
+    def get_field_prop_format(field_number, property_number):
+        return f"field {field_number} : property {property_number}"
+
     def empty_padding_list(length):
         return [""] * length
 
@@ -127,7 +130,6 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
           }
     """
     type_field_properties = {}
-    get_field_prop_format = lambda x, y: "field " + str(x) + " : property " + str(y)
     for event_count, data_type in enumerate(data_types_view):
         # Helpers to generate 'types' sheet
         type_field_properties[data_type.tag] = {}
@@ -201,8 +203,8 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
                 field_vals.append('yes' if field.is_indexed else 'no')
                 indexed_field_count += 1
         field_vals.extend(empty_padding_list(
-            max_fields - len(data_type.fields) +
-            len(indexed_field_numbers) - indexed_field_count
+            max_fields - len(data_type.fields)
+            + len(indexed_field_numbers) - indexed_field_count
         ))
         item_att_vals = (data_type.item_attributes + empty_padding_list(
             max_item_attributes - len(data_type.item_attributes)

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -1,5 +1,6 @@
 import io
 from datetime import datetime, timedelta
+from itertools import zip_longest
 
 from django.template.defaultfilters import yesno
 from django.utils.translation import gettext as _
@@ -304,14 +305,10 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
 
 
 def get_indexed_field_numbers(tables, max_fields):
-    indexed = set()
-    for x in range(1, max_fields + 1):
-        try:
-            if any(data_type.fields[x - 1].is_indexed for data_type in tables):
-                indexed.add(x - 1)
-        except IndexError:
-            continue
-    return indexed
+    class no_index:
+        is_indexed = False
+    field_lists = zip_longest(*(t.fields for t in tables), fillvalue=no_index)
+    return {i for i, fields in enumerate(field_lists) if any(f.is_indexed for f in fields)}
 
 
 def iter_types_headers(max_fields, indexed_field_numbers):

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -177,7 +177,7 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
         item_helpers_by_type[data_type.tag] = item_helpers
 
     # Prepare 'types' sheet data
-    indexed_field_numbers = get_indexed_field_numbers(data_types_view, max_fields)
+    indexed_field_numbers = get_indexed_field_numbers(data_types_view)
     types_sheet = {"headers": [], "rows": []}
     types_sheet["headers"] = [DELETE_HEADER, "table_id", 'is_global?']
     types_sheet["headers"].extend(iter_types_headers(max_fields, indexed_field_numbers))
@@ -304,7 +304,7 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
     return data_types_book, excel_sheets
 
 
-def get_indexed_field_numbers(tables, max_fields):
+def get_indexed_field_numbers(tables):
     class no_index:
         is_indexed = False
     field_lists = zip_longest(*(t.fields for t in tables), fillvalue=no_index)

--- a/corehq/apps/fixtures/tests/test_download.py
+++ b/corehq/apps/fixtures/tests/test_download.py
@@ -6,12 +6,12 @@ from ..models import FixtureDataType, FixtureTypeField
 
 def test_get_indexed_field_numbers():
     table = create_index_tables()[1]
-    eq(mod.get_indexed_field_numbers([table], 5), {0, 2, 4})
+    eq(mod.get_indexed_field_numbers([table]), {0, 2, 4})
 
 
 def test_get_indexed_field_numbers_for_multiple_tables():
     tables = create_index_tables()
-    eq(mod.get_indexed_field_numbers(tables, 7), {0, 1, 2, 4, 6})
+    eq(mod.get_indexed_field_numbers(tables), {0, 1, 2, 4, 6})
 
 
 def test_iter_types_headers():

--- a/corehq/apps/fixtures/tests/test_download.py
+++ b/corehq/apps/fixtures/tests/test_download.py
@@ -1,0 +1,55 @@
+from testil import eq
+
+from .. import download as mod
+from ..models import FixtureDataType, FixtureTypeField
+
+
+def test_get_indexed_field_numbers():
+    table = create_index_tables()[1]
+    eq(mod.get_indexed_field_numbers([table], 5), {0, 2, 4})
+
+
+def test_get_indexed_field_numbers_for_multiple_tables():
+    tables = create_index_tables()
+    eq(mod.get_indexed_field_numbers(tables, 7), {0, 1, 2, 4, 6})
+
+
+def test_iter_types_headers():
+    eq(list(mod.iter_types_headers(7, {0, 3, 6})), [
+        "field 1",
+        "field 1: is_indexed?",
+        "field 2",
+        "field 3",
+        "field 4",
+        "field 4: is_indexed?",
+        "field 5",
+        "field 6",
+        "field 7",
+        "field 7: is_indexed?",
+    ])
+
+
+def create_index_tables():
+    return [
+        FixtureDataType(fields=[
+            FixtureTypeField(field_name="a1", properties=[], is_indexed=True),
+            FixtureTypeField(field_name="a2", properties=[], is_indexed=True),
+            FixtureTypeField(field_name="a3", properties=[], is_indexed=False),
+        ]),
+        FixtureDataType(fields=[
+            FixtureTypeField(field_name="b1", properties=[], is_indexed=True),
+            FixtureTypeField(field_name="b2", properties=[], is_indexed=False),
+            FixtureTypeField(field_name="b3", properties=[], is_indexed=True),
+            FixtureTypeField(field_name="b4", properties=[], is_indexed=False),
+            FixtureTypeField(field_name="b5", properties=[], is_indexed=True),
+        ]),
+        FixtureDataType(fields=[
+            FixtureTypeField(field_name="c1", properties=[], is_indexed=False),
+            FixtureTypeField(field_name="c2", properties=[], is_indexed=False),
+            FixtureTypeField(field_name="c3", properties=[], is_indexed=False),
+            FixtureTypeField(field_name="c4", properties=[], is_indexed=False),
+            FixtureTypeField(field_name="c5", properties=[], is_indexed=False),
+            FixtureTypeField(field_name="c6", properties=[], is_indexed=False),
+            FixtureTypeField(field_name="c7", properties=[], is_indexed=True),
+        ]),
+    ]


### PR DESCRIPTION
Bug explanation: `indexed_field_numbers` was missing some index numbers if a table with more fields occurred after one with less fields in the `data_types_view` list because `data_type.fields[x - 1]` threw `IndexError` each time the earlier table with less fields was visited, which broke the tables iteration, skipping later tables with more fields.

Indexes were missing intermittently on multi-table downloads only since the order of tables in `data_types_view` is non-deterministic.

I am hoping to further refactor the lookup tables downloader soon since I am working in this area right now. It is one giant function with no tests that should be broken up into smaller functions (with tests, obviously).

https://dimagi-dev.atlassian.net/browse/SAAS-13599

:blowfish: Review by commit.

## Safety Assurance

### Safety story

All changes are either trivial or covered by (new) tests.

### Automated test coverage

Added tests for extracted functions, including one test that demonstrated the bug.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
