### PR TITLE
[USH] Case Search validation conditions

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -185,6 +185,7 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
             for prop in module.search_config.properties:
                 yield id_strings.search_property_locale(module, prop.name), trans(prop.label)
                 yield id_strings.search_property_hint_locale(module, prop.name), trans(prop.hint)
+                yield id_strings.search_property_required_msg(module, prop.name), trans(prop.required_message)
                 for i, validation in enumerate(prop.validation):
                     yield (id_strings.search_property_validation_msg(module, prop.name, i),
                            trans(validation.message))

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -185,10 +185,11 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
             for prop in module.search_config.properties:
                 yield id_strings.search_property_locale(module, prop.name), trans(prop.label)
                 yield id_strings.search_property_hint_locale(module, prop.name), trans(prop.hint)
-                yield id_strings.search_property_required_msg(module, prop.name), trans(prop.required_message)
-                for i, validation in enumerate(prop.validation):
-                    yield (id_strings.search_property_validation_msg(module, prop.name, i),
-                           trans(validation.message))
+                if prop.required.test:
+                    yield id_strings.search_property_required_text(module, prop.name), trans(prop.required.text)
+                for i, validation in enumerate(prop.validations):
+                    yield (id_strings.search_property_validation_text(module, prop.name, i),
+                           trans(validation.text))
 
         if hasattr(module, 'referral_list'):
             if module.referral_list.show:

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -185,6 +185,7 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
             for prop in module.search_config.properties:
                 yield id_strings.search_property_locale(module, prop.name), trans(prop.label)
                 yield id_strings.search_property_hint_locale(module, prop.name), trans(prop.hint)
+                yield id_strings.search_property_validation_msg(module, prop.name), trans(prop.hint)
 
         if hasattr(module, 'referral_list'):
             if module.referral_list.show:

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -185,7 +185,7 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
             for prop in module.search_config.properties:
                 yield id_strings.search_property_locale(module, prop.name), trans(prop.label)
                 yield id_strings.search_property_hint_locale(module, prop.name), trans(prop.hint)
-                yield id_strings.search_property_validation_msg(module, prop.name), trans(prop.hint)
+                yield id_strings.search_property_validation_msg(module, prop.name), trans(prop.validation[0].message)
 
         if hasattr(module, 'referral_list'):
             if module.referral_list.show:

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -188,8 +188,9 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
                 if prop.required.test:
                     yield id_strings.search_property_required_text(module, prop.name), trans(prop.required.text)
                 for i, validation in enumerate(prop.validations):
-                    yield (id_strings.search_property_validation_text(module, prop.name, i),
-                           trans(validation.text))
+                    if validation.has_text:
+                        yield (id_strings.search_property_validation_text(module, prop.name, i),
+                               trans(validation.text))
 
         if hasattr(module, 'referral_list'):
             if module.referral_list.show:

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -185,7 +185,9 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
             for prop in module.search_config.properties:
                 yield id_strings.search_property_locale(module, prop.name), trans(prop.label)
                 yield id_strings.search_property_hint_locale(module, prop.name), trans(prop.hint)
-                yield id_strings.search_property_validation_msg(module, prop.name), trans(prop.validation[0].message)
+                for i, validation in enumerate(prop.validation):
+                    yield (id_strings.search_property_validation_msg(module, prop.name, i),
+                           trans(validation.message))
 
         if hasattr(module, 'referral_list'):
             if module.referral_list.show:

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -203,14 +203,7 @@ class CommCareFeatureSupportMixin(object):
         )
 
     @property
