### PR TITLE
validate build for inline search

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -370,11 +370,18 @@ class ModuleBaseValidator(object):
                     'module': self.get_module_info(),
                 })
 
-        if self.module.put_in_root and self.module.session_endpoint_id:
-            errors.append({
-                'type': 'endpoint to display only forms',
-                'module': self.get_module_info(),
-            })
+        uses_inline_search = module_uses_inline_search(self.module)
+        if self.module.put_in_root:
+            if self.module.session_endpoint_id:
+                errors.append({
+                    'type': 'endpoint to display only forms',
+                    'module': self.get_module_info(),
+                })
+            if uses_inline_search:
+                errors.append({
+                    'type': 'inline search to display only forms',
+                    'module': self.get_module_info(),
+                })
 
         if hasattr(self.module, 'parent_select') and self.module.parent_select.active:
             if self.module.parent_select.relationship == 'parent':
@@ -406,7 +413,7 @@ class ModuleBaseValidator(object):
                     'type': 'smart links multi select',
                     'module': self.get_module_info(),
                 })
-            if module_uses_inline_search(self.module):
+            if uses_inline_search:
                 errors.append({
                     'type': 'smart links inline search',
                     'module': self.get_module_info(),

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -396,6 +396,14 @@ class ModuleBaseValidator(object):
                     'type': 'invalid parent select id',
                     'module': self.get_module_info(),
                 })
+            else:
+                module_id = self.module.parent_select.module_id
+                parent_select_module = self.module.get_app().get_module_by_unique_id(module_id)
+                if parent_select_module and module_uses_inline_search(parent_select_module):
+                    errors.append({
+                        'type': 'parent select is inline search module',
+                        'module': self.get_module_info(),
+                    })
 
         if module_uses_smart_links(self.module):
             if not self.module.session_endpoint_id:

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -405,6 +405,13 @@ class ModuleBaseValidator(object):
                         'module': self.get_module_info(),
                     })
 
+            if uses_inline_search:
+                if self.module.parent_select.relationship:
+                    errors.append({
+                        'type': 'inline search parent select relationship',
+                        'module': self.get_module_info(),
+                    })
+
         if module_uses_smart_links(self.module):
             if not self.module.session_endpoint_id:
                 errors.append({

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -441,7 +441,7 @@ class ModuleBaseValidator(object):
                     'module': self.get_module_info(),
                 })
 
-        if hasattr(self.module, 'root_module_id') and self.module.root_module_id:
+        if self.module.root_module_id:
             root_module = self.module.get_app().get_module_by_unique_id(self.module.root_module_id)
             if root_module and module_uses_inline_search(root_module):
                 errors.append({

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -419,6 +419,14 @@ class ModuleBaseValidator(object):
                     'module': self.get_module_info(),
                 })
 
+        if hasattr(self.module, 'root_module_id') and self.module.root_module_id:
+            root_module = self.module.get_app().get_module_by_unique_id(self.module.root_module_id)
+            if root_module and module_uses_inline_search(root_module):
+                errors.append({
+                    'type': 'inline search as parent module',
+                    'module': self.get_module_info(),
+                })
+
         return errors
 
     def validate_detail_columns(self, columns):

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -210,6 +210,12 @@
                 uses parent case selection but parent case list is using
                 "make search input available after search". This workflow is unsupported.
               {% endblocktrans %}
