### PR TITLE
Change Update Translations PR/commit text to skip CI

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -50,11 +50,9 @@ jobs:
           branch-suffix: short-commit-hash
           commit-message: |
             Update translations
+
+            [ci skip]
           title: 'Update Translations'
           labels: product/invisible
           body: |
             GitHub Actions automatically ran update-translations.sh and used [create-pull-request](https://github.com/peter-evans/create-pull-request) to open this pull request.
-
-            Please **close and reopen** this pull request to have tests run.<sup>†</sup>
-
-            <sup>†</sup> Workaround for [this GitHub Actions constraint](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)


### PR DESCRIPTION
## Technical Summary

This reflects our consensus decision not to run the build on these
automated translations changes, just like we haven't been doing
with our previous process.

In addition to the quirks that prevent CI from running on PRs
opened by a previous GitHub Actions workflow, we decided that the CI
tests did not provide much if any value in catching errors in the
automated translations file, and that such errors are much more likely
to be caught by the previous GA workflow that generates the translations
changes.

### Safety story
This doesn't really affect production at all compared to our status quo process.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
