### PR TITLE
disambiguate 'context' in UCR code

### DIFF
--- a/corehq/apps/locations/tests/test_location_expressions.py
+++ b/corehq/apps/locations/tests/test_location_expressions.py
@@ -196,7 +196,7 @@ class TestAncestorLocationExpression(LocationHierarchyTest):
             'type': 'ancestor_location',
             'location_id': self.city.location_id,
             'location_type': "continent",
-        }, context)
+        })
 
         ancestor_location = expression({}, context)
         self.assertIsNotNone(ancestor_location)
@@ -211,7 +211,7 @@ class TestAncestorLocationExpression(LocationHierarchyTest):
             'type': 'ancestor_location',
             'location_id': self.kingdom.location_id,
             'location_type': "nonsense",
-        }, context)
+        })
 
         ancestor_location = expression({}, context)
         self.assertIsNone(ancestor_location)
@@ -222,7 +222,7 @@ class TestAncestorLocationExpression(LocationHierarchyTest):
             'type': 'ancestor_location',
             'location_id': "gibberish",
             'location_type': "kingdom",
-        }, context)
+        })
 
         ancestor_location = expression({}, context)
         self.assertIsNone(ancestor_location)
@@ -234,7 +234,7 @@ class TestAncestorLocationExpression(LocationHierarchyTest):
             'location_id': self.city.location_id,
             'location_type': "continent",
             'location_property': "_id"
-        }, context)
+        })
 
         ancestor_location_property = expression({}, context)
         self.assertIsNotNone(ancestor_location_property)

--- a/corehq/apps/locations/tests/test_location_expressions.py
+++ b/corehq/apps/locations/tests/test_location_expressions.py
@@ -49,7 +49,7 @@ class TestLocationTypeExpression(TestCase):
             expected,
             self.expression(
                 doc,
-                context=EvaluationContext({"domain": domain}, 0)
+                EvaluationContext({"domain": domain}, 0)
             )
         )
 

--- a/corehq/apps/locations/ucr_expressions.py
+++ b/corehq/apps/locations/ucr_expressions.py
@@ -48,15 +48,15 @@ class LocationParentIdSpec(JsonObject):
     location_id_expression = DictProperty(required=True)
 
 
-def location_type_name(spec, context):
+def location_type_name(spec, factory_context):
     wrapped = LocationTypeSpec.wrap(spec)
     wrapped.configure(
-        location_id_expression=ExpressionFactory.from_spec(wrapped.location_id_expression, context)
+        location_id_expression=ExpressionFactory.from_spec(wrapped.location_id_expression, factory_context)
     )
     return wrapped
 
 
-def location_parent_id(spec, context):
+def location_parent_id(spec, factory_context):
     LocationParentIdSpec.wrap(spec)  # this is just for validation
     spec = {
         "type": "related_doc",
@@ -67,7 +67,7 @@ def location_parent_id(spec, context):
             "property_name": "parent_location_id",
         }
     }
-    return ExpressionFactory.from_spec(spec, context)
+    return ExpressionFactory.from_spec(spec, factory_context)
 
 
 class AncestorLocationExpression(JsonObject):
@@ -147,10 +147,10 @@ class AncestorLocationExpression(JsonObject):
         }
 
 
-def ancestor_location(spec, context):
+def ancestor_location(spec, factory_context):
     wrapped = AncestorLocationExpression.wrap(spec)
     wrapped.configure(
-        ExpressionFactory.from_spec(wrapped.location_id, context),
-        ExpressionFactory.from_spec(wrapped.location_type, context),
+        ExpressionFactory.from_spec(wrapped.location_id, factory_context),
+        ExpressionFactory.from_spec(wrapped.location_type, factory_context),
     )
     return wrapped

--- a/corehq/apps/locations/ucr_expressions.py
+++ b/corehq/apps/locations/ucr_expressions.py
@@ -10,18 +10,18 @@ from corehq.util.quickcache import quickcache
 
 
 @ucr_context_cache(vary_on=('location_id',))
-def _get_location(location_id, context):
+def _get_location(location_id, evaluation_context):
     try:
         return SQLLocation.objects.select_related('location_type').get(
-            domain=context.root_doc['domain'],
+            domain=evaluation_context.root_doc['domain'],
             location_id=location_id
         )
     except SQLLocation.DoesNotExist:
         return None
 
 
-def _get_location_type_name(location_id, context):
-    location = _get_location(location_id, context)
+def _get_location_type_name(location_id, evaluation_context):
+    location = _get_location(location_id, evaluation_context)
     if not location:
         return None
 
@@ -35,12 +35,12 @@ class LocationTypeSpec(JsonObject):
     def configure(self, location_id_expression):
         self._location_id_expression = location_id_expression
 
-    def __call__(self, item, context=None):
-        doc_id = self._location_id_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        doc_id = self._location_id_expression(item, evaluation_context)
         if not doc_id:
             return None
 
-        return _get_location_type_name(doc_id, context)
+        return _get_location_type_name(doc_id, evaluation_context)
 
 
 class LocationParentIdSpec(JsonObject):
@@ -121,10 +121,10 @@ class AncestorLocationExpression(JsonObject):
         self._location_id_expression = location_id_expression
         self._location_type_expression = location_type_expression
 
-    def __call__(self, item, context=None):
-        location_id = self._location_id_expression(item, context)
-        location_type = self._location_type_expression(item, context)
-        location = self._get_ancestors_by_type(location_id, context).get(location_type)
+    def __call__(self, item, evaluation_context=None):
+        location_id = self._location_id_expression(item, evaluation_context)
+        location_type = self._location_type_expression(item, evaluation_context)
+        location = self._get_ancestors_by_type(location_id, evaluation_context).get(location_type)
         if not location:
             return None
 
@@ -135,8 +135,8 @@ class AncestorLocationExpression(JsonObject):
 
     @staticmethod
     @ucr_context_cache(vary_on=('location_id',))
-    def _get_ancestors_by_type(location_id, context):
-        location = _get_location(location_id, context)
+    def _get_ancestors_by_type(location_id, evaluation_context):
+        location = _get_location(location_id, evaluation_context)
         if not location:
             return {}
         ancestors = (location.get_ancestors(include_self=False)

--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -2262,7 +2262,7 @@ framework. To do so:
 
 ::
 
-    def custom_expression(spec, context):
+    def custom_expression(spec, evaluation_context):
         ...
 
 2. Extend the ``custom_ucr_expressions`` extension point:

--- a/corehq/apps/userreports/decorators.py
+++ b/corehq/apps/userreports/decorators.py
@@ -33,27 +33,27 @@ def catch_and_raise_exceptions(func):
 def ucr_context_cache(vary_on=()):
     """
     Decorator which caches calculations performed during a UCR EvaluationContext
-    The decorated function or method must have a parameter called 'context'
+    The decorated function or method must have a parameter called 'evaluation_context'
     which will be used by this decorator to store the cache.
     """
     def decorator(fn):
-        assert 'context' in fn.__code__.co_varnames
+        assert 'evaluation_context' in fn.__code__.co_varnames
         assert isinstance(vary_on, tuple)
 
         @wraps(fn)
         def _inner(*args, **kwargs):
             # shamelessly stolen from quickcache
             callargs = inspect.getcallargs(fn, *args, **kwargs)
-            context = callargs['context']
+            evaluation_context = callargs['evaluation_context']
             prefix = '{}.{}'.format(
                 fn.__name__[:40] + (fn.__name__[40:] and '..'),
                 hashlib.md5(inspect.getsource(fn).encode('utf-8')).hexdigest()[-8:]
             )
             cache_key = (prefix,) + tuple(callargs[arg_name] for arg_name in vary_on)
-            if context.exists_in_cache(cache_key):
-                return context.get_cache_value(cache_key)
+            if evaluation_context.exists_in_cache(cache_key):
+                return evaluation_context.get_cache_value(cache_key)
             res = fn(*args, **kwargs)
-            context.set_cache_value(cache_key, res)
+            evaluation_context.set_cache_value(cache_key, res)
             return res
         return _inner
     return decorator

--- a/corehq/apps/userreports/expressions/date_specs.py
+++ b/corehq/apps/userreports/expressions/date_specs.py
@@ -40,9 +40,9 @@ class AddDaysExpressionSpec(JsonObject):
         self._date_expression = date_expression
         self._count_expression = count_expression
 
-    def __call__(self, item, context=None):
-        date_val = transform_date(self._date_expression(item, context))
-        int_val = transform_int(self._count_expression(item, context))
+    def __call__(self, item, evaluation_context=None):
+        date_val = transform_date(self._date_expression(item, evaluation_context))
+        int_val = transform_int(self._count_expression(item, evaluation_context))
         if date_val is not None and int_val is not None:
             return date_val + datetime.timedelta(days=int_val)
         return None
@@ -79,9 +79,9 @@ class AddHoursExpressionSpec(JsonObject):
         self._date_expression = date_expression
         self._count_expression = count_expression
 
-    def __call__(self, item, context=None):
-        date_val = transform_datetime(self._date_expression(item, context))
-        int_val = transform_int(self._count_expression(item, context))
+    def __call__(self, item, evaluation_context=None):
+        date_val = transform_datetime(self._date_expression(item, evaluation_context))
+        int_val = transform_int(self._count_expression(item, evaluation_context))
         if date_val is not None and int_val is not None:
             return date_val + datetime.timedelta(hours=int_val)
         return None
@@ -121,9 +121,9 @@ class AddMonthsExpressionSpec(JsonObject):
         self._date_expression = date_expression
         self._months_expression = months_expression
 
-    def __call__(self, item, context=None):
-        date_val = transform_date(self._date_expression(item, context))
-        months_count_val = transform_int(self._months_expression(item, context))
+    def __call__(self, item, evaluation_context=None):
+        date_val = transform_date(self._date_expression(item, evaluation_context))
+        months_count_val = transform_int(self._months_expression(item, evaluation_context))
         if date_val is not None and months_count_val is not None:
             return date_val + relativedelta(months=months_count_val)
         return None
@@ -158,8 +158,8 @@ class MonthStartDateExpressionSpec(JsonObject):
     def configure(self, date_expression):
         self._date_expression = date_expression
 
-    def __call__(self, item, context=None):
-        date_val = transform_date(self._date_expression(item, context))
+    def __call__(self, item, evaluation_context=None):
+        date_val = transform_date(self._date_expression(item, evaluation_context))
         if date_val is not None:
             return datetime.date(date_val.year, date_val.month, 1)
         return None
@@ -175,8 +175,8 @@ class MonthEndDateExpressionSpec(JsonObject):
     def configure(self, date_expression):
         self._date_expression = date_expression
 
-    def __call__(self, item, context=None):
-        date_val = transform_date(self._date_expression(item, context))
+    def __call__(self, item, evaluation_context=None):
+        date_val = transform_date(self._date_expression(item, evaluation_context))
         if date_val is not None:
             first_week_day, last_day = calendar.monthrange(date_val.year, date_val.month)
             return datetime.date(date_val.year, date_val.month, last_day)
@@ -212,9 +212,9 @@ class DiffDaysExpressionSpec(JsonObject):
         self._from_date_expression = from_date_expression
         self._to_date_expression = to_date_expression
 
-    def __call__(self, item, context=None):
-        from_date_val = transform_date(self._from_date_expression(item, context))
-        to_date_val = transform_date(self._to_date_expression(item, context))
+    def __call__(self, item, evaluation_context=None):
+        from_date_val = transform_date(self._from_date_expression(item, evaluation_context))
+        to_date_val = transform_date(self._to_date_expression(item, evaluation_context))
         if from_date_val is not None and to_date_val is not None:
             return (to_date_val - from_date_val).days
         return None
@@ -231,7 +231,7 @@ def _datetime_now():
 class UTCNow(JsonObject):
     type = TypeProperty('utcnow')
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         return _datetime_now()
 
     def __str__(self):
@@ -266,8 +266,8 @@ class GregorianDateToEthiopianDateSpec(JsonObject):
     def configure(self, date_expression):
         self._date_expression = date_expression
 
-    def __call__(self, item, context=None):
-        date_val = transform_date(self._date_expression(item, context))
+    def __call__(self, item, evaluation_context=None):
+        date_val = transform_date(self._date_expression(item, evaluation_context))
         return get_gregorian_to_ethiopian(date_val)
 
 
@@ -299,8 +299,8 @@ class EthiopianDateToGregorianDateSpec(JsonObject):
     def configure(self, date_expression):
         self._date_expression = date_expression
 
-    def __call__(self, item, context=None):
-        unwrapped_date = self._date_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        unwrapped_date = self._date_expression(item, evaluation_context)
         if isinstance(unwrapped_date, (datetime.datetime, datetime.date)):
             unwrapped_date = unwrapped_date.strftime('%Y-%m-%d')
         return transform_date(get_ethiopian_to_gregorian(unwrapped_date))

--- a/corehq/apps/userreports/expressions/extension_expressions.py
+++ b/corehq/apps/userreports/expressions/extension_expressions.py
@@ -9,7 +9,7 @@ class IndexedCaseExpressionSpec(JsonObject):
     case_expression = DictProperty(required=True)
     index = StringProperty(required=False)
 
-    def configure(self, case_expression, context):
+    def configure(self, case_expression, factory_context):
         self._case_expression = case_expression
 
         index = self.index or 'parent'
@@ -55,7 +55,7 @@ class IndexedCaseExpressionSpec(JsonObject):
                 'type': 'identity'
             }
         }
