### PR TITLE
Updated case import to pass through CaseBlockError messages

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -150,8 +150,8 @@ class _Importer(object):
             else:
                 caseblock = row.get_update_caseblock()
                 self.results.add_updated(row_num)
-        except CaseBlockError:
-            raise exceptions.CaseGeneration()
+        except CaseBlockError as e:
+            raise exceptions.CaseGeneration(message=str(e))
 
         self.add_caseblock(RowAndCase(row_num, caseblock))
 


### PR DESCRIPTION
## Product Description
Before: all case block errors showed an "unknown reasons" message:

![Screen Shot 2022-06-16 at 12 08 58 PM](https://user-images.githubusercontent.com/1486591/174116409-59c71312-7393-4466-b637-9c46940e6136.png)

After: display the more specific message:
![Screen Shot 2022-06-16 at 12 09 03 PM](https://user-images.githubusercontent.com/1486591/174116521-e72e160e-e627-4a5f-a985-82e820a55661.png)

Error will be one of these:
```
(hq) jschweers ~/Documents/commcare-hq (master) $ pt raise.CaseBlockError
./corehq/ex-submodules/casexml/apps/case/mock/case_block.py
78:                raise CaseBlockError("Key '{}' specified twice".format(property_name))
87:                raise CaseBlockError('Valid values for an index relationship are "child" and "extension"')
245:            raise CaseBlockError("Can't transform to XML: {}; unexpected type {}.".format(value, type(value)))
```


## Safety Assurance

### Safety story
Small change, though it does affect a widely-used feature.

Tested locally by faking a CaseBlockError. Also tested a successful case import locally.

### Automated test coverage

Case importer has decent tests, though I don't know if any of them check for the exception message.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
