### PR TITLE
12 hour time in web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -30,6 +30,7 @@ hqDefine("cloudcare/js/form_entry/const", function () {
         COLLAPSIBLE: 'group-collapse',
         COLLAPSIBLE_OPEN: 'collapse-open',
         COLLAPSIBLE_CLOSED: 'collapse-closed',
+        TIME_12_HOUR: '12-hour',
         ETHIOPIAN: 'ethiopian',
 
         // Note it's important to differentiate these two

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -805,7 +805,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         if (question.style) {
             style = ko.utils.unwrapObservable(question.style.raw);
             if (style === Const.TIME_12_HOUR) {
-                this.clientFormat = 'HH:mm a';
+                this.clientFormat = 'h:mm a';
                 is12Hour = true;
             }
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -800,6 +800,18 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
 
     function TimeEntry(question, options) {
         this.templateType = 'time';
+        var style = "",
+            is12Hour = false;
+        if (question.style) {
+            style = ko.utils.unwrapObservable(question.style.raw);
+            if (style === Const.TIME_12_HOUR) {
+                this.clientFormat = 'HH:mm a';
+                is12Hour = true;
+            }
+        }
+        this.helpText = function () {
+            return is12Hour ? gettext("12-hour clock") : gettext("24-hour clock");
+        };
         DateTimeEntryBase.call(this, question, options);
     }
     TimeEntry.prototype = Object.create(DateTimeEntryBase.prototype);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -761,7 +761,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                     var d = moment(date, self.clientFormat);
                     return d.isValid() ? d : null;
                 },
-            }));
+            }, self.extraOptions));
             self.$picker.on("dp.change", function (e) {
                 if (!e.date) {
                     self.answer(Const.NO_ANSWER);
@@ -785,6 +785,9 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     // Formatting string should be in moment format: https://momentjs.com/docs/#/displaying/format/
     DateTimeEntryBase.prototype.serverFormat = undefined;
 
+    // Extra options to pass to datetimepicker widget
+    DateTimeEntryBase.prototype.extraOptions = {};
+
     function DateEntry(question, options) {
         this.templateType = 'date';
         DateTimeEntryBase.call(this, question, options);
@@ -804,6 +807,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
 
     TimeEntry.prototype.clientFormat = 'HH:mm';
     TimeEntry.prototype.serverFormat = 'HH:mm';
+    TimeEntry.prototype.extraOptions = {showTodayButton: false};
 
     function EthiopianDateEntry(question, options) {
         var self = this,

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -289,6 +289,33 @@ hqDefine('cloudcare/js/util', [
             icons: {
                 today: 'glyphicon glyphicon-calendar',
             },
+            tooltips: {     // use default text, but enable translations
+                today: gettext('Go to today'),
+                clear: gettext('Clear selection'),
+                close: gettext('Close the picker'),
+                selectMonth: gettext('Select Month'),
+                prevMonth: gettext('Previous Month'),
+                nextMonth: gettext('Next Month'),
+                selectYear: gettext('Select Year'),
+                prevYear: gettext('Previous Year'),
+                nextYear: gettext('Next Year'),
+                selectDecade: gettext('Select Decade'),
+                prevDecade: gettext('Previous Decade'),
+                nextDecade: gettext('Next Decade'),
+                prevCentury: gettext('Previous Century'),
+                nextCentury: gettext('Next Century'),
+                pickHour: gettext('Pick Hour'),
+                incrementHour: gettext('Increment Hour'),
+                decrementHour: gettext('Decrement Hour'),
+                pickMinute: gettext('Pick Minute'),
+                incrementMinute: gettext('Increment Minute'),
+                decrementMinute: gettext('Decrement Minute'),
+                pickSecond: gettext('Pick Second'),
+                incrementSecond: gettext('Increment Second'),
+                decrementSecond: gettext('Decrement Second'),
+                togglePeriod: gettext('Toggle Period'),
+                selectTime: gettext('Select Time'),
+            },
         };
     };
 

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -529,12 +529,12 @@
 </script>
 
 <script type="text/html" id="time-entry-ko-template">
-  <span class="help-block sr-only">{% trans "24-hour clock" %}</span>
+  <span class="help-block sr-only" data-bind="text: helpText()"></span>
   <div class="input-group">
     <input type="text" class="form-control" data-bind="attr: { id: entryId, 'aria-required': $parent.required() ? 'true' : 'false' }"/>
     <span class="input-group-addon"><i class="fa fa-clock-o"></i></span>
   </div>
-  <span class="help-block" aria-hidden="true">{% trans "24-hour clock" %}</span>
+  <span class="help-block" aria-hidden="true" data-bind="text: helpText()"></span>
 </script>
 
 <script type="text/html" id="ethiopian-date-entry-ko-template">


### PR DESCRIPTION
## Product Description
Add an appearance attribute, `12-hour`, to support a 12-hour clock. The USH delivery team has mentioned this a couple of times recently.

![Screen Shot 2022-06-01 at 11 17 32 AM](https://user-images.githubusercontent.com/1486591/171440008-55063eaf-c841-4567-aa34-f1f0ffa6dea4.png)

![Screen Shot 2022-06-01 at 11 17 37 AM](https://user-images.githubusercontent.com/1486591/171440040-646c319a-ac4e-4305-9bad-c6a6d301ecc4.png)

Also has a couple of minor followup changes for https://github.com/dimagi/commcare-hq/pull/31671

## Safety Assurance

### Safety story
Pretty small, tested locally (that the widget works and that the data submitted is correct). Going to ask QA to take a look at it anyway, because it's good to be paranoid about web apps ui changes.

### Automated test coverage

None.

### QA Plan

https://dimagi-dev.atlassian.net/browse/QA-4243

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