-        self._expression = ExpressionFactory.from_spec(spec, context)
+        self._expression = ExpressionFactory.from_spec(spec, factory_context)
 
     def __call__(self, item, context=None):
         return self._expression(item, context)
@@ -67,10 +67,10 @@ class IndexedCaseExpressionSpec(JsonObject):
         )
 
 
-def indexed_case_expression(spec, context):
+def indexed_case_expression(spec, factory_context):
     wrapped = IndexedCaseExpressionSpec.wrap(spec)
     wrapped.configure(
-        ExpressionFactory.from_spec(wrapped.case_expression, context),
-        context
+        ExpressionFactory.from_spec(wrapped.case_expression, factory_context),
+        factory_context
     )
     return wrapped

--- a/corehq/apps/userreports/expressions/extension_expressions.py
+++ b/corehq/apps/userreports/expressions/extension_expressions.py
@@ -57,8 +57,8 @@ class IndexedCaseExpressionSpec(JsonObject):
         }
         self._expression = ExpressionFactory.from_spec(spec, factory_context)
 
-    def __call__(self, item, context=None):
-        return self._expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        return self._expression(item, evaluation_context)
 
     def __str__(self):
         return "{case}/{index}".format(

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext as _
 
 from jsonobject.exceptions import BadValueError
 
+from corehq.apps.userreports.specs import FactoryContext
 from dimagi.utils.parsing import json_format_date, json_format_datetime
 from dimagi.utils.web import json_handler
 
@@ -386,6 +387,7 @@ class ExpressionFactory(object):
 
     @classmethod
     def from_spec(cls, spec, context=None):
+        context = context or FactoryContext.empty()
         if _is_literal(spec):
             return cls.from_spec(_convert_constant_to_expression_spec(spec), context)
         try:

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -55,14 +55,14 @@ from corehq.apps.userreports.expressions.specs import (
 )
 
 
-def _make_filter(spec, context):
+def _make_filter(spec, factory_context):
     # just pulled out here to keep the inline imports to a minimum
     # no way around this since the two factories inherently depend on each other
     from corehq.apps.userreports.filters.factory import FilterFactory
-    return FilterFactory.from_spec(spec, context)
+    return FilterFactory.from_spec(spec, factory_context)
 
 
-def _simple_expression_generator(wrapper_class, spec, context):
+def _simple_expression_generator(wrapper_class, spec, factory_context):
     return wrapper_class.wrap(spec)
 
 
@@ -75,257 +75,258 @@ _jsonpath_expression = functools.partial(_simple_expression_generator, JsonpathE
 _utcnow = functools.partial(_simple_expression_generator, UTCNow)
 
 
-def _property_name_expression(spec, context):
+def _property_name_expression(spec, factory_context):
     expression = PropertyNameGetterSpec.wrap(spec)
     expression.configure(
-        ExpressionFactory.from_spec(expression.property_name, context=context)
+        ExpressionFactory.from_spec(expression.property_name, factory_context)
     )
     return expression
 
 
-def _named_expression(spec, context):
+def _named_expression(spec, factory_context):
     expression = NamedExpressionSpec.wrap(spec)
-    expression.configure(context=context)
+    expression.configure(factory_context)
     return expression
 
 
-def _conditional_expression(spec, context):
+def _conditional_expression(spec, factory_context):
     wrapped = ConditionalExpressionSpec.wrap(spec)
     wrapped.configure(
-        _make_filter(wrapped.test, context),
-        ExpressionFactory.from_spec(wrapped.expression_if_true, context),
-        ExpressionFactory.from_spec(wrapped.expression_if_false, context),
+        _make_filter(wrapped.test, factory_context),
+        ExpressionFactory.from_spec(wrapped.expression_if_true, factory_context),
+        ExpressionFactory.from_spec(wrapped.expression_if_false, factory_context),
     )
     return wrapped
 
 
-def _switch_expression(spec, context):
+def _switch_expression(spec, factory_context):
     wrapped = SwitchExpressionSpec.wrap(spec)
     wrapped.configure(
-        ExpressionFactory.from_spec(wrapped.switch_on, context),
-        {k: ExpressionFactory.from_spec(v, context) for k, v in wrapped.cases.items()},
-        ExpressionFactory.from_spec(wrapped.default, context),
+        ExpressionFactory.from_spec(wrapped.switch_on, factory_context),
+        {k: ExpressionFactory.from_spec(v, factory_context) for k, v in wrapped.cases.items()},
+        ExpressionFactory.from_spec(wrapped.default, factory_context),
     )
     return wrapped
 
 
-def _array_index_expression(spec, context):
+def _array_index_expression(spec, factory_context):
     wrapped = ArrayIndexExpressionSpec.wrap(spec)
     wrapped.configure(
-        ExpressionFactory.from_spec(wrapped.array_expression, context),
-        ExpressionFactory.from_spec(wrapped.index_expression, context),
+        ExpressionFactory.from_spec(wrapped.array_expression, factory_context),
+        ExpressionFactory.from_spec(wrapped.index_expression, factory_context),
     )
     return wrapped
 
 
-def _root_doc_expression(spec, context):
+def _root_doc_expression(spec, factory_context):
     wrapped = RootDocExpressionSpec.wrap(spec)
-    wrapped.configure(ExpressionFactory.from_spec(wrapped.expression, context))
+    wrapped.configure(ExpressionFactory.from_spec(wrapped.expression, factory_context))
     return wrapped
 
 
-def _related_doc_expression(spec, context):
+def _related_doc_expression(spec, factory_context):
     wrapped = RelatedDocExpressionSpec.wrap(spec)
     wrapped.configure(
-        doc_id_expression=ExpressionFactory.from_spec(wrapped.doc_id_expression, context),
-        value_expression=ExpressionFactory.from_spec(wrapped.value_expression, context),
+        doc_id_expression=ExpressionFactory.from_spec(wrapped.doc_id_expression, factory_context),
+        value_expression=ExpressionFactory.from_spec(wrapped.value_expression, factory_context),
     )
     return wrapped
 
 
-def _iterator_expression(spec, context):
+def _iterator_expression(spec, factory_context):
     wrapped = IteratorExpressionSpec.wrap(spec)
     wrapped.configure(
-        expressions=[ExpressionFactory.from_spec(e, context) for e in wrapped.expressions],
-        test=_make_filter(wrapped.test, context) if wrapped.test else None
+        expressions=[ExpressionFactory.from_spec(e, factory_context) for e in wrapped.expressions],
+        test=_make_filter(wrapped.test, factory_context) if wrapped.test else None
     )
     return wrapped
 
 
-def _nested_expression(spec, context):
+def _nested_expression(spec, factory_context):
     wrapped = NestedExpressionSpec.wrap(spec)
     wrapped.configure(
-        argument_expression=ExpressionFactory.from_spec(wrapped.argument_expression, context),
-        value_expression=ExpressionFactory.from_spec(wrapped.value_expression, context),
+        argument_expression=ExpressionFactory.from_spec(wrapped.argument_expression, factory_context),
+        value_expression=ExpressionFactory.from_spec(wrapped.value_expression, factory_context),
     )
     return wrapped
 
 
-def _dict_expression(spec, context):
+def _dict_expression(spec, factory_context):
     wrapped = DictExpressionSpec.wrap(spec)
-    compiled_properties = {key: ExpressionFactory.from_spec(value, context) for key, value in wrapped.properties.items()}
-    wrapped.configure(
-        compiled_properties=compiled_properties,
-    )
+    compiled_properties = {
+        key: ExpressionFactory.from_spec(value, factory_context)
+        for key, value in wrapped.properties.items()
+    }
+    wrapped.configure(compiled_properties=compiled_properties)
     return wrapped
 
 
-def _add_days_expression(spec, context):
+def _add_days_expression(spec, factory_context):
     wrapped = AddDaysExpressionSpec.wrap(spec)
     wrapped.configure(
-        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
-        count_expression=ExpressionFactory.from_spec(wrapped.count_expression, context),
+        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, factory_context),
+        count_expression=ExpressionFactory.from_spec(wrapped.count_expression, factory_context),
     )
     return wrapped
 
 
-def _add_hours_expression(spec, context):
+def _add_hours_expression(spec, factory_context):
     wrapped = AddHoursExpressionSpec.wrap(spec)
     wrapped.configure(
-        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
-        count_expression=ExpressionFactory.from_spec(wrapped.count_expression, context),
+        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, factory_context),
+        count_expression=ExpressionFactory.from_spec(wrapped.count_expression, factory_context),
     )
     return wrapped
 
 
