### PR TITLE
Fixed nodeset tab UI defaulting

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -45,19 +45,20 @@ hqDefine("app_manager/js/details/column", function () {
         self.original.case_tile_field = ko.utils.unwrapObservable(self.original.case_tile_field) || "";
         self.case_tile_field = ko.observable(self.original.case_tile_field);
 
-        // Set up tab attributes
+        // Set up tab defaults
         var tabDefaults = {
             isTab: false,
             hasNodeset: false,
             nodeset: "",
-            // Blank string is meaningful for nodesetCaseType (indicating a custom expression), so be strict here
-            nodesetCaseType: _.has(self.original, "nodesetCaseType") ? self.original.nodesetCaseType : screen.childCaseTypes[0] || "",
+            nodesetCaseType: "",
             nodesetFilter: "",
             relevant: "",
         };
-        _.each(_.keys(tabDefaults), function (key) {
-            self.original[key] = self.original[key] || tabDefaults[key];
-        });
+        self.original = _.defaults(self.original, tabDefaults);
+        if (!self.original.nodeset && screen.childCaseTypes && screen.childCaseTypes.length) {
+            // If there's no nodeset but there are child case types, default to showing a case type
+            self.original.nodesetCaseType = screen.childCaseTypes[0];
+        }
         _.extend(self, _.pick(self.original, _.keys(tabDefaults)));
 
         self.screen = screen;

--- a/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
@@ -30,13 +30,16 @@ hqDefine('app_manager/js/details/detail_tab_nodeset', function () {
         hqImport("hqwebapp/js/main").eventize(self);
         self.nodeset.subscribe(function () {
             self.fire('change');
-            self.showFilter(false);
         });
-        self.nodesetCaseType.subscribe(function () {
+        self.nodesetCaseType.subscribe(function (newValue) {
             self.fire('change');
-            self.nodeset("");
-            self.showFilter(false);
-            self.nodesetFilter("");
+            if (newValue) {
+                self.nodeset("");
+                self.showFilter(true);
+            } else {
+                self.nodesetFilter("");
+                self.showFilter(false);
+            }
         });
         self.nodesetFilter.subscribe(function () {
             self.fire('change');


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2142

There are two, mutually exclusive, ways to configure the nodeset tab:

1. child case type and an optional filter, which populates `DetailTab.nodeset_case_type` and `DetailTab.nodeset_filter`:
![Screen Shot 2022-06-20 at 9 19 41 AM](https://user-images.githubusercontent.com/1486591/174611109-151cd999-9a9a-4d41-9561-e5fc466baae2.png)

2. a single xpath expression, which populates `DetailTab.nodeset`:
![Screen Shot 2022-06-20 at 9 19 33 AM](https://user-images.githubusercontent.com/1486591/174611123-dbd35268-5667-4ab1-a643-bda93fd34fde.png)

There are a handful of apps that have both a `nodeset_case_type` and a `nodeset`, which shouldn't be possible. This PR fixes a UI issue that allows that to happen.

## Feature Flag
Associate a nodeset with a case detail tab

## Safety Assurance

### Safety story
Tested locally. This change is flagged and has a pretty small footprint.

### Automated test coverage

None

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
