### PR TITLE
Add support to get all OptionValue fields in a class

### DIFF
--- a/corehq/motech/repeaters/optionvalue.py
+++ b/corehq/motech/repeaters/optionvalue.py
@@ -89,8 +89,6 @@ class OptionValue(property):
             if self.coder:
                 return self.coder.from_json(obj.options[self.name])
             return obj.options[self.name]
-        if self.default is self.NOT_SET:
-            raise AttributeError(self.name)
         value = self.get_default_value()
         obj.options[self.name] = value
         return value
@@ -110,6 +108,8 @@ class OptionValue(property):
         obj.options[self.name] = value
 
     def get_default_value(self):
+        if self.default is self.NOT_SET:
+            raise AttributeError(self.name)
         return self.default() if callable(self.default) else self.default
 
 

--- a/corehq/motech/repeaters/optionvalue.py
+++ b/corehq/motech/repeaters/optionvalue.py
@@ -91,7 +91,7 @@ class OptionValue(property):
             return obj.options[self.name]
         if self.default is self.NOT_SET:
             raise AttributeError(self.name)
-        value = self.default() if callable(self.default) else self.default
+        value = self.get_default_value()
         obj.options[self.name] = value
         return value
 
@@ -110,9 +110,7 @@ class OptionValue(property):
         obj.options[self.name] = value
 
     def get_default_value(self):
-        if self.default != self.NOT_SET:
-            return self.default
-        return None
+        return self.default() if callable(self.default) else self.default
 
 
 def _assert_options(obj):

--- a/corehq/motech/repeaters/optionvalue.py
+++ b/corehq/motech/repeaters/optionvalue.py
@@ -75,6 +75,9 @@ class OptionValue(property):
 
     def __set_name__(self, owner, name):
         self.name = name
+        if not hasattr(owner, '_all_option_value_fields'):
+            setattr(owner, '_all_option_value_fields', set())
+        owner._all_option_value_fields.add(self.name)
 
     def __get__(self, obj, objtype=None):
         if obj is None:

--- a/corehq/motech/repeaters/optionvalue.py
+++ b/corehq/motech/repeaters/optionvalue.py
@@ -109,6 +109,11 @@ class OptionValue(property):
             value = self.coder.to_json(value)
         obj.options[self.name] = value
 
+    def get_default_value(self):
+        if self.default != self.NOT_SET:
+            return self.default
+        return None
+
 
 def _assert_options(obj):
     assert hasattr(obj, 'options') and isinstance(obj.options, dict), \

--- a/corehq/motech/repeaters/tests/test_optionvalue.py
+++ b/corehq/motech/repeaters/tests/test_optionvalue.py
@@ -19,6 +19,10 @@ def test_all_option_value_fields_is_populated():
     eq(order._all_option_value_fields, {'dish', 'food_option', 'condiments'})
 
 
+def test_get_default_value():
+    eq(FoodOptions.food_option.get_default_value(), 'veg')
+
+
 def test_option_value_not_set():
     order = FoodOptions()
     with assert_raises(AttributeError):

--- a/corehq/motech/repeaters/tests/test_optionvalue.py
+++ b/corehq/motech/repeaters/tests/test_optionvalue.py
@@ -13,6 +13,12 @@ def test_basic_option_value():
     eq(order.options, {"dish": "Chicken"})
 
 
+def test_all_option_value_fields_is_populated():
+    order = FoodOptions()
+    order.dish = "something"
+    eq(order._all_option_value_fields, {'dish', 'food_option', 'condiments'})
+
+
 def test_option_value_not_set():
     order = FoodOptions()
     with assert_raises(AttributeError):

--- a/corehq/motech/repeaters/tests/test_proxy_models.py
+++ b/corehq/motech/repeaters/tests/test_proxy_models.py
@@ -260,7 +260,15 @@ class TestRepeaterModelsAttrEquality(ModelAttrEqualityHelper):
     def test_have_same_attrs(self):
         couch_attrs = self.get_cleaned_couch_attrs(Repeater)
         sql_attrs = self.get_sql_attrs(SQLRepeater)
-        self.assertEqual(couch_attrs ^ sql_attrs, {'_all_option_value_fields'})
+        self.assertEqual(couch_attrs ^ sql_attrs, set())
+
+    @classmethod
+    def get_sql_attrs(cls, model_cls):
+        sql_attrs = cls._get_user_defined_attrs(model_cls, cls.DummySQLModel)
+        # Dynamically Added by OptionValue class
+        if '_all_option_value_fields' in sql_attrs:
+            sql_attrs.remove('_all_option_value_fields')
+        return sql_attrs
 
     @classmethod
     def _couch_only_attrs(cls):
@@ -289,8 +297,6 @@ class TestRepeaterModelsAttrEquality(ModelAttrEqualityHelper):
             'repeater_id', 'set_next_attempt', 'next_attempt_at',
             'is_ready', 'options', '_repeater_type', 'last_attempt_at', 'repeat_records_ready', 'repeat_records',
             'all_objects', 'reset_next_attempt', 'is_deleted', 'PROXY_FIELD_NAME', 'Meta', 'repeater',
-            # dynamically added by OptionValue in some repeaters
-            '_all_option_value_fields',
             # added by django choicefield in models
             'get_request_method_display'
         }
