### PR TITLE
replace `post_case_blocks` with `submit_case_blocks`

### DIFF
--- a/corehq/apps/aggregate_ucrs/tests/test_aggregation.py
+++ b/corehq/apps/aggregate_ucrs/tests/test_aggregation.py
@@ -7,7 +7,6 @@ from sqlalchemy import Date, Integer, SmallInteger, UnicodeText
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
-from casexml.apps.case.util import post_case_blocks
 
 from corehq.apps.aggregate_ucrs.aggregations import (
     AGGREGATION_UNIT_CHOICE_WEEK,
@@ -25,6 +24,7 @@ from corehq.apps.aggregate_ucrs.tests.base import AggregationBaseTestMixin
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import delete_all_apps
 from corehq.apps.app_manager.xform_builder import XFormBuilder
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.userreports.app_manager.helpers import (
     get_case_data_source,
@@ -169,7 +169,7 @@ class UCRAggregationTest(TestCase, AggregationBaseTestMixin):
                 'parent': (cls.case_type, parent_id)
             }
         )
-        post_case_blocks([caseblock.as_xml()], domain=cls.domain)
+        submit_case_blocks(caseblock.as_text(), domain=cls.domain)
         return case_id
 
     @classmethod
@@ -183,22 +183,16 @@ class UCRAggregationTest(TestCase, AggregationBaseTestMixin):
             case_name=cls.case_name,
             close=True,
         )
-        post_case_blocks([caseblock.as_xml()], domain=cls.domain)
+        submit_case_blocks(caseblock.as_text(), domain=cls.domain)
         return case_id
 
     @classmethod
     def _create_parent_case(cls, case_name):
         parent_id = uuid.uuid4().hex
-        post_case_blocks(
-            [
-                CaseBlock(
-                    create=True,
-                    case_id=parent_id,
-                    case_name=case_name,
-                    case_type=cls.parent_case_type,
-                ).as_xml()
-            ], domain=cls.domain
+        case_block = CaseBlock(
+            create=True, case_id=parent_id, case_name=case_name, case_type=cls.parent_case_type
         )
+        submit_case_blocks(case_block.as_text(), domain=cls.domain)
         return parent_id
 
     @classmethod

--- a/corehq/apps/api/tests/ucr_resources.py
+++ b/corehq/apps/api/tests/ucr_resources.py
@@ -8,10 +8,10 @@ from django.urls import reverse
 from django.utils.http import urlencode
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.util import post_case_blocks
 
 from corehq.apps.api.resources import v0_5
 from corehq.apps.domain.models import Domain
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.userreports.models import (
     DataSourceConfiguration,
     ReportConfiguration,
@@ -190,8 +190,8 @@ class TestConfigurableReportDataResource(APIResourceTest):
                 case_id=id,
                 case_type=case_type,
                 update={cls.field_name: val},
-            ).as_xml()
-            post_case_blocks([case_block], {'domain': cls.domain.name})
+            ).as_text()
+            submit_case_blocks(case_block, domain=cls.domain.name)
             cls.cases.append(CommCareCase.objects.get_case(id, cls.domain.name))
 
         cls.report_columns = [

--- a/corehq/apps/change_feed/tests/test_data_sources.py
+++ b/corehq/apps/change_feed/tests/test_data_sources.py
@@ -89,7 +89,7 @@ def case_form_data():
     for i in range(3):
         case_id = uuid.uuid4().hex
         case_block = factory.get_case_block(case_id, case_type='case_type')
-        form, [case] = factory.post_case_blocks([case_block.as_xml()])
+        form, [case] = factory.post_case_blocks([case_block.as_text()])
         cases.append(case)
         forms.append(form)
 
@@ -150,7 +150,7 @@ def ledger_data():
                 date=datetime.utcnow(),
                 section_id='test',
                 entry=Entry(id='chocolate', quantity=4),
-            ).as_xml()
+            ).as_string()
             for case_id in case_ids
         ]
         form, _ = factory.post_case_blocks(balance_blocks)

--- a/corehq/apps/change_feed/tests/test_data_sources.py
+++ b/corehq/apps/change_feed/tests/test_data_sources.py
@@ -150,7 +150,7 @@ def ledger_data():
                 date=datetime.utcnow(),
                 section_id='test',
                 entry=Entry(id='chocolate', quantity=4),
-            ).as_string()
+            ).as_text()
             for case_id in case_ids
         ]
         form, _ = factory.post_case_blocks(balance_blocks)

--- a/corehq/apps/change_feed/tests/test_data_sources.py
+++ b/corehq/apps/change_feed/tests/test_data_sources.py
@@ -89,7 +89,7 @@ def case_form_data():
     for i in range(3):
         case_id = uuid.uuid4().hex
         case_block = factory.get_case_block(case_id, case_type='case_type')
-        form, [case] = factory.post_case_blocks([case_block])
+        form, [case] = factory.post_case_blocks([case_block.as_xml()])
         cases.append(case)
         forms.append(form)
 

--- a/corehq/apps/hqcase/tests/test_bugs.py
+++ b/corehq/apps/hqcase/tests/test_bugs.py
@@ -3,11 +3,11 @@ import uuid
 from django.test import TestCase
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2
 from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import format_username
@@ -34,8 +34,8 @@ class OtaRestoreBugTest(TestCase):
                 case_type='duck',
                 user_id=user._id,
                 owner_id=user._id,
-            ).as_xml()
-            _, [case] = post_case_blocks([case_block], {'domain': domain})
+            ).as_text()
+            _, [case] = submit_case_blocks(case_block, domain=domain)
             return case
 
         good_case = _submit_case(good_domain)

--- a/corehq/apps/hqcase/tests/test_case_sharing.py
+++ b/corehq/apps/hqcase/tests/test_case_sharing.py
@@ -2,10 +2,10 @@ from django.test import TestCase
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import deprecated_check_user_has_case
-from casexml.apps.case.util import post_case_blocks
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.groups.models import Group
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import format_username
 
@@ -50,7 +50,7 @@ class CaseSharingTest(TestCase):
                 user_id=user.user_id,
                 owner_id=owner.get_id,
             )
-            post_case_blocks([case_block], {'domain': self.domain})
+            submit_case_blocks(case_block, domain=self.domain)
             check_has_block(case_block, should_have, should_not_have)
 
         def update_and_test(case_id, owner=None, should_have=None, should_not_have=None):
@@ -59,7 +59,7 @@ class CaseSharingTest(TestCase):
                 update={'greeting': "Hello!"},
                 owner_id=owner.get_id if owner else None,
             )
