### PR TITLE
Use deleted domains view directly in cleanup tasks + refactor

### DIFF
--- a/corehq/apps/cleanup/dbaccessors.py
+++ b/corehq/apps/cleanup/dbaccessors.py
@@ -1,0 +1,74 @@
+from collections import defaultdict
+
+from django.db import connections
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.es import AppES, CaseES, CaseSearchES, FormES, GroupES, UserES
+from corehq.apps.userreports.util import (
+    LEGACY_UCR_TABLE_PREFIX,
+    UCR_TABLE_PREFIX,
+)
+from corehq.form_processor.models import CommCareCase, XFormInstance
+from corehq.sql_db.connections import UCR_ENGINE_ID, ConnectionManager
+from corehq.sql_db.util import get_db_aliases_for_partitioned_query
+
+
+def find_sql_forms_for_deleted_domains():
+    form_count_by_deleted_domain = {}
+    for domain in Domain.get_deleted_domain_names():
+        form_count = 0
+        for db_name in get_db_aliases_for_partitioned_query():
+            form_count += XFormInstance.objects.using(db_name).filter(domain=domain).count()
+        if form_count:
+            form_count_by_deleted_domain[domain] = form_count
+
+    return form_count_by_deleted_domain
+
+
+def find_sql_cases_for_deleted_domains():
+    case_count_by_deleted_domain = {}
+    for domain in Domain.get_deleted_domain_names():
+        case_count = 0
+        for db_name in get_db_aliases_for_partitioned_query():
+            case_count += CommCareCase.objects.using(db_name).filter(domain=domain).count()
+        if case_count:
+            case_count_by_deleted_domain[domain] = case_count
+
+    return case_count_by_deleted_domain
+
+
+def find_es_docs_for_deleted_domains():
+    es_doc_counts_by_deleted_domain = defaultdict(dict)
+    for domain in Domain.get_deleted_domain_names():
+        for hqESQuery in [AppES, CaseES, CaseSearchES, FormES, GroupES, UserES]:
+            query = hqESQuery().domain(domain)
+            count = query.count()
+            if count != 0:
+                es_doc_counts_by_deleted_domain[domain][hqESQuery.index] = count
+
+    return es_doc_counts_by_deleted_domain
+
+
+def find_ucr_tables_for_deleted_domains():
+    deleted_domain_names = Domain.get_deleted_domain_names()
+
+    connection_name = ConnectionManager().get_django_db_alias(UCR_ENGINE_ID)
+    table_names = connections[connection_name].introspection.table_names()
+    ucr_table_names = [name for name in table_names if
+                       name.startswith(UCR_TABLE_PREFIX) or name.startswith(LEGACY_UCR_TABLE_PREFIX)]
+
+    deleted_domains_to_tables = defaultdict(list)
+
+    for ucr_table_name in ucr_table_names:
+        table_domain = _get_domain_for_table_name(ucr_table_name)
+        if table_domain in deleted_domain_names:
+            deleted_domains_to_tables[table_domain].append(ucr_table_name)
+
+    return deleted_domains_to_tables
+
+
+def _get_domain_for_table_name(ucr_table_name):
+    if ucr_table_name.startswith(UCR_TABLE_PREFIX):
+        return ucr_table_name.split('_')[1]
+    else:
+        return ucr_table_name.split('_')[2]

--- a/corehq/apps/cleanup/dbaccessors.py
+++ b/corehq/apps/cleanup/dbaccessors.py
@@ -7,6 +7,7 @@ from corehq.apps.es import AppES, CaseES, CaseSearchES, FormES, GroupES, UserES
 from corehq.apps.userreports.util import (
     LEGACY_UCR_TABLE_PREFIX,
     UCR_TABLE_PREFIX,
+    get_domain_for_ucr_table_name,
 )
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.sql_db.connections import UCR_ENGINE_ID, ConnectionManager
@@ -60,15 +61,8 @@ def find_ucr_tables_for_deleted_domains():
     deleted_domains_to_tables = defaultdict(list)
 
     for ucr_table_name in ucr_table_names:
-        table_domain = _get_domain_for_table_name(ucr_table_name)
+        table_domain = get_domain_for_ucr_table_name(ucr_table_name)
         if table_domain in deleted_domain_names:
             deleted_domains_to_tables[table_domain].append(ucr_table_name)
 
     return deleted_domains_to_tables
-
-
-def _get_domain_for_table_name(ucr_table_name):
-    if ucr_table_name.startswith(UCR_TABLE_PREFIX):
-        return ucr_table_name.split('_')[1]
-    else:
-        return ucr_table_name.split('_')[2]

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -1,19 +1,18 @@
-from collections import defaultdict
 from datetime import datetime
 
 from django.conf import settings
 from django.core.management import call_command
-from django.db import connections
 
 from celery.schedules import crontab
 from celery.task import periodic_task
 
-from corehq.apps.domain.models import Domain
-from corehq.apps.es import AppES, CaseES, CaseSearchES, FormES, GroupES, UserES
+from corehq.apps.cleanup.dbaccessors import (
+    find_es_docs_for_deleted_domains,
+    find_sql_cases_for_deleted_domains,
+    find_sql_forms_for_deleted_domains,
+    find_ucr_tables_for_deleted_domains,
+)
 from corehq.apps.hqwebapp.tasks import mail_admins_async
-from corehq.form_processor.models import XFormInstance, CommCareCase
-from corehq.sql_db.connections import UCR_ENGINE_ID, ConnectionManager
-from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 
 UNDEFINED_XMLNS_LOG_DIR = settings.LOG_HOME
 
@@ -25,17 +24,10 @@ def clear_expired_sessions():
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def check_for_sql_cases_without_existing_domain():
-    case_count_by_deleted_domain = {}
-    for domain in Domain.get_deleted_domain_names():
-        case_count = 0
-        for db_name in get_db_aliases_for_partitioned_query():
-            case_count += CommCareCase.objects.using(db_name).filter(domain=domain).count()
-        if case_count:
-            case_count_by_deleted_domain[domain] = case_count
-
+    case_count_by_deleted_domain = find_sql_cases_for_deleted_domains()
     if case_count_by_deleted_domain:
         mail_admins_async.delay(
-            'There exist SQL cases belonging to a deleted domain',
+            'There exist SQL cases belonging to deleted domain(s)',
             f'{case_count_by_deleted_domain}\nConsider hard_delete_forms_and_cases_in_domain'
         )
     elif _is_monday():
