### PR TITLE
catch Http404 error and return a simple response

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -8,6 +8,7 @@ from django.http import (
     Http404,
     HttpResponse,
     HttpResponseBadRequest,
+    HttpResponseNotFound,
     JsonResponse,
 )
 from django.utils.translation import gettext as _
@@ -456,6 +457,9 @@ def case_fixture(request, domain, app_id):
             cases = _data_registry_case_fixture(request, domain, app_id, case_types, case_ids, registry)
         except RegistryAccessException as e:
             return HttpResponseBadRequest(str(e))
+        except Http404 as e:
+            # convert to a simple response to avoid the HTML error page
+            return HttpResponseNotFound(str(e))
     else:
         cases = _single_domain_case_fixture(request, domain, case_types, case_ids)
 


### PR DESCRIPTION
## Technical Summary
In case of a 404 don't return the full 404 HTML response, just return a simple response with a message. This mainly helps debugging when looking at errors in Sentry.

I considered using the `@json_error` decorator but it seemed weird to have and XML endpoint return errors in JSON.

## Feature Flag
data registry, inline case search

## Safety Assurance

### Safety story
very small change covered by tests

### Automated test coverage
existing coverage

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
