### PR TITLE
identify instances in xforms that use double quotes

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -312,6 +312,7 @@ def get_all_instances_referenced_in_xpaths(app, xpaths):
         if not xpath:
             continue
 
+        xpath = xpath.replace("&quot;", '"')
         instance_names = re.findall(instance_re, xpath, re.UNICODE)
         for instance_name in instance_names:
             factory = get_instance_factory(instance_name)

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -1,3 +1,4 @@
+import html
 import re
 from collections import defaultdict
 
@@ -312,7 +313,7 @@ def get_all_instances_referenced_in_xpaths(app, xpaths):
         if not xpath:
             continue
 
-        xpath = xpath.replace("&quot;", '"')
+        xpath = html.unescape(xpath)
         instance_names = re.findall(instance_re, xpath, re.UNICODE)
         for instance_name in instance_names:
             factory = get_instance_factory(instance_name)

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1029,7 +1029,12 @@ class XForm(WrappedNode):
           "country": "jr://fixture/item-list:country"
         }
         """
-        instance_nodes = self.model_node.findall('{f}instance')
+        def _get_instances():
+            return itertools.chain(
+                self.model_node.findall('{f}instance'),
+                self.model_node.findall('instance')
+            )
+        instance_nodes = _get_instances()
         instance_dict = {}
         for instance_node in instance_nodes:
             instance_id = instance_node.attrib.get('id')


### PR DESCRIPTION
## Technical Summary
In xforms double quotes will often get escaped as `&quot;` which evades the code that finds instance references.

This PR unescapes the quotations before looking for instance IDs.

Jira: https://dimagi-dev.atlassian.net/browse/USH-2089?focusedCommentId=209410

## Safety Assurance

### Safety story
Good test covered of all related code.

### Automated test coverage
Test added for this specific issue.

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
