### PR TITLE
rename inline search instance

### DIFF
--- a/corehq/apps/app_manager/management/commands/migrate_inline_search_instance.py
+++ b/corehq/apps/app_manager/management/commands/migrate_inline_search_instance.py
@@ -5,9 +5,10 @@ from corehq.apps.app_manager.management.commands.helpers import (
 )
 from corehq.toggles import USH_INLINE_SEARCH
 
-results_instance_re = re.compile(r"""instance\(['"]results['"]\)""", re.UNICODE)
-input_instance_re = re.compile(r"""instance\(['"]search-input:results['"]\)""", re.UNICODE)
-new_instance = "search_results"
+old_instance = "search_results"
+new_instance = "results:inline"
+results_instance_re = re.compile(rf"""instance\(['"]{old_instance}['"]\)""", re.UNICODE)
+input_instance_re = re.compile(rf"""instance\(['"]search-input:{old_instance}['"]\)""", re.UNICODE)
 results_new = f"instance('{new_instance}')"
 input_new = f"instance('search-input:{new_instance}')"
 

--- a/corehq/apps/app_manager/management/commands/migrate_inline_search_instance.py
+++ b/corehq/apps/app_manager/management/commands/migrate_inline_search_instance.py
@@ -33,6 +33,8 @@ class Command(AppMigrationCommandBase):
                 should_save |= self._migrate_detail(app_doc, module, 'short')
                 should_save |= self._migrate_detail(app_doc, module, 'long')
 
+        if should_save and not app_doc.get('copy_of') and app_doc.get('version'):
+            app_doc['version'] = app_doc['version'] + 1
         return app_doc if should_save else None
 
     def get_domains(self):

--- a/corehq/apps/app_manager/management/commands/migrate_inline_search_instance.py
+++ b/corehq/apps/app_manager/management/commands/migrate_inline_search_instance.py
@@ -1,0 +1,56 @@
+import re
+
+from corehq.apps.app_manager.management.commands.helpers import (
+    AppMigrationCommandBase,
+)
+from corehq.toggles import USH_INLINE_SEARCH
+
+results_instance_re = re.compile(r"""instance\(['"]results['"]\)""", re.UNICODE)
+input_instance_re = re.compile(r"""instance\(['"]search-input:results['"]\)""", re.UNICODE)
+new_instance = "search_results"
+results_new = f"instance('{new_instance}')"
+input_new = f"instance('search-input:{new_instance}')"
+
+
+class Command(AppMigrationCommandBase):
+    help = """"""
+
+    chunk_size = 1
+    include_builds = True
+    include_linked_apps = True
+
+    def migrate_app(self, app_doc):
+        should_save = False
+        for module in app_doc.get('modules', []):
+            search_config = module.get('search_config')
+            if (
+                search_config
+                and search_config.get('properties')
+                and search_config.get('auto_launch')
+                and search_config.get('inline_search')
+            ):
+                should_save |= self._migrate_detail(app_doc, module, 'short')
+                should_save |= self._migrate_detail(app_doc, module, 'long')
+
+        return app_doc if should_save else None
+
+    def get_domains(self):
+        return sorted(USH_INLINE_SEARCH.get_enabled_domains())
+
+    def _migrate_detail(self, app, module, detail):
+        details = module.get('case_details').get(detail)
+        should_save = False
+        for col in details.get('columns'):
+            field = col.get('field')
+            new_field = results_instance_re.sub(results_new, field)
+            new_field = input_instance_re.sub(input_new, new_field)
+            if field != new_field:
+                should_save = True
+                col['field'] = new_field
+                if self.log_debug:
+                    print("    ", field, "-->", new_field)
+
+        if should_save and self.log_info:
+            name = module['name'].get('en', module['name'])
+            print(f"Updated {detail} details for module '{name}' in app: {app['_id']}")
+        return should_save

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -119,7 +119,10 @@ from corehq.apps.app_manager.suite_xml.generator import (
     MediaSuiteGenerator,
     SuiteGenerator,
 )