-            post_case_blocks([case_block], {'domain': self.domain})
+            submit_case_blocks(case_block, domain=self.domain)
             check_has_block(case_block, should_have, should_not_have, line_by_line=False)
 
         def check_has_block(case_block, should_have, should_not_have, line_by_line=True):
@@ -118,7 +118,7 @@ class CaseSharingTest(TestCase):
             external_id=case_id,
             owner_id=owner_id,
             **kwargs
-        ).as_xml()
+        ).as_text()
         return case_block
 
     def get_update_block(self, case_id, owner_id=None, update=None):
@@ -127,5 +127,5 @@ class CaseSharingTest(TestCase):
             case_id=case_id,
             update=update,
             owner_id=owner_id or CaseBlock.undefined,
-        ).as_xml()
+        ).as_text()
         return case_block

--- a/corehq/apps/ota/tests/test_claim.py
+++ b/corehq/apps/ota/tests/test_claim.py
@@ -5,10 +5,10 @@ from django.test import TestCase
 from casexml.apps.case.cleanup import claim_case, get_first_claims
 from casexml.apps.case.const import CASE_INDEX_EXTENSION
 from casexml.apps.case.mock import CaseBlock, IndexAttrs
-from casexml.apps.case.util import post_case_blocks
 
 from corehq.apps.case_search.models import CLAIM_CASE_TYPE
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.ota.utils import get_restore_user
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.exceptions import CaseNotFound
@@ -49,8 +49,8 @@ class CaseClaimTests(TestCase):
             case_name=self.host_case_name,
             case_type=self.host_case_type,
             owner_id="not the user",
-        ).as_xml()
-        post_case_blocks([case_block], {'domain': DOMAIN})
+        ).as_text()
+        submit_case_blocks(case_block, domain=DOMAIN)
 
     def assert_claim(self, claim=None, claim_id=None):
         if claim is None:
@@ -125,8 +125,8 @@ class CaseClaimTests(TestCase):
                     relationship=CASE_INDEX_EXTENSION,
                 )
             }
-        ).as_xml()
-        post_case_blocks([case_block], {'domain': DOMAIN})
+        ).as_text()
+        submit_case_blocks(case_block, domain=DOMAIN)
         first_claim = get_first_claims(DOMAIN, self.user.user_id, [self.host_case_id])
         self.assertEqual(first_claim, {self.host_case_id})
 
@@ -142,8 +142,8 @@ class CaseClaimTests(TestCase):
             create=False,
             case_id=claim_id,
             index={"host": (self.host_case_type, "")}
-        ).as_xml()
-        post_case_blocks([case_block], {'domain': DOMAIN})
+        ).as_text()
+        submit_case_blocks(case_block, domain=DOMAIN)
 
         first_claim = get_first_claims(DOMAIN, self.user.user_id, [self.host_case_id])
         self.assertEqual(len(first_claim), 0)
@@ -162,5 +162,5 @@ class CaseClaimTests(TestCase):
             create=False,
             case_id=case_id,
             close=True
-        ).as_xml()
-        post_case_blocks([case_block], {'domain': DOMAIN})
+        ).as_text()
+        submit_case_blocks(case_block, domain=DOMAIN)

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -8,8 +8,8 @@ from flaky import flaky
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import delete_all_cases
-from casexml.apps.case.util import post_case_blocks
 from casexml.apps.phone.models import SyncLogSQL
+from corehq.apps.hqcase.utils import submit_case_blocks
 from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 from pillowtop.es_utils import initialize_index_and_mapping
 
@@ -60,7 +60,7 @@ class CaseClaimEndpointTests(TestCase):
         CaseSearchConfig.objects.get_or_create(pk=DOMAIN, enabled=True)
         delete_all_cases()
         self.case_id = uuid4().hex
-        _, [self.case] = post_case_blocks([CaseBlock(
+        _, [self.case] = submit_case_blocks(CaseBlock(
             create=True,
             case_id=self.case_id,
             case_type=CASE_TYPE,
@@ -69,9 +69,9 @@ class CaseClaimEndpointTests(TestCase):
             user_id=OWNER_ID,
             owner_id=OWNER_ID,
             update={'opened_by': OWNER_ID},
-        ).as_xml()], {'domain': DOMAIN})
+        ).as_text(), domain=DOMAIN)
         self.additional_case_id = uuid4().hex
-        _, [self.additional_case] = post_case_blocks([CaseBlock.deprecated_init(
+        _, [self.additional_case] = submit_case_blocks(CaseBlock.deprecated_init(
             create=True,
             case_id=self.additional_case_id,
             case_type=CASE_TYPE,
@@ -80,7 +80,7 @@ class CaseClaimEndpointTests(TestCase):
             user_id=OWNER_ID,
             owner_id=OWNER_ID,
             update={'opened_by': OWNER_ID},
-        ).as_xml()], {'domain': DOMAIN})
+        ).as_text(), domain=DOMAIN)
         self.case_ids = set([self.case_id, self.additional_case_id])
         domains_needing_search_index.clear()
         CaseSearchReindexerFactory(domain=DOMAIN).build().reindex()

--- a/corehq/apps/sms/tests/util.py
+++ b/corehq/apps/sms/tests/util.py
@@ -11,7 +11,6 @@ from dateutil.parser import parse
 from nose.tools import nottest
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.util import post_case_blocks
 
 from corehq.apps.accounting.models import SoftwarePlanEdition
 from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
@@ -20,6 +19,7 @@ from corehq.apps.accounting.utils import clear_plan_version_cache
 from corehq.apps.app_manager.models import import_app
 from corehq.apps.domain.models import Domain
 from corehq.apps.groups.models import Group
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.sms.api import process_username
 from corehq.apps.sms.models import (
     OUTGOING,
@@ -136,8 +136,8 @@ class TouchformsTestCase(LiveServerTestCase, DomainSubscriptionMixin):
             case_type='participant',
             owner_id=owner.get_id,
             user_id=owner.get_id,
-        ).as_xml()
-        post_case_blocks([case_block], {'domain': self.domain})
+        ).as_text()
+        submit_case_blocks(case_block, domain=self.domain)
 
     def add_parent_access(self, user, case):
         case_block = CaseBlock(
@@ -146,8 +146,8 @@ class TouchformsTestCase(LiveServerTestCase, DomainSubscriptionMixin):
             case_type='magic_map',
             owner_id=user.get_id,
             index={'parent': ('participant', case.case_id)}
-        ).as_xml()
-        post_case_blocks([case_block], {'domain': self.domain})
+        ).as_text()
+        submit_case_blocks(case_block, domain=self.domain)
 
     def create_web_user(self, username, password):
         user = WebUser.create(self.domain, username, password, None, None)

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase, TestCase
 from sqlagg import SumWhen
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.util import post_case_blocks
+from corehq.apps.hqcase.utils import submit_case_blocks
 
 from corehq.apps.userreports import tasks
 from corehq.apps.userreports.app_manager.helpers import clean_table_name
