### PR TITLE
Run update-translations every Wed

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,4 +1,7 @@
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 3'  # Every Wed at 06:00 UTC
 
 name: Update transifex translations
 jobs:


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-12685

There is no real urgency to merging this, but when we do, it'll trigger the "Update transifex translations" (which runs `scripts/update-translations.sh`) once a week on Wednesday at 6:00 UTC (which is 1am or 2am ET depending on DST). For tests to run, one of us has to manually close and reopen it, which is annoying. Then it can be reviewed, approved, and merged (all by the same person).

Since all translation string changes are now paired with the code changes that create them, the changes to review once a week are limited to just the actual foreign language translation changes. (Review should be looking for anything that looks off about the structure of it, not the content of the translations.)

## Safety Assurance

### Safety story
This change affects a process without directly affecting production. Since this introduces a review step where there wasn't one before, even if we expect the review to be somewhat cursory, it's as good as or better than what we had before in terms of safety/correctness.

I also tested that we're ready for this by triggering the "Update transifex translations" github action workflow, waiting for tests to pass, approving/merging it, and then triggering it again. The second time there were no further changes and it didn't open a PR, which shows that that process now has the desirable quality of being idempotent.

### Automated test coverage

The translation tests that run on every PR would catch if there's something wrong during the process (though there's not really anything to test on the change in this specific PR).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
