### PR TITLE
Minor linked domains error handling refactor + message improvement

### DIFF
--- a/corehq/apps/linked_domain/exceptions.py
+++ b/corehq/apps/linked_domain/exceptions.py
@@ -10,16 +10,11 @@ class DomainLinkNotAllowed(Exception):
     pass
 
 
-class AttemptedPushViolatesConstraints(Exception):
-    pass
-
-
-class DomainLinkNotFound(Exception):
-    pass
-
-
-class NoDownstreamDomainsProvided(Exception):
-    pass
+class InvalidPushException(Exception):
+    """Raised if attempted push is deemed invalid by validate_push"""
+    def __init__(self, message):
+        super().__init__()
+        self.message = message
 
 
 class MultipleDownstreamAppsError(Exception):

--- a/corehq/apps/linked_domain/tests/test_views.py
+++ b/corehq/apps/linked_domain/tests/test_views.py
@@ -99,7 +99,8 @@ class ValidatePushTests(TestCase):
         with self.assertRaises(InvalidPushException) as cm:
             validate_push(self.user, 'upstream', ['downstream'])
         self.assertEqual(cm.exception.message,
-                         'Links between one or more project spaces do not exist. Please contact support.')
+                         "The project space link between upstream and downstream does not exist. Ensure the "
+                         "link was not recently deleted.")
 
     def test_raises_exception_if_user_does_not_have_permission(self):
         DomainLink.objects.create(master_domain='upstream', linked_domain='downstream')

--- a/corehq/apps/linked_domain/tests/test_views.py
+++ b/corehq/apps/linked_domain/tests/test_views.py
@@ -4,12 +4,10 @@ from django.test import SimpleTestCase, TestCase
 
 from corehq.apps.domain.exceptions import DomainDoesNotExist
 from corehq.apps.linked_domain.exceptions import (
-    AttemptedPushViolatesConstraints,
     DomainLinkAlreadyExists,
     DomainLinkError,
     DomainLinkNotAllowed,
-    DomainLinkNotFound,
-    NoDownstreamDomainsProvided,
+    InvalidPushException,
     UserDoesNotHavePermission,
 )
 from corehq.apps.linked_domain.models import DomainLink
@@ -92,25 +90,32 @@ class ValidatePushTests(TestCase):
         cls.addClassCleanup(permissions_check_patcher.stop)
 
     def test_raises_exception_if_no_downstream_domains_selected(self):
-        with self.assertRaises(NoDownstreamDomainsProvided):
+        with self.assertRaises(InvalidPushException) as cm:
             validate_push(self.user, 'upstream', [])
+        self.assertEqual(cm.exception.message,
+                         'No downstream project spaces were selected. Please contact support.')
 
     def test_raises_exception_if_link_not_found(self):
-        with self.assertRaises(DomainLinkNotFound):
+        with self.assertRaises(InvalidPushException) as cm:
             validate_push(self.user, 'upstream', ['downstream'])
+        self.assertEqual(cm.exception.message,
+                         'Links between one or more project spaces do not exist. Please contact support.')
 
     def test_raises_exception_if_user_does_not_have_permission(self):
         DomainLink.objects.create(master_domain='upstream', linked_domain='downstream')
         self.mock_permissions_check.return_value = False
-        with self.assertRaises(UserDoesNotHavePermission):
+        with self.assertRaises(InvalidPushException) as cm:
             validate_push(self.user, 'upstream', ['downstream'])
+        self.assertEqual(cm.exception.message,
+                         "You do not have permission to push to all specified downstream project spaces.")
 
     def test_raises_exception_if_user_attempts_invalid_push(self):
+        """See CheckIfPushViolatesConstraintTests for more related tests"""
         DomainLink.objects.create(master_domain='upstream', linked_domain='downstream')
         self.mock_permissions_check.return_value = True
-        self.mock_violates_constraints.side_effect = AttemptedPushViolatesConstraints
+        self.mock_violates_constraints.side_effect = InvalidPushException(message='mocked exception')
 
-        with self.assertRaises(AttemptedPushViolatesConstraints):
+        with self.assertRaises(InvalidPushException):
             validate_push(self.user, 'upstream', ['downstream'])
 
     def test_successful_validation(self):
@@ -150,10 +155,8 @@ class CheckIfPushViolatesConstraintTests(TestCase):
         link2_patcher.start()
         self.addCleanup(link2_patcher.stop)
 
