### PR TITLE
Fix Zapier integrations to not require API_ACESS permission

### DIFF
--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -101,7 +101,7 @@ class HqBaseResource(CorsResourceMixin, JsonResourceMixin, Resource):
                 json.dumps({"error": msg}),
                 content_type="application/json",
                 status=401))
-        if request.user.is_superuser or domain_has_privilege(request.domain, privileges.API_ACCESS):
+        if request.user.is_superuser or domain_has_privilege(request.domain, self.get_required_privilege()):
             if isinstance(self, DomainSpecificResourceMixin):
                 track_workflow(request.user.username, "API Request", properties={
                     'domain': request.domain,
@@ -113,6 +113,9 @@ class HqBaseResource(CorsResourceMixin, JsonResourceMixin, Resource):
                 json.dumps({"error": "Your current subscription does not have access to this feature"}),
                 content_type="application/json",
                 status=401))
+
+    def get_required_privilege(self):
+        return privileges.API_ACCESS
 
 
 class SimpleSortableResourceMixin(object):

--- a/corehq/apps/zapier/api/v0_5.py
+++ b/corehq/apps/zapier/api/v0_5.py
@@ -2,6 +2,7 @@ from couchdbkit.exceptions import ResourceNotFound
 from tastypie import fields
 from tastypie.exceptions import NotFound
 from tastypie.resources import Resource
