### PR TITLE
Fix error in report.owner_email with null owner

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -613,6 +613,8 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
     @property
     @memoized
     def owner_email(self):
+        if self.owner is None:
+            return None
         if self.owner.is_web_user():
             return self.owner.username
 

--- a/corehq/apps/saved_reports/tests/test_models.py
+++ b/corehq/apps/saved_reports/tests/test_models.py
@@ -4,7 +4,7 @@ from smtplib import SMTPSenderRefused
 from dimagi.utils.django.email import LARGE_FILE_SIZE_ERROR_CODE
 from unittest.mock import create_autospec, patch, PropertyMock, ANY
 from corehq.apps.reports import views
-from corehq.apps.users.models import WebUser
+from corehq.apps.users.models import CouchUser, WebUser
 from corehq.apps.saved_reports import models
 from ..models import ReportNotification, ReportConfig
 
@@ -43,6 +43,12 @@ class TestReportNotification(SimpleTestCase):
         report = ReportNotification(owner_id='5', domain='test_domain', recipient_emails=['test@dimagi.com'])
         subscribed_user = self._create_user(email='test@dimagi.com')
         self.assertTrue(report.can_be_viewed_by(subscribed_user))
+
+    def test_report_with_unknown_owner_has_null_owner_email(self):
+        report = ReportNotification(owner_id='5', domain='test_domain')
+        with patch.object(CouchUser, "get_by_user_id", lambda uid: None):
+            self.assertIsNone(report.owner)
+            self.assertIsNone(report.owner_email)
 
     def _create_user(self, id='100', email='not-included', is_domain_admin=False):
         user_template = WebUser(domain='test_domain', username='test_user')


### PR DESCRIPTION
Second attempt at fixing https://dimagi-dev.atlassian.net/browse/SAAS-13593

## Safety Assurance

### Safety story

Very minor and simple change.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
