### PR TITLE
Ignore formdesigner submodule for translations

### DIFF
--- a/scripts/make-translations.sh
+++ b/scripts/make-translations.sh
@@ -6,10 +6,10 @@ function abort () {
 }
 
 echo "Gathering all translation strings.  Note that this will probably take a while"
-./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs/_build' --ignore 'coverage-report' --add-location file "$@"
+./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs/_build' --ignore 'coverage-report' --ignore 'submodules/formdesigner' --add-location file "$@"
 
 echo "Gathering javascript translation strings.  This will also probably take a while"
-./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs' --ignore 'coverage-report' --add-location file "$@"
+./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs' --ignore 'coverage-report' --ignore 'submodules/formdesigner' --add-location file "$@"
 
 echo "Compiling translation files."
 if ! ./manage.py compilemessages; then


### PR DESCRIPTION
## Product Description
This fixes translation inconsistencies for users that had their local vellum/formdesigner set up with a symlink vs an actual folder.

## Technical Summary
[Original ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13700)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
This is a fix for an existing issue preventing some people from pushing PRs.  If this has additional effects, those users will be unable to push PRs themselves, and we can iron it out. However, my own local testing suggests that symlinks were only used for the vellum/formdesigner submodule, so this is a pretty limited change.

### Automated test coverage

No tests

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
