### PR TITLE
Update wrap functions to remove unused variables

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -399,6 +399,7 @@ class OpenCaseAction(FormAction):
             data['name_update'] = {
                 'question_path': path
             }
+            data.pop('name_path', None)
         return super(OpenCaseAction, cls).wrap(data)
 
 
@@ -428,6 +429,7 @@ class OpenSubCaseAction(FormAction, IndexedSchema):
             data['name_update'] = {
                 'question_path': path
             }
+            data.pop('case_name', None)
         if 'case_properties' in data:
             data['case_properties'] = wrap_transition_from_old_update_case_action(data['case_properties'])
         return super(OpenSubCaseAction, cls).wrap(data)
@@ -679,6 +681,7 @@ class AdvancedOpenCaseAction(AdvancedAction):
             data['name_update'] = {
                 'question_path': path
             }
+            data.pop('name_path', None)
         return super(AdvancedOpenCaseAction, cls).wrap(data)
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Part of [USH-2205](https://dimagi-dev.atlassian.net/browse/USH-2205?atlOrigin=eyJpIjoiZjdkZDc2MTQ5MDI3NDY1ZGI0Yzg1YjY3MDYwMzI4ZTUiLCJwIjoiaiJ9).

The wrap functions deployed as part of the original "removing the _enetered convention" should have included this code to delete these old variables. And in order to eliminate these wrap functions by running a migration to "wrap" every application, we need to remove these variables inside the wrap function. So this is setup code for the actual migration.

## Safety Assurance

### Safety story

I've tested this locally and this code has been live on staging for 3 days.

The highest risk is probably that this code is somehow incompatible with apps created before the _entered convention code was deployed in February, and that haven't been wrapped since then (haven't been viewed in app builder).

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
