### PR TITLE
Remove ASCII whitespace characters from filename

### DIFF
--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -105,7 +105,7 @@ class DownloadBase(object):
         headers and causes the download to fail.
         """
         if isinstance(content_disposition, str):
-            return re.compile('[\r\n]').sub('', content_disposition)
+            return re.sub(r'[\t\n\v\f\r]', '', content_disposition)
 
         return content_disposition
 

--- a/corehq/util/files.py
+++ b/corehq/util/files.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import re
 from six.moves.urllib.parse import quote
 from text_unidecode import unidecode
 
@@ -36,8 +37,9 @@ def safe_filename_header(filename, extension=None):
     # and http://greenbytes.de/tech/tc2231/#attfnboth as a solution to disastrous browser compatibility
     filename = safe_filename(filename, extension)
     ascii_filename = unidecode(filename)
+    header_filename = re.sub(r'[\t\n\v\f\r]', '', ascii_filename)
     return 'attachment; filename="{}"; filename*=UTF-8\'\'{}'.format(
-        ascii_filename, quote(filename.encode('utf8')))
+        header_filename, quote(filename.encode('utf8')))
 
 
 class TransientTempfile(object):


### PR DESCRIPTION
Remove all ASCII whitespace characters (except space) from filename
when used for the 'Content-Disposition' HTTP header.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-13241

## Safety Assurance

### Safety story
The change has been tested on staging and works as expected.

### Automated test coverage
This impacts Nginx, so test coverage doesn't seem useful or practical.

### QA Plan
I believe the scope of the change, which expands in a limited way an existing function,
and the manual testing performed are sufficient to rule out possible regressions.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
