### PR TITLE
Support email formatted usernames with validation

### DIFF
--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -83,7 +83,6 @@ class TestCommCareUserResource(APIResourceTest):
 
     @sync_users_to_es()
     def test_get_list(self):
-
         commcare_user = CommCareUser.create(domain=self.domain.name, username='fake_user', password='*****',
                                             created_by=None, created_via=None)
         self.addCleanup(commcare_user.delete, self.domain.name, deleted_by=None)
@@ -111,7 +110,6 @@ class TestCommCareUserResource(APIResourceTest):
 
     @flaky
     def test_get_single(self):
-
         commcare_user = CommCareUser.create(domain=self.domain.name, username='fake_user', password='*****',
                                             created_by=None, created_via=None)
         self.addCleanup(commcare_user.delete, self.domain.name, deleted_by=None)
@@ -136,7 +134,6 @@ class TestCommCareUserResource(APIResourceTest):
         })
 
     def test_create(self):
-
         group = Group({"name": "test"})
         group.save()
         self.addCleanup(group.delete)
@@ -162,8 +159,8 @@ class TestCommCareUserResource(APIResourceTest):
             }
         }
         response = self._assert_auth_post_resource(self.list_endpoint,
-                                    json.dumps(user_json),
-                                    content_type='application/json')
+                                                   json.dumps(user_json),
+                                                   content_type='application/json')
         self.assertEqual(response.status_code, 201)
         [user_back] = CommCareUser.by_domain(self.domain.name)
         self.addCleanup(user_back.delete, self.domain.name, deleted_by=None)
@@ -192,13 +189,11 @@ class TestCommCareUserResource(APIResourceTest):
                                                    json.dumps(user_json),
                                                    content_type='application/json')
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.content.decode('utf-8'),
-            '{"error": "Username \'jdoe\' is already taken."}'
-        )
+        self.assertEqual(response.content.decode('utf-8'),
+                         f'{{"error": "Username \'jdoe@{self.domain.name}.commcarehq.org\' is already taken or '
+                         f'reserved."}}')
 
     def test_update(self):
-
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
                                    created_by=None, created_via=None, phone_number="50253311398")
         group = Group({"name": "test"})
@@ -276,7 +271,6 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(user_history.changed_via, USER_CHANGE_VIA_API)
 
     def test_update_fails(self):
-
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
                                    created_by=None, created_via=None, phone_number="50253311398")
         group = Group({"name": "test"})
@@ -514,7 +508,6 @@ class TestBulkUserAPI(APIResourceTest):
 
 @es_test
 class TestIdentityResource(APIResourceTest):
-
     resource = v0_5.IdentityResource
     api_name = 'v0.5'
 
@@ -526,8 +519,8 @@ class TestIdentityResource(APIResourceTest):
     @classmethod
     def _get_list_endpoint(cls):
         return reverse('api_dispatch_list',
-                kwargs=dict(api_name=cls.api_name,
-                            resource_name=cls.resource._meta.resource_name))
+                       kwargs=dict(api_name=cls.api_name,
+                                   resource_name=cls.resource._meta.resource_name))
 
     @sync_users_to_es()
     def test_get_list(self):

--- a/corehq/apps/users/exceptions.py
+++ b/corehq/apps/users/exceptions.py
@@ -24,10 +24,3 @@ class ReservedUsernameException(Exception):
     """Raised if username is a reserved name (e.g., admin)"""
     def __init__(self, username):
         self.username = username
-
-
-class UsernameAlreadyExists(Exception):
-    """Raised if username is associated with a current or deleted user"""
-    def __init__(self, username, is_deleted):
-        self.username = username
-        self.is_deleted = is_deleted

