### PR TITLE
Add an option to filter by can_view_report to UserDomains API endpoint

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -791,6 +791,7 @@ class UserDomainsResource(CorsResourceMixin, Resource):
         feature_flag = request.GET.get("feature_flag")
         if feature_flag and feature_flag not in toggles.all_toggle_slugs():
             raise BadRequest(f"{feature_flag!r} is not a valid feature flag")
+        can_view_reports = request.GET.get("can_view_reports")
         couch_user = CouchUser.from_django_user(request.user)
         username = request.user.username
         results = []
@@ -799,6 +800,8 @@ class UserDomainsResource(CorsResourceMixin, Resource):
                 continue
             domain_object = Domain.get_by_name(domain)
             if feature_flag and feature_flag not in toggles.toggles_dict(username=username, domain=domain):
+                continue
+            if can_view_reports and not couch_user.can_view_reports(domain):
                 continue
             results.append(UserDomain(
                 domain_name=domain_object.name,


### PR DESCRIPTION
## Product Description
Adds an additional param to `api/v0.5/user_domains/` endpoint to filter domains where user `can_view_reports`. This is required for Superset.

Fixes https://dimagi-dev.atlassian.net/browse/QA-4302

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

This is a very trivial change and I have tested locally.

### Automated test coverage

Tests already exist for this.
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not required as tests should be enough.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

@kaapstorm 