### PR TITLE
Block users from being added to groups not in the same domain

### DIFF
--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -134,7 +134,7 @@ class TestCommCareUserResource(APIResourceTest):
         })
 
     def test_create(self):
-        group = Group({"name": "test"})
+        group = Group({"name": "test", "domain": self.domain.name})
         group.save()
         self.addCleanup(group.delete)
 
@@ -196,7 +196,7 @@ class TestCommCareUserResource(APIResourceTest):
     def test_update(self):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
                                    created_by=None, created_via=None, phone_number="50253311398")
-        group = Group({"name": "test"})
+        group = Group({"name": "test", "domain": self.domain.name})
         group.save()
 
         self.addCleanup(user.delete, self.domain.name, deleted_by=None)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

A ValidationError will be raised when attempting to add users to a group that doesn't belong to the domain the user belongs to (via API or Web)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12899)

The CommCareUser method `set_groups` now checks that the domain of the group its attempting to add the user to, has the same domain as the user. 

Initially the ticket claimed the error (a user being added to an out-of-domain group and blocking bulk downloads) happened after a user was created via API but the `UserHistory` logs for the offending mobile user shows that they were added to the out-of-domain group via `web`.  I'm still not sure how this was possible but a simple fix (even without this PR) is to add and then remove the offending user to a in-domain group via the `Edit Group Membership` page in the user settings, though this is only possible once you figure out which user is causing the issue. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally, will test on staging. 

Whenever a user's groups are updated it overwrites it's previous list of groups. Since this only blocks faulty groups from being added, this shouldn't overwrite existing group data unless the list is valid. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
