### PR TITLE
Fixed ShadowMenu grid validation issue

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -62,9 +62,11 @@ class MenuContributor(SuiteContributorByModule):
                 if len(menu.commands):
                     menus.append(menu)
 
-        if self.app.grid_display_for_all_modules() or \
-                self.app.grid_display_for_some_modules() and module.grid_display_style():
+        if self.app.grid_display_for_all_modules():
             self._give_non_root_menus_grid_style(menus)
+        elif self.app.grid_display_for_some_modules():
+            if hasattr(module, 'grid_display_style') and module.grid_display_style():
+                self._give_non_root_menus_grid_style(menus)
         if self.app.use_grid_menus:
             self._give_root_menu_grid_style(menus)
 


### PR DESCRIPTION
## Product Description
Fixes app build error for apps that use shadow menus and the per-menu grid display setting.

## Technical Summary
https://sentry.io/organizations/dimagi/issues/3317658431/

https://dimagi-dev.atlassian.net/servicedesk/customer/portal/1/SUPPORT-13960

Bug introduced in https://github.com/dimagi/commcare-hq/pull/31827

I took a look through this file for other places that module attributes are referenced and didn't see any others that aren't available in shadow menus (or aren't already protected).

## Feature Flag
Shadow menus

## Safety Assurance

### Safety story
Pretty standard guard clause. Tested locally.

### Automated test coverage

Presumably none.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
