### PR TITLE
Do module-dependent form validations for shadow modules

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -329,7 +329,6 @@ class ModuleBaseValidator(object):
         This is the real validation logic, to be overridden/augmented by subclasses.
         '''
         errors = []
-        app = self.module.get_app()
         needs_case_detail = self.module.requires_case_details()
         needs_case_type = needs_case_detail or any(f.is_registration_form() for f in self.module.get_forms())
         if needs_case_detail or needs_case_type:
@@ -353,34 +352,7 @@ class ModuleBaseValidator(object):
 
         errors.extend(self.validate_parent_select())
 
-        if module_uses_smart_links(self.module):
-            if not self.module.session_endpoint_id:
-                errors.append({
-                    'type': 'smart links missing endpoint',
-                    'module': self.get_module_info(),
-                })
-            if self.module.parent_select.active:
-                errors.append({
-                    'type': 'smart links select parent first',
-                    'module': self.get_module_info(),
-                })
-            if self.module.is_multi_select():
-                errors.append({
-                    'type': 'smart links multi select',
-                    'module': self.get_module_info(),
-                })
-            if module_uses_inline_search(self.module):
-                errors.append({
-                    'type': 'smart links inline search',
-                    'module': self.get_module_info(),
-                })
-
-        if module_loads_registry_case(self.module):
-            if self.module.is_multi_select():
-                errors.append({
-                    'type': 'data registry multi select',
-                    'module': self.get_module_info(),
-                })
+        errors.extend(self.validate_smart_links())
 
         if self.module.root_module_id:
             root_module = self.module.get_app().get_module_by_unique_id(self.module.root_module_id)
@@ -474,6 +446,39 @@ class ModuleBaseValidator(object):
             if self.module.parent_select.relationship:
                 errors.append({
                     'type': 'inline search parent select relationship',
+                    'module': self.get_module_info(),
+                })
+
+        return errors
+
+    def validate_smart_links(self):
+        errors = []
+        if module_uses_smart_links(self.module):
+            if not self.module.session_endpoint_id:
+                errors.append({
+                    'type': 'smart links missing endpoint',
+                    'module': self.get_module_info(),
+                })
+            if self.module.parent_select.active:
+                errors.append({
+                    'type': 'smart links select parent first',
+                    'module': self.get_module_info(),
+                })
+            if self.module.is_multi_select():
+                errors.append({
+                    'type': 'smart links multi select',
+                    'module': self.get_module_info(),
+                })
+            if module_uses_inline_search(self.module):
+                errors.append({
+                    'type': 'smart links inline search',
+                    'module': self.get_module_info(),
+                })
+
+        if module_loads_registry_case(self.module):
+            if self.module.is_multi_select():
+                errors.append({
+                    'type': 'data registry multi select',
                     'module': self.get_module_info(),
                 })
 

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -349,18 +349,7 @@ class ModuleBaseValidator(object):
                     'module': self.get_module_info(),
                 })
 
-        uses_inline_search = module_uses_inline_search(self.module)
-        if self.module.put_in_root:
-            if self.module.session_endpoint_id:
-                errors.append({
-                    'type': 'endpoint to display only forms',
-                    'module': self.get_module_info(),
-                })
-            if uses_inline_search:
-                errors.append({
-                    'type': 'inline search to display only forms',
-                    'module': self.get_module_info(),
-                })
+        errors.extend(self.validate_display_only_forms())
 
         if hasattr(self.module, 'parent_select') and self.module.parent_select.active:
             if self.module.parent_select.relationship == 'parent':
@@ -384,7 +373,7 @@ class ModuleBaseValidator(object):
                         'module': self.get_module_info(),
                     })
 
-            if uses_inline_search:
+            if module_uses_inline_search(self.module):
                 if self.module.parent_select.relationship:
                     errors.append({
                         'type': 'inline search parent select relationship',
@@ -407,7 +396,7 @@ class ModuleBaseValidator(object):
                     'type': 'smart links multi select',
                     'module': self.get_module_info(),
                 })
-            if uses_inline_search:
+            if module_uses_inline_search(self.module):
                 errors.append({
                     'type': 'smart links inline search',
                     'module': self.get_module_info(),
@@ -463,6 +452,21 @@ class ModuleBaseValidator(object):
                     'form': form,
                 })
 
+        return errors
+
+    def validate_display_only_forms(self):
+        errors = []
+        if self.module.put_in_root:
+            if self.module.session_endpoint_id:
+                errors.append({
+                    'type': 'endpoint to display only forms',
+                    'module': self.get_module_info(),
+                })
+            if module_uses_inline_search(self.module):
+                errors.append({
+                    'type': 'inline search to display only forms',
+                    'module': self.get_module_info(),
+                })
         return errors
 
     def validate_detail_columns(self, detail):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1209,8 +1209,8 @@ class FormBase(DocumentSchema):
     def timing_context(self):
         return self.get_app().timing_context
 
-    def validate_for_build(self, validate_module=True):
-        return self.validator.validate_for_build(validate_module)
+    def validate_for_build(self):
+        return self.validator.validate_for_build()
 
     def get_unique_id(self):
         """

--- a/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
@@ -19,7 +19,6 @@ from corehq.util.test_utils import flag_enabled
 @patch.object(Application, 'enable_practice_users', return_value=False)
 class BuildErrorsInlineSearchTest(SimpleTestCase):
 
-    # TODO: add test for shadow
     def test_inline_search_as_parent(self, *args):
         """an inline search module can't be a parent module"""
         factory = AppFactory(build_version='2.51.0')

--- a/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
@@ -19,6 +19,7 @@ from corehq.util.test_utils import flag_enabled
 @patch.object(Application, 'enable_practice_users', return_value=False)
 class BuildErrorsInlineSearchTest(SimpleTestCase):
 
+    # TODO: add test for shadow
     def test_inline_search_as_parent(self, *args):
         """an inline search module can't be a parent module"""
         factory = AppFactory(build_version='2.51.0')


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2156

## Technical Summary
Validations for EOF nav depend on both the form's configuration and its module's configuration. Forms that appear in shadow menus are currently only being validated against their source module, but they should also be validated against the shadow menus.

## Feature Flag
Should only affect apps using shadow menus

## Safety Assurance

### Safety story
There's decent test coverage. There is some risk that apps that previous built will no loner build...but these should only be apps using EOF nav configuration that doesn't work (which, granted, it's possible they haven't noticed).

I'm considering writing a script to figure out if any apps will experience new build errors, haven't decided if this is necessary. Open to commentary. There are ~600 projects using shadow menus.

### Automated test coverage

There's moderate test coverage for build errors, at least enough to exercise the affected code, and this PR adds a test for the behavior change.

### QA Plan
Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
