### PR TITLE
Add migration to clean-up orphaned report indices

### DIFF
--- a/corehq/ex-submodules/pillowtop/migrations/0007_remove_report_indices.py
+++ b/corehq/ex-submodules/pillowtop/migrations/0007_remove_report_indices.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+from corehq.util.django_migrations import skip_on_fresh_install
+from corehq.elastic import get_es_new
+
+
+@skip_on_fresh_install
+def delete_report_indices(*args, **kwargs):
+    es = get_es_new()
+    for index_name in [
+            'report_xforms_20160824_1708',
+            'report_cases_czei39du507m9mmpqk3y01x72a3ux4p0',
+    ]:
+        if es.indices.exists(index_name):
+            es.indices.delete(index_name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pillowtop', '0006_add_geopoint_to_case_search_index'),
+    ]
+
+    operations = [migrations.RunPython(
+        delete_report_indices,
+        reverse_code=migrations.RunPython.noop,
+        elidable=True,
+    )]

--- a/migrations.lock
+++ b/migrations.lock
@@ -631,6 +631,7 @@ pillowtop
  0004_offset_to_big_int
  0005_kafkacheckpoint_doc_modification_time
  0006_add_geopoint_to_case_search_index
+ 0007_remove_report_indices
 products
  0001_initial
 project_limits


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Follow-up from https://github.com/dimagi/commcare-hq/pull/31803, to be merged weeks later
This will actually delete the two "reports" indices orphaned there.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
By the time this is merged, these indices will be unreachable by HQ code

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

This depends heavily on the removal in https://github.com/dimagi/commcare-hq/pull/31803
<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

This PR contains a migration, so to revert it, we'd first want to roll back the migration.  The reverse migration is a noop, and it should be safe to perform, though of course it won't bring back the deleted index.  The migration only deletes the indices if they exist, so it can be run as many times as you like without issue, though I can't imagine we'd need to make use of that.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
