### PR TITLE
Case API v0.6: Ensure you can find uncreated cases by external id

### DIFF
--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -169,6 +169,10 @@ def _populate_index_case_ids(domain, updates):
     case_ids['external_id'] = _get_case_ids_by_external_id(domain, [
         index.external_id for update in updates for index in update.indices.values()
     ])
+    case_ids['external_id'].update(
+        (update.external_id, update.get_case_id())
+        for update in updates if update.external_id
+    )
     for update in updates:
         for index in update.indices.values():
             for id_prop in case_ids:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Followup from https://github.com/dimagi/commcare-hq/pull/31777
I just realized that the way I did this only accounts for cases that already exist, but not those created during the same bulk action.  This rectifies that.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
automated testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
