### PR TITLE
Domains with no exports now display line count correctly

### DIFF
--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -274,8 +274,8 @@ class EnterpriseODataReport(EnterpriseReport):
 
     def rows_for_domain(self, domain_obj):
         export_count = self.total_for_domain(domain_obj)
-        if export_count > self.MAXIMUM_EXPECTED_EXPORTS:
-            return [self._get_domain_summary_line(domain_obj, export_count, None)]
+        if export_count == 0 or export_count > self.MAXIMUM_EXPECTED_EXPORTS:
+            return [self._get_domain_summary_line(domain_obj, export_count)]
 
         exports = self.export_fetcher.get_exports(domain_obj.name)
 
@@ -291,11 +291,11 @@ class EnterpriseODataReport(EnterpriseReport):
     def _get_export_line_counts(self, exports):
         return {export._id: export.get_count() for export in exports}
 
-    def _get_domain_summary_line(self, domain_obj, export_count, export_line_counts):
-        if export_line_counts:
-            total_line_count = sum(export_line_counts.values())
-        else:
+    def _get_domain_summary_line(self, domain_obj, export_count, export_line_counts={}):
+        if export_count > self.MAXIMUM_EXPECTED_EXPORTS:
             total_line_count = _('ERROR: Too many exports. Please contact customer service')
+        else:
+            total_line_count = sum(export_line_counts.values())
 
         return [
             export_count,

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -76,6 +76,17 @@ class EnterpriseODataReportTests(SimpleTestCase):
             'domain_one', None, 'http://localhost:8000/a/domain_one/settings/project/']
         ])
 
+    @patch.object(ODataExportFetcher, 'get_export_count')
+    def test_no_exports_for_domain_shows_0_rowcount(self, mock_export_count):
+        mock_export_count.return_value = 0
+        domain_one = self._create_domain(name='domain_one', max_exports=25)
+
+        report = self._create_report_for_domains(domain_one)
+
+        self.assertEqual(report.rows, [
+            [0, 25, None, 0, 'domain_one', None, 'http://localhost:8000/a/domain_one/settings/project/']
+        ])
+
 # setup / helpers
 
     def setUp(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
There was a bug where a domain with no odata exports would display a line feed of: 'ERROR: Too many exports. Please contact customer service' rather than 0. (https://dimagi-dev.atlassian.net/browse/SAAS-13611)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

### Automated test coverage

Fully covered with a new unit test

### QA Plan

No QA


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