-def _add_months_expression(spec, context):
+def _add_months_expression(spec, factory_context):
     wrapped = AddMonthsExpressionSpec.wrap(spec)
     wrapped.configure(
-        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
-        months_expression=ExpressionFactory.from_spec(wrapped.months_expression, context),
+        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, factory_context),
+        months_expression=ExpressionFactory.from_spec(wrapped.months_expression, factory_context),
     )
     return wrapped
 
 
-def _month_start_date_expression(spec, context):
+def _month_start_date_expression(spec, factory_context):
     wrapped = MonthStartDateExpressionSpec.wrap(spec)
     wrapped.configure(
-        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
+        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, factory_context),
     )
     return wrapped
 
 
-def _month_end_date_expression(spec, context):
+def _month_end_date_expression(spec, factory_context):
     wrapped = MonthEndDateExpressionSpec.wrap(spec)
     wrapped.configure(
-        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
+        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, factory_context),
     )
     return wrapped
 
 
-def _diff_days_expression(spec, context):
+def _diff_days_expression(spec, factory_context):
     wrapped = DiffDaysExpressionSpec.wrap(spec)
     wrapped.configure(
-        from_date_expression=ExpressionFactory.from_spec(wrapped.from_date_expression, context),
-        to_date_expression=ExpressionFactory.from_spec(wrapped.to_date_expression, context),
+        from_date_expression=ExpressionFactory.from_spec(wrapped.from_date_expression, factory_context),
+        to_date_expression=ExpressionFactory.from_spec(wrapped.to_date_expression, factory_context),
     )
     return wrapped
 
 
-def _gregorian_date_to_ethiopian_date(spec, context):
+def _gregorian_date_to_ethiopian_date(spec, factory_context):
     wrapped = GregorianDateToEthiopianDateSpec.wrap(spec)
     wrapped.configure(
-        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
+        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, factory_context),
     )
     return wrapped
 
 
-def _ethiopian_date_to_gregorian_date(spec, context):
+def _ethiopian_date_to_gregorian_date(spec, factory_context):
     wrapped = EthiopianDateToGregorianDateSpec.wrap(spec)
     wrapped.configure(
-        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
+        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, factory_context),
     )
     return wrapped
 
 
