### PR TITLE
Fixed 500 on viewing tableau report when logged out

### DIFF
--- a/corehq/apps/reports/standard/tableau.py
+++ b/corehq/apps/reports/standard/tableau.py
@@ -41,8 +41,9 @@ class TableauView(BaseDomainView):
     def dispatch(self, request, *args, **kwargs):
         if self.visualization is None:
             raise Http404()
-        if not self.request.couch_user.can_view_tableau_viz(self.domain, f"{self.kwargs.get('viz_id')}"):
-            raise Http403
+        if hasattr(self.request, 'couch_user'):
+            if not self.request.couch_user.can_view_tableau_viz(self.domain, f"{self.kwargs.get('viz_id')}"):
+                raise Http403
         return super().dispatch(request, *args, **kwargs)
 
     @property


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2223

Redirect the user properly to the login page, then redirect them to the report once they've logged in.

I'd like to run the super dispatch logic first but don't have a good way to do that. We do something similar in UCRs: https://github.com/dimagi/commcare-hq/blob/e4367adc29f4c513b7fee42ac66084832fbeaf84/corehq/apps/userreports/views.py#L246

## Feature Flag
Embedded tableau

## Safety Assurance

### Safety story
Innocent, standard change to flagged feature. Tested locally.

### Automated test coverage

None

### QA Plan

None


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
