### PR TITLE
Fixed remote accessor for auto update rules

### DIFF
--- a/corehq/apps/linked_domain/remote_accessors.py
+++ b/corehq/apps/linked_domain/remote_accessors.py
@@ -96,7 +96,7 @@ def get_hmac_callout_settings(domain_link):
 
 
 def get_auto_update_rules(domain_link):
-    return _do_simple_request('linked_domain:auto_update_rules', domain_link)
+    return _do_simple_request('linked_domain:auto_update_rules', domain_link)['rules']
 
 
 def get_remote_linkable_ucr(domain_link):

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -134,7 +134,7 @@ def toggles_and_previews(request, domain):
 @login_or_api_key
 @require_linked_domain
 def auto_update_rules(request, domain):
-    return JsonResponse(get_auto_update_rules(domain))
+    return JsonResponse({'rules': get_auto_update_rules(domain)})
 
 
 @login_or_api_key


### PR DESCRIPTION
## Product Description
Fixes pulling/pushing auto update rules for remote linked project spaces.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-1922

Fixed this on the view level, which is consistent with similar models, like user roles. That does mean that there isn't test coverage for this change - we don't have view-level coverage here.

## Feature Flag
Linked project spaces

## Safety Assurance

### Safety story
Well-isolated change to a fairly recent feature used by few if any projects.

### Automated test coverage

None

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
