### PR TITLE
Add tests for model attribute comparison in couch-to-sql toolchain

### DIFF
--- a/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
+++ b/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
@@ -343,6 +343,13 @@ class Command(BaseCommand):
             submodels=submodels
         )
 
+    def generate_test_file(self):
+        return render_tempate(
+            'migration_attr_equality_test.j2',
+            class_name=self.class_name,
+            models_path=self.models_path
+        )
+
     def is_submodel_key(self, key):
         return "." in key or self.is_field_type_submodel(key)
 

--- a/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
+++ b/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
@@ -98,6 +98,12 @@ class Command(BaseCommand):
         print(f"\n################# add {command_file} #################")
         print(command_content)
 
+        test_file_name = f'test_{self.class_name.lower()}_attr_comparision.py'
+        test_file = os.path.join("corehq", "apps", self.django_app, "tests", test_file_name)
+        test_content = self.generate_test_file()
+        print(f"\n################# add {test_file} #################\n")
+        print(test_content)
+
     def evaluate_doc(self, doc, prefix=None):
         for key, value in doc.items():
             if key in self.COUCH_FIELDS:

--- a/corehq/apps/cleanup/management/commands/templates/migration_attr_equality_test.j2
+++ b/corehq/apps/cleanup/management/commands/templates/migration_attr_equality_test.j2
@@ -10,14 +10,13 @@ class Test{{class_name}}ModelsAttrEquality(ModelAttrEqualityHelper):
         sql_attrs = self.get_sql_attrs(SQL{{class_name}})
         self.assertEqual(couch_attrs ^ sql_attrs, set())
 
-    @classmethod
-    def _couch_only_attrs(cls):
-        return {
-            # removed attrs
-            # renamed attrs
-            # not used attrs
-        }
+    couch_only_attrs = {*[
+        # removed attrs
+        # renamed attrs
+        # not used attrs
+    ]}
 
-    @classmethod
-    def _sql_only_attrs(cls):
-        return {}
+    sql_only_attrs = {*[
+        # new attrs
+        # renamed attrs
+    ]}

--- a/corehq/apps/cleanup/management/commands/templates/migration_attr_equality_test.j2
+++ b/corehq/apps/cleanup/management/commands/templates/migration_attr_equality_test.j2
@@ -1,0 +1,23 @@
+from corehq.apps.cleanup.tests.util import ModelAttrEqualityHelper
+from {{models_path}} import {{class_name}}
+from {{models_path}} import SQL{{class_name}}
+
+
+class Test{{class_name}}ModelsAttrEquality(ModelAttrEqualityHelper):
+
+    def test_have_same_attrs(self):
+        couch_attrs = self.get_cleaned_couch_attrs({{class_name}})
+        sql_attrs = self.get_sql_attrs(SQL{{class_name}})
+        self.assertEqual(couch_attrs ^ sql_attrs, set())
+
+    @classmethod
+    def _couch_only_attrs(cls):
+        return {
+            # removed attrs
+            # renamed attrs
+            # not used attrs
+        }
+
+    @classmethod
+    def _sql_only_attrs(cls):
+        return {}

--- a/corehq/apps/cleanup/tests/util.py
+++ b/corehq/apps/cleanup/tests/util.py
@@ -1,0 +1,44 @@
+import inspect
+
+from django.db import models
+from django.test import SimpleTestCase
+
+from dimagi.ext.couchdbkit import Document
+from dimagi.utils.couch.migration import (
+    SyncCouchToSQLMixin,
+    SyncSQLToCouchMixin,
+)
+
+
+class ModelAttrEqualityHelper(SimpleTestCase):
+    class DummySQLModel(models.Model, SyncSQLToCouchMixin):
+        pass
+
+    class DummyCouchModel(Document, SyncCouchToSQLMixin):
+        pass
+
+    @classmethod
+    def _get_user_defined_attrs(cls, model_cls, dummy_model):
+        model_attrs = dir(dummy_model)
+        return {item[0]
+                for item in inspect.getmembers(model_cls)
+                if item[0] not in model_attrs}
+
+    @classmethod
+    def get_sql_attrs(cls, model_cls):
+        return cls._get_user_defined_attrs(model_cls, cls.DummySQLModel)
+
+    @classmethod
+    def get_cleaned_couch_attrs(cls, couch_model_cls):
+        couch_attrs = cls._get_user_defined_attrs(couch_model_cls, cls.DummyCouchModel)
+        extra_attrs = cls._couch_only_attrs()
+        new_attrs = cls._sql_only_attrs()
+        return (couch_attrs - extra_attrs).union(new_attrs)
+
+    @classmethod
+    def _couch_only_attrs(cls):
+        return set()
+
+    @classmethod
+    def _sql_only_attrs(cls):
+        return set()

