### PR TITLE
don't cleary query data unless necessary

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -251,6 +251,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             if (index === 0) {
                 this.selections = null;
                 this.sessionId = null;
+                this.queryData = null;
             } else {
                 this.selections = this.selections.splice(0, index);
                 var key = this.selections.join(",");
@@ -264,7 +265,6 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             this.page = null;
             this.search = null;
             this.sortIndex = null;
-            this.queryData = null;
             sessionStorage.removeItem('selectedValues');
         };
     };


### PR DESCRIPTION
## Product Description
Bugfix for https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/issue/SUPPORT-13914
https://dimagi-dev.atlassian.net/browse/USH-2215

## Technical Summary
Query data should not be cleared unless navigation returns to the root of the app. This bug was introduced in https://github.com/dimagi/commcare-hq/pull/29322.

## Feature Flag
case search

## Safety Assurance

### Safety story
I have tested that this fixes the breadcrumb navigation issue and also does not re-introduce the bug from https://dimagi-dev.atlassian.net/browse/USH-794

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
