### PR TITLE
Improve API access control for linked domains

### DIFF
--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -13,19 +13,6 @@ from corehq.privileges import RELEASE_MANAGEMENT, LITE_RELEASE_MANAGEMENT
 from corehq.util.quickcache import quickcache
 
 
-@quickcache(['upstream', 'downstream'], timeout=60 * 60)
-def get_domain_link(upstream, downstream):
-    """
-    :param upstream: upstream domain name
-    :param downstream: downstream domain name
-    :returns: ``DomainLink`` object or None if no link exists
-    """
-    try:
-        return DomainLink.objects.get(master_domain=upstream, linked_domain=downstream)
-    except DomainLink.DoesNotExist:
-        return None
-
-
 @quickcache(['domain'], timeout=60 * 60)
 def get_upstream_domain_link(domain):
     """

--- a/corehq/apps/linked_domain/dbaccessors.py
+++ b/corehq/apps/linked_domain/dbaccessors.py
@@ -13,6 +13,19 @@ from corehq.privileges import RELEASE_MANAGEMENT, LITE_RELEASE_MANAGEMENT
 from corehq.util.quickcache import quickcache
 
 
+@quickcache(['upstream', 'downstream'], timeout=60 * 60)
+def get_domain_link(upstream, downstream):
+    """
+    :param upstream: upstream domain name
+    :param downstream: downstream domain name
+    :returns: ``DomainLink`` object or None if no link exists
+    """
+    try:
+        return DomainLink.objects.get(master_domain=upstream, linked_domain=downstream)
+    except DomainLink.DoesNotExist:
+        return None
+
+
 @quickcache(['domain'], timeout=60 * 60)
 def get_upstream_domain_link(domain):
     """

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -2,7 +2,6 @@ from functools import wraps
 
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, Http404
 
-from corehq.apps.linked_domain.dbaccessors import get_domain_link
 from corehq.apps.linked_domain.util import can_user_access_linked_domains
 
 REMOTE_REQUESTER_HEADER = 'HTTP_HQ_REMOTE_REQUESTER'

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, Http404
 
-from corehq.apps.linked_domain.dbaccessors import get_upstream_domain_link
+from corehq.apps.linked_domain.dbaccessors import get_domain_link
 from corehq.apps.linked_domain.util import can_user_access_linked_domains
 
 REMOTE_REQUESTER_HEADER = 'HTTP_HQ_REMOTE_REQUESTER'
@@ -33,8 +33,8 @@ def require_linked_domain(fn):
         if not requester:
             return HttpResponseBadRequest()
 
-        link = get_upstream_domain_link(requester)
-        if not link or link.master_domain != domain:
+        domain_link = get_domain_link(upstream=domain, downstream=requester)
+        if not domain_link:
             return HttpResponseForbidden()
 
         return fn(request, domain, *args, **kwargs)

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -32,18 +32,12 @@ def require_existing_domain_link(fn):
     """
     @wraps(fn)
     def _inner(request, domain, *args, **kwargs):
-        if not hasattr(request, 'couch_user'):
-            raise Http404()
 
         requester = request.META.get(REMOTE_REQUESTER_HEADER, None)
         if not requester:
             return HttpResponseBadRequest()
 
-        domain_link = get_domain_link(upstream=domain, downstream=requester)
-        if not domain_link:
-            return HttpResponseForbidden()
-
-        if not can_user_access_linked_domains(request.couch_user, domain):
+        if not get_domain_link(upstream=domain, downstream=requester):
             return HttpResponseForbidden()
 
         return fn(request, domain, *args, **kwargs)

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -26,7 +26,10 @@ def require_access_to_linked_domains(view_func):
     return _inner
 
 
-def require_linked_domain(fn):
+def require_existing_domain_link(fn):
+    """
+    Ensure the requesting domain is linked downstream of the specified domain
+    """
     @wraps(fn)
     def _inner(request, domain, *args, **kwargs):
         requester = request.META.get(REMOTE_REQUESTER_HEADER, None)

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -1,10 +1,8 @@
 from functools import wraps
 
-from django.http import HttpResponseBadRequest, HttpResponseForbidden, Http404
+from django.http import Http404, HttpResponseForbidden
 
 from corehq.apps.linked_domain.util import can_user_access_linked_domains
-
-REMOTE_REQUESTER_HEADER = 'HTTP_HQ_REMOTE_REQUESTER'
 
 
 def require_access_to_linked_domains(view_func):

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -32,12 +32,18 @@ def require_existing_domain_link(fn):
     """
     @wraps(fn)
     def _inner(request, domain, *args, **kwargs):