@@ -173,8 +173,8 @@ class TestExpandedColumn(TestCase):
             case_id=id,
             case_type=self.case_type,
             update=properties,
-        ).as_xml()
-        post_case_blocks([case_block], {'domain': self.domain})
+        ).as_text()
+        submit_case_blocks(case_block, domain=self.domain)
         return CommCareCase.objects.get_case(id, self.domain)
 
     def _build_report(self, vals, field='my_field', build_data_source=True):

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
-from casexml.apps.case.util import post_case_blocks
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.pillow_utils import rebuild_table
 from corehq.form_processor.signals import sql_case_post_save
@@ -560,7 +560,7 @@ class ProcessRelatedDocTypePillowTest(TestCase):
         delete_all_xforms()
 
     def _post_case_blocks(self, iteration=0):
-        return post_case_blocks(
+        return submit_case_blocks(
             [
                 CaseBlock(
                     create=iteration == 0,
@@ -568,7 +568,7 @@ class ProcessRelatedDocTypePillowTest(TestCase):
                     case_name='parent-name',
                     case_type='bug',
                     update={'update-prop-parent': iteration},
-                ).as_xml(),
+                ).as_text(),
                 CaseBlock(
                     create=iteration == 0,
                     case_id='child-id',
@@ -576,7 +576,7 @@ class ProcessRelatedDocTypePillowTest(TestCase):
                     case_type='bug-child',
                     index={'parent': ('bug', 'parent-id')},
                     update={'update-prop-child': iteration}
-                ).as_xml()
+                ).as_text()
             ], domain=self.domain
         )
 
@@ -648,7 +648,7 @@ class ReuseEvaluationContextTest(TestCase):
         delete_all_xforms()
 
     def _post_case_blocks(self, iteration=0):
-        return post_case_blocks(
+        return submit_case_blocks(
             [
                 CaseBlock(
                     create=iteration == 0,
@@ -656,7 +656,7 @@ class ReuseEvaluationContextTest(TestCase):
                     case_name='parent-name',
                     case_type='bug',
                     update={'update-prop-parent': iteration},
-                ).as_xml(),
+                ).as_text(),
                 CaseBlock(
                     create=iteration == 0,
                     case_id='child-id',
@@ -664,7 +664,7 @@ class ReuseEvaluationContextTest(TestCase):
                     case_type='bug-child',
                     index={'parent': ('bug', 'parent-id')},
                     update={'update-prop-child': iteration}
-                ).as_xml()
+                ).as_text()
             ], domain=self.domain
         )
 
@@ -736,7 +736,7 @@ class AsyncIndicatorTest(TestCase):
         parent_id, child_id = uuid.uuid4().hex, uuid.uuid4().hex
         for i in range(3):
             since = self.pillow.get_change_feed().get_latest_offsets()
-            form, cases = post_case_blocks(
+            submit_case_blocks(
                 [
                     CaseBlock(
                         create=i == 0,
@@ -744,7 +744,7 @@ class AsyncIndicatorTest(TestCase):
                         case_name='parent-name',
                         case_type='bug',
                         update={'update-prop-parent': i},
-                    ).as_xml(),
+                    ).as_text(),
                     CaseBlock(
                         create=i == 0,
                         case_id=child_id,
@@ -752,7 +752,7 @@ class AsyncIndicatorTest(TestCase):
                         case_type='bug-child',
                         index={'parent': ('bug', parent_id)},
                         update={'update-prop-child': i}
-                    ).as_xml()
+                    ).as_text()
                 ], domain=self.domain
             )
             # ensure indicator is added
@@ -781,7 +781,7 @@ class AsyncIndicatorTest(TestCase):
         config.return_value = None
         since = self.pillow.get_change_feed().get_latest_offsets()
         parent_id, child_id = uuid.uuid4().hex, uuid.uuid4().hex
-        form, cases = post_case_blocks(
+        submit_case_blocks(
             [
                 CaseBlock(
                     create=True,
@@ -789,7 +789,7 @@ class AsyncIndicatorTest(TestCase):
                     case_name='parent-name',
                     case_type='bug',
                     update={'update-prop-parent': 0},
-                ).as_xml(),
+                ).as_text(),
                 CaseBlock(
                     create=True,
                     case_id=child_id,
@@ -797,7 +797,7 @@ class AsyncIndicatorTest(TestCase):
                     case_type='bug-child',
                     index={'parent': ('bug', parent_id)},
                     update={'update-prop-child': 0}
-                ).as_xml()
+                ).as_text()
             ], domain=self.domain
         )
 
@@ -842,7 +842,7 @@ class AsyncIndicatorTest(TestCase):
         parent_id, child_id = uuid.uuid4().hex, uuid.uuid4().hex
         since = self.pillow.get_change_feed().get_latest_offsets()
         for i in range(3):
-            form, cases = post_case_blocks(
+            submit_case_blocks(
                 [
                     CaseBlock(
                         create=i == 0,
@@ -850,7 +850,7 @@ class AsyncIndicatorTest(TestCase):
                         case_name='parent-name',
                         case_type='bug',
                         update={'update-prop-parent': i},
-                    ).as_xml(),
+                    ).as_text(),
                     CaseBlock(
                         create=i == 0,
                         case_id=child_id,
@@ -858,7 +858,7 @@ class AsyncIndicatorTest(TestCase):
                         case_type='bug-child',
                         index={'parent': ('bug', parent_id)},
                         update={'update-prop-child': i}
-                    ).as_xml()
+                    ).as_text()
                 ], domain=self.domain
             )
         self.pillow.process_changes(since=since, forever=False)
@@ -914,7 +914,7 @@ class IndicatorConfigFilterTest(SimpleTestCase):
 def _save_sql_case(doc):
     system_props = ['_id', '_rev', 'opened_on', 'owner_id', 'doc_type', 'domain', 'type']
     with drop_connected_signals(sql_case_post_save):
