### PR TITLE
Replace soft with hard delete for cases and forms

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -7,6 +7,8 @@ from django.contrib.auth.models import User
 from django.db import transaction
 from django.db.models import Q
 
+from dimagi.utils.chunked import chunked
+
 from corehq.apps.accounting.models import Subscription
 from corehq.apps.accounting.utils import get_change_status
 from corehq.apps.userreports.dbaccessors import (
@@ -14,13 +16,15 @@ from corehq.apps.userreports.dbaccessors import (
 )
 from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.dbaccessors import get_all_commcare_users_by_domain
-from corehq.apps.users.util import log_user_change, SYSTEM_USER_ID
+from corehq.apps.users.util import SYSTEM_USER_ID, log_user_change
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.models import BlobMeta
 from corehq.elastic import ESError
 from corehq.form_processor.models import CommCareCase, XFormInstance
-from corehq.sql_db.util import get_db_aliases_for_partitioned_query, paginate_query_across_partitioned_databases
-from dimagi.utils.chunked import chunked
+from corehq.sql_db.util import (
+    get_db_aliases_for_partitioned_query,
+    paginate_query_across_partitioned_databases,
+)
 from settings import HQ_ACCOUNT_ROOT
 
 logger = logging.getLogger(__name__)

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -167,6 +167,7 @@ def _terminate_subscriptions(domain_name):
 def delete_all_cases(domain_name):
     logger.info('Deleting cases...')
     case_ids = CommCareCase.objects.get_case_ids_in_domain(domain_name)
+    case_ids += CommCareCase.objects.get_deleted_case_ids_in_domain(domain_name)
     for case_id_chunk in chunked(with_progress_bar(case_ids, stream=silence_during_tests()), 500):
         CommCareCase.objects.hard_delete_cases(domain_name, list(case_id_chunk))
     logger.info('Deleting cases complete.')
@@ -178,6 +179,7 @@ def delete_all_forms(domain_name):
         XFormInstance.objects.get_form_ids_in_domain(domain_name, doc_type)
         for doc_type in doc_type_to_state
     ]))
+    form_ids += XFormInstance.objects.get_deleted_form_ids_in_domain(domain_name)
     for form_id_chunk in chunked(with_progress_bar(form_ids, stream=silence_during_tests()), 500):
         XFormInstance.objects.hard_delete_forms(domain_name, list(form_id_chunk))
     logger.info('Deleting forms complete.')

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -164,22 +164,22 @@ def _terminate_subscriptions(domain_name):
         ).update(is_hidden_to_ops=True)
 
 
-def _delete_all_cases(domain_name):
+def delete_all_cases(domain_name):
     logger.info('Deleting cases...')
     case_ids = CommCareCase.objects.get_case_ids_in_domain(domain_name)
     for case_id_chunk in chunked(with_progress_bar(case_ids, stream=silence_during_tests()), 500):
-        CommCareCase.objects.soft_delete_cases(domain_name, list(case_id_chunk))
+        CommCareCase.objects.hard_delete_cases(domain_name, list(case_id_chunk))
     logger.info('Deleting cases complete.')
 
 
-def _delete_all_forms(domain_name):
+def delete_all_forms(domain_name):
     logger.info('Deleting forms...')
     form_ids = list(itertools.chain(*[
         XFormInstance.objects.get_form_ids_in_domain(domain_name, doc_type)
         for doc_type in doc_type_to_state
     ]))
     for form_id_chunk in chunked(with_progress_bar(form_ids, stream=silence_during_tests()), 500):
-        XFormInstance.objects.soft_delete_forms(domain_name, list(form_id_chunk))
+        XFormInstance.objects.hard_delete_forms(domain_name, list(form_id_chunk))
     logger.info('Deleting forms complete.')
 
 
@@ -271,8 +271,8 @@ DOMAIN_DELETE_OPERATIONS = [
     CustomDeletion('sms', _delete_domain_backends, ['SQLMobileBackend']),
     CustomDeletion('users', _delete_web_user_membership, []),
     CustomDeletion('accounting', _terminate_subscriptions, ['Subscription']),
-    CustomDeletion('form_processor', _delete_all_cases, ['CommCareCase']),
-    CustomDeletion('form_processor', _delete_all_forms, ['XFormInstance']),
+    CustomDeletion('form_processor', delete_all_cases, ['CommCareCase']),
+    CustomDeletion('form_processor', delete_all_forms, ['XFormInstance']),
     ModelDeletion('aggregate_ucrs', 'AggregateTableDefinition', 'domain', [
         'PrimaryColumn', 'SecondaryColumn', 'SecondaryTableDefinition', 'TimeAggregationDefinition',
     ]),

--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -3,11 +3,9 @@ import textwrap
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 
-from dimagi.utils.chunked import chunked
 
 from corehq.apps.domain.dbaccessors import iter_all_domains_and_deleted_domains_with_name
 from corehq.apps.domain.utils import silence_during_tests
-from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.sql_db.util import (
     estimate_partitioned_row_count,
     paginate_query_across_partitioned_databases,
@@ -50,8 +48,6 @@ class Command(BaseCommand):
             if confirm != domain_name:
                 print("\n\t\tDomain deletion cancelled.")
                 return
-        self.hard_delete_cases(domain_name)
-        self.hard_delete_forms(domain_name)
         print(f"Soft-Deleting domain {domain_name} "
               "(i.e. switching its type to Domain-Deleted, "
               "which will prevent anyone from reusing that domain)")
@@ -59,20 +55,6 @@ class Command(BaseCommand):
             assert domain_obj.name == domain_name  # Just to be really sure!
             domain_obj.delete(leave_tombstone=True)
         print("Operation completed")
-
-    @staticmethod
-    def hard_delete_cases(domain_name):
-        print("Hard-deleting cases...")
-        case_ids = iter_ids(CommCareCase, 'case_id', domain_name)
-        for chunk in chunked(case_ids, 1000, list):
-            CommCareCase.objects.hard_delete_cases(domain_name, chunk)
-
-    @staticmethod
-    def hard_delete_forms(domain_name):
-        print("Hard-deleting forms...")
-        form_ids = iter_ids(XFormInstance, 'form_id', domain_name)
-        for chunk in chunked(form_ids, 1000, list):
-            XFormInstance.objects.hard_delete_forms(domain_name, chunk)
 
 
 def iter_ids(model_class, field, domain, chunk_size=1000):

--- a/corehq/apps/domain/management/commands/hard_delete_forms_and_cases_in_domain.py
+++ b/corehq/apps/domain/management/commands/hard_delete_forms_and_cases_in_domain.py
@@ -2,7 +2,7 @@ import logging
 
 from django.core.management import BaseCommand
 
-from .delete_domain import Command as delete_domain
+from ...deletion import delete_all_cases, delete_all_forms
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +33,6 @@ class Command(BaseCommand):
                 print("\n\t\tDomain deletion cancelled.")
                 return
 
-        delete_domain.hard_delete_cases(domain)
-        delete_domain.hard_delete_forms(domain)
+        delete_all_cases(domain)
+        delete_all_forms(domain)
         logger.info('Done.')


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Related to https://dimagi-dev.atlassian.net/browse/SAAS-13488

Followup to https://github.com/dimagi/commcare-hq/pull/31805. Given that when deleting a domain, we now hard delete forms and cases first which renders the soft deletes in `DOMAIN_DELETE_OPERATIONS` no-ops, it seems we can replace the soft deletes with the hard deletes. This simplifies the delete_domain command, and ensures that any time a domain is deleted, all forms and cases associated with that domain are hard deleted.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