--- a/corehq/apps/cleanup/tests/util.py
+++ b/corehq/apps/cleanup/tests/util.py
@@ -11,11 +11,19 @@ from dimagi.utils.couch.migration import (
 
 
 class ModelAttrEqualityHelper(SimpleTestCase):
+    """
+    Helper class to test the equality of couch and a SQL models during a couch to sql migration.
+    Update `couch_only_attrs` and `sql_only_attrs` as per requirements
+    """
     class DummySQLModel(models.Model, SyncSQLToCouchMixin):
         pass
 
     class DummyCouchModel(Document, SyncCouchToSQLMixin):
         pass
+
+    couch_only_attrs = set()
+
+    sql_only_attrs = set()
 
     @classmethod
     def _get_user_defined_attrs(cls, model_cls, dummy_model):
@@ -31,14 +39,6 @@ class ModelAttrEqualityHelper(SimpleTestCase):
     @classmethod
     def get_cleaned_couch_attrs(cls, couch_model_cls):
         couch_attrs = cls._get_user_defined_attrs(couch_model_cls, cls.DummyCouchModel)
-        extra_attrs = cls._couch_only_attrs()
-        new_attrs = cls._sql_only_attrs()
+        extra_attrs = cls.couch_only_attrs
+        new_attrs = cls.sql_only_attrs
         return (couch_attrs - extra_attrs).union(new_attrs)
-
-    @classmethod
-    def _couch_only_attrs(cls):
-        return set()
-
-    @classmethod
-    def _sql_only_attrs(cls):
-        return set()

--- a/docs/couch_to_sql_models.rst
+++ b/docs/couch_to_sql_models.rst
@@ -76,8 +76,8 @@ This should contain:
     - The test file uses a `ModelAttrEquality` util which has methods for running the equality tests.
     - The test class that is generated will have two attributes  `couch_only_attrs`, `sql_only_attrs` and one method `test_have_same_attrs`.
     - Generally during a migration some attributes and methods are renamed or removed as per need. To accomodate the changes you can update `couch_only_attrs` and `sql_only_attrs`.
-    - `couch_only_attrs` is supposed to be a set of attributes and methods which are either removed, renamed or not used anymore in SQL.
-    - `sql_only_attrs` would be having of attributes and methods that are new in the SQL model.
+    - `couch_only_attrs` should be a set of attributes and methods which are either removed, renamed or not used anymore in SQL.
+    - `sql_only_attrs` should be a set of attributes and methods that are new in the SQL model.
     - `test_have_same_attrs` will test the equality of the attributes. The default implementation should work if you have populated `couch_only_attrs` and `sql_only_attrs` but you can modify it's implementation as needed.
   - Add the generated migration command. Notes on this code:
 

--- a/docs/couch_to_sql_models.rst
+++ b/docs/couch_to_sql_models.rst
@@ -45,7 +45,7 @@ This should contain:
 
 - A new model and a management command that fetches all couch docs and creates or updates the corresponding SQL model(s).
 
-  - Start by running the management command ``evaluate_couch_model_for_sql django_app_name MyDocType`` on a production environment. This will produce code to add to your models file, a new management command and also a test which will ensure that the couch model and sql model has same attributes.
+  - Start by running the management command ``evaluate_couch_model_for_sql django_app_name MyDocType`` on a production environment. This will produce code to add to your models file, a new management command and also a test which will ensure that the couch model and sql model have the same attributes.
 
     - The reason to run on production is that it will examine existing documents to help determine things like ``max_length``. This also means it can take a while. If you have reasonable data locally, running it locally is fine - but since the sql class will often have stricter data validation than couch, it's good to run it on prod at some point.
 
@@ -73,12 +73,12 @@ This should contain:
 
   - Run ``makemigrations``
   - Add the test that was generated to it's respective place.
-    - The test file uses `ModelAttrEquality` util which has mehods for running the equality tests.
-    - The test class that is generated will have three methods namely `_couch_only_attrs`,  `_sql_only_attrs` and `test_have_same_attrs`.
+    - The test file uses a `ModelAttrEquality` util which has methods for running the equality tests.
+    - The test class that is generated will have three methods: `_couch_only_attrs`, `_sql_only_attrs` and `test_have_same_attrs`.
     - Generally during a migration some attributes and methods are renamed or removed as per need. To accomodate the changes you can update `_couch_only_attrs` and `_sql_only_attrs`.
     - `_couch_only_attrs` is supposed to return a set of attributes and methods which are either removed, renamed or not used anymore in SQL.
-    - `_sql_only_attrs` would return a set of attributes and methods that are added newly in the SQL model.
-    - `test_have_same_attrs` is the test method that would run to test the equality of the attributes. The default implementation should work if you have populated above methods but you can modify it's implementation as per your requirement.
+    - `_sql_only_attrs` would return a set of attributes and methods that are new in the SQL model.
+    - `test_have_same_attrs` will test the equality of the attributes. The default implementation should work if you have populated the above methods but you can modify it's implementation as needed.
   - Add the generated migration command. Notes on this code:
 
     - The generated migration does not handle submodels. Edit ``update_or_create_sql_object`` to add support.

--- a/docs/couch_to_sql_models.rst
+++ b/docs/couch_to_sql_models.rst
@@ -45,7 +45,7 @@ This should contain:
 
 - A new model and a management command that fetches all couch docs and creates or updates the corresponding SQL model(s).
 
-  - Start by running the management command ``evaluate_couch_model_for_sql django_app_name MyDocType`` on a production environment. This will produce code to add to your models file and also a new management command.
+  - Start by running the management command ``evaluate_couch_model_for_sql django_app_name MyDocType`` on a production environment. This will produce code to add to your models file, a new management command and also a test which will ensure that the couch model and sql model has same attributes.
 
     - The reason to run on production is that it will examine existing documents to help determine things like ``max_length``. This also means it can take a while. If you have reasonable data locally, running it locally is fine - but since the sql class will often have stricter data validation than couch, it's good to run it on prod at some point.
 
@@ -72,7 +72,13 @@ This should contain:
     - Some docs have attributes that are couch ids of other docs. These are weak spots easy to forget when the referenced doc type is migrated. Add a comment so these show up in a grep for the referenced doc type.
 
   - Run ``makemigrations``
-
+  - Add the test that was generated to it's respective place.
+    - The test file uses `ModelAttrEquality` util which has mehods for running the equality tests.
+    - The test class that is generated will have three methods namely `_couch_only_attrs`,  `_sql_only_attrs` and `test_have_same_attrs`.
+    - Generally during a migration some attributes and methods are renamed or removed as per need. To accomodate the changes you can update `_couch_only_attrs` and `_sql_only_attrs`.
+    - `_couch_only_attrs` is supposed to return a set of attributes and methods which are either removed, renamed or not used anymore in SQL.
+    - `_sql_only_attrs` would return a set of attributes and methods that are added newly in the SQL model.
+    - `test_have_same_attrs` is the test method that would run to test the equality of the attributes. The default implementation should work if you have populated above methods but you can modify it's implementation as per your requirement.
   - Add the generated migration command. Notes on this code:
 
     - The generated migration does not handle submodels. Edit ``update_or_create_sql_object`` to add support.

--- a/docs/couch_to_sql_models.rst
+++ b/docs/couch_to_sql_models.rst
@@ -74,11 +74,11 @@ This should contain:
   - Run ``makemigrations``
   - Add the test that was generated to it's respective place.
     - The test file uses a `ModelAttrEquality` util which has methods for running the equality tests.
-    - The test class that is generated will have three methods: `_couch_only_attrs`, `_sql_only_attrs` and `test_have_same_attrs`.
-    - Generally during a migration some attributes and methods are renamed or removed as per need. To accomodate the changes you can update `_couch_only_attrs` and `_sql_only_attrs`.
-    - `_couch_only_attrs` is supposed to return a set of attributes and methods which are either removed, renamed or not used anymore in SQL.
-    - `_sql_only_attrs` would return a set of attributes and methods that are new in the SQL model.
-    - `test_have_same_attrs` will test the equality of the attributes. The default implementation should work if you have populated the above methods but you can modify it's implementation as needed.
+    - The test class that is generated will have two attributes  `couch_only_attrs`, `sql_only_attrs` and one method `test_have_same_attrs`.
+    - Generally during a migration some attributes and methods are renamed or removed as per need. To accomodate the changes you can update `couch_only_attrs` and `sql_only_attrs`.
+    - `couch_only_attrs` is supposed to be a set of attributes and methods which are either removed, renamed or not used anymore in SQL.
+    - `sql_only_attrs` would be having of attributes and methods that are new in the SQL model.
+    - `test_have_same_attrs` will test the equality of the attributes. The default implementation should work if you have populated `couch_only_attrs` and `sql_only_attrs` but you can modify it's implementation as needed.
   - Add the generated migration command. Notes on this code:
 
     - The generated migration does not handle submodels. Edit ``update_or_create_sql_object`` to add support.


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
While writing tests for Repeaters, I have raised a PR that would check if the couch model and SQL model have the same attributes.  @orangejenny suggested having them in the `couch-to-sql` toolchain and autogenerate the test file. Based on the feedback, I have updated it to include the test also at the end of `evaluate_couch_model_for_sql` command.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested the command with `ReportConfiguration` model in local and it was working fine. And the changes does not effect any live feature of HQ and is just meant for couch-to-sql migration code generation.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
