### PR TITLE
Fix bug in bulk load password validation

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -489,10 +489,11 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             password = ''.join(random.choices(string_set, k=10))
             row['password'] = password
 
+        if(row.get('password')):
+            row['password'] = str(row.get('password'))
         try:
             domain_info = get_domain_info(domain, upload_domain, user_specs, domain_info_by_domain,
-                                        group_memoizer)
-
+            group_memoizer)
             for validator in domain_info.validators:
                 validator(row)
         except UserUploadError as e:

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -54,7 +54,6 @@ from dimagi.utils.dates import add_months_to_date
 from django.conf import settings
 
 
-
 class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
     @classmethod
     def setUpClass(cls):
@@ -884,6 +883,17 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
             False
         )
         self.assertTrue(self.user.is_active)
+
+    def test_password_is_not_string(self):
+        rows = import_users_and_groups(
+            self.domain.name,
+            [self._get_spec(password=123)],
+            [],
+            self.uploading_user.get_id,
+            self.upload_record.pk,
+            False
+        )['messages']['rows']
+        self.assertEqual(rows[0]['row']['password'], "123")
 
     def test_update_user_no_username(self):
         import_users_and_groups(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When bulking upload mobile workers, if passwords are as easy as "1234", by default the cell type will be "general", then excel will cast it into "number". 
This will result in TypeError, if user require strong password, because password validation method expect password is a string.

Before fix:
<img width="452" alt="image" src="https://user-images.githubusercontent.com/39149002/178130369-39a60f1e-85bf-4259-bb9e-64170610901c.png">
After fix:
![image](https://user-images.githubusercontent.com/39149002/178130380-cebecd52-2542-4a29-8420-acfc7d2b836b.png)



## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: [QA-4311](https://dimagi-dev.atlassian.net/browse/QA-4311)  
Convert password variable to string right after the import.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Wrote test in `test_importer.py`.
Tried bulk upload with strong password required locally and on staging, both worked as I expected
Requested a QA run.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

New test added.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Ticket: https://dimagi-dev.atlassian.net/browse/QA-4311


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