-def _evaluator_expression(spec, context):
+def _evaluator_expression(spec, factory_context):
     wrapped = EvalExpressionSpec.wrap(spec)
     wrapped.configure(
-        context_variables={slug: ExpressionFactory.from_spec(expression, context)
+        context_variables={slug: ExpressionFactory.from_spec(expression, factory_context)
                            for slug, expression in wrapped.context_variables.items()}
     )
     return wrapped
 
 
-def _get_forms_expression(spec, context):
+def _get_forms_expression(spec, factory_context):
     wrapped = FormsExpressionSpec.wrap(spec)
     wrapped.configure(
-        case_id_expression=ExpressionFactory.from_spec(wrapped.case_id_expression, context)
+        case_id_expression=ExpressionFactory.from_spec(wrapped.case_id_expression, factory_context)
     )
     return wrapped
 
 
-def _get_subcases_expression(spec, context):
+def _get_subcases_expression(spec, factory_context):
     wrapped = SubcasesExpressionSpec.wrap(spec)
     wrapped.configure(
-        case_id_expression=ExpressionFactory.from_spec(wrapped.case_id_expression, context)
+        case_id_expression=ExpressionFactory.from_spec(wrapped.case_id_expression, factory_context)
     )
     return wrapped
 
 
-def _get_case_sharing_groups_expression(spec, context):
+def _get_case_sharing_groups_expression(spec, factory_context):
     wrapped = CaseSharingGroupsExpressionSpec.wrap(spec)
     wrapped.configure(
-        user_id_expression=ExpressionFactory.from_spec(wrapped.user_id_expression, context)
+        user_id_expression=ExpressionFactory.from_spec(wrapped.user_id_expression, factory_context)
     )
     return wrapped
 
 
-def _get_reporting_groups_expression(spec, context):
+def _get_reporting_groups_expression(spec, factory_context):
     wrapped = ReportingGroupsExpressionSpec.wrap(spec)
     wrapped.configure(
-        user_id_expression=ExpressionFactory.from_spec(wrapped.user_id_expression, context)
+        user_id_expression=ExpressionFactory.from_spec(wrapped.user_id_expression, factory_context)
     )
     return wrapped
 
 
-def _filter_items_expression(spec, context):
+def _filter_items_expression(spec, factory_context):
     wrapped = FilterItemsExpressionSpec.wrap(spec)
     wrapped.configure(
-        items_expression=ExpressionFactory.from_spec(wrapped.items_expression, context),
-        filter_expression=_make_filter(wrapped.filter_expression, context)
+        items_expression=ExpressionFactory.from_spec(wrapped.items_expression, factory_context),
+        filter_expression=_make_filter(wrapped.filter_expression, factory_context)
     )
     return wrapped
 
 
-def _map_items_expression(spec, context):
+def _map_items_expression(spec, factory_context):
     wrapped = MapItemsExpressionSpec.wrap(spec)
     wrapped.configure(
-        items_expression=ExpressionFactory.from_spec(wrapped.items_expression, context),
-        map_expression=ExpressionFactory.from_spec(wrapped.map_expression, context)
+        items_expression=ExpressionFactory.from_spec(wrapped.items_expression, factory_context),
+        map_expression=ExpressionFactory.from_spec(wrapped.map_expression, factory_context)
     )
     return wrapped
 
 
-def _reduce_items_expression(spec, context):
+def _reduce_items_expression(spec, factory_context):
     wrapped = ReduceItemsExpressionSpec.wrap(spec)
     wrapped.configure(
-        items_expression=ExpressionFactory.from_spec(wrapped.items_expression, context)
+        items_expression=ExpressionFactory.from_spec(wrapped.items_expression, factory_context)
     )
     return wrapped
 
 
-def _flatten_expression(spec, context):
+def _flatten_expression(spec, factory_context):
     wrapped = FlattenExpressionSpec.wrap(spec)
     wrapped.configure(
-        items_expression=ExpressionFactory.from_spec(wrapped.items_expression, context)
+        items_expression=ExpressionFactory.from_spec(wrapped.items_expression, factory_context)
     )
     return wrapped
 
 
-def _sort_items_expression(spec, context):
+def _sort_items_expression(spec, factory_context):
     wrapped = SortItemsExpressionSpec.wrap(spec)
     wrapped.configure(
-        items_expression=ExpressionFactory.from_spec(wrapped.items_expression, context),
-        sort_expression=ExpressionFactory.from_spec(wrapped.sort_expression, context)
+        items_expression=ExpressionFactory.from_spec(wrapped.items_expression, factory_context),
+        sort_expression=ExpressionFactory.from_spec(wrapped.sort_expression, factory_context)
     )
     return wrapped
 
 
-def _split_string_expression(spec, context):
+def _split_string_expression(spec, factory_context):
     wrapped = SplitStringExpressionSpec.wrap(spec)
     wrapped.configure(
-        ExpressionFactory.from_spec(wrapped.string_expression, context),
-        ExpressionFactory.from_spec(wrapped.index_expression, context),
+        ExpressionFactory.from_spec(wrapped.string_expression, factory_context),
+        ExpressionFactory.from_spec(wrapped.index_expression, factory_context),
     )
     return wrapped
 
 
-def _coalesce_expression(spec, context):
+def _coalesce_expression(spec, factory_context):
     wrapped = CoalesceExpressionSpec.wrap(spec)
     wrapped.configure(
-        ExpressionFactory.from_spec(wrapped.expression, context),
-        ExpressionFactory.from_spec(wrapped.default_expression, context),
+        ExpressionFactory.from_spec(wrapped.expression, factory_context),
+        ExpressionFactory.from_spec(wrapped.default_expression, factory_context),
     )
     return wrapped
 
@@ -386,12 +387,12 @@ class ExpressionFactory(object):
         cls.spec_map[type_name] = factory_func
 
     @classmethod
-    def from_spec(cls, spec, context=None):
-        context = context or FactoryContext.empty()
+    def from_spec(cls, spec, factory_context=None):
+        factory_context = factory_context or FactoryContext.empty()
         if _is_literal(spec):
-            return cls.from_spec(_convert_constant_to_expression_spec(spec), context)
+            return cls.from_spec(_convert_constant_to_expression_spec(spec), factory_context)
         try:
-            return cls.spec_map[spec['type']](spec, context)
+            return cls.spec_map[spec['type']](spec, factory_context)
         except KeyError:
             raise BadSpecError(_('Invalid or missing expression type: {} for expression: {}. '
                                  'Valid options are: {}').format(

--- a/corehq/apps/userreports/expressions/getters.py
+++ b/corehq/apps/userreports/expressions/getters.py
@@ -22,8 +22,8 @@ class TransformedGetter(object):
         self.getter = getter
         self.transform = transform
 
-    def __call__(self, item, context=None):
-        extracted = self.getter(item, context)
+    def __call__(self, item, evaluation_context=None):
+        extracted = self.getter(item, evaluation_context)
         if self.transform:
             return self.transform(extracted)
         return extracted
@@ -34,7 +34,7 @@ class DictGetter(object):
     def __init__(self, property_name):
         self.property_name = property_name
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         if not isinstance(item, dict):
             return None
         try:
@@ -53,7 +53,7 @@ class NestedDictGetter(object):
     def __init__(self, property_path):
         self.property_path = property_path
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         return safe_recursive_lookup(item, self.property_path)
 
 

--- a/corehq/apps/userreports/expressions/list_specs.py
+++ b/corehq/apps/userreports/expressions/list_specs.py
@@ -14,8 +14,8 @@ from corehq.apps.userreports.util import add_tabbed_text
 from .utils import SUPPORTED_UCR_AGGREGATIONS, aggregate_items
 
 
-def _evaluate_items_expression(itemx_ex, doc, context):
-    result = itemx_ex(doc, context)
+def _evaluate_items_expression(itemx_ex, doc, evaluation_context):
+    result = itemx_ex(doc, evaluation_context)
     if not isinstance(result, list):
         return []
     else:
@@ -65,12 +65,12 @@ class FilterItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
         self._items_expression = items_expression
         self._filter_expression = filter_expression
 
-    def __call__(self, doc, context=None):
-        items = _evaluate_items_expression(self._items_expression, doc, context)
+    def __call__(self, doc, evaluation_context=None):
+        items = _evaluate_items_expression(self._items_expression, doc, evaluation_context)
 
         values = []
         for item in items:
-            if self._filter_expression(item, context):
+            if self._filter_expression(item, evaluation_context):
                 values.append(item)
 
         return values
@@ -125,10 +125,10 @@ class MapItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
         self._items_expression = items_expression
         self._map_expression = map_expression
 
-    def __call__(self, doc, context=None):
-        items = _evaluate_items_expression(self._items_expression, doc, context)
+    def __call__(self, doc, evaluation_context=None):
+        items = _evaluate_items_expression(self._items_expression, doc, evaluation_context)
 
-        return [self._map_expression(i, context) for i in items]
+        return [self._map_expression(i, evaluation_context) for i in items]
 
     def __str__(self):
         return "map:\n{items}\nto:\n{map}\n".format(items=add_tabbed_text(str(self._items_expression)),
@@ -191,8 +191,8 @@ class ReduceItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
                 SUPPORTED_UCR_AGGREGATIONS
             ))
 
-    def __call__(self, doc, context=None):
-        items = _evaluate_items_expression(self._items_expression, doc, context)
+    def __call__(self, doc, evaluation_context=None):
+        items = _evaluate_items_expression(self._items_expression, doc, evaluation_context)
         return aggregate_items(items, self.aggregation_fn)
 
     def __str__(self):
@@ -223,8 +223,8 @@ class FlattenExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
     def configure(self, items_expression):
         self._items_expression = items_expression
 
-    def __call__(self, doc, context=None):
-        items = _evaluate_items_expression(self._items_expression, doc, context)
+    def __call__(self, doc, evaluation_context=None):
+        items = _evaluate_items_expression(self._items_expression, doc, evaluation_context)
         #  all items should be iterable, if not return empty list
         for item in items:
             if not isinstance(item, list):
@@ -281,12 +281,12 @@ class SortItemsExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
         self._items_expression = items_expression
         self._sort_expression = sort_expression
 
-    def __call__(self, doc, context=None):
-        items = _evaluate_items_expression(self._items_expression, doc, context)
+    def __call__(self, doc, evaluation_context=None):
+        items = _evaluate_items_expression(self._items_expression, doc, evaluation_context)
 
         try:
             def sort_key(item):
-                value = self._sort_expression(item, context)
+                value = self._sort_expression(item, evaluation_context)
                 # swap 0 and 1 to sort nulls last instead of first
                 return (0 if value is None else 1), value
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -206,10 +206,10 @@ class NamedExpressionSpec(JsonObject):
     type = TypeProperty('named')
     name = StringProperty(required=True)
 
-    def configure(self, context):
-        if self.name not in context.named_expressions:
+    def configure(self, factory_context):
+        if self.name not in factory_context.named_expressions:
             raise BadSpecError('Name {} not found in list of named expressions!'.format(self.name))
-        self._context = context
+        self._factory_context = factory_context
 
     def _context_cache_key(self, item):
         return 'named_expression-{}-{}'.format(self.name, id(item))
@@ -219,7 +219,7 @@ class NamedExpressionSpec(JsonObject):
         if context and context.exists_in_cache(key):
             return context.get_cache_value(key)
 
-        result = self._context.named_expressions[self.name](item, context)
+        result = self._factory_context.named_expressions[self.name](item, context)
         if context:
             context.set_iteration_cache_value(key, result)
         return result

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -42,7 +42,7 @@ from .utils import eval_statements
 class IdentityExpressionSpec(JsonObject):
     type = TypeProperty('identity')
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         return item
 
     def __str__(self):
@@ -63,8 +63,8 @@ class IterationNumberExpressionSpec(JsonObject):
     """
     type = TypeProperty('base_iteration_number')
 
-    def __call__(self, item, context=None):
-        return context.iteration
+    def __call__(self, item, evaluation_context=None):
+        return evaluation_context.iteration
 
     def __str__(self):
         return "Iteration Count"
@@ -96,7 +96,7 @@ class ConstantGetterSpec(JsonObject):
             ))
         return super(ConstantGetterSpec, self).wrap(obj)
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         return self.constant
 
     def __str__(self):
@@ -126,8 +126,8 @@ class PropertyNameGetterSpec(JsonObject):
     def configure(self, property_name_expression):
         self._property_name_expression = property_name_expression
 
-    def __call__(self, item, context=None):
-        raw_value = item.get(self._property_name_expression(item, context)) if isinstance(item, dict) else None
+    def __call__(self, item, evaluation_context=None):
+        raw_value = item.get(self._property_name_expression(item, evaluation_context)) if isinstance(item, dict) else None
         return transform_for_datatype(self.datatype)(raw_value)
 
     def __str__(self):
@@ -157,7 +157,7 @@ class PropertyPathGetterSpec(JsonObject):
     property_path = ListProperty(str, required=True)
     datatype = DataTypeProperty(required=False)
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         transform = transform_for_datatype(self.datatype)
         return transform(safe_recursive_lookup(item, self.property_path))
 
@@ -214,14 +214,14 @@ class NamedExpressionSpec(JsonObject):
     def _context_cache_key(self, item):
         return 'named_expression-{}-{}'.format(self.name, id(item))
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         key = self._context_cache_key(item)
-        if context and context.exists_in_cache(key):
-            return context.get_cache_value(key)
+        if evaluation_context and evaluation_context.exists_in_cache(key):
+            return evaluation_context.get_cache_value(key)
 
-        result = self._factory_context.named_expressions[self.name](item, context)
-        if context:
-            context.set_iteration_cache_value(key, result)
+        result = self._factory_context.named_expressions[self.name](item, evaluation_context)
+        if evaluation_context:
+            evaluation_context.set_iteration_cache_value(key, result)
         return result
 
     def __str__(self):
@@ -277,11 +277,11 @@ class ConditionalExpressionSpec(JsonObject):
         self._true_expression = true_expression
         self._false_expression = false_expression
 
-    def __call__(self, item, context=None):
-        if self._test_function(item, context):
-            return self._true_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        if self._test_function(item, evaluation_context):
+            return self._true_expression(item, evaluation_context)
         else:
-            return self._false_expression(item, context)
+            return self._false_expression(item, evaluation_context)
 
     def __str__(self):
         return "if {test}:\n{true}\nelse:\n{false}".format(
@@ -319,12 +319,12 @@ class ArrayIndexExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
         self._array_expression = array_expression
         self._index_expression = index_expression
 
-    def __call__(self, item, context=None):
-        array_value = self._array_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        array_value = self._array_expression(item, evaluation_context)
         if not isinstance(array_value, list):
             return None
 
-        index_value = self._index_expression(item, context)
+        index_value = self._index_expression(item, evaluation_context)
         if not isinstance(index_value, int):
             return None
 
@@ -385,12 +385,12 @@ class SwitchExpressionSpec(JsonObject):
         self._case_expressions = case_expressions
         self._default_expression = default_expression
 
-    def __call__(self, item, context=None):
-        switch_value = self._switch_on_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        switch_value = self._switch_on_expression(item, evaluation_context)
         for c in self.cases:
             if switch_value == c:
-                return self._case_expressions[c](item, context)
-        return self._default_expression(item, context)
+                return self._case_expressions[c](item, evaluation_context)
+        return self._default_expression(item, evaluation_context)
 
     def __str__(self):
         map_text = ", ".join(
@@ -444,10 +444,10 @@ class IteratorExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
             # if not defined then all values should be returned
             self._test = lambda *args, **kwargs: True
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         values = []
         for expression in self._expression_fns:
-            value = expression(item, context)
+            value = expression(item, evaluation_context)
             if self._test(value):
                 values.append(value)
         return values
@@ -517,7 +517,7 @@ class JsonpathExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
             raise BadSpecError(f'Error parsing jsonpath expression <pre>{self.jsonpath}</pre>. '
                                f'Message is {str(e)}')
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         transform = transform_for_datatype(self.datatype)
         values = [transform(match.value) for match in self.jsonpath_expr.find(item)]
         if not values:
@@ -539,10 +539,10 @@ class RootDocExpressionSpec(JsonObject):
     def configure(self, expression):
         self._expression_fn = expression
 
-    def __call__(self, item, context=None):
-        if context is None:
+    def __call__(self, item, evaluation_context=None):
+        if evaluation_context is None:
             return None
-        return self._expression_fn(context.root_doc, context)
+        return self._expression_fn(evaluation_context.root_doc, evaluation_context)
 
     def __str__(self):
         return "doc/{expression}".format(expression=str(self._expression_fn))
@@ -586,28 +586,28 @@ class RelatedDocExpressionSpec(JsonObject):
         self._doc_id_expression = doc_id_expression
         self._value_expression = value_expression
 
-    def __call__(self, item, context=None):
-        doc_id = self._doc_id_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        doc_id = self._doc_id_expression(item, evaluation_context)
         if doc_id:
-            return self.get_value(doc_id, context)
+            return self.get_value(doc_id, evaluation_context)
 
     @staticmethod
     @ucr_context_cache(vary_on=('related_doc_type', 'doc_id',))
-    def _get_document(related_doc_type, doc_id, context):
+    def _get_document(related_doc_type, doc_id, evaluation_context):
         document_store = get_document_store_for_doc_type(
-            context.root_doc['domain'], related_doc_type,
+            evaluation_context.root_doc['domain'], related_doc_type,
             load_source="related_doc_expression")
         try:
             doc = document_store.get_document(doc_id)
         except DocumentNotFoundError:
             return None
-        if context.root_doc['domain'] != doc.get('domain'):
+        if evaluation_context.root_doc['domain'] != doc.get('domain'):
             return None
         return doc
 
-    def get_value(self, doc_id, context):
-        assert context.root_doc['domain']
-        doc = self._get_document(self.related_doc_type, doc_id, context)
+    def get_value(self, doc_id, evaluation_context):
+        assert evaluation_context.root_doc['domain']
+        doc = self._get_document(self.related_doc_type, doc_id, evaluation_context)
         # explicitly use a new evaluation context since this is a new document
         return self._value_expression(doc, EvaluationContext(doc, 0))
 
@@ -648,9 +648,9 @@ class NestedExpressionSpec(JsonObject):
         self._argument_expression = argument_expression
         self._value_expression = value_expression
 
-    def __call__(self, item, context=None):
-        argument = self._argument_expression(item, context)
-        return self._value_expression(argument, context)
+    def __call__(self, item, evaluation_context=None):
+        argument = self._argument_expression(item, evaluation_context)
+        return self._value_expression(argument, evaluation_context)
 
     def __str__(self):
         return "{arg}/{val}".format(val=str(self._value_expression), arg=str(self._argument_expression))
@@ -697,10 +697,10 @@ class DictExpressionSpec(JsonObject):
                 raise BadSpecError("Properties in a dict expression must be strings!")
         self._compiled_properties = compiled_properties
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         ret = {}
         for property_name, expression in self._compiled_properties.items():
-            ret[property_name] = expression(item, context)
+            ret[property_name] = expression(item, evaluation_context)
         return ret
 
     def __str__(self):
@@ -773,17 +773,17 @@ class EvalExpressionSpec(JsonObject):
     def configure(self, context_variables):
         self._context_variables = context_variables
 
-    def __call__(self, item, context=None):
-        var_dict = self.get_variables(item, context)
+    def __call__(self, item, evaluation_context=None):
+        var_dict = self.get_variables(item, evaluation_context)
         try:
             untransformed_value = eval_statements(self.statement, var_dict)
             return transform_for_datatype(self.datatype)(untransformed_value)
         except (InvalidExpression, SyntaxError, TypeError, ZeroDivisionError):
             return None
 
-    def get_variables(self, item, context):
+    def get_variables(self, item, evaluation_context):
         var_dict = {
-            slug: variable_expression(item, context)
+            slug: variable_expression(item, evaluation_context)
             for slug, variable_expression in self._context_variables.items()
         }
         return var_dict
@@ -805,43 +805,43 @@ class FormsExpressionSpec(JsonObject):
     def configure(self, case_id_expression):
         self._case_id_expression = case_id_expression
 
-    def __call__(self, item, context=None):
-        case_id = self._case_id_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        case_id = self._case_id_expression(item, evaluation_context)
 
         if not case_id:
             return []
 
-        assert context.root_doc['domain']
-        return self._get_forms(case_id, context)
+        assert evaluation_context.root_doc['domain']
+        return self._get_forms(case_id, evaluation_context)
 
-    def _get_forms(self, case_id, context):
-        domain = context.root_doc['domain']
+    def _get_forms(self, case_id, evaluation_context):
+        domain = evaluation_context.root_doc['domain']
 
         cache_key = (self.__class__.__name__, case_id, tuple(self.xmlns))
-        if context.get_cache_value(cache_key) is not None:
-            return context.get_cache_value(cache_key)
+        if evaluation_context.get_cache_value(cache_key) is not None:
+            return evaluation_context.get_cache_value(cache_key)
 
-        xforms = self._get_case_forms(case_id, context)
+        xforms = self._get_case_forms(case_id, evaluation_context)
         if self.xmlns:
             xforms = [f for f in xforms if f.xmlns in self.xmlns]
 
-        xforms = [self._get_form_json(f, context) for f in xforms if f.domain == domain]
+        xforms = [self._get_form_json(f, evaluation_context) for f in xforms if f.domain == domain]
 
-        context.set_cache_value(cache_key, xforms)
+        evaluation_context.set_cache_value(cache_key, xforms)
         return xforms
 
     @ucr_context_cache(vary_on=('case_id',))
-    def _get_case_forms(self, case_id, context):
-        domain = context.root_doc['domain']
+    def _get_case_forms(self, case_id, evaluation_context):
+        domain = evaluation_context.root_doc['domain']
         return FormProcessorInterface(domain).get_case_forms(case_id)
 
-    def _get_form_json(self, form, context):
+    def _get_form_json(self, form, evaluation_context):
         cache_key = (XFORM_CACHE_KEY_PREFIX, form.get_id)
-        if context.get_cache_value(cache_key) is not None:
-            return context.get_cache_value(cache_key)
+        if evaluation_context.get_cache_value(cache_key) is not None:
+            return evaluation_context.get_cache_value(cache_key)
 
         form_json = form.to_json()
-        context.set_cache_value(cache_key, form_json)
+        evaluation_context.set_cache_value(cache_key, form_json)
         return form_json
 
     def __str__(self):
@@ -860,17 +860,17 @@ class SubcasesExpressionSpec(JsonObject):
     def configure(self, case_id_expression):
         self._case_id_expression = case_id_expression
 
-    def __call__(self, item, context=None):
-        case_id = self._case_id_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        case_id = self._case_id_expression(item, evaluation_context)
         if not case_id:
             return []
 
-        assert context.root_doc['domain']
-        return self._get_subcases(case_id, context)
+        assert evaluation_context.root_doc['domain']
+        return self._get_subcases(case_id, evaluation_context)
 
     @ucr_context_cache(vary_on=('case_id',))
-    def _get_subcases(self, case_id, context):
-        domain = context.root_doc['domain']
+    def _get_subcases(self, case_id, evaluation_context):
+        domain = evaluation_context.root_doc['domain']
         return [c.to_json() for c in CommCareCase.objects.get_reverse_indexed_cases(domain, [case_id])]
 
     def __str__(self):
@@ -883,17 +883,17 @@ class _GroupsExpressionSpec(JsonObject):
     def configure(self, user_id_expression):
         self._user_id_expression = user_id_expression
 
-    def __call__(self, item, context=None):
-        user_id = self._user_id_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        user_id = self._user_id_expression(item, evaluation_context)
         if not user_id:
             return []
 
-        assert context.root_doc['domain']
-        return self._get_groups(user_id, context)
+        assert evaluation_context.root_doc['domain']
+        return self._get_groups(user_id, evaluation_context)
 
     @ucr_context_cache(vary_on=('user_id',))
-    def _get_groups(self, user_id, context):
-        domain = context.root_doc['domain']
+    def _get_groups(self, user_id, evaluation_context):
+        domain = evaluation_context.root_doc['domain']
         try:
             user = CommCareUser.get_by_user_id(user_id, domain)
         except CouchUser.AccountTypeError:
@@ -991,14 +991,14 @@ class SplitStringExpressionSpec(JsonObject):
         self._string_expression = string_expression
         self._index_expression = index_expression
 
-    def __call__(self, item, context=None):
-        string_value = self._string_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        string_value = self._string_expression(item, evaluation_context)
         if not isinstance(string_value, str):
             return None
 
         index_value = None
         if self.index_expression is not None:
-            index_value = self._index_expression(item, context)
+            index_value = self._index_expression(item, evaluation_context)
             if not isinstance(index_value, int):
                 return None
 
@@ -1043,9 +1043,9 @@ class CoalesceExpressionSpec(JsonObject):
         self._expression = expression
         self._default_expression = default_expression
 
-    def __call__(self, item, context=None):
-        expression_value = self._expression(item, context)
-        default_value = self._default_expression(item, context)
+    def __call__(self, item, evaluation_context=None):
+        expression_value = self._expression(item, evaluation_context)
+        default_value = self._default_expression(item, evaluation_context)
         if expression_value is None or expression_value == '':
             return default_value
         else:

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -127,7 +127,9 @@ class PropertyNameGetterSpec(JsonObject):
         self._property_name_expression = property_name_expression
 
     def __call__(self, item, evaluation_context=None):
-        raw_value = item.get(self._property_name_expression(item, evaluation_context)) if isinstance(item, dict) else None
+        raw_value = None
+        if isinstance(item, dict):
+            raw_value = item.get(self._property_name_expression(item, evaluation_context))
         return transform_for_datatype(self.datatype)(raw_value)
 
     def __str__(self):

--- a/corehq/apps/userreports/extension_points.py
+++ b/corehq/apps/userreports/extension_points.py
@@ -40,7 +40,7 @@ def custom_ucr_expressions() -> List[Tuple[str, str]]:
         The function must take two arguments:
 
         * spec: Dict
-        * context: FactoryContext instance
+        * factory_context: FactoryContext instance
     """
 
 

--- a/corehq/apps/userreports/filters/__init__.py
+++ b/corehq/apps/userreports/filters/__init__.py
@@ -12,7 +12,7 @@ class Filter(object):
     Base filter class
     """
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         return True
 
     def __str__(self):
@@ -24,8 +24,8 @@ class NOTFilter(Filter):
     def __init__(self, filter):
         self._filter = filter
 
-    def __call__(self, item, context=None):
-        return not self._filter(item, context)
+    def __call__(self, item, evaluation_context=None):
+        return not self._filter(item, evaluation_context)
 
     def __str__(self):
         return "not({})".format(str(self._filter))
@@ -40,8 +40,8 @@ class ANDFilter(Filter):
         self.filters = filters
         assert len(self.filters) > 0
 
-    def __call__(self, item, context=None):
-        return all(_filter(item, context) for _filter in self.filters)
+    def __call__(self, item, evaluation_context=None):
+        return all(_filter(item, evaluation_context) for _filter in self.filters)
 
     def __str__(self):
         return "and(\n{}\n)".format(
@@ -57,8 +57,8 @@ class ORFilter(Filter):
         self.filters = filters
         assert len(self.filters) > 0
 
-    def __call__(self, item, context=None):
-        return any(_filter(item, context) for _filter in self.filters)
+    def __call__(self, item, evaluation_context=None):
+        return any(_filter(item, evaluation_context) for _filter in self.filters)
 
     def __str__(self):
         return "or(\n{}\n)".format(
@@ -69,14 +69,14 @@ class CustomFilter(Filter):
     """
     This filter allows you to pass in a function reference to use as the filter
 
-    e.g. CustomFilter(lambda f, context: f['gender'] in ['male', 'female'])
+    e.g. CustomFilter(lambda f, evaluation_context: f['gender'] in ['male', 'female'])
     """
 
     def __init__(self, filter):
         self._filter = filter
 
-    def __call__(self, item, context=None):
-        return self._filter(item, context)
+    def __call__(self, item, evaluation_context=None):
+        return self._filter(item, evaluation_context)
 
     def __str__(self):
         return str(self._filter)
@@ -89,8 +89,9 @@ class SinglePropertyValueFilter(Filter):
         self.operator = operator
         self.reference_expression = reference_expression
 
-    def __call__(self, item, context=None):
-        return self.operator(self.expression(item, context), self.reference_expression(item, context))
+    def __call__(self, item, evaluation_context=None):
+        return self.operator(
+            self.expression(item, evaluation_context), self.reference_expression(item, evaluation_context))
 
     def __str__(self):
         return "{} {} '{}'".format(str(self.expression),
@@ -103,8 +104,8 @@ class NamedFilter(Filter):
         self.filter_name = filter_name
         self.filter = filter
 
-    def __call__(self, item, context=None):
-        return self.filter(item, context)
+    def __call__(self, item, evaluation_context=None):
+        return self.filter(item, evaluation_context)
 
     def __str__(self):
         return "{}:{}".format(NAMED_FILTER_PREFIX, self.filter_name)

--- a/corehq/apps/userreports/filters/factory.py
+++ b/corehq/apps/userreports/filters/factory.py
@@ -21,6 +21,7 @@ from corehq.apps.userreports.filters.specs import (
     PropertyMatchFilterSpec,
 )
 from corehq.apps.userreports.operators import equal, get_operator
+from corehq.apps.userreports.specs import FactoryContext
 
 
 def _build_compound_filter(spec, factory_context):
@@ -85,6 +86,7 @@ class FilterFactory(object):
 
     @classmethod
     def from_spec(cls, spec, factory_context=None):
+        factory_context = factory_context or FactoryContext.empty()
         cls.validate_spec(spec)
         try:
             return cls.constructor_map[spec['type']](spec, factory_context)

--- a/corehq/apps/userreports/filters/factory.py
+++ b/corehq/apps/userreports/filters/factory.py
@@ -23,7 +23,7 @@ from corehq.apps.userreports.filters.specs import (
 from corehq.apps.userreports.operators import equal, get_operator
 
 
-def _build_compound_filter(spec, context):
+def _build_compound_filter(spec, factory_context):
     compound_type_map = {
         'or': ORFilter,
         'and': ANDFilter,
@@ -36,16 +36,16 @@ def _build_compound_filter(spec, context):
     elif not isinstance(spec.get('filters'), list):
         raise BadSpecError(_('{0} filter type must include a "filters" list'.format(spec['type'])))
 
-    filters = [FilterFactory.from_spec(subspec, context) for subspec in spec['filters']]
+    filters = [FilterFactory.from_spec(subspec, factory_context) for subspec in spec['filters']]
     return compound_type_map[spec['type']](filters)
 
 
-def _build_not_filter(spec, context):
+def _build_not_filter(spec, factory_context):
     wrapped = NotFilterSpec.wrap(spec)
-    return NOTFilter(FilterFactory.from_spec(wrapped.filter, context))
+    return NOTFilter(FilterFactory.from_spec(wrapped.filter, factory_context))
 
 
-def _build_property_match_filter(spec, context):
+def _build_property_match_filter(spec, factory_context):
     warnings.warn(
         "property_match are deprecated. Use boolean_expression instead.",
         DeprecationWarning,
@@ -58,18 +58,18 @@ def _build_property_match_filter(spec, context):
     )
 
 
-def _build_boolean_expression_filter(spec, context):
+def _build_boolean_expression_filter(spec, factory_context):
     wrapped = BooleanExpressionFilterSpec.wrap(spec)
     return SinglePropertyValueFilter(
-        expression=ExpressionFactory.from_spec(wrapped.expression, context),
+        expression=ExpressionFactory.from_spec(wrapped.expression, factory_context),
         operator=get_operator(wrapped.operator),
-        reference_expression=ExpressionFactory.from_spec(wrapped.property_value, context),
+        reference_expression=ExpressionFactory.from_spec(wrapped.property_value, factory_context),
     )
 
 
-def _build_named_filter(spec, context):
+def _build_named_filter(spec, factory_context):
     wrapped = NamedFilterSpec.wrap(spec)
-    filter = context.named_filters[wrapped.name]
+    filter = factory_context.named_filters[wrapped.name]
     return NamedFilter(wrapped.name, filter)
 
 
@@ -84,10 +84,10 @@ class FilterFactory(object):
     }
 
     @classmethod
-    def from_spec(cls, spec, context=None):
+    def from_spec(cls, spec, factory_context=None):
         cls.validate_spec(spec)
         try:
-            return cls.constructor_map[spec['type']](spec, context)
+            return cls.constructor_map[spec['type']](spec, factory_context)
         except (AssertionError, BadValueError, WrappingAttributeError) as e:
             raise BadSpecError(_('Problem creating filter from spec: {}, message is {}').format(
                 json.dumps(spec, indent=2),

--- a/corehq/apps/userreports/indicators/__init__.py
+++ b/corehq/apps/userreports/indicators/__init__.py
@@ -47,7 +47,7 @@ class ConfigurableIndicatorMixIn(object):
     def get_columns(self):
         raise NotImplementedError()
 
-    def get_values(self, item, context=None):
+    def get_values(self, item, evaluation_context=None):
         raise NotImplementedError()
 
 
@@ -81,8 +81,8 @@ class BooleanIndicator(SingleColumnIndicator):
                                                wrapped_spec)
         self.filter = filter
 
-    def get_values(self, item, context=None):
-        value = 1 if self.filter(item, context) else 0
+    def get_values(self, item, evaluation_context=None):
+        value = 1 if self.filter(item, evaluation_context) else 0
         return [ColumnValue(self.column, value)]
 
 
@@ -99,8 +99,8 @@ class RawIndicator(SingleColumnIndicator):
         super(RawIndicator, self).__init__(display_name, column, wrapped_spec)
         self.getter = getter
 
-    def get_values(self, item, context=None):
-        return [ColumnValue(self.column, self.getter(item, context))]
+    def get_values(self, item, evaluation_context=None):
+        return [ColumnValue(self.column, self.getter(item, evaluation_context))]
 
 
 class CompoundIndicator(ConfigurableIndicator):
@@ -115,8 +115,8 @@ class CompoundIndicator(ConfigurableIndicator):
     def get_columns(self):
         return [c for ind in self.indicators for c in ind.get_columns()]
 
-    def get_values(self, item, context=None):
-        return [val for ind in self.indicators for val in ind.get_values(item, context)]
+    def get_values(self, item, evaluation_context=None):
+        return [val for ind in self.indicators for val in ind.get_values(item, evaluation_context)]
 
 
 class LedgerBalancesIndicator(ConfigurableIndicator):
@@ -140,9 +140,9 @@ class LedgerBalancesIndicator(ConfigurableIndicator):
     def get_columns(self):
         return [self._make_column(product_code) for product_code in self.product_codes]
 
-    def get_values(self, item, context=None):
+    def get_values(self, item, evaluation_context=None):
         case_id = self.case_id_expression(item)
-        domain = context.root_doc['domain']
+        domain = evaluation_context.root_doc['domain']
         values = self._get_values_by_product(domain, case_id)
         return [
             ColumnValue(self._make_column(product_code), values.get(product_code, self.default_value))

--- a/corehq/apps/userreports/indicators/factory.py
+++ b/corehq/apps/userreports/indicators/factory.py
@@ -35,7 +35,7 @@ def _build_count_indicator(spec, factory_context):
     return BooleanIndicator(
         wrapped.display_name,
         wrapped.column_id,
-        CustomFilter(lambda item, context=None: True),
+        CustomFilter(lambda item, evaluation_context=None: True),
         wrapped,
     )
 

--- a/corehq/apps/userreports/indicators/factory.py
+++ b/corehq/apps/userreports/indicators/factory.py
@@ -30,7 +30,7 @@ from corehq.apps.userreports.indicators.specs import (
 )
 
 
-def _build_count_indicator(spec, context):
+def _build_count_indicator(spec, factory_context):
     wrapped = IndicatorSpecBase.wrap(spec)
     return BooleanIndicator(
         wrapped.display_name,
@@ -40,7 +40,7 @@ def _build_count_indicator(spec, context):
     )
 
 
-def _build_raw_indicator(spec, context):
+def _build_raw_indicator(spec, factory_context):
     wrapped = RawIndicatorSpec.wrap(spec)
     column = Column(
         id=wrapped.column_id,
@@ -57,7 +57,7 @@ def _build_raw_indicator(spec, context):
     )
 
 
-def _build_expression_indicator(spec, context):
+def _build_expression_indicator(spec, factory_context):
     wrapped = ExpressionIndicatorSpec.wrap(spec)
     column = Column(
         id=wrapped.column_id,
@@ -69,32 +69,32 @@ def _build_expression_indicator(spec, context):
     return RawIndicator(
         wrapped.display_name,
         column,
-        getter=wrapped.parsed_expression(context),
+        getter=wrapped.parsed_expression(factory_context),
         wrapped_spec=wrapped,
     )
 
 
-def _build_small_boolean_indicator(spec, context):
+def _build_small_boolean_indicator(spec, factory_context):
     wrapped = SmallBooleanIndicatorSpec.wrap(spec)
     return SmallBooleanIndicator(
         wrapped.display_name,
         wrapped.column_id,
-        FilterFactory.from_spec(wrapped.filter, context),
+        FilterFactory.from_spec(wrapped.filter, factory_context),
         wrapped_spec=wrapped,
     )
 
 
-def _build_boolean_indicator(spec, context):
+def _build_boolean_indicator(spec, factory_context):
     wrapped = BooleanIndicatorSpec.wrap(spec)
     return BooleanIndicator(
         wrapped.display_name,
         wrapped.column_id,
-        FilterFactory.from_spec(wrapped.filter, context),
+        FilterFactory.from_spec(wrapped.filter, factory_context),
         wrapped_spec=wrapped,
     )
 
 
-def _build_choice_list_indicator(spec, context):
+def _build_choice_list_indicator(spec, factory_context):
     wrapped_spec = ChoiceListIndicatorSpec.wrap(spec)
     base_display_name = wrapped_spec.display_name
 
@@ -119,17 +119,17 @@ def _build_choice_list_indicator(spec, context):
     return CompoundIndicator(base_display_name, choice_indicators, wrapped_spec)
 
 
-def _build_ledger_balances_indicator(spec, context):
+def _build_ledger_balances_indicator(spec, factory_context):
     wrapped_spec = LedgerBalancesIndicatorSpec.wrap(spec)
     return LedgerBalancesIndicator(wrapped_spec)
 
 
-def _build_due_list_date_indicator(spec, context):
+def _build_due_list_date_indicator(spec, factory_context):
     wrapped_spec = DueListDateIndicatorSpec.wrap(spec)
     return DueListDateIndicator(wrapped_spec)
 
 
-def _build_repeat_iteration_indicator(spec, context):
+def _build_repeat_iteration_indicator(spec, factory_context):
     return RawIndicator(
         "base document iteration",
         Column(
@@ -143,7 +143,7 @@ def _build_repeat_iteration_indicator(spec, context):
     )
 
 
-def _build_inserted_at(spec, context):
+def _build_inserted_at(spec, factory_context):
     return RawIndicator(
         "inserted at",
         Column(
@@ -172,10 +172,10 @@ class IndicatorFactory(object):
     }
 
     @classmethod
-    def from_spec(cls, spec, context=None):
+    def from_spec(cls, spec, factory_context=None):
         cls.validate_spec(spec)
         try:
-            return cls.constructor_map[spec['type']](spec, context)
+            return cls.constructor_map[spec['type']](spec, factory_context)
         except BadValueError as e:
             # for now reraise jsonobject exceptions as BadSpecErrors
             raise BadSpecError(str(e))

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -1352,15 +1352,15 @@ class InvalidUCRData(models.Model):
 
 
 class UCRExpressionManager(models.Manager):
-    def get_filters_for_domain(self, domain, context):
+    def get_filters_for_domain(self, domain, factory_context):
         return {
-            f.name: f.wrapped_definition(context)
+            f.name: f.wrapped_definition(factory_context)
             for f in self.filter(domain=domain, expression_type=UCR_NAMED_FILTER)
         }
 
-    def get_expressions_for_domain(self, domain, context):
+    def get_expressions_for_domain(self, domain, factory_context):
         return {
-            f.name: f.wrapped_definition(context)
+            f.name: f.wrapped_definition(factory_context)
             for f in self.filter(domain=domain, expression_type=UCR_NAMED_EXPRESSION)
         }
 
@@ -1390,11 +1390,11 @@ class UCRExpression(models.Model):
         app_label = 'userreports'
         unique_together = ('name', 'domain')
 
-    def wrapped_definition(self, context):
+    def wrapped_definition(self, factory_context):
         if self.expression_type == UCR_NAMED_EXPRESSION:
-            return ExpressionFactory.from_spec(self.definition, context)
+            return ExpressionFactory.from_spec(self.definition, factory_context)
         elif self.expression_type == UCR_NAMED_FILTER:
-            return FilterFactory.from_spec(self.definition, context)
+            return FilterFactory.from_spec(self.definition, factory_context)
 
     def update_from_upstream(self, upstream_ucr_expression):
         """

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -315,7 +315,7 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
             _Validation(
                 validation.name,
                 validation.error_message,
-                FilterFactory.from_spec(validation.expression, context=self.get_factory_context())
+                FilterFactory.from_spec(validation.expression, self.get_factory_context())
             )
             for validation in self.validations
         ]
@@ -359,7 +359,7 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
                 'type': 'and',
                 'filters': built_in_filters + extras,
             },
