### PR TITLE
Fixed case search config page 500

### DIFF
--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -377,21 +377,21 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
     def page_context(self):
         apps = get_apps_in_domain(self.domain, include_remote=False)
         case_types = {t for app in apps for t in app.get_case_types() if t}
-        current_values = CaseSearchConfig.objects.get_or_none(pk=self.domain)
+        config = CaseSearchConfig.objects.get_or_none(pk=self.domain) or CaseSearchConfig(domain=self.domain)
         return {
             'case_types': sorted(list(case_types)),
             'case_search_url': reverse("case_search", args=[self.domain]),
             'values': {
-                'enabled': current_values.enabled if current_values else False,
-                'synchronous_web_apps': current_values.synchronous_web_apps,
+                'enabled': config.enabled,
+                'synchronous_web_apps': config.synchronous_web_apps,
                 'fuzzy_properties': {
-                    fp.case_type: fp.properties for fp in current_values.fuzzy_properties.all()
-                } if current_values else {},
+                    fp.case_type: fp.properties for fp in config.fuzzy_properties.all()
+                },
                 'ignore_patterns': [{
                     'case_type': rc.case_type,
                     'case_property': rc.case_property,
                     'regex': rc.regex
-                } for rc in current_values.ignore_patterns.all()] if current_values else {}
+                } for rc in config.ignore_patterns.all()]
             }
         }
 


### PR DESCRIPTION
## Product Description
Followup for https://github.com/dimagi/commcare-hq/pull/31812

Fixes this 500, which occurs for projects going to the case search config page for the first time: https://sentry.io/organizations/dimagi/issues/3391664253/

## Feature Flag
Case search

## Safety Assurance

### Safety story
Pretty minor change to flagged page that isn't used often. Tested locally.

### Automated test coverage

None

### QA Plan
 Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
