### PR TITLE
add input validation errors below input

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -141,10 +141,6 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         }
     });
 
-    FormplayerFrontend.on('showInputError', function (errorMessage, childView) {
-        showError(errorMessage, $(childView.el).find('.query-input-group'));
-    });
-
     FormplayerFrontend.on('showWarning', function (message) {
         showWarning(message, $("#cloudcare-notifications"));
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -141,6 +141,11 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         }
     });
 
+    FormplayerFrontend.on('showInputError', function (errorMessage, inputId) {
+        let jQueryFriendlyId = "#" + inputId.replace(" ", "\\ ");
+        showError(errorMessage, $(jQueryFriendlyId).parent());
+    });
+
     FormplayerFrontend.on('showWarning', function (message) {
         showWarning(message, $("#cloudcare-notifications"));
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -141,9 +141,8 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         }
     });
 
-    FormplayerFrontend.on('showInputError', function (errorMessage, inputId) {
-        let jQueryFriendlyId = "#" + inputId.replace(" ", "\\ ");
-        showError(errorMessage, $(jQueryFriendlyId).parent());
+    FormplayerFrontend.on('showInputError', function (errorMessage, childView) {
+        showError(errorMessage, $(childView.el).find('.query-input-group'));
     });
 
     FormplayerFrontend.on('showWarning', function (message) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -434,8 +434,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.children.each(function (childView) {
                 if (!childView.isValid()) {
                     invalidFields.push(childView.model.get('text'));
-                    childView.render();
                 }
+                childView.render();
             });
 
             if (invalidFields.length) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -226,8 +226,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     this.errorMessage = null;
                 }
                 this.hasError = hasError;
-                this.render();
             }
+            this.render();
             return !this.hasError;
         },
 