-        form, cases = post_case_blocks(
+        form, cases = submit_case_blocks(
             [
                 CaseBlock(
                     create=True,
@@ -924,7 +924,7 @@ def _save_sql_case(doc):
                     owner_id=doc['owner_id'],
                     date_opened=doc['opened_on'],
                     update={k: str(v) for k, v in doc.items() if k not in system_props}
-                ).as_xml()
+                ).as_text()
             ], domain=doc['domain']
         )
     return cases[0]

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -7,10 +7,10 @@ from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import delete_all_cases
-from casexml.apps.case.util import post_case_blocks
 
 from corehq import toggles
 from corehq.apps.domain.models import Domain
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.userreports import tasks
 from corehq.apps.userreports.dbaccessors import delete_all_report_configs
 from corehq.apps.userreports.models import (
@@ -38,9 +38,9 @@ class ConfigurableReportTestMixin(object):
             case_id=id,
             case_type=cls.case_type,
             update=properties,
-        ).as_xml()
+        ).as_text()
         with drop_connected_signals(sql_case_post_save):
-            post_case_blocks([case_block], {'domain': cls.domain})
+            submit_case_blocks(case_block, domain=cls.domain)
         return CommCareCase.objects.get_case(id, cls.domain)
 
     @classmethod

--- a/corehq/apps/zapier/tests/test_zapier_forwarding.py
+++ b/corehq/apps/zapier/tests/test_zapier_forwarding.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from django.test import TestCase
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.util import post_case_blocks
+from corehq.apps.hqcase.utils import submit_case_blocks
 
 from corehq.apps.zapier.consts import EventTypes
 from corehq.apps.zapier.models import ZapierSubscription
@@ -68,13 +68,13 @@ class TestZapierCaseForwarding(TestCase):
 
         # create case and run checks
         case_id = uuid.uuid4().hex
-        post_case_blocks(
+        submit_case_blocks(
             [
                 CaseBlock(
                     create=True,
                     case_id=case_id,
                     case_type=case_type,
-                ).as_xml()
+                ).as_text()
             ], domain=self.domain
         )
         # Enqueued repeat records have next_check set 48 hours in the future.
@@ -85,12 +85,12 @@ class TestZapierCaseForwarding(TestCase):
             self.assertEqual(case_id, record.payload_id)
 
         # update case and run checks
-        post_case_blocks(
+        submit_case_blocks(
             [
                 CaseBlock(
                     create=False,
                     case_id=case_id,
-                ).as_xml()
+                ).as_text()
             ], domain=self.domain
         )
         repeat_records = list(RepeatRecord.all(domain=self.domain, due_before=later))

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -2,7 +2,6 @@ import copy
 import uuid
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS, CASE_INDEX_CHILD
 
 
@@ -99,10 +98,11 @@ class CaseFactory(object):
                       for block in get_blocks(structure)]
 
     def post_case_blocks(self, caseblocks, form_extras=None, user_id=None, device_id=None):
+        from corehq.apps.hqcase.utils import submit_case_blocks
         submit_form_extras = copy.copy(self.form_extras)
         if form_extras is not None:
             submit_form_extras.update(form_extras)
