### PR TITLE
support 'indices.x' case search property filtering

### DIFF
--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -15,6 +15,7 @@ FUZZY_PROPERTIES = "fuzzy_properties"
 CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY = 'commcare_blacklisted_owner_ids'
 CASE_SEARCH_XPATH_QUERY_KEY = '_xpath_query'
 CASE_SEARCH_CASE_TYPE_KEY = "case_type"
+CASE_SEARCH_INDEX_KEY_PREFIX = "indices."
 
 # These use the `x_commcare_` prefix to distinguish them from 'filter' keys
 # This is a purely aesthetic distinction and not functional
@@ -70,6 +71,14 @@ class SearchCriteria:
     @property
     def is_ancestor_query(self):
         return '/' in self.key
+
+    @property
+    def is_index_query(self):
+        return self.key.startswith(CASE_SEARCH_INDEX_KEY_PREFIX)
+
+    @property
+    def index_query_identifier(self):
+        return self.key.removeprefix(CASE_SEARCH_INDEX_KEY_PREFIX)
 
     def get_date_range(self):
         """The format is __range__YYYY-MM-DD__YYYY-MM-DD"""

--- a/corehq/apps/case_search/tests/test_case_search_filters.py
+++ b/corehq/apps/case_search/tests/test_case_search_filters.py
@@ -184,3 +184,21 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
                 ['song'],
                 {'_xpath_query': "selected-all(3, 'New York Boston')"},
             )
+
+    def test_index_case_search(self):
+        self._create_case_search_config()
+        self._bootstrap_cases_in_es_for_domain(self.domain, [
+            {'_id': 'c1', 'foo': 'redbeard'},
+            {'_id': 'c2', 'case_type': 'child', 'index': {'parent': (self.case_type, 'c1')}},
+            {'_id': 'c3', 'case_type': 'child', 'index': {'parent': (self.case_type, 'c1')}},
+            {'_id': 'c4', 'case_type': 'child', 'index': {'host': (self.case_type, 'c1')}},
+        ])
+        actual = get_case_search_query(self.domain, ['child'], {
+            'indices.parent': ['c1'],
+        }).get_ids()
+        self.assertItemsEqual(actual, ['c2', 'c3'])
+
+        actual = get_case_search_query(self.domain, ['child'], {
+            'indices.host': ['c1'],
+        }).get_ids()
+        self.assertItemsEqual(actual, ['c4'])

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -30,6 +30,7 @@ from corehq.apps.es.case_search import (
     case_property_query,
     case_property_range_query,
     wrap_case_search_hit,
+    reverse_index_case_query,
 )
 from corehq.apps.registry.exceptions import (
     RegistryAccessException,
@@ -216,6 +217,8 @@ class CaseSearchQueryBuilder:
         if criteria.is_ancestor_query:
             query = f'{criteria.key} = "{value}"'
             return build_filter_from_xpath(self.query_domains, query, fuzzy=fuzzy)
+        elif criteria.is_index_query:
+            return reverse_index_case_query(value, criteria.index_query_identifier)
         else:
             return case_property_query(criteria.key, value, fuzzy=fuzzy)
 

--- a/corehq/apps/es/tests/utils.py
+++ b/corehq/apps/es/tests/utils.py
@@ -70,7 +70,7 @@ class ElasticTestMixin(object):
             index=TEST_INDEX_INFO.index,
             params={'explain': 'true'},
         )
-        self.assertTrue(validation['valid'])
+        self.assertTrue(validation['valid'], validation)
 
     def checkQuery(self, query, expected_json, is_raw_query=False, validate_query=True):
         self.maxDiff = None


### PR DESCRIPTION
## Product Description
This adds the ability to perform case search filtering using properties like `indices.parent` to perform parent filtering.

The current method of using `parent/@case_id` is much less efficient.

This is the first piece of work required to support parent filtering with case search in apps.

This work was prompted by https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/issue/SUPPORT-13843

## Technical Summary
Match `indices.x` to do an index filter on cases. This is the same syntax used by Case API v6.

## Feature Flag
Case search

## Safety Assurance

### Safety story
Adds a new case search filter. No changes to existing functionality. I also tested this locally.

### Automated test coverage
Added tests.

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
