### PR TITLE
ensure that js_api_keys does not permanently mutate settings.ANALYTICS_IDS

### DIFF
--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -100,8 +100,8 @@ def js_api_keys(request):
     if getattr(request, 'couch_user', None) and not request.couch_user.analytics_enabled:
         return {}  # disable js analytics
     api_keys = {
-        'ANALYTICS_IDS': settings.ANALYTICS_IDS,
-        'ANALYTICS_CONFIG': settings.ANALYTICS_CONFIG,
+        'ANALYTICS_IDS': settings.ANALYTICS_IDS.copy(),
+        'ANALYTICS_CONFIG': settings.ANALYTICS_CONFIG.copy(),
         'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN,
     }
     if getattr(request, 'project', None) and request.project.ga_opt_out and api_keys['ANALYTICS_IDS'].get('GOOGLE_ANALYTICS_API_ID'):

--- a/corehq/util/tests/test_context_processors.py
+++ b/corehq/util/tests/test_context_processors.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+from django.test import SimpleTestCase, RequestFactory
+
+from ..context_processors import js_api_keys
+
+
+class FakeCouchUser:
+    def __init__(self, analytics_enabled):
+        self.analytics_enabled = analytics_enabled
+
+
+class FakeProject:
+    def __init__(self, ga_opt_out):
+        self.ga_opt_out = ga_opt_out
+
+
+def _mock_is_hubspot_js_allowed_for_request(request):
+    return request.is_hubspot_js_allowed_for_request
+
+
+class TestJsApiKeys(SimpleTestCase):
+
+    def test_blocked_couch_user_returns_nothing(self):
+        blocked_request = RequestFactory().get('/test')
+        blocked_request.couch_user = FakeCouchUser(False)
+        self.assertEqual(js_api_keys(blocked_request), {})
+
+    def test_settings_is_not_mutated_when_google_analytics_is_deleted(self):
+        normal_request = RequestFactory().get('/test')
+        blocked_request = RequestFactory().get('/test')
+        blocked_request.project = FakeProject(True)
+        self.assertIsNone(js_api_keys(blocked_request)['ANALYTICS_IDS'].get('GOOGLE_ANALYTICS_API_ID'))
+        self.assertIsNotNone(js_api_keys(normal_request)['ANALYTICS_IDS'].get('GOOGLE_ANALYTICS_API_ID'))
+
+    @patch(
+        'corehq.util.context_processors.is_hubspot_js_allowed_for_request',
+        _mock_is_hubspot_js_allowed_for_request
+    )
+    def test_settings_is_not_mutated_when_hubspot_analytics_is_deleted(self):
+        normal_request = RequestFactory().get('/test')
+        normal_request.is_hubspot_js_allowed_for_request = True
+
+        blocked_request = RequestFactory().get('/test')
+        blocked_request.is_hubspot_js_allowed_for_request = False
+
+        blocked_js_keys = js_api_keys(blocked_request)
+        self.assertEqual(blocked_js_keys['ANALYTICS_IDS'].get('HUBSPOT_API_ID'), '')
+        self.assertEqual(blocked_js_keys['ANALYTICS_IDS'].get('HUBSPOT_API_KEY'), '')
+
+        normal_js_keys = js_api_keys(blocked_request)
+        self.assertIsNotNone(normal_js_keys['ANALYTICS_IDS'].get('HUBSPOT_API_ID'))
+        self.assertIsNotNone(normal_js_keys['ANALYTICS_IDS'].get('HUBSPOT_API_KEY'))

--- a/corehq/util/tests/test_context_processors.py
+++ b/corehq/util/tests/test_context_processors.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-from django.test import SimpleTestCase, RequestFactory
+from django.test import SimpleTestCase, RequestFactory, override_settings
 
 from ..context_processors import js_api_keys
 
@@ -18,6 +18,11 @@ def _mock_is_hubspot_js_allowed_for_request(request):
     return request.is_hubspot_js_allowed_for_request
 
 
+@override_settings(ANALYTICS_IDS={
+    'GOOGLE_ANALYTICS_API_ID': 'UA-for-tests-only',
+    'HUBSPOT_API_ID': 'test_api_id',
+    'HUBSPOT_API_KEY': 'test_api_key',
+})
 class TestJsApiKeys(SimpleTestCase):
 
     def test_blocked_couch_user_returns_nothing(self):

--- a/testsettings.py
+++ b/testsettings.py
@@ -123,10 +123,3 @@ METRICS_PROVIDERS = [
 ]
 
 FORMPLAYER_INTERNAL_AUTH_KEY = "abc123"
-
-
-ANALYTICS_IDS = {
-    'GOOGLE_ANALYTICS_API_ID': 'UA-for-tests-only',
-    'HUBSPOT_API_ID': 'test_api_id',
-    'HUBSPOT_API_KEY': 'test_api_key',
-}

--- a/testsettings.py
+++ b/testsettings.py
@@ -123,3 +123,10 @@ METRICS_PROVIDERS = [
 ]
 
 FORMPLAYER_INTERNAL_AUTH_KEY = "abc123"
+
+
+ANALYTICS_IDS = {
+    'GOOGLE_ANALYTICS_API_ID': 'UA-for-tests-only',
+    'HUBSPOT_API_ID': 'test_api_id',
+    'HUBSPOT_API_KEY': 'test_api_key',
+}


### PR DESCRIPTION
## Technical Summary
Turns out requests can permanently alter `settings` for all other requests!

This ensures that `js_api_keys` does not mutate `settings.ANALYTICS_IDS` for other unrelated requests if certain analytics features are blocked

## Safety Assurance

### Safety story
Fixes the bug reported in https://dimagi-dev.atlassian.net/browse/SAAS-11157
Comes with tests!

### Automated test coverage
Yes

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
