### PR TITLE
add api throttle to more api views

### DIFF
--- a/corehq/apps/api/resources/messaging_event/view.py
+++ b/corehq/apps/api/resources/messaging_event/view.py
@@ -6,7 +6,7 @@ from tastypie.exceptions import BadRequest
 
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
-from corehq.apps.api.decorators import allow_cors
+from corehq.apps.api.decorators import allow_cors, api_throttle
 from corehq.apps.api.resources.messaging_event.filters import filter_query
 from corehq.apps.api.resources.messaging_event.pagination import get_paged_data
 from corehq.apps.api.resources.messaging_event.serializers import serialize_event
@@ -21,6 +21,7 @@ from corehq.apps.sms.models import MessagingSubEvent, SMS, Email
 @api_auth
 @require_can_edit_data
 @requires_privilege_with_fallback(privileges.API_ACCESS)
+@api_throttle
 def messaging_events(request, domain, event_id=None):
     """Despite it's name this API is backed by the MessagingSubEvent model
     which has a more direct relationship with who the messages are being sent to.

--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -7,6 +7,7 @@ from couchdbkit.exceptions import DocTypeError, ResourceNotFound
 from dimagi.ext.couchdbkit import Document
 from soil import FileDownload
 
+from corehq.apps.api.decorators import api_throttle
 from corehq.apps.app_manager.views.utils import get_langs, report_build_time
 from corehq.apps.domain.decorators import api_auth
 from corehq.apps.domain.models import Domain
@@ -25,6 +26,7 @@ from ..dbaccessors import (
 
 @json_error
 @api_auth
+@api_throttle
 def list_apps(request, domain):
     def app_to_json(app):
         return {

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -32,6 +32,7 @@ from soil import CachedDownload, DownloadBase
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
 
+from corehq.apps.api.decorators import api_throttle
 from corehq.apps.domain.decorators import api_auth, login_and_domain_required
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.fixtures.dispatcher import require_can_edit_fixtures
@@ -430,6 +431,7 @@ class AsyncUploadFixtureAPIResponse(UploadFixtureAPIResponse):
 @require_POST
 @api_auth
 @require_can_edit_fixtures
+@api_throttle
 def upload_fixture_api(request, domain, **kwargs):
     """
         Use following curl-command to test.

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -50,6 +50,7 @@ from corehq.apps.analytics.tasks import (
     track_workflow,
     update_hubspot_properties,
 )
+from corehq.apps.api.decorators import api_throttle
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.util import purge_report_from_mobile_ucr
 from corehq.apps.change_feed.data_sources import (
@@ -1482,6 +1483,7 @@ def process_url_params(params, columns):
 @api_auth_with_scope(['reports:view'])
 @require_permission(HqPermissions.view_reports)
 @swallow_programming_errors
+@api_throttle
 def export_data_source(request, domain, config_id):
     """See README.rst for docs"""
     config, _ = get_datasource_config_or_404(config_id, domain)


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This builds on https://github.com/dimagi/commcare-hq/pull/31535 to apply the limits to even more APIs. I intentionally left out any api used by hq (most upload and download status urls, as well as the case and form attachments used by the case and form details reports).

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect. This brings them into agreement with our public descriptions of usage limits.

In particular consider how existing data may be impacted by this change.
-->
This decorator is already in use, and the newly limited apis should all be limited anyway.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