-        return post_case_blocks(
+        return submit_case_blocks(
             caseblocks,
             form_extras=submit_form_extras,
             domain=self.domain,
@@ -149,7 +149,7 @@ class CaseFactory(object):
     def create_or_update_cases(self, case_structures, form_extras=None, user_id=None, device_id=None):
         from corehq.form_processor.models import CommCareCase
         self.post_case_blocks(
-            [b.as_xml() for b in self.get_case_blocks(case_structures)],
+            [b.as_text() for b in self.get_case_blocks(case_structures)],
             form_extras,
             user_id=user_id,
             device_id=device_id,

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -79,7 +79,7 @@ class CaseFactory(object):
     def get_case_block(self, case_id, **kwargs):
         for k, v in self.case_defaults.items():
             kwargs.setdefault(k, v)
-        return CaseBlock(case_id=case_id, **kwargs).as_xml()
+        return CaseBlock(case_id=case_id, **kwargs)
 
     def get_case_blocks(self, case_structures):
 
@@ -149,7 +149,7 @@ class CaseFactory(object):
     def create_or_update_cases(self, case_structures, form_extras=None, user_id=None, device_id=None):
         from corehq.form_processor.models import CommCareCase
         self.post_case_blocks(
-            self.get_case_blocks(case_structures),
+            [b.as_xml() for b in self.get_case_blocks(case_structures)],
             form_extras,
             user_id=user_id,
             device_id=device_id,

--- a/corehq/ex-submodules/casexml/apps/case/mock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/mock.py
@@ -71,7 +71,7 @@ class CaseFactory(object):
     """
 
     def __init__(self, domain=None, case_defaults=None, form_extras=None):
-        self.domain = domain
+        self.domain = domain or 'test-domain'
         self.case_defaults = case_defaults if case_defaults is not None else {}
         self.form_extras = form_extras if form_extras is not None else {}
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -5,7 +5,6 @@ import os
 from casexml.apps.case.const import CASE_INDEX_EXTENSION
 from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure, CaseIndex
 from corehq.apps.reports.view_helpers import get_case_hierarchy, case_hierarchy_context
-from casexml.apps.case.util import post_case_blocks
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.exceptions import CaseNotFound
@@ -91,9 +90,7 @@ class CaseBugTest(TestCase, TestFileMixin):
         Submit multiple values for the same property in an update block
         """
         case_id = '061ecbae-d9be-4bb5-bdd4-e62abd5eaf7b'
-        post_case_blocks([
-            CaseBlock(create=True, case_id=case_id).as_xml()
-        ])
+        submit_case_blocks(CaseBlock(create=True, case_id=case_id).as_text(), domain='test-domain')
         xml_data = self.get_xml('duplicate_case_properties')
         result = submit_form_locally(xml_data, 'test-domain')
         self.assertEqual("", result.case.dynamic_case_properties()['foo'])
@@ -134,9 +131,9 @@ class CaseBugTest(TestCase, TestFileMixin):
     def test_submit_to_deleted_case(self):
         """submitting to a deleted case should succeed and affect the case"""
         case_id = uuid.uuid4().hex
-        xform, [case] = post_case_blocks([
+        xform, [case] = submit_case_blocks([
             CaseBlock(create=True, case_id=case_id, user_id='whatever',
-                update={'foo': 'bar'}).as_xml()
+                update={'foo': 'bar'}).as_text()
         ], domain="test-domain")
         CommCareCase.objects.soft_delete_cases("test-domain", [case_id])
 
@@ -144,10 +141,10 @@ class CaseBugTest(TestCase, TestFileMixin):
         self.assertEqual('bar', case.dynamic_case_properties()['foo'])
         self.assertTrue(case.is_deleted)
 
-        xform, [case] = post_case_blocks([
+        xform, [case] = submit_case_blocks([
             CaseBlock(create=False, case_id=case_id, user_id='whatever',
-                      update={'foo': 'not_bar'}).as_xml()
-        ])
+                      update={'foo': 'not_bar'}).as_text()
+        ], domain="test-domain")
         self.assertEqual('not_bar', case.dynamic_case_properties()['foo'])
         self.assertTrue(case.is_deleted)
 
@@ -156,13 +153,13 @@ class CaseBugTest(TestCase, TestFileMixin):
         case_id2 = uuid.uuid4().hex
         # updates before create and case blocks for different cases interleaved
         blocks = [
-            CaseBlock(create=False, case_id=case_id1, update={'p': '2'}).as_xml(),
-            CaseBlock(create=False, case_id=case_id2, update={'p': '2'}).as_xml(),
-            CaseBlock(create=True, case_id=case_id1, update={'p': '1'}).as_xml(),
-            CaseBlock(create=True, case_id=case_id2, update={'p': '1'}).as_xml()
+            CaseBlock(create=False, case_id=case_id1, update={'p': '2'}).as_text(),
+            CaseBlock(create=False, case_id=case_id2, update={'p': '2'}).as_text(),
+            CaseBlock(create=True, case_id=case_id1, update={'p': '1'}).as_text(),
+            CaseBlock(create=True, case_id=case_id2, update={'p': '1'}).as_text()
         ]
 
-        xform, cases = post_case_blocks(blocks)
+        xform, cases = submit_case_blocks(blocks, domain='test-domain')
         self.assertEqual(cases[0].get_case_property('p'), '2')
         self.assertEqual(cases[1].get_case_property('p'), '2')
 
@@ -174,11 +171,11 @@ class CaseBugTest(TestCase, TestFileMixin):
         blocks = [
             CaseBlock(create=True, case_id=case_id1, case_type="child", index={
                 "parent": ("parent", case_id2)
-            }).as_xml(),
-            CaseBlock(create=True, case_id=case_id2, case_type="parent").as_xml()
+            }).as_text(),
+            CaseBlock(create=True, case_id=case_id2, case_type="parent").as_text()
         ]
 
-        xform, cases = post_case_blocks(blocks)
+        xform, cases = submit_case_blocks(blocks, domain='test-domain')
         child_case = [case for case in cases if case.type == "child"][0]
         self.assertEqual(child_case.get_index("parent").referenced_id, case_id2)
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -6,8 +6,9 @@ from django.test import TestCase
 from casexml.apps.case.cleanup import rebuild_case_from_forms
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import delete_all_cases
-from casexml.apps.case.util import post_case_blocks, primary_actions
+from casexml.apps.case.util import primary_actions
 from corehq.apps.change_feed import topics
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.form_processor.models import CommCareCase, RebuildWithReason, XFormInstance
 from corehq.form_processor.tests.utils import sharded
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
@@ -18,9 +19,6 @@ REBUILD_TEST_DOMAIN = 'rebuild-test'
 def _post_util(create=False, case_id=None, user_id=None, owner_id=None,
               case_type=None, form_extras=None, close=False, date_modified=None,
               **kwargs):
-
-    form_extras = form_extras or {}
-    form_extras['domain'] = REBUILD_TEST_DOMAIN
 
     def uid():
         return uuid.uuid4().hex
@@ -33,8 +31,7 @@ def _post_util(create=False, case_id=None, user_id=None, owner_id=None,
                       date_modified=date_modified,
                       update=kwargs,
                       close=close)
-    block = block.as_xml()
-    post_case_blocks([block], form_extras)
+    submit_case_blocks([block.as_text()], REBUILD_TEST_DOMAIN, form_extras=form_extras)
     return case_id
 
 
@@ -210,12 +207,12 @@ class CaseRebuildTest(TestCase):
         way_earlier = now - timedelta(days=1)
         # make sure we timestamp everything so they have the right order
         create_block = CaseBlock(case_id, create=True, date_modified=way_earlier)
-        post_case_blocks(
-            [create_block.as_xml()], form_extras={'received_on': way_earlier}
+        submit_case_blocks(
+            [create_block.as_text()], 'test-domain', form_extras={'received_on': way_earlier}
         )
         update_block = CaseBlock(case_id, update={'foo': 'bar'}, date_modified=earlier)
-        post_case_blocks(
-            [update_block.as_xml()], form_extras={'received_on': earlier}
+        submit_case_blocks(
+            [update_block.as_text()], 'test-domain', form_extras={'received_on': earlier}
         )
 
         case = CommCareCase.objects.get_case(case_id, 'test-domain')
@@ -246,16 +243,16 @@ class CaseRebuildTest(TestCase):
 
     def test_archive_removes_index(self):
         parent_case_id = uuid.uuid4().hex
-        post_case_blocks([
-            CaseBlock(parent_case_id, create=True).as_xml()
-        ])
+        submit_case_blocks([
+            CaseBlock(parent_case_id, create=True).as_text()
+        ], 'test-domain')
         child_case_id = uuid.uuid4().hex
-        post_case_blocks([
-            CaseBlock(child_case_id, create=True).as_xml()
-        ])
-        xform, _ = post_case_blocks([
-            CaseBlock(child_case_id, index={'mom': ('mother', parent_case_id)}).as_xml()
-        ])
+        submit_case_blocks([
+            CaseBlock(child_case_id, create=True).as_text()
+        ], 'test-domain')
+        xform, _ = submit_case_blocks([
+            CaseBlock(child_case_id, index={'mom': ('mother', parent_case_id)}).as_text()
+        ], 'test-domain')
 
         case = CommCareCase.objects.get_case(child_case_id, 'test-domain')
         self.assertEqual(1, len(case.indices))

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
@@ -9,7 +9,6 @@ from casexml.apps.case import const
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.phone import xml
 from casexml.apps.case.tests.util import check_xml_line_by_line, delete_all_cases
-from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2, V2_NAMESPACE
 from casexml.apps.case.xml.parser import case_update_from_block
 
@@ -109,12 +108,12 @@ class Version2CaseParsingTest(TestCase):
 
         user_id = "bar-user-id"
         for prereq in ["some_referenced_id", "some_other_referenced_id"]:
-            post_case_blocks([
+            submit_case_blocks([
                 CaseBlock(
                     create=True, case_id=prereq,
                     user_id=user_id
-                ).as_xml()
-            ])
+                ).as_text()
+            ], 'test-domain')
 
         file_path = os.path.join(os.path.dirname(__file__), "data", "v2", "index_update.xml")
         with open(file_path, "rb") as f:

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -171,11 +171,12 @@ def _check_payload_has_cases(testcase, payload_string, username, case_blocks, sh
     blocks_from_restore = extract_caseblocks_from_xml(payload_string, version)
 
     def check_block(case_block):
-        case_block.set('xmlns', XMLNS)
-        case_block = _RestoreCaseBlock(
-            ElementTree.fromstring(ElementTree.tostring(case_block, encoding='utf-8')),
-            version=version,
-        )
+        if isinstance(case_block, str):
+            case_block = ElementTree.fromstring(case_block)
+        else:
+            case_block.set('xmlns', XMLNS)
+            case_block = ElementTree.fromstring(ElementTree.tostring(case_block, encoding='utf-8'))
+        case_block = _RestoreCaseBlock(case_block, version=version)
         case_id = case_block.get_case_id()
         n = 0
 

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -1,20 +1,20 @@
 from __future__ import generator_stop
-from collections import defaultdict, namedtuple
-import uuid
 
-from xml.etree import cElementTree as ElementTree
 import datetime
+import uuid
+from collections import defaultdict, namedtuple
 
-from django.conf import settings
 from django.utils.dateparse import parse_datetime
+
 from iso8601 import iso8601
 
-from casexml.apps.case.const import CASE_ACTION_UPDATE, CASE_ACTION_CREATE
+from casexml.apps.case.const import CASE_ACTION_CREATE, CASE_ACTION_UPDATE
 from casexml.apps.case.exceptions import PhoneDateValueError
 from casexml.apps.phone.models import delete_synclogs
 from casexml.apps.phone.xml import get_case_xml
-from corehq.util.soft_assert import soft_assert
+
 from corehq.form_processor.models import XFormInstance
+from corehq.util.soft_assert import soft_assert
 
 
 def validate_phone_datetime(datetime_string, none_ok=False, form_id=None):
@@ -35,35 +35,6 @@ def validate_phone_datetime(datetime_string, none_ok=False, form_id=None):
         return iso8601.parse_date(datetime_string)
     except iso8601.ParseError:
         raise PhoneDateValueError('{!r}'.format(datetime_string))
-
-
-def post_case_blocks(case_blocks, form_extras=None, domain=None, user_id=None, device_id=None):
-    """
-    Post case blocks.
-
-    Extras is used to add runtime attributes to the form before
-    sending it off to the case (current use case is sync-token pairing)
-
-    See `device_id` parameter documentation at
-    `corehq.apps.hqcase.utils.submit_case_blocks`.
-    """
-    from corehq.apps.hqcase.utils import submit_case_blocks
-
-    if form_extras is None:
-        form_extras = {}
-
-    domain = domain or form_extras.pop('domain', None)
-    if getattr(settings, 'UNIT_TESTING', False):
-        from casexml.apps.case.tests.util import TEST_DOMAIN_NAME
-        domain = domain or TEST_DOMAIN_NAME
-
-    return submit_case_blocks(
-        [ElementTree.tostring(case_block, encoding='utf-8').decode('utf-8') for case_block in case_blocks],
-        domain=domain,
-        form_extras=form_extras,
-        user_id=user_id,
-        device_id=device_id,
-    )
 
 
 def create_real_cases_from_dummy_cases(cases):

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -12,7 +12,7 @@ from iso8601 import iso8601
 from casexml.apps.case.const import CASE_ACTION_UPDATE, CASE_ACTION_CREATE
 from casexml.apps.case.exceptions import PhoneDateValueError
 from casexml.apps.phone.models import delete_synclogs
-from casexml.apps.phone.xml import get_case_element
+from casexml.apps.phone.xml import get_case_xml
 from corehq.util.soft_assert import soft_assert
 from corehq.form_processor.models import XFormInstance
 
@@ -76,6 +76,7 @@ def create_real_cases_from_dummy_cases(cases):
     returns a tuple of two lists: forms posted and cases created
 
     """
+    from corehq.apps.hqcase.utils import submit_case_blocks
     posted_cases = []
     posted_forms = []
     case_blocks_by_domain = defaultdict(list)
@@ -84,10 +85,10 @@ def create_real_cases_from_dummy_cases(cases):
             case.modified_on = datetime.datetime.utcnow()
         if not case._id:
             case._id = uuid.uuid4().hex
-        case_blocks_by_domain[case.domain].append(get_case_element(
+        case_blocks_by_domain[case.domain].append(get_case_xml(
             case, (CASE_ACTION_CREATE, CASE_ACTION_UPDATE), version='2.0'))
     for domain, case_blocks in case_blocks_by_domain.items():
-        form, cases = post_case_blocks(case_blocks, domain=domain)
+        form, cases = submit_case_blocks(case_blocks, domain=domain)
         posted_forms.append(form)
         posted_cases.extend(cases)
     return posted_forms, posted_cases

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -671,7 +671,7 @@ class SyncTokenUpdateTest(BaseSyncTest):
         self.device.post_changes(create=True, case_id=parent_id)
         case_id = uuid.uuid4().hex
         case_xml = self.device.case_factory.get_case_block(
-            case_id, create=True, close=True)
+            case_id, create=True, close=True).as_xml()
         # hackily insert an <index> block after the close
         index_wrapper = ElementTree.Element('index')
         index_elem = ElementTree.Element('parent')

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -680,7 +680,12 @@ class SyncTokenUpdateTest(BaseSyncTest):
         index_elem.text = parent_id
         index_wrapper.append(index_elem)
         case_xml.append(index_wrapper)
-        self.device.case_blocks.append(case_xml)
+
+        class FakeBlock:
+            def as_text(self):
+                return ElementTree.tostring(case_xml, encoding='unicode')
+
+        self.device.case_blocks.append(FakeBlock())
         self.device.post_changes()
         sync_log = self.device.last_sync.get_log()
         # before this test was written, the case stayed on the sync log even though it was closed

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -5,7 +5,6 @@ from xml.etree import cElementTree as ElementTree
 from django.test import TestCase
 from unittest.mock import patch
 
-from casexml.apps.case.util import post_case_blocks
 from casexml.apps.phone.exceptions import RestoreException
 from casexml.apps.phone.restore_caching import RestorePayloadPathCache
 from casexml.apps.case.mock import CaseBlock, CaseStructure, CaseIndex, CaseFactory
@@ -14,6 +13,7 @@ from casexml.apps.phone.utils import get_restore_config, MockDevice
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.tests.test_utils import delete_all_domains
 from corehq.apps.groups.models import Group
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.blobs import get_blob_db
@@ -1184,13 +1184,13 @@ class SyncTokenCachingTest(BaseSyncTest):
         # posting a case associated with this sync token should invalidate the cache
         # submitting a case not with the token will not touch the cache for that token
         case_id = "cache_noninvalidation"
-        post_case_blocks([CaseBlock(
+        submit_case_blocks([CaseBlock(
             create=True,
             case_id=case_id,
             user_id=self.user.user_id,
             owner_id=self.user.user_id,
             case_type=PARENT_TYPE,
-        ).as_xml()])
+        ).as_text()], TEST_DOMAIN_NAME)
         self.device.last_sync = sync0
         sync2 = self.device.sync(version=V2)
         self.assertEqual(sync1.payload, sync2.payload)
@@ -1923,10 +1923,10 @@ class LooseSyncTokenValidationTest(BaseSyncTest):
 
     def test_submission_with_bad_log_toggle_enabled(self):
         # this is just asserting that an exception is not raised when there's no synclog
-        post_case_blocks(
-            [CaseBlock(create=True, case_id='bad-log-toggle-enabled').as_xml()],
+        submit_case_blocks(
+            [CaseBlock(create=True, case_id='bad-log-toggle-enabled').as_text()],
+            'submission-domain-with-toggle',
             form_extras={"last_sync_token": 'not-a-valid-synclog-id'},
-            domain='submission-domain-with-toggle',
         )
 
     def test_restore_with_bad_log_toggle_enabled(self):

--- a/corehq/ex-submodules/casexml/apps/phone/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/utils.py
@@ -240,7 +240,7 @@ class MockDevice(object):
             # post device case changes
             token = self.last_sync.restore_id if self.last_sync else None
             form = self.case_factory.post_case_blocks(
-                [b.as_xml() for b in self.case_blocks],
+                [b.as_text() for b in self.case_blocks],
                 device_id=self.id,
                 form_extras={"last_sync_token": token},
                 user_id=self.user_id,

--- a/corehq/ex-submodules/casexml/apps/phone/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/utils.py
@@ -222,7 +222,7 @@ class MockDevice(object):
         if all(isinstance(s, CaseStructure) for s in cases):
             self.case_blocks.extend(factory.get_case_blocks(cases))
         else:
-            self.case_blocks.extend(b.as_xml() for b in cases)
+            self.case_blocks.extend(cases)
 
     def post_changes(self, *args, **kw):
         """Post enqueued changes from device to HQ
@@ -240,7 +240,7 @@ class MockDevice(object):
             # post device case changes
             token = self.last_sync.restore_id if self.last_sync else None
             form = self.case_factory.post_case_blocks(
-                self.case_blocks,
+                [b.as_xml() for b in self.case_blocks],
                 device_id=self.id,
                 form_extras={"last_sync_token": token},
                 user_id=self.user_id,

--- a/corehq/ex-submodules/casexml/apps/stock/mock.py
+++ b/corehq/ex-submodules/casexml/apps/stock/mock.py
@@ -22,6 +22,10 @@ class LedgerXML(XmlObject):
     def as_string(self):
         return self.serialize()
 
+    def as_text(self):
+        """Compatibility with ``CaseBlock``"""
+        return self.serialize().decode('utf8')
+
 
 class Value(LedgerXML):
     ROOT_NAME = 'value'

--- a/corehq/form_processor/tests/test_basics.py
+++ b/corehq/form_processor/tests/test_basics.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import deprecated_check_user_has_case
-from casexml.apps.case.util import post_case_blocks
 from casexml.apps.phone.restore_caching import RestorePayloadPathCache
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.case_search.models import CaseSearchConfig
@@ -16,7 +15,7 @@ from corehq.apps.cloudcare.const import DEVICE_ID as FORMPLAYER_DEVICE_ID
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import clear_domain_names
 from corehq.apps.es import CaseSearchES
-from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS
+from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS, submit_case_blocks
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import CouchUser
@@ -361,7 +360,7 @@ class FundamentalCaseTests(FundamentalBaseTests):
             }
         )
 
-        post_case_blocks([case.as_xml()], domain='some-domain')
+        submit_case_blocks([case.as_text()], domain='some-domain')
         # update the date_opened to date type to check for value on restore
         case.date_opened = case.date_opened.date()
         deprecated_check_user_has_case(self, user, case.as_xml())
@@ -476,7 +475,7 @@ class FundamentalCaseTests(FundamentalBaseTests):
             case_name='this is a very long case name that exceeds the 255 char limit' * 5
         )
 
-        xform, cases = post_case_blocks([case.as_xml()], domain=DOMAIN)
+        xform, cases = submit_case_blocks([case.as_text()], domain=DOMAIN)
         self.assertEqual(0, len(cases))
         self.assertTrue(xform.is_error)
         self.assertIn('CaseValueError', xform.problem)
@@ -525,13 +524,13 @@ class CaseSearchTests(FundamentalBaseTests):
 
 def _submit_case_block(create, case_id, xmlns=SYSTEM_FORM_XMLNS, device_id=None, **kwargs):
     domain = kwargs.pop('domain', DOMAIN)
-    return post_case_blocks(
+    return submit_case_blocks(
         [
             CaseBlock(
                 create=create,
                 case_id=case_id,
                 **kwargs
-            ).as_xml()
+            ).as_text()
         ],
         domain=domain,
         device_id=device_id,

--- a/corehq/form_processor/tests/test_dbcache.py
+++ b/corehq/form_processor/tests/test_dbcache.py
@@ -2,7 +2,7 @@ import uuid
 from django.test import TestCase, SimpleTestCase
 from casexml.apps.case.exceptions import IllegalCaseId
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.util import post_case_blocks
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.form_processor.backends.sql.casedb import CaseDbCacheSQL
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CommCareCase
@@ -21,12 +21,12 @@ class CaseDbCacheTest(TestCase):
 
     def testDomainCheck(self):
         id = uuid.uuid4().hex
-        post_case_blocks([
+        submit_case_blocks([
             CaseBlock(
                 create=True, case_id=id,
                 user_id='some-user'
-            ).as_xml()
-        ], {'domain': 'good-domain'})
+            ).as_text()
+        ], 'good-domain')
         bad_cache = self.interface.casedb_cache(domain='bad-domain')
         try:
             bad_cache.get(id)
@@ -91,7 +91,7 @@ class CaseDbCacheNoDbTest(SimpleTestCase):
 
 def _make_some_cases(howmany, domain='dbcache-test'):
     ids = [uuid.uuid4().hex for i in range(howmany)]
-    post_case_blocks([
+    submit_case_blocks([
         CaseBlock(
             create=True,
             case_id=ids[i],
@@ -99,6 +99,6 @@ def _make_some_cases(howmany, domain='dbcache-test'):
             update={
                 'my_index': i,
             }
-        ).as_xml() for i in range(howmany)
-    ], {'domain': domain})
+        ).as_text() for i in range(howmany)
+    ], domain)
     return ids

--- a/corehq/form_processor/tests/test_reprocess_errors.py
+++ b/corehq/form_processor/tests/test_reprocess_errors.py
@@ -6,7 +6,6 @@ from django.test import TestCase, TransactionTestCase
 from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure
-from casexml.apps.case.util import post_case_blocks
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.receiverwrapper.util import submit_form_locally
@@ -54,7 +53,7 @@ class ReprocessXFormErrorsTest(TestCase):
             index={'parent': ('parent_type', parent_case_id)}
         )
 
