### PR TITLE
Fix translations in HQ

### DIFF
--- a/corehq/apps/hqwebapp/utils/__init__.py
+++ b/corehq/apps/hqwebapp/utils/__init__.py
@@ -1,9 +1,7 @@
 import logging
 
 from django.conf import settings
-from django.template.loader import render_to_string
 from django.templatetags.i18n import language_name
-from django.utils.translation import LANGUAGE_SESSION_KEY, activate
 from django.views.decorators.debug import sensitive_variables
 
 from Crypto.Hash import SHA256
@@ -12,10 +10,7 @@ from Crypto.Signature import PKCS1_PSS
 from memoized import memoized
 
 from corehq.apps.hqwebapp.forms import BulkUploadForm
-from corehq.apps.hqwebapp.tasks import send_html_email_async
-from corehq.apps.users.models import WebUser
 from custom.nic_compliance.utils import get_raw_password
-
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +54,7 @@ def csrf_inline(request):
 
     Useful for adding inline forms in messages for e.g. while showing an "'undo' Archive Form" message
     """
-    from django.template import Template, RequestContext
+    from django.template import RequestContext, Template
     node = "{% csrf_token %}"
     return Template(node).render(RequestContext(request))
 
@@ -93,13 +88,3 @@ def get_environment_friendly_name():
     except KeyError:
         env = settings.SERVER_ENVIRONMENT
     return env
-
-
-def update_session_language(req, old_lang, new_lang):
-    # Update the language for this session if the user signing in has a different language than the current
-    # session default
-    if new_lang != old_lang:
-        # update the current session's language setting
-        req.session[LANGUAGE_SESSION_KEY] = new_lang
-        # and activate it for the current thread so the response page is translated too
-        activate(new_lang)

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -44,7 +44,7 @@ from corehq.apps.domain.decorators import (
 )
 from corehq import toggles
 from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.hqwebapp.utils import sign, update_session_language
+from corehq.apps.hqwebapp.utils import sign
 from corehq.apps.hqwebapp.views import BaseSectionPageView, CRUDPaginatedViewMixin
 from corehq.apps.settings.exceptions import DuplicateApiKeyName
 from corehq.apps.settings.forms import (
@@ -248,10 +248,11 @@ class MyAccountSettingsView(BaseMyAccountView):
         if self.form_type and self.form_type in self.form_actions:
             return self.form_actions[self.form_type]()
         if self.settings_form.is_valid():
-            old_lang = self.request.couch_user.language
             self.settings_form.update_user()
-            new_lang = self.request.couch_user.language
-            update_session_language(request, old_lang, new_lang)
+
+            res = redirect(reverse(MyAccountSettingsView.urlname))
+            res.set_cookie(settings.LANGUAGE_COOKIE_NAME, self.request.couch_user.language)
+            return res
 
         return self.get(request, *args, **kwargs)
 

--- a/corehq/apps/users/signals.py
+++ b/corehq/apps/users/signals.py
@@ -1,26 +1,11 @@
 from django.conf import settings
-from django.contrib.auth.signals import user_logged_in
 from django.db.models.signals import post_save
-from django.dispatch import Signal, receiver
+from django.dispatch import Signal
 
 from corehq.elastic import send_to_elasticsearch
 
 commcare_user_post_save = Signal()  # providing args: couch_user
 couch_user_post_save = Signal()  # providing args: couch_user
-
-
-@receiver(user_logged_in)
-def set_language(sender, **kwargs):
-    """
-    Whenever a user logs in, attempt to set their browser session
-    to the right language.
-    HT: http://mirobetm.blogspot.com/2012/02/django-language-set-in-database-field.html
-    """
-    from corehq.apps.users.models import CouchUser
-    user = kwargs['user']
-    couch_user = CouchUser.from_django_user(user)
-    if couch_user and couch_user.language:
-        kwargs['request'].session['django_language'] = couch_user.language
 
 
 # Signal that syncs django_user => couch_user

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -332,14 +332,7 @@ class BaseEditUserView(BaseUserSettingsView):
 
     def update_user(self):
         if self.form_user_update.is_valid():
-            old_lang = self.request.couch_user.language
-            if self.form_user_update.update_user():
-                # if editing our own account we should also update the language in the session
-                if self.editable_user._id == self.request.couch_user._id:
-                    new_lang = self.request.couch_user.language
-                    if new_lang != old_lang:
-                        self.request.session['django_language'] = new_lang
-                return True
+            return self.form_user_update.update_user()
 
     def post(self, request, *args, **kwargs):
         saved = False


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/SAAS-13601
You cannot currently change your language in HQ.  It uses whatever your browser's default language is, if available, or English.  I think this broke with the Django 3 upgrade a couple months ago.  This PR fixes that.

## Technical Summary

I believe this broke with the [Django 3 upgrade](https://docs.djangoproject.com/en/4.0/releases/3.0/#miscellaneous)

> Because accessing the language in the session rather than in the cookie is deprecated, `LocaleMiddleware` no longer looks for the user’s language in the session and `django.contrib.auth.logout()` no longer preserves the session’s language after logout.

This PR follows the guidelines described here: https://docs.djangoproject.com/en/4.0/topics/i18n/translation/#explicitly-setting-the-active-language

Django's algorithm is to check:

 * Lang prefix in the URL
 * A `django_language` cookie (NOT `lang`, as we use in app builder)
 * The Accept-Language HTTP header set by your browser
 * Fall back to the default (English)

I suspect point 3 there is why this issue wasn't brought to our attention earlier.

There are a couple cleanup commits here too.  I really wanted to include https://github.com/dimagi/commcare-hq/commit/afff1c900af867188ca9d54cd86e70630793b09c, which makes this dropdown show only languages that are actually available: 

![image](https://user-images.githubusercontent.com/2367539/171737684-e7dc46a6-792d-4cef-9e9b-aaca8f487706.png)

But it turns out that language setting also controls what language you view in web apps (though not live preview, I think), so I punted.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Tested this locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