@@ -46,17 +38,10 @@ def check_for_sql_cases_without_existing_domain():
 
 @periodic_task(run_every=crontab(minute=0, hour=1), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def check_for_sql_forms_without_existing_domain():
-    form_count_by_deleted_domain = {}
-    for domain in Domain.get_deleted_domain_names():
-        form_count = 0
-        for db_name in get_db_aliases_for_partitioned_query():
-            form_count += XFormInstance.objects.using(db_name).filter(domain=domain).count()
-        if form_count:
-            form_count_by_deleted_domain[domain] = form_count
-
+    form_count_by_deleted_domain = find_sql_forms_for_deleted_domains()
     if form_count_by_deleted_domain:
         mail_admins_async.delay(
-            'There exist SQL forms belonging to a deleted domain',
+            'There exist SQL forms belonging to deleted domain(s)',
             f'{form_count_by_deleted_domain}\nConsider hard_delete_forms_and_cases_in_domain'
         )
     elif _is_monday():
@@ -67,19 +52,14 @@ def check_for_sql_forms_without_existing_domain():
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def check_for_elasticsearch_data_without_existing_domain():
-    issue_found = False
-    for domain_name in Domain.get_deleted_domain_names():
-        for hqESQuery in [AppES, CaseES, CaseSearchES, FormES, GroupES, UserES]:
-            query = hqESQuery().domain(domain_name)
-            count = query.count()
-            if query.count() != 0:
-                issue_found = True
-                mail_admins_async.delay(
-                    'ES index "%s" contains %s items belonging to a deleted domain "%s"' % (
-                        query.index, count, domain_name
-                    ), ''
-                )
-    if not issue_found and _is_monday():
+    es_docs_by_deleted_domain = find_es_docs_for_deleted_domains()
+    if es_docs_by_deleted_domain:
+        for domain, es_docs in es_docs_by_deleted_domain.items():
+            mail_admins_async.delay(
+                f'Deleted domain "{domain}" has remaining ES docs',
+                f'{es_docs}\nConsider delete_es_docs_for_domain'
+            )
+    elif _is_monday():
         mail_admins_async.delay(
             'All data in ES belongs to valid domains', ''
         )
@@ -87,19 +67,7 @@ def check_for_elasticsearch_data_without_existing_domain():
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def check_for_ucr_tables_without_existing_domain():
-    deleted_domain_names = Domain.get_deleted_domain_names()
-
-    connection_name = ConnectionManager().get_django_db_alias(UCR_ENGINE_ID)
-    table_names = connections[connection_name].introspection.table_names()
-    ucr_table_names = [name for name in table_names if name.startswith('config_report')]
-
-    deleted_domains_to_tables = defaultdict(list)
-
-    for ucr_table_name in ucr_table_names:
-        table_domain = ucr_table_name.split('_')[2]
-        if table_domain in deleted_domain_names:
-            deleted_domains_to_tables[table_domain].append(ucr_table_name)
-
+    deleted_domains_to_tables = find_ucr_tables_for_deleted_domains()
     if deleted_domains_to_tables:
         for deleted_domain in deleted_domains_to_tables:
             mail_admins_async.delay(

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django.conf import settings
 from django.core.management import call_command
 
@@ -12,6 +10,7 @@ from corehq.apps.cleanup.dbaccessors import (
     find_sql_forms_for_deleted_domains,
     find_ucr_tables_for_deleted_domains,
 )
+from corehq.apps.cleanup.tests.util import is_monday
 from corehq.apps.hqwebapp.tasks import mail_admins_async
 
 UNDEFINED_XMLNS_LOG_DIR = settings.LOG_HOME
@@ -30,7 +29,7 @@ def check_for_sql_cases_without_existing_domain():
             'There exist SQL cases belonging to deleted domain(s)',
             f'{case_count_by_deleted_domain}\nConsider hard_delete_forms_and_cases_in_domain'
         )
-    elif _is_monday():
+    elif is_monday():
         mail_admins_async.delay(
             'All SQL cases belong to valid domains', ''
         )
@@ -44,7 +43,7 @@ def check_for_sql_forms_without_existing_domain():
             'There exist SQL forms belonging to deleted domain(s)',
             f'{form_count_by_deleted_domain}\nConsider hard_delete_forms_and_cases_in_domain'
         )
-    elif _is_monday():
+    elif is_monday():
         mail_admins_async.delay(
             'All SQL forms belong to valid domains', ''
         )
@@ -59,7 +58,7 @@ def check_for_elasticsearch_data_without_existing_domain():
                 f'Deleted domain "{domain}" has remaining ES docs',
                 f'{es_docs}\nConsider delete_es_docs_for_domain'
             )
-    elif _is_monday():
+    elif is_monday():
         mail_admins_async.delay(
             'All data in ES belongs to valid domains', ''
         )
@@ -74,9 +73,5 @@ def check_for_ucr_tables_without_existing_domain():
                 f'Deleted domain "{deleted_domain}" has remaining UCR tables',
                 f'{deleted_domains_to_tables[deleted_domain]}\nConsider prune_old_datasources'
             )
-    elif _is_monday():
+    elif is_monday():
         mail_admins_async.delay('All UCR tables belong to valid domains', '')
-
-
-def _is_monday():
-    return datetime.utcnow().isoweekday() == 1