--- a/corehq/apps/users/exceptions.py
+++ b/corehq/apps/users/exceptions.py
@@ -18,9 +18,3 @@ class MissingRoleException(Exception):
     Raised when encountering a WebUser without a role
     """
     pass
-
-
-class ReservedUsernameException(Exception):
-    """Raised if username is a reserved name (e.g., admin)"""
-    def __init__(self, username):
-        self.username = username

--- a/corehq/apps/users/exceptions.py
+++ b/corehq/apps/users/exceptions.py
@@ -26,12 +26,6 @@ class ReservedUsernameException(Exception):
         self.username = username
 
 
-class InvalidUsernameException(Exception):
-    """Raised if username contains invalid characters"""
-    def __init__(self, username):
-        self.username = username
-
-
 class UsernameAlreadyExists(Exception):
     """Raised if username is associated with a current or deleted user"""
     def __init__(self, username, is_deleted):

--- a/corehq/apps/users/tests/test_username_validation.py
+++ b/corehq/apps/users/tests/test_username_validation.py
@@ -4,8 +4,6 @@ from django.test import SimpleTestCase, TestCase
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.validation import (
-    ReservedUsernameException,
-    _check_for_reserved_usernames,
     _validate_complete_username,
     validate_mobile_username,
 )
@@ -32,7 +30,7 @@ class TestMobileUsernameValidation(TestCase):
             validate_mobile_username(None, self.domain)
 
     def test_reserved_username_raises_exception(self):
-        with self.assertRaises(ReservedUsernameException):
+        with self.assertRaises(ValidationError):
             validate_mobile_username('admin', self.domain)
 
     def test_empty_username_raises_exception(self):
@@ -46,23 +44,6 @@ class TestMobileUsernameValidation(TestCase):
     def test_already_used_username_raises_exception(self):
         with self.assertRaises(ValidationError):
             validate_mobile_username('test-user', self.domain)
-
-
-class TestCheckForReservedUsernames(SimpleTestCase):
-
-    def test_non_reserved_username_does_not_raise_exception(self):
-        try:
-            _check_for_reserved_usernames('not-reserved')
-        except ReservedUsernameException:
-            self.fail(f'Unexpected raised exception: {ReservedUsernameException}')
-
-    def test_admin_raises_exception(self):
-        with self.assertRaises(ReservedUsernameException):
-            _check_for_reserved_usernames('admin')
-
-    def test_demo_user_raises_exception(self):
-        with self.assertRaises(ReservedUsernameException):
-            _check_for_reserved_usernames('demo_user')
 
 
 class TestValidateCompleteUsername(SimpleTestCase):

--- a/corehq/apps/users/tests/test_username_validation.py
+++ b/corehq/apps/users/tests/test_username_validation.py
@@ -21,51 +21,79 @@ class TestMobileUsernameValidation(TestCase):
         cls.user = CommCareUser.create(cls.domain, 'test-user@test-domain.commcarehq.org', 'abc123', None, None)
         cls.addClassCleanup(cls.user.delete, cls.domain, None)
 
-    def test_valid_username_returns_successfully(self):
-        username = validate_mobile_username('test-user-1@test-domain.commcarehq.org', self.domain)
-        self.assertEqual(username, 'test-user-1@test-domain.commcarehq.org')
+    def test_no_exception_rasied_if_valid_username(self):
+        validate_mobile_username('test-user-1@test-domain.commcarehq.org', self.domain)
 
-    def test_none_username_raises_exception(self):
-        with self.assertRaises(ValidationError):
+    def test_exception_raised_if_username_is_none(self):
+        with self.assertRaises(ValidationError) as cm:
             validate_mobile_username(None, self.domain)
 
-    def test_empty_username_raises_exception(self):
-        with self.assertRaises(ValidationError):
+        self.assertEqual(cm.exception.message, "Username is required.")
+
+    def test_exception_raised_if_username_is_empty(self):
+        with self.assertRaises(ValidationError) as cm:
             validate_mobile_username('', self.domain)
 
-    def test_reserved_username_raises_exception(self):
+        self.assertEqual(cm.exception.message, "Username is required.")
+
+    def test_exception_raised_if_invalid_username(self):
+        """See TestValidateCompleteUsername for more detailed tests"""
         with self.assertRaises(ValidationError):
+            validate_mobile_username('invalid&test@test-domain.commcarehq.org', self.domain)
+
+    def test_exception_raised_if_username_is_reserved(self):
+        with self.assertRaises(ValidationError) as cm:
             validate_mobile_username('admin@test-domain.commcarehq.org', self.domain)
 
-    def test_invalid_email_raises_exception(self):
-        with self.assertRaises(ValidationError):
-            validate_mobile_username('test..user@test-domain.commcarehq.org', self.domain)
+        self.assertEqual(cm.exception.message,
+                         "Username 'admin@test-domain.commcarehq.org' is already taken or reserved.")
 
-    def test_already_used_username_raises_exception(self):
-        with self.assertRaises(ValidationError):
+    def test_exception_raised_if_username_is_actively_in_use(self):
+        with self.assertRaises(ValidationError) as cm:
             validate_mobile_username('test-user@test-domain.commcarehq.org', self.domain)
+
+        self.assertEqual(cm.exception.message,
+                         "Username 'test-user@test-domain.commcarehq.org' is already taken or reserved.")
+
+    def test_exception_raised_if_username_was_previously_used(self):
+        retired_user = CommCareUser.create(self.domain, 'retired@test-domain.commcarehq.org', 'abc123', None, None)
+        self.addCleanup(retired_user.delete, self.domain, None)
+        retired_user.retire(self.domain, None)
+
+        with self.assertRaises(ValidationError) as cm:
+            validate_mobile_username('retired@test-domain.commcarehq.org', self.domain)
+
+        self.assertEqual(cm.exception.message,
+                         "Username 'retired@test-domain.commcarehq.org' is already taken or reserved.")
 
 
 class TestValidateCompleteUsername(SimpleTestCase):
 
-    def test_valid_email_does_not_raise_exception(self):
+    def test_no_exception_raised_if_valid_email(self):
         try:
             _validate_complete_username('username@domain.commcarehq.org', 'domain')
         except ValidationError:
             self.fail(f'Unexpected raised exception: {ValidationError}')
 
-    def test_invalid_raises_exception(self):
-        with self.assertRaises(ValidationError):
+    def test_exception_raised_if_invalid_email(self):
+        with self.assertRaises(ValidationError) as cm:
             _validate_complete_username('username%domain.commcarehq.org', 'domain')
 
-    def test_trailing_period_raises_exception(self):
-        with self.assertRaises(ValidationError):
-            _validate_complete_username('username.@domain.commcarehq.org', 'domain')
+        self.assertEqual(cm.exception.message,
+                         "Username 'username%domain.commcarehq.org' must be a valid email address.")
 
-    def test_double_period_raises_exception(self):
-        with self.assertRaises(ValidationError):
-            _validate_complete_username('user..name@domain.commcarehq.org', 'domain')
+    def test_exception_raised_if_invalid_username(self):
+        """Invalid username refers to the first component of the email being invalid for HQ standards"""
+        with self.assertRaises(ValidationError) as cm:
+            _validate_complete_username('test%user@domain.commcarehq.org', 'domain')
 
-    def test_incorrect_email_domain_raises_exception(self):
-        with self.assertRaises(ValidationError):
+        self.assertEqual(cm.exception.message,
+                         "The username component 'test%user' of 'test%user@domain.commcarehq.org' may not "
+                         "contain special characters.")
+
+    def test_exception_raised_if_incorrect_email_domain(self):
+        with self.assertRaises(ValidationError) as cm:
             _validate_complete_username('user@domain2.commcarehq.org', 'domain')
+
+        self.assertEqual(cm.exception.message,
+                         "The username email domain '@domain2.commcarehq.org' should be '@domain.commcarehq.org'.")

--- a/corehq/apps/users/tests/test_username_validation.py
+++ b/corehq/apps/users/tests/test_username_validation.py
@@ -22,46 +22,50 @@ class TestMobileUsernameValidation(TestCase):
         cls.addClassCleanup(cls.user.delete, cls.domain, None)
 
     def test_valid_username_returns_successfully(self):
-        username = validate_mobile_username('test-user-1', self.domain)
+        username = validate_mobile_username('test-user-1@test-domain.commcarehq.org', self.domain)
         self.assertEqual(username, 'test-user-1@test-domain.commcarehq.org')
 
     def test_none_username_raises_exception(self):
         with self.assertRaises(ValidationError):
             validate_mobile_username(None, self.domain)
 
-    def test_reserved_username_raises_exception(self):
-        with self.assertRaises(ValidationError):
-            validate_mobile_username('admin', self.domain)
-
     def test_empty_username_raises_exception(self):
         with self.assertRaises(ValidationError):
             validate_mobile_username('', self.domain)
 
+    def test_reserved_username_raises_exception(self):
+        with self.assertRaises(ValidationError):
+            validate_mobile_username('admin@test-domain.commcarehq.org', self.domain)
+
     def test_invalid_email_raises_exception(self):
         with self.assertRaises(ValidationError):
-            validate_mobile_username('test..user', self.domain)
+            validate_mobile_username('test..user@test-domain.commcarehq.org', self.domain)
 
     def test_already_used_username_raises_exception(self):
         with self.assertRaises(ValidationError):
-            validate_mobile_username('test-user', self.domain)
+            validate_mobile_username('test-user@test-domain.commcarehq.org', self.domain)
 
 
 class TestValidateCompleteUsername(SimpleTestCase):
 
     def test_valid_email_does_not_raise_exception(self):
         try:
-            _validate_complete_username('username@domain.commcarehq.org')
+            _validate_complete_username('username@domain.commcarehq.org', 'domain')
         except ValidationError:
             self.fail(f'Unexpected raised exception: {ValidationError}')
 
     def test_invalid_raises_exception(self):
         with self.assertRaises(ValidationError):
-            _validate_complete_username('username%domain.commcarehq.org')
+            _validate_complete_username('username%domain.commcarehq.org', 'domain')
 
     def test_trailing_period_raises_exception(self):
         with self.assertRaises(ValidationError):
-            _validate_complete_username('username.@domain.commcarehq.org')
+            _validate_complete_username('username.@domain.commcarehq.org', 'domain')
 
     def test_double_period_raises_exception(self):
         with self.assertRaises(ValidationError):
-            _validate_complete_username('user..name@domain.commcarehq.org')
+            _validate_complete_username('user..name@domain.commcarehq.org', 'domain')
+
+    def test_incorrect_email_domain_raises_exception(self):
+        with self.assertRaises(ValidationError):
+            _validate_complete_username('user@domain2.commcarehq.org', 'domain')

--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -214,67 +214,9 @@ class TestGenerateMobileUsername(TestCase):
 
         self.assertEqual(username, 'test-user-1@test-domain.commcarehq.org')
 
-    def test_invalid_username_if_double_period(self):
-        with self.assertRaises(ValidationError) as cm:
-            generate_mobile_username('test..user', self.domain)
-
-        self.assertEqual(cm.exception.message,
-                         "Username 'test..user@test-domain.commcarehq.org' must be a valid email address.")
-
-    def test_invalid_username_if_trailing_period(self):
-        with self.assertRaises(ValidationError) as cm:
-            generate_mobile_username('test.user.', self.domain)
-
-        self.assertEqual(cm.exception.message,
-                         "Username 'test.user.@test-domain.commcarehq.org' must be a valid email address.")
-
-    def test_invalid_username_if_special_characters(self):
-        with self.assertRaises(ValidationError) as cm:
+    def test_exception_raised_if_username_validation_fails(self):
+        with self.assertRaises(ValidationError):
             generate_mobile_username('test%user', self.domain)
-
-        self.assertEqual(cm.exception.message,
-                         "The username component 'test%user' of 'test%user@test-domain.commcarehq.org' may not "
-                         "contain special characters.")
-
-    def test_username_is_not_available_message(self):
-        with self.assertRaises(ValidationError) as cm:
-            generate_mobile_username('test-user', self.domain)
-
-        self.assertEqual(cm.exception.message,
-                         "Username 'test-user@test-domain.commcarehq.org' is already taken or reserved.")
-
-    def test_username_was_previously_in_use_message(self):
-        retired_user = CommCareUser.create(self.domain, 'retired@test-domain.commcarehq.org', 'abc123', None, None)
-        self.addCleanup(retired_user.delete, self.domain, None)
-        retired_user.retire(self.domain, None)
-
-        with self.assertRaises(ValidationError) as cm:
-            generate_mobile_username('retired', self.domain)
-
-        self.assertEqual(cm.exception.message,
-                         "Username 'retired@test-domain.commcarehq.org' is already taken or reserved.")
-
-    def test_username_is_reserved_message(self):
-        with self.assertRaises(ValidationError) as cm:
-            generate_mobile_username('admin', self.domain)
-
-        self.assertEqual(cm.exception.message,
-                         "Username 'admin@test-domain.commcarehq.org' is already taken or reserved.")
-
-    def test_username_is_empty_message(self):
-        with self.assertRaises(ValidationError) as cm:
-            generate_mobile_username('', self.domain)
-
-        self.assertEqual(cm.exception.message,
-                         "Username '@test-domain.commcarehq.org' must be a valid email address.")
-
-    def test_username_email_domain_is_incorrect_message(self):
-        with self.assertRaises(ValidationError) as cm:
-            generate_mobile_username('test-user@test-domain2.commcarehq.org', self.domain)
-
-        self.assertEqual(cm.exception.message,
-                         "The username email domain '@test-domain2.commcarehq.org' should be "
-                         "'@test-domain.commcarehq.org'.")
 
 
 class TestIsUsernameAvailable(TestCase):

--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -212,23 +212,27 @@ class TestGenerateMobileUsername(TestCase):
 
         self.assertEqual(username, 'test-user-1@test-domain.commcarehq.org')
 
-    def test_invalid_username_double_period_message(self):
+    def test_invalid_username_if_double_period(self):
         with self.assertRaises(ValidationError) as cm:
             generate_mobile_username('test..user', self.domain)
 
-        self.assertEqual(cm.exception.message, "Username 'test..user' may not contain consecutive '.' (period).")
+        self.assertEqual(cm.exception.message,
+                         "Username 'test..user@test-domain.commcarehq.org' must be a valid email address.")
 
-    def test_invalid_username_trailing_period_message(self):
+    def test_invalid_username_if_trailing_period(self):
         with self.assertRaises(ValidationError) as cm:
             generate_mobile_username('test.user.', self.domain)
 
-        self.assertEqual(cm.exception.message, "Username 'test.user.' may not end with a '.' (period).")
+        self.assertEqual(cm.exception.message,
+                         "Username 'test.user.@test-domain.commcarehq.org' must be a valid email address.")
 
-    def test_invalid_username_generic_message(self):
+    def test_invalid_username_if_special_characters(self):
         with self.assertRaises(ValidationError) as cm:
             generate_mobile_username('test%user', self.domain)
 
-        self.assertEqual(cm.exception.message, "Username 'test%user' may not contain special characters.")
+        self.assertEqual(cm.exception.message,
+                         "The username component 'test%user' of 'test%user@test-domain.commcarehq.org' may not "
+                         "contain special characters.")
 
     def test_username_actively_in_use_message(self):
         with self.assertRaises(ValidationError) as cm:

--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -239,7 +239,8 @@ class TestGenerateMobileUsername(TestCase):
         with self.assertRaises(ValidationError) as cm:
             generate_mobile_username('test-user', self.domain)
 
-        self.assertEqual(cm.exception.message, "Username 'test-user@test-domain.commcarehq.org' is already taken.")
+        self.assertEqual(cm.exception.message,
+                         "Username 'test-user@test-domain.commcarehq.org' is already taken or reserved.")
 
     def test_username_was_previously_in_use_message(self):
         retired_user = CommCareUser.create(self.domain, 'retired@test-domain.commcarehq.org', 'abc123', None, None)
@@ -249,13 +250,15 @@ class TestGenerateMobileUsername(TestCase):
         with self.assertRaises(ValidationError) as cm:
             generate_mobile_username('retired', self.domain)
 
-        self.assertEqual(cm.exception.message, "Username 'retired@test-domain.commcarehq.org' is already taken.")
+        self.assertEqual(cm.exception.message,
+                         "Username 'retired@test-domain.commcarehq.org' is already taken or reserved.")
 
     def test_username_is_reserved_message(self):
         with self.assertRaises(ValidationError) as cm:
             generate_mobile_username('admin', self.domain)
 
-        self.assertEqual(cm.exception.message, "Username 'admin' is reserved.")
+        self.assertEqual(cm.exception.message,
+                         "Username 'admin@test-domain.commcarehq.org' is already taken or reserved.")
 
     def test_username_is_none_message(self):
         with self.assertRaises(ValidationError) as cm:
@@ -293,3 +296,7 @@ class TestIsUsernameAvailable(TestCase):
 
     def test_returns_false_if_incomplete_username(self):
         self.assertFalse(is_username_available('test-user'))
+
+    def test_returns_false_if_reserved_username(self):
+        self.assertFalse(is_username_available('admin'))
+        self.assertFalse(is_username_available('demo_user'))

--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -246,12 +246,9 @@ class TestIsUsernameAvailable(TestCase):
 
         self.assertFalse(is_username_available('retired@test-domain.commcarehq.org'))
 
-    def test_returns_false_if_incomplete_username(self):
-        self.assertFalse(is_username_available('test-user'))
-
     def test_returns_false_if_reserved_username(self):
         self.assertFalse(is_username_available('admin'))
-        self.assertFalse(is_username_available('demo_user'))
+        self.assertFalse(is_username_available('demo_user@test-domain.commcarehq.org'))
 
 
 class TestGetCompleteMobileUsername(SimpleTestCase):

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ValidationError
 from django.utils import html
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext as _
 
 from couchdbkit import ResourceNotFound
 from django_prbac.utils import has_privilege
@@ -50,14 +49,28 @@ def generate_mobile_username(username, domain):
     Returns the email formatted mobile username if successfully generated
     Handles exceptions raised by .validation.validate_mobile_username with user facing messages
     Any additional validation should live in .validation.validate_mobile_username
-    :param username: required str, expecting the first part of a mobile username
+    :param username: accepts both incomplete ('example-user') or complete ('example-user@domain.commcarehq.org')
     :param domain: required str, domain name
     :return: str, email formatted mobile username
     Example use: generate_mobile_username('username', 'domain') -> 'username@domain.commcarehq.org'
     """
     from .validation import validate_mobile_username