-            context=self.get_factory_context(),
+            self.get_factory_context(),
         )
 
     def _get_domain_filter_spec(self):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -456,7 +456,7 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
     @memoized
     def parsed_expression(self):
         if self.base_item_expression:
-            return ExpressionFactory.from_spec(self.base_item_expression, context=self.get_factory_context())
+            return ExpressionFactory.from_spec(self.base_item_expression, self.get_factory_context())
         return None
 
     @memoized

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -685,7 +685,7 @@ class NestedExpressionTest(SimpleTestCase):
         evaluation_context = EvaluationContext(doc)
         factory_context = FactoryContext({
             'test_named_expression': ExpressionFactory.from_spec(named_expression)
-        }, evaluation_context)
+        }, {})
 
         expression1 = ExpressionFactory.from_spec(
             {

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -639,7 +639,7 @@ class NestedExpressionTest(SimpleTestCase):
                     "type": "identity",
                 }
             },
-            context=FactoryContext({'three': ExpressionFactory.from_spec(3)}, {})
+            FactoryContext({'three': ExpressionFactory.from_spec(3)}, {})
         )
         self.assertEqual(3, expression({}))
 
@@ -655,7 +655,7 @@ class NestedExpressionTest(SimpleTestCase):
                     "name": "three"
                 }
             },
