### PR TITLE
once-off migration to migrate report instance IDs in case search prompts

### DIFF
--- a/corehq/apps/app_manager/management/commands/helpers.py
+++ b/corehq/apps/app_manager/management/commands/helpers.py
@@ -34,6 +34,8 @@ class AppMigrationCommandBase(BaseCommand):
     include_builds = False
     include_linked_apps = False
 
+    options = {}
+
     def add_arguments(self, parser):
         parser.add_argument(
             '--failfast',
@@ -71,11 +73,11 @@ class AppMigrationCommandBase(BaseCommand):
 
     @property
     def log_info(self):
-        return self.options["verbosity"] > 1
+        return self.options.get("verbosity", 0) > 1
 
     @property
     def log_debug(self):
-        return self.options["verbosity"] > 2
+        return self.options.get("verbosity", 0) > 2
 
     def _doc_types(self):
         doc_types = ["Application", "Application-Deleted"]

--- a/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_report_instance_ids.py
+++ b/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_report_instance_ids.py
@@ -14,8 +14,8 @@ class Command(AppMigrationCommandBase):
     report instance IDs in case search itemset prompts"""
 
     chunk_size = 1
-    include_builds = True
-    include_linked_apps = True
+    include_builds = False
+    include_linked_apps = False
 
     def migrate_app(self, app_doc):
         should_save = False

--- a/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_report_instance_ids.py
+++ b/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_report_instance_ids.py
@@ -20,13 +20,19 @@ class Command(AppMigrationCommandBase):
     def migrate_app(self, app_doc):
         should_save = False
         for module in app_doc.get('modules', []):
+            mod_should_save = False
             if module.get('search_config'):
                 properties = module.get('search_config').get('properties')
                 if not properties:
                     continue
                 for prop in properties:
-                    should_save |= update_itemset(prop, self.log_debug)
+                    mod_should_save |= update_itemset(prop, self.log_debug)
 
+            if mod_should_save and self.log_info:
+                print(f"Module '{module['unique_id']}' updated in app '{app_doc['_id']}'"
+                      f" in domain '{app_doc['domain']}'")
+
+            should_save |= mod_should_save
         return app_doc if should_save else None
 
     def get_domains(self):
@@ -55,6 +61,6 @@ def update_itemset(prop, debug):
         itemset['nodeset'] = new_nodeset
 
         if debug:
-            print(instance_id, "", new_instance_id)
-            print(nodeset, "", new_nodeset)
+            print("   ", instance_id, "-->", new_instance_id)
+            print("   ", nodeset, "-->", new_nodeset)
     return should_save

--- a/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_report_instance_ids.py
+++ b/corehq/apps/app_manager/management/commands/migrate_case_search_prompt_report_instance_ids.py
@@ -1,0 +1,60 @@
+import re
+
+from corehq.apps.app_manager.fixtures.mobile_ucr import (
+    ReportFixturesProviderV2,
+)
+from corehq.apps.app_manager.management.commands.helpers import (
+    AppMigrationCommandBase,
+)
+from corehq.toggles import SYNC_SEARCH_CASE_CLAIM
+
+
+class Command(AppMigrationCommandBase):
+    help = """One-time migration to add 'commcare-reports:' prefix to
+    report instance IDs in case search itemset prompts"""
+
+    chunk_size = 1
+    include_builds = True
+    include_linked_apps = True
+
+    def migrate_app(self, app_doc):
+        should_save = False
+        for module in app_doc.get('modules', []):
+            if module.get('search_config'):
+                properties = module.get('search_config').get('properties')
+                if not properties:
+                    continue
+                for prop in properties:
+                    should_save |= update_itemset(prop, self.log_debug)
+
+        return app_doc if should_save else None
+
+    def get_domains(self):
+        return sorted(SYNC_SEARCH_CASE_CLAIM.get_enabled_domains())
+
+
+def update_itemset(prop, debug):
+    itemset = prop.get('itemset')
+    if not itemset:
+        return False
+
+    instance_uri = itemset.get('instance_uri')
+    if not (instance_uri and instance_uri.startswith(f'jr://fixture/{ReportFixturesProviderV2.id}:')):
+        return False
+
+    should_save = False
+    instance_id = itemset.get('instance_id')
+    if instance_id and ReportFixturesProviderV2.id not in instance_id:
+        should_save = True
+        new_instance_id = f'{ReportFixturesProviderV2.id}:{instance_id}'
+        itemset['instance_id'] = new_instance_id
+        nodeset = itemset['nodeset']
+        new_nodeset = re.sub(r"instance\((.)" + instance_id,
+                     r"instance(\1" + ReportFixturesProviderV2.id + r":" + instance_id,
+                     (itemset.get('nodeset') or ''))
+        itemset['nodeset'] = new_nodeset
+
+        if debug:
+            print(instance_id, "", new_instance_id)
+            print(nodeset, "", new_nodeset)
+    return should_save

--- a/corehq/apps/app_manager/tests/test_management_commands.py
+++ b/corehq/apps/app_manager/tests/test_management_commands.py
@@ -1,0 +1,89 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.app_manager.management.commands.migrate_case_search_prompt_report_instance_ids import (
+    Command,
+)
+from corehq.apps.app_manager.models import (
+    Application,
+    BuildSpec,
+    CaseSearch,
+    CaseSearchProperty,
+    DetailColumn,
+    Itemset,
+    Module,
+)
+from corehq.apps.app_manager.util import get_correct_app_class
+
+
+class MigrateCaseSearchPromptReportItemsetIdsTest(SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.app = Application.new_app("some-domain", "Application to Migrate")
+        cls.app._id = '123'
+        cls.app.build_spec = BuildSpec(version='2.53.0', build_number=1)
+        cls.module = cls.app.add_module(Module.new_module("Followup", None))
+        cls.module.case_type = 'case'
+
+        cls.module.case_details.long.columns.append(
+            DetailColumn.wrap(dict(
+                header={"en": "name"},
+                model="case",
+                format="plain",
+                field="whatever",
+            ))
+        )
+
+        cls.module.search_config = CaseSearch()
+
+        cls.doc = cls.app.to_json()
+
+    def _migrate_property(self, prop):
+        self.doc['modules'][0]['search_config']['properties'] = [prop.to_json()]
+        app_doc = Command().migrate_app(self.doc)
+        if app_doc:
+            app = get_correct_app_class(app_doc).wrap(app_doc)
+            return app.modules[0].search_config.properties[0].itemset
+
+    def test_text(self):
+        self.assertIsNone(self._migrate_property(CaseSearchProperty(name='name', label={'en': 'Name'})))
+
+    def test_migrate(self):
+        itemset = self._migrate_property(CaseSearchProperty(
+            name='report', label={'en': 'report'},
+            itemset=self._get_itemset('123abc', "instance('123abc')/results/result"),
+        ))
+        self.assertEqual(itemset.instance_id, "commcare-reports:123abc")
+        self.assertEqual(itemset.instance_uri, "jr://fixture/commcare-reports:123abc")
+        self.assertEqual(itemset.nodeset, "instance('commcare-reports:123abc')/results/result")
+
+    def _get_itemset(self, instance_id, nodeset):
+        return Itemset(
+            instance_id=instance_id, instance_uri='jr://fixture/commcare-reports:123abc',
+            nodeset=nodeset, label='name', sort='name', value='value',
+        )
+
+    def test_migrate_other_quotes(self):
+        itemset = self._migrate_property(CaseSearchProperty(
+            name='report', label={'en': 'report'},
+            itemset=self._get_itemset('123abc', 'instance("123abc")/results/result'),
+        ))
+        self.assertEqual(itemset.instance_id, "commcare-reports:123abc")
+        self.assertEqual(itemset.instance_uri, "jr://fixture/commcare-reports:123abc")
+        self.assertEqual(itemset.nodeset, 'instance("commcare-reports:123abc")/results/result')
+
+    def test_already_migrated(self):
+        self.assertIsNone(self._migrate_property(CaseSearchProperty(
+            name='report', label={'en': 'report'},
+            itemset=self._get_itemset(
+                'commcare-reports:123abc', 'instance("commcare-reports:123abc")/results/result'
+            ),
+        )))
+
+    def test_different_instance(self):
+        self.assertIsNone(self._migrate_property(CaseSearchProperty(
+            name='group', label={'en': 'UserGroups'}, itemset=Itemset(
+                instance_id='user-groups', instance_uri='jr://fixture/user-groups',
+                nodeset="instance('user-groups')/groups", label='name', sort='name', value='value',
+            ),
+        )))


### PR DESCRIPTION
## Technical Summary
Followup to https://github.com/dimagi/commcare-hq/pull/31719 to migrate existing usages of the non-standard instance IDs to the standard ID.

```diff
- [report-uuid]
+ commcare-reports:[report-uuid]
```

## Safety Assurance

### Safety story
The current code already supports both versions of the instance. This migration just updates existing apps that use the old format to use the new format.

This has already been tested on staging.

### Automated test coverage
Tests for the migration have been added.

### QA Plan
Tested on staging.


### Migrations
- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
