### PR TITLE
Fixed save button enabling when it shouldn't

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -46,7 +46,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     searchAgainLabel: options.search_again_label,
                     searchFilter: options.search_filter,
                     blacklistedOwnerIdsExpression: options.blacklisted_owner_ids_expression,
-                    dataRegistry: options.data_registry,
+                    dataRegistry: options.data_registry || "",
                     dataRegistryWorkflow: options.data_registry_workflow,
                     additionalRegistryCases: options.additional_registry_cases,
                     customRelatedCaseProperty: options.custom_related_case_property,


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2221

## Technical Summary
Issue with the data registry dropdown in case search settings. If a data registry wasn't in use, the value sent over was null, which would get changed to a blank string (the value for the blank option), which knockout would register as a change, enabling the save button.

## Feature Flag
Data registries

## Safety Assurance

### Safety story
Tiny UI config change to feature used by ~1 project.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