@@ -349,21 +355,21 @@ class TestAppStructureRepeater(TestRepeaterModelsAttrEquality):
     def test_have_same_attrs(self):
         couch_attrs = self.get_cleaned_couch_attrs(AppStructureRepeater)
         sql_attrs = self.get_sql_attrs(SQLAppStructureRepeater)
-        self.assertEqual(couch_attrs ^ sql_attrs, {'_all_option_value_fields'})
+        self.assertEqual(couch_attrs ^ sql_attrs, set())
 
 
 class TestUserRepeater(TestRepeaterModelsAttrEquality):
     def test_have_same_attrs(self):
         couch_attrs = self.get_cleaned_couch_attrs(UserRepeater)
         sql_attrs = self.get_sql_attrs(SQLUserRepeater)
-        self.assertEqual(couch_attrs ^ sql_attrs, {'_all_option_value_fields'})
+        self.assertEqual(couch_attrs ^ sql_attrs, set())
 
 
 class TestLocationRepeater(TestRepeaterModelsAttrEquality):
     def test_have_same_attrs(self):
         couch_attrs = self.get_cleaned_couch_attrs(LocationRepeater)
         sql_attrs = self.get_sql_attrs(SQLLocationRepeater)
-        self.assertEqual(couch_attrs ^ sql_attrs, {'_all_option_value_fields'})
+        self.assertEqual(couch_attrs ^ sql_attrs, set())
 
 
 class TestDhsi2Repeater(TestRepeaterModelsAttrEquality):

--- a/corehq/motech/repeaters/tests/test_proxy_models.py
+++ b/corehq/motech/repeaters/tests/test_proxy_models.py
@@ -266,8 +266,7 @@ class TestRepeaterModelsAttrEquality(ModelAttrEqualityHelper):
     def get_sql_attrs(cls, model_cls):
         sql_attrs = cls._get_user_defined_attrs(model_cls, cls.DummySQLModel)
         # Dynamically Added by OptionValue class
-        if '_all_option_value_fields' in sql_attrs:
-            sql_attrs.remove('_all_option_value_fields')
+        sql_attrs.discard('_all_option_value_fields')
         return sql_attrs
 
     @classmethod

--- a/corehq/motech/repeaters/tests/test_proxy_models.py
+++ b/corehq/motech/repeaters/tests/test_proxy_models.py
@@ -260,7 +260,7 @@ class TestRepeaterModelsAttrEquality(ModelAttrEqualityHelper):
     def test_have_same_attrs(self):
         couch_attrs = self.get_cleaned_couch_attrs(Repeater)
         sql_attrs = self.get_sql_attrs(SQLRepeater)
-        self.assertEqual(couch_attrs ^ sql_attrs, set())
+        self.assertEqual(couch_attrs ^ sql_attrs, {'_all_option_value_fields'})
 
     @classmethod
     def _couch_only_attrs(cls):
@@ -289,7 +289,10 @@ class TestRepeaterModelsAttrEquality(ModelAttrEqualityHelper):
             'repeater_id', 'set_next_attempt', 'next_attempt_at',
             'is_ready', 'options', '_repeater_type', 'last_attempt_at', 'repeat_records_ready', 'repeat_records',
             'all_objects', 'reset_next_attempt', 'is_deleted', 'PROXY_FIELD_NAME', 'Meta', 'repeater',
-            'get_request_method_display'  # added by django choicefield in models
+            # dynamically added by OptionValue in some repeaters
+            '_all_option_value_fields',
+            # added by django choicefield in models
+            'get_request_method_display'
         }
 
 
@@ -346,21 +349,21 @@ class TestAppStructureRepeater(TestRepeaterModelsAttrEquality):
     def test_have_same_attrs(self):
         couch_attrs = self.get_cleaned_couch_attrs(AppStructureRepeater)
         sql_attrs = self.get_sql_attrs(SQLAppStructureRepeater)
-        self.assertEqual(couch_attrs ^ sql_attrs, set())
+        self.assertEqual(couch_attrs ^ sql_attrs, {'_all_option_value_fields'})
 
 
 class TestUserRepeater(TestRepeaterModelsAttrEquality):
     def test_have_same_attrs(self):
         couch_attrs = self.get_cleaned_couch_attrs(UserRepeater)
         sql_attrs = self.get_sql_attrs(SQLUserRepeater)
-        self.assertEqual(couch_attrs ^ sql_attrs, set())
+        self.assertEqual(couch_attrs ^ sql_attrs, {'_all_option_value_fields'})
 
 
 class TestLocationRepeater(TestRepeaterModelsAttrEquality):
     def test_have_same_attrs(self):
         couch_attrs = self.get_cleaned_couch_attrs(LocationRepeater)
         sql_attrs = self.get_sql_attrs(SQLLocationRepeater)
-        self.assertEqual(couch_attrs ^ sql_attrs, set())
+        self.assertEqual(couch_attrs ^ sql_attrs, {'_all_option_value_fields'})
 
 
 class TestDhsi2Repeater(TestRepeaterModelsAttrEquality):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The PR adds support to get all OptionValue fields defined in the model class. The use case came out during the implementation of https://github.com/dimagi/commcare-hq/pull/31792. On further discussion with @millerdev, we figured that it would be a good thing to have.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests are there for the changes
### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
