### PR TITLE
remove usages of 'flatten_result'

### DIFF
--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -20,7 +20,7 @@ from corehq.apps.reports.generic import GenericReportView
 from corehq.apps.reports.models import HQUserType
 from corehq.apps.reports.standard import ProjectReport
 from corehq.apps.reports.standard.cases.basic import CaseListMixin
-from corehq.apps.reports.standard.cases.data_sources import CaseDisplay
+from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
 from corehq.apps.reports.standard.inspect import SubmitHistoryMixin
 from corehq.apps.reports.util import get_simplified_users
 
@@ -82,18 +82,18 @@ class CaseReassignmentInterface(CaseListMixin, DataInterface):
             ' data-caseid="{case_id}" data-owner="{owner}" data-ownertype="{owner_type}" />')
 
         for row in self.es_results['hits'].get('hits', []):
-            case = self.get_case(row)
-            display = CaseDisplay(case, self.timezone, self.individual)
+            es_case = self.get_case(row)
+            display = CaseDisplayES(es_case, self.timezone, self.individual)
             yield [
                 format_html(
                     checkbox_format,
-                    case_id=case['_id'],
+                    case_id=es_case['_id'],
                     owner=display.owner_id,
                     owner_type=display.owner_type),
                 display.case_link,
                 display.case_type,
                 display.owner_display,
-                naturaltime(display.parse_date(display.case['modified_on'])),
+                naturaltime(display.parse_date(es_case['modified_on'])),
             ]
 
 

--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -1,29 +1,24 @@
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.urls import reverse
-from django.utils.safestring import mark_safe
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
-
 from memoized import memoized
 
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.es import cases as case_es
-from corehq.apps.es.users import UserES
 from corehq.apps.groups.models import Group
-from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.display import FormDisplay
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter
 from corehq.apps.reports.generic import GenericReportView
-from corehq.apps.reports.models import HQUserType
 from corehq.apps.reports.standard import ProjectReport
 from corehq.apps.reports.standard.cases.basic import CaseListMixin
 from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
 from corehq.apps.reports.standard.inspect import SubmitHistoryMixin
-from corehq.apps.reports.util import get_simplified_users
-
+from corehq.util.timezones.utils import parse_date
 from .dispatcher import EditDataInterfaceDispatcher
 
 
@@ -93,7 +88,7 @@ class CaseReassignmentInterface(CaseListMixin, DataInterface):
                 display.case_link,
                 display.case_type,
                 display.owner_display,
-                naturaltime(display.parse_date(es_case['modified_on'])),
+                naturaltime(parse_date(es_case['modified_on'])),
             ]
 
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -333,51 +333,6 @@ def indexed_on(gt=None, gte=None, lt=None, lte=None):
     return filters.date_range(INDEXED_ON, gt, gte, lt, lte)
 
 
