### PR TITLE
Moved visibility of select2

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_property_input.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_property_input.js
@@ -56,10 +56,12 @@ hqDefine('data_interfaces/js/case_property_input', [
             self.placeholder = gettext("case property name");
         },
         template: '<div>\
-          <select class="form-control"\
-                  required\
-                  data-bind="visible: showDropdown, value: valueObservable, autocompleteSelect2: casePropertyNames"\
-          ></select>\
+          <!-- ko if: showDropdown -->\
+            <select class="form-control"\
+                    required\
+                    data-bind="value: valueObservable, autocompleteSelect2: casePropertyNames"\
+            ></select>\
+          <!-- /ko -->\
           <input type="text"\
                  required\
                  class="textinput form-control"\


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/QA-4367

## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/31854

For some reason, the `visible` binding directly on the select2 isn't respected - presumably it hides the HTML select element but not all the associated select2 HTML - so I switched it to use a container with an `if` binding.

## Safety Assurance

### Safety story
Tested locally.

### Automated test coverage

No

### QA Plan

QA will verify, but I'll merge this on review because it's a bug in https://github.com/dimagi/commcare-hq/pull/31854 which is already merged.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
