### PR TITLE
include instance items with legacy ID format

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -109,7 +109,7 @@ from corehq.apps.domain.decorators import (
     track_domain_request,
 )
 from corehq.apps.domain.models import Domain
-from corehq.apps.fixtures.fixturegenerators import item_lists_by_app
+from corehq.apps.fixtures.fixturegenerators import item_lists_by_app, REPORT_FIXTURE, LOOKUP_TABLE_FIXTURE
 from corehq.apps.fixtures.models import FixtureDataType
 from corehq.apps.hqmedia.controller import MultimediaHTMLUploadController
 from corehq.apps.hqmedia.models import (
@@ -198,7 +198,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
     '''
     Get context items that are used by both basic and advanced modules.
     '''
-    item_lists = item_lists_by_app(app) if app.enable_search_prompt_appearance else []
+    item_lists = item_lists_by_app(app, module) if app.enable_search_prompt_appearance else []
     case_types = set(module.search_config.additional_case_types) | {module.case_type}
     context = {
         'details': _get_module_details_context(request, app, module, case_property_builder),
@@ -224,8 +224,8 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             'exclude_from_search_enabled': app.enable_exclude_from_search,
             'required_search_fields_enabled': app.enable_required_search_fields,
             'item_lists': item_lists,
-            'has_lookup_tables': bool([i for i in item_lists if i['fixture_type'] == 'lookup_table_fixture']),
-            'has_mobile_ucr': bool([i for i in item_lists if i['fixture_type'] == 'report_fixture']),
+            'has_lookup_tables': bool([i for i in item_lists if i['fixture_type'] == LOOKUP_TABLE_FIXTURE]),
+            'has_mobile_ucr': bool([i for i in item_lists if i['fixture_type'] == REPORT_FIXTURE]),
             'search_properties': module.search_config.properties if module_offers_search(module) else [],
             'auto_launch': module.search_config.auto_launch if module_offers_search(module) else False,
             'default_search': module.search_config.default_search if module_offers_search(module) else False,

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -17,6 +17,9 @@ from corehq.util.metrics import metrics_histogram
 from corehq.util.xml_utils import serialize
 from .utils import clean_fixture_field_name, get_index_schema_node
 
+LOOKUP_TABLE_FIXTURE = 'lookup_table_fixture'
+REPORT_FIXTURE = 'report_fixture'
+
 
 def item_lists_by_domain(domain, namespace_ids=False):
     ret = list()
@@ -50,9 +53,7 @@ def item_lists_by_domain(domain, namespace_ids=False):
     return ret
 
 
-def item_lists_by_app(app):
-    LOOKUP_TABLE_FIXTURE = 'lookup_table_fixture'
-    REPORT_FIXTURE = 'report_fixture'
+def item_lists_by_app(app, module):
     lookup_lists = item_lists_by_domain(app.domain, namespace_ids=True).copy()
     for item in lookup_lists:
         item['fixture_type'] = LOOKUP_TABLE_FIXTURE
@@ -62,18 +63,33 @@ def item_lists_by_app(app):
         for module in app.get_report_modules()
         for report_config in module.report_configs
     ]
+    if not report_configs:
+        return lookup_lists
+
+    legacy_instance_ids = {
+        prop.itemset.instance_id
+        for prop in module.search_config.properties
+        if prop.itemset.instance_id and 'commcare-reports:' not in prop.itemset.instance_id
+    }
     ret = list()
     for config in report_configs:
         instance_id = f'commcare-reports:{config.uuid}'  # follow HQ instance ID convention
         uri = f'jr://fixture/{instance_id}'
-        ret.append({
+        item = {
             'id': instance_id,
             'uri': uri,
             'path': "/rows/row",
             'name': config.header.get(app.default_language),
             'structure': {},
             'fixture_type': REPORT_FIXTURE,
-        })
+        }
+        ret.append(item)
+        if config.uuid in legacy_instance_ids:
+            # add in item with the legacy ID to support apps using the old ID format
+            legacy_item = item.copy()
+            legacy_item['id'] = config.uuid
+            legacy_item['name'] = f"{item['name']} (legacy)"
+            ret.append(legacy_item)
     return lookup_lists + ret
 
 


### PR DESCRIPTION
## Technical Summary
Followup from https://github.com/dimagi/commcare-hq/pull/31702 to prevent breaking apps using the old ID format.

Jira: https://dimagi-dev.atlassian.net/browse/SUPPORT-13580
## Feature Flag
mobile ucr

## Safety Assurance

### Safety story
I did test this thoroughly this time, all both:
* apps using old format
* apps using new format

### Automated test coverage
None

### QA Plan
None

### Migrations
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
