### PR TITLE
add couch view changes to reindex label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -10,7 +10,7 @@ minus_negate: false
 
 rules:
   - labels: ['reindex/migration']
-    patterns: ['migrations.lock|**/migrations/**|corehq/pillows/mappings/**']
+    patterns: ['migrations.lock|**/migrations/**|corehq/pillows/mappings/**|**/_design/**|corehq/couchapps/**']
 
   - labels: ['dependencies']
     patterns: ['requirements/**|package.json|yarn.lock']


### PR DESCRIPTION
This should add the `reindex` label whenever a couch view changes. I erred on the side of being maximally inclusive (didn't look for specific files like `map.js`, but I don't think it should have many, if any, false positives.