-        try:
-            check_if_push_violates_constraints(self.superuser, [full_access_link1, full_access_link2])
-        except Exception as e:
-            self.fail(f"Unexpected exception raised {e}")
+        # should not raise exception
+        check_if_push_violates_constraints(self.superuser, [full_access_link1, full_access_link2])
 
     def test_non_superuser_can_push_to_multiple_full_access_links(self):
         full_access_link1 = DomainLink.objects.create(master_domain='upstream', linked_domain='full1')
@@ -167,10 +170,8 @@ class CheckIfPushViolatesConstraintTests(TestCase):
         link2_patcher.start()
         self.addCleanup(link2_patcher.stop)
 
-        try:
-            check_if_push_violates_constraints(self.non_superuser, [full_access_link1, full_access_link2])
-        except Exception as e:
-            self.fail(f"Unexpected exception raised {e}")
+        # should not raise exception
+        check_if_push_violates_constraints(self.non_superuser, [full_access_link1, full_access_link2])
 
     def test_superuser_can_push_multiple_mixed_access_links(self):
         full_access_link = DomainLink.objects.create(master_domain='upstream', linked_domain='full')
@@ -184,10 +185,8 @@ class CheckIfPushViolatesConstraintTests(TestCase):
         link2_patcher.start()
         self.addCleanup(link2_patcher.stop)
 
-        try:
-            check_if_push_violates_constraints(self.superuser, [full_access_link, limited_access_link])
-        except Exception as e:
-            self.fail(f"Unexpected exception raised {e}")
+        # should not raise exception
+        check_if_push_violates_constraints(self.superuser, [full_access_link, limited_access_link])
 
     def test_raises_exception_if_non_superuser_pushes_to_multiple_mixed_access_links(self):
         full_access_link = DomainLink.objects.create(master_domain='upstream', linked_domain='full')
@@ -201,8 +200,11 @@ class CheckIfPushViolatesConstraintTests(TestCase):
         link2_patcher.start()
         self.addCleanup(link2_patcher.stop)
 
-        with self.assertRaises(AttemptedPushViolatesConstraints):
+        with self.assertRaises(InvalidPushException) as cm:
             check_if_push_violates_constraints(self.non_superuser, [full_access_link, limited_access_link])
+        self.assertEqual(cm.exception.message,
+                         "The attempted push is disallowed because it includes the following domains that can "
+                         "only be pushed to one at a time: limited")
 
     def test_superuser_can_push_multiple_limited_access_links(self):
         limited_access_link1 = DomainLink.objects.create(master_domain='upstream', linked_domain='limited1')
@@ -216,10 +218,8 @@ class CheckIfPushViolatesConstraintTests(TestCase):
         link2_patcher.start()
         self.addCleanup(link2_patcher.stop)
 
-        try:
-            check_if_push_violates_constraints(self.superuser, [limited_access_link1, limited_access_link2])
-        except Exception as e:
-            self.fail(f"Unexpected exception raised {e}")
+        # should not raise exception
+        check_if_push_violates_constraints(self.superuser, [limited_access_link1, limited_access_link2])
 
     def test_raises_exception_if_non_superuser_pushes_to_multiple_limited_access_links(self):
         limited_access_link1 = DomainLink.objects.create(master_domain='upstream', linked_domain='limited1')
@@ -233,8 +233,11 @@ class CheckIfPushViolatesConstraintTests(TestCase):
         link2_patcher.start()
         self.addCleanup(link2_patcher.stop)
 
-        with self.assertRaises(AttemptedPushViolatesConstraints):
+        with self.assertRaises(InvalidPushException) as cm:
             check_if_push_violates_constraints(self.non_superuser, [limited_access_link1, limited_access_link2])
+        self.assertEqual(cm.exception.message,
+                         "The attempted push is disallowed because it includes the following domains that can "
+                         "only be pushed to one at a time: limited1, limited2")
 
 
 class ValidatePullTests(TestCase):

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -487,14 +487,16 @@ def validate_push(user, domain, downstream_domains):
             message=gettext("No downstream project spaces were selected. Please contact support.")
         )
 
