### PR TITLE
Fix ghost "s email server" translation

### DIFF
--- a/corehq/apps/users/static/users/js/web_users.js
+++ b/corehq/apps/users/static/users/js/web_users.js
@@ -205,9 +205,13 @@ hqDefine("users/js/web_users",[
         $('.undeliverable-label').tooltip({
             placement: 'right',
             html: true,
-            title: gettext(`We have sent the invitation email to this user but the user's email server
-            rejected it. This usually means either the email address is incorrect or your organization
-            is blocking emails from our address (${initialPageData.get('fromAddress')}).`),
+            title: _.template(gettext(
+                "We have sent the invitation email to this user but the user's email server " +
+                "rejected it. This usually means either the email address is incorrect or your organization " +
+                "is blocking emails from our address (<%- fromAddress %>)."
+            ))({
+                fromAddress: initialPageData.get('fromAddress')
+            })
         });
     });
 });

--- a/corehq/apps/users/static/users/js/web_users.js
+++ b/corehq/apps/users/static/users/js/web_users.js
@@ -210,8 +210,8 @@ hqDefine("users/js/web_users",[
                 "rejected it. This usually means either the email address is incorrect or your organization " +
                 "is blocking emails from our address (<%- fromAddress %>)."
             ))({
-                fromAddress: initialPageData.get('fromAddress')
-            })
+                fromAddress: initialPageData.get('fromAddress'),
+            }),
         });
     });
 });

--- a/locale/en/LC_MESSAGES/djangojs.po
+++ b/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:40+0000\n"
+"POT-Creation-Date: 2022-06-06 20:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4479,6 +4479,13 @@ msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users.js
 msgid "Are you sure you want to delete this request?"
+msgstr ""
+
+#: corehq/apps/users/static/users/js/web_users.js
+msgid ""
+"We have sent the invitation email to this user but the user's email server "
+"rejected it. This usually means either the email address is incorrect or "
+"your organization is blocking emails from our address (<%- fromAddress %>)."
 msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users_list.js

--- a/locale/es/LC_MESSAGES/djangojs.po
+++ b/locale/es/LC_MESSAGES/djangojs.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:40+0000\n"
+"POT-Creation-Date: 2022-06-06 20:51+0000\n"
 "PO-Revision-Date: 2017-07-19 15:34+0000\n"
 "Last-Translator: Dimagi Dev <devops@dimagi.com>, 2022\n"
 "Language-Team: Spanish (https://www.transifex.com/dimagi/teams/9388/es/)\n"
@@ -4706,6 +4706,13 @@ msgstr "Eliminar solicitud"
 #: corehq/apps/users/static/users/js/web_users.js
 msgid "Are you sure you want to delete this request?"
 msgstr "¿Está seguro que desea eliminar esta solicitud?"
+
+#: corehq/apps/users/static/users/js/web_users.js
+msgid ""
+"We have sent the invitation email to this user but the user's email server "
+"rejected it. This usually means either the email address is incorrect or "
+"your organization is blocking emails from our address (<%- fromAddress %>)."
+msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users_list.js
 msgid "No users matched your search."

--- a/locale/fr/LC_MESSAGES/djangojs.po
+++ b/locale/fr/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:40+0000\n"
+"POT-Creation-Date: 2022-06-06 20:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4480,6 +4480,13 @@ msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users.js
 msgid "Are you sure you want to delete this request?"
+msgstr ""
+
+#: corehq/apps/users/static/users/js/web_users.js
+msgid ""
+"We have sent the invitation email to this user but the user's email server "
+"rejected it. This usually means either the email address is incorrect or "
+"your organization is blocking emails from our address (<%- fromAddress %>)."
 msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users_list.js

--- a/locale/fra/LC_MESSAGES/djangojs.po
+++ b/locale/fra/LC_MESSAGES/djangojs.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:40+0000\n"
+"POT-Creation-Date: 2022-06-06 20:51+0000\n"
 "PO-Revision-Date: 2017-07-19 15:34+0000\n"
 "Last-Translator: Tyler Wymer <twymer@dimagi.com>, 2022\n"
 "Language-Team: French (https://www.transifex.com/dimagi/teams/9388/fr/)\n"
@@ -4555,6 +4555,13 @@ msgstr "Supprimer la requête"
 #: corehq/apps/users/static/users/js/web_users.js
 msgid "Are you sure you want to delete this request?"
 msgstr "Êtes-vous certain de vouloir supprimer cette requête?"
+
+#: corehq/apps/users/static/users/js/web_users.js
+msgid ""
+"We have sent the invitation email to this user but the user's email server "
+"rejected it. This usually means either the email address is incorrect or "
+"your organization is blocking emails from our address (<%- fromAddress %>)."
+msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users_list.js
 msgid "No users matched your search."

--- a/locale/hi/LC_MESSAGES/djangojs.po
+++ b/locale/hi/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:40+0000\n"
+"POT-Creation-Date: 2022-06-06 20:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4480,6 +4480,13 @@ msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users.js
 msgid "Are you sure you want to delete this request?"
+msgstr ""
+
+#: corehq/apps/users/static/users/js/web_users.js
+msgid ""
+"We have sent the invitation email to this user but the user's email server "
+"rejected it. This usually means either the email address is incorrect or "
+"your organization is blocking emails from our address (<%- fromAddress %>)."
 msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users_list.js

