### PR TITLE
Call clear_login_attempts after resetting mobile user password

### DIFF
--- a/corehq/apps/users/tests/forms.py
+++ b/corehq/apps/users/tests/forms.py
@@ -3,7 +3,9 @@ from collections import namedtuple
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.forms import SetUserPasswordForm
+from corehq.apps.users.models import CommCareUser
 
 Project = namedtuple('Project', ['name', 'strong_mobile_passwords'])
 
@@ -56,3 +58,36 @@ class TestWeakSetUserPasswordForm(TestCase):
     def test_strong_password(self):
         form = self.form("TaylorSwift89!")
         self.assertTrue(form.is_valid())
+
+
+class TestSetMobileUserPasswordForm(TestCase):
+
+    def test_login_attempts_are_cleared_after_reset(self):
+        self.mobile_user.login_attempts = 10
+        self.mobile_user.save()
+
+        form = self.form("TaylorSwift89!")
+        form.full_clean()
+        form.save()
+
+        refetched_user = CommCareUser.get_by_username('test-user')
+        self.assertEqual(0, refetched_user.login_attempts)
+
+    def form(self, password):
+        django_user = self.mobile_user.get_django_user()
+        return SetUserPasswordForm(self.domain_obj, user_id=django_user.id, user=django_user, data={
+            "new_password1": password,
+            "new_password2": password,
+        })
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-domain'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+
+    def setUp(self):
+        super().setUp()
+        self.mobile_user = CommCareUser.create(self.domain, 'test-user', 'abc123', None, None)
+        self.addCleanup(self.mobile_user.delete, self.domain, deleted_by=None)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13520

Currently, if a web user resets a mobile user's password via HQ, the mobile user's `login_attempts` field is not reset to 0. This means if the mobile user is locked out, they are still unable to login without a developer resetting the `login_attempts` field on that user. This change clears login attempts after the reset password for a mobile user form is saved.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added automated test to ensure login attempts are reset after saving form.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
