### PR TITLE
display session timeouts

### DIFF
--- a/corehq/apps/settings/templates/settings/my_projects.html
+++ b/corehq/apps/settings/templates/settings/my_projects.html
@@ -8,22 +8,23 @@
     <table class="table table-striped table-bordered">
       <thead>
       <tr>
-        <th class="col-md-6">{% trans "Project" %}</th>
-        <th class="col-md-6">{% trans "Status" %}</th>
+        <th class="col-md-4">{% trans "Project" %}</th>
+        <th class="col-md-4">{% trans "Status" %}</th>
+        <th class="col-md-4">{% trans "Session Timeout (minutes)" %}</th>
       </tr>
       </thead>
       <tbody>
       {% if not domains %}
         <tr>
-          <td colspan="2">{% blocktrans %}You are currently not a member of any projects.{% endblocktrans %}</td>
+          <td colspan="3">{% blocktrans %}You are currently not a member of any projects.{% endblocktrans %}</td>
         </tr>
       {% endif %}
       {% for domain in domains %}
         <tr>
-          <td class="col-md-6">
+          <td class="col-md-4">
             <a href="{% url "domain_homepage" domain.name %}">{{ domain.name }}</a>
           </td>
-          <td class="col-md-6">
+          <td class="col-md-4">
             {% if not domain.is_admin %}
               <a class="btn btn-danger"
                  data-toggle="modal"
@@ -67,6 +68,7 @@
               <p class="text-muted">{% blocktrans %}You are this project's administrator.{% endblocktrans %}</p>
             {% endif %}
           </td>
+          <td class="col-md-4">{{ domain.session_timeout }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/corehq/apps/settings/templates/settings/my_projects.html
+++ b/corehq/apps/settings/templates/settings/my_projects.html
@@ -7,10 +7,13 @@
   <div class="row-fluid">
     <table class="table table-striped table-bordered">
       <thead>
+      {% firstof show_session_timeout|yesno:"col-md-4,col-md-6" as col_class %}
       <tr>
-        <th class="col-md-4">{% trans "Project" %}</th>
-        <th class="col-md-4">{% trans "Status" %}</th>
-        <th class="col-md-4">{% trans "Session Timeout (minutes)" %}</th>
+        <th class="{{ col_class }}">{% trans "Project" %}</th>
+        <th class="{{ col_class }}">{% trans "Status" %}</th>
+        {% if show_session_timeout %}
+        <th class="{{ col_class }}">{% trans "Session Timeout (minutes)" %}</th>
+        {% endif %}
       </tr>
       </thead>
       <tbody>
@@ -21,10 +24,10 @@
       {% endif %}
       {% for domain in domains %}
         <tr>
-          <td class="col-md-4">
+          <td class="{{ col_class }}">
             <a href="{% url "domain_homepage" domain.name %}">{{ domain.name }}</a>
           </td>
-          <td class="col-md-4">
+          <td class="{{ col_class }}">
             {% if not domain.is_admin %}
               <a class="btn btn-danger"
                  data-toggle="modal"
@@ -68,7 +71,9 @@
               <p class="text-muted">{% blocktrans %}You are this project's administrator.{% endblocktrans %}</p>
             {% endif %}
           </td>
-          <td class="col-md-4">{{ domain.session_timeout }}</td>
+          {% if show_session_timeout %}
+          <td class="{{ col_class }}">{{ domain.session_timeout }}{{ total }}</td>
+          {% endif %}
         </tr>
       {% endfor %}
       </tbody>

--- a/corehq/apps/settings/templates/settings/my_projects.html
+++ b/corehq/apps/settings/templates/settings/my_projects.html
@@ -12,7 +12,7 @@
         <th class="{{ col_class }}">{% trans "Project" %}</th>
         <th class="{{ col_class }}">{% trans "Status" %}</th>
         {% if show_session_timeout %}
-        <th class="{{ col_class }}">{% trans "Session Timeout (minutes)" %}</th>
+        <th class="{{ col_class }}">{% trans "Inactivity Timeout (minutes)" %}</th>
         {% endif %}
       </tr>
       </thead>

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -30,6 +30,7 @@ from two_factor.views import (
 
 from corehq.apps.domain.extension_points import has_custom_clean_password
 from corehq.apps.domain.forms import clean_password
+from corehq.apps.domain.models import Domain
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from corehq.apps.hqwebapp.views import not_found
@@ -274,7 +275,8 @@ class MyProjectsList(BaseMyAccountView):
         return {
             'domains': [{
                 'name': d,
-                'is_admin': self.request.couch_user.is_domain_admin(d)
+                'is_admin': self.request.couch_user.is_domain_admin(d),
+                'session_timeout': Domain.secure_timeout(d) or "",
             } for d in self.request.couch_user.get_domains()],
             'web_user': self.request.couch_user.is_web_user
         }

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -278,7 +278,8 @@ class MyProjectsList(BaseMyAccountView):
                 'is_admin': self.request.couch_user.is_domain_admin(d),
                 'session_timeout': Domain.secure_timeout(d) or "",
             } for d in self.request.couch_user.get_domains()],
-            'web_user': self.request.couch_user.is_web_user
+            'web_user': self.request.couch_user.is_web_user,
+            'show_session_timeout': self.request.user.is_superuser
         }
 
     @property


### PR DESCRIPTION
## Product Description
Display domain inactivity timeouts on the 'My Projects' page.

This is only shown for superusers since I wasn't sure if there was some security risk in always displaying it.

https://dimagi-dev.atlassian.net/browse/SUPPORT-14120

**Without timeout**
![image](https://user-images.githubusercontent.com/249606/178972860-5125914c-7136-431d-b676-5eac10c2ffc3.png)

**With timeout**
![image](https://user-images.githubusercontent.com/249606/178973236-2edbee4b-db8e-4843-b24b-e42ae0a82cfc.png)

## Safety Assurance

### Safety story
I tested this locally.

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
