### PR TITLE
ensure usercase assertion is added to forms in child modules

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2823,7 +2823,11 @@ class AdvancedForm(IndexedFormBase, FormMediaMixin, NavMenuItemMediaMixin):
         return any(action for action in self.actions.load_update_cases if match(action.case_type))
 
     def uses_usercase(self):
-        return self.uses_case_type(USERCASE_TYPE)
+        return (
+            self.uses_case_type(USERCASE_TYPE)
+            or any(action for action in self.actions.load_update_cases
+                   if action.auto_select and action.auto_select.mode == AUTO_SELECT_USERCASE)
+        )
 
     def all_other_forms_require_a_case(self):
         m = self.get_module()

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -832,7 +832,8 @@ class EntriesHelper(object):
             auto_select = action.auto_select
             load_case_from_fixture = action.load_case_from_fixture
             if auto_select and auto_select.mode:
-                datum, assertions = EntriesHelper.get_auto_select_datums_and_assertions(action, auto_select, form)
+                datum, assertions_ = EntriesHelper.get_auto_select_datums_and_assertions(action, auto_select, form)
+                assertions.extend(assertions_)
                 datums.append(FormDatumMeta(
                     datum=datum,
                     case_type=None,

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -249,9 +249,6 @@ class EntriesHelper(object):
             }[form.form_type]
             config_entry(module, e, form)
 
-            if form.uses_usercase():
-                EntriesHelper.add_usercase_id_assertion(e)
-
             EntriesHelper.add_custom_assertions(e, form)
 
             if (
@@ -452,6 +449,9 @@ class EntriesHelper(object):
 
         if form and self.app.case_sharing and case_sharing_requires_assertion(form):
             EntriesHelper.add_case_sharing_assertion(e)
+
+        if form and EntriesHelper.any_usercase_datums(all_datums):
+            EntriesHelper.add_usercase_id_assertion(e)
 
     def add_remote_query_datums(self, datums):
         """Add in any `query` datums that are necessary.

--- a/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-added-usercase.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-added-usercase.xml
@@ -33,5 +33,12 @@
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
     </session>
+    <assertions>
+      <assert test="count(instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]) = 1">
+        <text>
+          <locale id="case_autoload.usercase.case_missing"/>
+        </text>
+      </assert>
+    </assertions>
   </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/test_suite_usercase.py
+++ b/corehq/apps/app_manager/tests/test_suite_usercase.py
@@ -7,6 +7,7 @@ from corehq.apps.app_manager.models import (
     PreloadAction,
     UpdateCaseAction,
 )
+from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
     TestXmlMixin,
@@ -46,3 +47,45 @@ class SuiteUsercaseTest(SimpleTestCase, SuiteMixin):
         form.actions.usercase_preload.condition.type = 'always'
 
         self.assertXmlPartialEqual(self.get_xml('usercase_entry'), app.create_suite(), "./entry[1]")
+
+    def test_usercase_assertion_added_in_child_module(self, *args):
+        factory = AppFactory()
+
+        m0, m0f0 = factory.new_basic_module("parent", "parent")
+        factory.form_requires_case(m0f0, "parent")
+        factory.form_uses_usercase(m0f0, {"name": ConditionalCaseUpdate(question_path='/data/question1')})
+
+        m1, m1f0 = factory.new_basic_module("child", "child", parent_module=m0)
+        factory.form_requires_case(m1f0, "child", parent_case_type="parent")
+
+        expected = """
+        <partial>
+          <entry>
+            <command id="m1-f0">
+              <text>
+                <locale id="forms.m1f0"/>
+              </text>
+            </command>
+            <instance id="casedb" src="jr://instance/casedb"/>
+            <instance id="commcaresession" src="jr://instance/session"/>
+            <session>
+              <datum id="case_id"
+                nodeset="instance('casedb')/casedb/case[@case_type='parent'][@status='open']"
+                value="./@case_id" detail-select="m0_case_short"/>
+              <datum id="usercase_id"
+                function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
+              <datum id="case_id_child"
+                nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id]"
+                value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
+            </session>
+            <assertions>
+              <assert test="count(instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]) = 1">
+                <text>
+                  <locale id="case_autoload.usercase.case_missing"/>
+                </text>
+              </assert>
+            </assertions>
+          </entry>
+        </partial>
+        """  # noqa: E501
+        self.assertXmlPartialEqual(expected, factory.app.create_suite(), "./entry[2]")

--- a/corehq/apps/app_manager/tests/test_suite_usercase.py
+++ b/corehq/apps/app_manager/tests/test_suite_usercase.py
@@ -21,28 +21,28 @@ class SuiteUsercaseTest(SimpleTestCase, SuiteMixin):
     def test_usercase_id_added_update(self, *args):
         app = Application.new_app('domain', "Untitled Application")
 
-        child_module = app.add_module(Module.new_module("Untitled Module", None))
-        child_module.case_type = 'child'
+        module = app.add_module(Module.new_module("Untitled Module", None))
+        module.case_type = 'child'
 
-        child_form = app.new_form(0, "Untitled Form", None)
-        child_form.xmlns = 'http://id_m1-f0'
-        child_form.requires = 'case'
-        child_form.actions.usercase_update = UpdateCaseAction(
+        form = app.new_form(0, "Untitled Form", None)
+        form.xmlns = 'http://id_m1-f0'
+        form.requires = 'case'
+        form.actions.usercase_update = UpdateCaseAction(
             update={'name': ConditionalCaseUpdate(question_path='/data/question1')})
-        child_form.actions.usercase_update.condition.type = 'always'
+        form.actions.usercase_update.condition.type = 'always'
 
         self.assertXmlPartialEqual(self.get_xml('usercase_entry'), app.create_suite(), "./entry[1]")
 
     def test_usercase_id_added_preload(self, *args):
         app = Application.new_app('domain', "Untitled Application")
 
-        child_module = app.add_module(Module.new_module("Untitled Module", None))
-        child_module.case_type = 'child'
+        module = app.add_module(Module.new_module("Untitled Module", None))
+        module.case_type = 'child'
 
-        child_form = app.new_form(0, "Untitled Form", None)
-        child_form.xmlns = 'http://id_m1-f0'
-        child_form.requires = 'case'
-        child_form.actions.usercase_preload = PreloadAction(preload={'/data/question1': 'name'})
-        child_form.actions.usercase_preload.condition.type = 'always'
+        form = app.new_form(0, "Untitled Form", None)
+        form.xmlns = 'http://id_m1-f0'
+        form.requires = 'case'
+        form.actions.usercase_preload = PreloadAction(preload={'/data/question1': 'name'})
+        form.actions.usercase_preload.condition.type = 'always'
 
         self.assertXmlPartialEqual(self.get_xml('usercase_entry'), app.create_suite(), "./entry[1]")


### PR DESCRIPTION
## Technical Summary
Assertions are only checked when entering a form so any form that has a usercase datum should have the assertion to prevent errors in the form / during form submission e.g. [FORMPLAYER-TQ6](https://sentry.io/organizations/dimagi/issues/3338754358/)

## Safety Assurance

### Safety story
There is one other change related to advanced modules but I do not expect that to cause any issues. If anything it should result in additional assertions being added where they may have been missed before (which is good).

The change to `AdvancedForm.uses_usercase` function is a fix to catch the case where the usercase is being auto-loaded. I do not expect this to negatively impact any of the [usages](https://github.com/dimagi/commcare-hq/search?q=.uses_usercase%28%29).

### Automated test coverage
Test added for the child module assertion. Existing functionality well covered by tests.

### QA Plan
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