-        post_case_blocks([case.as_xml()], domain=self.domain)
+        submit_case_blocks([case.as_text()], domain=self.domain)
 
         get_forms_by_type = XFormInstance.objects.get_forms_by_type
         error_forms = get_forms_by_type(self.domain, 'XFormError', 10)
@@ -74,7 +73,7 @@ class ReprocessXFormErrorsTest(TestCase):
             case_name='parent',
         )
 
-        post_case_blocks([case.as_xml()], domain=self.domain)
+        submit_case_blocks([case.as_text()], domain=self.domain)
 
         reprocess_xform_error(XFormInstance.objects.get_form(form.form_id))
 

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
@@ -5,12 +5,12 @@ from django.test import TestCase
 
 from casexml.apps.case.const import CASE_INDEX_EXTENSION
 from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure, CaseIndex
-from casexml.apps.case.util import post_case_blocks
 from corehq.apps.accounting.models import SoftwarePlanEdition
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.accounting.utils import clear_plan_version_cache
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.domain.shortcuts import create_user, create_domain
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.registry.tests.utils import create_registry_for_test, Invitation, Grant
 from corehq.apps.users.models import CommCareUser
 from corehq.motech.models import ConnectionSettings
@@ -66,13 +66,13 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
 
         cls.target_case_id_1 = uuid.uuid4().hex
         cls.target_case_id_2 = uuid.uuid4().hex
