### PR TITLE
Validate email when creating or updating a mobile user

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -219,7 +219,6 @@ class CommCareUserResource(v0_1.CommCareUserResource):
                 password=bundle.data['password'],
                 created_by=bundle.request.couch_user,
                 created_via=USER_CHANGE_VIA_API,
-                email=bundle.data.get('email', '').lower(),
             )
             # password was just set
             bundle.data.pop('password', None)

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -224,7 +224,10 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             bundle.data.pop('password', None)
             # do not call update with username key
             bundle.data.pop('username', None)
-            self._update(bundle)
+            errors = self._update(bundle)
+            if errors:
+                formatted_errors = ', '.join(errors)
+                raise BadRequest(_('The request resulted in the following errors: {}').format(formatted_errors))
             bundle.obj.save()
         except Exception:
             if bundle.obj._id:

--- a/corehq/apps/api/tests/test_user_updates.py
+++ b/corehq/apps/api/tests/test_user_updates.py
@@ -62,6 +62,12 @@ class TestUpdateUserMethods(TestCase):
         update(self.user, 'email', 'updated@dimagi.com')
         self.assertEqual(self.user.email, 'updated@dimagi.com')
 
+    def test_update_email_raises_exception_if_invalid_email(self):
+        with self.assertRaises(UpdateUserException) as cm:
+            update(self.user, 'email', 'updated@dimagi@com')
+        self.assertEqual(cm.exception.message,
+                         "The value 'updated@dimagi@com' for 'email' must be a valid email address")
+
     def test_update_first_name_succeeds(self):
         self.user.first_name = 'Initial'
         update(self.user, 'first_name', 'Updated')

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -83,7 +83,6 @@ class TestCommCareUserResource(APIResourceTest):
 
     @sync_users_to_es()
     def test_get_list(self):
-
         commcare_user = CommCareUser.create(domain=self.domain.name, username='fake_user', password='*****',
                                             created_by=None, created_via=None)
         self.addCleanup(commcare_user.delete, self.domain.name, deleted_by=None)
@@ -111,7 +110,6 @@ class TestCommCareUserResource(APIResourceTest):
 
     @flaky
     def test_get_single(self):
-
         commcare_user = CommCareUser.create(domain=self.domain.name, username='fake_user', password='*****',
                                             created_by=None, created_via=None)
         self.addCleanup(commcare_user.delete, self.domain.name, deleted_by=None)
@@ -136,7 +134,6 @@ class TestCommCareUserResource(APIResourceTest):
         })
 
     def test_create(self):
-
         group = Group({"name": "test"})
         group.save()
         self.addCleanup(group.delete)
@@ -162,8 +159,8 @@ class TestCommCareUserResource(APIResourceTest):
             }
         }
         response = self._assert_auth_post_resource(self.list_endpoint,
-                                    json.dumps(user_json),
-                                    content_type='application/json')
+                                                   json.dumps(user_json),
+                                                   content_type='application/json')
         self.assertEqual(response.status_code, 201)
         [user_back] = CommCareUser.by_domain(self.domain.name)
         self.addCleanup(user_back.delete, self.domain.name, deleted_by=None)
@@ -197,8 +194,23 @@ class TestCommCareUserResource(APIResourceTest):
             '{"error": "Username \'jdoe\' is already taken."}'
         )
 
-    def test_update(self):
+    def test_bad_request_if_invalid_data_in_create(self):
+        user_json = {
+            "username": "jdoe",
+            "password": "qwer1234",
+            "email": "jdoe@example@com"
+        }
+        response = self._assert_auth_post_resource(self.list_endpoint,
+                                                   json.dumps(user_json),
+                                                   content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.content.decode('utf-8'),
+            '{"error": "The request resulted in the following errors: The value \'jdoe@example@com\' for '
+            '\'email\' must be a valid email address"}'
+        )
 
+    def test_update(self):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
                                    created_by=None, created_via=None, phone_number="50253311398")
         group = Group({"name": "test"})
@@ -276,7 +288,6 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(user_history.changed_via, USER_CHANGE_VIA_API)
 
     def test_update_fails(self):
-
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
                                    created_by=None, created_via=None, phone_number="50253311398")
         group = Group({"name": "test"})
@@ -514,7 +525,6 @@ class TestBulkUserAPI(APIResourceTest):
 
 @es_test
 class TestIdentityResource(APIResourceTest):
-
     resource = v0_5.IdentityResource
     api_name = 'v0.5'
 
@@ -526,8 +536,8 @@ class TestIdentityResource(APIResourceTest):
     @classmethod
     def _get_list_endpoint(cls):
         return reverse('api_dispatch_list',
-                kwargs=dict(api_name=cls.api_name,
-                            resource_name=cls.resource._meta.resource_name))
+                       kwargs=dict(api_name=cls.api_name,
+                                   resource_name=cls.resource._meta.resource_name))
 
     @sync_users_to_es()
     def test_get_list(self):

--- a/corehq/apps/api/user_updates.py
+++ b/corehq/apps/api/user_updates.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.utils.translation import gettext as _
 
 from dimagi.utils.couch.bulk import get_docs
@@ -42,7 +43,12 @@ def update(user, field, value, user_change_logger=None):
 
 
 def _update_email(user, email, user_change_logger):
-    _simple_update(user, 'email', email.lower(), user_change_logger)
+    email = email.lower()
+    try:
+        validate_email(email)
+    except ValidationError:
+        raise UpdateUserException(_("The value '{}' for 'email' must be a valid email address").format(email))
+    _simple_update(user, 'email', email, user_change_logger)
 
 
 def _update_first_name(user, first_name, user_change_logger):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12609

There is currently no email validation for the 'email' field on mobile users via the API. This ensures that when creating or updating a mobile user, the email is validated via django's email validator.

The email field is optional when creating a mobile user, which is why I chose to remove it from the initial create call, knowing it will be passed into the update method. I also noticed the errors returned from the `_update` method weren't actually being handled (maybe a reason to switch back to raising the first exception rather than a list of errors).

The theme of these improvements has been _incremental_, so if you see something inherent to the design that you would like to change but is out of this scope, feel free to create a ticket to improve in the future.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added a test to cover this.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-4114 (will not run until post-deploy)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
