### PR TITLE
Fix argument in DHIS2 error handler

### DIFF
--- a/corehq/motech/dhis2/static/dhis2/js/dhis2_entity_config.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dhis2_entity_config.js
@@ -70,7 +70,7 @@ hqDefine('dhis2/js/dhis2_entity_config', [
                     errors.push(String(error));
                 }
             }
-            if (errors) {
+            if (errors.length > 0) {
                 self.errorMessage(errors.join('\n----------------------\n'));
                 return self;
             }

--- a/corehq/motech/dhis2/templates/dhis2/dataset_map_json.html
+++ b/corehq/motech/dhis2/templates/dhis2/dataset_map_json.html
@@ -34,7 +34,7 @@
 </script>
 
 <form id="dataset-map"
-      class="form-horizontal"
+      class="form-horizontal ko-template"
       method="post"
       data-bind="submit: submit">
   <div data-bind="template: {

--- a/corehq/motech/dhis2/templates/dhis2/dhis2_entity_config.html
+++ b/corehq/motech/dhis2/templates/dhis2/dhis2_entity_config.html
@@ -35,7 +35,7 @@
 </script>
 
 <form id="dhis2-entity-config"
-      class="form-horizontal"
+      class="form-horizontal ko-template"
       method="post"
       data-bind="submit: submit">
     <div data-bind="template: {

--- a/corehq/motech/dhis2/templates/dhis2/dhis2_events_config.html
+++ b/corehq/motech/dhis2/templates/dhis2/dhis2_events_config.html
@@ -28,7 +28,7 @@
     {% trans "Form config" %}
 </label>
 <form id="dhis2-form-config"
-      class="form-horizontal"
+      class="form-horizontal ko-template"
       method="post"
       data-bind="submit: submit">
   <div data-bind="template: {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Fixed a form submit button that would always return self before getting to post and so never saved. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13748)
Accidentally set a check to see if a list was empty like python not javascript (see files changed). 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[DHIS2 Integration](https://staging.commcarehq.org/hq/flags/edit/dhis2_integration/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

This PR is a bug fix for [this PR](https://github.com/dimagi/commcare-hq/pull/31825) that was deployed 2 days ago. As long as this is rolled back first everything should be fine. 

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