--- a/corehq/apps/cleanup/tests/test_dbaccessors.py
+++ b/corehq/apps/cleanup/tests/test_dbaccessors.py
@@ -1,0 +1,194 @@
+from django.test import TestCase
+
+from pillowtop.es_utils import initialize_index_and_mapping
+
+from corehq.apps.cleanup.dbaccessors import (
+    find_es_docs_for_deleted_domains,
+    find_sql_cases_for_deleted_domains,
+    find_sql_forms_for_deleted_domains,
+    find_ucr_tables_for_deleted_domains,
+)
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.es import FormES
+from corehq.apps.es.tests.utils import es_test
+from corehq.apps.userreports.app_manager.helpers import clean_table_name
+from corehq.apps.userreports.models import DataSourceConfiguration
+from corehq.apps.userreports.util import get_indicator_adapter
+from corehq.elastic import get_es_new, send_to_elasticsearch
+from corehq.form_processor.tests.utils import create_case, create_form_for_test
+from corehq.pillows.mappings import (
+    APP_INDEX_INFO,
+    CASE_INDEX_INFO,
+    CASE_SEARCH_INDEX_INFO,
+    GROUP_INDEX_INFO,
+    USER_INDEX_INFO,
+    XFORM_INDEX_INFO,
+)
+from corehq.pillows.xform import transform_xform_for_elasticsearch
+from corehq.util.elastic import ensure_index_deleted, reset_es_index
+
+
+class TestFindSQLFormsForDeletedDomains(TestCase):
+
+    def test_deleted_domain_with_form_data_is_flagged(self):
+        create_form_for_test(self.deleted_domain.name)
+        counts_by_domain = find_sql_forms_for_deleted_domains()
+        self.assertEqual(counts_by_domain[self.deleted_domain.name], 1)
+
+    def test_missing_domain_with_form_data_is_not_flagged(self):
+        create_form_for_test('missing-domain')
+        counts_by_domain = find_sql_forms_for_deleted_domains()
+        self.assertTrue('missing-domain' not in counts_by_domain)
+
+    def test_active_domain_with_form_data_is_not_flagged(self):
+        create_form_for_test(self.active_domain.name)
+        counts_by_domain = find_sql_forms_for_deleted_domains()
+        self.assertTrue(self.active_domain.name not in counts_by_domain)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.active_domain = create_domain('active-domain')
+        cls.deleted_domain = create_domain('deleted-domain')
+        cls.deleted_domain.delete(leave_tombstone=True)
+        cls.addClassCleanup(cls.active_domain.delete)
+        cls.addClassCleanup(cls.deleted_domain.delete)
+
+
+class TestFindSQLCasesForDeletedDomains(TestCase):
+
+    def test_deleted_domain_with_case_data_is_flagged(self):
+        create_case(self.deleted_domain.name, save=True)
+        counts_by_domain = find_sql_cases_for_deleted_domains()
+        self.assertEqual(counts_by_domain[self.deleted_domain.name], 1)
+
+    def test_missing_domain_with_case_data_is_not_flagged(self):
+        create_case('missing-domain', save=True)
+        counts_by_domain = find_sql_cases_for_deleted_domains()
+        self.assertTrue('missing-domain' not in counts_by_domain)
+
+    def test_active_domain_with_case_data_is_not_flagged(self):
+        create_case(self.active_domain.name, save=True)
+        counts_by_domain = find_sql_cases_for_deleted_domains()
+        self.assertTrue(self.active_domain.name not in counts_by_domain)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.active_domain = create_domain('active-domain')
+        cls.deleted_domain = create_domain('deleted-domain')
+        cls.deleted_domain.delete(leave_tombstone=True)
+        cls.addClassCleanup(cls.active_domain.delete)
+        cls.addClassCleanup(cls.deleted_domain.delete)
+
+
+@es_test
+class TestFindESDocsForDeletedDomains(TestCase):
+
+    def test_deleted_domain_with_es_data_is_flagged(self):
+        form = create_form_for_test(self.deleted_domain.name)
+        send_to_elasticsearch('forms', transform_xform_for_elasticsearch(form.to_json()))
+        self.es.indices.refresh(XFORM_INDEX_INFO.index)
+
+        counts_by_domain = find_es_docs_for_deleted_domains()
+
+        es_doc_counts = counts_by_domain[self.deleted_domain.name]
+        self.assertTrue(es_doc_counts[FormES.index], 1)
+
+    def test_missing_domain_with_es_data_is_not_flagged(self):
+        form = create_form_for_test('missing-domain')
+        send_to_elasticsearch('forms', transform_xform_for_elasticsearch(form.to_json()))
+        self.es.indices.refresh(XFORM_INDEX_INFO.index)
+
+        counts_by_domain = find_es_docs_for_deleted_domains()
+
+        self.assertTrue('missing-domain' not in counts_by_domain)
+
+    def test_active_domain_with_es_data_is_not_flagged(self):
+        form = create_form_for_test(self.active_domain.name)
+        send_to_elasticsearch('forms', transform_xform_for_elasticsearch(form.to_json()))
+        self.es.indices.refresh(XFORM_INDEX_INFO.index)
+
+        counts_by_domain = find_es_docs_for_deleted_domains()
+
+        self.assertTrue(self.active_domain.name not in counts_by_domain)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.active_domain = create_domain('active-domain')
+        cls.deleted_domain = create_domain('deleted-domain')
+        cls.deleted_domain.delete(leave_tombstone=True)
+        cls.addClassCleanup(cls.active_domain.delete)
+        cls.addClassCleanup(cls.deleted_domain.delete)
+
+    def setUp(self):
+        super().setUp()
+        self._setup_es()
+
+    def _setup_es(self):
+        self.es = get_es_new()
+        es_indices = [XFORM_INDEX_INFO, CASE_INDEX_INFO, CASE_SEARCH_INDEX_INFO, APP_INDEX_INFO, GROUP_INDEX_INFO,
+                      USER_INDEX_INFO]
+        for index in es_indices:
+            reset_es_index(index)
+            initialize_index_and_mapping(self.es, index)
+            self.addCleanup(ensure_index_deleted, index.index)
+
+
+class TestFindUCRTablesForDeletedDomains(TestCase):
+
+    def test_deleted_domain_with_ucr_tables_is_flagged(self):
+        config = self._create_data_source_config(self.deleted_domain.name)
+        adapter = get_indicator_adapter(config, raise_errors=True)
+        adapter.build_table()
+
+        counts_by_domain = find_ucr_tables_for_deleted_domains()
+
+        self.assertTrue(counts_by_domain[self.deleted_domain.name], [config.table_id])
+
+    def test_missing_domain_with_ucr_tables_is_not_flagged(self):
+        config = self._create_data_source_config('missing-domain')
+        adapter = get_indicator_adapter(config, raise_errors=True)
+        adapter.build_table()
+
+        counts_by_domain = find_ucr_tables_for_deleted_domains()
+
+        self.assertTrue('missing-domain' not in counts_by_domain)
+
+    def test_active_domain_with_ucr_tables_is_not_flagged(self):
+        config = self._create_data_source_config(self.active_domain.name)
+        adapter = get_indicator_adapter(config, raise_errors=True)
+        adapter.build_table()
+
+        counts_by_domain = find_ucr_tables_for_deleted_domains()
+
+        self.assertTrue(self.active_domain.name not in counts_by_domain)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.active_domain = create_domain('active-domain')
+        cls.deleted_domain = create_domain('deleted-domain')
+        cls.deleted_domain.delete(leave_tombstone=True)
+        cls.addClassCleanup(cls.active_domain.delete)
+        cls.addClassCleanup(cls.deleted_domain.delete)
+
+    @staticmethod
+    def _create_data_source_config(domain):
+        return DataSourceConfiguration(
+            domain=domain,
+            display_name='foo',
+            referenced_doc_type='CommCareCase',
+            table_id=clean_table_name('domain', 'test-table'),
+            configured_indicators=[{
+                "type": "expression",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": 'name'
+                },
+                "column_id": 'name',
+                "display_name": 'name',
+                "datatype": "string"
+            }],
+        )

