### PR TITLE
Updated max usage in _merge_dicts for python 3

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -241,7 +241,7 @@ class ExportItem(DocumentSchema, ReadablePathMixin):
     def merge(cls, one, two):
         item = one
         item.label = two.label  # always take the newest label
-        item.last_occurrences = _merge_dicts(one.last_occurrences, two.last_occurrences, max)
+        item.last_occurrences = _merge_dicts(one.last_occurrences, two.last_occurrences)
         item.inferred = one.inferred or two.inferred
         item.inferred_from |= two.inferred_from
         return item
@@ -1499,7 +1499,7 @@ class MultipleChoiceItem(ExportItem):
             resolvefn=lambda option1, option2:
                 Option(
                     value=option1.value,
-                    last_occurrences=_merge_dicts(option1.last_occurrences, option2.last_occurrences, max)
+                    last_occurrences=_merge_dicts(option1.last_occurrences, option2.last_occurrences)
                 ),
         )
 
@@ -1791,8 +1791,7 @@ class ExportDataSchema(Document):
 
             group_schema1.last_occurrences = _merge_dicts(
                 group_schema1.last_occurrences,
-                group_schema2.last_occurrences,
-                max
+                group_schema2.last_occurrences
             )
             group_schema1.inferred = group_schema1.inferred or group_schema2.inferred
             items = _merge_lists(
@@ -1816,8 +1815,7 @@ class ExportDataSchema(Document):
             previous_group_schemas = group_schemas
             last_app_versions = _merge_dicts(
                 last_app_versions,
-                current_schema.last_app_versions,
-                max,
+                current_schema.last_app_versions
             )
 
         schema.group_schemas = group_schemas
@@ -2418,14 +2416,12 @@ def _merge_lists(one, two, keyfn, resolvefn):
     return merged
 
 
-def _merge_dicts(one, two, resolvefn):
+def _merge_dicts(one, two):
     """Merges two dicts. The algorithm is to first create a dictionary of all the keys that exist in one and
-    two but not in both. Then iterate over each key that belongs in both while calling the resovlefn function
-    to ensure the propery value gets set.
+    two but not in both. Then iterate over each key that belongs in both, selecting the one with the higher value.
 
     :param one: The first dictionary
     :param two: The second dictionary
-    :param resolvefn: A function that takes two values and resolves to one
     :returns: The merged dictionary
     """
     # keys either in one or two, but not both
@@ -2433,6 +2429,11 @@ def _merge_dicts(one, two, resolvefn):
         key: one.get(key, two.get(key))
         for key in one.keys() ^ two.keys()
     }
+
+    def resolvefn(a, b):
+        if a is None or b is None:
+            return a or b
+        return max(a, b)
 
     # merge keys that exist in both
     merged.update({


### PR DESCRIPTION
## Technical Summary
This is a pre-existing issue that QA raised while verifying https://dimagi-dev.atlassian.net/browse/QA-4332

https://sentry.io/organizations/dimagi/issues/2781032554/

All calls to `_merge_dicts` pass in `max` as the resolution, so I just changed that from a param and to an inner function that can handle `None`.

The error is preventing data dictionary syncing but coming out of exports code. I didn't dig into the exact circumstances that cause it or if it could also cause issues in exports. It's in staging sentry ~1500 times but not at all on prod, so I'm guessing it's something edge-case-y on the QA domain where it's manifesting.

## Feature Flag
Data dictionary

## Safety Assurance

### Safety story
Basically depending on automated tests and on this being a straightforward change.

I'll deploy it to staging and verify that the data dictionary syncs for the domain that's having problems.

### Automated test coverage

Not sure. Probably?

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
