### PR TITLE
migrate usages of old 'block_upgrade' migration to newer 'prompt_for_historical'

### DIFF
--- a/corehq/apps/app_manager/migrations/0017_migrate_case_search_relevant.py
+++ b/corehq/apps/app_manager/migrations/0017_migrate_case_search_relevant.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from corehq.util.django_migrations import block_upgrade_for_removed_migration
+from corehq.util.django_migrations import prompt_for_historical_migration, get_migration_name
 
 
 class Migration(migrations.Migration):
@@ -10,5 +10,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        block_upgrade_for_removed_migration("8b87df0e4a504101645faa536bed7bc9ca58761c")
+        prompt_for_historical_migration(
+            "app_manager", get_migration_name(__file__), "8b87df0e4a504101645faa536bed7bc9ca58761c")
     ]

--- a/corehq/apps/app_manager/migrations/0018_migrate_case_search_labels.py
+++ b/corehq/apps/app_manager/migrations/0018_migrate_case_search_labels.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from corehq.util.django_migrations import block_upgrade_for_removed_migration
+from corehq.util.django_migrations import prompt_for_historical_migration, get_migration_name
 
 
 class Migration(migrations.Migration):
@@ -10,5 +10,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        block_upgrade_for_removed_migration("9cc207180e9ebde1c06a98f5e3da1c29b9d37dee"),
+        prompt_for_historical_migration(
+            "app_manager", get_migration_name(__file__), "9cc207180e9ebde1c06a98f5e3da1c29b9d37dee"),
     ]

--- a/corehq/apps/commtrack/migrations/0005_populate_config_models.py
+++ b/corehq/apps/commtrack/migrations/0005_populate_config_models.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations
 
-from corehq.util.django_migrations import block_upgrade_for_removed_migration
+from corehq.util.django_migrations import prompt_for_historical_migration, get_migration_name
 
 
 class Migration(migrations.Migration):
@@ -12,5 +12,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        block_upgrade_for_removed_migration("539a7399b995e03fd9ead14ca64a8e66b9b576a4")
+        prompt_for_historical_migration(
+            "commtrack", get_migration_name(__file__), "539a7399b995e03fd9ead14ca64a8e66b9b576a4")
     ]

--- a/corehq/apps/users/migrations/0016_webappspermissions.py
+++ b/corehq/apps/users/migrations/0016_webappspermissions.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from corehq.util.django_migrations import block_upgrade_for_removed_migration
+from corehq.util.django_migrations import prompt_for_historical_migration, get_migration_name
 
 
 class Migration(migrations.Migration):
@@ -10,5 +10,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        block_upgrade_for_removed_migration('a7c40ca6acf609b22b495ab986c11f3524b47ce7')
+        prompt_for_historical_migration(
+            "users", get_migration_name(__file__), "a7c40ca6acf609b22b495ab986c11f3524b47ce7")
     ]

--- a/corehq/apps/users/migrations/0019_editreportspermissions.py
+++ b/corehq/apps/users/migrations/0019_editreportspermissions.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from corehq.util.django_migrations import block_upgrade_for_removed_migration
+from corehq.util.django_migrations import prompt_for_historical_migration, get_migration_name
 
 
 class Migration(migrations.Migration):
@@ -10,5 +10,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        block_upgrade_for_removed_migration('a7c40ca6acf609b22b495ab986c11f3524b47ce7')
+        prompt_for_historical_migration(
+            "users", get_migration_name(__file__), "a7c40ca6acf609b22b495ab986c11f3524b47ce7")
     ]

--- a/corehq/apps/users/migrations/0021_add_view_apps_permission.py
+++ b/corehq/apps/users/migrations/0021_add_view_apps_permission.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from corehq.util.django_migrations import block_upgrade_for_removed_migration
+from corehq.util.django_migrations import prompt_for_historical_migration, get_migration_name
 
 
 class Migration(migrations.Migration):
@@ -10,5 +10,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        block_upgrade_for_removed_migration('a7c40ca6acf609b22b495ab986c11f3524b47ce7')
+        prompt_for_historical_migration(
+            "users", get_migration_name(__file__), "a7c40ca6acf609b22b495ab986c11f3524b47ce7")
     ]

--- a/corehq/apps/users/migrations/0024_add_login_as_all_users.py
+++ b/corehq/apps/users/migrations/0024_add_login_as_all_users.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from corehq.util.django_migrations import block_upgrade_for_removed_migration
+from corehq.util.django_migrations import prompt_for_historical_migration, get_migration_name
 
 
 class Migration(migrations.Migration):
@@ -10,5 +10,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = {
-        block_upgrade_for_removed_migration('a7c40ca6acf609b22b495ab986c11f3524b47ce7')
+        prompt_for_historical_migration(
+            "users", get_migration_name(__file__), "a7c40ca6acf609b22b495ab986c11f3524b47ce7")
     }

--- a/corehq/util/django_migrations.py
+++ b/corehq/util/django_migrations.py
@@ -167,34 +167,6 @@ def prompt_for_historical_migration(app_name, migration_name, required_commit):
     return migrations.RunPython(_run_command, reverse_code=migrations.RunPython.noop)
 
 
-def block_upgrade_for_removed_migration(commit_with_migration):
-    """Returns a Django migration operation that will block the upgrade if the migration
-    has not run (fresh installs will not get blocked).
-
-    :param commit_with_migration: A Git commit hash that contains the migration.
-    """
-    @skip_on_fresh_install
-    def show_message(apps, schema_editor):
-        print("""
-            A migration must be performed before this environment can be upgraded to the latest version
-            of CommCareHQ. The migration has been removed from the current version of the code so an older
-            version must be used.
-        """)
-        print("")
-        print(f"""
-        Run the following commands to run the migration and get up to date:
-
-            commcare-cloud <env> fab setup_limited_release --set code_branch={commit_with_migration}
-
-            commcare-cloud <env> django-manage --release <release created by previous command> migrate_multi
-
-            commcare-cloud <env> deploy commcare
-        """)
-        sys.exit(1)
-
-    return migrations.RunPython(show_message, reverse_code=migrations.RunPython.noop, elidable=True)
-
-
 def update_es_mapping(index_name, quiet=False):
     """Returns a django migration Operation which calls the `update_es_mapping`
     management command to update the mapping on an Elastic index.


### PR DESCRIPTION
## Technical Summary
Replaces usages of `block_upgrade_for_removed_migration` with `prompt_for_historical_migration` which is both newer and better.

## Safety Assurance

### Safety story
No-op change to old migrations

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
