### PR TITLE
edit view for UCR expression library

### DIFF
--- a/corehq/apps/data_interfaces/urls.py
+++ b/corehq/apps/data_interfaces/urls.py
@@ -17,7 +17,7 @@ from corehq.apps.data_interfaces.views import (
     find_by_id,
     xform_management_job_poll,
 )
-from corehq.apps.userreports.views import UCRExpressionListView
+from corehq.apps.userreports.views import UCRExpressionListView, UCRExpressionEditView
 
 from .interfaces import FormManagementMode
 
@@ -56,4 +56,6 @@ urlpatterns = [
     url(r'^export/', include('corehq.apps.export.urls')),
     url(r'^find/$', find_by_id, name="data_find_by_id"),
     url(r'^ucr_expressions/$', UCRExpressionListView.as_view(), name=UCRExpressionListView.urlname),
+    url(r'^ucr_expressions/(?P<expression_id>\d+)/$', UCRExpressionEditView.as_view(),
+        name=UCRExpressionEditView.urlname),
 ]

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
@@ -93,6 +93,7 @@ hqDefine('hqwebapp/js/base_ace', [
         editor.getSession().on('change', function () {
             observable(editor.getSession().getValue());
         });
+        return editor;
     };
 
 

--- a/corehq/apps/userreports/forms.py
+++ b/corehq/apps/userreports/forms.py
@@ -41,12 +41,3 @@ class UCRExpressionForm(forms.ModelForm):
     def save(self, commit=True):
         self.instance.domain = self.domain
         return super().save(commit)
-
-
-class UCRExpressionUpdateForm(UCRExpressionForm):
-    class Meta(UCRExpressionForm.Meta):
-        fields = UCRExpressionForm.Meta.fields + ['id']
-
-    def __init__(self, request, *args, **kwargs):
-        super().__init__(request, *args, **kwargs)
-        self.fields['id'] = forms.CharField(widget=forms.HiddenInput())

--- a/corehq/apps/userreports/static/userreports/js/ucr_expression.js
+++ b/corehq/apps/userreports/static/userreports/js/ucr_expression.js
@@ -47,6 +47,9 @@ hqDefine("userreports/js/ucr_expression", [
                 dataType: 'json',
                 success: function (response, status, xhr, form) {
                     alertUser.alert_user(gettext("Expression saved"), 'success');
+                    if (response.warning) {
+                        alertUser.alert_user(response.warning, 'warning');
+                    }
                 },
                 error: function(response) {
                     if (response.responseJSON && response.responseJSON.errors) {

--- a/corehq/apps/userreports/static/userreports/js/ucr_expression.js
+++ b/corehq/apps/userreports/static/userreports/js/ucr_expression.js
@@ -1,0 +1,72 @@
+hqDefine("userreports/js/ucr_expression", [
+    'moment',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/base_ace',
+    'hqwebapp/js/alert_user',
+], function (
+    moment,
+    ko,
+    _,
+    initialPageData,
+    baseAce,
+    alertUser,
+) {
+    let EditModel = function(data) {
+        const mapping = {
+            'copy': ["domain", "definition_raw"],
+            'observe': ["name", "description", "expression_type"],
+        };
+
+        let self = ko.mapping.fromJS(data, mapping);
+
+        self.definition = ko.observable(JSON.stringify(self.definition_raw, null, 2));
+
+        self.getDefinitionJSON = function () {
+            try {
+                return JSON.parse(self.definition());
+            } catch (err) {
+                return null;
+            }
+        };
+
+        self.hasParseError = ko.computed(function () {
+            return self.getDefinitionJSON() === null;
+        }, self);
+
+        self.formatJson = function () {
+            let expr = self.getDefinitionJSON();
+            if (expr !== null) {
+                self.editor.getSession().setValue(JSON.stringify(expr, null, 2));
+            }
+        };
+
+        self.saveExpression = function (form) {
+            $(form).ajaxSubmit({
+                dataType: 'json',
+                success: function (response, status, xhr, form) {
+                    alertUser.alert_user(gettext("Expression saved"), 'success');
+                },
+                error: function(response) {
+                    if (response.responseJSON && response.responseJSON.errors) {
+                        _.each(response.responseJSON.errors, function (error) {
+                            alertUser.alert_user(error, 'danger');
+                        });
+                    }
+                }
+            });
+            return false;
+        };
+
+        return self;
+    };
+
+    $(function () {
+        let viewModel = EditModel(
+            initialPageData.get("expression")
+        );
+        $("#edit-expression").koApplyBindings(viewModel);
+        viewModel.editor = baseAce.initObservableJsonWidget($('.observablejsonwidget')[0]);
+    });
+});

--- a/corehq/apps/userreports/templates/userreports/ucr_expression.html
+++ b/corehq/apps/userreports/templates/userreports/ucr_expression.html
@@ -56,7 +56,7 @@
                 {% trans "Definition" %}
               </label>
               <div class="col-xs-12 col-sm-10 col-md-10 col-lg-10 controls">
-                <textarea id="definition" name="definition" class="form-control observablejsonwidget" data-bind="value: definition"></textarea>
+                <textarea id="definition" name="definition" class="form-control observablejsonwidget vertical-resize" data-bind="value: definition"></textarea>
                 <div class="help-block" data-bind="visible: hasParseError">
                   {% blocktrans %}
                     Your expression has parse errors!

--- a/corehq/apps/userreports/templates/userreports/ucr_expression.html
+++ b/corehq/apps/userreports/templates/userreports/ucr_expression.html
@@ -1,0 +1,84 @@
+{% extends "hqwebapp/base_section.html" %}
+{% load compress %}
+{% load hq_shared_tags %}
+{% load i18n %}
+
+{% block js %}{{ block.super }}
+  {% compress js %}
+    <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
+    <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
+    <script src="{% static 'userreports/js/widgets.js' %}"></script>
+  {% endcompress %}
+{% endblock %}
+
+{% requirejs_main "userreports/js/ucr_expression" %}
+
+{% block page_content %}
+{% initial_page_data "expression" expression %}
+<div id="edit-expression">
+    <div class="row">
+      <div class="col-xs-12 col-sm-10 col-md-8 col-lg-8">
+        <form class="form-horizontal" method="post" data-bind="submit: saveExpression">
+          {% csrf_token %}
+          <fieldset>
+            <div class="form-group">
+              <label for="expression_type" class="col-xs-12 col-sm-2 col-md-2 col-lg-2 control-label">
+                {% trans "Type" %}
+              </label>
+              <div class="col-xs-12 col-sm-6 col-md-6 col-lg-4 controls">
+                <select name="expression_type" class="form-control" id="expression_type" data-bind="value: expression_type">
+                  <option value="named_expression">{% trans "Named Expression" %}</option>
+                  <option value="named_filter">{% trans "Named Filter" %}</option>
+                </select>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="name" class="col-xs-12 col-sm-2 col-md-2 col-lg-2 control-label">
+                {% trans "Name" %}
+              </label>
+              <div class="col-xs-12 col-sm-6 col-md-6 col-lg-4 controls">
+                <input name="name" class="form-control" id="name" data-bind="value: name">
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="description" class="col-xs-12 col-sm-2 col-md-2 col-lg-2 control-label">
+                {% trans "Description" %}
+              </label>
+              <div class="col-xs-12 col-sm-7 col-md-7 col-lg-7 controls">
+                <textarea name="description" class="form-control" id="description" data-bind="value: description">
+                </textarea>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="definition" class="col-xs-12 col-sm-2 col-md-2 col-lg-2 control-label">
+                {% trans "Definition" %}
+              </label>
+              <div class="col-xs-12 col-sm-10 col-md-10 col-lg-10 controls">
+                <textarea id="definition" name="definition" class="form-control observablejsonwidget" data-bind="value: definition"></textarea>
+                <div class="help-block" data-bind="visible: hasParseError">
+                  {% blocktrans %}
+                    Your expression has parse errors!
+                    For more details, try pasting into a <a href="http://jsonlint.com/" target="_blank">JSON Validator</a>.
+                  {% endblocktrans %}
+                </div>
+                <div class="pull-right">
+                  <button class="btn btn-primary" data-bind="click: formatJson">
+                    {% trans "Format JSON" %}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+          <div class="form-actions">
+            <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6 col-sm-offset-4 col-md-offset-4 col-lg-offset-2 controls">
+              <button class="btn btn btn-primary" type="submit" data-bind="disable: hasParseError">Save</button>
+              <a href="{% url 'ucr_expressions' domain %}" class="btn btn-default">Cancel</a>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+</div>
+{% endblock %}

--- a/corehq/apps/userreports/templates/userreports/ucr_expressions.html
+++ b/corehq/apps/userreports/templates/userreports/ucr_expressions.html
@@ -11,48 +11,15 @@
     <td data-bind="text: description"></td>
     <td data-bind="text: definition"></td>
     <td> <!-- actions -->
-        <button type="button"
-                data-toggle="modal"
-                data-bind="
-                    visible: ! upstream_id,
-                    attr: {
-                        'data-target': '#update-expression-' + id
-                    }
-                "
-                class="btn btn-primary">
+        <a class="btn btn-primary"
+                data-bind="attr: {href: edit_url}">
             {% trans "Update Expression" %}
-        </button>
+        </a>
         <a class="btn btn-primary"
                 href="{% url 'domain_links' domain %}"
                 data-bind="visible: upstream_id">
             {% trans "Linked Project Spaces" %}
         </a>
-
-        <div class="modal fade"
-             data-bind="
-                attr: {
-                    id: 'update-expression-' + id
-                }
-             ">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button"
-                                class="close"
-                                data-dismiss="modal"
-                                aria-hidden="true">&times;</button>
-                        <h3>
-                            {% blocktrans %}
-                                Update Expression <strong data-bind="text: name"></strong>:
-                            {% endblocktrans %}
-                        </h3>
-                    </div>
-                    <div class="modal-body">
-                        <div data-bind="html: updateForm"></div>
-                    </div>
-                </div>
-            </div>
-        </div>
     </td>
 </script>
 {% endblock %}

--- a/corehq/apps/userreports/templates/userreports/ucr_expressions.html
+++ b/corehq/apps/userreports/templates/userreports/ucr_expressions.html
@@ -9,7 +9,25 @@
     <td data-bind="text: name"></td>
     <td data-bind="text: type"></td>
     <td data-bind="text: description"></td>
-    <td data-bind="text: definition"></td>
+    <td>
+      <span data-bind="text: definition_preview"></span>
+      <a data-toggle="modal" data-bind="attr: {'data-target': '#update-expression-' + id}">
+        ({% trans "see more" %})
+      </a>
+      <div class="modal fade" data-bind="attr: {id: 'update-expression-' + id}">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h3 data-bind="text: name"></h3>
+                    </div>
+                    <div class="modal-body">
+                        <div><pre data-bind="text: definition"></pre></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </td>
     <td> <!-- actions -->
         <a class="btn btn-primary"
                 data-bind="attr: {href: edit_url}">

--- a/corehq/apps/userreports/urls.py
+++ b/corehq/apps/userreports/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import path, include, re_path as url
 
 from corehq.apps.userreports.reports.view import (
     DownloadUCRStatusView,

--- a/corehq/apps/userreports/urls.py
+++ b/corehq/apps/userreports/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.userreports.reports.view import (
     DownloadUCRStatusView,

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1787,6 +1787,10 @@ class UCRExpressionEditView(BaseProjectDataView):
         form = UCRExpressionForm(self.request, self.request.POST, instance=self.expression)
         if form.is_valid():
             form.save()
+            try:
+                self.expression.wrapped_definition(EvaluationContext({}))
+            except BadSpecError as e:
+                return JsonResponse({"warning": _("Problem with expression: {}").format(e)})
             return JsonResponse({})
 
         return JsonResponse({"errors": [

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -110,10 +110,7 @@ from corehq.apps.userreports.exceptions import (
 )
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.filters.factory import FilterFactory
-from corehq.apps.userreports.forms import (
-    UCRExpressionForm,
-    UCRExpressionUpdateForm,
-)
+from corehq.apps.userreports.forms import UCRExpressionForm
 from corehq.apps.userreports.indicators.factory import IndicatorFactory
 from corehq.apps.userreports.models import (
     DataSourceConfiguration,
@@ -1721,7 +1718,7 @@ class UCRExpressionListView(BaseProjectDataView, CRUDPaginatedViewMixin):
             'description': expression.description,
             'definition': self._truncate_value(json.dumps(expression.definition)),
             'upstream_id': expression.upstream_id,
-            'updateForm': self.get_update_form_response(self.get_update_form(instance=expression)),
+            'edit_url': reverse(UCRExpressionEditView.urlname, args=[self.domain, expression.id]),
         }
 
     def _truncate_value(self, value):
@@ -1747,18 +1744,51 @@ class UCRExpressionListView(BaseProjectDataView, CRUDPaginatedViewMixin):
             "template": "base-ucr-statement-template",
         }
 
-    def get_update_form(self, instance=None):
-        if instance is None:
-            instance = UCRExpression.objects.get(
-                id=self.request.POST.get("id"), domain=self.domain
-            )
-        if self.request.method == "POST" and self.action == "update":
-            return UCRExpressionUpdateForm(self.request, self.request.POST, instance=instance)
-        return UCRExpressionUpdateForm(self.request, instance=instance)
 
-    def get_updated_item_data(self, update_form):
-        updated_expression = update_form.save()
-        return {
-            "itemData": self._item_data(updated_expression),
-            "template": "base-ucr-statement-template",
-        }
+@method_decorator(toggles.UCR_EXPRESSION_REGISTRY.required_decorator(), name='dispatch')
+class UCRExpressionEditView(BaseProjectDataView):
+    page_title = _("Edit UCR Expression")
+    urlname = "edit_ucr_expression"
+    template_name = "userreports/ucr_expression.html"
+
+    @property
+    def expression_id(self):
+        return self.kwargs['expression_id']
+
+    @property
+    @memoized
+    def expression(self):
+        try:
+            return UCRExpression.objects.get(id=self.expression_id)
+        except UCRExpression.DoesNotExist:
+            raise Http404
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=(self.domain, self.expression_id,))
+
+    @property
+    def main_context(self):
+        main_context = super(UCRExpressionEditView, self).main_context
+
+        main_context.update({
+            "expression": {
+                "id": self.expression.id,
+                "domain": self.expression.domain,
+                "name": self.expression.name,
+                "description": self.expression.description,
+                "expression_type": self.expression.expression_type,
+                "definition_raw": self.expression.definition,
+            },
+        })
+        return main_context
+
+    def post(self, request, domain, **kwargs):
+        form = UCRExpressionForm(self.request, self.request.POST, instance=self.expression)
+        if form.is_valid():
+            form.save()
+            return JsonResponse({})
+
+        return JsonResponse({"errors": [
+            f"{field} {error}" for field, error in form.errors.items()
+        ]}, status=400)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1716,7 +1716,8 @@ class UCRExpressionListView(BaseProjectDataView, CRUDPaginatedViewMixin):
             'name': expression.name,
             'type': expression.expression_type,
             'description': expression.description,
-            'definition': self._truncate_value(json.dumps(expression.definition)),
+            'definition': json.dumps(expression.definition, indent=2),
+            'definition_preview': self._truncate_value(json.dumps(expression.definition)),
             'upstream_id': expression.upstream_id,
             'edit_url': reverse(UCRExpressionEditView.urlname, args=[self.domain, expression.id]),
         }

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -132,6 +132,7 @@ msgstr ""
 #: corehq/apps/hqadmin/reports.py
 #: corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
 #: corehq/apps/notifications/forms.py corehq/apps/reports/standard/sms.py
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/ex-submodules/casexml/apps/case/views.py
 msgid "Type"
@@ -423,6 +424,7 @@ msgstr ""
 #: corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
 #: corehq/apps/toggle_ui/templates/toggle/flags.html
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/apps/users/templates/users/enterprise_users.html
 #: corehq/apps/users/templates/users/web_users.html
@@ -8776,6 +8778,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/reports_home.html
 #: corehq/apps/sms/forms.py corehq/apps/sms/views.py
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py corehq/motech/dhis2/forms.py
 #: corehq/motech/dhis2/views.py
 msgid "Description"
@@ -33464,6 +33467,7 @@ msgid "Evaluate!"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/expression_debugger.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 msgid "Format JSON"
 msgstr ""
 
@@ -33777,16 +33781,30 @@ msgstr ""
 msgid "Step 1 of 2 - Select Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid "Update Expression"
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Expression"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Filter"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#: corehq/apps/userreports/views.py
+msgid "Definition"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid ""
+"\n"
+"                    Your expression has parse errors!\n"
+"                    For more details, try pasting into a <a href=\"http://"
+"jsonlint.com/\" target=\"_blank\">JSON Validator</a>.\n"
+"                  "
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid ""
-"\n"
-"                                Update Expression <strong data-bind=\"text: "
-"name\"></strong>:\n"
-"                            "
+msgid "Update Expression"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -34195,13 +34213,13 @@ msgid "UCR Expressions"
 msgstr ""
 
 #: corehq/apps/userreports/views.py
-msgid "Definition"
-msgstr ""
-
-#: corehq/apps/userreports/views.py
 msgid ""
 "UCR Expression with name \"{create_form.cleaned_data['name']}\" already "
 "exists."
+msgstr ""
+
+#: corehq/apps/userreports/views.py
+msgid "Edit UCR Expression"
 msgstr ""
 
 #: corehq/apps/users/account_confirmation.py

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -33804,6 +33804,10 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
+msgid "see more"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
 msgid "Update Expression"
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/djangojs.po
+++ b/locale/en/LC_MESSAGES/djangojs.po
@@ -4123,6 +4123,10 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
+#: corehq/apps/userreports/static/userreports/js/ucr_expression.js
+msgid "Expression saved"
+msgstr ""
+
 #: corehq/apps/users/static/users/js/edit_commcare_user.js
 msgid "Password changed successfully."
 msgstr ""

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -35276,6 +35276,12 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
+#, fuzzy
+#| msgid "Learn more"
+msgid "see more"
+msgstr "Aprenda más"
+
+#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
 msgid "Update Expression"
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -141,6 +141,7 @@ msgstr "Mostrar Solo las Suscripciones de Prueba"
 #: corehq/apps/hqadmin/reports.py
 #: corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
 #: corehq/apps/notifications/forms.py corehq/apps/reports/standard/sms.py
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/ex-submodules/casexml/apps/case/views.py
 msgid "Type"
@@ -443,6 +444,7 @@ msgstr "Se requiere un nombre para este nuevo rol."
 #: corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
 #: corehq/apps/toggle_ui/templates/toggle/flags.html
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/apps/users/templates/users/enterprise_users.html
 #: corehq/apps/users/templates/users/web_users.html
@@ -9355,6 +9357,7 @@ msgstr "Reporte"
 #: corehq/apps/reports/templates/reports/reports_home.html
 #: corehq/apps/sms/forms.py corehq/apps/sms/views.py
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py corehq/motech/dhis2/forms.py
 #: corehq/motech/dhis2/views.py
 msgid "Description"
@@ -34917,6 +34920,7 @@ msgid "Evaluate!"
 msgstr "¡Evaluar! "
 
 #: corehq/apps/userreports/templates/userreports/expression_debugger.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 msgid "Format JSON"
 msgstr ""
 
@@ -35245,16 +35249,34 @@ msgstr ""
 msgid "Step 1 of 2 - Select Data Source"
 msgstr "Paso 1 de 2 - Seleccionar Fuente de Datos"
 
-#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid "Update Expression"
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#, fuzzy
+#| msgid "Add Expression"
+msgid "Named Expression"
+msgstr "Agregue Expresión"
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#, fuzzy
+#| msgid "Date Filter"
+msgid "Named Filter"
+msgstr "Filtro de Fecha"
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#: corehq/apps/userreports/views.py
+msgid "Definition"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid ""
+"\n"
+"                    Your expression has parse errors!\n"
+"                    For more details, try pasting into a <a href=\"http://"
+"jsonlint.com/\" target=\"_blank\">JSON Validator</a>.\n"
+"                  "
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid ""
-"\n"
-"                                Update Expression <strong data-bind=\"text: "
-"name\"></strong>:\n"
-"                            "
+msgid "Update Expression"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -35699,14 +35721,16 @@ msgid "UCR Expressions"
 msgstr ""
 
 #: corehq/apps/userreports/views.py
-msgid "Definition"
-msgstr ""
-
-#: corehq/apps/userreports/views.py
 msgid ""
 "UCR Expression with name \"{create_form.cleaned_data['name']}\" already "
 "exists."
 msgstr ""
+
+#: corehq/apps/userreports/views.py
+#, fuzzy
+#| msgid "Add Expression"
+msgid "Edit UCR Expression"
+msgstr "Agregue Expresión"
 
 #: corehq/apps/users/account_confirmation.py
 #, python-brace-format

--- a/locale/es/LC_MESSAGES/djangojs.po
+++ b/locale/es/LC_MESSAGES/djangojs.po
@@ -4323,6 +4323,12 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
+#: corehq/apps/userreports/static/userreports/js/ucr_expression.js
+#, fuzzy
+#| msgid "Expression"
+msgid "Expression saved"
+msgstr "Expresión"
+
 #: corehq/apps/users/static/users/js/edit_commcare_user.js
 msgid "Password changed successfully."
 msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -33803,6 +33803,10 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
+msgid "see more"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
 msgid "Update Expression"
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -133,6 +133,7 @@ msgstr ""
 #: corehq/apps/hqadmin/reports.py
 #: corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
 #: corehq/apps/notifications/forms.py corehq/apps/reports/standard/sms.py
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/ex-submodules/casexml/apps/case/views.py
 msgid "Type"
@@ -424,6 +425,7 @@ msgstr ""
 #: corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
 #: corehq/apps/toggle_ui/templates/toggle/flags.html
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/apps/users/templates/users/enterprise_users.html
 #: corehq/apps/users/templates/users/web_users.html
@@ -8777,6 +8779,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/reports_home.html
 #: corehq/apps/sms/forms.py corehq/apps/sms/views.py
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py corehq/motech/dhis2/forms.py
 #: corehq/motech/dhis2/views.py
 msgid "Description"
@@ -33463,6 +33466,7 @@ msgid "Evaluate!"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/expression_debugger.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 msgid "Format JSON"
 msgstr ""
 
@@ -33776,16 +33780,30 @@ msgstr ""
 msgid "Step 1 of 2 - Select Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid "Update Expression"
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Expression"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Filter"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#: corehq/apps/userreports/views.py
+msgid "Definition"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid ""
+"\n"
+"                    Your expression has parse errors!\n"
+"                    For more details, try pasting into a <a href=\"http://"
+"jsonlint.com/\" target=\"_blank\">JSON Validator</a>.\n"
+"                  "
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid ""
-"\n"
-"                                Update Expression <strong data-bind=\"text: "
-"name\"></strong>:\n"
-"                            "
+msgid "Update Expression"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -34194,13 +34212,13 @@ msgid "UCR Expressions"
 msgstr ""
 
 #: corehq/apps/userreports/views.py
-msgid "Definition"
-msgstr ""
-
-#: corehq/apps/userreports/views.py
 msgid ""
 "UCR Expression with name \"{create_form.cleaned_data['name']}\" already "
 "exists."
+msgstr ""
+
+#: corehq/apps/userreports/views.py
+msgid "Edit UCR Expression"
 msgstr ""
 
 #: corehq/apps/users/account_confirmation.py

--- a/locale/fr/LC_MESSAGES/djangojs.po
+++ b/locale/fr/LC_MESSAGES/djangojs.po
@@ -4124,6 +4124,10 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
+#: corehq/apps/userreports/static/userreports/js/ucr_expression.js
+msgid "Expression saved"
+msgstr ""
+
 #: corehq/apps/users/static/users/js/edit_commcare_user.js
 msgid "Password changed successfully."
 msgstr ""

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -163,6 +163,7 @@ msgstr "Afficher seulement les inscriptions en versions d'essai"
 #: corehq/apps/hqadmin/reports.py
 #: corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
 #: corehq/apps/notifications/forms.py corehq/apps/reports/standard/sms.py
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/ex-submodules/casexml/apps/case/views.py
 msgid "Type"
@@ -466,6 +467,7 @@ msgstr "Un nom est requis pour ce nouveau rôle."
 #: corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
 #: corehq/apps/toggle_ui/templates/toggle/flags.html
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/apps/users/templates/users/enterprise_users.html
 #: corehq/apps/users/templates/users/web_users.html
@@ -9235,6 +9237,7 @@ msgstr "Rapport"
 #: corehq/apps/reports/templates/reports/reports_home.html
 #: corehq/apps/sms/forms.py corehq/apps/sms/views.py
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py corehq/motech/dhis2/forms.py
 #: corehq/motech/dhis2/views.py
 msgid "Description"
@@ -34824,6 +34827,7 @@ msgid "Evaluate!"
 msgstr "Évaluer!"
 
 #: corehq/apps/userreports/templates/userreports/expression_debugger.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 msgid "Format JSON"
 msgstr ""
 
@@ -35137,16 +35141,34 @@ msgstr ""
 msgid "Step 1 of 2 - Select Data Source"
 msgstr "Etape 1 sur 2 - Sélectionnez la source des données"
 
-#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid "Update Expression"
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#, fuzzy
+#| msgid "Add Expression"
+msgid "Named Expression"
+msgstr "Ajouter expression"
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#, fuzzy
+#| msgid "Date Filter"
+msgid "Named Filter"
+msgstr "Filtrer par date"
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#: corehq/apps/userreports/views.py
+msgid "Definition"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid ""
+"\n"
+"                    Your expression has parse errors!\n"
+"                    For more details, try pasting into a <a href=\"http://"
+"jsonlint.com/\" target=\"_blank\">JSON Validator</a>.\n"
+"                  "
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid ""
-"\n"
-"                                Update Expression <strong data-bind=\"text: "
-"name\"></strong>:\n"
-"                            "
+msgid "Update Expression"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -35589,14 +35611,16 @@ msgid "UCR Expressions"
 msgstr ""
 
 #: corehq/apps/userreports/views.py
-msgid "Definition"
-msgstr ""
-
-#: corehq/apps/userreports/views.py
 msgid ""
 "UCR Expression with name \"{create_form.cleaned_data['name']}\" already "
 "exists."
 msgstr ""
+
+#: corehq/apps/userreports/views.py
+#, fuzzy
+#| msgid "Add Expression"
+msgid "Edit UCR Expression"
+msgstr "Ajouter expression"
 
 #: corehq/apps/users/account_confirmation.py
 #, python-brace-format

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -35168,6 +35168,12 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
+#, fuzzy
+#| msgid "Learn more"
+msgid "see more"
+msgstr "Lire plus"
+
+#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
 msgid "Update Expression"
 msgstr ""
 

--- a/locale/fra/LC_MESSAGES/djangojs.po
+++ b/locale/fra/LC_MESSAGES/djangojs.po
@@ -4174,6 +4174,12 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
+#: corehq/apps/userreports/static/userreports/js/ucr_expression.js
+#, fuzzy
+#| msgid "Expression"
+msgid "Expression saved"
+msgstr "Expression"
+
 #: corehq/apps/users/static/users/js/edit_commcare_user.js
 msgid "Password changed successfully."
 msgstr ""

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -33803,6 +33803,10 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
+msgid "see more"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
 msgid "Update Expression"
 msgstr ""
 

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -133,6 +133,7 @@ msgstr ""
 #: corehq/apps/hqadmin/reports.py
 #: corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
 #: corehq/apps/notifications/forms.py corehq/apps/reports/standard/sms.py
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/ex-submodules/casexml/apps/case/views.py
 msgid "Type"
@@ -424,6 +425,7 @@ msgstr ""
 #: corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
 #: corehq/apps/toggle_ui/templates/toggle/flags.html
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/apps/users/templates/users/enterprise_users.html
 #: corehq/apps/users/templates/users/web_users.html
@@ -8777,6 +8779,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/reports_home.html
 #: corehq/apps/sms/forms.py corehq/apps/sms/views.py
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py corehq/motech/dhis2/forms.py
 #: corehq/motech/dhis2/views.py
 msgid "Description"
@@ -33463,6 +33466,7 @@ msgid "Evaluate!"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/expression_debugger.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 msgid "Format JSON"
 msgstr ""
 
@@ -33776,16 +33780,30 @@ msgstr ""
 msgid "Step 1 of 2 - Select Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid "Update Expression"
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Expression"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Filter"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#: corehq/apps/userreports/views.py
+msgid "Definition"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid ""
+"\n"
+"                    Your expression has parse errors!\n"
+"                    For more details, try pasting into a <a href=\"http://"
+"jsonlint.com/\" target=\"_blank\">JSON Validator</a>.\n"
+"                  "
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid ""
-"\n"
-"                                Update Expression <strong data-bind=\"text: "
-"name\"></strong>:\n"
-"                            "
+msgid "Update Expression"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -34194,13 +34212,13 @@ msgid "UCR Expressions"
 msgstr ""
 
 #: corehq/apps/userreports/views.py
-msgid "Definition"
-msgstr ""
-
-#: corehq/apps/userreports/views.py
 msgid ""
 "UCR Expression with name \"{create_form.cleaned_data['name']}\" already "
 "exists."
+msgstr ""
+
+#: corehq/apps/userreports/views.py
+msgid "Edit UCR Expression"
 msgstr ""
 
 #: corehq/apps/users/account_confirmation.py

--- a/locale/hi/LC_MESSAGES/djangojs.po
+++ b/locale/hi/LC_MESSAGES/djangojs.po
@@ -4124,6 +4124,10 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
+#: corehq/apps/userreports/static/userreports/js/ucr_expression.js
+msgid "Expression saved"
+msgstr ""
+
 #: corehq/apps/users/static/users/js/edit_commcare_user.js
 msgid "Password changed successfully."
 msgstr ""

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -33818,6 +33818,10 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
+msgid "see more"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
 msgid "Update Expression"
 msgstr ""
 

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -146,6 +146,7 @@ msgstr ""
 #: corehq/apps/hqadmin/reports.py
 #: corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
 #: corehq/apps/notifications/forms.py corehq/apps/reports/standard/sms.py
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/ex-submodules/casexml/apps/case/views.py
 msgid "Type"
@@ -437,6 +438,7 @@ msgstr ""
 #: corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
 #: corehq/apps/toggle_ui/templates/toggle/flags.html
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/apps/users/templates/users/enterprise_users.html
 #: corehq/apps/users/templates/users/web_users.html
@@ -8790,6 +8792,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/reports_home.html
 #: corehq/apps/sms/forms.py corehq/apps/sms/views.py
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py corehq/motech/dhis2/forms.py
 #: corehq/motech/dhis2/views.py
 msgid "Description"
@@ -33476,6 +33479,7 @@ msgid "Evaluate!"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/expression_debugger.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 msgid "Format JSON"
 msgstr ""
 
@@ -33789,16 +33793,32 @@ msgstr ""
 msgid "Step 1 of 2 - Select Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid "Update Expression"
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Expression"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#, fuzzy
+#| msgid "Add Filter"
+msgid "Named Filter"
+msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#: corehq/apps/userreports/views.py
+msgid "Definition"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid ""
+"\n"
+"                    Your expression has parse errors!\n"
+"                    For more details, try pasting into a <a href=\"http://"
+"jsonlint.com/\" target=\"_blank\">JSON Validator</a>.\n"
+"                  "
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid ""
-"\n"
-"                                Update Expression <strong data-bind=\"text: "
-"name\"></strong>:\n"
-"                            "
+msgid "Update Expression"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -34207,13 +34227,13 @@ msgid "UCR Expressions"
 msgstr ""
 
 #: corehq/apps/userreports/views.py
-msgid "Definition"
-msgstr ""
-
-#: corehq/apps/userreports/views.py
 msgid ""
 "UCR Expression with name \"{create_form.cleaned_data['name']}\" already "
 "exists."
+msgstr ""
+
+#: corehq/apps/userreports/views.py
+msgid "Edit UCR Expression"
 msgstr ""
 
 #: corehq/apps/users/account_confirmation.py

--- a/locale/hin/LC_MESSAGES/djangojs.po
+++ b/locale/hin/LC_MESSAGES/djangojs.po
@@ -4127,6 +4127,10 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
+#: corehq/apps/userreports/static/userreports/js/ucr_expression.js
+msgid "Expression saved"
+msgstr ""
+
 #: corehq/apps/users/static/users/js/edit_commcare_user.js
 msgid "Password changed successfully."
 msgstr ""

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -34033,6 +34033,10 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
+msgid "see more"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
 msgid "Update Expression"
 msgstr ""
 

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -164,6 +164,7 @@ msgstr "Mostrar somente as Subscrições de Ensaio"
 #: corehq/apps/hqadmin/reports.py
 #: corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
 #: corehq/apps/notifications/forms.py corehq/apps/reports/standard/sms.py
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/ex-submodules/casexml/apps/case/views.py
 msgid "Type"
@@ -459,6 +460,7 @@ msgstr ""
 #: corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
 #: corehq/apps/toggle_ui/templates/toggle/flags.html
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/apps/users/templates/users/enterprise_users.html
 #: corehq/apps/users/templates/users/web_users.html
@@ -8846,6 +8848,7 @@ msgstr "Relatório"
 #: corehq/apps/reports/templates/reports/reports_home.html
 #: corehq/apps/sms/forms.py corehq/apps/sms/views.py
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py corehq/motech/dhis2/forms.py
 #: corehq/motech/dhis2/views.py
 msgid "Description"
@@ -33691,6 +33694,7 @@ msgid "Evaluate!"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/expression_debugger.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 msgid "Format JSON"
 msgstr ""
 
@@ -34004,16 +34008,32 @@ msgstr ""
 msgid "Step 1 of 2 - Select Data Source"
 msgstr "Passo 1 de 2 - Selecione a Origem dos Dados"
 
-#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid "Update Expression"
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Expression"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#, fuzzy
+#| msgid "Date Filter"
+msgid "Named Filter"
+msgstr "Filtro de Data"
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#: corehq/apps/userreports/views.py
+msgid "Definition"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid ""
+"\n"
+"                    Your expression has parse errors!\n"
+"                    For more details, try pasting into a <a href=\"http://"
+"jsonlint.com/\" target=\"_blank\">JSON Validator</a>.\n"
+"                  "
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid ""
-"\n"
-"                                Update Expression <strong data-bind=\"text: "
-"name\"></strong>:\n"
-"                            "
+msgid "Update Expression"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -34422,13 +34442,13 @@ msgid "UCR Expressions"
 msgstr ""
 
 #: corehq/apps/userreports/views.py
-msgid "Definition"
-msgstr ""
-
-#: corehq/apps/userreports/views.py
 msgid ""
 "UCR Expression with name \"{create_form.cleaned_data['name']}\" already "
 "exists."
+msgstr ""
+
+#: corehq/apps/userreports/views.py
+msgid "Edit UCR Expression"
 msgstr ""
 
 #: corehq/apps/users/account_confirmation.py

--- a/locale/por/LC_MESSAGES/djangojs.po
+++ b/locale/por/LC_MESSAGES/djangojs.po
@@ -4136,6 +4136,10 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
+#: corehq/apps/userreports/static/userreports/js/ucr_expression.js
+msgid "Expression saved"
+msgstr ""
+
 #: corehq/apps/users/static/users/js/edit_commcare_user.js
 msgid "Password changed successfully."
 msgstr ""

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -33803,6 +33803,10 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
+msgid "see more"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
 msgid "Update Expression"
 msgstr ""
 

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -133,6 +133,7 @@ msgstr ""
 #: corehq/apps/hqadmin/reports.py
 #: corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
 #: corehq/apps/notifications/forms.py corehq/apps/reports/standard/sms.py
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/ex-submodules/casexml/apps/case/views.py
 msgid "Type"
@@ -424,6 +425,7 @@ msgstr ""
 #: corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
 #: corehq/apps/toggle_ui/templates/toggle/flags.html
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/apps/users/templates/users/enterprise_users.html
 #: corehq/apps/users/templates/users/web_users.html
@@ -8777,6 +8779,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/reports_home.html
 #: corehq/apps/sms/forms.py corehq/apps/sms/views.py
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py corehq/motech/dhis2/forms.py
 #: corehq/motech/dhis2/views.py
 msgid "Description"
@@ -33463,6 +33466,7 @@ msgid "Evaluate!"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/expression_debugger.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 msgid "Format JSON"
 msgstr ""
 
@@ -33776,16 +33780,30 @@ msgstr ""
 msgid "Step 1 of 2 - Select Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid "Update Expression"
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Expression"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Filter"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#: corehq/apps/userreports/views.py
+msgid "Definition"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid ""
+"\n"
+"                    Your expression has parse errors!\n"
+"                    For more details, try pasting into a <a href=\"http://"
+"jsonlint.com/\" target=\"_blank\">JSON Validator</a>.\n"
+"                  "
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid ""
-"\n"
-"                                Update Expression <strong data-bind=\"text: "
-"name\"></strong>:\n"
-"                            "
+msgid "Update Expression"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -34194,13 +34212,13 @@ msgid "UCR Expressions"
 msgstr ""
 
 #: corehq/apps/userreports/views.py
-msgid "Definition"
-msgstr ""
-
-#: corehq/apps/userreports/views.py
 msgid ""
 "UCR Expression with name \"{create_form.cleaned_data['name']}\" already "
 "exists."
+msgstr ""
+
+#: corehq/apps/userreports/views.py
+msgid "Edit UCR Expression"
 msgstr ""
 
 #: corehq/apps/users/account_confirmation.py

--- a/locale/pt/LC_MESSAGES/djangojs.po
+++ b/locale/pt/LC_MESSAGES/djangojs.po
@@ -4124,6 +4124,10 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
+#: corehq/apps/userreports/static/userreports/js/ucr_expression.js
+msgid "Expression saved"
+msgstr ""
+
 #: corehq/apps/users/static/users/js/edit_commcare_user.js
 msgid "Password changed successfully."
 msgstr ""

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -33809,6 +33809,10 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
+msgid "see more"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
 msgid "Update Expression"
 msgstr ""
 

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -137,6 +137,7 @@ msgstr ""
 #: corehq/apps/hqadmin/reports.py
 #: corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
 #: corehq/apps/notifications/forms.py corehq/apps/reports/standard/sms.py
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/ex-submodules/casexml/apps/case/views.py
 msgid "Type"
@@ -428,6 +429,7 @@ msgstr ""
 #: corehq/apps/sso/templates/sso/enterprise_admin/manage_sso.html
 #: corehq/apps/toggle_ui/templates/toggle/flags.html
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py
 #: corehq/apps/users/templates/users/enterprise_users.html
 #: corehq/apps/users/templates/users/web_users.html
@@ -8781,6 +8783,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/reports_home.html
 #: corehq/apps/sms/forms.py corehq/apps/sms/views.py
 #: corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 #: corehq/apps/userreports/views.py corehq/motech/dhis2/forms.py
 #: corehq/motech/dhis2/views.py
 msgid "Description"
@@ -33467,6 +33470,7 @@ msgid "Evaluate!"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/expression_debugger.html
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
 msgid "Format JSON"
 msgstr ""
 
@@ -33780,16 +33784,32 @@ msgstr ""
 msgid "Step 1 of 2 - Select Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid "Update Expression"
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid "Named Expression"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#, fuzzy
+#| msgid "Add Filter"
+msgid "Named Filter"
+msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+#: corehq/apps/userreports/views.py
+msgid "Definition"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/ucr_expression.html
+msgid ""
+"\n"
+"                    Your expression has parse errors!\n"
+"                    For more details, try pasting into a <a href=\"http://"
+"jsonlint.com/\" target=\"_blank\">JSON Validator</a>.\n"
+"                  "
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/ucr_expressions.html
-msgid ""
-"\n"
-"                                Update Expression <strong data-bind=\"text: "
-"name\"></strong>:\n"
-"                            "
+msgid "Update Expression"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -34198,13 +34218,13 @@ msgid "UCR Expressions"
 msgstr ""
 
 #: corehq/apps/userreports/views.py
-msgid "Definition"
-msgstr ""
-
-#: corehq/apps/userreports/views.py
 msgid ""
 "UCR Expression with name \"{create_form.cleaned_data['name']}\" already "
 "exists."
+msgstr ""
+
+#: corehq/apps/userreports/views.py
+msgid "Edit UCR Expression"
 msgstr ""
 
 #: corehq/apps/users/account_confirmation.py

--- a/locale/sw/LC_MESSAGES/djangojs.po
+++ b/locale/sw/LC_MESSAGES/djangojs.po
@@ -4127,6 +4127,10 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
+#: corehq/apps/userreports/static/userreports/js/ucr_expression.js
+msgid "Expression saved"
+msgstr ""
+
 #: corehq/apps/users/static/users/js/edit_commcare_user.js
 msgid "Password changed successfully."
 msgstr ""


### PR DESCRIPTION
## Product Description
Move editing of UCR expressions to a separate view. This allows for more functionality that was possible in the dialog e.g. formatting, better validation, more real estate.

![image](https://user-images.githubusercontent.com/249606/174078028-19909b9b-9683-42d9-b84e-dcddd42cf5d3.png)

This is also a step towards adding the ability to create test cases for expressions.

The list view is also updated to include a dialog for viewing the full expression:

![image](https://user-images.githubusercontent.com/249606/174567069-76adc61c-252b-4cd8-b53c-151972f8f81b.png)

![image](https://user-images.githubusercontent.com/249606/174566745-a33d0b5c-07aa-4964-9ccd-bff0d1ac5aa5.png)


## Technical Summary
New view for editing UCR expressions

## Feature Flag
UCR_EXPRESSION_REGISTRY

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