-from corehq.apps.app_manager.suite_xml.post_process.remote_requests import RESULTS_INSTANCE
+from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
+    RESULTS_INSTANCE,
+    RESULTS_INSTANCE_INLINE
+)
 from corehq.apps.app_manager.suite_xml.utils import get_select_chain
 from corehq.apps.app_manager.tasks import prune_auto_generated_builds
 from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans, trans
@@ -2071,8 +2074,11 @@ class Detail(IndexedSchema, CaseListLookupMixin):
 
     def get_instance_name(self, module):
         value_is_the_default = self.instance_name == 'casedb'
-        if value_is_the_default and module_loads_registry_case(module) or module_uses_inline_search(module):
-            return RESULTS_INSTANCE
+        if value_is_the_default:
+            if module_uses_inline_search(module):
+                return RESULTS_INSTANCE_INLINE
+            elif module_loads_registry_case(module):
+                return RESULTS_INSTANCE
         return self.instance_name
 
     def get_tab_spans(self):

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -247,8 +247,6 @@ INSTANCE_KWARGS_BY_ID = {
     'casedb': dict(id='casedb', src='jr://instance/casedb'),
     'commcaresession': dict(id='commcaresession', src='jr://instance/session'),
     'registry': dict(id='registry', src='jr://instance/remote'),
-    'results': dict(id='results', src='jr://instance/remote'),
-    'search_results': dict(id='search_results', src='jr://instance/remote'),
     'selected_cases': dict(id='selected_cases', src='jr://instance/selected-entities'),
     'search_selected_cases': dict(id='search_selected_cases', src='jr://instance/selected-entities'),
 }
@@ -269,6 +267,12 @@ def generic_fixture_instances(app, instance_name):
 @register_factory('search-input')
 def search_input_instances(app, instance_name):
     return Instance(id=instance_name, src='jr://instance/search-input')
+
+
+@register_factory('results')
+def remote_instances(app, instance_name):
+    return Instance(id=instance_name, src='jr://instance/remote')
+
 
 
 @register_factory('commcare')

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -274,7 +274,6 @@ def remote_instances(app, instance_name):
     return Instance(id=instance_name, src='jr://instance/remote')
 
 
-
 @register_factory('commcare')
 def commcare_fixture_instances(app, instance_name):
     if instance_name == 'commcare:reports' and toggles.MOBILE_UCR.enabled(app.domain):

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -248,6 +248,7 @@ INSTANCE_KWARGS_BY_ID = {
     'commcaresession': dict(id='commcaresession', src='jr://instance/session'),
     'registry': dict(id='registry', src='jr://instance/remote'),
     'results': dict(id='results', src='jr://instance/remote'),
+    'search_results': dict(id='search_results', src='jr://instance/remote'),
     'selected_cases': dict(id='selected_cases', src='jr://instance/selected-entities'),
     'search_selected_cases': dict(id='search_selected_cases', src='jr://instance/selected-entities'),
 }

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -62,7 +62,7 @@ from corehq.util.view_utils import absolute_reverse
 
 # The name of the instance where search results are stored
 RESULTS_INSTANCE = 'results'
-RESULTS_INSTANCE_INLINE = 'search_results'
+RESULTS_INSTANCE_INLINE = 'results:inline'
 
 # The name of the instance where search results are stored when querying a data registry
 REGISTRY_INSTANCE = 'registry'

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -62,6 +62,7 @@ from corehq.util.view_utils import absolute_reverse
 
 # The name of the instance where search results are stored
 RESULTS_INSTANCE = 'results'
+RESULTS_INSTANCE_INLINE = 'search_results'
 
 # The name of the instance where search results are stored when querying a data registry
 REGISTRY_INSTANCE = 'registry'
@@ -78,12 +79,14 @@ class QuerySessionXPath(InstanceXpath):
 
 
 class RemoteRequestFactory(object):
-    def __init__(self, suite, module, detail_section_elements, case_session_var=None):
+    def __init__(self, suite, module, detail_section_elements,
+                 case_session_var=None, storage_instance=RESULTS_INSTANCE):
         self.suite = suite
         self.app = module.get_app()
         self.domain = self.app.domain
         self.module = module
         self.detail_section_elements = detail_section_elements
