### PR TITLE
Loosen fuzzy query config

### DIFF
--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -503,11 +503,11 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
                                         }
                                     ],
                                     "must": {
-                                        "match": {
+                                        "fuzzy": {
                                             "case_properties.value": {
-                                                "query": "Jon John Jhon",
-                                                "operator": "or",
-                                                "fuzziness": "AUTO"
+                                                "value": "Jon John Jhon",
+                                                "fuzziness": "AUTO",
+                                                "max_expansions": 100
                                             }
                                         }
                                     }

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -505,7 +505,7 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
                                     "must": {
                                         "fuzzy": {
                                             "case_properties.value": {
-                                                "value": "Jon John Jhon",
+                                                "value": "jon john jhon",
                                                 "fuzziness": "AUTO",
                                                 "max_expansions": 100
                                             }

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -172,7 +172,7 @@ def case_property_query(case_property_name, value, fuzzy=False, multivalue_mode=
     if fuzzy:
         return filters.OR(
             # fuzzy match
-            case_property_text_query(case_property_name, value, fuzziness='AUTO', operator=multivalue_mode),
+            case_property_fuzzy_query(case_property_name, value, fuzziness='AUTO'),
             # non-fuzzy match. added to improve the score of exact matches
             case_property_text_query(case_property_name, value, operator=multivalue_mode),
         )
@@ -200,7 +200,21 @@ def exact_case_property_text_query(case_property_name, value):
     )
 
 
-def case_property_text_query(case_property_name, value, fuzziness='0', operator=None):
+def case_property_fuzzy_query(case_property_name, value, fuzziness='AUTO'):
+    """Filter by case_properties.key and do a fuzzy search on case_properties.value
+
+    This does not do exact matches on the multi-words case property values. If the value has
+    multiple words, they will be OR'd together in this query. You may want to
+    use the `exact_case_property_text_query` instead.
+
+    """
+    return _base_property_query(
+        case_property_name,
+        queries.fuzzy(value, '{}.{}'.format(CASE_PROPERTIES_PATH, VALUE), fuzziness=fuzziness)
+    )
+
+
+def case_property_text_query(case_property_name, value, operator=None):
     """Filter by case_properties.key and do a text search in case_properties.value
 
     This does not do exact matches on the case property value. If the value has
@@ -210,7 +224,7 @@ def case_property_text_query(case_property_name, value, fuzziness='0', operator=
     """
     return _base_property_query(
         case_property_name,
-        queries.match(value, '{}.{}'.format(CASE_PROPERTIES_PATH, VALUE), fuzziness=fuzziness, operator=operator)
+        queries.match(value, '{}.{}'.format(CASE_PROPERTIES_PATH, VALUE), operator=operator)
     )
 
 

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -99,6 +99,8 @@ def ids_query(doc_ids):
 def match(search_string, field, fuzziness="AUTO", operator=None):
     if operator not in [None, 'and', 'or']:
         raise ValueError(" 'operator' argument should be one of: 'and', 'or' ")
+    if fuzziness != "0":
+        return fuzzy(search_string, field, fuzziness)
     return {
         "match": {
             field: {
@@ -106,6 +108,18 @@ def match(search_string, field, fuzziness="AUTO", operator=None):
                 # OR is the accepted default for the operator on an ES match query
                 "operator": 'and' if operator == 'and' else 'or',
                 "fuzziness": fuzziness,
+            }
+        }
+    }
+
+
+def fuzzy(search_string, field, fuzziness="AUTO"):
+    return {
+        "fuzzy": {
+            field: {
+                "value": search_string.lower(),
+                "fuzziness": fuzziness,
+                "max_expansions": 100
             }
         }
     }

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -99,7 +99,7 @@ def ids_query(doc_ids):
 def match(search_string, field, fuzziness="AUTO", operator=None):
     if operator not in [None, 'and', 'or']:
         raise ValueError(" 'operator' argument should be one of: 'and', 'or' ")
-    if fuzziness != "0":
+    if f"{fuzziness}" != "0":
         return fuzzy(search_string, field, fuzziness)
     return {
         "match": {
@@ -117,7 +117,7 @@ def fuzzy(search_string, field, fuzziness="AUTO"):
     return {
         "fuzzy": {
             field: {
-                "value": search_string.lower(),
+                "value": f"{search_string}".lower(),
                 "fuzziness": fuzziness,
                 "max_expansions": 100
             }

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -96,18 +96,15 @@ def ids_query(doc_ids):
     return {"ids": {"values": doc_ids}}
 
 
-def match(search_string, field, fuzziness="AUTO", operator=None):
+def match(search_string, field, operator=None):
     if operator not in [None, 'and', 'or']:
         raise ValueError(" 'operator' argument should be one of: 'and', 'or' ")
-    if f"{fuzziness}" != "0":
-        return fuzzy(search_string, field, fuzziness)
     return {
         "match": {
             field: {
                 "query": search_string,
                 # OR is the accepted default for the operator on an ES match query
                 "operator": 'and' if operator == 'and' else 'or',
-                "fuzziness": fuzziness,
             }
         }
     }

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -105,6 +105,7 @@ def match(search_string, field, operator=None):
                 "query": search_string,
                 # OR is the accepted default for the operator on an ES match query
                 "operator": 'and' if operator == 'and' else 'or',
+                "fuzziness": "0",
             }
         }
     }

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -165,11 +165,11 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                                                                 }
                                                             ],
                                                             "must": {
-                                                                "match": {
+                                                                "fuzzy": {
                                                                     "case_properties.value": {
-                                                                        "query": "polly",
-                                                                        "operator": "or",
-                                                                        "fuzziness": "AUTO"
+                                                                        "value": "polly",
+                                                                        "fuzziness": "AUTO",
+                                                                        "max_expansions": 100
                                                                     }
                                                                 }
                                                             }

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -198,6 +198,6 @@ def metadata(key, value):
         'user_data_es',
         filters.AND(
             filters.term(field='user_data_es.key', value=key),
-            queries.match(field='user_data_es.value', search_string=value, fuzziness=0),
+            queries.match(field='user_data_es.value', search_string=value),
         )
     )


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2095

This will make fuzzy queries more permissive, returning more results.

[This question](https://stackoverflow.com/questions/50368459/why-is-my-elastic-search-prefix-query-case-sensitive-despite-using-lowercase-fil) recommends lowercasing the search query, since we use a lowercase filter: https://github.com/dimagi/commcare-hq/blob/7124556769698e87f93314616bc9632b1e63e795/corehq/ex-submodules/pillowtop/es_utils.py#L20

The exact behavior of `max_expansions` is somewhat nebulous. From [this commentary](https://medium.com/@mourjo_sen/a-detailed-comparison-between-autocompletion-strategies-in-elasticsearch-66cb9e9c62c4):

> Note that this limit on expansions is done per-shard, do depending on the data on the shard, your results will vary, which makes this quite non-deterministic from the client point-of-view.

`max_expansions` defaults to 50 (see docs [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html)), so I'm doubling it.

## Feature Flag
Case search

## Safety Assurance

### Safety story

The major risk here is performance, as noted in the [ES docs on max_expansions](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html). I've done some testing in the reported domain and our largest CICT domain (results in ticket).


### Automated test coverage

In PR.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
