### PR TITLE
Avoid overlapping choice text

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -42,6 +42,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     // Checkbox questions in a Question List Group.
     Entry.prototype.getColStyle = function (numChoices) {
         var colWidth = parseInt(12 / (numChoices + 1)) || 1;
+        colWidth = colWidth >= 3 ? colWidth : 3;
         return 'col-xs-' + colWidth;
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -41,6 +41,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     // Allows multiple input entries on the same row for Combined Multiple Choice and Combined
     // Checkbox questions in a Question List Group.
     Entry.prototype.getColStyle = function (numChoices) {
+        // Account for number of choices plus column for clear button
         var colWidth = parseInt(12 / (numChoices + 1)) || 1;
         return 'col-xs-' + colWidth;
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -42,7 +42,6 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     // Checkbox questions in a Question List Group.
     Entry.prototype.getColStyle = function (numChoices) {
         var colWidth = parseInt(12 / (numChoices + 1)) || 1;
-        colWidth = colWidth >= 3 ? colWidth : 3;
         return 'col-xs-' + colWidth;
     };
 

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -488,7 +488,7 @@
 <script type="text/html" id="choice-label-entry-ko-template">
   <div class="row">
     <!-- ko foreach: choices -->
-      <div data-bind="attr: { 'class': $parent.colStyle }">
+      <div data-bind="attr: { 'class': $parent.colStyle }, style: { 'word-wrap': 'break-word' }">
         <!-- ko if: $parent.hideLabel -->
           <input type="radio" data-bind="
                 checked: $parent.rawAnswer,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12811

This feels like there is no right answer. Currently, we wrap text only at whitespace, so if there is a long word in the choice text, it will run into the next column space and overlap with that text. I think the ideal solution is some combo of limiting minimum column size to 3 instead of 1 to give this some breathing room, and potentially a more strict word wrap whenever needed. 

That results in something like:

![Screen Shot 2022-06-30 at 8 43 48 AM](https://user-images.githubusercontent.com/15785053/176721110-eb9008d0-3dc5-403c-9e5e-2c42af2d33c5.png)

The downside of this is if we add another choice, the multi-line wrapping of the long choice impacts where the next row starts to add columns:

![Screen Shot 2022-06-30 at 8 44 38 AM](https://user-images.githubusercontent.com/15785053/176721241-d9363a14-dbc7-4b70-b9ec-544e3405d126.png)
## Feature Flag

<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Locally tested.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
UI change.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