--- a/corehq/apps/cleanup/tests/util.py
+++ b/corehq/apps/cleanup/tests/util.py
@@ -1,4 +1,5 @@
 import inspect
+from datetime import datetime
 
 from django.db import models
 from django.test import SimpleTestCase
@@ -42,3 +43,7 @@ class ModelAttrEqualityHelper(SimpleTestCase):
         extra_attrs = cls.couch_only_attrs
         new_attrs = cls.sql_only_attrs
         return (couch_attrs - extra_attrs).union(new_attrs)
+
+
+def is_monday():
+    return datetime.utcnow().isoweekday() == 1

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -691,7 +691,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     @classmethod
     def get_deleted_domain_names(cls):
         domains = Domain.view("domain/deleted_domains", include_docs=False, reduce=False).all()
-        return sorted({d['key'] for d in domains})
+        return {d['key'] for d in domains}
 
     @classmethod
     def get_all_ids(cls):

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -689,6 +689,11 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
         return sorted({d['key'] for d in cls.get_all(include_docs=False)})
 
     @classmethod
+    def get_deleted_domain_names(cls):
+        domains = Domain.view("domain/deleted_domains", include_docs=False, reduce=False).all()
+        return sorted({d['key'] for d in domains})
+
+    @classmethod
     def get_all_ids(cls):
         return [d['id'] for d in cls.get_all(include_docs=False)]
 

