### PR TITLE
[bugfix] Worker Activity Times Report throwing 500

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -320,7 +320,6 @@ def get_forms(domain, startdate, enddate, user_ids=None, app_ids=None, xmlnss=No
         FormES()
         .domain(domain)
         .filter(date_filter_fn(gte=startdate, lte=enddate))
-        .app(app_ids)
         .xmlns(xmlnss)
         .size(5000)
     )
@@ -329,6 +328,9 @@ def get_forms(domain, startdate, enddate, user_ids=None, app_ids=None, xmlnss=No
         query = (query
             .user_ids_handle_unknown(user_ids)
             .remove_default_filter('has_user'))
+
+    if app_ids:
+        query = query.app(app_ids)
 
     result = query.run()
     return PagedResult(total=result.total, hits=result.hits)

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1278,7 +1278,7 @@ class WorkerActivityTimes(WorkerMonitoringChartBase,
         users = _get_selected_users(self.domain, self.request)
         user_ids = [user.user_id for user in users]
         xmlnss = [form['xmlns'] for form in self.all_relevant_forms.values()]
-        app_ids = [form['app_id'] for form in self.all_relevant_forms.values()]
+        app_ids = [form['app_id'] for form in self.all_relevant_forms.values() if form['app_id']]
 
         paged_result = get_forms(
             self.domain,

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -166,6 +166,33 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self.assertEqual(paged_result.hits[0]['form']['meta']['userID'], user_id)
         self.assertEqual(paged_result.hits[0]['received_on'], '2013-07-02T00:00:00.000000Z')
 
+    def test_get_forms_with_empty_appid(self):
+        start = datetime(2013, 7, 1)
+        end = datetime(2013, 7, 30)
+        xmlns = 'http://a.b.org'
+        app_id = 'randmoappid'
+        user_id = 'abcd'
+
+        self._send_form_to_es(
+            app_id=app_id,
+            xmlns=xmlns,
+            received_on=datetime(2013, 7, 2),
+            user_id=user_id,
+        )
+
+        paged_result = get_forms(
+            self.domain,
+            start,
+            end,
+            user_ids=[user_id],
+            app_ids=[],
+            xmlnss=xmlns,
+        )
+        self.assertEqual(paged_result.total, 1)
+        self.assertEqual(paged_result.hits[0]['xmlns'], xmlns)
+        self.assertEqual(paged_result.hits[0]['form']['meta']['userID'], user_id)
+        self.assertEqual(paged_result.hits[0]['received_on'], '2013-07-02T00:00:00.000000Z')
+
     def test_get_form_ids_having_multimedia(self):
         start = datetime(2013, 7, 1)
         end = datetime(2013, 7, 30)

--- a/corehq/apps/reports/tests/test_worker_activity_times.py
+++ b/corehq/apps/reports/tests/test_worker_activity_times.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+import uuid
+from django.http.request import QueryDict
+from django.test import TestCase
+from django.test.client import RequestFactory
+import pytz
+from corehq.apps.reports.standard.monitoring import WorkerActivityTimes
+from corehq.form_processor.models.forms import XFormInstance
+from corehq.pillows.xform import transform_xform_for_elasticsearch
+from dimagi.utils.dates import DateSpan
+
+from pillowtop.es_utils import initialize_index_and_mapping
+
+from corehq.apps.users.models import (
+    CommCareUser,
+    WebUser,
+)
+from corehq.elastic import get_es_new, send_to_elasticsearch
+from corehq.pillows.mappings.xform_mapping import XFORM_INDEX, XFORM_INDEX_INFO
+
+from corehq.util.elastic import ensure_index_deleted
+
+
+class TestWorkerActivityTimesReport(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'worker-activity-time-test'
+        cls.user = WebUser(username='test_activity_report@cchq.com', domains=[cls.domain])
+        cls.request_factory = RequestFactory()
+
+        cls.form_list = [XFormInstance(**{
+            'form_id': str(uuid.uuid4()),
+            'domain': cls.domain,
+            'received_on': d,
+            'xmlns': 'http://openrosa.org/formdesigner/E17E4FC5',
+        }) for d in [datetime.now(), datetime.now() - timedelta(days=1)]]
+
+        user_uuid = str(uuid.uuid4())
+        dummy_user = {
+            '_id': user_uuid,
+            'domain': cls.domain,
+            'username': 'mobile-worker',
+            'password': 'Some secret Pass',
+            'created_by': None,
+            'created_via': None,
+            'email': 'mobileworker@commcarehq.com',
+            'is_active': True,
+            'doc_type': 'CommcareUser'
+        }
+        cls.user_obj = CommCareUser(**dummy_user)
+        cls.form_list = []
+        cls.es = get_es_new()
+        initialize_index_and_mapping(cls.es, XFORM_INDEX_INFO)
+        cls._send_forms_to_es()
+
+    def setUp(self):
+        super().setUp()
+        self.request = self.request_factory.get('')
+        self.request.couch_user = self.user
+        self.request.domain = self.domain
+        self.request.can_access_all_locations = True
+
+    @classmethod
+    def tearDownClass(cls):
+        ensure_index_deleted(XFORM_INDEX)
+        super().tearDownClass()
+
+    @classmethod
+    def _send_forms_to_es(cls):
+        for form in cls.form_list:
+            send_to_elasticsearch('forms', transform_xform_for_elasticsearch(form.to_json()))
+        cls.es.indices.refresh(XFORM_INDEX_INFO.index)
+
+    @patch('corehq.apps.reports.standard.monitoring._get_selected_users')
+    @patch('corehq.apps.reports.generic.get_timezone')
+    def test_activity_times_does_not_error(self, tz_patch, user_patch):
+        user_patch.return_value = [self.user_obj]
+        tz_patch.return_value = pytz.utc
+        q_dict = QueryDict('', mutable=True)
+        q_dict.update({
+            'filterSet': 'true',
+            'emw': 't__4',
+            'form_unknown': 'yes',
+            'form_unknown_xmlns': 'http://openrosa.org/formdesigner/E17E4FC5',
+            'form_status': 'active',
+            'form_app_id': '',
+            'form_module': '',
+            'form_xmlns': '',
+            'show_advanced': 'on',
+            'sub_time': ''
+        })
+        self.request.GET = q_dict
+        self.request.datespan = DateSpan.since(7)
+        data = WorkerActivityTimes(request=self.request, domain=self.domain).activity_times
+        self.assertEqual(len(data), 0)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SAAS-12705

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
In worker activity times Reports when we were trying to query Unknown Forms then it was [erroring](https://sentry.io/organizations/dimagi/issues/3355311197/?environment=production&query=is%3Aunresolved) out. The reason was `['None']` was being passed in ES query which was failing. I have added checks which would prevent this in future.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
Tested this on local
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
NA
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