@@ -429,33 +429,26 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         submitAction: function (e) {
             e.preventDefault();
 
-            var Util = hqImport("cloudcare/js/formplayer/utils/util");
-            var urlObject = Util.currentUrlToObject();
-            urlObject.setQueryData(this.getAnswers(), false);
-            var parent = this;
-            var fetchingPrompts = FormplayerFrontend.getChannel().request("app:select:menus", urlObject);
 
-            $.when(fetchingPrompts).done(function (response) {
-                FormplayerFrontend.trigger('clearNotifications', errorHTML, true);
-                var invalidFields = [];
-                parent.children.each(function (childView) {
-                    if (!childView.isValid()) {
-                        invalidFields.push(childView.model.get('text'));
-                    }
-                });
-
-                if (invalidFields.length) {
-                    var errorHTML = "Please check the following fields:";
-                    errorHTML += "<ul>" + _.map(invalidFields, function (f) {
-                        return "<li>" + DOMPurify.sanitize(f) + "</li>";
-                    }).join("") + "</ul>";
-                    FormplayerFrontend.trigger('showError', errorHTML, true);
-
-                    return;
+            FormplayerFrontend.trigger('clearNotifications', errorHTML, true);
+            var invalidFields = [];
+            this.children.each(function (childView) {
+                if (!childView.isValid()) {
+                    invalidFields.push(childView.model.get('text'));
                 }
-                FormplayerFrontend.trigger("menu:query", parent.getAnswers());
             });
 
+            if (invalidFields.length) {
+                var errorHTML = "Please check the following fields:";
+                errorHTML += "<ul>" + _.map(invalidFields, function (f) {
+                    return "<li>" + DOMPurify.sanitize(f) + "</li>";
+                }).join("") + "</ul>";
+                FormplayerFrontend.trigger('showError', errorHTML, true);
+
+                return;
+            }
+
+            FormplayerFrontend.trigger("menu:query", this.getAnswers());
         },
 
         setStickyQueryInputs: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -218,8 +218,12 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
         isValid: function () {
             var hasError = !this._isValid();
-            if (hasError !== this.hasError) {
+            if (hasError) {
                 this.errorMessage = this.model.get("error");
+            } else {
+                this.errorMessage = "";
+            }
+            if (hasError !== this.hasError) {
                 this.hasError = hasError;
                 this.render();
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -173,7 +173,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.parentView = this.options.parentView;
             this.model = this.options.model;
             this.hasError = false;
-            this.errorMessage = "";
+            this.errorMessage = null;
 
             var allStickyValues = hqImport("cloudcare/js/formplayer/utils/util").getStickyQueryInputs(),
                 stickyValue = allStickyValues[this.model.get('id')],
@@ -222,8 +222,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 if (hasError) {
                     this.errorMessage = this.model.get("error");
                 } else {
-                    this.model.set("error", "");
-                    this.errorMessage = "";
+                    this.model.set("error", null);
+                    this.errorMessage = null;
                 }
                 this.hasError = hasError;
                 this.render();
@@ -234,8 +234,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         clear: function () {
             var self = this;
             self.model.set('value', '');
-            self.model.set('error', '');
-            self.errorMessage = "";
+            self.model.set('error', null);
+            self.errorMessage = null;
             self.model.set('searchForBlank', false);
             if (self.ui.date.length) {
                 self.ui.date.data("DateTimePicker").clear();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -422,23 +422,23 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             e.preventDefault();
             FormplayerFrontend.trigger('clearNotifications', errorHTML, true);
             var invalidFields = [];
-                this.children.each(function (childView) {
-                    if (!childView.isValid()) {
-                        invalidFields.push(childView.model.get('text'));
-                        FormplayerFrontend.trigger('showInputError', childView.model.get("error") ||
-                        "Please enter a value for this field.", childView.model.get("text"));
-                    }
-                });
-
-                if (invalidFields.length) {
-                    var errorHTML = "Please check the following fields:";
-                    errorHTML += "<ul>" + _.map(invalidFields, function (f) {
-                        return "<li>" + f + "</li>";
-                    }).join("") + "</ul>";
-                    FormplayerFrontend.trigger('showError', errorHTML, true);
-
-                    return;
+            this.children.each(function (childView) {
+                if (!childView.isValid()) {
+                    invalidFields.push(childView.model.get('text'));
+                    FormplayerFrontend.trigger('showInputError', childView.model.get("error") ||
+                    "Please enter a value for this field.", childView.model.get("text"));
                 }
+            });
+
+            if (invalidFields.length) {
+                var errorHTML = "Please check the following fields:";
+                errorHTML += "<ul>" + _.map(invalidFields, function (f) {
+                    return "<li>" + f + "</li>";
+                }).join("") + "</ul>";
+                FormplayerFrontend.trigger('showError', errorHTML, true);
+
+                return;
+            }
 
             FormplayerFrontend.trigger("menu:query", this.getAnswers());
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -435,7 +435,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 if (!childView.isValid()) {
                     invalidFields.push(childView.model.get('text'));
                 }
-                childView.render();
             });
 
             if (invalidFields.length) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -195,16 +195,15 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             searchForBlank: '.search-for-blank',
         },
 
-        modelEvents: {
-            'change': 'render',
-        },
-
         events: {
             'change @ui.queryField': 'changeQueryField',
             'dp.change @ui.queryField': 'changeDateQueryField',
             'click @ui.searchForBlank': 'toggleBlankSearch',
         },
 
+        modelEvents: {
+            'change': 'render',
+        },
 
         _isValid: function () {
             if (this.model.get("error")) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -159,6 +159,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 audioUri = this.options.model.get('audioUri'),
                 appId = this.model.collection.appId,
                 value = this.options.model.get('value');
+                errorMessage = this.options.model.get('error');
 
             return {
                 imageUrl: imageUri ? FormplayerFrontend.getChannel().request('resourceMap', imageUri, appId) : "",
@@ -226,6 +227,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         clear: function () {
             var self = this;
             self.model.set('value', '');
+            self.model.set('errorMessage', '');
             self.model.set('searchForBlank', false);
             if (self.ui.date.length) {
                 self.ui.date.data("DateTimePicker").clear();
@@ -250,11 +252,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             } else if (this.model.get('input') === 'address') {
                 // geocoderItemCallback sets the value on the model
             } else {
-                if (!this.isValid()) {
-                    FormplayerFrontend.trigger('showInputError', gettext(this.model.get("error")) ||
-                    gettext("Please enter a value for this field."), this);
-                    return;
-                }
                 this.model.set('value', $(e.currentTarget).val());
             }
             this.parentView.setStickyQueryInputs();
@@ -428,8 +425,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.children.each(function (childView) {
                 if (!childView.isValid()) {
                     invalidFields.push(childView.model.get('text'));
-                    FormplayerFrontend.trigger('showInputError', gettext(childView.model.get("error")) ||
-                    gettext("Please enter a value for this field."), childView);
+                    childView.model.set("errorMessage", (childView.model.get("error") ||
+                    "Please enter a value for this field."));
                 }
             });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -430,8 +430,10 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             var self = this;
             e.preventDefault();
 
-
             var invalidFields = [];
+            var errorHTML = gettext("Please check the following fields:");
+
+            FormplayerFrontend.trigger('clearNotifications', errorHTML, true);
 
             var Util = hqImport("cloudcare/js/formplayer/utils/util");
             var urlObject = Util.currentUrlToObject();
@@ -439,9 +441,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             var fetchingPrompts = FormplayerFrontend.getChannel().request("app:select:menus", urlObject);
 
             $.when(fetchingPrompts).done(function (response) {
-                FormplayerFrontend.trigger('clearNotifications', errorHTML, true);
                 for (var i = 0; i < response.models.length; i++) {
-                        self.collection.models[i].set('error', response.models[i].get('error'));
+                    self.collection.models[i].set('error', response.models[i].get('error'));
                 }
                 self.children.each(function (childView) {
                     if (!childView.isValid()) {
@@ -450,7 +451,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 });
 
                 if (invalidFields.length) {
-                    var errorHTML = "Please check the following fields:";
                     errorHTML += "<ul>" + _.map(invalidFields, function (f) {
                         return "<li>" + DOMPurify.sanitize(f) + "</li>";
                     }).join("") + "</ul>";

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -226,6 +226,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     this.errorMessage = null;
                 }
                 this.hasError = hasError;
+                this.render();
             }
             return !this.hasError;
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -251,8 +251,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 // geocoderItemCallback sets the value on the model
             } else {
                 if (!this.isValid()) {
-                    FormplayerFrontend.trigger('showInputError', this.model.get("error") ||
-                    "Please enter a value for this field.", this);
+                    FormplayerFrontend.trigger('showInputError', gettext(this.model.get("error")) ||
+                    gettext("Please enter a value for this field."), this);
                     return;
                 }
                 this.model.set('value', $(e.currentTarget).val());
@@ -428,8 +428,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.children.each(function (childView) {
                 if (!childView.isValid()) {
                     invalidFields.push(childView.model.get('text'));
-                    FormplayerFrontend.trigger('showInputError', childView.model.get("error") ||
-                    "Please enter a value for this field.", childView);
+                    FormplayerFrontend.trigger('showInputError', gettext(childView.model.get("error")) ||
+                    gettext("Please enter a value for this field."), childView);
                 }
             });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -233,6 +233,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         clear: function () {
             var self = this;
             self.model.set('value', '');
+            self.model.set('error', '');
             self.errorMessage = "";
             self.model.set('searchForBlank', false);
             if (self.ui.date.length) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -227,7 +227,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 }
                 this.hasError = hasError;
             }
-            this.render();
             return !this.hasError;
         },
 
@@ -435,6 +434,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.children.each(function (childView) {
                 if (!childView.isValid()) {
                     invalidFields.push(childView.model.get('text'));
+                    childView.render();
                 }
             });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -204,7 +204,10 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         },
 
         _isValid: function () {
-            if (!this.model.get('required') && !this.model.get("error")) {
+            if (this.model.get("error")) {
+                return false;
+            }
+            if (!this.model.get('required')) {
                 return true;
             }
             var answer = this.getEncodedValue();
@@ -249,7 +252,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             } else {
                 if (!this.isValid()) {
                     FormplayerFrontend.trigger('showInputError', this.model.get("error") ||
-                    "Please enter a value for this field.", this.model.get("text"));
+                    "Please enter a value for this field.", this);
                     return;
                 }
                 this.model.set('value', $(e.currentTarget).val());
@@ -426,7 +429,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 if (!childView.isValid()) {
                     invalidFields.push(childView.model.get('text'));
                     FormplayerFrontend.trigger('showInputError', childView.model.get("error") ||
-                    "Please enter a value for this field.", childView.model.get("text"));
+                    "Please enter a value for this field.", childView);
                 }
             });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -218,12 +218,12 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
         isValid: function () {
             var hasError = !this._isValid();
-            if (hasError) {
-                this.errorMessage = this.model.get("error");
-            } else {
-                this.errorMessage = "";
-            }
             if (hasError !== this.hasError) {
+                if (hasError) {
+                    this.errorMessage = this.model.get("error");
+                } else {
+                    this.errorMessage = "";
+                }
                 this.hasError = hasError;
                 this.render();
             }
@@ -233,7 +233,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         clear: function () {
             var self = this;
             self.model.set('value', '');
-            this.errorMessage = "";
+            self.errorMessage = "";
             self.model.set('searchForBlank', false);
             if (self.ui.date.length) {
                 self.ui.date.data("DateTimePicker").clear();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -433,7 +433,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             if (invalidFields.length) {
                 var errorHTML = "Please check the following fields:";
                 errorHTML += "<ul>" + _.map(invalidFields, function (f) {
-                    return "<li>" + f + "</li>";
+                    return "<li>" + DOMPurify.sanitize(f) + "</li>";
                 }).join("") + "</ul>";
                 FormplayerFrontend.trigger('showError', errorHTML, true);
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -240,6 +240,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             if (self.ui.date.length) {
                 self.ui.date.data("DateTimePicker").clear();
             }
+            self.hasError = false;
+            self.render();
+            FormplayerFrontend.trigger('clearNotifications');
         },
 
         getEncodedValue: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -219,7 +219,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         isValid: function () {
             var hasError = !this._isValid();
             if (hasError !== this.hasError) {
-                this.errorMessage = this.model.get("error") || "Please enter a value for this field.";
+                this.errorMessage = this.model.get("error");
                 this.hasError = hasError;
                 this.render();
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -195,15 +195,16 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             searchForBlank: '.search-for-blank',
         },
 
+        modelEvents: {
+            'change': 'render',
+        },
+
         events: {
             'change @ui.queryField': 'changeQueryField',
             'dp.change @ui.queryField': 'changeDateQueryField',
             'click @ui.searchForBlank': 'toggleBlankSearch',
         },
 
-        modelEvents: {
-            'change': 'render',
-        },
 
         _isValid: function () {
             if (this.model.get("error")) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -428,6 +428,12 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
         submitAction: function (e) {
             e.preventDefault();
+
+            var Util = hqImport("cloudcare/js/formplayer/utils/util");
+            var urlObject = Util.currentUrlToObject();
+            urlObject.setQueryData(this.getAnswers(), false);
+            FormplayerFrontend.getChannel().request("app:select:menus", urlObject);
+
             FormplayerFrontend.trigger('clearNotifications', errorHTML, true);
             var invalidFields = [];
             this.children.each(function (childView) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -233,6 +233,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         clear: function () {
             var self = this;
             self.model.set('value', '');
+            this.errorMessage = "";
             self.model.set('searchForBlank', false);
             if (self.ui.date.length) {
                 self.ui.date.data("DateTimePicker").clear();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -222,6 +222,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 if (hasError) {
                     this.errorMessage = this.model.get("error");
                 } else {
+                    this.model.set("error", "");
                     this.errorMessage = "";
                 }
                 this.hasError = hasError;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -159,13 +159,13 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 audioUri = this.options.model.get('audioUri'),
                 appId = this.model.collection.appId,
                 value = this.options.model.get('value');
-                errorMessage = this.options.model.get('error');
 
             return {
                 imageUrl: imageUri ? FormplayerFrontend.getChannel().request('resourceMap', imageUri, appId) : "",
                 audioUrl: audioUri ? FormplayerFrontend.getChannel().request('resourceMap', audioUri, appId) : "",
                 value: value,
                 hasError: this.hasError,
+                errorMessage: this.errorMessage,
             };
         },
 
@@ -173,6 +173,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.parentView = this.options.parentView;
             this.model = this.options.model;
             this.hasError = false;
+            this.errorMessage = "";
 
             var allStickyValues = hqImport("cloudcare/js/formplayer/utils/util").getStickyQueryInputs(),
                 stickyValue = allStickyValues[this.model.get('id')],
@@ -218,6 +219,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         isValid: function () {
             var hasError = !this._isValid();
             if (hasError !== this.hasError) {
+                this.errorMessage = this.model.get("error") || "Please enter a value for this field.";
                 this.hasError = hasError;
                 this.render();
             }
@@ -227,7 +229,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         clear: function () {
             var self = this;
             self.model.set('value', '');
-            self.model.set('errorMessage', '');
             self.model.set('searchForBlank', false);
             if (self.ui.date.length) {
                 self.ui.date.data("DateTimePicker").clear();
@@ -425,8 +426,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.children.each(function (childView) {
                 if (!childView.isValid()) {
                     invalidFields.push(childView.model.get('text'));
-                    childView.model.set("errorMessage", (childView.model.get("error") ||
-                    "Please enter a value for this field."));
+                    // childView.model.set("errorMessage", (childView.model.get("error") ||
+                    // "Please enter a value for this field."));
                 }
             });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -426,8 +426,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.children.each(function (childView) {
                 if (!childView.isValid()) {
                     invalidFields.push(childView.model.get('text'));
-                    // childView.model.set("errorMessage", (childView.model.get("error") ||
-                    // "Please enter a value for this field."));
                 }
             });
 

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -83,7 +83,7 @@
            data-receive="<%- receive %>"
            <% if (required) { %> aria-required="true"<% } %>>
            <% } %>
-           <% if (errorMessage) { %> <span  class="help-block has-error"> "<%- errorMessage || "" %>"  <% } %>
+           <% if (errorMessage) { %> <div class="help-block has-error"> <%- errorMessage || "" %> </div> <% } %>
            <% if (allow_blank_value) { %>
             <label class="control-label">
               <input type="checkbox" class="search-for-blank" <% if (searchForBlank) { %>checked<% } %>>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -83,7 +83,7 @@
            data-receive="<%- receive %>"
            <% if (required) { %> aria-required="true"<% } %>>
            <% } %>
-           <% if (errorMessage) { %> <span  class="text-danger"> "<%- errorMessage || "" %>"  <% } %>
+           <% if (errorMessage) { %> <span  class="help-block has-error"> "<%- errorMessage || "" %>"  <% } %>
            <% if (allow_blank_value) { %>
             <label class="control-label">
               <input type="checkbox" class="search-for-blank" <% if (searchForBlank) { %>checked<% } %>>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -82,13 +82,13 @@
            value="<%- value %>"
            data-receive="<%- receive %>"
            <% if (required) { %> aria-required="true"<% } %>>
-    <% } %>
-
-    <% if (allow_blank_value) { %>
-    <label class="control-label">
-        <input type="checkbox" class="search-for-blank" <% if (searchForBlank) { %>checked<% } %>>
-        {% trans "Include results where '<%- text %>' is blank" %}
-    </label>
-    <% } %>
+           <% } %>
+           <% if (errorMessage) { %> <span  class="text-danger"> "<%- errorMessage || "" %>"  <% } %>
+           <% if (allow_blank_value) { %>
+            <label class="control-label">
+              <input type="checkbox" class="search-for-blank" <% if (searchForBlank) { %>checked<% } %>>
+              {% trans "Include results where '<%- text %>' is blank" %}
+            </label>
+            <% } %>
   </td>
 </script>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This adds input errors, either custom validation or required message, below the relevant input on change event. It also consolidates the required and custom validation error functionality on submit event, listing the fields that need attention at the top of the page and the specific errors under the relevant inputs.

![input_validation](https://user-images.githubusercontent.com/42388648/178580155-0f2700ea-f3f1-4e1a-ad43-2517e3a00982.gif)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
ticket: https://dimagi-dev.atlassian.net/browse/USH-2225
related tickets: 
https://dimagi-dev.atlassian.net/browse/USH-2175
https://dimagi-dev.atlassian.net/browse/USH-2185
spec: https://docs.google.com/document/d/1wF9SFfX7-R86cPRgabrqbTU9BaGdp3IlAYlTjInWXTU/edit
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
USH_CASE_CLAIM_UPDATES: USH Specific toggle to support several different case search/claim workflows in web apps

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
This should be tested along with related tickets listed above once they are complete.
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