--- a/corehq/apps/domain/tests/test_domain_name_generation.py
+++ b/corehq/apps/domain/tests/test_domain_name_generation.py
@@ -1,10 +1,7 @@
 from django.test import TestCase
-from django.test.testcases import SimpleTestCase
 
 from corehq.apps.domain.exceptions import NameUnavailableException
 from corehq.apps.domain.models import Domain
-from corehq.apps.domain.utils import get_domain_url_slug
-from corehq.util.test_utils import generate_cases
 
 
 class DomainNameGenerationTest(TestCase):
@@ -45,16 +42,3 @@ class DomainNameGenerationTest(TestCase):
 
         self.add_domain("name")
         self.assertEqual(Domain.generate_name('very long name', 5), 'nam-1')
-
-
-class DomainNameShorteningTest(SimpleTestCase):
-    pass
-
-
-@generate_cases([
-    ('long name with stop words in it', 30, 'name-stop-words'),
-    ('long name with stop words in it', 14, 'name-stop'),
-], DomainNameShorteningTest)
-def test_shorten_name(self, hr_name, max_length, expected):
-    result = get_domain_url_slug(hr_name, max_length=max_length)
-    self.assertEqual(result, expected)

--- a/corehq/apps/domain/tests/test_utils.py
+++ b/corehq/apps/domain/tests/test_utils.py
@@ -15,7 +15,7 @@ from corehq.apps.domain.utils import (
 )
 from corehq.apps.users.models import CommCareUser
 from corehq.motech.utils import b64_aes_decrypt
-from corehq.util.test_utils import unit_testing_only
+from corehq.util.test_utils import generate_cases, unit_testing_only
 
 
 @unit_testing_only
@@ -168,5 +168,9 @@ class TestGetDomainURLSlug(SimpleTestCase):
         # cuts off entire word if exceeds max_length
         self.assertEqual('test', get_domain_url_slug('test-length', max_length=8))
 
-    def test_stop_words_excluded(self):
-        self.assertEqual('name-stop-words', get_domain_url_slug('long name with stop words in it', max_length=30))
+    @generate_cases([
+        ('long name with stop words in it', 30, 'name-stop-words'),
+        ('long name with stop words in it', 14, 'name-stop'),
+    ])
+    def test_stop_words_excluded(self, hr_name, max_length, expected):
+        self.assertEqual(expected, get_domain_url_slug(hr_name, max_length=max_length))

--- a/corehq/apps/domain/utils.py
+++ b/corehq/apps/domain/utils.py
@@ -77,7 +77,7 @@ def domain_name_stop_words():
         return {word.strip() for word in f.readlines() if word[0] != '#'}
 
 
-def get_domain_url_slug(hr_name, max_length=25, separator='-'):
+def get_domain_url_slug(hr_name, max_length=25):
     from dimagi.utils.name_to_url import name_to_url
     name = name_to_url(hr_name, "project")
     if len(name) <= max_length:
@@ -91,6 +91,7 @@ def get_domain_url_slug(hr_name, max_length=25, separator='-'):
     except StopIteration:
         return ''
 
+    separator = '-'
     for word in words:
         if len(text + separator + word) <= max_length:
             text += separator + word

--- a/corehq/apps/userreports/tests/test_utils.py
+++ b/corehq/apps/userreports/tests/test_utils.py
@@ -106,6 +106,7 @@ class TestGetDomainForUCRTableName(SimpleTestCase):
 
     def test_modern_prefix(self):
         domain = get_domain_url_slug('test')