-    # TODO: separate username generation and validation
-    return validate_mobile_username(username, domain)
+    username = get_complete_mobile_username(username, domain)
+    validate_mobile_username(username, domain)
+    return username
+
+
+def get_complete_mobile_username(username, domain):
+    """
+    :param username: accepts both incomplete ('example-user') or complete ('example-user@domain.commcarehq.org')
+    :param domain: domain associated with the mobile user
+    :return: the complete username ('example-user@domain.commcarehq.org')
+    """
+    # this method is not responsible for validation, and therefore does the most basic email format check
+    if not re.match(".+@.+", username):
+        username = format_username(username, domain)
+
+    return username
 
 
 def cc_user_domain(domain):

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -67,7 +67,7 @@ def get_complete_mobile_username(username, domain):
     :return: the complete username ('example-user@domain.commcarehq.org')
     """
     # this method is not responsible for validation, and therefore does the most basic email format check
-    if not re.match(".+@.+", username):
+    if '@' not in username:
         username = format_username(username, domain)
 
     return username
@@ -494,11 +494,11 @@ def is_username_available(username):
     :return: boolean
     """
     from corehq.apps.users.dbaccessors import user_exists
-    # enforce complete username, otherwise check is meaningless
-    if not re.match("[a-z0-9.+-_]+@[a-z0-9.+-_]+.commcarehq.org", username):
-        return False
 
