### PR TITLE
update the wording in the 'delete menu' modal

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/module_link.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/module_link.html
@@ -63,16 +63,25 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title">
+            {% if module.module_type == 'basic' %}
               {% if module.is_surveys %}
-                  {% blocktrans %}
-                  Are you sure you want to delete this survey folder?
-                  {% endblocktrans %}
+                {% trans "Survey Menu" as menu %}
               {% else %}
-                  {% blocktrans %}
-                  Are you sure you want to delete this case list?
-                  {% endblocktrans %}
+                {% trans "Case List" as menu %}
               {% endif %}
+            {% elif module.module_type == 'report' %}
+              {% trans "Report Menu" as menu %}
+            {% elif module.module_type == 'advanced' %}
+              {% trans "Advanced Menu" as menu %}
+            {% elif module.module_type == 'shadow' %}
+              {% trans "Shadow Menu" as menu %}
+            {% else %}
+              {% trans "menu" as menu %}
+            {% endif %}
+            <h4 class="modal-title">
+              {% blocktrans %}
+                Are you sure you want to delete this {{ menu }}?
+              {% endblocktrans %}
             </h4>
           </div>
           <form action="{% url "delete_module" domain app.id module.unique_id %}"
@@ -84,15 +93,9 @@
                 <strong>{{ module.name|html_trans:langs }}</strong>!
               </p>
               <p>
-                {% if module.is_surveys %}
-                    {% blocktrans %}
-                    This action will also delete all forms in this survey folder.
-                    {% endblocktrans %}
-                {% else %}
-                    {% blocktrans %}
-                    This action will also delete all forms in this case list.
-                    {% endblocktrans %}
-                {% endif %}
+                {% blocktrans %}
+                This action will also delete all forms in this {{ menu }}.
+                {% endblocktrans %}
               </p>
             </div>
             <div class="modal-footer">
@@ -101,11 +104,7 @@
               </button>
               <button type="submit" class="disable-on-submit btn btn-danger">
                   <i class="fa fa-trash"></i>
-                  {% if module.is_surveys %}
-                      {% trans "Delete Surveys" %}
-                  {% else %}
-                      {% trans "Delete Case List" %}
-                  {% endif %}
+                  {% trans "Delete" %} {{ module.name|html_trans:langs }}
               </button>
             </div>
           </form>


### PR DESCRIPTION
## Product Description
Update the wording in the 'delete menu' modal. Previously this called reports, advanced and shadow modules 'surveys'. Also the button text used the menu type and not the menu name which made it harder to determine what was being deleted (at first I thought it was using the wrong menu name).

![image](https://user-images.githubusercontent.com/249606/171633746-06bdc617-268a-4262-8cdc-074c5f84dac7.png)

## Safety Assurance

### Safety story
Template change only

### Automated test coverage
NA

### QA Plan
None


### Migrations
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