+        if not hasattr(request, 'couch_user'):
+            raise Http404()
+
         requester = request.META.get(REMOTE_REQUESTER_HEADER, None)
         if not requester:
             return HttpResponseBadRequest()
 
         domain_link = get_domain_link(upstream=domain, downstream=requester)
         if not domain_link:
+            return HttpResponseForbidden()
+
+        if not can_user_access_linked_domains(request.couch_user, domain):
             return HttpResponseForbidden()
 
         return fn(request, domain, *args, **kwargs)

--- a/corehq/apps/linked_domain/decorators.py
+++ b/corehq/apps/linked_domain/decorators.py
@@ -24,22 +24,3 @@ def require_access_to_linked_domains(view_func):
             return HttpResponseForbidden()
 
     return _inner
-
-
-def require_existing_domain_link(fn):
-    """
-    Ensure the requesting domain is linked downstream of the specified domain
-    """
-    @wraps(fn)
-    def _inner(request, domain, *args, **kwargs):
-
-        requester = request.META.get(REMOTE_REQUESTER_HEADER, None)
-        if not requester:
-            return HttpResponseBadRequest()
-
-        if not get_domain_link(upstream=domain, downstream=requester):
-            return HttpResponseForbidden()
-
-        return fn(request, domain, *args, **kwargs)
-
-    return _inner

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -83,13 +83,11 @@ class DomainLink(models.Model):
     def save(self, *args, **kwargs):
         super(DomainLink, self).save(*args, **kwargs)
         from corehq.apps.linked_domain.dbaccessors import (
-            get_domain_link,
             get_linked_domains,
             get_upstream_domain_link,
             is_active_downstream_domain,
             is_active_upstream_domain,
         )
-        get_domain_link.clear(self.master_domain, self.linked_domain)
         get_upstream_domain_link.clear(self.linked_domain)
         is_active_downstream_domain.clear(self.linked_domain)
 

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -83,11 +83,13 @@ class DomainLink(models.Model):
     def save(self, *args, **kwargs):
         super(DomainLink, self).save(*args, **kwargs)
         from corehq.apps.linked_domain.dbaccessors import (
-            get_upstream_domain_link,
+            get_domain_link,
             get_linked_domains,
+            get_upstream_domain_link,
             is_active_downstream_domain,
             is_active_upstream_domain,
         )
+        get_domain_link.clear(self.master_domain, self.linked_domain)
         get_upstream_domain_link.clear(self.linked_domain)
         is_active_downstream_domain.clear(self.linked_domain)
 

--- a/corehq/apps/linked_domain/tests/test_linked_case_claim.py
+++ b/corehq/apps/linked_domain/tests/test_linked_case_claim.py
@@ -1,4 +1,5 @@
 import json
+from unittest import mock
 
 from unittest.mock import patch
 
@@ -77,7 +78,8 @@ class TestRemoteLinkedCaseClaim(BaseLinkedCaseClaimTest):
         url = reverse('linked_domain:case_search_config', args=[self.domain])
         headers = self.auth_headers.copy()
         headers[REMOTE_REQUESTER_HEADER] = self.domain_link.linked_domain
-        resp = self.client.get(url, **headers)
+        with mock.patch('corehq.apps.linked_domain.decorators.can_user_access_linked_domains', return_value=True):
+            resp = self.client.get(url, **headers)
 
         fake_case_search_config_getter.return_value = json.loads(resp.content)
 

--- a/corehq/apps/linked_domain/tests/test_linked_case_claim.py
+++ b/corehq/apps/linked_domain/tests/test_linked_case_claim.py
@@ -1,6 +1,4 @@
 import json