+        self.assertEqual(domain, 'test')
         table_name = get_table_name(domain, '1234', prefix=UCR_TABLE_PREFIX)
 
         result = get_domain_for_ucr_table_name(table_name)
@@ -114,6 +115,7 @@ class TestGetDomainForUCRTableName(SimpleTestCase):
 
     def test_legacy_prefix(self):
         domain = get_domain_url_slug('test')
+        self.assertEqual(domain, 'test')
         table_name = get_table_name(domain, '1234', prefix=LEGACY_UCR_TABLE_PREFIX)
 
         result = get_domain_for_ucr_table_name(table_name)
@@ -122,6 +124,7 @@ class TestGetDomainForUCRTableName(SimpleTestCase):
 
     def test_domain_name_with_underscore(self):
         domain = get_domain_url_slug('test_domain')
+        self.assertEqual(domain, 'test-domain')
         table_name = get_table_name(domain, '1234')
 
         result = get_domain_for_ucr_table_name(table_name)
@@ -136,3 +139,12 @@ class TestGetDomainForUCRTableName(SimpleTestCase):
         result = get_domain_for_ucr_table_name(table_name)
 
         self.assertEqual(result, 'test-u4500')
+
+    def test_domain_name_with_illegal_name(self):
+        # should not be possible, but ensures unicode roundtrip works
+        domain = 'test\u4500'
+        table_name = get_table_name(domain, '1234')
+
+        result = get_domain_for_ucr_table_name(table_name)
+
+        self.assertEqual(result, domain)

--- a/corehq/apps/userreports/tests/test_utils.py
+++ b/corehq/apps/userreports/tests/test_utils.py
@@ -1,13 +1,18 @@
 from django.test import SimpleTestCase
+
 from testil import eq
 
+from dimagi.utils.couch.undo import remove_deleted_doc_type_suffix
+
+from corehq.apps.domain.utils import get_domain_url_slug
 from corehq.apps.userreports.sql import get_column_name
 from corehq.apps.userreports.util import (
+    LEGACY_UCR_TABLE_PREFIX,
     UCR_TABLE_PREFIX,
+    get_domain_for_ucr_table_name,
     get_table_name,
     truncate_value,
 )
-from dimagi.utils.couch.undo import remove_deleted_doc_type_suffix
 
 
 class UtilitiesTestCase(SimpleTestCase):
@@ -95,3 +100,39 @@ def test_remove_deleted_doc_type_suffix():
         (_check, 'DataSource-Deleted', 'DataSource'),
         (_check, 'DataSource-Deleted-Deleted', 'DataSource'),
     ]
+
+
+class TestGetDomainForUCRTableName(SimpleTestCase):
+
+    def test_modern_prefix(self):
+        domain = get_domain_url_slug('test')
+        table_name = get_table_name(domain, '1234', prefix=UCR_TABLE_PREFIX)
+
+        result = get_domain_for_ucr_table_name(table_name)
+
+        self.assertEqual(result, 'test')
+
+    def test_legacy_prefix(self):
+        domain = get_domain_url_slug('test')
+        table_name = get_table_name(domain, '1234', prefix=LEGACY_UCR_TABLE_PREFIX)
+
+        result = get_domain_for_ucr_table_name(table_name)
+
+        self.assertEqual(result, 'test')
+
+    def test_domain_name_with_underscore(self):
+        domain = get_domain_url_slug('test_domain')
+        table_name = get_table_name(domain, '1234')
+
+        result = get_domain_for_ucr_table_name(table_name)
+
+        self.assertEqual(result, 'test-domain')
+
+    def test_domain_name_with_unicode(self):
+        # domain names are typically unicode escaped prior to this call
+        domain = get_domain_url_slug('test\\u4500')
+        table_name = get_table_name(domain, '1234')
+
+        result = get_domain_for_ucr_table_name(table_name)
+
+        self.assertEqual(result, 'test-u4500')

