### PR TITLE
pass domain string to filter, not obj

### DIFF
--- a/corehq/apps/users/migrations/0046_add_default_mobile_worker_role.py
+++ b/corehq/apps/users/migrations/0046_add_default_mobile_worker_role.py
@@ -11,7 +11,7 @@ from corehq.util.django_migrations import skip_on_fresh_install
 @skip_on_fresh_install
 def _add_default_mobile_worker_role(apps, schema_editor):
     default_mobile_worker_roles = UserRole.objects.filter(is_commcare_user_default=True)
-    for domain in Domain.get_all():
+    for domain in Domain.get_all_names():
         has_dmw_role = default_mobile_worker_roles.filter(domain=domain).exists()
         if not has_dmw_role:
             UserRole.create(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
https://github.com/dimagi/commcare-hq/pull/31776#discussion_r898305355

`domain` here is a domain object - it should use `Domain.get_all_names()`.  Weirdly enough, this will usually work as written because of this
https://github.com/dimagi/commcare-hq/blob/1bd5f684cbf6d0fc08624dcc395b20a8e4429604/corehq/apps/domain/models.py#L744-L749
But it won't find default roles on any projects that have specified a human-readable name.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Tested locally
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
This makes a minor correction to a migration that hasn't yet been run on prod

- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

This PR should be considered together with https://github.com/dimagi/commcare-hq/pull/31776

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
