### PR TITLE
Generate multi-select auto launch XML

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -53,7 +53,7 @@ NEXT_INPUT_INSTANCE = "next_input"
 
 AUTO_LAUNCH_EXPRESSIONS = {
     "single-select": "$next_input = '' or count(instance('casedb')/casedb/case[@case_id=$next_input]) = 0",
-    "multi-select": ("count(instance('" + NEXT_INPUT_INSTANCE + "')/results/value[count(instance(‘casedb’)"
+    "multi-select": ("count(instance('" + NEXT_INPUT_INSTANCE + "')/results/value[count(instance('casedb')"
                     "/casedb/case[@case_id = current()/.]) =0 ]) > 0")
 }
 

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -49,12 +49,11 @@ from corehq.apps.app_manager.util import (
 from corehq.apps.app_manager.xpath import CaseXPath, CaseTypeXpath, XPath, interpolate_xpath, session_var
 from corehq.util.timer import time_method
 
-NEXT_INPUT_INSTANCE = "next_input"
-
 AUTO_LAUNCH_EXPRESSIONS = {
     "single-select": "$next_input = '' or count(instance('casedb')/casedb/case[@case_id=$next_input]) = 0",
-    "multi-select": ("count(instance('" + NEXT_INPUT_INSTANCE + "')/results/value[count(instance('casedb')"
-                    "/casedb/case[@case_id = current()/.]) =0 ]) > 0")
+    "multi-select": ("count(instance('next_input')/results/value) = 0"
+                     " or count(instance('next_input')/results/value"
+                     "[count(instance('casedb')/casedb/case[@case_id = current()/.]) = 0]) > 0")
 }
 
 

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -24,6 +24,7 @@ from corehq.apps.app_manager.models import (
     FormLink,
     UpdateCaseAction,
 )
+from corehq.apps.app_manager.suite_xml.sections.details import AUTO_LAUNCH_EXPRESSIONS
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -111,9 +112,9 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
         suite = self.factory.app.create_suite()
 
         self.assertXmlPartialEqual(
-            """
+            f"""
             <partial>
-              <action auto_launch="true()" redo_last="false">
+              <action auto_launch="{AUTO_LAUNCH_EXPRESSIONS['multi-select']}" redo_last="false">
                 <display>
                   <text>
                     <locale id="case_search.m0"/>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -15,7 +15,7 @@ from corehq.apps.app_manager.models import (
     Module, DetailColumn, ShadowModule,
 )
 from corehq.apps.app_manager.suite_xml.sections.details import (
-    AUTO_LAUNCH_EXPRESSION,
+    AUTO_LAUNCH_EXPRESSIONS,
     DetailContributor
 )
 from corehq.apps.app_manager.suite_xml.sections.entries import EntriesContributor
@@ -406,7 +406,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         suite = self.app.create_suite()
         expected = f"""
         <partial>
-          <action auto_launch="{AUTO_LAUNCH_EXPRESSION}" redo_last="false">
+          <action auto_launch="{AUTO_LAUNCH_EXPRESSIONS['single-select']}" redo_last="false">
             <display>
               <text>
                 <locale id="case_search.m0"/>


### PR DESCRIPTION
## Product Description

The auto-launch action that occurs when a user clicks the submit button from the case search screen looks a little different for multi-select case lists. The attribute needs to be based on a next input instance that holds the GUID referring to a set of cases, rather than based on a single case ID.

Here is the [Jira ticket](https://dimagi-dev.atlassian.net/browse/USH-2174) and here is [the spec](https://docs.google.com/document/d/1N_Zg1vqRQofSsJo7X0Bj4WHktTroVofkpUIWt8_3Bhc/edit#heading=h.rqpotndwp5wg).


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

USH_INLINE_SEARCH

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Automated tests for generated suite XML.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Hmm, not sure what the QA status of inline search is, but if that's not happened yet then this change will be tested in that cycle.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