-        post_case_blocks(
+        submit_case_blocks(
             [
                 CaseBlock(
                     case_id=case_id,
                     create=True,
                     case_type="patient",
-                ).as_xml()
+                ).as_text()
                 for case_id in [cls.target_case_id_1, cls.target_case_id_2]
             ],
             domain=cls.target_domain

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -586,7 +586,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
             case_id="a_case_id",
             create=True,
             case_type="planet",
-        ).as_xml()
+        ).as_text()
         CaseFactory(self.domain).post_case_blocks([white_listed_case])
         self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 
@@ -594,7 +594,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
             case_id="b_case_id",
             create=True,
             case_type="cat",
-        ).as_xml()
+        ).as_text()
         CaseFactory(self.domain).post_case_blocks([non_white_listed_case])
         self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -29,6 +29,7 @@ from django.test.utils import CaptureQueriesContext
 
 from unittest import mock
 
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.decorators import ContextDecorator
 
@@ -735,7 +736,6 @@ def set_parent_case(domain, child_case, parent_case, relationship='child', ident
 
 def update_case(domain, case_id, case_properties, user_id=None):
     from casexml.apps.case.mock import CaseBlock
-    from casexml.apps.case.util import post_case_blocks
 
     kwargs = {
         'case_id': case_id,
@@ -745,8 +745,8 @@ def update_case(domain, case_id, case_properties, user_id=None):
     if user_id:
         kwargs['user_id'] = user_id
 
-    post_case_blocks(
-        [CaseBlock.deprecated_init(**kwargs).as_xml()], domain=domain
+    submit_case_blocks(
+        [CaseBlock.deprecated_init(**kwargs).as_text()], domain=domain
     )
 
 

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -29,7 +29,6 @@ from django.test.utils import CaptureQueriesContext
 
 from unittest import mock
 
-from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.decorators import ContextDecorator
 
@@ -731,22 +730,6 @@ def set_parent_case(domain, child_case, parent_case, relationship='child', ident
                 relationship=relationship
             )],
         )
-    )
-
-
-def update_case(domain, case_id, case_properties, user_id=None):
-    from casexml.apps.case.mock import CaseBlock
-
-    kwargs = {
-        'case_id': case_id,
-        'update': case_properties,
-    }
-
-    if user_id:
-        kwargs['user_id'] = user_id
-
-    submit_case_blocks(
-        [CaseBlock.deprecated_init(**kwargs).as_text()], domain=domain
     )
 
 

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -7,7 +7,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.util import post_case_blocks
+from corehq.apps.hqcase.utils import submit_case_blocks
 from dimagi.utils.parsing import json_format_date
 
 from corehq.apps.app_manager.util import enable_usercase
