### PR TITLE
rename query.@storage_instance in remote requests

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -119,7 +119,10 @@ from corehq.apps.app_manager.suite_xml.generator import (
     MediaSuiteGenerator,
     SuiteGenerator,
 )
-from corehq.apps.app_manager.suite_xml.post_process.remote_requests import RESULTS_INSTANCE
+from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
+    RESULTS_INSTANCE,
+    SEARCH_RESULTS_INSTANCE,
+)
 from corehq.apps.app_manager.suite_xml.utils import get_select_chain
 from corehq.apps.app_manager.tasks import prune_auto_generated_builds
 from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans, trans
@@ -2535,7 +2538,7 @@ class ModuleDetailsMixin(object):
 
     def search_detail(self, short_or_long):
         detail = deepcopy(getattr(self.case_details, short_or_long))
-        detail.instance_name = RESULTS_INSTANCE
+        detail.instance_name = SEARCH_RESULTS_INSTANCE
         return detail
 
     def rename_lang(self, old_lang, new_lang):
@@ -3256,7 +3259,7 @@ class AdvancedModule(ModuleBase):
 
     def search_detail(self, short_or_long):
         detail = deepcopy(getattr(self.case_details, short_or_long))
-        detail.instance_name = RESULTS_INSTANCE
+        detail.instance_name = SEARCH_RESULTS_INSTANCE
         return detail
 
     @memoized

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -248,6 +248,7 @@ INSTANCE_KWARGS_BY_ID = {
     'commcaresession': dict(id='commcaresession', src='jr://instance/session'),
     'registry': dict(id='registry', src='jr://instance/remote'),
     'results': dict(id='results', src='jr://instance/remote'),
+    'search_results': dict(id='search_results', src='jr://instance/remote'),
     'selected_cases': dict(id='selected_cases', src='jr://instance/selected-entities'),
     'search_selected_cases': dict(id='search_selected_cases', src='jr://instance/selected-entities'),
 }

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -62,6 +62,7 @@ from corehq.util.view_utils import absolute_reverse
 
 # The name of the instance where search results are stored
 RESULTS_INSTANCE = 'results'
+SEARCH_RESULTS_INSTANCE = 'search_results'
 
 # The name of the instance where search results are stored when querying a data registry
 REGISTRY_INSTANCE = 'registry'
@@ -150,11 +151,11 @@ class RemoteRequestFactory(object):
             data=self.build_remote_request_datums(),
         )
 