-from unittest import mock
-
 from unittest.mock import patch
 
 from corehq.apps.case_search.models import (
@@ -8,7 +6,7 @@ from corehq.apps.case_search.models import (
     FuzzyProperties,
     IgnorePatterns,
 )
-from corehq.apps.linked_domain.decorators import REMOTE_REQUESTER_HEADER
+from corehq.apps.linked_domain import decorators
 from corehq.apps.linked_domain.tests.test_linked_apps import BaseLinkedDomainTest
 from corehq.apps.linked_domain.updates import update_case_search_config
 from corehq.apps.users.models import HQApiKey, WebUser
@@ -77,8 +75,7 @@ class TestRemoteLinkedCaseClaim(BaseLinkedCaseClaimTest):
     def test_remote_linked_app(self, fake_case_search_config_getter):
         url = reverse('linked_domain:case_search_config', args=[self.domain])
         headers = self.auth_headers.copy()
-        headers[REMOTE_REQUESTER_HEADER] = self.domain_link.linked_domain
-        with mock.patch('corehq.apps.linked_domain.decorators.can_user_access_linked_domains', return_value=True):
+        with patch.object(decorators, 'can_user_access_linked_domains', return_value=True):
             resp = self.client.get(url, **headers)
 
         fake_case_search_config_getter.return_value = json.loads(resp.content)

--- a/corehq/apps/linked_domain/tests/test_remote_auth.py
+++ b/corehq/apps/linked_domain/tests/test_remote_auth.py
@@ -1,8 +1,7 @@
 import json
-import uuid
+from unittest import mock
 
 from django.test import TestCase
-
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.linked_domain.decorators import REMOTE_REQUESTER_HEADER
@@ -13,46 +12,62 @@ from corehq.util.view_utils import absolute_reverse
 
 
 class RemoteAuthTest(TestCase):
+
+    def test_returns_401_if_no_headers(self):
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_returns_400_if_no_remote_header_included(self):
+        headers = {'HTTP_AUTHORIZATION': f'apikey test:{self.api_key.key}'}
+        resp = self.client.get(self.url, **headers)
+
+        self.assertEqual(resp.status_code, 400)
+
+    def test_returns_403_if_remote_header_specifies_incorrect_requester(self):
+        headers = {
+            'HTTP_AUTHORIZATION': f'apikey test:{self.api_key.key}',
+            REMOTE_REQUESTER_HEADER: 'wrong',
+        }
+        resp = self.client.get(self.url, **headers)
+
+        self.assertEqual(resp.status_code, 403)
+
+    def test_returns_403_if_no_linked_domain_access(self):
+        headers = {
+            'HTTP_AUTHORIZATION': f'apikey test:{self.api_key.key}',
+            REMOTE_REQUESTER_HEADER: self.downstream_domain_requester,
+        }
+        with mock.patch('corehq.apps.linked_domain.decorators.can_user_access_linked_domains', return_value=False):
+            resp = self.client.get(self.url, **headers)
+
+        self.assertEqual(resp.status_code, 403)
+
+    def test_returns_200_if_linked_domain_access(self):
+        headers = {
+            'HTTP_AUTHORIZATION': f'apikey test:{self.api_key.key}',
+            REMOTE_REQUESTER_HEADER: self.downstream_domain_requester,
+        }
+
+        with mock.patch('corehq.apps.linked_domain.decorators.can_user_access_linked_domains', return_value=True):
+            resp = self.client.get(self.url, **headers)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(json.loads(resp.content), {'toggles': [], 'previews': []})
+
     @classmethod
     def setUpClass(cls):
         super(RemoteAuthTest, cls).setUpClass()
 
-        cls.master_domain = uuid.uuid4().hex
-        cls.linked_domain = uuid.uuid4().hex
+        cls.upstream_domain = 'upstream'
+        cls.downstream_domain = 'downstream'
+        cls.domain_obj = create_domain(cls.upstream_domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
 
-        cls.domain = create_domain(cls.master_domain)
-        cls.couch_user = WebUser.create(cls.master_domain, "test", "foobar", None, None)
-        cls.django_user = cls.couch_user.get_django_user()
-        cls.api_key, _ = HQApiKey.objects.get_or_create(user=cls.django_user)
+        cls.couch_user = WebUser.create(cls.upstream_domain, "test", "foobar", None, None)
+        cls.addClassCleanup(cls.couch_user.delete, cls.upstream_domain, deleted_by=None)
+        cls.api_key, _ = HQApiKey.objects.get_or_create(user=cls.couch_user.get_django_user())
 
-        cls.auth_headers = {'HTTP_AUTHORIZATION': 'apikey test:%s' % cls.api_key.key}
+        cls.downstream_domain_requester = absolute_reverse('domain_homepage', args=[cls.downstream_domain])
+        cls.domain_link = DomainLink.link_domains(cls.downstream_domain_requester, cls.upstream_domain)
 
-        cls.linked_domain_requester = absolute_reverse('domain_homepage', args=[cls.linked_domain])
-        cls.domain_link = DomainLink.link_domains(cls.linked_domain_requester, cls.master_domain)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.couch_user.delete(cls.domain.name, deleted_by=None)
-        cls.api_key.delete()
-        cls.domain_link.delete()
-        cls.domain.delete()
-        super(RemoteAuthTest, cls).tearDownClass()
-
-    def test_remote_auth(self):
-        url = reverse('linked_domain:toggles', args=[self.master_domain])
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 401)
-
-        resp = self.client.get(url, **self.auth_headers)
-        self.assertEqual(resp.status_code, 400)
-
-        headers = self.auth_headers.copy()
-        headers[REMOTE_REQUESTER_HEADER] = 'wrong'
-        resp = self.client.get(url, **headers)
-        self.assertEqual(resp.status_code, 403)
-
-        headers[REMOTE_REQUESTER_HEADER] = self.linked_domain_requester
-        resp = self.client.get(url, **headers)
-        self.assertEqual(resp.status_code, 200)
-        resp_json = json.loads(resp.content)
-        self.assertEqual(resp_json, {'toggles': [], 'previews': []})
+        cls.url = reverse('linked_domain:toggles', args=[cls.upstream_domain])

--- a/corehq/apps/linked_domain/tests/test_remote_auth.py
+++ b/corehq/apps/linked_domain/tests/test_remote_auth.py
@@ -1,9 +1,10 @@
 import json
-from unittest import mock
+from unittest.mock import patch
 
 from django.test import TestCase
 
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.linked_domain import decorators
 from corehq.apps.linked_domain.decorators import REMOTE_REQUESTER_HEADER
 from corehq.apps.linked_domain.models import DomainLink
 from corehq.apps.users.models import HQApiKey, WebUser
@@ -37,7 +38,7 @@ class RemoteAuthTest(TestCase):
             'HTTP_AUTHORIZATION': f'apikey test:{self.api_key.key}',
             REMOTE_REQUESTER_HEADER: self.downstream_domain_requester,
         }
