### PR TITLE
Default Mobile Worker Initial Migration

### DIFF
--- a/corehq/apps/users/migrations/0046_add_default_mobile_worker_role.py
+++ b/corehq/apps/users/migrations/0046_add_default_mobile_worker_role.py
@@ -1,0 +1,36 @@
+# Adds the default mobile worker role to existing projects that don't yet have one.
+from django.db import migrations
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.users.models import Permissions
+from corehq.apps.users.models_role import UserRole
+from corehq.apps.users.role_utils import UserRolePresets
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _add_default_mobile_worker_role(apps, schema_editor):
+    for domain in Domain.get_all():
+        items = UserRole.objects.filter(domain=domain, is_commcare_user_default=True)
+        if len(items) == 0:
+            UserRole.create(
+                domain,
+                UserRolePresets.MOBILE_WORKER,
+                permissions=Permissions(),
+                is_commcare_user_default=True,
+            )
+        elif len(items) == 1:
+            continue
+        else:
+            raise Exception(f"More than one role on domain {domain} set as user default")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0045_add_view_tableau_permission'),
+    ]
+
+    operations = [
+        migrations.RunPython(_add_default_mobile_worker_role, migrations.RunPython.noop)
+    ]

--- a/corehq/apps/users/migrations/0046_add_default_mobile_worker_role.py
+++ b/corehq/apps/users/migrations/0046_add_default_mobile_worker_role.py
@@ -12,16 +12,14 @@ from corehq.util.django_migrations import skip_on_fresh_install
 def _add_default_mobile_worker_role(apps, schema_editor):
     default_mobile_worker_roles = UserRole.objects.filter(is_commcare_user_default=True)
     for domain in Domain.get_all():
-        dmw_roles_in_domain = default_mobile_worker_roles.filter(domain=domain)
-        if len(dmw_roles_in_domain) == 0:
+        has_dmw_role = default_mobile_worker_roles.filter(domain=domain).exists()
+        if not has_dmw_role:
             UserRole.create(
                 domain,
                 UserRolePresets.MOBILE_WORKER,
                 permissions=Permissions(),
                 is_commcare_user_default=True,
             )
-        elif 1 <= len(dmw_roles_in_domain) == 1:
-            continue
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/users/migrations/0046_add_default_mobile_worker_role.py
+++ b/corehq/apps/users/migrations/0046_add_default_mobile_worker_role.py
@@ -10,19 +10,18 @@ from corehq.util.django_migrations import skip_on_fresh_install
 
 @skip_on_fresh_install
 def _add_default_mobile_worker_role(apps, schema_editor):
+    default_mobile_worker_roles = UserRole.objects.filter(is_commcare_user_default=True)
     for domain in Domain.get_all():
-        items = UserRole.objects.filter(domain=domain, is_commcare_user_default=True)
-        if len(items) == 0:
+        dmw_roles_in_domain = default_mobile_worker_roles.filter(domain=domain)
+        if len(dmw_roles_in_domain) == 0:
             UserRole.create(
                 domain,
                 UserRolePresets.MOBILE_WORKER,
                 permissions=Permissions(),
                 is_commcare_user_default=True,
             )
-        elif len(items) == 1:
+        elif 1 <= len(dmw_roles_in_domain) == 1:
             continue
-        else:
-            raise Exception(f"More than one role on domain {domain} set as user default")
 
 
 class Migration(migrations.Migration):

--- a/migrations.lock
+++ b/migrations.lock
@@ -1024,6 +1024,7 @@ users
  0043_add_release_management_permission
  0044_userrole_is_commcare_user_default
  0045_add_view_tableau_permission
+ 0046_add_default_mobile_worker_role
 util
  0001_initial
  0002_complaintbouncemeta_permanentbouncemeta_transientbounceemail


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Related Jira ticket: [USH-2127](https://dimagi-dev.atlassian.net/browse/USH-2127?atlOrigin=eyJpIjoiM2Q0Y2RmZmNlZjJhNDAwOWI4NGE4NzViNjAxN2M0ZDciLCJwIjoiaiJ9). This is part of the suite of changes to add a Default Mobile Worker (DMW) role to HQ ([here](https://docs.google.com/document/d/1zDMHtvZAk8t0oNcuRxgzCBnyFHkGwb2m-C0o6hZMCjg/edit#) is the spec) and the [Mobile Endpoints Access epic](https://dimagi-dev.atlassian.net/browse/USH-1408).


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Following up on Ethan's [latest PR](https://github.com/dimagi/commcare-hq/pull/31754#event-6772943985) that adds a "Mobile Worker Default" role, this migration adds that role to existing domains that don't yet have it. But the role will be added with the original permissions given by the original default `Permissions()` instead of the new permissions given to the DMW role. 

The code this migration is dependent on has already been merged and deployed.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

The set of DMW changes will culminate in a single QA review.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change