+            {% case "inline search parent select relationship" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                uses parent case selection and is configured with
+                "make search input available after search". This workflow is unsupported.
+              {% endblocktrans %}
             {% case "circular case hierarchy" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -204,6 +204,12 @@
                 uses "Display only forms" and is also configured with
                 "make search input available after search". This workflow is unsupported.
               {% endblocktrans %}
+            {% case "parent select is inline search module" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                uses parent case selection but parent case list is using
+                "make search input available after search". This workflow is unsupported.
+              {% endblocktrans %}
             {% case "circular case hierarchy" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -198,6 +198,12 @@
                 has a Parent Menu configured with "make search input available after search",
                 This workflow is unsupported.
               {% endblocktrans %}
+            {% case "inline search to display only forms" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                uses "Display only forms" and is also configured with
+                "make search input available after search". This workflow is unsupported.
+              {% endblocktrans %}
             {% case "circular case hierarchy" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -192,6 +192,12 @@
                 uses smart links and is configured to make search input available after search.
                 These two features are not compatible.
               {% endblocktrans %}
+            {% case "inline search as parent module" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                has a Parent Menu configured with "make search input available after search",
+                This workflow is unsupported.
+              {% endblocktrans %}
             {% case "circular case hierarchy" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -219,24 +219,3 @@ class BuildErrorsTest(SimpleTestCase):
             'type': 'smart links multi select',
             'module': {'id': 0, 'unique_id': 'basic_module', 'name': {'en': 'basic module'}}
         }, factory.app.validate_app())
-
-    @flag_enabled('DATA_REGISTRY')
-    @patch.object(Application, 'supports_data_registry', lambda: True)
-    def test_inline_search_module_errors(self, *args):
-        factory = AppFactory()
-        module, form = factory.new_basic_module('basic', 'person')
-        factory.form_requires_case(form, 'person')
-
-        module.search_config = CaseSearch(
-            search_label=CaseSearchLabel(label={'en': 'Search'}),
-            properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
-            data_registry="so_many_cases",
-            data_registry_workflow=REGISTRY_WORKFLOW_SMART_LINK,
-            auto_launch=True,
-            inline_search=True,
-        )
-
-        self.assertIn({
-            'type': "smart links inline search",
-            'module': {'id': 0, 'unique_id': 'basic_module', 'name': {'en': 'basic module'}}
-        }, factory.app.validate_app())

--- a/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
@@ -20,6 +20,7 @@ from corehq.util.test_utils import flag_enabled
 class BuildErrorsInlineSearchTest(SimpleTestCase):
 
     def test_inline_search_as_parent(self, *args):
+        """an inline search module can't be a parent module"""
         factory = AppFactory(build_version='2.51.0')
         m0, _ = factory.new_basic_module('first', 'case')
         m1, _ = factory.new_basic_module('second', 'case', parent_module=m0)
@@ -52,6 +53,7 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
         self.assertIn("smart links inline search", _get_error_types(factory.app))
 
     def test_inline_search_display_only_forms(self, *args):
+        """can't use 'display only forms' with inline search"""
         factory = AppFactory(build_version='2.51.0')
         m0, _ = factory.new_basic_module('first', 'case')
         m0.put_in_root = True
@@ -66,6 +68,7 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
         self.assertIn("inline search to display only forms", _get_error_types(factory.app))
 
     def test_parent_select_to_inline_search(self, *args):
+        """an inline module can't be the target of parent select"""
         factory = AppFactory(build_version='2.51.0')
         m0, _ = factory.new_basic_module('first', 'case')
 
@@ -83,6 +86,24 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
 
         self.assertIn("parent select is inline search module", _get_error_types(factory.app))
 
+    def test_parent_select_of_inline_search_module(self, *args):
+        """inline search can't use parent select with relationship='parent'"""
+        factory = AppFactory(build_version='2.51.0')
+        m0, _ = factory.new_basic_module('first', 'case')
+
+        m0.search_config = CaseSearch(
+            search_label=CaseSearchLabel(label={'en': 'Search'}),
+            properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
+            auto_launch=True,
+            inline_search=True,
+        )
+
+        m1, _ = factory.new_basic_module('second', 'case')
+
+        m0.parent_select.active = True
+        m0.parent_select.module_id = m0.get_or_create_unique_id()
+
+        self.assertIn("inline search parent select relationship", _get_error_types(factory.app))
 
 
 def _get_error_types(app):

--- a/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
@@ -51,6 +51,21 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
 
         self.assertIn("smart links inline search", _get_error_types(factory.app))
 
+    def test_inline_search_display_only_forms(self, *args):
+        factory = AppFactory(build_version='2.51.0')
+        m0, _ = factory.new_basic_module('first', 'case')
+        m0.put_in_root = True
+
+        m0.search_config = CaseSearch(
+            search_label=CaseSearchLabel(label={'en': 'Search'}),
+            properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
+            auto_launch=True,
+            inline_search=True,
+        )
+
+        self.assertIn("inline search to display only forms", _get_error_types(factory.app))
+
+
 
 def _get_error_types(app):
     return [error['type'] for error in app.validate_app()]

--- a/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
@@ -19,6 +19,20 @@ from corehq.util.test_utils import flag_enabled
 @patch.object(Application, 'enable_practice_users', return_value=False)
 class BuildErrorsInlineSearchTest(SimpleTestCase):
 
+    def test_inline_search_as_parent(self, *args):
+        factory = AppFactory(build_version='2.51.0')
+        m0, _ = factory.new_basic_module('first', 'case')
+        m1, _ = factory.new_basic_module('second', 'case', parent_module=m0)
+
+        m0.search_config = CaseSearch(
+            search_label=CaseSearchLabel(label={'en': 'Search'}),
+            properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
+            auto_launch=True,
+            inline_search=True,
+        )
+
+        self.assertIn("inline search as parent module", _get_error_types(factory.app))
+
     @flag_enabled('DATA_REGISTRY')
     @patch.object(Application, 'supports_data_registry', lambda: True)
     def test_inline_search_smart_links(self, *args):

--- a/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
@@ -65,6 +65,24 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
 
         self.assertIn("inline search to display only forms", _get_error_types(factory.app))
 
+    def test_parent_select_to_inline_search(self, *args):
+        factory = AppFactory(build_version='2.51.0')
+        m0, _ = factory.new_basic_module('first', 'case')
+
+        m0.search_config = CaseSearch(
+            search_label=CaseSearchLabel(label={'en': 'Search'}),
+            properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
+            auto_launch=True,
+            inline_search=True,
+        )
+
+        m1, _ = factory.new_basic_module('second', 'case')
+        m1.parent_select.active = True
+        m1.parent_select.relationship = None
+        m1.parent_select.module_id = m0.get_or_create_unique_id()
+
+        self.assertIn("parent select is inline search module", _get_error_types(factory.app))
+
 
 
 def _get_error_types(app):

--- a/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from corehq.apps.app_manager.const import REGISTRY_WORKFLOW_SMART_LINK
+from corehq.apps.app_manager.models import (
+    Application,
+    CaseSearch,
+    CaseSearchLabel,
+    CaseSearchProperty,
+)
+from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.util.test_utils import flag_enabled
+
+
+@patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+@patch('corehq.apps.app_manager.helpers.validators.domain_has_privilege', return_value=True)
+@patch('corehq.apps.builds.models.BuildSpec.supports_j2me', return_value=False)
+@patch.object(Application, 'enable_practice_users', return_value=False)
+class BuildErrorsInlineSearchTest(SimpleTestCase):
+
+    @flag_enabled('DATA_REGISTRY')
+    @patch.object(Application, 'supports_data_registry', lambda: True)
+    def test_inline_search_smart_links(self, *args):
+        factory = AppFactory()
+        module, form = factory.new_basic_module('basic', 'person')
+        factory.form_requires_case(form, 'person')
+
+        module.search_config = CaseSearch(
+            search_label=CaseSearchLabel(label={'en': 'Search'}),
+            properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
+            data_registry="so_many_cases",
+            data_registry_workflow=REGISTRY_WORKFLOW_SMART_LINK,
+            auto_launch=True,
+            inline_search=True,
+        )
+
+        self.assertIn("smart links inline search", _get_error_types(factory.app))
+
+
+def _get_error_types(app):
+    return [error['type'] for error in app.validate_app()]

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:39+0000\n"
+"POT-Creation-Date: 2022-06-09 08:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6160,6 +6160,50 @@ msgid ""
 "                uses smart links and is configured to make search input "
 "available after search.\n"
 "                These two features are not compatible.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                has a Parent Menu configured with \"make search input "
+"available after search\",\n"
+"                This workflow is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses \"Display only forms\" and is also configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection but parent case list is using\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection and is configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
 "              "
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-07 17:42+0000\n"
+"POT-Creation-Date: 2022-06-09 08:54+0000\n"
 "PO-Revision-Date: 2014-03-24 22:36+0000\n"
 "Last-Translator: Sravan Reddy <sreddy@dimagi.com>, 2017\n"
 "Language-Team: Spanish (http://www.transifex.com/dimagi/commcare-hq/language/"
@@ -6655,6 +6655,50 @@ msgid ""
 "                uses smart links and is configured to make search input "
 "available after search.\n"
 "                These two features are not compatible.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                has a Parent Menu configured with \"make search input "
+"available after search\",\n"
+"                This workflow is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses \"Display only forms\" and is also configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection but parent case list is using\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection and is configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
 "              "
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:39+0000\n"
+"POT-Creation-Date: 2022-06-09 08:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6161,6 +6161,50 @@ msgid ""
 "                uses smart links and is configured to make search input "
 "available after search.\n"
 "                These two features are not compatible.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                has a Parent Menu configured with \"make search input "
+"available after search\",\n"
+"                This workflow is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses \"Display only forms\" and is also configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection but parent case list is using\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection and is configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
 "              "
 msgstr ""
 

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -36,7 +36,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-07 17:42+0000\n"
+"POT-Creation-Date: 2022-06-09 08:54+0000\n"
 "PO-Revision-Date: 2014-03-24 22:36+0000\n"
 "Last-Translator: Tyler Wymer <twymer@dimagi.com>, 2014\n"
 "Language-Team: French (http://www.transifex.com/dimagi/commcare-hq/language/"
@@ -6533,6 +6533,50 @@ msgid ""
 "                uses smart links and is configured to make search input "
 "available after search.\n"
 "                These two features are not compatible.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                has a Parent Menu configured with \"make search input "
+"available after search\",\n"
+"                This workflow is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses \"Display only forms\" and is also configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection but parent case list is using\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection and is configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
 "              "
 msgstr ""
 

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:39+0000\n"
+"POT-Creation-Date: 2022-06-09 08:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6161,6 +6161,50 @@ msgid ""
 "                uses smart links and is configured to make search input "
 "available after search.\n"
 "                These two features are not compatible.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                has a Parent Menu configured with \"make search input "
+"available after search\",\n"
+"                This workflow is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses \"Display only forms\" and is also configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection but parent case list is using\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection and is configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
 "              "
 msgstr ""
 

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-07 17:42+0000\n"
+"POT-Creation-Date: 2022-06-09 08:54+0000\n"
 "PO-Revision-Date: 2014-03-24 22:36+0000\n"
 "Last-Translator: Zsolt Bölöny <bolony.zsolt@gmail.com>, 2013\n"
 "Language-Team: Hindi (http://www.transifex.com/dimagi/commcare-hq/language/"
@@ -6174,6 +6174,50 @@ msgid ""
 "                uses smart links and is configured to make search input "
 "available after search.\n"
 "                These two features are not compatible.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                has a Parent Menu configured with \"make search input "
+"available after search\",\n"
+"                This workflow is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses \"Display only forms\" and is also configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection but parent case list is using\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection and is configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
 "              "
 msgstr ""
 

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -37,7 +37,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-07 17:42+0000\n"
+"POT-Creation-Date: 2022-06-09 08:54+0000\n"
 "PO-Revision-Date: 2014-03-24 22:36+0000\n"
 "Last-Translator: Tyler Wymer <twymer@dimagi.com>, 2014\n"
 "Language-Team: Portuguese (http://www.transifex.com/dimagi/commcare-hq/"
@@ -6230,6 +6230,50 @@ msgid ""
 "                uses smart links and is configured to make search input "
 "available after search.\n"
 "                These two features are not compatible.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                has a Parent Menu configured with \"make search input "
+"available after search\",\n"
+"                This workflow is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses \"Display only forms\" and is also configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection but parent case list is using\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection and is configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
 "              "
 msgstr ""
 

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:39+0000\n"
+"POT-Creation-Date: 2022-06-09 08:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6161,6 +6161,50 @@ msgid ""
 "                uses smart links and is configured to make search input "
 "available after search.\n"
 "                These two features are not compatible.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                has a Parent Menu configured with \"make search input "
+"available after search\",\n"
+"                This workflow is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses \"Display only forms\" and is also configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection but parent case list is using\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection and is configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
 "              "
 msgstr ""
 

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-03 13:39+0000\n"
+"POT-Creation-Date: 2022-06-09 08:54+0000\n"
 "PO-Revision-Date: 2014-03-24 22:36+0000\n"
 "Last-Translator: esoergel, 2015\n"
 "Language-Team: Swahili (http://www.transifex.com/dimagi/commcare-hq/language/"
@@ -6165,6 +6165,50 @@ msgid ""
 "                uses smart links and is configured to make search input "
 "available after search.\n"
 "                These two features are not compatible.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                has a Parent Menu configured with \"make search input "
+"available after search\",\n"
+"                This workflow is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses \"Display only forms\" and is also configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection but parent case list is using\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+#, python-format
+msgid ""
+"\n"
+"                <a href=\"%(module_url)s\">%(module_name)s</a>\n"
+"                uses parent case selection and is configured with\n"
+"                \"make search input available after search\". This workflow "
+"is unsupported.\n"
 "              "
 msgstr ""
 


### PR DESCRIPTION
## Product Description
Modules using inline search do not interact well with all other app features. This PR adds build validation to check for unsupported workflows:

* Inline search can not be parent module
  * The case claim request isn’t included in child module entries 
* Parent select
  * Inline search module can never the target of ‘parent select’
    * The case claim request isn’t included in module’s entries
  * Inline search can use parent select but only with relationship = ‘other’
    * Parent filtering doesn’t work if relationship = ‘parent’


## Feature Flag
inline search

## Safety Assurance

### Safety story
Adds build errors for various app configurations involving inline search

### Automated test coverage
Added test coverage for the build errors

### QA Plan
No separate QA plan. Will be done as part of the inline search QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
