### PR TITLE
remove inline search assertion

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -249,9 +249,6 @@ class EntriesHelper(object):
             if form.uses_usercase():
                 EntriesHelper.add_usercase_id_assertion(e)
 
-            if using_inline_search:
-                EntriesHelper.add_case_claim_assertion(e)
-
             EntriesHelper.add_custom_assertions(e, form)
 
             if (
@@ -363,18 +360,6 @@ class EntriesHelper(object):
                                                 "[hq_user_id=instance('commcaresession')/session/context/userid])"
                                                 " = 1", "case_autoload.usercase.case_missing")
         entry.assertions.append(assertion)
-
-    @staticmethod
-    def add_case_claim_assertion(entry):
-        # TODO: what about multi-selects?
-        case_datums = [datum for datum in entry.datums if datum.nodeset]
-        if case_datums:
-            case_id = f"instance('commcaresession')/session/data/{case_datums[-1].id}"
-            assertion = EntriesHelper.get_assertion(
-                f"count(instance('casedb')/casedb/case[@case_id={case_id}]) = 1",
-                "case_search.claimed_case.case_missing"
-            )
-            entry.assertions.append(assertion)
 
     @staticmethod
     def get_extra_case_id_datums(form):

--- a/corehq/apps/app_manager/tests/data/suite_inline_search/shadow_module_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_inline_search/shadow_module_entry.xml
@@ -29,13 +29,5 @@
                    nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                    value="./@case_id"/>
         </session>
-        <assertions>
-            <assert
-                test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 1">
-                <text>
-                    <locale id="case_search.claimed_case.case_missing"/>
-                </text>
-            </assert>
-        </assertions>
     </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -115,13 +115,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                 <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
                     value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             </session>
-            <assertions>
-              <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 1">
-                <text>
-                  <locale id="case_search.claimed_case.case_missing"/>
-                </text>
-              </assert>
-            </assertions>
           </entry>
         </partial>"""  # noqa: E501
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]")


### PR DESCRIPTION
## Technical Summary
This causes an issue with Formplayer xpath query caching. Removing now but may add it back later.

Jira: https://dimagi-dev.atlassian.net/browse/USH-2060

## Feature Flag
inline search

## Safety Assurance

### Safety story
small suite xml change that is covered by tests

### Automated test coverage
Updated existing tests

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
