### PR TITLE
Sk/child module inline search

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2072,7 +2072,7 @@ class Detail(IndexedSchema, CaseListLookupMixin):
     def get_instance_name(self, module):
         value_is_the_default = self.instance_name == 'casedb'
         if value_is_the_default and module_loads_registry_case(module) or module_uses_inline_search(module):
-            return RESULTS_INSTANCE
+            return "selected_cases" if module.is_multi_select() else RESULTS_INSTANCE
         return self.instance_name
 
     def get_tab_spans(self):

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -463,7 +463,7 @@ class EntriesHelper(object):
                 if loads_registry_case or module_uses_inline_search(module):
                     query_datum = self.get_query_datum(module, datum)
                     result.append(query_datum)
-                    result.append(self.rename_datum_nodeset(datum, query_datum))
+                    result.append(self.rename_datum_nodeset_for_query(datum, query_datum))
                     if loads_registry_case:
                         result.append(self.get_data_registry_case_datums(datum, module))
                 else:
@@ -472,7 +472,7 @@ class EntriesHelper(object):
                 result.append(datum)
         return result
 
-    def rename_datum_nodeset(self, datum, query_datum):
+    def rename_datum_nodeset_for_query(self, datum, query_datum):
         """Rename the instance in the case datum to match the instance used by the query datum
         The logic here is heavily reliant on the logic in ``get_select_chain_with_sessions``
         """
@@ -594,7 +594,7 @@ class EntriesHelper(object):
 
         storage_instance = self.get_query_storage_instance(datum.id)
 
-        factory = RemoteRequestFactory(None, module, [])
+        factory = RemoteRequestFactory(None, module, [], case_session_var=datum.id)
         query = factory.build_remote_request_queries(storage_instance)[0]
         return FormDatumMeta(datum=query, case_type=None, requires_selection=False, action=None)
 
@@ -604,6 +604,8 @@ class EntriesHelper(object):
         )
         if datum_id == 'case_id':
             return RESULTS_INSTANCE
+        if datum_id == 'selected_cases':
+            return 'selected_cases'
         if 'case_id_' in datum_id:
             # e.g. case_id_{case_type}
             return RESULTS_INSTANCE + ":" + datum_id[len('case_id_'):]

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -429,7 +429,7 @@ class EntriesHelper(object):
             datums.extend(EntriesHelper.get_new_case_id_datums_meta(form))
             datums.extend(EntriesHelper.get_extra_case_id_datums(form))
 
-        return self.add_parent_datums(datums, module)
+        return self.rename_datums_for_root_module(datums, module)
 
     def configure_entry_module_form(self, module, e, form=None, use_filter=True, **kwargs):
         def case_sharing_requires_assertion(form):
@@ -889,7 +889,7 @@ class EntriesHelper(object):
             except IndexError:
                 pass
 
-        return self.add_parent_datums(datums, module), assertions
+        return self.rename_datums_for_root_module(datums, module), assertions
 
     def _get_first_forms_datums(self, module):
         """
@@ -908,7 +908,7 @@ class EntriesHelper(object):
             return []
         return self.get_datums_meta_for_form_generic(form)
 
-    def add_parent_datums(self, datums, module):
+    def rename_datums_for_root_module(self, datums, module):
         parent_datums = self._get_first_forms_datums(module.root_module)
         if not parent_datums:
             return datums

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -323,6 +323,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         )
 
     def test_parent_select(self):
+        """test that instance IDs are correct and not duplicated"""
         self._configure_parent_select_module()
         suite = self.app.create_suite()
 
@@ -575,6 +576,7 @@ class InlineSearchChildModuleTest(SimpleTestCase, SuiteMixin):
         )
 
     def test_child_module_of_module_with_inline_search(self):
+        # TODO - claim multiple cases
         self.m0.search_config = CaseSearch(
             properties=[CaseSearchProperty(name='name', label={'en': 'Name'})],
             auto_launch=True,
@@ -641,3 +643,23 @@ class InlineSearchChildModuleTest(SimpleTestCase, SuiteMixin):
         </partial>
         """
         self.assertXmlPartialEqual(m1_expected, suite, "./entry[2]/session")