-            context=FactoryContext({'three': ExpressionFactory.from_spec(3)}, {})
+            FactoryContext({'three': ExpressionFactory.from_spec(3)}, {})
         )
         self.assertEqual(3, expression({}))
 
@@ -706,7 +706,7 @@ class NestedExpressionTest(SimpleTestCase):
                     "name": "test_named_expression"
                 }
             },
-            context=factory_context
+            factory_context
         )
         expression2 = ExpressionFactory.from_spec(
             {
@@ -727,7 +727,7 @@ class NestedExpressionTest(SimpleTestCase):
                     "name": "test_named_expression"
                 }
             },
-            context=factory_context
+            factory_context
         )
         self.assertEqual(expression1(doc, evaluation_context), 'my_parent_id')
         self.assertEqual(expression2(doc, evaluation_context), 'my_parent_id2')

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -830,7 +830,7 @@ class RootDocExpressionTest(SimpleTestCase):
             None,
             self.expression(
                 {"base_property": "item_value"},
-                context=EvaluationContext({}, 0)
+                EvaluationContext({}, 0)
             )
         )
 
@@ -839,7 +839,7 @@ class RootDocExpressionTest(SimpleTestCase):
             "base_value",
             self.expression(
                 {"base_property": "item_value"},
-                context=EvaluationContext({"base_property": "base_value"}, 0)
+                EvaluationContext({"base_property": "base_value"}, 0)
             )
         )
 
