### PR TITLE
DHIS2: Add "programOwners" to "relationships"

### DIFF
--- a/corehq/motech/dhis2/schema.py
+++ b/corehq/motech/dhis2/schema.py
@@ -109,6 +109,7 @@ def get_note_schema() -> dict:
 
 
 def get_relationship_schema() -> dict:
+    program_owner_schema = get_program_owner_schema()
     return {
         "relationshipType": id_schema,
         SchemaOptional("relationshipName"): str,
@@ -117,11 +118,13 @@ def get_relationship_schema() -> dict:
         "from": {
             "trackedEntityInstance": {
                 "trackedEntityInstance": id_schema,
+                SchemaOptional("programOwners"): [program_owner_schema],
             }
         },
         "to": {
             "trackedEntityInstance": {
                 "trackedEntityInstance": id_schema,
+                SchemaOptional("programOwners"): [program_owner_schema],
             }
         },
         SchemaOptional("created"): datetime_schema,
@@ -139,6 +142,7 @@ def get_tracked_entity_schema() -> dict:
     geometry_schema = get_geometry_schema()
     note_schema = get_note_schema()
     relationship_schema = get_relationship_schema()
+    program_owner_schema = get_program_owner_schema()
     return {
         SchemaOptional("attributes"): [attribute_schema],
         SchemaOptional("created"): datetime_schema,
@@ -176,7 +180,7 @@ def get_tracked_entity_schema() -> dict:
         SchemaOptional("lastUpdatedAtClient"): datetime_schema,
         "orgUnit": id_schema,
         SchemaOptional("potentialDuplicate"): bool,
-        SchemaOptional("programOwners"): [object],
+        SchemaOptional("programOwners"): [program_owner_schema],
         SchemaOptional("relationships"): [relationship_schema],
         SchemaOptional("storedBy"): str,
         SchemaOptional("trackedEntityInstance"): id_schema,
@@ -204,4 +208,12 @@ def get_user_info_schema():
         "surname": str,
         "uid": id_schema,
         "username": str,
+    }
+
+
+def get_program_owner_schema():
+    return {
+        "ownerOrgUnit": id_schema,
+        "program": id_schema,
+        "trackedEntityInstance": id_schema,
     }

--- a/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
+++ b/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
@@ -107,7 +107,28 @@
             ]
         }
     ],
-    "relationships": [],
+    "relationships": [
+        {
+            "bidirectional": false,
+            "created": "2022-07-13T03:26:06.680",
+            "from": {
+                "trackedEntityInstance": {
+                    "programOwners": [],
+                    "trackedEntityInstance": "oDfdLQ0bOzY"
+                }
+            },
+            "lastUpdated": "2022-07-13T03:26:06.680",
+            "relationship": "K0UypYSV9rP",
+            "relationshipName": "Mother -> Child",
+            "relationshipType": "pmEdu7DAEQL",
+            "to": {
+                "trackedEntityInstance": {
+                    "programOwners": [],
+                    "trackedEntityInstance": "T6PdaIWODvO"
+                }
+            }
+        }
+    ],
     "attributes": [
         {
             "attribute": "RFSPyNDnRzV",


### PR DESCRIPTION
## Technical Summary

Resolves an error where data from DHIS2 is failing our schema validation. This updates our schema to represent DHIS2 data accurately.

Specifically, it adds "programOwners" to the schema of a relationship, and defines the "programOwners" schema.

## Feature Flag
"DHIS2 integration"

## Safety Assurance

### Automated test coverage

Includes updated test

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
