### PR TITLE
only do a full bootstrap on startup or the migration process

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -277,7 +277,7 @@ class ConfigurableReportTableManager(UcrTableManager):
             for source in provider.get_data_sources_modified_since(timestamp)
         ]
         filtered_data_sources = self.get_filtered_configs(new_data_sources)
-        invalid_data_sources = (ds._id for ds in new_data_sources) - (ds._id for ds in filtered_data_sources)
+        invalid_data_sources = {ds._id for ds in new_data_sources} - {ds._id for ds in filtered_data_sources}
         self._add_data_sources_to_table_adapters(filtered_data_sources)
 
     def _add_data_sources_to_table_adapters(self, new_data_sources, invalid_data_sources):

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -276,7 +276,7 @@ class ConfigurableReportTableManager(UcrTableManager):
             for provider in self.data_source_providers
             for source in provider.get_data_sources_modified_since(timestamp)
         ]
-        filtered_data_sources = self.get_filtered_configs(new_data_source)
+        filtered_data_sources = self.get_filtered_configs(new_data_sources)
         self._add_data_sources_to_table_adapters(filtered_data_sources)
 
     def _add_data_sources_to_table_adapters(self, new_data_sources):

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -222,18 +222,21 @@ class ConfigurableReportTableManager(UcrTableManager):
         ]
 
     def get_filtered_configs(self, configs=None):
-        configs = configs or self.get_all_configs()
 
-        if self.exclude_ucrs:
-            configs = [config for config in configs if config.table_id not in self.exclude_ucrs]
+        if configs is None:
+            configs = self.get_all_configs()
 
-        if self.include_ucrs:
-            configs = [config for config in configs if config.table_id in self.include_ucrs]
-        elif self.ucr_division:
-            configs = _filter_by_hash(configs, self.ucr_division)
+        if configs:
+            if self.exclude_ucrs:
+                configs = [config for config in configs if config.table_id not in self.exclude_ucrs]
 
-        configs = _filter_domains_to_skip(configs)
-        configs = _filter_invalid_config(configs)
+            if self.include_ucrs:
+                configs = [config for config in configs if config.table_id in self.include_ucrs]
+            elif self.ucr_division:
+                configs = _filter_by_hash(configs, self.ucr_division)
+
+            configs = _filter_domains_to_skip(configs)
+            configs = _filter_invalid_config(configs)
 
         return configs
 
@@ -315,7 +318,8 @@ class RegistryDataSourceTableManager(UcrTableManager):
         return self.data_source_provider.get_data_sources()
 
     def get_filtered_configs(self, configs=None):
-        configs = configs or self.get_all_configs()
+        if configs is None:
+            configs = self.get_all_configs()
         configs = _filter_invalid_config(configs)
         return configs
 

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -278,7 +278,7 @@ class ConfigurableReportTableManager(UcrTableManager):
         ]
         filtered_data_sources = self.get_filtered_configs(new_data_sources)
         invalid_data_sources = {ds._id for ds in new_data_sources} - {ds._id for ds in filtered_data_sources}
-        self._add_data_sources_to_table_adapters(filtered_data_sources)
+        self._add_data_sources_to_table_adapters(filtered_data_sources, invalid_data_sources)
 
     def _add_data_sources_to_table_adapters(self, new_data_sources, invalid_data_sources):
         for new_data_source in new_data_sources:

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -121,7 +121,7 @@ class ConfigurableReportTableManagerDbTest(TestCase):
         # test in same domain
         data_source_2 = self._copy_data_source(data_source_1)
         data_source_2.save()
-        table_manager._add_data_sources_to_table_adapters([data_source_2])
+        table_manager._add_data_sources_to_table_adapters([data_source_2], set())
         self.assertEqual(1, len(table_manager.table_adapters_by_domain))
         self.assertEqual(2, len(table_manager.table_adapters_by_domain[ds_1_domain]))
         self.assertEqual(
@@ -133,7 +133,7 @@ class ConfigurableReportTableManagerDbTest(TestCase):
         ds3_domain = 'new_domain'
         data_source_3.domain = ds3_domain
         data_source_3.save()
-        table_manager._add_data_sources_to_table_adapters([data_source_3])
+        table_manager._add_data_sources_to_table_adapters([data_source_3], set())
         # should now be 2 domains in the map
         self.assertEqual(2, len(table_manager.table_adapters_by_domain))
         # ensure domain 1 unchanged
@@ -145,7 +145,7 @@ class ConfigurableReportTableManagerDbTest(TestCase):
         self.assertEqual(data_source_3, table_manager.table_adapters_by_domain[ds3_domain][0].config)
 
         # finally pass in existing data sources and ensure they modify in place
-        table_manager._add_data_sources_to_table_adapters([data_source_1, data_source_3])
+        table_manager._add_data_sources_to_table_adapters([data_source_1, data_source_3], set())
         self.assertEqual(2, len(table_manager.table_adapters_by_domain))
         self.assertEqual(
             {data_source_1, data_source_2},


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The bootstrap that happens every three hours causes a pretty notable memory memory spike on pillow machines. This is in part because it is a memory heavy process that will only get more so as more people use UCRs, but in part because all pillow processes on a machine basically do it at the same time, so it ends up using about 20X memory. https://app.datadoghq.com/dashboard/ewu-jyr-udt/change-feeds-pillows?fullscreen_end_ts=1654803637572&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1654630837572&fullscreen_widget=265293246&from_ts=1654630824488&to_ts=1654803624488&live=true

This changes the pillow to only do a full bootstrap in processes that run migrations. Others just use the incremental update to data sources that was occurring anyway. I added the config validation from the full bootstrap to the incremental process to make the two more equivalent. 

The one place it might represent a real change is that the regular bootstrap does remove configs from domains set as `migration_in_progress`. This only happens once every 3 hours (during the bootstrap) so there is still a decent lag after that occurs, and the migration flags should prevent any case changes, meaning no cases from those domains should hit the pillow to begin with, but that is a change.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This should not change any existing behavior, and to the extent the included configs differ, it is excluding invalid configurations, which should reduce errors.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
