### PR TITLE
Changed the redirect when a report is deleted

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -872,7 +872,7 @@ def delete_report(request, domain, report_id):
     ProjectReportsTab.clear_dropdown_cache(domain, request.couch_user)
     redirect = request.GET.get("redirect", None)
     if not redirect:
-        redirect = reverse('configurable_reports_home', args=[domain])
+        redirect = reverse('saved_reports', args=[domain])
     return HttpResponseRedirect(redirect)
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Users will now be redirected to saved reports page as per this [ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12732).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Link to Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12732).
Users were getting a 404 because of a feature flag not being enabled to the previous url, so I changed the url as requested.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