-    def enable_exclude_from_search(self):
-        return (
-            toggles.USH_CASE_CLAIM_UPDATES.enabled(self.domain)
-            and self._require_minimum_version('2.53')
-        )
-
-    @property
-    def enable_required_search_fields(self):
+    def ush_case_claim_2_53(self):
         return (
             toggles.USH_CASE_CLAIM_UPDATES.enabled(self.domain)
             and self._require_minimum_version('2.53')

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -274,9 +274,10 @@ def search_property_hint_locale(module, search_prop):
     return "search_property.m{module.id}.{search_prop}.hint".format(module=module, search_prop=search_prop)
 
 
-@pattern('search_property.m%d.%s.validation_msg')
+@pattern('search_property.m%d.%s.validation.message')
 def search_property_validation_msg(module, search_prop):
-    return "search_property.m{module.id}.{search_prop}.validation_msg".format(module=module, search_prop=search_prop)
+    return "search_property.m{module.id}.{search_prop}.validation.message".format(
+        module=module, search_prop=search_prop)
 
 
 @pattern('custom_assertion.m%d.f%d.%d')

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -274,14 +274,14 @@ def search_property_hint_locale(module, search_prop):
     return "search_property.m{module.id}.{search_prop}.hint".format(module=module, search_prop=search_prop)
 
 
-@pattern('search_property.m%d.%s.required.message')
-def search_property_required_msg(module, search_prop):
-    return f"search_property.m{module.id}.{search_prop}.required.message"
+@pattern('search_property.m%d.%s.required.text')
+def search_property_required_text(module, search_prop):
+    return f"search_property.m{module.id}.{search_prop}.required.text"
 
 
-@pattern('search_property.m%d.%s.validation.%d.message')
-def search_property_validation_msg(module, search_prop, index):
-    return f"search_property.m{module.id}.{search_prop}.validation.{index}.message"
+@pattern('search_property.m%d.%s.validation.%d.text')
+def search_property_validation_text(module, search_prop, index):
+    return f"search_property.m{module.id}.{search_prop}.validation.{index}.text"
 
 
 @pattern('custom_assertion.m%d.f%d.%d')

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -274,10 +274,9 @@ def search_property_hint_locale(module, search_prop):
     return "search_property.m{module.id}.{search_prop}.hint".format(module=module, search_prop=search_prop)
 
 
-@pattern('search_property.m%d.%s.validation.message')
-def search_property_validation_msg(module, search_prop):
-    return "search_property.m{module.id}.{search_prop}.validation.message".format(
-        module=module, search_prop=search_prop)
+@pattern('search_property.m%d.%s.validation.%d.message')
+def search_property_validation_msg(module, search_prop, index):
+    return f"search_property.m{module.id}.{search_prop}.validation.{index}.message"
 
 
 @pattern('custom_assertion.m%d.f%d.%d')

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -274,6 +274,11 @@ def search_property_hint_locale(module, search_prop):
     return "search_property.m{module.id}.{search_prop}.hint".format(module=module, search_prop=search_prop)
 
 
+@pattern('search_property.m%d.%s.validation_msg')
+def search_property_validation_msg(module, search_prop):
+    return "search_property.m{module.id}.{search_prop}.validation_msg".format(module=module, search_prop=search_prop)
+
+
 @pattern('custom_assertion.m%d.f%d.%d')
 def custom_assertion_locale(module, form, id):
     return 'custom_assertion.m{module.id}.f{form.id}.{id}'.format(module=module, form=form, id=id)

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -274,6 +274,11 @@ def search_property_hint_locale(module, search_prop):
     return "search_property.m{module.id}.{search_prop}.hint".format(module=module, search_prop=search_prop)
 
 
+@pattern('search_property.m%d.%s.required.message')
+def search_property_required_msg(module, search_prop):
+    return f"search_property.m{module.id}.{search_prop}.required.message"
+
+
 @pattern('search_property.m%d.%s.validation.%d.message')
 def search_property_validation_msg(module, search_prop, index):
     return f"search_property.m{module.id}.{search_prop}.validation.{index}.message"

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -203,6 +203,10 @@ LATEST_APK_VALUE = 'latest'
 LATEST_APP_VALUE = 0
 
 
+class LabelProperty(DictProperty):
+    """Stores a {lang_code: translated_string} dict"""
+
+
 def jsonpath_update(datum_context, value):
     field = datum_context.path.fields[0]
     parent = jsonpath.Parent().find(datum_context)[0]
@@ -2142,7 +2146,7 @@ class Detail(IndexedSchema, CaseListLookupMixin):
 
 class CaseList(IndexedSchema, NavMenuItemMediaMixin):
 
-    label = DictProperty()
+    label = LabelProperty()
     show = BooleanProperty(default=False)
 
     def rename_lang(self, old_lang, new_lang):
@@ -2154,7 +2158,7 @@ class CaseList(IndexedSchema, NavMenuItemMediaMixin):
 
 class CaseSearchValidationCondition(DocumentSchema):
     xpath = StringProperty()
-    message = DictProperty()  # eg: {'en': 'bad format'})
+    message = LabelProperty()
 
 
 class Itemset(DocumentSchema):
@@ -2173,11 +2177,11 @@ class CaseSearchProperty(DocumentSchema):
     Case properties available to search on.
     """
     name = StringProperty()
-    label = DictProperty()
+    label = LabelProperty()
     appearance = StringProperty(exclude_if_none=True)
     input_ = StringProperty(exclude_if_none=True)
     default_value = StringProperty(exclude_if_none=True)
-    hint = DictProperty()
+    hint = LabelProperty()
     hidden = BooleanProperty(default=False)
     allow_blank_value = BooleanProperty(default=False)
     exclude = BooleanProperty(default=False)
@@ -2201,19 +2205,19 @@ class BaseCaseSearchLabel(NavMenuItemMediaMixin):
 
 
 class CaseSearchLabel(BaseCaseSearchLabel):
-    label = DictProperty(default={'en': 'Search All Cases'})
+    label = LabelProperty(default={'en': 'Search All Cases'})
 
 
 class CaseSearchAgainLabel(BaseCaseSearchLabel):
-    label = DictProperty(default={'en': 'Search Again'})
+    label = LabelProperty(default={'en': 'Search Again'})
 
 
 class CaseSearch(DocumentSchema):
     """
     Properties and search command label
     """
-    command_label = DictProperty(default={'en': 'Search All Cases'})
-    again_label = DictProperty(default={'en': 'Search Again'})
+    command_label = LabelProperty(default={'en': 'Search All Cases'})
+    again_label = LabelProperty(default={'en': 'Search Again'})
     search_label = SchemaProperty(CaseSearchLabel)
     search_again_label = SchemaProperty(CaseSearchAgainLabel)
     properties = SchemaListProperty(CaseSearchProperty)
@@ -2228,7 +2232,7 @@ class CaseSearch(DocumentSchema):
     data_registry = StringProperty(exclude_if_none=True)
     data_registry_workflow = StringProperty(exclude_if_none=True)  # one of REGISTRY_WORKFLOW_*
     additional_registry_cases = StringListProperty()               # list of xpath expressions
-    title_label = DictProperty(default={})
+    title_label = LabelProperty(default={})
 
     # case property referencing another case's ID
     custom_related_case_property = StringProperty(exclude_if_none=True)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -911,6 +911,10 @@ class Assertion(DocumentSchema):
     test = StringProperty()
     text = DictProperty(StringProperty)
 
+    @property
+    def has_text(self):
+        return any(self.text.values())
+
 
 class CustomAssertion(Assertion):
     """Custom assertions to add to the assertions block

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2186,6 +2186,7 @@ class CaseSearchProperty(DocumentSchema):
     allow_blank_value = BooleanProperty(default=False)
     exclude = BooleanProperty(default=False)
     required = StringProperty(exclude_if_none=True)
+    required_message = LabelProperty()
     validation = SchemaListProperty(CaseSearchValidationCondition)
 
     # applicable when appearance is a receiver

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2154,7 +2154,7 @@ class CaseList(IndexedSchema, NavMenuItemMediaMixin):
 
 class CaseSearchValidationCondition(DocumentSchema):
     xpath = StringProperty()
-    message = StringProperty(exclude_if_none=True)
+    message = DictProperty()  # eg: {'en': 'bad format'})
 
 
 class Itemset(DocumentSchema):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -901,7 +901,13 @@ class FormSchedule(DocumentSchema):
     termination_condition = SchemaProperty(FormActionCondition)
 
 
+# It's a shame to have both Assertion and CustomAssertion, as they're
+# essentially the same, but some usages of Assertion are optional
+# SchemaPropertys, and marking `test` as required precludes that. Setting the
+# SchemaProperty itself as optional doesn't work
+# https://github.com/dimagi/commcare-hq/pull/31885#discussion_r918391347
 class Assertion(DocumentSchema):
+    """Parallel of the Assertion xml entity in the suite file"""
     test = StringProperty()
     text = DictProperty(StringProperty)
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2152,6 +2152,11 @@ class CaseList(IndexedSchema, NavMenuItemMediaMixin):
         return self._module.get_app()
 
 
+class CaseSearchValidationCondition(DocumentSchema):
+    xpath = StringProperty()
+    message = StringProperty(exclude_if_none=True)
+
+
 class Itemset(DocumentSchema):
     instance_id = StringProperty(exclude_if_none=True)
     instance_uri = StringProperty(exclude_if_none=True)
@@ -2177,6 +2182,7 @@ class CaseSearchProperty(DocumentSchema):
     allow_blank_value = BooleanProperty(default=False)
     exclude = BooleanProperty(default=False)
     required = StringProperty(exclude_if_none=True)
+    validation = SchemaListProperty(CaseSearchValidationCondition)
 
     # applicable when appearance is a receiver
     receiver_expression = StringProperty(exclude_if_none=True)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2193,16 +2193,9 @@ class CaseSearchProperty(DocumentSchema):
 
     @classmethod
     def wrap(cls, data):
-        original = deepcopy(data)
-        required = data.pop('required', None)
-        if required:
-            # TODO its always str
-            if isinstance(required, str):
-                data['required'] = {'test': required}
-            elif isinstance(required, list):
-                data['required'] = required[0]
-            else:
-                data['required'] = required
+        required = data.get('required')
+        if required and isinstance(required, str):
+            data['required'] = {'test': required}
 
         old_validations = data.pop('validation', None)  # it was changed to plural
         if old_validations:
@@ -2211,7 +2204,6 @@ class CaseSearchProperty(DocumentSchema):
                 'text': old['message'],
             } for old in old_validations if old.get('xpath')]
 
-        data.pop('required_message', None)
         return super().wrap(data)
 
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -91,10 +91,10 @@ hqDefine("app_manager/js/details/case_claim", function () {
             receiverExpression: '',
             itemsetOptions: {},
             exclude: false,
-            required: '',
-            requiredMessage: '',
-            validationXPath: '',
-            validationMessage: '',
+            requiredTest: '',
+            requiredText: '',
+            validationTest: '',
+            validationText: '',
         });
         var self = {};
         self.uniqueId = generateSemiRandomId();
@@ -107,10 +107,10 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.defaultValue = ko.observable(options.defaultValue);
         self.hidden = ko.observable(options.hidden);
         self.exclude = ko.observable(options.exclude);