-        with mock.patch('corehq.apps.linked_domain.decorators.can_user_access_linked_domains', return_value=False):
+        with patch.object(decorators, 'can_user_access_linked_domains', return_value=False):
             resp = self.client.get(self.url, **headers)
 
         self.assertEqual(resp.status_code, 403)
@@ -48,7 +49,7 @@ class RemoteAuthTest(TestCase):
             REMOTE_REQUESTER_HEADER: self.downstream_domain_requester,
         }
 
-        with mock.patch('corehq.apps.linked_domain.decorators.can_user_access_linked_domains', return_value=True):
+        with patch.object(decorators, 'can_user_access_linked_domains', return_value=True):
             resp = self.client.get(self.url, **headers)
 
         self.assertEqual(resp.status_code, 200)
@@ -56,7 +57,7 @@ class RemoteAuthTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(RemoteAuthTest, cls).setUpClass()
+        super().setUpClass()
 
         cls.upstream_domain = 'upstream'
         cls.downstream_domain = 'downstream'

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -48,10 +48,7 @@ from corehq.apps.linked_domain.dbaccessors import (
     get_linked_domains,
     get_upstream_domain_link,
 )
-from corehq.apps.linked_domain.decorators import (
-    require_access_to_linked_domains,
-    require_existing_domain_link,
-)
+from corehq.apps.linked_domain.decorators import require_access_to_linked_domains
 from corehq.apps.linked_domain.exceptions import (
     AttemptedPushViolatesConstraints,
     DomainLinkAlreadyExists,
@@ -120,28 +117,24 @@ from corehq.util.timezones.utils import get_timezone_for_request
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def tableau_server_and_visualizations(request, domain):
     return JsonResponse(get_tableau_server_and_visualizations(domain))
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def toggles_and_previews(request, domain):
     return JsonResponse(get_enabled_toggles_and_previews(domain))
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def auto_update_rules(request, domain):
     return JsonResponse({'rules': get_auto_update_rules(domain)})
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def custom_data_models(request, domain):
     limit_types = request.GET.getlist('type')
@@ -149,42 +142,36 @@ def custom_data_models(request, domain):
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def fixture(request, domain, tag):
     return JsonResponse(get_fixture(domain, tag))
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def user_roles(request, domain):
     return JsonResponse({'user_roles': get_user_roles(domain)})
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def brief_apps(request, domain):
     return JsonResponse({'brief_apps': get_brief_app_docs_in_domain(domain, include_remote=False)})
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def app_by_version(request, domain, app_id, version):
     return JsonResponse({'app': get_build_doc_by_version(domain, app_id, version)})
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def released_app_versions(request, domain):
     return JsonResponse({'versions': get_latest_released_app_versions_by_app_id(domain)})
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def case_search_config(request, domain):
     try:
@@ -196,7 +183,6 @@ def case_search_config(request, domain):
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 @require_permission(HqPermissions.view_reports)
 def linkable_ucr(request, domain):
@@ -213,7 +199,6 @@ def linkable_ucr(request, domain):
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def ucr_config(request, domain, config_id):
     report_config = ReportConfiguration.get(config_id)
@@ -229,7 +214,6 @@ def ucr_config(request, domain, config_id):
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def get_latest_released_app_source(request, domain, app_id):
     master_app = get_app(None, app_id)
@@ -244,28 +228,24 @@ def get_latest_released_app_source(request, domain, app_id):
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def data_dictionary(request, domain):
     return JsonResponse(get_data_dictionary(domain))
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def dialer_settings(request, domain):
     return JsonResponse(get_dialer_settings(domain))
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def otp_settings(request, domain):
     return JsonResponse(get_otp_settings(domain))
 
 
 @login_or_api_key
-@require_existing_domain_link
 @require_access_to_linked_domains
 def hmac_callout_settings(request, domain):
     return JsonResponse(get_hmac_callout_settings(domain))

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -50,7 +50,7 @@ from corehq.apps.linked_domain.dbaccessors import (
 )
 from corehq.apps.linked_domain.decorators import (
     require_access_to_linked_domains,
-    require_linked_domain,
+    require_existing_domain_link,
 )
 from corehq.apps.linked_domain.exceptions import (
     AttemptedPushViolatesConstraints,
@@ -120,62 +120,62 @@ from corehq.util.timezones.utils import get_timezone_for_request
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def tableau_server_and_visualizations(request, domain):
     return JsonResponse(get_tableau_server_and_visualizations(domain))
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def toggles_and_previews(request, domain):
     return JsonResponse(get_enabled_toggles_and_previews(domain))
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def auto_update_rules(request, domain):
     return JsonResponse({'rules': get_auto_update_rules(domain)})
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def custom_data_models(request, domain):
     limit_types = request.GET.getlist('type')
     return JsonResponse(get_custom_data_models(domain, limit_types))
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def fixture(request, domain, tag):
     return JsonResponse(get_fixture(domain, tag))
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def user_roles(request, domain):
     return JsonResponse({'user_roles': get_user_roles(domain)})
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def brief_apps(request, domain):
     return JsonResponse({'brief_apps': get_brief_app_docs_in_domain(domain, include_remote=False)})
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def app_by_version(request, domain, app_id, version):
     return JsonResponse({'app': get_build_doc_by_version(domain, app_id, version)})
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def released_app_versions(request, domain):
     return JsonResponse({'versions': get_latest_released_app_versions_by_app_id(domain)})
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def case_search_config(request, domain):
     try:
         config = CaseSearchConfig.objects.get(domain=domain).to_json()
@@ -186,7 +186,7 @@ def case_search_config(request, domain):
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 @require_permission(HqPermissions.view_reports)
 def linkable_ucr(request, domain):
     """Returns a list of reports to be used by the downstream
@@ -202,7 +202,7 @@ def linkable_ucr(request, domain):
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def ucr_config(request, domain, config_id):
     report_config = ReportConfiguration.get(config_id)
     if report_config.domain != domain:
@@ -217,7 +217,7 @@ def ucr_config(request, domain, config_id):
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def get_latest_released_app_source(request, domain, app_id):
     master_app = get_app(None, app_id)
     if master_app.domain != domain:
@@ -231,25 +231,25 @@ def get_latest_released_app_source(request, domain, app_id):
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def data_dictionary(request, domain):
     return JsonResponse(get_data_dictionary(domain))
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def dialer_settings(request, domain):
     return JsonResponse(get_dialer_settings(domain))
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def otp_settings(request, domain):
     return JsonResponse(get_otp_settings(domain))
 
 
 @login_or_api_key
-@require_linked_domain
+@require_existing_domain_link
 def hmac_callout_settings(request, domain):
     return JsonResponse(get_hmac_callout_settings(domain))
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -121,24 +121,28 @@ from corehq.util.timezones.utils import get_timezone_for_request
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def tableau_server_and_visualizations(request, domain):
     return JsonResponse(get_tableau_server_and_visualizations(domain))
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def toggles_and_previews(request, domain):
     return JsonResponse(get_enabled_toggles_and_previews(domain))
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def auto_update_rules(request, domain):
     return JsonResponse({'rules': get_auto_update_rules(domain)})
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def custom_data_models(request, domain):
     limit_types = request.GET.getlist('type')
     return JsonResponse(get_custom_data_models(domain, limit_types))
@@ -146,36 +150,42 @@ def custom_data_models(request, domain):
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def fixture(request, domain, tag):
     return JsonResponse(get_fixture(domain, tag))
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def user_roles(request, domain):
     return JsonResponse({'user_roles': get_user_roles(domain)})
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def brief_apps(request, domain):
     return JsonResponse({'brief_apps': get_brief_app_docs_in_domain(domain, include_remote=False)})
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def app_by_version(request, domain, app_id, version):
     return JsonResponse({'app': get_build_doc_by_version(domain, app_id, version)})
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def released_app_versions(request, domain):
     return JsonResponse({'versions': get_latest_released_app_versions_by_app_id(domain)})
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def case_search_config(request, domain):
     try:
         config = CaseSearchConfig.objects.get(domain=domain).to_json()
@@ -187,6 +197,7 @@ def case_search_config(request, domain):
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 @require_permission(HqPermissions.view_reports)
 def linkable_ucr(request, domain):
     """Returns a list of reports to be used by the downstream
@@ -203,6 +214,7 @@ def linkable_ucr(request, domain):
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def ucr_config(request, domain, config_id):
     report_config = ReportConfiguration.get(config_id)
     if report_config.domain != domain:
@@ -218,6 +230,7 @@ def ucr_config(request, domain, config_id):
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def get_latest_released_app_source(request, domain, app_id):
     master_app = get_app(None, app_id)
     if master_app.domain != domain:
@@ -232,24 +245,28 @@ def get_latest_released_app_source(request, domain, app_id):
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def data_dictionary(request, domain):
     return JsonResponse(get_data_dictionary(domain))
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def dialer_settings(request, domain):
     return JsonResponse(get_dialer_settings(domain))
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def otp_settings(request, domain):
     return JsonResponse(get_otp_settings(domain))
 
 
 @login_or_api_key
 @require_existing_domain_link
+@require_access_to_linked_domains
 def hmac_callout_settings(request, domain):
     return JsonResponse(get_hmac_callout_settings(domain))
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13357

~I've been hesitant to create this PR because I'm not thrilled with this, but do think we need to enhance access control around API endpoints for linked domains. The main change is to check if the requesting user has access to linked domains in addition to just checking if the requesting domain is part of an active domain link.~

**Update** The API endpoints impacted by this change are responsible for retrieving data models from the upstream domain being queried. Previously, a check enforced that the domain being queried was part of active link with the domain specified in `REMOTE_REQUESTER_HEADER`. This is to ensure that the requesting user/domain has proper access to this data. In practice, this request is made by HQ directly, and this kind of check isn't necessary in that context so I'm assuming this check is strictly a security measure.

I've replaced this check with the standard check for access to linked domains, which opens up the possibility that a user with linked domains permissions in both domains could retrieve data models from a domain that is **not** part of an active link with the requesting domain. I'm inclined to think this isn't a risk since the user has access to this information given their linked domain permission. Does this sound particularly concerning to anyone?

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Will test locally before merging. Want to get some opinions first.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
