### PR TITLE
Save confirmation link expiry value to DB

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -534,6 +534,7 @@ class DomainGlobalSettingsForm(forms.Form):
         domain.project_description = self.cleaned_data['project_description']
         domain.default_mobile_ucr_sync_interval = self.cleaned_data.get('mobile_ucr_sync_interval', None)
         domain.default_geocoder_location = self.cleaned_data.get('default_geocoder_location')
+        domain.confirmation_link_expiry_time = self.cleaned_data['confirmation_link_expiry']
         try:
             self._save_logo_configuration(domain)
         except IOError as err:

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -534,7 +534,7 @@ class DomainGlobalSettingsForm(forms.Form):
         domain.project_description = self.cleaned_data['project_description']
         domain.default_mobile_ucr_sync_interval = self.cleaned_data.get('mobile_ucr_sync_interval', None)
         domain.default_geocoder_location = self.cleaned_data.get('default_geocoder_location')
-        domain.confirmation_link_expiry_time = self.cleaned_data['confirmation_link_expiry']
+        domain.confirmation_link_expiry_time = self.cleaned_data.get('confirmation_link_expiry')
         try:
             self._save_logo_configuration(domain)
         except IOError as err:

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -441,7 +441,8 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     # seconds between sending mobile UCRs to users. Can be overridden per user
     default_mobile_ucr_sync_interval = IntegerProperty()
 
-    confirmation_link_expiry_time = IntegerProperty(default=168)
+    # Number of hours SMS confirmation link will be valid (default 1 week)
+    confirmation_link_expiry_time = IntegerProperty(default=7 * 24)
 
     ga_opt_out = BooleanProperty(default=False)
 

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -1,7 +1,11 @@
-from django.test import SimpleTestCase
-from unittest.mock import patch
+from django.test import SimpleTestCase, TestCase
+from unittest.mock import Mock, patch
+from corehq.apps.domain.models import Domain
 
-from ..forms import PrivacySecurityForm
+from corehq.toggles import NAMESPACE_DOMAIN, TWO_STAGE_USER_PROVISIONING_BY_SMS
+from corehq.toggles.shortcuts import set_toggle
+
+from ..forms import DomainGlobalSettingsForm, PrivacySecurityForm
 from .. import forms
 
 
@@ -54,3 +58,56 @@ class PrivacySecurityFormTests(SimpleTestCase):
     def get_visible_fields(self, form):
         fieldset = form.helper.layout.fields[0]
         return [field[0] for field in fieldset.fields]
+
+
+class TestDomainGlobalSettingsForm(TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.domain = Domain(name='test_domain')
+        self.domain.save()
+
+    def test_confirmation_link_expiry_not_present_when_flag_not_set(self):
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, False, namespace=NAMESPACE_DOMAIN)
+        form = self.create_form()
+        self.assertTrue('confirmation_link_expiry' not in form.fields)
+
+    def test_confirmation_link_expiry_default_present_when_flag_set(self):
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, True, namespace=NAMESPACE_DOMAIN)
+        form = self.create_form(confirmation_link_expiry=self.domain.confirmation_link_expiry_time)
+        form.full_clean()
+        form.save(Mock(), self.domain)
+        self.assertTrue('confirmation_link_expiry' in form.fields)
+        self.assertEqual(168, self.domain.confirmation_link_expiry_time)
+
+    def test_confirmation_link_expiry_custom_present_when_flag_set(self):
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, True, namespace=NAMESPACE_DOMAIN)
+        form = self.create_form(confirmation_link_expiry=100)
+        form.full_clean()
+        form.save(Mock(), self.domain)
+        self.assertTrue('confirmation_link_expiry' in form.fields)
+        self.assertEqual(100, self.domain.confirmation_link_expiry_time)
+
+    def test_confirmation_link_expiry_error_when_invalid_value(self):
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, True, namespace=NAMESPACE_DOMAIN)
+        form = self.create_form(confirmation_link_expiry='abc')
+        form.full_clean()
+        self.assertIsNotNone(form.errors)
+        self.assertEqual(1, len(form.errors))
+        self.assertEqual(['Enter a whole number.'], form.errors.get("confirmation_link_expiry"))
+
+    def create_form(self, **kwargs):
+        data = {
+            "hr_name": "foo",
+            "project_description": "sample",
+            "default_timezone": "UTC",
+        }
+        if kwargs:
+            for field, value in kwargs.items():
+                data.update({field: value})
+        return DomainGlobalSettingsForm(data, domain=self.domain)
+
+    def tearDown(self):
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, "test_domain", False, namespace=NAMESPACE_DOMAIN)
+        self.domain.delete()
+        super().tearDown()

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -108,6 +108,6 @@ class TestDomainGlobalSettingsForm(TestCase):
         return DomainGlobalSettingsForm(data, domain=self.domain)
 
     def tearDown(self):
-        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, "test_domain", False, namespace=NAMESPACE_DOMAIN)
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, False, namespace=NAMESPACE_DOMAIN)
         self.domain.delete()
         super().tearDown()


### PR DESCRIPTION
## Product Description
Changes made to expiry field is not saved into DB and always using the default value.
<img width="993" alt="image" src="https://user-images.githubusercontent.com/14318173/175943410-1cd16c2e-b5a5-4a2a-aad6-18bc2840d188.png">

## Technical Summary
Added saving logic to Form.save() before Domain.save() is called

## Feature Flag
TWO_STAGE_USER_PROVISIONING_BY_SMS

## Safety Assurance

### Safety story
Local testing

### Automated test coverage
Unit tests

### QA Plan
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