-        self.required = ko.observable(options.required);
-        self.requiredMessage = ko.observable(options.requiredMessage);
-        self.validationXPath = ko.observable(options.validationXPath);
-        self.validationMessage = ko.observable(options.validationMessage);
+        self.requiredTest = ko.observable(options.requiredTest);
+        self.requiredText = ko.observable(options.requiredText);
+        self.validationTest = ko.observable(options.validationTest);
+        self.validationText = ko.observable(options.validationText);
         self.appearanceFinal = ko.computed(function () {
             var appearance = self.appearance();
             if (appearance === 'report_fixture' || appearance === 'lookup_table_fixture') {
@@ -163,7 +163,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         subscribeToSave(self, [
             'name', 'label', 'hint', 'appearance', 'defaultValue', 'hidden',
             'receiverExpression', 'isMultiselect', 'allowBlankValue', 'exclude',
-            'required', 'requiredMessage', 'validationXPath', 'validationMessage',
+            'requiredTest', 'requiredText', 'validationTest', 'validationText',
         ], saveButton);
         return self;
     };
@@ -353,10 +353,10 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 isMultiselect: searchProperty.input_ === "select",
                 allowBlankValue: searchProperty.allow_blank_value,
                 exclude: searchProperty.exclude,
-                required: searchProperty.required,
-                requiredMessage: searchProperty.required_message[lang],
-                validationXPath: validation ? validation.xpath : '',
-                validationMessage: validation ? validation.message[lang] : '',
+                requiredTest: searchProperty.required.test,
+                requiredText: searchProperty.required.text[lang],
+                validationTest: validation ? validation.test : '',
+                validationText: validation ? validation.text[lang] : '',
                 defaultValue: searchProperty.default_value,
                 hidden: searchProperty.hidden,
                 receiverExpression: searchProperty.receiver_expression,
@@ -397,10 +397,10 @@ hqDefine("app_manager/js/details/case_claim", function () {
                         is_multiselect: p.isMultiselect(),
                         allow_blank_value: p.allowBlankValue(),
                         exclude: p.exclude(),
-                        required: p.required(),
-                        required_message: p.requiredMessage(),
-                        validation_xpath: p.validationXPath(),
-                        validation_message: p.validationMessage(),
+                        required_test: p.requiredTest(),
+                        required_text: p.requiredText(),
+                        validation_test: p.validationTest(),
+                        validation_text: p.validationText(),
                         default_value: p.defaultValue(),
                         hidden: p.hidden(),
                         receiver_expression: p.receiverExpression(),

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -339,42 +339,41 @@ hqDefine("app_manager/js/details/case_claim", function () {
         var self = {};
 
         self.searchConfig = searchConfigModel(searchConfigOptions, lang, searchFilterObservable, saveButton);
-        self.searchProperties = ko.observableArray();
         self.defaultProperties = ko.observableArray();
 
-        if (searchProperties.length > 0) {
-            // searchProperties is a list of CaseSearchProperty objects
-            _.each(searchProperties, function (searchProperty) {
-                // The model supports multiple validation conditions, but we don't need the UI for it yet
-                var validation = searchProperty.validation[0];
-                self.searchProperties.push(searchPropertyModel({
-                    name: searchProperty.name,
-                    label: searchProperty.label[lang],
-                    hint: searchProperty.hint[lang],
-                    appearance: _getAppearance(searchProperty),
-                    isMultiselect: searchProperty.input_ === "select",
-                    allowBlankValue: searchProperty.allow_blank_value,
-                    exclude: searchProperty.exclude,
-                    required: searchProperty.required,
-                    requiredMessage: searchProperty.required_message[lang],
-                    validationXPath: validation ? validation.xpath : '',
-                    validationMessage: validation ? validation.message[lang] : '',
-                    defaultValue: searchProperty.default_value,
-                    hidden: searchProperty.hidden,
-                    receiverExpression: searchProperty.receiver_expression,
-                    itemsetOptions: {
-                        instance_id: searchProperty.itemset.instance_id,
-                        instance_uri: searchProperty.itemset.instance_uri,
-                        nodeset: searchProperty.itemset.nodeset,
-                        label: searchProperty.itemset.label,
-                        value: searchProperty.itemset.value,
-                        sort: searchProperty.itemset.sort,
-                    },
-                }, saveButton));
-            });
-        } else {
-            self.searchProperties.push(searchPropertyModel({}, saveButton));
-        }
+        // searchProperties is a list of CaseSearchProperty objects
+        var wrappedSearchProperties = _.map(searchProperties, function (searchProperty) {
+            // The model supports multiple validation conditions, but we don't need the UI for it yet
+            var validation = searchProperty.validation[0];
+            return searchPropertyModel({
+                name: searchProperty.name,
+                label: searchProperty.label[lang],
+                hint: searchProperty.hint[lang],
+                appearance: _getAppearance(searchProperty),
+                isMultiselect: searchProperty.input_ === "select",
+                allowBlankValue: searchProperty.allow_blank_value,
+                exclude: searchProperty.exclude,
+                required: searchProperty.required,
+                requiredMessage: searchProperty.required_message[lang],
+                validationXPath: validation ? validation.xpath : '',
+                validationMessage: validation ? validation.message[lang] : '',
+                defaultValue: searchProperty.default_value,
+                hidden: searchProperty.hidden,
+                receiverExpression: searchProperty.receiver_expression,
+                itemsetOptions: {
+                    instance_id: searchProperty.itemset.instance_id,
+                    instance_uri: searchProperty.itemset.instance_uri,
+                    nodeset: searchProperty.itemset.nodeset,
+                    label: searchProperty.itemset.label,
+                    value: searchProperty.itemset.value,
+                    sort: searchProperty.itemset.sort,
+                },
+            }, saveButton);
+        });
+
+        self.searchProperties = ko.observableArray(
+            wrappedSearchProperties.length > 0 ? wrappedSearchProperties : [searchPropertyModel({}, saveButton)]
+        );
 
         self.addProperty = function () {
             self.searchProperties.push(searchPropertyModel({}, saveButton));

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -350,7 +350,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 self.searchProperties.push(searchPropertyModel({
                     name: searchProperty.name,
                     label: searchProperty.label[lang],
-                    hint: searchProperty.hint[lang] || "",
+                    hint: searchProperty.hint[lang],
                     appearance: _getAppearance(searchProperty),
                     isMultiselect: searchProperty.input_ === "select",
                     allowBlankValue: searchProperty.allow_blank_value,

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -314,6 +314,27 @@ hqDefine("app_manager/js/details/case_claim", function () {
         return self;
     };
 
+    var _getAppearance = function (searchProperty) {
+        // init with blank string to avoid triggering save button
+        var appearance = searchProperty.appearance || "";
+        if (searchProperty.input_ === "select1" || searchProperty.input_ === "select") {
+            var uri = searchProperty.itemset.instance_uri;
+            if (uri !== null && uri.includes("commcare-reports")) {
+                appearance = "report_fixture";
+            }
+            else {
+                appearance = "lookup_table_fixture";
+            }
+        }
+        if (searchProperty.appearance === "address") {
+            appearance = "address";
+        }
+        if (["date", "daterange"].indexOf(searchProperty.input_) !== -1) {
+            appearance = searchProperty.input_;
+        }
+        return appearance;
+    };
+
     var searchViewModel = function (searchProperties, defaultProperties, searchConfigOptions, lang, saveButton, searchFilterObservable) {
         var self = {};
 
@@ -324,29 +345,13 @@ hqDefine("app_manager/js/details/case_claim", function () {
         if (searchProperties.length > 0) {
             for (var i = 0; i < searchProperties.length; i++) {
                 // searchProperties is a list of CaseSearchProperty objects
-                var appearance = searchProperties[i].appearance || "";  // init with blank string to avoid triggering save button
-                if (searchProperties[i].input_ === "select1" || searchProperties[i].input_ === "select") {
-                    var uri = searchProperties[i].itemset.instance_uri;
-                    if (uri !== null && uri.includes("commcare-reports")) {
-                        appearance = "report_fixture";
-                    }
-                    else {
-                        appearance = "lookup_table_fixture";
-                    }
-                }
-                if (searchProperties[i].appearance === "address") {
-                    appearance = "address";
-                }
-                if (["date", "daterange"].indexOf(searchProperties[i].input_) !== -1) {
-                    appearance = searchProperties[i].input_;
-                }
                 // The model supports multiple validation conditions, but we don't need the UI for it yet
                 var validation = searchProperties[i].validation[0];
                 self.searchProperties.push(searchPropertyModel({
                     name: searchProperties[i].name,
                     label: searchProperties[i].label[lang],
                     hint: searchProperties[i].hint[lang] || "",
-                    appearance: appearance,
+                    appearance: _getAppearance(searchProperties[i]),
                     isMultiselect: searchProperties[i].input_ === "select",
                     allowBlankValue: searchProperties[i].allow_blank_value,
                     exclude: searchProperties[i].exclude,

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -343,35 +343,35 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.defaultProperties = ko.observableArray();
 
         if (searchProperties.length > 0) {
-            for (var i = 0; i < searchProperties.length; i++) {
-                // searchProperties is a list of CaseSearchProperty objects
+            // searchProperties is a list of CaseSearchProperty objects
+            _.each(searchProperties, function (searchProperty) {
                 // The model supports multiple validation conditions, but we don't need the UI for it yet
-                var validation = searchProperties[i].validation[0];
+                var validation = searchProperty.validation[0];
                 self.searchProperties.push(searchPropertyModel({
-                    name: searchProperties[i].name,
-                    label: searchProperties[i].label[lang],
-                    hint: searchProperties[i].hint[lang] || "",
-                    appearance: _getAppearance(searchProperties[i]),
-                    isMultiselect: searchProperties[i].input_ === "select",
-                    allowBlankValue: searchProperties[i].allow_blank_value,
-                    exclude: searchProperties[i].exclude,
-                    required: searchProperties[i].required,
-                    requiredMessage: searchProperties[i].required_message[lang],
+                    name: searchProperty.name,
+                    label: searchProperty.label[lang],
+                    hint: searchProperty.hint[lang] || "",
+                    appearance: _getAppearance(searchProperty),
+                    isMultiselect: searchProperty.input_ === "select",
+                    allowBlankValue: searchProperty.allow_blank_value,
+                    exclude: searchProperty.exclude,
+                    required: searchProperty.required,
+                    requiredMessage: searchProperty.required_message[lang],
                     validationXPath: validation ? validation.xpath : '',
                     validationMessage: validation ? validation.message[lang] : '',
-                    defaultValue: searchProperties[i].default_value,
-                    hidden: searchProperties[i].hidden,
-                    receiverExpression: searchProperties[i].receiver_expression,
+                    defaultValue: searchProperty.default_value,
+                    hidden: searchProperty.hidden,
+                    receiverExpression: searchProperty.receiver_expression,
                     itemsetOptions: {
-                        instance_id: searchProperties[i].itemset.instance_id,
-                        instance_uri: searchProperties[i].itemset.instance_uri,
-                        nodeset: searchProperties[i].itemset.nodeset,
-                        label: searchProperties[i].itemset.label,
-                        value: searchProperties[i].itemset.value,
-                        sort: searchProperties[i].itemset.sort,
+                        instance_id: searchProperty.itemset.instance_id,
+                        instance_uri: searchProperty.itemset.instance_uri,
+                        nodeset: searchProperty.itemset.nodeset,
+                        label: searchProperty.itemset.label,
+                        value: searchProperty.itemset.value,
+                        sort: searchProperty.itemset.sort,
                     },
                 }, saveButton));
-            }
+            });
         } else {
             self.searchProperties.push(searchPropertyModel({}, saveButton));
         }

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -92,6 +92,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             itemsetOptions: {},
             exclude: false,
             required: '',
+            requiredMessage: '',
             validationXPath: '',
             validationMessage: '',
         });
@@ -107,6 +108,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.hidden = ko.observable(options.hidden);
         self.exclude = ko.observable(options.exclude);
         self.required = ko.observable(options.required);
+        self.requiredMessage = ko.observable(options.requiredMessage);
         self.validationXPath = ko.observable(options.validationXPath);
         self.validationMessage = ko.observable(options.validationMessage);
         self.appearanceFinal = ko.computed(function () {
@@ -161,7 +163,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         subscribeToSave(self, [
             'name', 'label', 'hint', 'appearance', 'defaultValue', 'hidden',
             'receiverExpression', 'isMultiselect', 'allowBlankValue', 'exclude',
-            'required', 'validationXPath', 'validationMessage',
+            'required', 'requiredMessage', 'validationXPath', 'validationMessage',
         ], saveButton);
         return self;
     };
@@ -322,9 +324,6 @@ hqDefine("app_manager/js/details/case_claim", function () {
         if (searchProperties.length > 0) {
             for (var i = 0; i < searchProperties.length; i++) {
                 // searchProperties is a list of CaseSearchProperty objects
-                // property labels/hints come in keyed by lang.
-                var label = searchProperties[i].label[lang];
-                var hint = searchProperties[i].hint[lang] || "";
                 var appearance = searchProperties[i].appearance || "";  // init with blank string to avoid triggering save button
                 if (searchProperties[i].input_ === "select1" || searchProperties[i].input_ === "select") {
                     var uri = searchProperties[i].itemset.instance_uri;
@@ -341,18 +340,18 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 if (["date", "daterange"].indexOf(searchProperties[i].input_) !== -1) {
                     appearance = searchProperties[i].input_;
                 }
-                var isMultiselect = searchProperties[i].input_ === "select",
-                    // The model supports multiple validation conditions, but we don't need the UI for it yet
-                    validation = searchProperties[i].validation[0];
+                // The model supports multiple validation conditions, but we don't need the UI for it yet
+                var validation = searchProperties[i].validation[0];
                 self.searchProperties.push(searchPropertyModel({
                     name: searchProperties[i].name,
-                    label: label,
-                    hint: hint,
+                    label: searchProperties[i].label[lang],
+                    hint: searchProperties[i].hint[lang] || "",
                     appearance: appearance,
-                    isMultiselect: isMultiselect,
+                    isMultiselect: searchProperties[i].input_ === "select",
                     allowBlankValue: searchProperties[i].allow_blank_value,
                     exclude: searchProperties[i].exclude,
                     required: searchProperties[i].required,
+                    requiredMessage: searchProperties[i].required_message[lang],
                     validationXPath: validation ? validation.xpath : '',
                     validationMessage: validation ? validation.message[lang] : '',
                     defaultValue: searchProperties[i].default_value,
@@ -395,6 +394,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                         allow_blank_value: p.allowBlankValue(),
                         exclude: p.exclude(),
                         required: p.required(),
+                        required_message: p.requiredMessage(),
                         validation_xpath: p.validationXPath(),
                         validation_message: p.validationMessage(),
                         default_value: p.defaultValue(),

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -344,7 +344,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         // searchProperties is a list of CaseSearchProperty objects
         var wrappedSearchProperties = _.map(searchProperties, function (searchProperty) {
             // The model supports multiple validation conditions, but we don't need the UI for it yet
-            var validation = searchProperty.validation[0];
+            var validation = searchProperty.validations[0];
             return searchPropertyModel({
                 name: searchProperty.name,
                 label: searchProperty.label[lang],

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -389,6 +389,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     function (p) { return p.name().length > 0; }  // Skip properties where name is blank
                 ),
                 function (p) {
+                    var ifNotHidden = function (val) { return p.hidden() ? "" : val; };
                     return {
                         name: p.name(),
                         label: p.label().length ? p.label() : p.name(),  // If label isn't set, use name
@@ -397,10 +398,10 @@ hqDefine("app_manager/js/details/case_claim", function () {
                         is_multiselect: p.isMultiselect(),
                         allow_blank_value: p.allowBlankValue(),
                         exclude: p.exclude(),
-                        required_test: p.requiredTest(),
-                        required_text: p.requiredText(),
-                        validation_test: p.validationTest(),
-                        validation_text: p.validationText(),
+                        required_test: ifNotHidden(p.requiredTest()),
+                        required_text: ifNotHidden(p.requiredText()),
+                        validation_test: ifNotHidden(p.validationTest()),
+                        validation_text: ifNotHidden(p.validationText()),
                         default_value: p.defaultValue(),
                         hidden: p.hidden(),
                         receiver_expression: p.receiverExpression(),

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -92,6 +92,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
             itemsetOptions: {},
             exclude: false,
             required: '',
+            validationXPath: '',
+            validationMessage: '',
         });
         var self = {};
         self.uniqueId = generateSemiRandomId();
@@ -105,6 +107,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.hidden = ko.observable(options.hidden);
         self.exclude = ko.observable(options.exclude);
         self.required = ko.observable(options.required);
+        self.validationXPath = ko.observable(options.validationXPath);
+        self.validationMessage = ko.observable(options.validationMessage);
         self.appearanceFinal = ko.computed(function () {
             var appearance = self.appearance();
             if (appearance === 'report_fixture' || appearance === 'lookup_table_fixture') {
@@ -156,7 +160,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
 
         subscribeToSave(self, [
             'name', 'label', 'hint', 'appearance', 'defaultValue', 'hidden',
-            'receiverExpression', 'isMultiselect', 'allowBlankValue', 'exclude', 'required',
+            'receiverExpression', 'isMultiselect', 'allowBlankValue', 'exclude',
+            'required', 'validationXPath', 'validationMessage',
         ], saveButton);
         return self;
     };
@@ -336,7 +341,9 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 if (["date", "daterange"].indexOf(searchProperties[i].input_) !== -1) {
                     appearance = searchProperties[i].input_;
                 }
-                var isMultiselect = searchProperties[i].input_ === "select";
+                var isMultiselect = searchProperties[i].input_ === "select",
+                    // The model supports multiple validation conditions, but we don't need the UI for it yet
+                    validation = searchProperties[i].validation[0];
                 self.searchProperties.push(searchPropertyModel({
                     name: searchProperties[i].name,
                     label: label,
@@ -346,6 +353,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     allowBlankValue: searchProperties[i].allow_blank_value,
                     exclude: searchProperties[i].exclude,
                     required: searchProperties[i].required,
+                    validationXPath: validation ? validation.xpath : '',
+                    validationMessage: validation ? validation.message[lang] : '',
                     defaultValue: searchProperties[i].default_value,
                     hidden: searchProperties[i].hidden,
                     receiverExpression: searchProperties[i].receiver_expression,
@@ -386,6 +395,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
                         allow_blank_value: p.allowBlankValue(),
                         exclude: p.exclude(),
                         required: p.required(),
+                        validation_xpath: p.validationXPath(),
+                        validation_message: p.validationMessage(),
                         default_value: p.defaultValue(),
                         hidden: p.hidden(),
                         receiver_expression: p.receiverExpression(),

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -71,6 +71,8 @@ class EntryInstances(PostProcessor):
                     xpaths.add(prompt.required.test)
                 if prompt.default_value:
                     xpaths.add(prompt.default_value)
+                for validation in prompt.validation:
+                    xpaths.add(validation.test)
         if entry.post:
             if entry.post.relevant:
                 xpaths.add(entry.post.relevant)

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -68,7 +68,7 @@ class EntryInstances(PostProcessor):
                 if prompt.itemset:
                     xpaths.add(prompt.itemset.nodeset)
                 if prompt.required:
-                    xpaths.add(prompt.required)
+                    xpaths.add(prompt.required.test)
                 if prompt.default_value:
                     xpaths.add(prompt.default_value)
         if entry.post:

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -71,7 +71,7 @@ class EntryInstances(PostProcessor):
                     xpaths.add(prompt.required.test)
                 if prompt.default_value:
                     xpaths.add(prompt.default_value)
-                for validation in prompt.validation:
+                for validation in prompt.validations:
                     xpaths.add(validation.test)
         if entry.post:
             if entry.post.relevant:

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -32,6 +32,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     StackJump,
     Text,
     TextXPath,
+    Validation,
     XPathVariable,
 )
 from corehq.apps.app_manager.util import (
@@ -274,6 +275,14 @@ class RemoteRequestFactory(object):
                 kwargs['exclude'] = "true()"
             if prop.required:
                 kwargs['required'] = interpolate_xpath(prop.required)
+            if prop.validation:
+                kwargs['validation'] = [
+                    Validation(
+                        xpath=condition.xpath,
+                        message=condition.message,
+                    )
+                    for condition in prop.validation
+                ]
             prompts.append(QueryPrompt(**kwargs))
         return prompts
 

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -274,18 +274,18 @@ class RemoteRequestFactory(object):
                 kwargs['allow_blank_value'] = prop.allow_blank_value
             if prop.exclude:
                 kwargs['exclude'] = "true()"
-            if prop.required:
+            if prop.required.test:
                 kwargs['required'] = Required(
-                    test=interpolate_xpath(prop.required),
-                    text=[Text(locale_id=id_strings.search_property_required_msg(self.module, prop.name))],
+                    test=interpolate_xpath(prop.required.test),
+                    text=[Text(locale_id=id_strings.search_property_required_text(self.module, prop.name))],
                 )
-            if prop.validation:
-                kwargs['validation'] = [
+            if prop.validations:
+                kwargs['validations'] = [
                     Validation(
-                        test=interpolate_xpath(condition.xpath),
-                        text=[Text(locale_id=id_strings.search_property_validation_msg(self.module, prop.name, i))],
+                        test=interpolate_xpath(validation.test),
+                        text=[Text(locale_id=id_strings.search_property_validation_text(self.module, prop.name, i))],
                     )
-                    for i, condition in enumerate(prop.validation)
+                    for i, validation in enumerate(prop.validations)
                 ]
             prompts.append(QueryPrompt(**kwargs))
         return prompts

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -27,6 +27,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     RemoteRequestPost,
     RemoteRequestQuery,
     RemoteRequestSession,
+    Required,
     SessionDatum,
     Stack,
     StackJump,
@@ -274,12 +275,15 @@ class RemoteRequestFactory(object):
             if prop.exclude:
                 kwargs['exclude'] = "true()"
             if prop.required:
-                kwargs['required'] = interpolate_xpath(prop.required)
+                kwargs['required'] = Required(
+                    test=interpolate_xpath(prop.required),
+                    text=[Text(locale_id=id_strings.search_property_required_msg(self.module, prop.name))],
+                )
             if prop.validation:
                 kwargs['validation'] = [
                     Validation(
                         test=interpolate_xpath(condition.xpath),
-                        text=Text(locale_id=id_strings.search_property_validation_msg(self.module, prop.name, i)),
+                        text=[Text(locale_id=id_strings.search_property_validation_msg(self.module, prop.name, i))],
                     )
                     for i, condition in enumerate(prop.validation)
                 ]

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -283,7 +283,9 @@ class RemoteRequestFactory(object):
                 kwargs['validations'] = [
                     Validation(
                         test=interpolate_xpath(validation.test),
-                        text=[Text(locale_id=id_strings.search_property_validation_text(self.module, prop.name, i))],
+                        text=[Text(
+                            locale_id=id_strings.search_property_validation_text(self.module, prop.name, i)
+                        )] if validation.has_text else [],
                     )
                     for i, validation in enumerate(prop.validations)
                 ]

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -278,7 +278,7 @@ class RemoteRequestFactory(object):
             if prop.validation:
                 kwargs['validation'] = [
                     Validation(
-                        test=condition.xpath,
+                        test=interpolate_xpath(condition.xpath),
                         text=Text(locale_id=id_strings.search_property_validation_msg(self.module, prop.name, i)),
                     )
                     for i, condition in enumerate(prop.validation)

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -278,7 +278,7 @@ class RemoteRequestFactory(object):
             if prop.validation:
                 kwargs['validation'] = [
                     Validation(
-                        xpath=condition.xpath,
+                        test=condition.xpath,
                         text=Text(locale_id=id_strings.search_property_validation_msg(self.module, prop.name)),
                     )
                     for condition in prop.validation

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -279,9 +279,9 @@ class RemoteRequestFactory(object):
                 kwargs['validation'] = [
                     Validation(
                         test=condition.xpath,
-                        text=Text(locale_id=id_strings.search_property_validation_msg(self.module, prop.name)),
+                        text=Text(locale_id=id_strings.search_property_validation_msg(self.module, prop.name, i)),
                     )
-                    for condition in prop.validation
+                    for i, condition in enumerate(prop.validation)
                 ]
             prompts.append(QueryPrompt(**kwargs))
         return prompts

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -279,7 +279,7 @@ class RemoteRequestFactory(object):
                 kwargs['validation'] = [
                     Validation(
                         xpath=condition.xpath,
-                        message=condition.message,
+                        text=Text(locale_id=id_strings.search_property_validation_msg(self.module, prop.name)),
                     )
                     for condition in prop.validation
                 ]

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -521,7 +521,7 @@ class QueryPrompt(DisplayNode):
     allow_blank_value = BooleanField('@allow_blank_value', required=False)
     exclude = StringField('@exclude', required=False)
     required = NodeField('required', Required, required=False)
-    validation = NodeListField('validation', Validation)
+    validations = NodeListField('validation', Validation)
 
     itemset = NodeField('itemset', Itemset)
 

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -501,6 +501,12 @@ class Assertion(XmlObject):
     text = NodeListField('text', Text)
 
 
+class Validation(XmlObject):
+    ROOT_NAME = 'validation'
+    xpath = XPathField('@xpath')
+    message = StringField('@message', required=False)
+
+
 class QueryPrompt(DisplayNode):
     ROOT_NAME = 'prompt'
 
@@ -513,6 +519,7 @@ class QueryPrompt(DisplayNode):
     allow_blank_value = BooleanField('@allow_blank_value', required=False)
     exclude = StringField('@exclude', required=False)
     required = StringField('@required', required=False)
+    validation = NodeListField('validation', Validation)
 
     itemset = NodeField('itemset', Itemset)
 

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -501,10 +501,12 @@ class Assertion(XmlObject):
     text = NodeListField('text', Text)
 
 
-class Validation(XmlObject):
+class Required(Assertion):
+    ROOT_NAME = 'required'
+
+
+class Validation(Assertion):
     ROOT_NAME = 'validation'
-    test = XPathField('@test')
-    text = NodeField('text', Text)
 
 
 class QueryPrompt(DisplayNode):
@@ -518,7 +520,7 @@ class QueryPrompt(DisplayNode):
     default_value = StringField('@default', required=False)
     allow_blank_value = BooleanField('@allow_blank_value', required=False)
     exclude = StringField('@exclude', required=False)
-    required = StringField('@required', required=False)
+    required = NodeField('required', Required, required=False)
     validation = NodeListField('validation', Validation)
 
     itemset = NodeField('itemset', Itemset)

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -504,7 +504,7 @@ class Assertion(XmlObject):
 class Validation(XmlObject):
     ROOT_NAME = 'validation'
     xpath = XPathField('@xpath')
-    message = StringField('@message', required=False)
+    text = NodeField('text', Text)
 
 
 class QueryPrompt(DisplayNode):

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -503,7 +503,7 @@ class Assertion(XmlObject):
 
 class Validation(XmlObject):
     ROOT_NAME = 'validation'
-    xpath = XPathField('@xpath')
+    test = XPathField('@test')
     text = NodeField('text', Text)
 
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -145,7 +145,7 @@
                   </div>
                 </div>
                 </fieldset>
-                {% if js_options.has_geocoder_privs or js_options.exclude_from_search_enabled %}
+                {% if js_options.has_geocoder_privs or js_options.ush_case_claim_2_53 %}
                     <fieldset>
                       <legend>{% trans "Advanced Options" %}</legend>
                       {% if js_options.has_geocoder_privs %}
@@ -168,7 +168,7 @@
                           </div>
                         </div>
                       {% endif %}
-                      {% if js_options.exclude_from_search_enabled %}
+                      {% if js_options.ush_case_claim_2_53 %}
                         <div class="form-group">
                           <label class="control-label col-xs-12 col-sm-3">
                             {% trans "Exclude From Search Filters" %}
@@ -177,8 +177,6 @@
                             <input type="checkbox" data-bind="checked: exclude"/>
                           </div>
                         </div>
-                      {% endif %}
-                      {% if js_options.required_search_fields_enabled %}
                         <div class="form-group">
                           <label class="control-label col-xs-12 col-sm-3">
                             {% trans "Required" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -193,7 +193,7 @@
                             <input class="form-control" type="text" data-bind="value: validationXPath" placeholder="true()"/>
                           </div>
                         </div>
-                        <div class="form-group">
+                        <div class="form-group" data-bind="visible: validationXPath">
                           <label class="control-label col-xs-12 col-sm-3">
                             {% trans "Validation Message" %}
                           </label>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -182,15 +182,15 @@
                             {% trans "Required" %}
                           </label>
                           <div class="col-xs-12 col-sm-9">
-                            <textarea class="form-control vertical-resize" data-bind="value: required" placeholder="true()"></textarea>
+                            <textarea class="form-control vertical-resize" data-bind="value: requiredTest" placeholder="true()"></textarea>
                           </div>
                         </div>
-                        <div class="form-group" data-bind="visible: required">
+                        <div class="form-group" data-bind="visible: requiredTest">
                             <label class="control-label col-xs-12 col-sm-3">
                                 {% trans "Required Message" %}
                             </label>
                             <div class="col-xs-12 col-sm-9">
-                                <textarea class="form-control vertical-resize" data-bind="value: requiredMessage"></textarea>
+                                <textarea class="form-control vertical-resize" data-bind="value: requiredText"></textarea>
                             </div>
                         </div>
                         <div class="form-group">
@@ -198,15 +198,15 @@
                             {% trans "Validation Condition" %}
                           </label>
                           <div class="col-xs-12 col-sm-9">
-                            <textarea class="form-control vertical-resize" data-bind="value: validationXPath" placeholder="true()"></textarea>
+                            <textarea class="form-control vertical-resize" data-bind="value: validationTest" placeholder="true()"></textarea>
                           </div>
                         </div>
-                        <div class="form-group" data-bind="visible: validationXPath">
+                        <div class="form-group" data-bind="visible: validationTest">
                           <label class="control-label col-xs-12 col-sm-3">
                             {% trans "Validation Message" %}
                           </label>
                           <div class="col-xs-12 col-sm-9">
-                            <textarea class="form-control vertical-resize" data-bind="value: validationMessage"></textarea>
+                            <textarea class="form-control vertical-resize" data-bind="value: validationText"></textarea>
                           </div>
                         </div>
                       {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -190,7 +190,7 @@
                             {% trans "Validation Condition" %}
                           </label>
                           <div class="col-xs-12 col-sm-9">
-                            <input class="form-control" type="text" data-bind="value: validationXPath" placeholder="true()"/>
+                            <textarea class="form-control vertical-resize" data-bind="value: validationXPath" placeholder="true()"></textarea>
                           </div>
                         </div>
                         <div class="form-group" data-bind="visible: validationXPath">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -185,6 +185,22 @@
                             <textarea class="form-control vertical-resize" data-bind="value: required" placeholder="true()"></textarea>
                           </div>
                         </div>
+                        <div class="form-group">
+                          <label class="control-label col-xs-12 col-sm-3">
+                            {% trans "Validation Condition" %}
+                          </label>
+                          <div class="col-xs-12 col-sm-9">
+                            <input class="form-control" type="text" data-bind="value: validationXPath" placeholder="true()"/>
+                          </div>
+                        </div>
+                        <div class="form-group">
+                          <label class="control-label col-xs-12 col-sm-3">
+                            {% trans "Validation Message" %}
+                          </label>
+                          <div class="col-xs-12 col-sm-9">
+                            <textarea class="form-control vertical-resize" data-bind="value: validationMessage"></textarea>
+                          </div>
+                        </div>
                       {% endif %}
                     </fieldset>
                 {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -185,6 +185,14 @@
                             <textarea class="form-control vertical-resize" data-bind="value: required" placeholder="true()"></textarea>
                           </div>
                         </div>
+                        <div class="form-group" data-bind="visible: required">
+                            <label class="control-label col-xs-12 col-sm-3">
+                                {% trans "Required Message" %}
+                            </label>
+                            <div class="col-xs-12 col-sm-9">
+                                <textarea class="form-control vertical-resize" data-bind="value: requiredMessage"></textarea>
+                            </div>
+                        </div>
                         <div class="form-group">
                           <label class="control-label col-xs-12 col-sm-3">
                             {% trans "Validation Condition" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -177,36 +177,38 @@
                             <input type="checkbox" data-bind="checked: exclude"/>
                           </div>
                         </div>
-                        <div class="form-group">
-                          <label class="control-label col-xs-12 col-sm-3">
-                            {% trans "Required" %}
-                          </label>
-                          <div class="col-xs-12 col-sm-9">
-                            <textarea class="form-control vertical-resize" data-bind="value: requiredTest" placeholder="true()"></textarea>
-                          </div>
-                        </div>
-                        <div class="form-group" data-bind="visible: requiredTest">
+                        <div data-bind="hidden: hidden">
+                          <div class="form-group">
                             <label class="control-label col-xs-12 col-sm-3">
-                                {% trans "Required Message" %}
+                              {% trans "Required" %}
                             </label>
                             <div class="col-xs-12 col-sm-9">
-                                <textarea class="form-control vertical-resize" data-bind="value: requiredText"></textarea>
+                              <textarea class="form-control vertical-resize" data-bind="value: requiredTest" placeholder="true()"></textarea>
                             </div>
-                        </div>
-                        <div class="form-group">
-                          <label class="control-label col-xs-12 col-sm-3">
-                            {% trans "Validation Condition" %}
-                          </label>
-                          <div class="col-xs-12 col-sm-9">
-                            <textarea class="form-control vertical-resize" data-bind="value: validationTest" placeholder="true()"></textarea>
                           </div>
-                        </div>
-                        <div class="form-group" data-bind="visible: validationTest">
-                          <label class="control-label col-xs-12 col-sm-3">
-                            {% trans "Validation Message" %}
-                          </label>
-                          <div class="col-xs-12 col-sm-9">
-                            <textarea class="form-control vertical-resize" data-bind="value: validationText"></textarea>
+                          <div class="form-group" data-bind="visible: requiredTest">
+                              <label class="control-label col-xs-12 col-sm-3">
+                                  {% trans "Required Message" %}
+                              </label>
+                              <div class="col-xs-12 col-sm-9">
+                                  <textarea class="form-control vertical-resize" data-bind="value: requiredText"></textarea>
+                              </div>
+                          </div>
+                          <div class="form-group">
+                            <label class="control-label col-xs-12 col-sm-3">
+                              {% trans "Validation Condition" %}
+                            </label>
+                            <div class="col-xs-12 col-sm-9">
+                              <textarea class="form-control vertical-resize" data-bind="value: validationTest" placeholder="true()"></textarea>
+                            </div>
+                          </div>
+                          <div class="form-group" data-bind="visible: validationTest">
+                            <label class="control-label col-xs-12 col-sm-3">
+                              {% trans "Validation Message" %}
+                            </label>
+                            <div class="col-xs-12 col-sm-9">
+                              <textarea class="form-control vertical-resize" data-bind="value: validationText"></textarea>
+                            </div>
                           </div>
                         </div>
                       {% endif %}

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -866,7 +866,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             CaseSearchProperty(name='email', label={'en': 'Email'}, validation=[
                 CaseSearchValidationCondition(
                     xpath="contains(instance('search-input:results')/input/field[@name='email'], '@')",
-                    message="Please enter a valid email address",
+                    message={"en": "Please enter a valid email address",
+                             "it": "Si prega di inserire un indirizzo email valido"},
                 )
             ]),
         ]
@@ -879,7 +880,11 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                 <locale id="search_property.m0.name"/>
               </text>
             </display>
-            <validation xpath="2 + 2 = 5"/>
+            <validation xpath="2 + 2 = 5">
+              <text>
+                <locale id="search_property.m0.name.validation_msg"/>
+              </text>
+            </validation>
           </prompt>
           <prompt key="email">
             <display>
@@ -887,10 +892,11 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                 <locale id="search_property.m0.email"/>
               </text>
             </display>
-            <validation
-                xpath="contains(instance('search-input:results')/input/field[@name='email'], '@')"
-                message="Please enter a valid email address"
-            />
+            <validation xpath="contains(instance('search-input:results')/input/field[@name='email'], '@')">
+              <text>
+                <locale id="search_property.m0.email.validation_msg"/>
+              </text>
+            </validation>
           </prompt>
         </partial>
         """

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -882,7 +882,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             </display>
             <validation test="2 + 2 = 5">
               <text>
-                <locale id="search_property.m0.name.validation.message"/>
+                <locale id="search_property.m0.name.validation.0.message"/>
               </text>
             </validation>
           </prompt>
@@ -894,7 +894,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             </display>
             <validation test="contains(instance('search-input:results')/input/field[@name='email'], '@')">
               <text>
-                <locale id="search_property.m0.email.validation.message"/>
+                <locale id="search_property.m0.email.validation.0.message"/>
               </text>
             </validation>
           </prompt>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -868,7 +868,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
     def test_case_search_validation_conditions(self, *args):
         self.module.search_config.properties = [
             CaseSearchProperty(name='name', label={'en': 'Name'}, validations=[
-                Assertion(test='2 + 2 = 5')
+                Assertion(test='2 + 2 = 5', text={"en": ""})
             ]),
             CaseSearchProperty(name='email', label={'en': 'Email'}, validations=[
                 Assertion(
@@ -887,11 +887,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                 <locale id="search_property.m0.name"/>
               </text>
             </display>
-            <validation test="2 + 2 = 5">
-              <text>
-                <locale id="search_property.m0.name.validation.0.text"/>
-              </text>
-            </validation>
+            <validation test="2 + 2 = 5" />
           </prompt>
           <prompt key="email">
             <display>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -847,12 +847,17 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         suite = self.app.create_suite()
         expected = """
         <partial>
-          <prompt key="name" required="instance('commcaresession')/session/user/data/is_supervisor = 'n'">
+          <prompt key="name">
             <display>
               <text>
                 <locale id="search_property.m0.name"/>
               </text>
             </display>
+            <required test="instance('commcaresession')/session/user/data/is_supervisor = 'n'">
+              <text>
+                <locale id="search_property.m0.name.required.message"/>
+              </text>
+            </required>
           </prompt>
         </partial>
         """

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -880,9 +880,9 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                 <locale id="search_property.m0.name"/>
               </text>
             </display>
-            <validation xpath="2 + 2 = 5">
+            <validation test="2 + 2 = 5">
               <text>
-                <locale id="search_property.m0.name.validation_msg"/>
+                <locale id="search_property.m0.name.validation.message"/>
               </text>
             </validation>
           </prompt>
@@ -892,9 +892,9 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                 <locale id="search_property.m0.email"/>
               </text>
             </display>
-            <validation xpath="contains(instance('search-input:results')/input/field[@name='email'], '@')">
+            <validation test="contains(instance('search-input:results')/input/field[@name='email'], '@')">
               <text>
-                <locale id="search_property.m0.email.validation_msg"/>
+                <locale id="search_property.m0.email.validation.message"/>
               </text>
             </validation>
           </prompt>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -6,11 +6,11 @@ from corehq.apps.app_manager.const import REGISTRY_WORKFLOW_SMART_LINK
 from corehq.apps.app_manager.models import (
     AdvancedModule,
     Application,
+    Assertion,
     CaseSearch,
     CaseSearchAgainLabel,
     CaseSearchLabel,
     CaseSearchProperty,
-    CaseSearchValidationCondition,
     DefaultCaseSearchProperty,
     Itemset,
     Module, DetailColumn, ShadowModule,
@@ -843,7 +843,9 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
     def test_required(self, *args):
-        self.module.search_config.properties[0].required = "#session/user/data/is_supervisor = 'n'"
+        self.module.search_config.properties[0].required = Assertion(
+            test="#session/user/data/is_supervisor = 'n'",
+        )
         suite = self.app.create_suite()
         expected = """
         <partial>
@@ -855,7 +857,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             </display>
             <required test="instance('commcaresession')/session/user/data/is_supervisor = 'n'">
               <text>
-                <locale id="search_property.m0.name.required.message"/>
+                <locale id="search_property.m0.name.required.text"/>
               </text>
             </required>
           </prompt>
@@ -865,14 +867,14 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
     def test_case_search_validation_conditions(self, *args):
         self.module.search_config.properties = [
-            CaseSearchProperty(name='name', label={'en': 'Name'}, validation=[
-                CaseSearchValidationCondition(xpath='2 + 2 = 5')
+            CaseSearchProperty(name='name', label={'en': 'Name'}, validations=[
+                Assertion(test='2 + 2 = 5')
             ]),
-            CaseSearchProperty(name='email', label={'en': 'Email'}, validation=[
-                CaseSearchValidationCondition(
-                    xpath="contains(instance('search-input:results')/input/field[@name='email'], '@')",
-                    message={"en": "Please enter a valid email address",
-                             "it": "Si prega di inserire un indirizzo email valido"},
+            CaseSearchProperty(name='email', label={'en': 'Email'}, validations=[
+                Assertion(
+                    test="contains(instance('search-input:results')/input/field[@name='email'], '@')",
+                    text={"en": "Please enter a valid email address",
+                          "it": "Si prega di inserire un indirizzo email valido"},
                 )
             ]),
         ]
@@ -887,7 +889,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             </display>
             <validation test="2 + 2 = 5">
               <text>
-                <locale id="search_property.m0.name.validation.0.message"/>
+                <locale id="search_property.m0.name.validation.0.text"/>
               </text>
             </validation>
           </prompt>
@@ -899,7 +901,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             </display>
             <validation test="contains(instance('search-input:results')/input/field[@name='email'], '@')">
               <text>
-                <locale id="search_property.m0.email.validation.0.message"/>
+                <locale id="search_property.m0.email.validation.0.text"/>
               </text>
             </validation>
           </prompt>

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1029,14 +1029,16 @@ def _update_search_properties(module, search_properties, lang='en'):
         if prop['exclude']:
             ret['exclude'] = prop['exclude']
         if prop['required']:
-            ret['required'] = prop['required']
-            _current_msg = current.required_message if current else {}
-            ret['required_message'] = {**_current_msg, lang: prop['required_message']}
+            _current_text = current.required.text if current.required else {}
+            ret['required'] = {
+                'test': prop['required'],
+                'text': {**_current_text, lang: prop['required_message']}
+            }
         if prop['validation_xpath']:
-            _current_msg = current.validation[0].message if current and current.validation else {}
-            ret['validation'] = [{
-                'xpath': prop['validation_xpath'],
-                'message': {**_current_msg, lang: prop['validation_message']},
+            _current_text = current.validations[0].text if current and current.validations else {}
+            ret['validations'] = [{
+                'test': prop['validation_xpath'],
+                'text': {**_current_text, lang: prop['validation_message']},
             }]
         if prop.get('appearance', '') == 'fixture':
             if prop.get('is_multiselect', False):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1030,6 +1030,8 @@ def _update_search_properties(module, search_properties, lang='en'):
             ret['exclude'] = prop['exclude']
         if prop['required']:
             ret['required'] = prop['required']
+            _current_msg = current.required_message if current else {}
+            ret['required_message'] = {**_current_msg, lang: prop['required_message']}
         if prop['validation_xpath']:
             _current_msg = current.validation[0].message if current and current.validation else {}
             ret['validation'] = [{

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1033,6 +1033,11 @@ def _update_search_properties(module, search_properties, lang='en'):
             ret['exclude'] = prop['exclude']
         if prop['required']:
             ret['required'] = prop['required']
+        if prop['validation_xpath']:
+            ret['validation'] = [{
+                'xpath': prop['validation_xpath'],
+                'message': {'en': prop['validation_message']},  # TODO
+            }]
         if prop.get('appearance', '') == 'fixture':
             if prop.get('is_multiselect', False):
                 ret['input_'] = 'select'

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1009,22 +1009,19 @@ def _update_search_properties(module, search_properties, lang='en'):
     True
 
     """
-    current = {p.name: p.label for p in module.search_config.properties}
+    props_by_name = {p.name: p for p in module.search_config.properties}
     for prop in search_properties:
-        if prop['name'] in current:
-            label = current[prop['name']].copy()
-            label.update({lang: prop['label']})
-        else:
-            label = {lang: prop['label']}
-        hint = {lang: prop['hint']}
+        current = props_by_name.get(prop['name'])
+
+        _current_label = current.label if current else {}
+        _current_hint = current.hint if current else {}
         ret = {
             'name': prop['name'],
-            'label': label,
+            'label': {**_current_label, lang: prop['label']},
+            'hint': {**_current_hint, lang: prop['hint']},
         }
         if prop['default_value']:
             ret['default_value'] = prop['default_value']
-        if prop['hint']:
-            ret['hint'] = hint
         if prop['hidden']:
             ret['hidden'] = prop['hidden']
         if prop['allow_blank_value']:
@@ -1034,9 +1031,10 @@ def _update_search_properties(module, search_properties, lang='en'):
         if prop['required']:
             ret['required'] = prop['required']
         if prop['validation_xpath']:
+            _current_msg = current.validation[0].message if current and current.validation else {}
             ret['validation'] = [{
                 'xpath': prop['validation_xpath'],
-                'message': {'en': prop['validation_message']},  # TODO
+                'message': {**_current_msg, lang: prop['validation_message']},
             }]
         if prop.get('appearance', '') == 'fixture':
             if prop.get('is_multiselect', False):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -223,8 +223,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
                 domain_has_privilege(app.domain, privileges.GEOCODER)
                 and toggles.USH_CASE_CLAIM_UPDATES.enabled(app.domain)
             ),
-            'exclude_from_search_enabled': app.enable_exclude_from_search,
-            'required_search_fields_enabled': app.enable_required_search_fields,
+            'ush_case_claim_2_53': app.ush_case_claim_2_53,
             'item_lists': item_lists,
             'has_lookup_tables': bool([i for i in item_lists if i['fixture_type'] == LOOKUP_TABLE_FIXTURE]),
             'has_mobile_ucr': bool([i for i in item_lists if i['fixture_type'] == REPORT_FIXTURE]),

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1028,17 +1028,17 @@ def _update_search_properties(module, search_properties, lang='en'):
             ret['allow_blank_value'] = prop['allow_blank_value']
         if prop['exclude']:
             ret['exclude'] = prop['exclude']
-        if prop['required']:
+        if prop['required_test']:
             _current_text = current.required.text if current.required else {}
             ret['required'] = {
-                'test': prop['required'],
-                'text': {**_current_text, lang: prop['required_message']}
+                'test': prop['required_test'],
+                'text': {**_current_text, lang: prop['required_text']}
             }
-        if prop['validation_xpath']:
+        if prop['validation_test']:
             _current_text = current.validations[0].text if current and current.validations else {}
             ret['validations'] = [{
-                'test': prop['validation_xpath'],
-                'text': {**_current_text, lang: prop['validation_message']},
+                'test': prop['validation_test'],
+                'text': {**_current_text, lang: prop['validation_text']},
             }]
         if prop.get('appearance', '') == 'fixture':
             if prop.get('is_multiselect', False):


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2175
https://docs.google.com/document/d/1wF9SFfX7-R86cPRgabrqbTU9BaGdp3IlAYlTjInWXTU/edit
This adds the ability to configure validation conditions for case search input.  Sure feels an awful lot like we're rebuilding xforms.
![image](https://user-images.githubusercontent.com/2367539/177627182-b45e3cb0-1d97-4393-8d9d-90d4a7ae8363.png)

## Technical Summary
see commit messages for details

## Feature Flag
USH_CASE_CLAIM_UPDATES: USH Specific toggle to support several different case search/claim workflows in web apps

## Safety Assurance

### Safety story
Automated tests included for the suite changes, plus manual testing of the UI portion

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
I believe this can be merged independently, then QA'd when the webapps and formplayer portions are complete.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