-def flatten_result(hit, include_score=False, is_related_case=False):
-    """Flattens a result from CaseSearchES into the format that Case serializers
-    expect
-
-    i.e. instead of {'name': 'blah', 'case_properties':{'key':'foo', 'value':'bar'}} we return
-    {'name': 'blah', 'foo':'bar'}
-
-    Note that some dynamic case properties, if present, will overwrite
-    internal case properties:
-
-        domain
-        type
-        opened_on
-        opened_by
-        modified_on
-        server_modified_on
-        modified_by         -> also overwrites user_id
-        closed
-        closed_on
-        closed_by
-        deleted
-        deleted_on
-        deletion_id
-    """
-    try:
-        result = hit['_source']
-    except KeyError:
-        result = hit
-
-    if include_score:
-        result[RELEVANCE_SCORE] = hit['_score']
-    if is_related_case:
-        result[IS_RELATED_CASE] = "true"
-    case_properties = result.pop(CASE_PROPERTIES_PATH, [])
-    for case_property in case_properties:
-        key = case_property.get('key')
-        value = case_property.get('value')
-        if key is not None and key not in SPECIAL_CASE_PROPERTIES and value:
-            result[key] = value
-
-    for key in SYSTEM_PROPERTIES:
-        result.pop(key, None)
-    return result
-
-
 def wrap_case_search_hit(hit, include_score=False, is_related_case=False):
     """Convert case search index hit to CommCareCase
 

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -18,7 +18,6 @@ from corehq.apps.es.case_search import (
     case_property_query,
     case_property_range_query,
     case_property_text_query,
-    flatten_result,
     wrap_case_search_hit,
 )
 from corehq.apps.es.const import SIZE_LIMIT
@@ -217,28 +216,6 @@ class TestCaseSearchES(ElasticTestMixin, SimpleTestCase):
                  .case_property_query("name", "redbeard")
                  .case_property_query("parrot_name", "polly", clause="should", fuzzy=True))
         self.checkQuery(query, json_output, validate_query=False)
-
-    def test_flatten_result(self):
-        expected = {'name': 'blah', 'foo': 'bar', 'baz': 'buzz', RELEVANCE_SCORE: "1.095"}
-        self.assertEqual(
-            flatten_result(
-                {
-                    "_score": "1.095",
-                    "_source": {
-                        'name': 'blah',
-                        'case_properties': [
-                            {'key': '@case_id', 'value': 'should be removed'},
-                            {'key': 'name', 'value': 'should be removed'},
-                            {'key': 'case_name', 'value': 'should be removed'},
-                            {'key': 'last_modified', 'value': 'should be removed'},
-                            {'key': 'foo', 'value': 'bar'},
-                            {'key': 'baz', 'value': 'buzz'}]
-                    }
-                },
-                include_score=True
-            ),
-            expected
-        )
 
     def test_blacklisted_owner_ids(self):
         query = self.es.domain('swashbucklers').blacklist_owner_id('123').owner('234')

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -298,11 +298,11 @@ def user_can_access_other_user(domain, user, other_user):
 
 
 def user_can_access_case(domain, user, case):
-    from corehq.apps.reports.standard.cases.data_sources import CaseDisplay
+    from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
     if user.has_permission(domain, 'access_all_locations'):
         return True
 
-    info = CaseDisplay(case.to_json())
+    info = CaseDisplayES(case.to_json())
     if info.owner_type == 'location':
         return user_can_access_location_id(domain, user, info.owner_id)
     elif info.owner_type == 'user':

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -298,11 +298,11 @@ def user_can_access_other_user(domain, user, other_user):
 
 
 def user_can_access_case(domain, user, case):
-    from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
+    from corehq.apps.reports.standard.cases.data_sources import CaseDisplaySQL
     if user.has_permission(domain, 'access_all_locations'):
         return True
 
-    info = CaseDisplayES(case.to_json())
+    info = CaseDisplaySQL(case)
     if info.owner_type == 'location':
         return user_can_access_location_id(domain, user, info.owner_id)
     elif info.owner_type == 'user':

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -20,6 +20,7 @@ from django.utils.html import conditional_escape
 from celery.utils.log import get_task_logger
 from memoized import memoized
 
+from corehq.util.timezones.utils import get_timezone
 from couchexport.export import export_from_tables, get_writer
 from couchexport.shortcuts import export_response
 from dimagi.utils.modules import to_function
@@ -38,12 +39,10 @@ from corehq.apps.reports.cache import request_cache
 from corehq.apps.reports.datatables import DataTablesHeader
 from corehq.apps.reports.filters.dates import DatespanFilter
 from corehq.apps.reports.tasks import export_all_rows_task
-from corehq.apps.reports.util import DatatablesParams, get_report_timezone
+from corehq.apps.reports.util import DatatablesParams
 from corehq.apps.saved_reports.models import ReportConfig
 from corehq.apps.users.models import CouchUser
 from corehq.util.view_utils import absolute_reverse, request_as_dict, reverse
-
-from corehq import toggles
 
 CHART_SPAN_MAP = {1: '10', 2: '6', 3: '4', 4: '3', 5: '2', 6: '2'}
 
@@ -269,7 +268,7 @@ class GenericReportView(object):
     @property
     @memoized
     def timezone(self):
-        return get_report_timezone(self.request, self.domain)
+        return get_timezone(self.request, self.domain)
 
     @property
     @memoized

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -29,7 +29,7 @@ from corehq.elastic import ESError
 from corehq.toggles import CASE_LIST_EXPLORER
 from corehq.util.timezones.conversions import PhoneTime
 
-from .data_sources import CaseDisplay
+from .data_sources import CaseDisplayES
 
 
 class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin):
@@ -228,7 +228,7 @@ class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
     @property
     def rows(self):
         for row in self.es_results['hits'].get('hits', []):
-            display = CaseDisplay(self.get_case(row), self.timezone, self.individual)
+            display = CaseDisplayES(self.get_case(row), self.timezone, self.individual)
 
             yield [
                 display.case_type,

--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -9,7 +9,7 @@ from corehq.apps.case_search.const import (
     SPECIAL_CASE_PROPERTIES_MAP,
 )
 from corehq.apps.case_search.exceptions import CaseFilterError
-from corehq.apps.es.case_search import CaseSearchES, flatten_result
+from corehq.apps.es.case_search import CaseSearchES, wrap_case_search_hit
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.exceptions import BadRequestError
@@ -156,12 +156,12 @@ class CaseListExplorer(CaseListReport):
     @property
     def rows(self):
         track_workflow(self.request.couch_user.username, f"{self.name}: Search Performed")
-        data = (flatten_result(row) for row in self.es_results['hits'].get('hits', []))
+        data = (wrap_case_search_hit(row) for row in self.es_results['hits'].get('hits', []))
         return self._get_rows(data)
 
     @property
     def get_all_rows(self):
-        data = (flatten_result(r) for r in iter_es_docs_from_query(self._build_query(sort=False)))
+        data = (wrap_case_search_hit(r) for r in iter_es_docs_from_query(self._build_query(sort=False)))
         return self._get_rows(data)
 
     def _get_rows(self, data):

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -383,8 +383,7 @@ class SafeCaseDisplay(object):
     """
     def __init__(self, case, timezone, override_user_id=None):
         self.case = case
-        self.timezone = timezone
-        self.override_user_id = override_user_id
+        self.display = CaseDisplaySQL(self.case, timezone, override_user_id)
 
     def get(self, name):
         if name == '_link':
@@ -394,7 +393,7 @@ class SafeCaseDisplay(object):
             return json.dumps([index.to_json() for index in self.case.indices])
 
         if name in (SPECIAL_CASE_PROPERTIES + CASE_COMPUTED_METADATA):
-            return getattr(CaseDisplaySQL(self.case, self.timezone, self.override_user_id), name.replace('@', ''))
+            return getattr(self.display, name.replace('@', ''))
 
         return self.case.get_case_property(name)
 

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -1,11 +1,13 @@
 import json
+from datetime import date
 
