### PR TITLE
add vertical resize

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_feedback.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_feedback.html
@@ -67,7 +67,7 @@
               {% trans "Any other comments?" %}
             </label>
             <textarea data-bind="value: additionalFeedback"
-                      class="form-control"></textarea>
+                      class="form-control vertical-resize"></textarea>
           </div>
         </div>
         <div class="modal-body"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_inline_edit.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_inline_edit.html
@@ -19,7 +19,7 @@
     <div class="read-write form-inline" data-bind="visible: isEditing(), css: containerClass">
       <div class="form-group langcode-container" data-bind="css: {'has-lang': lang}">
         <!-- ko if: nodeName === "textarea" -->
-        <textarea class="form-control" data-bind="
+        <textarea class="form-control vertical-resize" data-bind="
                         attr: {name: name, id: id, placeholder: placeholder, rows: rows, cols: cols},
                         value: value,
                         hasFocus: isEditing(),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
In our Style guide, textarea component will now have vertical-resize class, so that horizontal-resize is disabled. 
This will improve UI of our Style Guide, so that both text area won't be able to surpass the main component block they reside in.
This can also set an example for furture textarea component.

**Before fix:**

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/39149002/179243891-1a37d535-4718-4405-bd39-01436287dd5f.png">
<img width="857" alt="image" src="https://user-images.githubusercontent.com/39149002/179243950-61219dad-cee1-4a11-8708-6a4fb78a2ae5.png">

**After fix:**

<img width="307" alt="image" src="https://user-images.githubusercontent.com/39149002/179244523-76612e9a-c149-4276-bb3a-1df9951e9894.png">
<img width="611" alt="image" src="https://user-images.githubusercontent.com/39149002/179244571-48dd93e2-474a-4683-a2af-9686c86b5f0e.png">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
No ticket, this PR originated from a [Slack thread](https://dimagi.slack.com/archives/C0BGN9LDU/p1657824455715509):
@jingcheng16: I just take a look at our [Style Guide](https://www.commcarehq.org/styleguide/molecules/#molecules-feedback), it seems like both inline editing and feedback allowing user to horizontally resizing. I agree it would be helpful for adding a guideline there.
@orangejenny: would you be open to updating the style guide? i’m happy to review / provide feedback.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
