### PR TITLE
Restrict global sms gateway settings to devs

### DIFF
--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -27,6 +27,7 @@ from django.views.generic import View
 from couchdbkit import ResourceNotFound
 from django_prbac.utils import has_privilege
 from memoized import memoized
+from corehq.apps.smsbillables.dispatcher import SMSAdminInterfaceDispatcher
 
 from couchexport.export import export_raw
 from couchexport.models import Format
@@ -1387,6 +1388,13 @@ class GlobalSmsGatewayListView(CRUDPaginatedViewMixin, BaseAdminSectionView):
 
     @method_decorator(require_superuser)
     def dispatch(self, request, *args, **kwargs):
+        if not request.couch_user.is_staff:
+            return HttpResponseRedirect(
+                reverse(
+                    SMSAdminInterfaceDispatcher.name(),
+                    kwargs={'report_slug': 'sms_billables'}
+                )
+            )
         return super(GlobalSmsGatewayListView, self).dispatch(request, *args, **kwargs)
 
     @property

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1542,6 +1542,8 @@ class AddGlobalGatewayView(AddGatewayViewMixin, BaseAdminSectionView):
 
     @method_decorator(require_superuser)
     def dispatch(self, request, *args, **kwargs):
+        if not request.couch_user.is_staff:
+            return HttpResponseRedirect(reverse("no_permissions"))
         return super(AddGlobalGatewayView, self).dispatch(request, *args, **kwargs)
 
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -2240,18 +2240,19 @@ class SMSAdminTab(UITab):
         from corehq.apps.sms.views import (GlobalSmsGatewayListView,
             AddGlobalGatewayView, EditGlobalGatewayView)
         items = SMSAdminInterfaceDispatcher.navigation_sections(request=self._request, domain=self.domain)
-        items.append((_('SMS Connectivity'), [
-            {'title': _('Gateways'),
-             'url': reverse(GlobalSmsGatewayListView.urlname),
-             'subpages': [
-                 {'title': _('Add Gateway'),
-                  'urlname': AddGlobalGatewayView.urlname},
-                 {'title': _('Edit Gateway'),
-                  'urlname': EditGlobalGatewayView.urlname},
-            ]},
-            {'title': _('Default Gateways'),
-             'url': reverse('global_backend_map')},
-        ]))
+        if self.couch_user.is_staff:
+            items.append((_('SMS Connectivity'), [
+                {'title': _('Gateways'),
+                'url': reverse(GlobalSmsGatewayListView.urlname),
+                'subpages': [
+                    {'title': _('Add Gateway'),
+                    'urlname': AddGlobalGatewayView.urlname},
+                    {'title': _('Edit Gateway'),
+                    'urlname': EditGlobalGatewayView.urlname},
+                ]},
+                {'title': _('Default Gateways'),
+                'url': reverse('global_backend_map')},
+            ]))
         return items
 
     @property


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
We are restricting access to edit Global SMS configs to developers only i.e users whose `is_staff` is set to True. Earlier any superuser had the ability to edit these. 

The view that is shown to users who are superusers and have `is_staff` flag set to True.
<img width="1259" alt="Screenshot 2022-06-08 at 2 12 03 PM" src="https://user-images.githubusercontent.com/7694243/172573994-7c22ca69-c535-4cb9-9ec9-d33a963b9b71.png">

The view shown to user when they are superusers but does not have `is_staff` set to False.

<img width="1606" alt="Screenshot 2022-06-08 at 2 11 45 PM" src="https://user-images.githubusercontent.com/7694243/172573974-3b510988-5a7f-4bb4-897c-0fbe257246e8.png">

## Technical Smmary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13505
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on Local.
### Automated test coverage
NA
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
