### PR TITLE
Pin Redis version to 6.2 for tests and local

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -83,7 +83,7 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-couchdb2:}/usr/src/couchdb/dev/lib/node1/data
 
   redis:
-    image: redis:7.0
+    image: redis:6.2
     expose:
       - "6379"
     volumes:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -83,7 +83,7 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-couchdb2:}/usr/src/couchdb/dev/lib/node1/data
 
   redis:
-    image: redis
+    image: redis:6.2
     expose:
       - "6379"
     volumes:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -83,7 +83,7 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-couchdb2:}/usr/src/couchdb/dev/lib/node1/data
 
   redis:
-    image: redis:6.2
+    image: redis:7.0
     expose:
       - "6379"
     volumes:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SAAS-13372
We haven't pinned Redis in our docker-compose file which is used to run tests and for dev setup. It is resulting in tests being run with the latest version of Redis which is 7.X and might cause unaccounted bugs/issues in future. Since we are planning to upgrade Redis to 6.2, the PR sets that version in compose file.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular, consider how existing data may be impacted by this change.
-->
Pretty safe. Changes only affect dev and test enviornment.
### Automated test coverage
NA
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions


### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
