### PR TITLE
add county, postcode and district fields to broadcast obj

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -108,8 +108,10 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
             try {
                 if (contextValue.id.startsWith('district')) {
                     broadcastObj.county = contextValue.text;
+                    broadcastObj.district = contextValue.text;
                 } else if (contextValue.id.startsWith('postcode')) {
                     broadcastObj.zipcode = contextValue.text;
+                    broadcastObj.postcode = contextValue.text;
                 } else if (contextValue.id.startsWith('place')) {
                     broadcastObj.city = contextValue.text;
                 } else if (contextValue.id.startsWith('country')) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -96,7 +96,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
     };
 
     /**
-     * Composes a boardcast object from mapbox result to be used by receivers
+     * Composes a broadcast object from mapbox result to be used by receivers
      * @param {Object} mapboxResult - Mapbox query result object
      */
     module.getBroadcastObject = function (mapboxResult) {
@@ -106,7 +106,9 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         };
         mapboxResult.context.forEach(function (contextValue) {
             try {
-                if (contextValue.id.startsWith('postcode')) {
+                if (contextValue.id.startsWith('district')) {
+                    broadcastObj.county = contextValue.text;
+                } else if (contextValue.id.startsWith('postcode')) {
                     broadcastObj.zipcode = contextValue.text;
                 } else if (contextValue.id.startsWith('place')) {
                     broadcastObj.city = contextValue.text;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds a field for `county` which maps to the `district` in mapbox response.

<img width="1157" alt="Screen Shot 2022-06-13 at 3 11 06 PM" src="https://user-images.githubusercontent.com/42388648/173427233-3ca86382-3430-4f5b-b964-db53011b50b4.png">

<img width="1167" alt="Screen Shot 2022-06-13 at 3 42 09 PM" src="https://user-images.githubusercontent.com/42388648/173432181-3c106874-4578-44fc-9927-cb51440f6021.png">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-1981

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
no QA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