+from corehq import privileges
 
 from corehq.apps.api.resources.meta import CustomResourceMeta
 from corehq.apps.api.resources.v0_4 import (
@@ -23,6 +24,9 @@ class ZapierXFormInstanceResource(XFormInstanceResource):
         remove_advanced_fields(bundle.data)
         return bundle
 
+    def get_required_privilege(self):
+        return privileges.ZAPIER_INTEGRATION
+
 
 class ZapierApplicationResource(BaseApplicationResource):
     """
@@ -30,6 +34,9 @@ class ZapierApplicationResource(BaseApplicationResource):
     """
     id = fields.CharField(attribute='_id')
     name = fields.CharField(attribute='name')
+
+    def get_required_privilege(self):
+        return privileges.ZAPIER_INTEGRATION
 
 
 class CustomField(object):

--- a/corehq/apps/zapier/tests/test_polling.py
+++ b/corehq/apps/zapier/tests/test_polling.py
@@ -1,0 +1,138 @@
+import json
+from datetime import datetime
+from unittest.mock import patch
+from django.test import SimpleTestCase, RequestFactory
+from django.contrib.auth.models import User
+
+from corehq import privileges
+from corehq.apps.api import resources
+from corehq.apps.api.resources import v0_4
+from corehq.apps.app_manager.models import Application
+from corehq.apps.api.models import ESXFormInstance
+
+from corehq.apps.zapier.api.v0_5 import ZapierApplicationResource, ZapierXFormInstanceResource
+
+
+class XFormPollingTests(SimpleTestCase):
+    def test_can_poll_with_only_zapier_privilege(self):
+        self.forms = [self._create_form(id='7', domain='test-domain')]
+        self.domain_privileges = [privileges.ZAPIER_INTEGRATION]
+        request = self._create_request('test@test.com', 'test-domain', api_key='121212')
+
+        result = self.resource.dispatch('list', request,
+            domain='test-domain', api_name='v0.5', resource_name='form')
+        rows_found = json.loads(result.content.decode('utf8'))['meta']['total_count']
+        self.assertEqual(rows_found, 1)
+
+    def setUp(self):
+        self.resource = ZapierXFormInstanceResource()
+
+        self.domain_privileges = [privileges.ZAPIER_INTEGRATION]
+        self.forms = []
+
+        resource_patcher = patch.object(self.resource, 'obj_get_list', side_effect=self._mock_get_forms)
+        resource_patcher.start()
+        self.addCleanup(resource_patcher.stop)
+
+        domain_privilege_patcher = patch.object(
+            resources, 'domain_has_privilege', side_effect=self._mock_domain_has_privilege)
+        domain_privilege_patcher.start()
+        self.addCleanup(domain_privilege_patcher.stop)
+
+        workflow_patcher = patch.object(resources, 'track_workflow')
+        workflow_patcher.start()
+        self.addCleanup(workflow_patcher.stop)
+
+        #####
+        # Tastypie mocks
+        auth_patcher = patch.object(self.resource._meta.authentication, 'is_authenticated', return_value=True)
+        auth_patcher.start()
+        self.addCleanup(auth_patcher.stop)
+
+        accessed_patcher = patch.object(self.resource._meta.throttle, 'accessed', return_value=None)
+        accessed_patcher.start()
+        self.addCleanup(accessed_patcher.stop)
+        #####
+
+    def _create_form(self, id, domain='test-domain'):
+        return ESXFormInstance({
+            '_id': id,
+            'domain': domain,
+            'received_on': 'x',
+            'inserted_at': 'x',
+            'form': {
+                'some_data': 'test'
+            }
+        })
+
+    def _create_request(self, username, domain, api_key):
+        user = User(username=username)
+        request = RequestFactory().get('url', username=username, api_key=api_key)
+        request.user = request.couch_user = user
+        request.domain = domain
+
+        return request
+
+    def _mock_domain_has_privilege(self, domain, privilege):
+        return privilege in self.domain_privileges
+
+    def _mock_get_forms(self, *args, **kwargs):
+        return self.forms
+
+
+class ApplicationPollingTests(SimpleTestCase):
+    def test_can_poll_with_only_zapier_privilege(self):
+        self.applications = [self._create_app('1'), self._create_app('2')]
+        self.domain_privileges = [privileges.ZAPIER_INTEGRATION]
+        request = self._create_request('test@test.com', 'test-domain', api_key='121212')
+
+        result = self.resource.dispatch('list', request,
+            domain='test-domain', api_name='v0.5', resource_name='application')
+        rows_found = json.loads(result.content.decode('utf8'))['meta']['total_count']
+        self.assertEqual(rows_found, 2)
+
+    def setUp(self):
+        self.resource = ZapierApplicationResource()
+        self.domain_privileges = [privileges.ZAPIER_INTEGRATION]
+        self.applications = []
+
+        apps_patcher = patch.object(v0_4, 'get_apps_in_domain', side_effect=self._mock_get_applications)
+        apps_patcher.start()
+        self.addCleanup(apps_patcher.stop)
+
+        domain_privilege_patcher = patch.object(
+            resources, 'domain_has_privilege', side_effect=self._mock_domain_has_privilege)
+        domain_privilege_patcher.start()
+        self.addCleanup(domain_privilege_patcher.stop)
+
+        workflow_patcher = patch.object(resources, 'track_workflow')
+        workflow_patcher.start()
+        self.addCleanup(workflow_patcher.stop)
+
+        #####
+        # Tastypie mocks
+        auth_patcher = patch.object(self.resource._meta.authentication, 'is_authenticated', return_value=True)
+        auth_patcher.start()
+        self.addCleanup(auth_patcher.stop)
+
+        accessed_patcher = patch.object(self.resource._meta.throttle, 'accessed', return_value=None)
+        accessed_patcher.start()
+        self.addCleanup(accessed_patcher.stop)
+        #####
+
+    def _create_request(self, username, domain, api_key):
+        user = User(username=username)
+        request = RequestFactory().get('url', username=username, api_key=api_key)
+        request.user = request.couch_user = user
+        request.domain = domain
+
+        return request
+
+    def _create_app(self, id, name='test'):
+        return Application(_id=id, name=name, date_created=datetime.now())
+
+    def _mock_domain_has_privilege(self, domain, privilege):
+        return privilege in self.domain_privileges
+
+    def _mock_get_applications(self, *args, **kwargs):
+        return self.applications


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Fixes issue present in: https://dimagi-dev.atlassian.net/browse/SAAS-13640. Essentially, both the `ZAPIER_INTEGRATION` and `API_ACCESS` permissions were required for Zapier integrations to work. In the past, this hasn't been an issue, because advanced subscriptions have generally had both. However, there is nothing forcing this to be the case, and so this fix changes it so that Zapier integrations will only require the Zapier permission.

## Safety Assurance

### Safety story
This work was done through TDD, where the problem was verified to occur without these changes, and then verified to be eliminated after these changes were made. I pulled up our Zapier integration specification to verify what URL and data would be sent as part of these requests.  These changes were made assuming that requiring `API_ACCESS` was an oversight, and that only `ZAPIER_INTEGRATION` should be required. However, since both permissions largely occurred side-by-side, even if this assumption is wrong, it shouldn't change much -- users who will now only need Zapier permissions likely had `API_ACCESS` permissions before anyhow.

### Automated test coverage

Two new test suites were created in _zapier/tests/test_polling_

### QA Plan

No QA needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
