### PR TITLE
disable 'previous screen' workflow for inline search forms

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -872,6 +872,8 @@ class FormBaseValidator(object):
         elif self.form.post_form_workflow == WORKFLOW_PREVIOUS:
             if module.is_multi_select() or module.root_module and module.root_module.is_multi_select():
                 errors.append(dict(type='previous multi select form links', **meta))
+            if self.form.requires_case() and module_uses_inline_search(module):
+                errors.append(dict(type='workflow previous inline search', **meta))
 
         # this isn't great but two of FormBase's subclasses have form_filter
         if hasattr(self.form, 'form_filter') and self.form.form_filter:

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -95,6 +95,13 @@
                 a multi-select case list and the "Previous Screen" workflow, which are not compatible.
               {% endblocktrans %}
               {% include "app_manager/partials/form_error_message.html" %}
+            {% case "workflow previous inline search" %}
+              {% blocktrans %}
+                Please check that end of form navigation is correct.
+                Modules configured to "make search input available after search" do not support
+                the "Previous Screen" workflow.
+              {% endblocktrans %}
+              {% include "app_manager/partials/form_error_message.html" %}
             {% case "endpoint to display only forms" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 <a href="{{ module_url }}">{{ module_name }}</a>

--- a/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from corehq.apps.app_manager.const import REGISTRY_WORKFLOW_SMART_LINK
+from corehq.apps.app_manager.const import REGISTRY_WORKFLOW_SMART_LINK, WORKFLOW_PREVIOUS
 from corehq.apps.app_manager.models import (
     Application,
     CaseSearch,
@@ -66,6 +66,21 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
         )
 
         self.assertIn("inline search to display only forms", _get_error_types(factory.app))
+
+    def test_inline_search_previous_screen(self, *args):
+        factory = AppFactory(build_version='2.51.0')
+        m0, m0f0 = factory.new_basic_module('first', 'case')
+        factory.form_requires_case(m0f0)
+
+        m0.search_config = CaseSearch(
+            search_label=CaseSearchLabel(label={'en': 'Search'}),
+            properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
+            auto_launch=True,
+            inline_search=True,
+        )
+        m0f0.post_form_workflow = WORKFLOW_PREVIOUS
+
+        self.assertIn("workflow previous inline search", _get_error_types(factory.app))
 
     def test_parent_select_to_inline_search(self, *args):
         """an inline module can't be the target of parent select"""

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -88,6 +88,7 @@ from corehq.apps.app_manager.util import (
     is_usercase_in_use,
     save_xform,
     module_loads_registry_case,
+    module_uses_inline_search,
 )
 from corehq.apps.app_manager.views.media_utils import handle_media_edits
 from corehq.apps.app_manager.views.notifications import notify_form_changed
@@ -769,7 +770,7 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
     if not module.root_module_id or not module.root_module.is_multi_select():
         if not module.put_in_root:
             form_workflows[WORKFLOW_MODULE] = _("Menu: ") + trans(module.name, langs)
-        if not module.is_multi_select():
+        if not (module.is_multi_select() or module_uses_inline_search(module)):
             form_workflows[WORKFLOW_PREVIOUS] = _("Previous Screen")
     if module.root_module_id and not module.root_module.put_in_root:
         if not module.root_module.is_multi_select():

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5990,6 +5990,16 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+msgid ""
+"\n"
+"                Please check that end of form navigation is correct.\n"
+"                Modules configured to \"make search input available after "
+"search\" do not support\n"
+"                the \"Previous Screen\" workflow.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
 #, python-format
 msgid ""
 "\n"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -6485,6 +6485,16 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+msgid ""
+"\n"
+"                Please check that end of form navigation is correct.\n"
+"                Modules configured to \"make search input available after "
+"search\" do not support\n"
+"                the \"Previous Screen\" workflow.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
 #, python-format
 msgid ""
 "\n"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -5991,6 +5991,16 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+msgid ""
+"\n"
+"                Please check that end of form navigation is correct.\n"
+"                Modules configured to \"make search input available after "
+"search\" do not support\n"
+"                the \"Previous Screen\" workflow.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
 #, python-format
 msgid ""
 "\n"

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -6363,6 +6363,16 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+msgid ""
+"\n"
+"                Please check that end of form navigation is correct.\n"
+"                Modules configured to \"make search input available after "
+"search\" do not support\n"
+"                the \"Previous Screen\" workflow.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
 #, python-format
 msgid ""
 "\n"

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -5991,6 +5991,16 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+msgid ""
+"\n"
+"                Please check that end of form navigation is correct.\n"
+"                Modules configured to \"make search input available after "
+"search\" do not support\n"
+"                the \"Previous Screen\" workflow.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
 #, python-format
 msgid ""
 "\n"

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -6004,6 +6004,16 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+msgid ""
+"\n"
+"                Please check that end of form navigation is correct.\n"
+"                Modules configured to \"make search input available after "
+"search\" do not support\n"
+"                the \"Previous Screen\" workflow.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
 #, python-format
 msgid ""
 "\n"

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -6060,6 +6060,16 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+msgid ""
+"\n"
+"                Please check that end of form navigation is correct.\n"
+"                Modules configured to \"make search input available after "
+"search\" do not support\n"
+"                the \"Previous Screen\" workflow.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
 #, python-format
 msgid ""
 "\n"

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -5991,6 +5991,16 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+msgid ""
+"\n"
+"                Please check that end of form navigation is correct.\n"
+"                Modules configured to \"make search input available after "
+"search\" do not support\n"
+"                the \"Previous Screen\" workflow.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
 #, python-format
 msgid ""
 "\n"

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -5995,6 +5995,16 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+msgid ""
+"\n"
+"                Please check that end of form navigation is correct.\n"
+"                Modules configured to \"make search input available after "
+"search\" do not support\n"
+"                the \"Previous Screen\" workflow.\n"
+"              "
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
 #, python-format
 msgid ""
 "\n"


### PR DESCRIPTION
## Technical Summary
After EOF nav the session query data is cleared in web apps and not passed back to Formplayer which results in navigation being unable to follow the same path.

## Feature Flag
inline search

## Safety Assurance

### Safety story
Minimal changes to validate inline search with 'previous screen' workflow.

### Automated test coverage
Good existing coverage and new test added

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