+        self.storage_instance = storage_instance
         if case_session_var:
             self.case_session_var = case_session_var
         else:
@@ -154,7 +157,7 @@ class RemoteRequestFactory(object):
         return [
             RemoteRequestQuery(
                 url=absolute_reverse('app_aware_remote_search', args=[self.app.domain, self.app._id]),
-                storage_instance=RESULTS_INSTANCE,
+                storage_instance=self.storage_instance,
                 template='case',
                 data=self._remote_request_query_datums,
                 prompts=self.build_query_prompts(),
@@ -170,12 +173,12 @@ class RemoteRequestFactory(object):
             short_detail_id = 'search_short'
             long_detail_id = 'search_long'
 
-        nodeset = CaseTypeXpath(self.module.case_type).case(instance_name=RESULTS_INSTANCE)
+        nodeset = CaseTypeXpath(self.module.case_type).case(instance_name=self.storage_instance)
         if toggles.USH_CASE_CLAIM_UPDATES.enabled(self.app.domain):
             additional_types = list(set(self.module.additional_case_types) - {self.module.case_type})
             if additional_types:
                 nodeset = CaseTypeXpath(self.module.case_type).cases(
-                    additional_types, instance_name=RESULTS_INSTANCE)
+                    additional_types, instance_name=self.storage_instance)
             if self.module.search_config.search_filter:
                 nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
         nodeset += EXCLUDE_RELATED_CASES_FILTER
@@ -337,7 +340,7 @@ class RemoteRequestFactory(object):
 
     def _get_case_domain_xpath(self):
         case_id_xpath = CaseIDXPath(session_var(self.case_session_var))
-        return case_id_xpath.case(instance_name=RESULTS_INSTANCE).slash(COMMCARE_PROJECT)
+        return case_id_xpath.case(instance_name=self.storage_instance).slash(COMMCARE_PROJECT)
 
 
 class SessionEndpointRemoteRequestFactory(RemoteRequestFactory):

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -539,7 +539,7 @@ class EntriesHelper(object):
             uses_inline_search = module_uses_inline_search(detail_module)
             if loads_registry_case or uses_inline_search:
                 if uses_inline_search:
-                    instance_name, root_element = "search_results", "results"
+                    instance_name, root_element = "results:inline", "results"
                 elif loads_registry_case:
                     instance_name, root_element = "results", "results"
                 if detail_module.search_config.search_filter:

--- a/corehq/apps/app_manager/tests/data/suite_inline_search/detail_tabs.xml
+++ b/corehq/apps/app_manager/tests/data/suite_inline_search/detail_tabs.xml
@@ -24,7 +24,7 @@
         </template>
       </field>
     </detail>
-    <detail nodeset="instance('results')/results/case[@case_type='child'][index/parent=current()/@case_id][@status='open']">
+    <detail nodeset="instance('search_results')/results/case[@case_type='child'][index/parent=current()/@case_id][@status='open']">
       <title>
         <text>
           <locale id="m0.case_long.tab.2.title"/>

--- a/corehq/apps/app_manager/tests/data/suite_inline_search/detail_tabs.xml
+++ b/corehq/apps/app_manager/tests/data/suite_inline_search/detail_tabs.xml
@@ -24,7 +24,7 @@
         </template>
       </field>
     </detail>
-    <detail nodeset="instance('search_results')/results/case[@case_type='child'][index/parent=current()/@case_id][@status='open']">
+    <detail nodeset="instance('results:inline')/results/case[@case_type='child'][index/parent=current()/@case_id][@status='open']">
       <title>
         <text>
           <locale id="m0.case_long.tab.2.title"/>

--- a/corehq/apps/app_manager/tests/data/suite_inline_search/shadow_module_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_inline_search/shadow_module_entry.xml
@@ -14,7 +14,7 @@
         <instance id="casedb" src="jr://instance/casedb"/>
         <instance id="commcaresession" src="jr://instance/session"/>
         <session>
-            <query default_search="false" storage-instance="results" template="case"
+            <query default_search="false" storage-instance="search_results" template="case"
                    url="http://localhost:8000/a/test_domain/phone/search/456/">
                 <data key="case_type" ref="'case'"/>
                 <prompt key="name">
@@ -26,7 +26,7 @@
                 </prompt>
             </query>
             <datum detail-confirm="m1_case_long" detail-select="m1_case_short" id="case_id"
-                   nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
+                   nodeset="instance('search_results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                    value="./@case_id"/>
         </session>
     </entry>

--- a/corehq/apps/app_manager/tests/data/suite_inline_search/shadow_module_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_inline_search/shadow_module_entry.xml
@@ -14,7 +14,7 @@
         <instance id="casedb" src="jr://instance/casedb"/>
         <instance id="commcaresession" src="jr://instance/session"/>
         <session>
-            <query default_search="false" storage-instance="search_results" template="case"
+            <query default_search="false" storage-instance="results:inline" template="case"
                    url="http://localhost:8000/a/test_domain/phone/search/456/">
                 <data key="case_type" ref="'case'"/>
                 <prompt key="name">
@@ -26,7 +26,7 @@
                 </prompt>
             </query>
             <datum detail-confirm="m1_case_long" detail-select="m1_case_short" id="case_id"
-                   nodeset="instance('search_results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
+                   nodeset="instance('results:inline')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                    value="./@case_id"/>
         </session>
     </entry>

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -213,7 +213,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             expected_detail_columns, suite, "./detail[@id='m0_case_short']/field/template/text/xpath")
 
     def test_case_detail_tabs_with_inline_search(self):