--- a/corehq/apps/userreports/tests/test_utils.py
+++ b/corehq/apps/userreports/tests/test_utils.py
@@ -4,7 +4,6 @@ from testil import eq
 
 from dimagi.utils.couch.undo import remove_deleted_doc_type_suffix
 
-from corehq.apps.domain.utils import get_domain_url_slug
 from corehq.apps.userreports.sql import get_column_name
 from corehq.apps.userreports.util import (
     LEGACY_UCR_TABLE_PREFIX,
@@ -105,8 +104,7 @@ def test_remove_deleted_doc_type_suffix():
 class TestGetDomainForUCRTableName(SimpleTestCase):
 
     def test_modern_prefix(self):
-        domain = get_domain_url_slug('test')
-        self.assertEqual(domain, 'test')
+        domain = 'test'
         table_name = get_table_name(domain, '1234', prefix=UCR_TABLE_PREFIX)
 
         result = get_domain_for_ucr_table_name(table_name)
@@ -114,8 +112,7 @@ class TestGetDomainForUCRTableName(SimpleTestCase):
         self.assertEqual(result, 'test')
 
     def test_legacy_prefix(self):
-        domain = get_domain_url_slug('test')
-        self.assertEqual(domain, 'test')
+        domain = 'test'
         table_name = get_table_name(domain, '1234', prefix=LEGACY_UCR_TABLE_PREFIX)
 
         result = get_domain_for_ucr_table_name(table_name)
@@ -123,8 +120,7 @@ class TestGetDomainForUCRTableName(SimpleTestCase):
         self.assertEqual(result, 'test')
 
     def test_domain_name_with_underscore(self):
-        domain = get_domain_url_slug('test_domain')
-        self.assertEqual(domain, 'test-domain')
+        domain = 'test-domain'
         table_name = get_table_name(domain, '1234')
 
         result = get_domain_for_ucr_table_name(table_name)
@@ -132,8 +128,7 @@ class TestGetDomainForUCRTableName(SimpleTestCase):
         self.assertEqual(result, 'test-domain')
 
     def test_domain_name_with_unicode(self):
-        # domain names are typically unicode escaped prior to this call
-        domain = get_domain_url_slug('test\\u4500')
+        domain = 'test-u4500'
         table_name = get_table_name(domain, '1234')
 
         result = get_domain_for_ucr_table_name(table_name)

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -342,3 +342,12 @@ def wrap_report_config_by_type(config, allow_deleted=False):
         }[doc_type].wrap(config)
     except KeyError:
         raise ReportConfigurationNotFoundError()
+
+
+def get_domain_for_ucr_table_name(table_name):
+    if table_name.startswith(UCR_TABLE_PREFIX):
+        return table_name.split('_')[1]
+    elif table_name.startswith(LEGACY_UCR_TABLE_PREFIX):
+        return table_name.split('_')[2]
+    else:
+        raise ValueError(f"Expected {table_name} to start with {UCR_TABLE_PREFIX} or {LEGACY_UCR_TABLE_PREFIX}")


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13741

We currently enforce that when a domain is deleted, a tombstone must be left behind:
https://github.com/dimagi/commcare-hq/blob/b4907e3a32fd88c69131d08cbd023a93e730676e/corehq/apps/domain/models.py#L773-L776

which means that the deleted_domains couch view should be sufficient to use as reference when flagging potential data cleanup issues.

4fd1b5e3a5503f8c153b89a5a5980523e90b5a9e makes the change to use the deleted_domains couch view instead of the `_get_missing_domains` helper. 
ec0a03924da4a65a8080a37af26a8e1c9fe50520 is a refactor to make the interesting part of the periodic tasks more easily testable. These now live in the dbaccessors.py file in this app. I also slightly modified some of the email messages sent.
efb01a2332cc25974677fefedc302afb73735c9f is just me being nitpicky and only wanting tasks in tasks.py, but if that irks anyone just let me know
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
These tasks do not take any action, but are only informational so there is no immediate risk. The risk to be aware of is if action is to be taken based on the information sent out by these tasks. Given that these now have some test coverage and are targeting deleted domains only, this is much safer than the previous state.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added automated tests in corehq/apps/cleanup/tests/test_dbaccessors.py
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