--- a/locale/hin/LC_MESSAGES/djangojs.po
+++ b/locale/hin/LC_MESSAGES/djangojs.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:40+0000\n"
+"POT-Creation-Date: 2022-06-06 20:51+0000\n"
 "PO-Revision-Date: 2017-07-19 15:34+0000\n"
 "Last-Translator: Dimagi Dev <devops@dimagi.com>, 2021\n"
 "Language-Team: Hindi (https://www.transifex.com/dimagi/teams/9388/hi/)\n"
@@ -4483,6 +4483,13 @@ msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users.js
 msgid "Are you sure you want to delete this request?"
+msgstr ""
+
+#: corehq/apps/users/static/users/js/web_users.js
+msgid ""
+"We have sent the invitation email to this user but the user's email server "
+"rejected it. This usually means either the email address is incorrect or "
+"your organization is blocking emails from our address (<%- fromAddress %>)."
 msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users_list.js

--- a/locale/por/LC_MESSAGES/djangojs.po
+++ b/locale/por/LC_MESSAGES/djangojs.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:40+0000\n"
+"POT-Creation-Date: 2022-06-06 20:51+0000\n"
 "PO-Revision-Date: 2017-07-19 15:34+0000\n"
 "Last-Translator: Séfora Vazirna <seforan@gmail.com>, 2022\n"
 "Language-Team: Portuguese (https://www.transifex.com/dimagi/teams/9388/pt/)\n"
@@ -4512,6 +4512,13 @@ msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users.js
 msgid "Are you sure you want to delete this request?"
+msgstr ""
+
+#: corehq/apps/users/static/users/js/web_users.js
+msgid ""
+"We have sent the invitation email to this user but the user's email server "
+"rejected it. This usually means either the email address is incorrect or "
+"your organization is blocking emails from our address (<%- fromAddress %>)."
 msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users_list.js

--- a/locale/pt/LC_MESSAGES/djangojs.po
+++ b/locale/pt/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:40+0000\n"
+"POT-Creation-Date: 2022-06-06 20:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4480,6 +4480,13 @@ msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users.js
 msgid "Are you sure you want to delete this request?"
+msgstr ""
+
+#: corehq/apps/users/static/users/js/web_users.js
+msgid ""
+"We have sent the invitation email to this user but the user's email server "
+"rejected it. This usually means either the email address is incorrect or "
+"your organization is blocking emails from our address (<%- fromAddress %>)."
 msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users_list.js

--- a/locale/sw/LC_MESSAGES/djangojs.po
+++ b/locale/sw/LC_MESSAGES/djangojs.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:40+0000\n"
+"POT-Creation-Date: 2022-06-06 20:51+0000\n"
 "PO-Revision-Date: 2017-07-19 15:34+0000\n"
 "Last-Translator: Dimagi Dev <devops@dimagi.com>, 2021\n"
 "Language-Team: Swahili (https://www.transifex.com/dimagi/teams/9388/sw/)\n"
@@ -4483,6 +4483,13 @@ msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users.js
 msgid "Are you sure you want to delete this request?"
+msgstr ""
+
+#: corehq/apps/users/static/users/js/web_users.js
+msgid ""
+"We have sent the invitation email to this user but the user's email server "
+"rejected it. This usually means either the email address is incorrect or "
+"your organization is blocking emails from our address (<%- fromAddress %>)."
 msgstr ""
 
 #: corehq/apps/users/static/users/js/web_users_list.js

--- a/scripts/make-translations.sh
+++ b/scripts/make-translations.sh
@@ -25,12 +25,13 @@ if ! ./manage.py compilemessages; then
 fi
 
 # Remove diffs for files where the only thing that changed was POT-Creation-Date
-# Todo: It's a bit hacky that this relies on git state to undo unncessary changes
+# Todo: It's a bit hacky that this relies on git state to undo unnecessary changes
 # Todo: Ideally we'd change the management commands above to just not produce the diff in the first place
 git diff --name-only | grep '^locale/' | while read -r filename
 do
     if ! git diff -U0 -- "$filename" | tail -n +6 | grep -v '^[+-]"POT-Creation-Date:\s' > /dev/null
     then
-        git checkout -- "$filename"
+        # disable hooks for this command
+        git -c core.hooksPath=/dev/null checkout -- "$filename"
     fi
 done


### PR DESCRIPTION
## Technical Summary

Fix ghost "s email server" translation stemming from an unsupported string style in web_users.js. I believe the backtick (`` ` ``) character isn't getting interpreted as bounding a string, and instead it's treating the `'` in the word `user's` as the start of a string. By rearranging the syntax used here to something more vanilla, I think we'll not only correctly translate this string, but also prevent the instability around whether this `s email servers` string gets collected at all—sometimes it was getting collected and sometimes it wasn't, causing weird diffs back and forth.

I also snuck in a very minor change to `make-translations.sh` that makes the post-checkout hook not run on the git hack it does towards the end to get rid of some irrelevant changes. This makes it go a bit smoother since it's doing `checkout` in a loop over all the changed locale files.

## Safety Assurance

### Safety story
This is a pretty clear change to one string on one page, so it's pretty easy to test manually that it still works. I tested it and (1) the page doesn't have a JS error or anything (2) the string shows up just the way it's intended. Screenshot:

<img width="430" alt="Screen Shot 2022-06-06 at 5 35 50 PM" src="https://user-images.githubusercontent.com/137212/172253495-5d19ce6c-bf51-470f-b4ce-202267228dfe.png">


### Automated test coverage

I think the relevant tests for my change are the ones that test that running `make translations` again does not create any additional diff.

### QA Plan
No formal QA or further testing planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