@@ -1457,7 +1457,7 @@ class TestEvaluationContext(SimpleTestCase):
         counter = MagicMock()
 
         @ucr_context_cache(vary_on=('arg1', 'arg2',))
-        def fn_that_should_be_cached(arg1, arg2, context):
+        def fn_that_should_be_cached(arg1, arg2, evaluation_context):
             counter()
 
         context = EvaluationContext({})
@@ -1473,7 +1473,7 @@ class TestEvaluationContext(SimpleTestCase):
 
         class MyObject(object):
             @ucr_context_cache(vary_on=('arg1', 'arg2',))
-            def method_that_should_be_cached(self, arg1, arg2, context):
+            def method_that_should_be_cached(self, arg1, arg2, evaluation_context):
                 counter()
 
         context = EvaluationContext({})
@@ -1489,11 +1489,11 @@ class TestEvaluationContext(SimpleTestCase):
         counter = MagicMock()
 
         @ucr_context_cache(vary_on=('arg1',))
-        def fn_that_should_be_cached(arg1, context):
+        def fn_that_should_be_cached(arg1, evaluation_context):
             counter()
 
         @ucr_context_cache(vary_on=('arg1',))
-        def another_fn_that_should_be_cached(arg1, context):
+        def another_fn_that_should_be_cached(arg1, evaluation_context):
             counter()
 
         context = EvaluationContext({})