-    def build_remote_request_queries(self):
+    def build_remote_request_queries(self, storage_instance=SEARCH_RESULTS_INSTANCE):
         return [
             RemoteRequestQuery(
                 url=absolute_reverse('app_aware_remote_search', args=[self.app.domain, self.app._id]),
-                storage_instance=RESULTS_INSTANCE,
+                storage_instance=storage_instance,
                 template='case',
                 data=self._remote_request_query_datums,
                 prompts=self.build_query_prompts(),
@@ -170,12 +171,12 @@ class RemoteRequestFactory(object):
             short_detail_id = 'search_short'
             long_detail_id = 'search_long'
 
-        nodeset = CaseTypeXpath(self.module.case_type).case(instance_name=RESULTS_INSTANCE)
+        nodeset = CaseTypeXpath(self.module.case_type).case(instance_name=SEARCH_RESULTS_INSTANCE)
         if toggles.USH_CASE_CLAIM_UPDATES.enabled(self.app.domain):
             additional_types = list(set(self.module.additional_case_types) - {self.module.case_type})
             if additional_types:
                 nodeset = CaseTypeXpath(self.module.case_type).cases(
-                    additional_types, instance_name=RESULTS_INSTANCE)
+                    additional_types, instance_name=SEARCH_RESULTS_INSTANCE)
             if self.module.search_config.search_filter:
                 nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
         nodeset += EXCLUDE_RELATED_CASES_FILTER
@@ -337,7 +338,7 @@ class RemoteRequestFactory(object):
 
     def _get_case_domain_xpath(self):
         case_id_xpath = CaseIDXPath(session_var(self.case_session_var))
-        return case_id_xpath.case(instance_name=RESULTS_INSTANCE).slash(COMMCARE_PROJECT)
+        return case_id_xpath.case(instance_name=SEARCH_RESULTS_INSTANCE).slash(COMMCARE_PROJECT)
 
 
 class SessionEndpointRemoteRequestFactory(RemoteRequestFactory):

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -572,9 +572,10 @@ class EntriesHelper(object):
         workflow and put the query directly in the entry.
         The case details is then populated with data from the results of the query.
         """
-        from corehq.apps.app_manager.suite_xml.post_process.remote_requests import RemoteRequestFactory
+        from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
+            RemoteRequestFactory, RESULTS_INSTANCE)
         factory = RemoteRequestFactory(None, module, [])
-        query = factory.build_remote_request_queries()[0]
+        query = factory.build_remote_request_queries(RESULTS_INSTANCE)[0]
         return FormDatumMeta(datum=query, case_type=None, requires_selection=False, action=None)
 
     def get_data_registry_case_datums(self, datum, module):

--- a/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
@@ -18,7 +18,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <instance id="search_selected_cases" src="jr://instance/selected-entities"/>
     <session>
-      <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/multiple-referrals/phone/search/{app_id}/">
+      <query default_search="false" storage-instance="search_results" template="case" url="https://www.example.com/a/multiple-referrals/phone/search/{app_id}/">
         <data key="case_type" ref="'person'"/>
         <prompt key="name">
           <display>
@@ -35,7 +35,7 @@
           </display>
         </prompt>
       </query>
-      <instance-datum detail-confirm="m0_search_long" detail-select="m0_search_short" id="search_selected_cases" nodeset="instance('results')/results/case[@case_type='person'][not(commcare_is_related_case=true())]" value="./@case_id"/>
+      <instance-datum detail-confirm="m0_search_long" detail-select="m0_search_short" id="search_selected_cases" nodeset="instance('search_results')/results/case[@case_type='person'][not(commcare_is_related_case=true())]" value="./@case_id"/>
     </session>
     <stack>
       <push>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -22,7 +22,7 @@
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"
-             storage-instance="results"
+             storage-instance="search_results"
              template="case">
         <data key="case_type" ref="'case'"/>
         <data key="&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;" ref="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;"/>
@@ -43,7 +43,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_is_related_case=true())]"
+             nodeset="instance('search_results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="{module_id}_search_long"
              detail-select="{module_id}_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -20,7 +20,7 @@
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"
-             storage-instance="results"
+             storage-instance="search_results"
              template="case">
         <data key="case_type" ref="'case'"/>
         <data key="&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;" ref="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;"/>
@@ -41,7 +41,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_is_related_case=true())]"
+             nodeset="instance('search_results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_case_long"
              detail-select="m0_case_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_command_detail.xml
@@ -178,7 +178,7 @@
       </header>
       <template>
         <text>
-          <xpath function="instance('results')/results/case[@case_id=current()/index/parent]/whatever"/>
+          <xpath function="instance('search_results')/results/case[@case_id=current()/index/parent]/whatever"/>
         </text>
       </template>
     </field>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -19,7 +19,7 @@
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"
-             storage-instance="results"
+             storage-instance="search_results"
              template="case">
         <data key="case_type" ref="'case'"/>
         <data key="commcare_blacklisted_owner_ids" ref="instance('commcaresession')/session/context/userid"/>
@@ -32,7 +32,7 @@
         </prompt>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_is_related_case=true())]"
+             nodeset="instance('search_results')/results/case[@case_type='case'][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -20,14 +20,14 @@
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"
-             storage-instance="results"
+             storage-instance="search_results"
              template="case">
         <data key="case_type" ref="'case'"/>
         <data key="&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;" ref="instance('casedb')/case[@case_id='instance('commcaresession')/session/data/case_id']/&#616;&#359;s&#570;&#359;&#589;&#570;&#7549;"/>
         <data key="name" ref="instance('locations')/locations/location[@id=123]/@type"/>
       </query>
       <datum id="search_case_id"
-             nodeset="instance('results')/results/case[@case_type='case'][not(commcare_is_related_case=true())]"
+             nodeset="instance('search_results')/results/case[@case_type='case'][not(commcare_is_related_case=true())]"
              value="./@case_id"
              detail-confirm="m0_search_long"
              detail-select="m0_search_short"/>

--- a/corehq/apps/app_manager/tests/data/suite/smart_link_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/smart_link_remote_request.xml
@@ -13,7 +13,7 @@
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
-      <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/test_domain/phone/search/{app_id}/">
+      <query default_search="false" storage-instance="search_results" template="case" url="https://www.example.com/a/test_domain/phone/search/{app_id}/">
         <data key="case_type" ref="'leaf'"/>
         <data key="x_commcare_data_registry" ref="'a_registry'"/>
         <prompt key="name">
@@ -31,16 +31,16 @@
           </display>
         </prompt>
       </query>
-      <datum detail-confirm="m1_search_long" detail-select="m1_search_short" id="search_case_id" nodeset="instance('results')/results/case[@case_type='leaf'][not(commcare_is_related_case=true())]" value="./@case_id"/>
+      <datum detail-confirm="m1_search_long" detail-select="m1_search_short" id="search_case_id" nodeset="instance('search_results')/results/case[@case_type='leaf'][not(commcare_is_related_case=true())]" value="./@case_id"/>
     </session>
     <stack>
-      <push if="not(instance('results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project = instance('commcaresession')/session/user/data/commcare_project)">
+      <push if="not(instance('search_results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project = instance('commcaresession')/session/user/data/commcare_project)">
         <jump>
           <url>
             <text>
               <xpath function="concat('https://www.example.com/a/', $domain, '/app/v1/{app_id}/child_endpoint/', '?case_id_leaf=', $case_id_leaf, '&amp;case_id=', $case_id)">
                 <variable name="domain">
-                  <xpath function="instance('results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project"/>
+                  <xpath function="instance('search_results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project"/>
                 </variable>
                 <variable name="case_id">
                   <xpath function="instance('commcaresession')/session/data/case_id"/>
@@ -53,7 +53,7 @@
           </url>
         </jump>
       </push>
-      <push if="instance('results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project = instance('commcaresession')/session/user/data/commcare_project">
+      <push if="instance('search_results')/results/case[@case_id=instance('commcaresession')/session/data/search_case_id]/commcare_project = instance('commcaresession')/session/user/data/commcare_project">
         <rewind value="instance('commcaresession')/session/data/search_case_id"/>
       </push>
     </stack>

--- a/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_remote_request.xml
@@ -14,7 +14,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <instance id="item-list:textures" src="jr://fixture/item-list:textures"/>
     <session>
-      <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/test_domain/phone/search/456/">
+      <query default_search="false" storage-instance="search_results" template="case" url="https://www.example.com/a/test_domain/phone/search/456/">
         <data key="case_type" ref="'case'"/>
         <data key="x_commcare_data_registry" ref="'myregistry'"/>
         <prompt key="name">
@@ -37,7 +37,7 @@
           </itemset>
         </prompt>
       </query>
-      <datum detail-confirm="m1_search_long" detail-select="m1_search_short" id="search_case_id" nodeset="instance('results')/results/case[@case_type='case'][not(commcare_is_related_case=true())]" value="./@case_id"/>
+      <datum detail-confirm="m1_search_long" detail-select="m1_search_short" id="search_case_id" nodeset="instance('search_results')/results/case[@case_type='case'][not(commcare_is_related_case=true())]" value="./@case_id"/>
     </session>
     <stack>
       <push>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -21,13 +21,12 @@ from corehq.apps.app_manager.suite_xml.sections.details import (
 from corehq.apps.app_manager.suite_xml.sections.entries import EntriesContributor
 from corehq.apps.app_manager.suite_xml.generator import SuiteGenerator
 from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
-    RESULTS_INSTANCE,
+    SEARCH_RESULTS_INSTANCE,
     RemoteRequestFactory,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
-    TestXmlMixin,
     parse_normalize,
     patch_get_xform_resource_overrides,
 )
@@ -91,7 +90,7 @@ class RemoteRequestSmartLinkTest(SimpleTestCase, SuiteMixin):
         self.assertEqual([v.name for v in vars], ['domain', 'case_id', 'case_id_leaf'])
         session_case_id = "instance('commcaresession')/session/data/search_case_id"
         self.assertEqual([v.xpath.function for v in vars], [
-            f"instance('results')/results/case[@case_id={session_case_id}]/commcare_project",
+            f"instance('{SEARCH_RESULTS_INSTANCE}')/results/case[@case_id={session_case_id}]/commcare_project",
             "instance('commcaresession')/session/data/case_id",
             "instance('commcaresession')/session/data/search_case_id",
         ])
@@ -292,8 +291,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
             "instance('{}')/{}/case[@case_type='{}'][{}]{}".format(
-                RESULTS_INSTANCE,
-                RESULTS_INSTANCE,
+                SEARCH_RESULTS_INSTANCE,
+                "results",
                 self.module.case_type,
                 search_filter,
                 EXCLUDE_RELATED_CASES_FILTER
@@ -310,8 +309,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         ref_path = './remote-request[1]/session/datum/@nodeset'
         self.assertEqual(
             "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][{}]{}".format(
-                RESULTS_INSTANCE,
-                RESULTS_INSTANCE,
+                SEARCH_RESULTS_INSTANCE,
+                "results",
                 self.module.case_type,
                 another_case_type,
                 self.module.search_config.search_filter,
@@ -352,8 +351,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         ref_path = './remote-request[2]/session/datum/@nodeset'
         self.assertEqual(
             "instance('{}')/{}/case[@case_type='{}' or @case_type='{}']{}".format(
-                RESULTS_INSTANCE,
-                RESULTS_INSTANCE,
+                SEARCH_RESULTS_INSTANCE,
+                "results",
                 self.module.case_type,
                 another_case_type,
                 EXCLUDE_RELATED_CASES_FILTER

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -202,9 +202,16 @@ class CaseSelectionXPath(XPath):
     selector = ''
 
     def case(self, instance_name='casedb', case_name='case'):
-        return CaseXPath("instance('{inst}')/{inst}/{case}[{sel}={self}]".format(
-            inst=instance_name, case=case_name, sel=self.selector, self=self
+        return CaseXPath("instance('{inst}')/{root}/{case}[{sel}={self}]".format(
+            inst=instance_name, root=self.get_instance_root(instance_name),
+            case=case_name, sel=self.selector, self=self
         ))
+
+    @staticmethod
+    def get_instance_root(instance_name):
+        return {
+            "search_results": "results"
+        }.get(instance_name, instance_name)
 
 
 class CaseIDXPath(CaseSelectionXPath):
@@ -224,8 +231,8 @@ class CaseTypeXpath(CaseSelectionXPath):
         for type in additional_types:
             quoted = CaseTypeXpath("'{}'".format(type))
             selector = "{selector} or {sel}={quoted}".format(selector=selector, sel=self.selector, quoted=quoted)
-        return CaseXPath("instance('{inst}')/{inst}/{case}[{sel}]".format(
-            inst=instance_name, case=case_name, sel=selector
+        return CaseXPath("instance('{inst}')/{root}/{case}[{sel}]".format(
+            inst=instance_name, root=self.get_instance_root(instance_name), case=case_name, sel=selector
         ))
 
 


### PR DESCRIPTION
## Technical Summary
This is to avoid naming conflicts when using normal case search
in conjunction with inline case search e.g. parent module
uses inline and child module uses normal. Both can't use the
same instance name.

The alternative is to rename the instance used in 'inline search' from `results` to something else.

## Feature Flag
case search

## Safety Assurance

### Safety story
I need to check whether the 'results' instance is referenced in case details columns for modules using case search. If so we'll need to rename those as well

### Automated test coverage
Tests updated

### QA Plan
?


### Migrations
None yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

TODO
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
