### PR TITLE
fix manual link datums

### DIFF
--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -948,7 +948,7 @@ def get_form_datums(request, domain, app_id):
         make_datum(datum) for datum in helper.get_datums_meta_for_form_generic(form)
         if datum.requires_selection
     ]
-    return json_response(datums)
+    return JsonResponse(datums)
 
 
 @require_GET

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -944,17 +944,10 @@ def get_form_datums(request, domain, app_id):
         return {'name': datum.id, 'case_type': datum.case_type}
 
     helper = EntriesHelper(app)
-    datums = []
-    root_module = form.get_module().root_module
-    if root_module:
-        datums.extend([
-            make_datum(datum) for datum in helper.get_datums_meta_for_form_generic(root_module.get_form(0))
-            if datum.requires_selection
-        ])
-    datums.extend([
+    datums = [
         make_datum(datum) for datum in helper.get_datums_meta_for_form_generic(form)
         if datum.requires_selection
-    ])
+    ]
     return json_response(datums)
 
 


### PR DESCRIPTION
## Technical Summary
I discovered that the 'manual' datums were duplicating any parent case datums.  The parent case datums are already added in the `get_datums_meta_for_form_generic` method.

## Safety Assurance

### Safety story
This impacts form linking workflows that require manual linking. Existing links will continue to work and new links where parent modules are involved won't ask for duplicate case datums.

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
