### PR TITLE
Removed try/catch layer in linked domain release app

### DIFF
--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -141,23 +141,18 @@ The following linked project spaces received content:
 
         app_id = model['detail']['app_id']
         found = False
-        error_prefix = ""
-        try:
-            for linked_app in get_apps_in_domain(domain_link.linked_domain, include_remote=False):
-                if is_linked_app(linked_app) and linked_app.family_id == app_id:
-                    found = True
-                    app = update_linked_app(linked_app, app_id, user.user_id)
+        for linked_app in get_apps_in_domain(domain_link.linked_domain, include_remote=False):
+            if is_linked_app(linked_app) and linked_app.family_id == app_id:
+                found = True
+                app = update_linked_app(linked_app, app_id, user.user_id)
 
-            if not found:
-                return self._error_tuple(_("Could not find app"))
+        if not found:
+            return self._error_tuple(_("Could not find app"))
 
-            if build_and_release:
-                error_prefix = _("Updated app but did not build or release: ")
-                build = app.make_build()
-                build.is_released = True
-                build.save(increment_version=False)
-        except Exception as e:  # intentionally broad
-            return self._error_tuple(error_prefix + str(e))
+        if build_and_release:
+            build = app.make_build()
+            build.is_released = True
+            build.save(increment_version=False)
 
     def _release_report(self, domain_link, model, user_id):
         report_id = model['detail']['report_id']

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -22849,10 +22849,6 @@ msgid "Could not find app"
 msgstr ""
 
 #: corehq/apps/linked_domain/tasks.py
-msgid "Updated app but did not build or release: "
-msgstr ""
-
-#: corehq/apps/linked_domain/tasks.py
 msgid "Feature flag for {} is not enabled"
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -23871,10 +23871,6 @@ msgid "Could not find app"
 msgstr ""
 
 #: corehq/apps/linked_domain/tasks.py
-msgid "Updated app but did not build or release: "
-msgstr ""
-
-#: corehq/apps/linked_domain/tasks.py
 msgid "Feature flag for {} is not enabled"
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -22850,10 +22850,6 @@ msgid "Could not find app"
 msgstr ""
 
 #: corehq/apps/linked_domain/tasks.py
-msgid "Updated app but did not build or release: "
-msgstr ""
-
-#: corehq/apps/linked_domain/tasks.py
 msgid "Feature flag for {} is not enabled"
 msgstr ""
 

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -23766,10 +23766,6 @@ msgid "Could not find app"
 msgstr ""
 
 #: corehq/apps/linked_domain/tasks.py
-msgid "Updated app but did not build or release: "
-msgstr ""
-
-#: corehq/apps/linked_domain/tasks.py
 msgid "Feature flag for {} is not enabled"
 msgstr ""
 

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -22850,10 +22850,6 @@ msgid "Could not find app"
 msgstr ""
 
 #: corehq/apps/linked_domain/tasks.py
-msgid "Updated app but did not build or release: "
-msgstr ""
-
-#: corehq/apps/linked_domain/tasks.py
 msgid "Feature flag for {} is not enabled"
 msgstr ""
 

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -22863,10 +22863,6 @@ msgid "Could not find app"
 msgstr ""
 
 #: corehq/apps/linked_domain/tasks.py
-msgid "Updated app but did not build or release: "
-msgstr ""
-
-#: corehq/apps/linked_domain/tasks.py
 msgid "Feature flag for {} is not enabled"
 msgstr ""
 

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -23018,10 +23018,6 @@ msgid "Could not find app"
 msgstr ""
 
 #: corehq/apps/linked_domain/tasks.py
-msgid "Updated app but did not build or release: "
-msgstr ""
-
-#: corehq/apps/linked_domain/tasks.py
 msgid "Feature flag for {} is not enabled"
 msgstr ""
 

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -22850,10 +22850,6 @@ msgid "Could not find app"
 msgstr ""
 
 #: corehq/apps/linked_domain/tasks.py
-msgid "Updated app but did not build or release: "
-msgstr ""
-
-#: corehq/apps/linked_domain/tasks.py
 msgid "Feature flag for {} is not enabled"
 msgstr ""
 

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -22854,10 +22854,6 @@ msgid "Could not find app"
 msgstr ""
 
 #: corehq/apps/linked_domain/tasks.py
-msgid "Updated app but did not build or release: "
-msgstr ""
-
-#: corehq/apps/linked_domain/tasks.py
 msgid "Feature flag for {} is not enabled"
 msgstr ""
 


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2202

Error in https://github.com/dimagi/commcare-hq/pull/27878/

This function, `_release_app`, is one of several helpers called in [this block](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/linked_domain/tasks.py#L243-L255). The other helpers only return user-facing, expected errors (e.g., feature flag not turned on).

Removing the try/catch in `_release_app` lets any exceptions be caught instead by the try/catch above, which also sends them to sentry. `_release_app` had its own try/catch for the sake of being able to tell the user whether the error occurred while updating the app or releasing it. In practice, this isn't a useful enough distinction to justify the extra complexity. Whether the error in the update or the build/release, the user needs to address and re-push.

## Feature Flag
Linked domains

## Safety Assurance

### Safety story
Limited change. Smoke tested the new code locally.

### Automated test coverage

Not of this particular line.

### QA Plan

Not requesting QA.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change