--- a/corehq/apps/userreports/tests/test_indicators.py
+++ b/corehq/apps/userreports/tests/test_indicators.py
@@ -28,8 +28,8 @@ from corehq.form_processor.utils.xform import TestFormMetadata
 
 class SingleIndicatorTestBase(SimpleTestCase):
 
-    def _check_result(self, indicator, document, value, context=None):
-        [result] = indicator.get_values(document, context=context)
+    def _check_result(self, indicator, document, value, evaluation_context=None):
+        [result] = indicator.get_values(document, evaluation_context)
         self.assertEqual(value, result.value)
 
 

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1617,16 +1617,16 @@ class DataSourceSummaryView(BaseUserConfigReportsView):
         }
 
     def indicator_summary(self):
-        context = self.config.get_factory_context()
+        factory_context = self.config.get_factory_context()
         wrapped_specs = [
-            IndicatorFactory.from_spec(spec, context).wrapped_spec
+            IndicatorFactory.from_spec(spec, factory_context).wrapped_spec
             for spec in self.config.configured_indicators
         ]
         return [
             {
                 "column_id": wrapped.column_id,
                 "comment": wrapped.comment,
-                "readable_output": wrapped.readable_output(context)
+                "readable_output": wrapped.readable_output(factory_context)
             }
             for wrapped in wrapped_specs if wrapped
         ]

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1653,8 +1653,8 @@ class DataSourceSummaryView(BaseUserConfigReportsView):
 
     def configured_filter_summary(self):
         if self.config.configured_filter:
-            return str(FilterFactory.from_spec(self.config.configured_filter,
-                                            context=self.config.get_factory_context()))
+            return str(FilterFactory.from_spec(
+                self.config.configured_filter, self.config.get_factory_context()))
         return _("No filter defined")
 
     def _add_links_to_output(self, items):

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1016,8 +1016,7 @@ def _get_parsed_expression(domain, factory_context, expression_text, expression_
     try:
         expression_json = json.loads(expression_text)
         return ExpressionFactory.from_spec(
-            expression_json,
-            context=factory_context
+            expression_json, factory_context
         )
     except BadSpecError as e:
         raise HttpException(400, _("Problem with expression: {}").format(e))

--- a/custom/_legacy/mvp/ucr/reports/expressions.py
+++ b/custom/_legacy/mvp/ucr/reports/expressions.py
@@ -9,7 +9,7 @@ ADULT_FORM = "http://openrosa.org/formdesigner/60666f0dc7688fdef369947196722ff2f
 class TreatmentPlaceExpressionSpec(JsonObject):
     type = TypeProperty('mvp_treatment_place_name')
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         doc = item['form']
         form = item['xmlns']
         treatment_place_name = ""
@@ -35,7 +35,7 @@ class TreatmentPlaceExpressionSpec(JsonObject):
 class DeathPlaceExpressionSpec(JsonObject):
     type = TypeProperty('mvp_death_place')
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         doc = item['form']
         form = item['xmlns']
         death_place = ""
@@ -74,7 +74,7 @@ class DeathPlaceExpressionSpec(JsonObject):
 class MedicalCauseExpressionSpec(JsonObject):
     type = TypeProperty('mvp_medical_cause')
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         doc = item['form']
         form = item['xmlns']
         death_cause = ""
@@ -145,7 +145,7 @@ class MedicalCauseExpressionSpec(JsonObject):
 class TreatmentProviderExpressionSpec(JsonObject):
     type = TypeProperty('mvp_treatment_provider_name')
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         doc = item['form']
         form = item['xmlns']
         treatment_providers = ""
@@ -214,7 +214,7 @@ class TreatmentProviderExpressionSpec(JsonObject):
 class NoTreatmentReasonExpressionSpec(JsonObject):
     type = TypeProperty('mvp_no_treatment_reason')
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         doc = item['form']
         form = item['xmlns']
         no_treatment_reason = ""
@@ -264,26 +264,26 @@ class NoTreatmentReasonExpressionSpec(JsonObject):
         return no_treatment_reason
 
 
-def treatment_provider_name_expression(spec, context):
+def treatment_provider_name_expression(spec, factory_context):
     wrapped = TreatmentProviderExpressionSpec.wrap(spec)
     return wrapped
 
 
-def death_place_expression(spec, context):
+def death_place_expression(spec, factory_context):
     wrapped = DeathPlaceExpressionSpec.wrap(spec)
     return wrapped
 
 
-def treatment_place_name_expression(spec, context):
+def treatment_place_name_expression(spec, factory_context):
     wrapped = TreatmentPlaceExpressionSpec.wrap(spec)
     return wrapped
 
 
-def no_treatment_reason_expression(spec, context):
+def no_treatment_reason_expression(spec, factory_context):
     wrapped = NoTreatmentReasonExpressionSpec.wrap(spec)
     return wrapped
 
 
-def medical_cause_expression(spec, context):
+def medical_cause_expression(spec, factory_context):
     wrapped = MedicalCauseExpressionSpec.wrap(spec)
     return wrapped

--- a/custom/abt/reports/expressions.py
+++ b/custom/abt/reports/expressions.py
@@ -195,7 +195,7 @@ class AbtExpressionSpec(JsonObject):
     def _get_responsible_follow_up(self, spec):
         return spec.get('responsible_follow_up', "")
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         """
         Given a document (item), return a list of documents representing each
         of the flagged questions.
@@ -374,17 +374,17 @@ class AbtSupervisorV2020ExpressionSpec(AbtExpressionSpec):
     comment_from_root = True
 
 
-def abt_supervisor_expression(spec, context):
+def abt_supervisor_expression(spec, factory_context):
     return AbtSupervisorExpressionSpec.wrap(spec)
 
 
-def abt_supervisor_v2_expression(spec, context):
+def abt_supervisor_v2_expression(spec, factory_context):
     return AbtSupervisorV2ExpressionSpec.wrap(spec)
 
 
-def abt_supervisor_v2019_expression(spec, context):
+def abt_supervisor_v2019_expression(spec, factory_context):
     return AbtSupervisorV2019ExpressionSpec.wrap(spec)
 
 
-def abt_supervisor_v2020_expression(spec, context):
+def abt_supervisor_v2020_expression(spec, factory_context):
     return AbtSupervisorV2020ExpressionSpec.wrap(spec)

--- a/custom/champ/tests/utils.py
+++ b/custom/champ/tests/utils.py
@@ -58,7 +58,7 @@ class TestDataSourceExpressions(SimpleTestCase):
         if column['type'] == 'boolean':
             return FilterFactory.from_spec(
                 column['filter'],
-                context=FactoryContext(self.named_expressions, {})
+                FactoryContext(self.named_expressions, {})
             )
         else:
             self.assertEqual(column['datatype'], column_type)

--- a/custom/champ/tests/utils.py
+++ b/custom/champ/tests/utils.py
@@ -64,7 +64,7 @@ class TestDataSourceExpressions(SimpleTestCase):
             self.assertEqual(column['datatype'], column_type)
             return ExpressionFactory.from_spec(
                 column['expression'],
-                context=FactoryContext(self.named_expressions, {})
+                FactoryContext(self.named_expressions, {})
             )
 
     @classmethod

--- a/custom/eqa/expressions.py
+++ b/custom/eqa/expressions.py
@@ -63,7 +63,7 @@ class EQAExpressionSpec(JsonObject):
     display_text = StringProperty()
     xmlns = StringProperty()
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         curr_form, prev_form = get_two_last_forms(item, self.xmlns)
 
         path_question = 'form/%s' % self.question_id
@@ -86,7 +86,7 @@ class EQAActionItemSpec(JsonObject):
     section = StringProperty()
     question_id = StringProperty()
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         xforms_ids = CommCareCase.objects.get_case_xform_ids(item['_id'])
         forms = XFormInstance.objects.get_forms(xforms_ids, item['domain'])
         f_forms = [f for f in forms if f.xmlns == self.xmlns]
@@ -143,7 +143,7 @@ class EQAPercentExpression(JsonObject):
     display_text = StringProperty()
     xmlns = StringProperty()
 
-    def __call__(self, item, context=None):
+    def __call__(self, item, evaluation_context=None):
         curr_form, prev_form = get_two_last_forms(item, self.xmlns)
 
         path_question = 'form/%s' % self.question_id
@@ -169,16 +169,16 @@ class EQAPercentExpression(JsonObject):
         }
 
 
-def eqa_expression(spec, context):
+def eqa_expression(spec, factory_context):
     wrapped = EQAExpressionSpec.wrap(spec)
     return wrapped
 
 
-def cqi_action_item(spec, context):
+def cqi_action_item(spec, factory_context):
     wrapped = EQAActionItemSpec.wrap(spec)
     return wrapped
 
 
-def eqa_percent_expression(spec, context):
+def eqa_percent_expression(spec, factory_context):
     wrapped = EQAPercentExpression.wrap(spec)
     return wrapped


### PR DESCRIPTION
## Technical Summary
Looking through this code I found that there are 2 context classes: `FactoryContext` and `EvaluationContext`. Both are passed to functions as the `context` arg which is confusing. In some test the wrong context was passed in.

This PR attempts to make it more clear which is used where by referring to one as `factory_context` and the other as `evaluation_context`.

Best reviewed by commit 🐡 

## Safety Assurance

### Safety story
This is not a function change, only a refactor but it does touch a lot of code. I do think though that it's easy enough to see what the changes are and determine that they are correct.

The code is generally well covered by tests.

### Automated test coverage
No new tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