@@ -49,13 +49,13 @@ class CaseCommandsTest(TestCase):
             call_command('add_hq_user_id_to_case', self.domain, 'checkin', '--username=afakeuserthatdoesnotexist')
 
     def submit_case_block(self, create, case_id, **kwargs):
-        return post_case_blocks(
+        return submit_case_blocks(
             [
                 CaseBlock(
                     create=create,
                     case_id=case_id,
                     **kwargs
-                ).as_xml()
+                ).as_text()
             ], domain=self.domain
         )
 

--- a/custom/inddex/example_data/data.py
+++ b/custom/inddex/example_data/data.py
@@ -3,7 +3,6 @@ import os
 import uuid
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.util import post_case_blocks
 
 from corehq.apps.case_importer.do_import import do_import
 from corehq.apps.case_importer.util import ImporterConfig, WorksheetWrapper
@@ -12,6 +11,7 @@ from corehq.apps.fixtures.models import (
     FixtureDataType,
     FixtureTypeField,
 )
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.userreports.models import StaticDataSourceConfiguration
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.users.models import CommCareUser
@@ -76,10 +76,10 @@ def _update_case_id_properties(domain, user):
                     case_id=case.case_id,
                     user_id=user._id,
                     update=update,
-                ).as_xml()
+                ).as_text()
             )
 
-    post_case_blocks(case_blocks, domain=domain, user_id=user._id)
+    submit_case_blocks(case_blocks, domain=domain, user_id=user._id)
 
 
 def _read_csv(filename):


### PR DESCRIPTION
This is a refactor in preparation for some changes related to https://dimagi-dev.atlassian.net/browse/USH-958

## Technical Summary
`post_case_blocks` is a wrapper around `submit_case_blocks` that doesn't add any real value. Removing this method leaves only 2 methods for updating cases:

* `submit_form_locally`
* `submit_case_blocks` (which calls `submit_form_locally`)

## Safety Assurance

### Safety story
The changes are mostly straight forward and in addition, all changes are isolated to test code with one exception:

The Zapier views use `CaseFactory`.

### Automated test coverage
Changes are isolated to test code and the Zapier views do have unit tests.

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
