### PR TITLE
include domain in user stub fields

### DIFF
--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -115,7 +115,7 @@ class EmwfOptionsController(object):
         else:
             user_query = self.active_user_es_query(query)
         users = (user_query
-                 .fields(SimplifiedUserInfo.ES_FIELDS + ['domain'])
+                 .fields(SimplifiedUserInfo.ES_FIELDS)
                  .start(start)
                  .size(size)
                  .sort("username.exact"))

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -944,6 +944,7 @@ class TestUserESAccessors(TestCase):
         self.assertEqual(results[0], {
             '_id': self.user._id,
             '__group_ids': [],
+            'domain': self.user.domain,
             'username': self.user.username,
             'is_active': True,
             'first_name': self.user.first_name,
@@ -960,6 +961,7 @@ class TestUserESAccessors(TestCase):
         self.assertEqual(results[0], {
             '_id': self.user._id,
             '__group_ids': [],
+            'domain': self.user.domain,
             'username': self.user.username,
             'is_active': False,
             'first_name': self.user.first_name,

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -174,7 +174,8 @@ class SimplifiedUserInfo(
         ))):
 
     ES_FIELDS = [
-        '_id', 'username', 'first_name', 'last_name', 'doc_type', 'is_active', 'location_id', '__group_ids'
+        '_id', 'domain', 'username', 'first_name', 'last_name',
+        'doc_type', 'is_active', 'location_id', '__group_ids'
     ]
 
     @property

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -109,7 +109,7 @@ class TestUserSyncToEs(SimpleTestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], {
             '_id': user._id,
-            'domain': self.user.domain,
+            'domain': user.domain,
             'username': user.username,
             'is_active': True,
             'first_name': user.first_name,

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -109,6 +109,7 @@ class TestUserSyncToEs(SimpleTestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], {
             '_id': user._id,
+            'domain': self.user.domain,
             'username': user.username,
             'is_active': True,
             'first_name': user.first_name,


### PR DESCRIPTION
## Technical Summary
bug fix: https://sentry.io/organizations/dimagi/issues/3207684644/

Add `domain` to list of attributes fetched from ES when querying for 'user stubs'.

## Safety Assurance

### Safety story
Updated tests and checked all usages of the field and functions that use it.

### Automated test coverage
tests updated

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
