### PR TITLE
Fix downgraded pyjwt and pygithub

### DIFF
--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -45,6 +45,7 @@ cffi==1.14.3
     # via
     #   cryptography
     #   csiphash
+    #   pynacl
 chardet==3.0.4
     # via
     #   ghdiff
@@ -347,7 +348,7 @@ pycryptodomex==3.14.1
     # via
     #   oic
     #   pyjwkest
-pygithub==1.54.1
+pygithub==1.55
     # via -r base-requirements.in
 pygments==2.11.2
     # via sphinx
@@ -355,10 +356,12 @@ pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwkest==1.4.2
     # via oic
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   pygithub
     #   twilio
+pynacl==1.5.0
+    # via pygithub
 pyparsing==2.4.7
     # via
     #   httplib2

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -48,6 +48,7 @@ cffi==1.14.3
     # via
     #   cryptography
     #   csiphash
+    #   pynacl
 chardet==3.0.4
     # via
     #   ghdiff
@@ -360,7 +361,7 @@ pycryptodomex==3.14.1
     # via
     #   oic
     #   pyjwkest
-pygithub==1.54.1
+pygithub==1.55
     # via -r base-requirements.in
 pygments==2.11.2
     # via ipython
@@ -368,10 +369,12 @@ pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwkest==1.4.2
     # via oic
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   pygithub
     #   twilio
+pynacl==1.5.0
+    # via pygithub
 pyopenssl==20.0.1
     # via
     #   -r prod-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -40,6 +40,7 @@ cffi==1.14.3
     # via
     #   cryptography
     #   csiphash
+    #   pynacl
 chardet==3.0.4
     # via
     #   ghdiff
@@ -323,16 +324,18 @@ pycryptodomex==3.14.1
     # via
     #   oic
     #   pyjwkest
-pygithub==1.54.1
+pygithub==1.55
     # via -r base-requirements.in
 pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwkest==1.4.2
     # via oic
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   pygithub
     #   twilio
+pynacl==1.5.0
+    # via pygithub
 pyopenssl==20.0.1
     # via -r sso-requirements.in
 pyparsing==3.0.7

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -42,6 +42,7 @@ cffi==1.14.3
     # via
     #   cryptography
     #   csiphash
+    #   pynacl
 chardet==3.0.4
     # via
     #   ghdiff
@@ -356,16 +357,18 @@ pycryptodomex==3.14.1
     # via
     #   oic
     #   pyjwkest
-pygithub==1.54.1
+pygithub==1.55
     # via -r base-requirements.in
 pygooglechart==0.4.0
     # via -r base-requirements.in
 pyjwkest==1.4.2
     # via oic
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   pygithub
     #   twilio
+pynacl==1.5.0
+    # via pygithub
 pyopenssl==20.0.1
     # via -r sso-requirements.in
 pyparsing==3.0.7


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
It looks like https://github.com/dimagi/commcare-hq/pull/31567 accidentally removed the recent upgrades to pygithub and pyjwt. Only the dev-requirements.txt file kept the upgrade. I imagine there was a conflict that wasn't resolved properly?

This upgrade has already been done in https://github.com/dimagi/commcare-hq/pull/31676
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
