### PR TITLE
Es/es query

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -312,23 +312,6 @@ class ESQuery(object):
             queries.search_string_query(search_string, default_fields)
         )
 
-    def _assemble(self):
-        """Build out the es_query dict"""
-        self._filters.extend(list(self._default_filters.values()))
-        if self._start is not None:
-            self.es_query['from'] = self._start
-        self.es_query['size'] = self._size if self._size is not None else SIZE_LIMIT
-        if self._exclude_source:
-            self.es_query['_source'] = False
-        elif self._source is not None:
-            self.es_query['_source'] = self._source
-        if self.uses_aggregations():
-            self.es_query['size'] = 0
-            self.es_query['aggs'] = {
-                agg.name: agg.assemble()
-                for agg in self._aggregations
-            }
-
     def fields(self, fields):
         """
             Restrict the fields returned from elasticsearch
@@ -376,6 +359,23 @@ class ESQuery(object):
         query = deepcopy(self)
         query._assemble()
         return query.es_query
+
+    def _assemble(self):
+        """Build out the es_query dict"""
+        self._filters.extend(list(self._default_filters.values()))
+        if self._start is not None:
+            self.es_query['from'] = self._start
+        self.es_query['size'] = self._size if self._size is not None else SIZE_LIMIT
+        if self._exclude_source:
+            self.es_query['_source'] = False
+        elif self._source is not None:
+            self.es_query['_source'] = self._source
+        if self.uses_aggregations():
+            self.es_query['size'] = 0
+            self.es_query['aggs'] = {
+                agg.name: agg.assemble()
+                for agg in self._aggregations
+            }
 
     def dumps(self, pretty=False):
         """Returns the JSON query that will be sent to elasticsearch."""

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -196,21 +196,14 @@ class ESQuery(object):
             size = sliced_or_int.stop - start
         return self.start(start).size(size).run().hits
 
-    def run(self, include_hits=False):
+    def run(self):
         """Actually run the query.  Returns an ESQuerySet object."""
-        query = self._clean_before_run(include_hits)
         raw = run_query(
-            query.index,
-            query.raw_query,
+            self.index,
+            self.raw_query,
             for_export=self.for_export,
         )
-        return ESQuerySet(raw, deepcopy(query))
-
-    def _clean_before_run(self, include_hits=False):
-        query = deepcopy(self)
-        if not include_hits and query.uses_aggregations():
-            query = query.size(0)
-        return query
+        return ESQuerySet(raw, deepcopy(self))
 
     def scroll(self):
         """
@@ -329,7 +322,8 @@ class ESQuery(object):
             self.es_query['_source'] = False
         elif self._source is not None:
             self.es_query['_source'] = self._source