-import pytz
-from couchdbkit import ResourceNotFound
 from django.template.defaultfilters import yesno
 from django.urls import NoReverseMatch
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
+
+import pytz
+from couchdbkit import ResourceNotFound
 
 from corehq.apps.case_search.const import (
     CASE_COMPUTED_METADATA,
@@ -120,9 +122,11 @@ class CaseDisplayBase:
         else:
             return "%s (bad ID format)" % self.case_name
 
-    def _fmt_date(self, date, is_phonetime=True):
+    def _fmt_date(self, value, is_phonetime=True):
+        if not isinstance(value, date):
+            return ''
         return report_date_to_json(
-            date,
+            value,
             self.timezone,
             self.date_format,
             is_phonetime=is_phonetime

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -1,14 +1,11 @@
-import datetime
 import json
 
 import pytz
+from couchdbkit import ResourceNotFound
 from django.template.defaultfilters import yesno
 from django.urls import NoReverseMatch
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
-
-import dateutil
-from couchdbkit import ResourceNotFound
 
 from corehq.apps.case_search.const import (
     CASE_COMPUTED_METADATA,
@@ -20,7 +17,6 @@ from corehq.apps.reports.util import get_user_id_from_form
 from corehq.apps.reports.v2.utils import report_date_to_json
 from corehq.apps.users.models import CouchUser
 from corehq.const import USER_DATETIME_FORMAT_WITH_SEC
-from corehq.util.dates import iso_string_to_datetime
 from corehq.util.quickcache import quickcache
 from corehq.util.timezones.utils import parse_date
 from corehq.util.view_utils import absolute_reverse

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -25,7 +25,7 @@ from corehq.util.timezones.conversions import PhoneTime
 from corehq.util.view_utils import absolute_reverse
 
 
-class CaseDisplay:
+class CaseDisplayES:
     """This class wraps a raw case from ES to provide simpler access
     to certain properties as well as formatting for properties for use in
     the UI"""
@@ -259,7 +259,7 @@ class SafeCaseDisplay(object):
             return json.dumps(self.case.get('indices', []))
 
         if name in (SPECIAL_CASE_PROPERTIES + CASE_COMPUTED_METADATA):
-            return getattr(CaseDisplay(self.case, self.timezone, self.override_user_id), name.replace('@', ''))
+            return getattr(CaseDisplayES(self.case, self.timezone, self.override_user_id), name.replace('@', ''))
 
         return self.case.get(name)
 

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -391,7 +391,7 @@ class SafeCaseDisplay(object):
             return self._link
 
         if name == 'indices':
-            return json.dumps(self.case.get('indices', []))
+            return json.dumps([index.to_json() for index in self.case.indices])
 
         if name in (SPECIAL_CASE_PROPERTIES + CASE_COMPUTED_METADATA):
             return getattr(CaseDisplaySQL(self.case, self.timezone, self.override_user_id), name.replace('@', ''))

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -161,8 +161,8 @@ class CaseDisplayBase:
 
     def __getattr__(self, item):
         if item in self.aliases:
-            item = self.aliases[item]
-        return object.__getattribute__(self, item)
+            return getattr(self, self.aliases[item])
+        raise AttributeError(item)
 
     @property
     def last_modified_by_user_username(self):

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -174,7 +174,7 @@ class CaseDisplayBase:
 
     def __getattr__(self, item):
         if item in self.aliases:
-            return getattr(self, self.aliases[item])
+            item = self.aliases[item]
         return getattr(self, item)
 
     @property
@@ -361,7 +361,7 @@ class CaseDisplaySQL(CaseDisplayBase):
 
     @property
     def opened_on(self):
-        return self._fmt_date(self.case.opened_by)
+        return self._fmt_date(self.case.opened_on)
 
     @property
     def modified_on(self):

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -162,7 +162,7 @@ class CaseDisplayBase:
     def __getattr__(self, item):
         if item in self.aliases:
             item = self.aliases[item]
-        return getattr(self, item)
+        return object.__getattribute__(self, item)
 
     @property
     def last_modified_by_user_username(self):

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -22,7 +22,7 @@ from corehq.apps.users.models import CouchUser
 from corehq.const import USER_DATETIME_FORMAT_WITH_SEC
 from corehq.util.dates import iso_string_to_datetime
 from corehq.util.quickcache import quickcache
-from corehq.util.timezones.conversions import PhoneTime
+from corehq.util.timezones.utils import parse_date
 from corehq.util.view_utils import absolute_reverse
 
 
@@ -108,19 +108,6 @@ class CaseDisplayBase:
                 return user.username
         except CouchUser.AccountTypeError:
             return None
-
-    def parse_date(self, date_string):
-        try:
-            return iso_string_to_datetime(date_string)
-        except Exception:
-            try:
-                date_obj = dateutil.parser.parse(date_string)
-                if isinstance(date_obj, datetime.datetime):
-                    return date_obj.replace(tzinfo=None)
-                else:
-                    return date_obj
-            except Exception:
-                return date_string
 
     @property
     def closed_display(self):
@@ -298,19 +285,19 @@ class CaseDisplayES(CaseDisplayBase):
 
     @property
     def opened_on(self):
-        return self._fmt_date(self.parse_date(self.case['opened_on']))
+        return self._fmt_date(parse_date(self.case['opened_on']))
 
     @property
     def modified_on(self):
-        return self._fmt_date(self.parse_date(self.case['modified_on']))
+        return self._fmt_date(parse_date(self.case['modified_on']))
 
     @property
     def closed_on(self):
-        return self._fmt_date(self.parse_date(self.case['closed_on']))
+        return self._fmt_date(parse_date(self.case['closed_on']))
 
     @property
     def server_last_modified_date(self):
-        return self._fmt_date(self.parse_date(self.case['server_modified_on']), False)
+        return self._fmt_date(parse_date(self.case['server_modified_on']), False)
 
     @property
     def closed_by_user_id(self):

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -17,6 +17,7 @@ from corehq.apps.case_search.const import (
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.util import get_user_id_from_form
+from corehq.apps.reports.v2.utils import report_date_to_json
 from corehq.apps.users.models import CouchUser
 from corehq.const import USER_DATETIME_FORMAT_WITH_SEC
 from corehq.util.dates import iso_string_to_datetime
@@ -129,12 +130,13 @@ class CaseDisplayBase:
         else:
             return "%s (bad ID format)" % self.case_name
 
-    def _dateprop(self, date):
-        if isinstance(date, datetime.datetime):
-            user_time = PhoneTime(date, self.timezone).user_time(self.timezone)
-            return user_time.ui_string(self.date_format)
-        else:
-            return ''
+    def _fmt_date(self, date, is_phonetime=True):
+        return report_date_to_json(
+            date,
+            self.timezone,
+            self.date_format,
+            is_phonetime=is_phonetime
+        )
 
     @property
     def owner_display(self):
@@ -292,19 +294,19 @@ class CaseDisplayES(CaseDisplayBase):
 
     @property
     def opened_on(self):
-        return self._dateprop(self.parse_date(self.case['opened_on']))
+        return self._fmt_date(self.parse_date(self.case['opened_on']))
 
     @property
     def modified_on(self):
-        return self._dateprop(self.parse_date(self.case['modified_on']))
+        return self._fmt_date(self.parse_date(self.case['modified_on']))
 
     @property
     def closed_on(self):
-        return self._dateprop(self.parse_date(self.case['closed_on']))
+        return self._fmt_date(self.parse_date(self.case['closed_on']))
 
     @property
     def server_last_modified_date(self):
-        return self._dateprop(self.parse_date(self.case['server_modified_on']))
+        return self._fmt_date(self.parse_date(self.case['server_modified_on']), False)
 
     @property
     def closed_by_user_id(self):
@@ -355,19 +357,19 @@ class CaseDisplaySQL(CaseDisplayBase):
 
     @property
     def opened_on(self):
-        return self._dateprop(self.case.opened_by)
+        return self._fmt_date(self.case.opened_by)
 
     @property
     def modified_on(self):
-        return self._dateprop(self.case.modified_on)
+        return self._fmt_date(self.case.modified_on)
 
     @property
     def closed_on(self):
-        return self._dateprop(self.case.closed_on)
+        return self._fmt_date(self.case.closed_on)
 
     @property
     def server_last_modified_date(self):
-        return self._dateprop(self.case.server_modified_on)
+        return self._fmt_date(self.case.server_modified_on, False)
 
     @property
     def closed_by_user_id(self):

--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -32,6 +32,14 @@ class CaseDisplayBase:
     the UI"""
 
     date_format = USER_DATETIME_FORMAT_WITH_SEC
+    aliases = {
+        'status': 'closed_display',
+        'opened_by_username': 'creating_user',
+        'owner_name': 'owner_display',
+        'name': 'case_name',
+        'date_opened': 'opened_on',
+        'last_modified': 'modified_on',
+    }
 
     def __init__(self, case, timezone=pytz.UTC, override_user_id=None):
         """
@@ -117,7 +125,6 @@ class CaseDisplayBase:
     @property
     def closed_display(self):
         return yesno(self.is_closed, "closed,open")
-    status = closed_display
 
     @property
     def case_link(self):
@@ -145,7 +152,6 @@ class CaseDisplayBase:
             return format_html('<span class="label label-default">{}</span>', owner['name'])
         else:
             return owner['name']
-    owner_name = owner_display
 
     def user_not_found_display(self, user_id):
         return _("Unknown [%s]") % user_id
@@ -157,7 +163,6 @@ class CaseDisplayBase:
             return _("No data")
         else:
             return user['name'] or self.user_not_found_display(user['id'])
-    opened_by_username = creating_user
 
     @property
     def opened_by_user_id(self):
@@ -166,6 +171,11 @@ class CaseDisplayBase:
             return _("No data")
         else:
             return user['id']
+
+    def __getattr__(self, item):
+        if item in self.aliases:
+            return getattr(self, self.aliases[item])
+        return getattr(self, item)
 
     @property
     def last_modified_by_user_username(self):
@@ -186,8 +196,6 @@ class CaseDisplayBase:
     @property
     def case_name(self):
         raise NotImplementedError
-
-    name = case_name
 
     @property
     def case_id(self):
@@ -213,13 +221,9 @@ class CaseDisplayBase:
     def opened_on(self):
         raise NotImplementedError
 
-    date_opened = opened_on
-
     @property
     def modified_on(self):
         raise NotImplementedError
-
-    last_modified = modified_on
 
     @property
     def closed_on(self):

--- a/corehq/apps/reports/tests/test_case_display.py
+++ b/corehq/apps/reports/tests/test_case_display.py
@@ -10,6 +10,7 @@ def test_happy_case_display():
     }
     case_display = CaseDisplayES(case_dict)
     assert_equal(case_display.modified_on, 'Apr 06, 2022 12:13:14 UTC')
+    assert_equal(case_display.last_modified, 'Apr 06, 2022 12:13:14 UTC')
 
 
 def test_bad_case_display():

--- a/corehq/apps/reports/tests/test_case_display.py
+++ b/corehq/apps/reports/tests/test_case_display.py
@@ -1,6 +1,5 @@
-from datetime import datetime, timezone
+from nose.tools import assert_equal
 
-from nose.tools import assert_equal, assert_not_equal
 from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
 
 
@@ -20,41 +19,6 @@ def test_bad_case_display():
     }
     case_display = CaseDisplayES(case_dict)
     assert_equal(case_display.modified_on, '')
-
-
-def test_parse_date_iso_datetime():
-    parsed = CaseDisplayES({}).parse_date('2022-04-06T12:13:14Z')
-    assert_equal(parsed, datetime(2022, 4, 6, 12, 13, 14))
-    # `date` is timezone naive
-    assert_not_equal(parsed, datetime(2022, 4, 6, 12, 13, 14,
-                                      tzinfo=timezone.utc))
-
-
-def test_parse_date_noniso_datetime():
-    parsed = CaseDisplayES({}).parse_date('Apr 06, 2022 12:13:14 UTC')
-    assert_equal(parsed, datetime(2022, 4, 6, 12, 13, 14))
-    assert_not_equal(parsed, datetime(2022, 4, 6, 12, 13, 14,
-                                      tzinfo=timezone.utc))
-
-
-def test_parse_date_date():
-    parsed = CaseDisplayES({}).parse_date('2022-04-06')
-    assert_equal(parsed, datetime(2022, 4, 6, 0, 0, 0))
-
-
-def test_parse_date_str():
-    parsed = CaseDisplayES({}).parse_date('broken')
-    assert_equal(parsed, 'broken')
-
-
-def test_parse_date_none():
-    parsed = CaseDisplayES({}).parse_date(None)
-    assert_equal(parsed, None)
-
-
-def test_parse_date_int():
-    parsed = CaseDisplayES({}).parse_date(4)
-    assert_equal(parsed, 4)
 
 
 def test_blank_owner_id():

--- a/corehq/apps/reports/tests/test_case_display.py
+++ b/corehq/apps/reports/tests/test_case_display.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from nose.tools import assert_equal, assert_not_equal
-from corehq.apps.reports.standard.cases.data_sources import CaseDisplay
+from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
 
 
 def test_happy_case_display():
@@ -9,7 +9,7 @@ def test_happy_case_display():
         'name': 'Foo',
         'modified_on': '2022-04-06T12:13:14Z',
     }
-    case_display = CaseDisplay(case_dict)
+    case_display = CaseDisplayES(case_dict)
     assert_equal(case_display.modified_on, 'Apr 06, 2022 12:13:14 UTC')
 
 
@@ -18,12 +18,12 @@ def test_bad_case_display():
         'name': "It's a trap",
         'modified_on': 'broken',
     }
