### PR TITLE
make answer value of AddressEntry a stringified geocoder broadcast obj

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -264,7 +264,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             self.broadcastTopics.forEach(function (broadcastTopic) {
                 question.parentPubSub.notifySubscribers(broadcastObj, broadcastTopic);
             });
-            if ((!broadcastObj || _.isEmpty(broadcastObj)) && question.answer()) {
+            if (_.isEmpty(broadcastObj)) {
                 question.answer(Const.NO_ANSWER);
             } else {
                 question.answer(JSON.stringify(broadcastObj));

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -260,10 +260,14 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.geocoderItemCallback = function (item) {
             self.rawAnswer(item.place_name);
             self.editing = false;
+            var broadcastObj = Utils.getBroadcastObject(item);
             self.broadcastTopics.forEach(function (broadcastTopic) {
-                var broadcastObj = Utils.getBroadcastObject(item);
                 question.parentPubSub.notifySubscribers(broadcastObj, broadcastTopic);
             });
+            question.answer(JSON.stringify(broadcastObj));
+            if (!question.answer()) {
+                question.answer("");
+            }
             // The default full address returned to the search bar
             return item.place_name;
         };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -264,7 +264,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             self.broadcastTopics.forEach(function (broadcastTopic) {
                 question.parentPubSub.notifySubscribers(broadcastObj, broadcastTopic);
             });
-            if (_.isEmpty(broadcastObj) && question.answer()) {
+            if ((!broadcastObj || _.isEmpty(broadcastObj)) && question.answer()) {
                 question.answer(Const.NO_ANSWER);
             } else {
                 question.answer(JSON.stringify(broadcastObj));

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -237,7 +237,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
      * The entry that represents an address entry.
      * Takes in a `broadcastStyles` list of strings in format `broadcast-<topic>` to broadcast
      * the address item that is selected. Item contains `full`, `street`, `city`, `us_state`, `us_state_long`,
-     * `zipcode`, `country`, `country_short`, `region`.
+     * `postcode`, `zipcode`, `district`, `county`, `country`, `country_short`, `region`.
      */
     function AddressEntry(question, options) {
         var self = this;
@@ -264,9 +264,10 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             self.broadcastTopics.forEach(function (broadcastTopic) {
                 question.parentPubSub.notifySubscribers(broadcastObj, broadcastTopic);
             });
-            question.answer(JSON.stringify(broadcastObj));
-            if (!question.answer()) {
-                question.answer("");
+            if (_.isEmpty(broadcastObj) && question.answer()) {
+                question.answer(Const.NO_ANSWER);
+            } else {
+                question.answer(JSON.stringify(broadcastObj));
             }
             // The default full address returned to the search bar
             return item.place_name;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
no visible changes to UI
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This change sets the value of the answer to an AddressEntry question to a stringified geocoder broadcast object.
The question value can be accessed via an xpath function implemented in this [related PR](https://github.com/dimagi/commcare-core/pull/1122) and used in a hidden question in a form.
[spec](https://docs.google.com/document/d/1v2AziWCpVI8MO8FTmEapUYwoN9rmYTQbjt-MlEWJcdU/edit#)
[jira ticket](https://dimagi-dev.atlassian.net/browse/USH-1947)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-4307

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