-    local_username = username.split('@')[0]
+    local_username = username
+    if '@' in local_username:
+        # assume email format since '@' is an invalid character for usernames
+        local_username = username.split('@')[0]
     reserved_usernames = ['admin', 'demo_user']
     if local_username in reserved_usernames:
         return False

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -22,7 +22,6 @@ from casexml.apps.case.const import (
 from corehq import privileges
 from corehq.apps.callcenter.const import CALLCENTER_USER
 from corehq.apps.users.exceptions import (
-    InvalidUsernameException,
     UsernameAlreadyExists,
     ReservedUsernameException,
 )
@@ -64,14 +63,6 @@ def generate_mobile_username(username, domain):
     error = None
     try:
         return validate_mobile_username(username, domain)
-    except InvalidUsernameException:
-        error = _("Username '{}' may not contain special characters.").format(username)
-        if not username:
-            error = _("Username is required.")
-        elif '..' in username:
-            error = _("Username '{}' may not contain consecutive '.' (period).").format(username)
-        elif username.endswith('.'):
-            error = _("Username '{}' may not end with a '.' (period).").format(username)
     except UsernameAlreadyExists as e:
         if e.is_deleted:
             error = _("Username '{}' belonged to a user that was deleted and cannot be reused.").format(username)

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -2,9 +2,6 @@ from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils.translation import gettext as _
 
-from corehq.apps.users.exceptions import (
-    ReservedUsernameException,
-)
 from corehq.apps.users.util import format_username, is_username_available
 from corehq.apps.users.views.mobile import BAD_MOBILE_USERNAME_REGEX
 
@@ -21,20 +18,13 @@ def validate_mobile_username(username, domain):
     if not username:
         raise ValidationError(_("Username is required."))
 
-    _check_for_reserved_usernames(username)
     username_as_email = format_username(username, domain)
     _validate_complete_username(username_as_email)
 
     if not is_username_available(username_as_email):
-        raise ValidationError(_("Username '{}' is already taken.").format(username_as_email))
+        raise ValidationError(_("Username '{}' is already taken or reserved.").format(username_as_email))
 
     return username_as_email
-
-
-def _check_for_reserved_usernames(username):
-    reserved_usernames = ['admin', 'demo_user']
-    if username in reserved_usernames:
-        raise ReservedUsernameException(username)
 
 
 def _validate_complete_username(username):

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -8,7 +8,7 @@ from corehq.apps.users.views.mobile import BAD_MOBILE_USERNAME_REGEX
 
 def validate_mobile_username(username, domain):
     """
-    Raises a ValidationError is any issue with the complete username is encountered
+    Raises a ValidationError if any issue with the complete username is encountered
     :param username: str, expects complete username ('username@example.commcarehq.org')
     :param domain: str, required
     """

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -2,32 +2,26 @@ from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils.translation import gettext as _
 
-from corehq.apps.users.util import format_username, is_username_available
+from corehq.apps.users.util import is_username_available
 from corehq.apps.users.views.mobile import BAD_MOBILE_USERNAME_REGEX
 
 
 def validate_mobile_username(username, domain):
     """
-    Returns the email formatted mobile username if valid
-    Otherwise raises custom exceptions based on the issue encountered with the username
-    :param username: str, required
+    Raises a ValidationError is any issue with the complete username is encountered
+    :param username: str, expects complete username ('username@example.commcarehq.org')
     :param domain: str, required
-    :return: str, email formatted mobile username
-    Example: validate_mobile_username('username', 'domain') -> 'username@domain.commcarehq.org'
     """
     if not username:
         raise ValidationError(_("Username is required."))
 
-    username_as_email = format_username(username, domain)
-    _validate_complete_username(username_as_email)
+    _validate_complete_username(username, domain)
 
-    if not is_username_available(username_as_email):
-        raise ValidationError(_("Username '{}' is already taken or reserved.").format(username_as_email))
-
-    return username_as_email
+    if not is_username_available(username):
+        raise ValidationError(_("Username '{}' is already taken or reserved.").format(username))
 
 
-def _validate_complete_username(username):
+def _validate_complete_username(username, domain):
     """
     Raises a ValidationError if the username is invalid
     :param username: expects str formatted like 'username@example.commcarehq.org'
@@ -37,9 +31,14 @@ def _validate_complete_username(username):
     except ValidationError:
         raise ValidationError(_("Username '{}' must be a valid email address.").format(username))
 
-    email_username = username.split('@')[0]
+    email_username, email_domain = username.split('@')
     if BAD_MOBILE_USERNAME_REGEX.search(email_username) is not None:
         raise ValidationError(
             _("The username component '{}' of '{}' may not contain special characters.").format(
                 email_username, username)
         )
+
+    expected_domain = f"{domain}.commcarehq.org"
+    if email_domain != expected_domain:
+        raise ValidationError(
+            _("The username email domain '@{}' should be '@{}'.").format(email_domain, expected_domain))

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -36019,32 +36019,24 @@ msgstr ""
 msgid "Copy and paste admin emails"
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain special characters."
-msgstr ""
-
-#: corehq/apps/users/util.py
+#: corehq/apps/users/validation.py
 msgid "Username is required."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain consecutive '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' is already taken or reserved."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not end with a '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' must be a valid email address."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' belonged to a user that was deleted and cannot be reused."
+#: corehq/apps/users/validation.py
+msgid "The username component '{}' of '{}' may not contain special characters."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' is already taken."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is reserved."
+#: corehq/apps/users/validation.py
+msgid "The username email domain '@{}' should be '@{}'."
 msgstr ""
 
 #: corehq/apps/users/views/__init__.py

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -37616,32 +37616,28 @@ msgstr "¿Está seguro que desea eliminar esta invitación?"
 msgid "Copy and paste admin emails"
 msgstr "Copiar y pegar correos electrónicos administrativos"
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain special characters."
-msgstr ""
-
-#: corehq/apps/users/util.py
+#: corehq/apps/users/validation.py
 msgid "Username is required."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain consecutive '.' (period)."
+#: corehq/apps/users/validation.py
+#, fuzzy
+#| msgid "Name '%s' is already taken."
+msgid "Username '{}' is already taken or reserved."
+msgstr "El nombre '%s' no está disponible. "
+
+#: corehq/apps/users/validation.py
+#, fuzzy
+#| msgid "Please enter a valid email address."
+msgid "Username '{}' must be a valid email address."
+msgstr "Por favor ingrese una dirección de correo válida."
+
+#: corehq/apps/users/validation.py
+msgid "The username component '{}' of '{}' may not contain special characters."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not end with a '.' (period)."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' belonged to a user that was deleted and cannot be reused."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is already taken."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is reserved."
+#: corehq/apps/users/validation.py
+msgid "The username email domain '@{}' should be '@{}'."
 msgstr ""
 
 #: corehq/apps/users/views/__init__.py

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -36018,32 +36018,24 @@ msgstr ""
 msgid "Copy and paste admin emails"
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain special characters."
-msgstr ""
-
-#: corehq/apps/users/util.py
+#: corehq/apps/users/validation.py
 msgid "Username is required."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain consecutive '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' is already taken or reserved."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not end with a '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' must be a valid email address."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' belonged to a user that was deleted and cannot be reused."
+#: corehq/apps/users/validation.py
+msgid "The username component '{}' of '{}' may not contain special characters."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' is already taken."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is reserved."
+#: corehq/apps/users/validation.py
+msgid "The username email domain '@{}' should be '@{}'."
 msgstr ""
 
 #: corehq/apps/users/views/__init__.py

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -37508,32 +37508,28 @@ msgstr "Êtes  vous certain de vouloir supprimer cette invitation?"
 msgid "Copy and paste admin emails"
 msgstr "Copier et coller des messages électroniques d'admin"
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain special characters."
-msgstr ""
-
-#: corehq/apps/users/util.py
+#: corehq/apps/users/validation.py
 msgid "Username is required."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain consecutive '.' (period)."
+#: corehq/apps/users/validation.py
+#, fuzzy
+#| msgid "Name '%s' is already taken."
+msgid "Username '{}' is already taken or reserved."
+msgstr "Le nom '%s' est déjà en cours d'utilisation."
+
+#: corehq/apps/users/validation.py
+#, fuzzy
+#| msgid "Please enter a valid email address."
+msgid "Username '{}' must be a valid email address."
+msgstr "Veuillez entrer une adresse mail valide."
+
+#: corehq/apps/users/validation.py
+msgid "The username component '{}' of '{}' may not contain special characters."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not end with a '.' (period)."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' belonged to a user that was deleted and cannot be reused."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is already taken."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is reserved."
+#: corehq/apps/users/validation.py
+msgid "The username email domain '@{}' should be '@{}'."
 msgstr ""
 
 #: corehq/apps/users/views/__init__.py

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -36018,32 +36018,24 @@ msgstr ""
 msgid "Copy and paste admin emails"
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain special characters."
-msgstr ""
-
-#: corehq/apps/users/util.py
+#: corehq/apps/users/validation.py
 msgid "Username is required."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain consecutive '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' is already taken or reserved."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not end with a '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' must be a valid email address."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' belonged to a user that was deleted and cannot be reused."
+#: corehq/apps/users/validation.py
+msgid "The username component '{}' of '{}' may not contain special characters."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' is already taken."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is reserved."
+#: corehq/apps/users/validation.py
+msgid "The username email domain '@{}' should be '@{}'."
 msgstr ""
 
 #: corehq/apps/users/views/__init__.py

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -36033,32 +36033,24 @@ msgstr ""
 msgid "Copy and paste admin emails"
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain special characters."
-msgstr ""
-
-#: corehq/apps/users/util.py
+#: corehq/apps/users/validation.py
 msgid "Username is required."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain consecutive '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' is already taken or reserved."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not end with a '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' must be a valid email address."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' belonged to a user that was deleted and cannot be reused."
+#: corehq/apps/users/validation.py
+msgid "The username component '{}' of '{}' may not contain special characters."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' is already taken."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is reserved."
+#: corehq/apps/users/validation.py
+msgid "The username email domain '@{}' should be '@{}'."
 msgstr ""
 
 #: corehq/apps/users/views/__init__.py

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -36294,32 +36294,24 @@ msgstr ""
 msgid "Copy and paste admin emails"
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain special characters."
-msgstr ""
-
-#: corehq/apps/users/util.py
+#: corehq/apps/users/validation.py
 msgid "Username is required."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain consecutive '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' is already taken or reserved."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not end with a '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' must be a valid email address."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' belonged to a user that was deleted and cannot be reused."
+#: corehq/apps/users/validation.py
+msgid "The username component '{}' of '{}' may not contain special characters."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' is already taken."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is reserved."
+#: corehq/apps/users/validation.py
+msgid "The username email domain '@{}' should be '@{}'."
 msgstr ""
 
 #: corehq/apps/users/views/__init__.py

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -36018,32 +36018,24 @@ msgstr ""
 msgid "Copy and paste admin emails"
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain special characters."
-msgstr ""
-
-#: corehq/apps/users/util.py
+#: corehq/apps/users/validation.py
 msgid "Username is required."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain consecutive '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' is already taken or reserved."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not end with a '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' must be a valid email address."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' belonged to a user that was deleted and cannot be reused."
+#: corehq/apps/users/validation.py
+msgid "The username component '{}' of '{}' may not contain special characters."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' is already taken."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is reserved."
+#: corehq/apps/users/validation.py
+msgid "The username email domain '@{}' should be '@{}'."
 msgstr ""
 
 #: corehq/apps/users/views/__init__.py

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -36024,32 +36024,24 @@ msgstr ""
 msgid "Copy and paste admin emails"
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain special characters."
-msgstr ""
-
-#: corehq/apps/users/util.py
+#: corehq/apps/users/validation.py
 msgid "Username is required."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not contain consecutive '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' is already taken or reserved."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' may not end with a '.' (period)."
+#: corehq/apps/users/validation.py
+msgid "Username '{}' must be a valid email address."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' belonged to a user that was deleted and cannot be reused."
+#: corehq/apps/users/validation.py
+msgid "The username component '{}' of '{}' may not contain special characters."
 msgstr ""
 
-#: corehq/apps/users/util.py
-msgid "Username '{}' is already taken."
-msgstr ""
-
-#: corehq/apps/users/util.py
-msgid "Username '{}' is reserved."
+#: corehq/apps/users/validation.py
+msgid "The username email domain '@{}' should be '@{}'."
 msgstr ""
 
 #: corehq/apps/users/views/__init__.py


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

### Quick Context
**Complete username**: `test-user@domain.commcarehq.org`, also referred to as email-formatted username
**Incomplete username**: `test-user`

### Issue/Mini-Retro
Prior to https://github.com/dimagi/commcare-hq/pull/31683, the mobile user API supported creating mobile users with either an incomplete or complete username, but did not have any validation around this. My original intention with that PR was to simply add validation for this existing feature which would have been safer to rollout to the existing API version. However towards the end of that PR I decided it would be best to remove support for specifying complete/email-formatted usernames as it made sense to have HQ handle this, and would simplify validation logic.

There was some talk of how this would impact users on the PR itself, so I looked for ways to figure out how users were currently using the API. I didn't have any meaningful findings from this, and at this point should have realized this breaking change should either be rolled out on a new API version, or in a way that doesn't suddenly drop support for complete usernames (deprecating first). Unfortunately I did not realize this, and went forward with that PR.

### Solution
Seeing as the downstream impact is still unknown, and support for this should have never been removed in this way, I'm adding support for complete usernames back to the mobile user API with validation included.

**Review by commit.**

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This expands support for mobile usernames back to where it was before introducing a breaking change. The riskiest part is an error in validation that prevents users from being able to properly create users via the API. Locally tested.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests around validation where needed.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Reverting this PR has the potential to break existing mobile user API use cases with regards to creating mobile users.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