-        if self._aggregations:
+        if self.uses_aggregations():
+            self.es_query['size'] = 0
             self.es_query['aggs'] = {
                 agg.name: agg.assemble()
                 for agg in self._aggregations
@@ -512,11 +506,10 @@ class ESQuerySet(object):
     @property
     def hits(self):
         """Return the docs from the response."""
-        raw_hits = self.raw_hits
-        if not raw_hits and self.query.uses_aggregations() and self.query._size == 0:
-            raise ESError("no hits, did you forget about no_hits_with_aggs?")
+        if self.query.uses_aggregations():
+            raise ESError("We exclude hits for aggregation queries")
 
-        return [self.normalize_result(self.query, r) for r in raw_hits]
+        return [self.normalize_result(self.query, r) for r in self.raw_hits]
 
     @property
     def total(self):

--- a/corehq/apps/es/fake/es_query_fake.py
+++ b/corehq/apps/es/fake/es_query_fake.py
@@ -227,6 +227,12 @@ class ESQueryFake(object):
 
         return self._filtered(_date_comparison)
 
+    def uses_aggregations(self):
+        return False
+
+    def aggregation(self, _):
+        raise NotImplementedError("Aggregations aren't supported by ESQueryFake")
+
     def __getattr__(self, item):
         """
         To make it really easy to add methods to a fake only as needed by real tests,

--- a/corehq/apps/es/tests/test_aggregations.py
+++ b/corehq/apps/es/tests/test_aggregations.py
@@ -68,7 +68,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                     }
                 }
             },
-            "size": SIZE_LIMIT
+            "size": 0
         }
 
         query = HQESQuery('cases').aggregations([
@@ -195,7 +195,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                     }
                 },
             },
-            "size": SIZE_LIMIT
+            "size": 0
         }
         query = HQESQuery('cases').aggregation(
             RangeAggregation('by_date', 'name', [
@@ -229,7 +229,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                     }
                 },
             },
-            "size": SIZE_LIMIT
+            "size": 0
         }
         query = HQESQuery('cases').aggregation(
             StatsAggregation('name_stats', 'name', script='MY weird script')
@@ -258,7 +258,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                     }
                 },
             },
-            "size": SIZE_LIMIT
+            "size": 0
         }
         query = HQESQuery('cases').aggregation(
             ExtendedStatsAggregation('name_stats', 'name', script='MY weird script')
@@ -296,7 +296,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                     },
                 },
             },
-            "size": SIZE_LIMIT
+            "size": 0
         }
         query = HQESQuery('cases').aggregation(
             TopHitsAggregation(
@@ -329,7 +329,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                     }
                 },
             },
-            "size": SIZE_LIMIT
+            "size": 0
         }
         query = HQESQuery('cases').aggregation(
             MissingAggregation(
@@ -362,7 +362,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                     }
                 }
             },
-            "size": SIZE_LIMIT
+            "size": 0
         }
         query = HQESQuery('forms').date_histogram('by_day', 'date', 'day', '-01:00')
         self.checkQuery(query, json_output)
@@ -411,7 +411,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                     }
                 },
             },
-            "size": SIZE_LIMIT
+            "size": 0
         }
         query = HQESQuery('cases').aggregation(
             NestedAggregation(
@@ -446,7 +446,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                     },
                 },
             },
-            "size": SIZE_LIMIT
+            "size": 0
         }
         query = HQESQuery('cases').aggregation(
             TermsAggregation('name', 'name').order('sort_field')

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -1,6 +1,6 @@
-from copy import deepcopy
-from django.test import SimpleTestCase
 from unittest.mock import patch
+
+from django.test import SimpleTestCase
 
 from corehq.apps.es import filters, forms, users
 from corehq.apps.es.const import SIZE_LIMIT
@@ -260,37 +260,6 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
             {"timeStart": {"order": "asc"}},
         ]
         self.checkQuery(query.sort('timeStart', reset_sort=False), json_output)
-
-    def test_cleanup_before_run(self):
-        json_output = {
-            "query": {
-                "bool": {
-                    "filter": [
-                        {
-                            "match_all": {}
-                        }
-                    ],
-                    "must": {
-                        "match_all": {}
-                    }
-                }
-            },
-            "size": SIZE_LIMIT,
-            "aggs": {
-                "by_day": {
-                    "date_histogram": {
-                        "field": "date",
-                        "interval": "day",
-                        "time_zone": "-01:00"
-                    }
-                }
-            }
-        }
-        expected_output = deepcopy(json_output)
-        expected_output['size'] = 0
-        query = HQESQuery('forms').date_histogram('by_day', 'date', 'day', '-01:00')
-        self.checkQuery(query, json_output)
-        self.checkQuery(query._clean_before_run(), expected_output)
 
     def test_exclude_source(self):
         json_output = {


### PR DESCRIPTION
## Technical Summary
Final processing of the query was split between two locations - this combines them, so `raw_query` and `pprint` represent the query that gets sent to ES.  Impetus was I got confused because an aggregation query displayed as having a size of `SIZE_LIMIT`, but returned no results.  This was because it was amended just before being sent.

## Feature Flag
no

## Safety Assurance

### Safety story


### Automated test coverage

Lots of tests for this already

### QA Plan

N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