-    case_display = CaseDisplay(case_dict)
+    case_display = CaseDisplayES(case_dict)
     assert_equal(case_display.modified_on, '')
 
 
 def test_parse_date_iso_datetime():
-    parsed = CaseDisplay({}).parse_date('2022-04-06T12:13:14Z')
+    parsed = CaseDisplayES({}).parse_date('2022-04-06T12:13:14Z')
     assert_equal(parsed, datetime(2022, 4, 6, 12, 13, 14))
     # `date` is timezone naive
     assert_not_equal(parsed, datetime(2022, 4, 6, 12, 13, 14,
@@ -31,41 +31,41 @@ def test_parse_date_iso_datetime():
 
 
 def test_parse_date_noniso_datetime():
-    parsed = CaseDisplay({}).parse_date('Apr 06, 2022 12:13:14 UTC')
+    parsed = CaseDisplayES({}).parse_date('Apr 06, 2022 12:13:14 UTC')
     assert_equal(parsed, datetime(2022, 4, 6, 12, 13, 14))
     assert_not_equal(parsed, datetime(2022, 4, 6, 12, 13, 14,
                                       tzinfo=timezone.utc))
 
 
 def test_parse_date_date():
-    parsed = CaseDisplay({}).parse_date('2022-04-06')
+    parsed = CaseDisplayES({}).parse_date('2022-04-06')
     assert_equal(parsed, datetime(2022, 4, 6, 0, 0, 0))
 
 
 def test_parse_date_str():
-    parsed = CaseDisplay({}).parse_date('broken')
+    parsed = CaseDisplayES({}).parse_date('broken')
     assert_equal(parsed, 'broken')
 
 
 def test_parse_date_none():
-    parsed = CaseDisplay({}).parse_date(None)
+    parsed = CaseDisplayES({}).parse_date(None)
     assert_equal(parsed, None)
 
 
 def test_parse_date_int():
-    parsed = CaseDisplay({}).parse_date(4)
+    parsed = CaseDisplayES({}).parse_date(4)
     assert_equal(parsed, 4)
 
 
 def test_blank_owner_id():
     # previously this would error
-    owner_type, meta = CaseDisplay({}).owner
+    owner_type, meta = CaseDisplayES({}).owner
     assert_equal(owner_type, 'user')
     assert_equal(meta, {'id': '', 'name': ''})
 
 
 def test_null_owner_id():
     # previously this would error
-    owner_type, meta = CaseDisplay({'owner_id': None}).owner
+    owner_type, meta = CaseDisplayES({'owner_id': None}).owner
     assert_equal(owner_type, 'user')
     assert_equal(meta, {'id': None, 'name': None})

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -362,16 +362,6 @@ def validate_xform_for_edit(xform):
     return None
 
 
-def get_report_timezone(request, domain):
-    if not domain:
-        return pytz.utc
-    else:
-        try:
-            return get_timezone_for_user(request.couch_user, domain)
-        except AttributeError:
-            return get_timezone_for_user(None, domain)
-
-
 @quickcache(['domain', 'mobile_user_and_group_slugs'], timeout=10)
 def is_query_too_big(domain, mobile_user_and_group_slugs, request_user):
     from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter

--- a/corehq/apps/reports/v2/endpoints/datagrid.py
+++ b/corehq/apps/reports/v2/endpoints/datagrid.py
@@ -30,7 +30,7 @@ class DatagridEndpoint(BaseDataEndpoint):
 
         is_timeout = False
         try:
-            results = [formatter(self.request, self.domain, r).get_context()
+            results = [formatter(r, self.timezone).get_context()
                        for r in query.run().raw['hits'].get('hits', [])]
             took = query.run().raw.get('took')
         except ESError:

--- a/corehq/apps/reports/v2/filters/xpath_column.py
+++ b/corehq/apps/reports/v2/filters/xpath_column.py
@@ -10,9 +10,9 @@ from corehq.apps.case_search.const import (
     CASE_COMPUTED_METADATA,
     SPECIAL_CASE_PROPERTIES,
 )
-from corehq.apps.reports.util import get_report_timezone
 from corehq.apps.reports.v2.exceptions import ColumnFilterNotFound
 from corehq.apps.reports.v2.models import BaseFilter
+from corehq.util.timezones.utils import get_timezone
 
 ChoiceMeta = namedtuple('ChoiceMeta', 'title name operator')
 AppliedFilterContext = namedtuple(
@@ -131,7 +131,7 @@ class DateXpathColumnFilter(BaseXpathColumnFilter):
     @property
     @memoized
     def _timezone(self):
-        return get_report_timezone(self.request, self.domain)
+        return get_timezone(self.request, self.domain)
 
     def _adjust_to_utc(self, date):
         if not self.adjust_to_utc:

--- a/corehq/apps/reports/v2/formatters/cases.py
+++ b/corehq/apps/reports/v2/formatters/cases.py
@@ -1,110 +1,27 @@
-from django.urls import NoReverseMatch
-from django.utils.translation import gettext as _
-
-from couchdbkit import ResourceNotFound
-
 from corehq.apps.case_search.const import (
     CASE_COMPUTED_METADATA,
     SPECIAL_CASE_PROPERTIES,
     SPECIAL_CASE_PROPERTIES_MAP,
 )
 from corehq.apps.es.case_search import flatten_result
-from corehq.apps.groups.models import Group
-from corehq.apps.locations.models import SQLLocation
-from corehq.apps.reports.v2.models import BaseDataFormatter
-from corehq.apps.reports.v2.utils import report_date_to_json
-from corehq.apps.reports.util import get_user_id_from_form
-from corehq.apps.users.models import CouchUser
-from corehq.util.quickcache import quickcache
-from corehq.util.timezones.utils import parse_date
-from corehq.util.view_utils import absolute_reverse
+from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
+from corehq.const import SERVER_DATETIME_FORMAT
 
 
-class CaseDataFormatter(BaseDataFormatter):
+class CaseDataFormatter(CaseDisplayES):
 
-    def __init__(self, request, domain, raw_data):
-        super(CaseDataFormatter, self).__init__(request, domain)
-        self.raw_data = flatten_result(raw_data)
+    date_format = SERVER_DATETIME_FORMAT
 
-    @property
-    def owner_id(self):
-        """Special Case Property @owner_id"""
-        if 'owner_id' in self.raw_data:
-            return self.raw_data.get('owner_id')
-        elif 'user_id' in self.raw_data:
-            return self.raw_data.gert('user_id')
-        else:
-            return ''
-
-    @property
-    def date_opened(self):
-        """Special Case Property date_opened"""
-        return self._fmt_dateprop('opened_on')
-
-    @property
-    def last_modified(self):
-        """Special Case Property last_modified"""
-        return self._fmt_dateprop('modified_on')
-
-    @property
-    def closed_by_username(self):
-        """Computed metadata"""
-        return self._get_username(self.closed_by_user_id)
-
-    @property
-    def last_modified_by_user_username(self):
-        """Computed metadata"""
-        return self._get_username(self.raw_data.get('user_id'))
-
-    @property
-    def opened_by_username(self):
-        """Computed metadata"""
-        user = self._creating_user
-        if user is None:
-            return _("No Data")
-        return user['name'] or self._user_not_found_display(user['id'])
-
-    @property
-    def owner_name(self):
-        """Computed metadata"""
-        owner_type, owner = self._owner
-        if owner_type == 'group':
-            return '<span class="label label-default">%s</span>' % owner['name']
-        return owner['name']
-
-    @property
-    def closed_by_user_id(self):
-        """Computed metadata"""
-        return self.raw_data.get('closed_by')
-
-    @property
-    def opened_by_user_id(self):
-        """Computed metadata"""
-        user = self._creating_user
-        if user is None:
-            return _("No data")
-        return user['id']
-
-    @property
-    def server_last_modified_date(self):
-        """Computed metadata"""
-        return self._fmt_dateprop('server_modified_on', False)
+    def __init__(self, raw_data, timezone):
+        case = flatten_result(raw_data)
+        super().__init__(case, timezone)
 
     def get_context(self):
         context = {}
-        context.update(self.raw_data)
+        context.update(self.case)
         context.update(self._case_info_context)
-        context['_link'] = self._link
+        context['_link'] = self.case_detail_url
         return context
-
-    @property
-    def _link(self):
-        try:
-            return absolute_reverse(
-                'case_data', args=[self.domain, self.raw_data.get('_id')]
-            )
-        except NoReverseMatch:
-            return None
 
     @property
     def _case_info_context(self):
@@ -123,71 +40,4 @@ class CaseDataFormatter(BaseDataFormatter):
             "CaseDataFormatter.{} not found".format(prop))
 
     def _get_special_property(self, prop):
-        return (SPECIAL_CASE_PROPERTIES_MAP[prop]
-            .value_getter(self.raw_data))
-
-    def _fmt_dateprop(self, prop, is_phonetime=True):
-        return report_date_to_json(
-            self.request,
-            self.domain,
-            parse_date(self.raw_data[prop]),
-            is_phonetime=is_phonetime
-        )
-
-    @property
-    @quickcache(['self.owner_id'])
-    def _owning_group(self):
-        try:
-            return Group.get(self.owner_id)
-        except ResourceNotFound:
-            return None
-
-    @property
-    @quickcache(['self.owner_id'])
-    def _location(self):
-        return SQLLocation.objects.get_or_None(location_id=self.owner_id)
-
-    @property
-    @quickcache(['self.owner_id'])
-    def _owner(self):
-        if self._owning_group and self._owning_group.name:
-            return ('group', {'id': self._owning_group._id,
-                              'name': self._owning_group.name})
-        elif self._location:
-            return ('location', {'id': self._location.location_id,
-                                 'name': self._location.display_name})
-        return ('user', self._user_meta(self.owner_id))
-
-    @property
-    def _creating_user(self):
-        try:
-            creator_id = self.raw_data['opened_by']
-        except KeyError:
-            creator_id = None
-            if 'actions' in self.raw_data:
-                for action in self.raw_data['actions']:
-                    if action['action_type'] == 'create':
-                        creator_id = get_user_id_from_form(action["xform_id"])
-                        break
-
-        if not creator_id:
-            return None
-        return self._user_meta(creator_id)
-
-    def _user_meta(self, user_id):
-        return {'id': user_id, 'name': self._get_username(user_id)}
-
-    def _user_not_found_display(self, user_id):
-        return _("Unknown [%s]") % user_id
-
-    @quickcache(['user_id'])
-    def _get_username(self, user_id):
-        if not user_id:
-            return None
-
-        try:
-            user = CouchUser.get_by_user_id(user_id)
-            if user:
-                return user.username
-        except CouchUser.AccountTypeError:
-            return None
+        return SPECIAL_CASE_PROPERTIES_MAP[prop].value_getter(self.raw_data)

--- a/corehq/apps/reports/v2/formatters/cases.py
+++ b/corehq/apps/reports/v2/formatters/cases.py
@@ -23,7 +23,7 @@ from corehq.util.view_utils import absolute_reverse
 class CaseDataFormatter(BaseDataFormatter):
 
     def __init__(self, request, domain, raw_data):
-        super(CaseDataFormatter, self).__init__(request, domain, raw_data)
+        super(CaseDataFormatter, self).__init__(request, domain)
         self.raw_data = flatten_result(raw_data)
 
     @property

--- a/corehq/apps/reports/v2/formatters/cases.py
+++ b/corehq/apps/reports/v2/formatters/cases.py
@@ -3,22 +3,22 @@ from corehq.apps.case_search.const import (
     SPECIAL_CASE_PROPERTIES,
     SPECIAL_CASE_PROPERTIES_MAP,
 )
-from corehq.apps.es.case_search import flatten_result
-from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
+from corehq.apps.es.case_search import wrap_case_search_hit
+from corehq.apps.reports.standard.cases.data_sources import CaseDisplaySQL
 from corehq.const import SERVER_DATETIME_FORMAT
 
 
-class CaseDataFormatter(CaseDisplayES):
+class CaseDataFormatter(CaseDisplaySQL):
 
     date_format = SERVER_DATETIME_FORMAT
 
     def __init__(self, raw_data, timezone):
-        case = flatten_result(raw_data)
+        case = wrap_case_search_hit(raw_data)
         super().__init__(case, timezone)
 
     def get_context(self):
         context = {}
-        context.update(self.case)
+        context.update(self.case.to_json())
         context.update(self._case_info_context)
         context['_link'] = self.case_detail_url
         return context

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -166,7 +166,7 @@ class BaseDataEndpoint(BaseEndpoint):
 
 class BaseDataFormatter(object):
 
-    def __init__(self, request, domain, raw_data):
+    def __init__(self, request, domain):
         self.domain = domain
         self.request = request
 

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -11,6 +11,7 @@ from corehq.apps.reports.v2.exceptions import (
     EndpointNotFoundError,
     ReportFilterNotFound,
 )
+from corehq.util.timezones.utils import get_timezone
 
 EndpointContext = namedtuple('EndpointContext', 'slug urlname')
 ColumnMeta = namedtuple('ColumnMeta', 'title name width sort')
@@ -146,6 +147,10 @@ class BaseEndpoint(object):
     @memoized
     def report_context(self):
         return json.loads(self.data.get('reportContext', "{}"))
+
+    @property
+    def timezone(self):
+        return get_timezone(self.request, self.domain)
 
 
 class BaseOptionsEndpoint(BaseEndpoint):

--- a/corehq/apps/reports/v2/utils.py
+++ b/corehq/apps/reports/v2/utils.py
@@ -3,13 +3,12 @@ from corehq.util.timezones.conversions import PhoneTime, ServerTime
 from corehq.util.timezones.utils import get_timezone
 
 
-def report_date_to_json(request, domain, date, is_phonetime=True):
-    timezone = get_timezone(request, domain)
+def report_date_to_json(date, timezone, date_format, is_phonetime=True):
     if date:
         if is_phonetime:
             user_time = PhoneTime(date, timezone).user_time(timezone)
         else:
             user_time = ServerTime(date).user_time(timezone)
-        user_time.ui_string(SERVER_DATETIME_FORMAT)
+        return user_time.ui_string(date_format)
     else:
         return ''

--- a/corehq/apps/reports/v2/views.py
+++ b/corehq/apps/reports/v2/views.py
@@ -5,6 +5,7 @@ from django.views.decorators.http import require_POST
 
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.reports.v2.reports import get_report
+from corehq.util.json import CommCareJSONEncoder
 
 
 @login_and_domain_required
@@ -17,7 +18,7 @@ def endpoint_data(request, domain, report_slug, endpoint_slug):
     endpoint = report_config.get_data_endpoint(endpoint_slug)
 
     return HttpResponse(
-        json.dumps(report_config.get_data_response(endpoint)),
+        json.dumps(report_config.get_data_response(endpoint), cls=CommCareJSONEncoder),
         content_type="application/json"
     )
 

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -1117,6 +1117,10 @@ class CommCareCaseIndex(PartitionedModel, models.Model, SaveStateMixin):
     def relationship_id_to_name(relationship_id):
         return CommCareCaseIndex.RELATIONSHIP_INVERSE_MAP[relationship_id]
 
+    def to_json(self):
+        from ..serializers import CommCareCaseIndexSerializer
+        return CommCareCaseIndexSerializer(self).data
+
     def __eq__(self, other):
         return isinstance(other, CommCareCaseIndex) and (
             self.case_id == other.case_id

--- a/corehq/form_processor/tests/test_models.py
+++ b/corehq/form_processor/tests/test_models.py
@@ -197,6 +197,16 @@ def test_case_to_json():
             'actions': 'eating sleeping typing',
             'indices': 'Dow_Jones_Industrial_Average S&P_500',
         },
+        indices=[
+            dict(
+                case_id=case_id,
+                domain='healsec',
+                identifier='host',
+                referenced_type='person',
+                referenced_id='abc123',
+                relationship_id=CommCareCaseIndex.EXTENSION,
+            )
+        ]
     )
     case_dict = case.to_json()
     assert_equal(case_dict, {
@@ -220,7 +230,15 @@ def test_case_to_json():
         'external_id': None,
         'family_name': 'Case',
         'given_name': 'Justin',
-        'indices': [],  # Not replaced by case_json
+        'indices': [
+            {
+                'case_id': case_id,
+                'identifier': 'host',
+                'referenced_type': 'person',
+                'referenced_id': 'abc123',
+                'relationship': 'extension',
+            },
+        ],  # Not replaced by case_json
         'location_id': None,
         'modified_by': '',
         'modified_on': None,
@@ -232,4 +250,24 @@ def test_case_to_json():
         'type': 'case',
         'user_id': '',
         'xform_ids': [],
+    })
+
+
+def test_case_index_to_json():
+    case_id = str(uuid4())
+    index = CommCareCaseIndex(
+        case_id=case_id,
+        domain='healsec',
+        identifier='host',
+        referenced_type='person',
+        referenced_id='abc123',
+        relationship_id=CommCareCaseIndex.EXTENSION,
+    )
+    index_dict = index.to_json()
+    assert_equal(index_dict, {
+        'case_id': case_id,
+        'identifier': 'host',
+        'referenced_type': 'person',
+        'referenced_id': 'abc123',
+        'relationship': 'extension',
     })

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -22124,7 +22124,6 @@ msgstr ""
 #: corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
 #: corehq/apps/reports/commtrack/standard.py
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 msgid "No data"
 msgstr ""
 
@@ -26793,7 +26792,6 @@ msgid "[no name]"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 #, python-format
 msgid "Unknown [%s]"
 msgstr ""
@@ -28805,10 +28803,6 @@ msgstr ""
 
 #: corehq/apps/reports/v2/filters/xpath_column.py
 msgid "Date is after"
-msgstr ""
-
-#: corehq/apps/reports/v2/formatters/cases.py
-msgid "No Data"
 msgstr ""
 
 #: corehq/apps/reports/v2/models.py

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -23144,7 +23144,6 @@ msgstr ""
 #: corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
 #: corehq/apps/reports/commtrack/standard.py
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 msgid "No data"
 msgstr "No hay datos"
 
@@ -27989,7 +27988,6 @@ msgid "[no name]"
 msgstr "[no tiene nombre]"
 
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 #, python-format
 msgid "Unknown [%s]"
 msgstr "Desconocido  [%s]"
@@ -30078,10 +30076,6 @@ msgstr ""
 #: corehq/apps/reports/v2/filters/xpath_column.py
 msgid "Date is after"
 msgstr ""
-
-#: corehq/apps/reports/v2/formatters/cases.py
-msgid "No Data"
-msgstr "No hay Datos"
 
 #: corehq/apps/reports/v2/models.py
 msgid "The report endpoint for {}/{} cannot be found."
@@ -42563,6 +42557,9 @@ msgstr ""
 #: manage.py
 msgid "Enter valid JSON"
 msgstr ""
+
+#~ msgid "No Data"
+#~ msgstr "No hay Datos"
 
 #~ msgid "Read Only (No Reports)"
 #~ msgstr "Solo Lectura (No Reportes)"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -22125,7 +22125,6 @@ msgstr ""
 #: corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
 #: corehq/apps/reports/commtrack/standard.py
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 msgid "No data"
 msgstr ""
 
@@ -26794,7 +26793,6 @@ msgid "[no name]"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 #, python-format
 msgid "Unknown [%s]"
 msgstr ""
@@ -28806,10 +28804,6 @@ msgstr ""
 
 #: corehq/apps/reports/v2/filters/xpath_column.py
 msgid "Date is after"
-msgstr ""
-
-#: corehq/apps/reports/v2/formatters/cases.py
-msgid "No Data"
 msgstr ""
 
 #: corehq/apps/reports/v2/models.py

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -23038,7 +23038,6 @@ msgstr ""
 #: corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
 #: corehq/apps/reports/commtrack/standard.py
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 msgid "No data"
 msgstr "Aucune donnée"
 
@@ -27883,7 +27882,6 @@ msgid "[no name]"
 msgstr "[no name]"
 
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 #, python-format
 msgid "Unknown [%s]"
 msgstr "Inconnu [%s]"
@@ -29976,10 +29974,6 @@ msgstr ""
 #: corehq/apps/reports/v2/filters/xpath_column.py
 msgid "Date is after"
 msgstr ""
-
-#: corehq/apps/reports/v2/formatters/cases.py
-msgid "No Data"
-msgstr "Pas de données"
 
 #: corehq/apps/reports/v2/models.py
 msgid "The report endpoint for {}/{} cannot be found."
@@ -42493,6 +42487,9 @@ msgstr "Le Score à la Fonctionnalité"
 #: manage.py
 msgid "Enter valid JSON"
 msgstr "Saisir un JSON valide"
+
+#~ msgid "No Data"
+#~ msgstr "Pas de données"
 
 #~ msgid "Read Only (No Reports)"
 #~ msgstr "Lecture seule (sans rapports)"

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -22125,7 +22125,6 @@ msgstr ""
 #: corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
 #: corehq/apps/reports/commtrack/standard.py
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 msgid "No data"
 msgstr ""
 
@@ -26794,7 +26793,6 @@ msgid "[no name]"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 #, python-format
 msgid "Unknown [%s]"
 msgstr ""
@@ -28806,10 +28804,6 @@ msgstr ""
 
 #: corehq/apps/reports/v2/filters/xpath_column.py
 msgid "Date is after"
-msgstr ""
-
-#: corehq/apps/reports/v2/formatters/cases.py
-msgid "No Data"
 msgstr ""
 
 #: corehq/apps/reports/v2/models.py

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -22138,7 +22138,6 @@ msgstr ""
 #: corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
 #: corehq/apps/reports/commtrack/standard.py
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 msgid "No data"
 msgstr ""
 
@@ -26807,7 +26806,6 @@ msgid "[no name]"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 #, python-format
 msgid "Unknown [%s]"
 msgstr ""
@@ -28819,10 +28817,6 @@ msgstr ""
 
 #: corehq/apps/reports/v2/filters/xpath_column.py
 msgid "Date is after"
-msgstr ""
-
-#: corehq/apps/reports/v2/formatters/cases.py
-msgid "No Data"
 msgstr ""
 
 #: corehq/apps/reports/v2/models.py

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -22291,7 +22291,6 @@ msgstr ""
 #: corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
 #: corehq/apps/reports/commtrack/standard.py
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 msgid "No data"
 msgstr ""
 
@@ -26982,7 +26981,6 @@ msgid "[no name]"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 #, python-format
 msgid "Unknown [%s]"
 msgstr ""
@@ -29025,10 +29023,6 @@ msgstr ""
 
 #: corehq/apps/reports/v2/filters/xpath_column.py
 msgid "Date is after"
-msgstr ""
-
-#: corehq/apps/reports/v2/formatters/cases.py
-msgid "No Data"
 msgstr ""
 
 #: corehq/apps/reports/v2/models.py

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -22125,7 +22125,6 @@ msgstr ""
 #: corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
 #: corehq/apps/reports/commtrack/standard.py
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 msgid "No data"
 msgstr ""
 
@@ -26794,7 +26793,6 @@ msgid "[no name]"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 #, python-format
 msgid "Unknown [%s]"
 msgstr ""
@@ -28806,10 +28804,6 @@ msgstr ""
 
 #: corehq/apps/reports/v2/filters/xpath_column.py
 msgid "Date is after"
-msgstr ""
-
-#: corehq/apps/reports/v2/formatters/cases.py
-msgid "No Data"
 msgstr ""
 
 #: corehq/apps/reports/v2/models.py

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -22129,7 +22129,6 @@ msgstr ""
 #: corehq/apps/hqwebapp/templates/hqwebapp/proptable/dl_property_table.html
 #: corehq/apps/reports/commtrack/standard.py
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 msgid "No data"
 msgstr ""
 
@@ -26798,7 +26797,6 @@ msgid "[no name]"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/data_sources.py
-#: corehq/apps/reports/v2/formatters/cases.py
 #, python-format
 msgid "Unknown [%s]"
 msgstr ""
@@ -28810,10 +28808,6 @@ msgstr ""
 
 #: corehq/apps/reports/v2/filters/xpath_column.py
 msgid "Date is after"
-msgstr ""
-
-#: corehq/apps/reports/v2/formatters/cases.py
-msgid "No Data"
 msgstr ""
 
 #: corehq/apps/reports/v2/models.py


### PR DESCRIPTION
## Technical Summary
I started looking at [this bug](https://dimagi-dev.atlassian.net/browse/USH-2115) which is caused by a case property called `domain` shadowing the real `case.domain` property. This is a known effect of using the `flatten_result` method to convert data coming from the case search ES index into a 'case dict'.

@millerdev created a different way of dealing with case search data in https://github.com/dimagi/commcare-hq/pull/30915 but did not address the last remaining usages of `flatten_result`.

This PR finally addresses those and completely removes `flatten_result` which were used by the Case List Explorer and Case Data Explorer.

Best reviewed by commit.

## Safety Assurance

### Safety story
I did some local testing of the CLE and CDE and everything appears to be working normally.

### Automated test coverage
There is not much test coverage of the 'CaseDisplay' classes since they mostly just perform simple data access.

### QA Plan
I was not intending to have this QA'd but I could be persuaded.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
