### PR TITLE
Es/eqa expression

### DIFF
--- a/custom/eqa/expressions.py
+++ b/custom/eqa/expressions.py
@@ -37,10 +37,10 @@ def get_yes_no(val):
         return 'N/A'
 
 
-@quickcache(['item', 'xmlns'])
-def get_two_last_forms(item, xmlns):
-    xforms_ids = CommCareCase.objects.get_case_xform_ids(item['_id'])
-    forms = XFormInstance.objects.get_forms(xforms_ids, item['domain'])
+@quickcache(['domain', 'case_id', 'xmlns'])
+def get_two_last_forms(domain, case_id, xmlns):
+    xforms_ids = CommCareCase.objects.get_case_xform_ids(case_id)
+    forms = XFormInstance.objects.get_forms(xforms_ids, domain)
     f_forms = [f for f in forms if f.xmlns == xmlns]
     s_forms = sorted(f_forms, key=lambda x: x.received_on)
 
@@ -64,7 +64,7 @@ class EQAExpressionSpec(JsonObject):
     xmlns = StringProperty()
 
     def __call__(self, item, evaluation_context=None):
-        curr_form, prev_form = get_two_last_forms(item, self.xmlns)
+        curr_form, prev_form = get_two_last_forms(item['domain'], item['_id'], self.xmlns)
 
         path_question = 'form/%s' % self.question_id
 
@@ -144,7 +144,7 @@ class EQAPercentExpression(JsonObject):
     xmlns = StringProperty()
 
     def __call__(self, item, evaluation_context=None):
-        curr_form, prev_form = get_two_last_forms(item, self.xmlns)
+        curr_form, prev_form = get_two_last_forms(item['domain'], item['_id'], self.xmlns)
 
         path_question = 'form/%s' % self.question_id
 

--- a/custom/eqa/expressions.py
+++ b/custom/eqa/expressions.py
@@ -1,9 +1,9 @@
-from corehq.apps.app_manager.models import Application
-from corehq.apps.userreports.specs import TypeProperty
-from corehq.form_processor.models import CommCareCase, XFormInstance
-from corehq.util.quickcache import quickcache
 from dimagi.ext.jsonobject import JsonObject, StringProperty
 
+from corehq.apps.app_manager.models import Application
+from corehq.apps.userreports.decorators import ucr_context_cache
+from corehq.apps.userreports.specs import TypeProperty
+from corehq.form_processor.models import CommCareCase, XFormInstance
 
 STATUSES = {
     (1, 0): "Improved",
@@ -37,8 +37,8 @@ def get_yes_no(val):
         return 'N/A'
 
 
-@quickcache(['domain', 'case_id', 'xmlns'])
-def get_two_last_forms(domain, case_id, xmlns):
+@ucr_context_cache(vary_on=('domain', 'case_id', 'xmlns',))
+def get_two_last_forms(domain, case_id, xmlns, evaluation_context):
     xforms_ids = CommCareCase.objects.get_case_xform_ids(case_id)
     forms = XFormInstance.objects.get_forms(xforms_ids, domain)
     f_forms = [f for f in forms if f.xmlns == xmlns]
@@ -64,7 +64,7 @@ class EQAExpressionSpec(JsonObject):
     xmlns = StringProperty()
 
     def __call__(self, item, evaluation_context=None):
-        curr_form, prev_form = get_two_last_forms(item['domain'], item['_id'], self.xmlns)
+        curr_form, prev_form = get_two_last_forms(item['domain'], item['_id'], self.xmlns, evaluation_context)
 
         path_question = 'form/%s' % self.question_id
 
@@ -144,7 +144,7 @@ class EQAPercentExpression(JsonObject):
     xmlns = StringProperty()
 
     def __call__(self, item, evaluation_context=None):
-        curr_form, prev_form = get_two_last_forms(item['domain'], item['_id'], self.xmlns)
+        curr_form, prev_form = get_two_last_forms(item['domain'], item['_id'], self.xmlns, evaluation_context)
 
         path_question = 'form/%s' % self.question_id
 


### PR DESCRIPTION
## Product Description
This should resolve a recurring error in generating some UCRs with a particular custom expression.

## Technical Summary
This has been throwing a 500 error when trying to assemble the quickcache key:
```Bad type "<class 'django.utils.functional.lazy.<locals>.__proxy__'>": []```

https://sentry.io/organizations/dimagi/issues/3372326722/
https://sentry.io/organizations/dimagi/issues/3319307493/

That looks to me like something in there is a to-be-translated proxy string.  We lazily include things like indices and transactions in the "JSON", and quickcache doesn't know how to serialize those promises.  The arg to the cache key is currently an entire case JSON, which seems excessive.  This PR switches it to cache this result in the UCR evaluation context.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
I don't have a great idea for testing this - there are no existing tests in the module, and I have no idea how to set up the appropriate data locally to try it out.  The developers who wrote this initially are no longer around for us to check with.  Still, this is a frequent hard failure on prod, so it's hard for me to imagine my change breaking any worse than that.  

I'm relying mostly on my own confidence of the code here, which I'm normally not very comfortable with, but it seems appropriate under the circumstances.

### Automated test coverage
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