-        """Test that the detail nodeset uses the correct instance (search_results not casedb)"""
+        """Test that the detail nodeset uses the correct instance (results:inline not casedb)"""
         self.app.get_module(0).case_details.long.tabs = [
             DetailTab(starting_index=0),
             DetailTab(starting_index=1, has_nodeset=True, nodeset_case_type="child")
@@ -355,7 +355,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
 
         suite = self.app.create_suite()
 
-        expected_entry = """
+        expected_entry = f"""
         <partial>
           <entry>
             <form>xmlns1.0</form>
@@ -375,7 +375,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                 nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']"
                 value="./@case_id" detail-select="m2_case_short"/>
               <query url="http://localhost:8000/a/test_domain/phone/search/123/"
-                storage-instance="search_results" template="case" default_search="false">
+                storage-instance="{RESULTS_INSTANCE_INLINE}" template="case" default_search="false">
                 <data key="case_type" ref="'case'"/>
                 <prompt key="name">
                   <display>
@@ -386,7 +386,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                 </prompt>
               </query>
               <datum id="case_id"
-                nodeset="instance('search_results')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
+                nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
                 value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             </session>
           </entry>

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -16,7 +16,7 @@ from corehq.apps.app_manager.models import (
     ShadowModule,
 )
 from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
-    RESULTS_INSTANCE,
+    RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
@@ -85,7 +85,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
     def test_inline_search(self):
         suite = self.app.create_suite()
 
-        expected_entry_query = """
+        expected_entry_query = f"""
         <partial>
           <entry>
             <form>xmlns1.0</form>
@@ -101,8 +101,8 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             <instance id="casedb" src="jr://instance/casedb"/>
             <instance id="commcaresession" src="jr://instance/session"/>
             <session>
-                <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="results"
-                    template="case" default_search="false">
+                <query url="http://localhost:8000/a/test_domain/phone/search/123/"
+                    storage-instance="{RESULTS_INSTANCE_INLINE}" template="case" default_search="false">
                   <data key="case_type" ref="'case'"/>
                   <prompt key="name">
                     <display>
@@ -112,7 +112,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                     </display>
                   </prompt>
                 </query>
-                <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
+                <datum id="case_id" nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
                     value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             </session>
           </entry>
@@ -129,61 +129,91 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         self.module.case_list.show = True
         suite = self.app.create_suite()
 
-        expected_entry_query = """
-            <partial>
-              <entry>
-                <command id="m0-case-list">
-                  <text>
-                    <locale id="case_lists.m0"/>
-                  </text>
-                </command>
-                <session>
-                    <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="results"
-                        template="case" default_search="false">
-                      <data key="case_type" ref="'case'"/>
-                      <prompt key="name">
-                        <display>
-                          <text>
-                            <locale id="search_property.m0.name"/>
-                          </text>
-                        </display>
-                      </prompt>
-                    </query>
-                    <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
-                        value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
-                </session>
-              </entry>
-            </partial>"""  # noqa: E501
+        expected_entry_query = f"""
+        <partial>
+          <entry>
+            <command id="m0-case-list">
+              <text>
+                <locale id="case_lists.m0"/>
+              </text>
+            </command>
+            <session>
+                <query url="http://localhost:8000/a/test_domain/phone/search/123/"
+                    storage-instance="{RESULTS_INSTANCE_INLINE}" template="case" default_search="false">
+                  <data key="case_type" ref="'case'"/>
+                  <prompt key="name">
+                    <display>
+                      <text>
+                        <locale id="search_property.m0.name"/>
+                      </text>
+                    </display>
+                  </prompt>
+                </query>
+                <datum id="case_id" nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
+                    value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+            </session>
+          </entry>
+        </partial>"""  # noqa: E501
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[2]")
 
     def test_inline_search_multi_select(self):
         self.module.case_details.short.multi_select = True
-
+        self.module.case_details.short.columns.append(
+            DetailColumn.wrap(dict(
+                header={"en": "parent name"},
+                model="case",
+                format="plain",
+                field="parent/name"
+            ))
+        )
         suite = self.app.create_suite()
 
-        expected_entry_post = """
+        expected_entry_query = f"""
         <partial>
+          <entry>
+            <form>xmlns1.0</form>
             <post url="http://localhost:8000/a/test_domain/phone/claim-case/"
                 relevant="$case_id != ''">
-             <data key="case_id"
-                nodeset="instance('selected_cases')/results/value" ref="."
-                exclude="count(instance('casedb')/casedb/case[@case_id=current()/.]) = 1"/>
+             <data exclude="count(instance('casedb')/casedb/case[@case_id=current()/.]) = 1"
+                key="case_id" nodeset="instance('selected_cases')/results/value" ref="."/>
             </post>
+            <command id="m0-f0">
+              <text>
+                <locale id="forms.m0f0"/>
+              </text>
+            </command>
+            <instance id="casedb" src="jr://instance/casedb"/>
+            <instance id="selected_cases" src="jr://instance/selected-entities"/>
+            <session>
+                <query url="http://localhost:8000/a/test_domain/phone/search/123/"
+                    storage-instance="{RESULTS_INSTANCE_INLINE}"
+                    template="case" default_search="false">
+                  <data key="case_type" ref="'case'"/>
+                  <prompt key="name">
+                    <display>
+                      <text>
+                        <locale id="search_property.m0.name"/>
+                      </text>
+                    </display>
+                  </prompt>
+                </query>
+                <instance-datum id="selected_cases" nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
+                    value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+            </session>
+          </entry>
         </partial>"""  # noqa: E501
-        self.assertXmlPartialEqual(expected_entry_post, suite, "./entry[1]/post")
+        self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]")
 
-        expected_entry_datum = """
-                <partial>
-                    <instance-datum id="selected_cases"
-                        nodeset="instance('results')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
-                        value="./@case_id"
-                        detail-confirm="m0_case_long"
-                        detail-select="m0_case_short"/>
-                </partial>"""  # noqa: E501
-        self.assertXmlPartialEqual(expected_entry_datum, suite, "./entry[1]/session/instance-datum")
+        expected_detail_columns = f"""
+        <partial>
+          <xpath function="case_name"/>
+          <xpath function="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_id=current()/index/parent]/case_name"/>
+        </partial>"""  # noqa: E501
+        self.assertXmlPartialEqual(
+            expected_detail_columns, suite, "./detail[@id='m0_case_short']/field/template/text/xpath")
 
     def test_case_detail_tabs_with_inline_search(self):
-        """Test that the detail nodeset uses the correct instance (results not casedb)"""
+        """Test that the detail nodeset uses the correct instance (search_results not casedb)"""
         self.app.get_module(0).case_details.long.tabs = [
             DetailTab(starting_index=0),
             DetailTab(starting_index=1, has_nodeset=True, nodeset_case_type="child")
@@ -197,11 +227,11 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
     def test_form_linking_to_inline_search_module_from_registration_form(self):
         self.module.search_config.additional_case_types = ["other_case"]
         suite = self.app.create_suite()
-        expected = """
+        expected = f"""
         <partial>
           <create>
             <command value="'m0'"/>
-            <query id="results" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
+            <query id="{RESULTS_INSTANCE_INLINE}" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
               <data key="case_type" ref="'case'"/>
               <data key="case_type" ref="'other_case'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_new_case_0"/>
@@ -209,7 +239,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             <datum id="case_id" value="instance('commcaresession')/session/data/case_id_new_case_0"/>
             <command value="'m0-f0'"/>
           </create>
-        </partial>"""
+        </partial>"""  # noqa: E501
         self.assertXmlPartialEqual(
             expected,
             suite,
@@ -249,18 +279,18 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         app._id = "123"
         suite = app.create_suite()
         self.assertXmlPartialEqual(
-            """
+            f"""
             <partial>
               <create>
                 <command value="'m1'"/>
-                <query id="results" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
+                <query id="{RESULTS_INSTANCE_INLINE}" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
                   <data key="case_type" ref="'case'"/>
                   <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
                 </query>
                 <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
               </create>
             </partial>
-            """,
+            """,  # noqa: E501
             suite,
             "./entry[2]/stack/create"
         )
@@ -378,8 +408,8 @@ class InlineSearchShadowModuleTest(SimpleTestCase, SuiteMixin):
         suite = parse_normalize(suite_xml, to_string=False)
         self.assertEqual(
             "instance('{}')/{}/case[@case_type='{}' or @case_type='{}'][@status='open']{}".format(
-                RESULTS_INSTANCE,
-                RESULTS_INSTANCE,
+                RESULTS_INSTANCE_INLINE,
+                "results",
                 self.module.case_type,
                 another_case_type,
                 EXCLUDE_RELATED_CASES_FILTER
@@ -428,23 +458,23 @@ class InlineSearchFormLinkChildModuleTest(SimpleTestCase, SuiteMixin):
         # wrap to have assign_references called
         self.app = Application.wrap(factory.app.to_json())
 
-    def test_form_link_in_child_module_with_registry_search(self):
+    def test_form_link_in_child_module_with_inline_search(self):
         suite = self.app.create_suite()
 
-        expected = """
+        expected = f"""
         <partial>
           <create>
             <command value="'m0'"/>
             <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
             <command value="'m1'"/>
-            <query id="results" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
+            <query id="{RESULTS_INSTANCE_INLINE}" value="http://localhost:8000/a/test_domain/phone/case_fixture/123/">
               <data key="case_type" ref="'case'"/>
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id_case"/>
             </query>
             <datum id="case_id_case" value="instance('commcaresession')/session/data/case_id_case"/>
             <command value="'m1-f1'"/>
           </create>
-        </partial>"""
+        </partial>"""  # noqa: E501
 
         self.assertXmlPartialEqual(
             expected,

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -21,7 +21,8 @@ from corehq.apps.app_manager.models import (
     ParentSelect,
     ShadowModule,
 )
-from corehq.apps.app_manager.suite_xml.post_process.remote_requests import RESULTS_INSTANCE
+from corehq.apps.app_manager.suite_xml.post_process.remote_requests import RESULTS_INSTANCE, \
+    RESULTS_INSTANCE_INLINE
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -540,7 +541,7 @@ class InlineSearchDataRegistryModuleTest(SimpleTestCase, SuiteMixin):
             </command>
             <instance id="commcaresession" src="jr://instance/session"/>
             <session>
-                <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="search_results"
+                <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="{RESULTS_INSTANCE_INLINE}"
                     template="case" default_search="false">
                   <data key="case_type" ref="'case'"/>
                   <data key="{CASE_SEARCH_REGISTRY_ID_KEY}" ref="'myregistry'"/>
@@ -552,7 +553,7 @@ class InlineSearchDataRegistryModuleTest(SimpleTestCase, SuiteMixin):
                     </display>
                   </prompt>
                 </query>
-                <datum id="case_id" nodeset="instance('search_results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
+                <datum id="case_id" nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                     value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
                 <query url="http://localhost:8000/a/test_domain/phone/case_fixture/123/"
                 storage-instance="registry" template="case" default_search="true">

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -540,7 +540,7 @@ class InlineSearchDataRegistryModuleTest(SimpleTestCase, SuiteMixin):
             </command>
             <instance id="commcaresession" src="jr://instance/session"/>
             <session>
-                <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="results"
+                <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="search_results"
                     template="case" default_search="false">
                   <data key="case_type" ref="'case'"/>
                   <data key="{CASE_SEARCH_REGISTRY_ID_KEY}" ref="'myregistry'"/>
@@ -552,7 +552,7 @@ class InlineSearchDataRegistryModuleTest(SimpleTestCase, SuiteMixin):
                     </display>
                   </prompt>
                 </query>
-                <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
+                <datum id="case_id" nodeset="instance('search_results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                     value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
                 <query url="http://localhost:8000/a/test_domain/phone/case_fixture/123/"
                 storage-instance="registry" template="case" default_search="true">

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -202,9 +202,16 @@ class CaseSelectionXPath(XPath):
     selector = ''
 
     def case(self, instance_name='casedb', case_name='case'):
-        return CaseXPath("instance('{inst}')/{inst}/{case}[{sel}={self}]".format(
-            inst=instance_name, case=case_name, sel=self.selector, self=self
+        return CaseXPath("instance('{inst}')/{root}/{case}[{sel}={self}]".format(
+            inst=instance_name, root=self.get_instance_root(instance_name),
+            case=case_name, sel=self.selector, self=self
         ))
+
+    @staticmethod
+    def get_instance_root(instance_name):
+        return {
+            "search_results": "results"
+        }.get(instance_name, instance_name)
 
 
 class CaseIDXPath(CaseSelectionXPath):
@@ -224,8 +231,8 @@ class CaseTypeXpath(CaseSelectionXPath):
         for type in additional_types:
             quoted = CaseTypeXpath("'{}'".format(type))
             selector = "{selector} or {sel}={quoted}".format(selector=selector, sel=self.selector, quoted=quoted)
-        return CaseXPath("instance('{inst}')/{inst}/{case}[{sel}]".format(
-            inst=instance_name, case=case_name, sel=selector
+        return CaseXPath("instance('{inst}')/{root}/{case}[{sel}]".format(
+            inst=instance_name, root=self.get_instance_root(instance_name), case=case_name, sel=selector
         ))
 
 

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -210,7 +210,7 @@ class CaseSelectionXPath(XPath):
     @staticmethod
     def get_instance_root(instance_name):
         return {
-            "search_results": "results"
+            "results:inline": "results"
         }.get(instance_name, instance_name)
 
 


### PR DESCRIPTION
## Technical Summary
This changes the name of the query storage instance when using 'inline search'. The purpose of the rename is to avoid name clashes with other workflows.

Although this is not strictly necessary with the limitations placed on the feature in https://github.com/dimagi/commcare-hq/pull/31752 I think it is a good idea in case we do ever want to lift any of those restrictions.

The instance is being renamed from `results` to `search_results` (alternate name suggestions welcome).

## Feature Flag
inline search

## Safety Assurance

### Safety story
This only impacts modules using 'inline search'. Normal case search remains unchanged and uses the 'results' instance.

This will break apps that have been built with this feature on staging (the feature is not in use on production yet). I plan to write a migration to fix the staging apps.

### Automated test coverage
Updated

### QA Plan
https://dimagi-dev.atlassian.net/browse/QA-4228


### Migrations
I will be writing a single use migration only for staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Rolling this back after there are apps that use the new name will require a migration to change the references in apps.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
