### PR TITLE
Better error messaging when reverting to a bad build

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -386,11 +386,18 @@ def revert_to_copy(request, domain, app_id):
     else:
         copy_build_comment_template = _("Reverted to version {old_version}")
 
-    copy = app.make_build(
-        comment=copy_build_comment_template.format(**copy_build_comment_params),
-        user_id=request.couch_user.get_id,
-    )
-    copy.save(increment_version=False)
+    try:
+        copy = app.make_build(
+            comment=copy_build_comment_template.format(**copy_build_comment_params),
+            user_id=request.couch_user.get_id,
+        )
+        copy.save(increment_version=False)
+    except AppValidationError:
+        messages.error(
+            request,
+            _("Unable to create new build. Please click 'Make New Version' to see errors.")
+        )
+
     return back_to_main(request, domain, app_id=app_id)
 
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -10278,6 +10278,11 @@ msgid "Reverted to version {old_version}"
 msgstr ""
 
 #: corehq/apps/app_manager/views/releases.py
+msgid ""
+"Unable to create new build. Please click 'Make New Version' to see errors."
+msgstr ""
+
+#: corehq/apps/app_manager/views/releases.py
 msgid "App diff"
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -10905,6 +10905,11 @@ msgid "Reverted to version {old_version}"
 msgstr ""
 
 #: corehq/apps/app_manager/views/releases.py
+msgid ""
+"Unable to create new build. Please click 'Make New Version' to see errors."
+msgstr ""
+
+#: corehq/apps/app_manager/views/releases.py
 msgid "App diff"
 msgstr "Aplicación diff"
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -10279,6 +10279,11 @@ msgid "Reverted to version {old_version}"
 msgstr ""
 
 #: corehq/apps/app_manager/views/releases.py
+msgid ""
+"Unable to create new build. Please click 'Make New Version' to see errors."
+msgstr ""
+
+#: corehq/apps/app_manager/views/releases.py
 msgid "App diff"
 msgstr ""
 

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -10772,6 +10772,11 @@ msgid "Reverted to version {old_version}"
 msgstr ""
 
 #: corehq/apps/app_manager/views/releases.py
+msgid ""
+"Unable to create new build. Please click 'Make New Version' to see errors."
+msgstr ""
+
+#: corehq/apps/app_manager/views/releases.py
 msgid "App diff"
 msgstr "App diff"
 

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -10279,6 +10279,11 @@ msgid "Reverted to version {old_version}"
 msgstr ""
 
 #: corehq/apps/app_manager/views/releases.py
+msgid ""
+"Unable to create new build. Please click 'Make New Version' to see errors."
+msgstr ""
+
+#: corehq/apps/app_manager/views/releases.py
 msgid "App diff"
 msgstr ""
 

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -10293,6 +10293,11 @@ msgid "Reverted to version {old_version}"
 msgstr ""
 
 #: corehq/apps/app_manager/views/releases.py
+msgid ""
+"Unable to create new build. Please click 'Make New Version' to see errors."
+msgstr ""
+
+#: corehq/apps/app_manager/views/releases.py
 msgid "App diff"
 msgstr ""
 

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -10356,6 +10356,11 @@ msgid "Reverted to version {old_version}"
 msgstr ""
 
 #: corehq/apps/app_manager/views/releases.py
+msgid ""
+"Unable to create new build. Please click 'Make New Version' to see errors."
+msgstr ""
+
+#: corehq/apps/app_manager/views/releases.py
 msgid "App diff"
 msgstr ""
 

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -10279,6 +10279,11 @@ msgid "Reverted to version {old_version}"
 msgstr ""
 
 #: corehq/apps/app_manager/views/releases.py
+msgid ""
+"Unable to create new build. Please click 'Make New Version' to see errors."
+msgstr ""
+
+#: corehq/apps/app_manager/views/releases.py
 msgid "App diff"
 msgstr ""
 

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -10283,6 +10283,11 @@ msgid "Reverted to version {old_version}"
 msgstr ""
 
 #: corehq/apps/app_manager/views/releases.py
+msgid ""
+"Unable to create new build. Please click 'Make New Version' to see errors."
+msgstr ""
+
+#: corehq/apps/app_manager/views/releases.py
 msgid "App diff"
 msgstr ""
 


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2214

It's possible, although rare, to revert to a build that can no longer be built, due to additional validation being added to the build process. Previously, this would show a 500 page with a success message. Now it will correctly load the releases page, with better messaging:

![Screen Shot 2022-07-01 at 12 22 38 PM](https://user-images.githubusercontent.com/1486591/176933780-909f963b-381a-405c-a201-3bdee049ed1f.png)

## Safety Assurance

### Safety story
Pretty innocent change. Tested on staging, reverting to an invalid build and to a valid build.

### Automated test coverage

None

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