-    try:
-        domain_links = [
-            DomainLink.objects.get(master_domain=domain, linked_domain=dd) for dd in downstream_domains
-        ]
-    except DomainLink.DoesNotExist:
-        raise InvalidPushException(
-            message=gettext("Links between one or more project spaces do not exist. Please contact support.")
-        )
+    domain_links = []
+    for dd in downstream_domains:
+        try:
+            domain_links.append(DomainLink.objects.get(master_domain=domain, linked_domain=dd))
+        except DomainLink.DoesNotExist:
+            raise InvalidPushException(
+                message=gettext(
+                    "The project space link between {} and {} does not exist. Ensure the link was not recently "
+                    "deleted.").format(domain, dd)
+            )
 
     if not user_has_access_in_all_domains(user, downstream_domains):
         raise InvalidPushException(

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -53,12 +53,10 @@ from corehq.apps.linked_domain.decorators import (
     require_linked_domain,
 )
 from corehq.apps.linked_domain.exceptions import (
-    AttemptedPushViolatesConstraints,
     DomainLinkAlreadyExists,
     DomainLinkError,
     DomainLinkNotAllowed,
-    DomainLinkNotFound,
-    NoDownstreamDomainsProvided,
+    InvalidPushException,
     UnsupportedActionError,
     UserDoesNotHavePermission,
 )
@@ -408,31 +406,13 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
 
     @allow_remote_invocation
     def create_release(self, in_data):
-        error_message = ''
         try:
             validate_push(self.request.couch_user, self.domain, in_data['linked_domains'])
-        except NoDownstreamDomainsProvided:
-            error_message = gettext("No downstream project spaces were selected. Please contact support.")
-        except DomainLinkNotFound:
-            error_message = gettext(
-                "Links between one or more project spaces do not exist. Please contact support."
-            )
-        except AttemptedPushViolatesConstraints:
-            formatted_domains = ', '.join(in_data['linked_domains'])
-            error_message = gettext('''
-                The attempted push from {} to {} is disallowed. Please contact support.
-            '''.format(self.domain, formatted_domains))
-            notify_exception(self.request, "Triggered AttemptedPushViolatesConstraints exception")
-        except UserDoesNotHavePermission:
-            error_message = gettext(
-                "You do not have permission to push to all specified downstream project spaces."
-            )
-        finally:
-            if error_message:
-                return {
-                    'success': False,
-                    'message': error_message,
-                }
+        except InvalidPushException as e:
+            return {
+                'success': False,
+                'message': e.message,
+            }
 
         push_models.delay(self.domain, in_data['models'], in_data['linked_domains'],
                           in_data['build_apps'], self.request.couch_user.username)
@@ -503,17 +483,23 @@ def link_domains(couch_user, upstream_domain, downstream_domain):
 
 def validate_push(user, domain, downstream_domains):
     if not downstream_domains:
-        raise NoDownstreamDomainsProvided
+        raise InvalidPushException(
+            message=gettext("No downstream project spaces were selected. Please contact support.")
+        )
 
     try:
         domain_links = [
             DomainLink.objects.get(master_domain=domain, linked_domain=dd) for dd in downstream_domains
         ]
     except DomainLink.DoesNotExist:
-        raise DomainLinkNotFound
+        raise InvalidPushException(
+            message=gettext("Links between one or more project spaces do not exist. Please contact support.")
+        )
 
     if not user_has_access_in_all_domains(user, downstream_domains):
-        raise UserDoesNotHavePermission
+        raise InvalidPushException(
+            message=gettext("You do not have permission to push to all specified downstream project spaces.")
+        )
 
     check_if_push_violates_constraints(user, domain_links)
 
@@ -535,7 +521,11 @@ def check_if_push_violates_constraints(user, domain_links):
         # all links are full access
         return
 
-    raise AttemptedPushViolatesConstraints
+    limited_domains = [d.linked_domain for d in limited_access_links]
+    error_message = gettext(
+        "The attempted push is disallowed because it includes the following domains that can only be pushed to "
+        "one at a time: {}".format(', '.join(limited_domains)))
+    raise InvalidPushException(message=error_message)
 
 
 def validate_pull(user, domain_link):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The original error message "Links between one or more project spaces do not exist. Please contact support." while accurate, was not very helpful in the context of [this ticket](https://dimagi-dev.atlassian.net/browse/SUPPORT-14001). It didn't explain which domain(s) were causing the issue, and in this example where nearly 70 domains were being pushed to, it wasn't trivial to figure out what the problematic domain was. This change should make it obvious which linked domain does not appear to be part of an active domain link. For the record this was caused by the browser sending stale data to the server, so a simple refresh was all that was needed to resolve it.

Past me also got carried away with custom exceptions, so I took the opportunity to correct that a bit here, and am much happier with the caller code for `validate_push`.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Automated tests. Will test on staging.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests in place in corehq/apps/linked_domains/tests/test_views.py.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
