### PR TITLE
Export-audit-data Management Command: Change arg type

### DIFF
--- a/corehq/apps/auditcare/management/commands/export_audit_data.py
+++ b/corehq/apps/auditcare/management/commands/export_audit_data.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from corehq.util.argparse_types import date_type
+import dateutil.parser
 
 from ...utils.export import write_export_from_all_log_events
 
@@ -14,14 +14,14 @@ class Command(BaseCommand):
             '-s',
             '--startdate',
             dest='start',
-            type=date_type,
+            type=dateutil.parser.parse,
             help="The start date - format YYYY-MM-DD",
         )
         parser.add_argument(
             '-e',
             '--enddate',
             dest='end',
-            type=date_type,
+            type=dateutil.parser.parse,
             help="The end date - format YYYY-MM-DD",
         )
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
For interrupt I'm running the `export-audit-data` command but ran into a `AttributeError: 'datetime.date' object has no attribute 'date'` at `line 134, in get_date_range_where where["event_date__gt"] = start_date.date()`

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is happening because the type is already a `datetime.date` and that line is calling `date()`. Instead I made the type a `datetime.datetime` object that will corrently be the `datetime.date` object when that line is called.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change is isolated to a management command that is doing querying

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
