### PR TITLE
Case API v0.6: Allow creating or updating indices by external ID

### DIFF
--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -19,14 +19,15 @@ def is_simple_dict(d):
 
 class JsonIndex(jsonobject.JsonObject):
     case_id = jsonobject.StringProperty()
+    external_id = jsonobject.StringProperty()
     temporary_id = jsonobject.StringProperty()
     case_type = jsonobject.StringProperty(required=True)
     relationship = jsonobject.StringProperty(required=True, choices=('child', 'extension'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not (bool(self.case_id) ^ bool(self.temporary_id)):
-            raise BadValueError("You must set either case_id or temporary_id, and not both.")
+        if len(list(filter(None, [self.case_id, self.external_id, self.temporary_id]))) != 1:
+            raise BadValueError("Indices must specify case_id, external_id, or temporary ID, and only one")
 
 
 class BaseJsonCaseChange(jsonobject.JsonObject):
@@ -107,6 +108,8 @@ def handle_case_update(domain, data, user, device_id, case_id=None):
     else:
         updates = [_get_individual_update(domain, data, user, case_id)]
 
+    _populate_index_case_ids(domain, updates)
+
     xform, cases = _submit_case_updates(updates, domain, user, device_id)
     if xform.is_error:
         raise SubmissionError(xform.problem, xform.form_id,)
@@ -145,8 +148,6 @@ def _get_bulk_updates(domain, all_data, user):
         except BadValueError as e:
             errors.append(f'Error in row {i}: {e}')
 
-    populate_index_case_ids(updates)
-
     if errors:
         raise UserError("; ".join(errors))
 
@@ -158,18 +159,44 @@ def _missing_cases(domain, case_ids):
     return set(case_ids) - set(real_case_ids)
 
 
-def populate_index_case_ids(updates):
-    case_ids_by_temp_id = {
+def _populate_index_case_ids(domain, updates):
+    case_ids = {}
+    case_ids['temporary_id'] = {
         update.temporary_id: update.get_case_id()
         for update in updates if getattr(update, 'temporary_id', None)
     }
+    case_ids['external_id'] = _get_case_ids_by_external_id(domain, [
+        index.external_id for update in updates for index in update.indices.values()
+    ])
     for update in updates:
         for index in update.indices.values():
-            if index.temporary_id:
-                try:
-                    index.case_id = case_ids_by_temp_id[index.temporary_id]
-                except KeyError:
-                    raise UserError(f"Could not find a case with temporary ID '{index.temporary_id}'")
+            for id_prop in case_ids:
+                key = getattr(index, id_prop)
+                if key:
+                    try:
+                        index.case_id = case_ids[id_prop][key]
+                    except KeyError:
+                        raise UserError(f"Could not find a case with {id_prop} '{key}'")
+
+
+def _get_case_ids_by_external_id(domain, external_ids):
+    def _to_case_id(external_id):
+        try:
+            case = CommCareCase.objects.get_case_by_external_id(
+                domain,
+                external_id,
+                raise_multiple=True
+            )
+        except CommCareCase.MultipleObjectsReturned:
+            raise UserError(f"There are multiple cases with external_id {external_id}")
+        if not case:
+            raise UserError(f"Could not find a case with external_id '{external_id}'")
+        return case.case_id
+
+    return {
+        external_id: _to_case_id(external_id)
+        for external_id in filter(None, set(external_ids))
+    }
 
 
 def _get_case_update(data, user_id, case_id=None):


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2097
Allow creating or updating indices by external ID in the v0.6 Case API

## Technical Summary
This is pretty straightforward - the client must specify one of the valid ID fields, then we must do an "enrich" step where we transform that to an actual ID if necessary.  I already did something like this for "temporary_id" in the bulk upload, so it was an easy enough extension to support external ID with the aid of a lookup.

Would love to do that lookup in bulk, but I'm not sure how.

## Feature Flag
Enable the v0.6 Case API

## Safety Assurance

### Safety story
I used TDD, and the feature isn't released yet anyways
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
