### PR TITLE
Fixed attr binding for web apps password input

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -332,8 +332,10 @@
   <input type="password" class="form-control" data-bind="
         value: $data.rawAnswer,
         valueUpdate: valueUpdate,
-        id: entryId,
-        attr: {'aria-required': $parent.required() ? 'true' : 'false'},
+        attr: {
+          id: entryId,
+          'aria-required': $parent.required() ? 'true' : 'false',
+        },
     "/>
   <span class="help-block type" aria-hidden="true" data-bind="text: helpText()"></span>
 </script>


### PR DESCRIPTION
## Technical Summary
The HTML id isn't being set for password questions.

I don't know that there are any implications for this - it doesn't look like the `FreeTextEntry` used by passwords references the id - but it ought to be correct.

## Safety Assurance

### Safety story
This is pretty trivial. Made this change locally and web apps still loads.

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