+
+        expected_stack = """
+        <partial>
+         <create>
+           <command value="'m0'"/>
+           <query id="results" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
+             <data key="case_type" ref="'case'"/>
+             <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+           </query>
+           <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
+           <command value="'m1'"/>
+           <query id="results:case" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
+             <data key="case_type" ref="'case'"/>
+             <data key="case_id" ref="instance('commcaresession')/session/data/case_id_case"/>
+           </query>
+           <datum id="case_id_case" value="instance('commcaresession')/session/data/case_id_case"/>
+           <command value="'m1-f1'"/>
+         </create>
+        </partial>"""
+        self.assertXmlPartialEqual(expected_stack, suite, "./entry[2]/stack/create")

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -126,6 +126,14 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
 
     def test_inline_search_multi_select(self):
         self.module.case_details.short.multi_select = True
+        self.module.case_details.short.columns.append(
+            DetailColumn.wrap(dict(
+                header={"en": "parent name"},
+                model="case",
+                format="plain",
+                field="parent/name"
+            ))
+        )
         suite = self.app.create_suite()
 
         instance_id = "selected_cases"
@@ -164,6 +172,14 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
           </entry>
         </partial>"""  # noqa: E501
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]")
+
+        expected_detail_columns = f"""
+        <partial>
+          <xpath function="case_name"/>
+          <xpath function="instance('{instance_id}')/results/case[@case_id=current()/index/parent]/case_name"/>
+        </partial>"""
+        self.assertXmlPartialEqual(
+            expected_detail_columns, suite, "./detail[@id='m0_case_short']/field/template/text/xpath")
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_inline_search_case_list_item(self):

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -202,9 +202,16 @@ class CaseSelectionXPath(XPath):
     selector = ''
 
     def case(self, instance_name='casedb', case_name='case'):
-        return CaseXPath("instance('{inst}')/{inst}/{case}[{sel}={self}]".format(
-            inst=instance_name, case=case_name, sel=self.selector, self=self
+        return CaseXPath("instance('{inst}')/{root}/{case}[{sel}={self}]".format(
+            inst=instance_name, root=self.get_instance_root(instance_name),
+            case=case_name, sel=self.selector, self=self
         ))
+
+    @staticmethod
+    def get_instance_root(instance_name):
+        return {
+            "selected_cases": "results"
+        }.get(instance_name, instance_name)
 
 
 class CaseIDXPath(CaseSelectionXPath):
@@ -224,8 +231,8 @@ class CaseTypeXpath(CaseSelectionXPath):
         for type in additional_types:
             quoted = CaseTypeXpath("'{}'".format(type))
             selector = "{selector} or {sel}={quoted}".format(selector=selector, sel=self.selector, quoted=quoted)
-        return CaseXPath("instance('{inst}')/{inst}/{case}[{sel}]".format(
-            inst=instance_name, case=case_name, sel=selector
+        return CaseXPath("instance('{inst}')/{root}/{case}[{sel}]".format(
+            inst=instance_name, root=self.get_instance_root(instance_name), case=case_name, sel=selector
         ))
 
 


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/31739

@AddisonDunn I was looking at this and got a bit carried away.

@orangejenny 
I'm also starting to have second thoughts about supporting 'inline search' in conjunction with child modules and parent select (where both parent / child modules use 'inline search'). There are a host of issues that come up when we start renaming these instances:

* instance references in case details e.g "parent/name"
  * these use the 'results' instance by default but we reuse the same detail when doing child modules / parent select which will have different instance IDs
* having multiple queries in an entry means we have to do a case claim for both the selected cases
  * mix that with multi-select case lists and now we're in trouble
* having 'dynamic' instance names will make it very hard for app builders to know how to reference the data (similar to the current issue we have with referencing the case ID session variable with child modules / parent select).
* using parent select with inline search doesn't really work since the 'claim' request only happens at the end of the session (right before form entry) so it is unlikely the parent will be available.