### PR TITLE
case rule from identification

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -37,7 +37,7 @@ from corehq.apps.data_interfaces.deduplication import (
 )
 from corehq.apps.data_interfaces.utils import property_references_parent
 from corehq.apps.es.cases import CaseES
-from corehq.apps.hqcase.utils import bulk_update_cases, update_case
+from corehq.apps.hqcase.utils import bulk_update_cases, update_case, AUTO_UPDATE_XMLNS
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.models import DEFAULT_PARENT_IDENTIFIER
 from corehq.form_processor.exceptions import CaseNotFound
@@ -68,7 +68,6 @@ from corehq.util.quickcache import quickcache
 from corehq.util.test_utils import unit_testing_only
 
 ALLOWED_DATE_REGEX = re.compile(r'^\d{4}-\d{2}-\d{2}')
-AUTO_UPDATE_XMLNS = 'http://commcarehq.org/hq_case_update_rule'
 
 
 def _try_date_conversion(date_or_string):

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -910,7 +910,7 @@ class UpdateCaseDefinition(BaseUpdateCaseDefinition):
             if case_id == case.case_id:
                 continue
             result = update_case(case.domain, case_id, case_properties=properties, close=False,
-                                 xmlns=AUTO_UPDATE_XMLNS, max_wait=15)
+                                 xmlns=AUTO_UPDATE_XMLNS, max_wait=15, device_id=rule.id)
             rule.log_submission(result[0].form_id)
             num_related_updates += 1
 
@@ -923,7 +923,7 @@ class UpdateCaseDefinition(BaseUpdateCaseDefinition):
 
         if close_case or properties:
             result = update_case(case.domain, case.case_id, case_properties=properties, close=close_case,
-                                 xmlns=AUTO_UPDATE_XMLNS, max_wait=15)
+                                 xmlns=AUTO_UPDATE_XMLNS, max_wait=15, device_id=rule.id)
 
             rule.log_submission(result[0].form_id)
 

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -13,6 +13,7 @@ from dimagi.utils.couch import CriticalSection
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
+from corehq.apps.hqcase.utils import AUTO_UPDATE_XMLNS
 from corehq.form_processor.models import XFormInstance
 from corehq.motech.repeaters.dbaccessors import (
     get_couch_repeat_record_ids_by_payload_id,
@@ -28,7 +29,6 @@ from corehq.util.decorators import serial_task
 from .deduplication import reset_deduplicate_rule, backfill_deduplicate_rule
 from .interfaces import FormManagementMode
 from .models import (
-    AUTO_UPDATE_XMLNS,
     AutomaticUpdateRule,
     CaseDuplicate,
     CaseRuleSubmission,

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -9,7 +9,6 @@ from casexml.apps.case.mock import CaseFactory
 
 from corehq.apps import hqcase
 from corehq.apps.data_interfaces.models import (
-    AUTO_UPDATE_XMLNS,
     AutomaticUpdateRule,
     CaseRuleActionResult,
     CaseRuleSubmission,
@@ -990,7 +989,7 @@ class CaseRuleOnSaveTests(BaseCaseRuleTest):
             # When the last update is an auto case update, we don't run the rule on save
             with patch('corehq.apps.data_interfaces.models.AutomaticUpdateRule.run_rule') as run_rule_patch:
                 hqcase.utils.update_case(self.domain, case.case_id, case_properties={'do_update': 'Y'},
-                    xmlns=AUTO_UPDATE_XMLNS)
+                    xmlns=hqcase.utils.AUTO_UPDATE_XMLNS)
                 run_rule_patch.assert_not_called()
 
     def test_do_not_run_on_save_when_flag_is_disabled(self):

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -19,10 +19,12 @@ from corehq.form_processor.models import CommCareCase
 CASEBLOCK_CHUNKSIZE = 100
 SYSTEM_FORM_XMLNS = 'http://commcarehq.org/case'
 EDIT_FORM_XMLNS = 'http://commcarehq.org/case/edit'
+AUTO_UPDATE_XMLNS = 'http://commcarehq.org/hq_case_update_rule'
 
 SYSTEM_FORM_XMLNS_MAP = {
     SYSTEM_FORM_XMLNS: gettext_lazy('System Form'),
     EDIT_FORM_XMLNS: gettext_lazy('Data Cleaning Form'),
+    AUTO_UPDATE_XMLNS: gettext_lazy('Automatic Case Update Rule'),
 }
 
 ALLOWED_CASE_IDENTIFIER_TYPES = [

--- a/custom/covid/rules/custom_actions.py
+++ b/custom/covid/rules/custom_actions.py
@@ -9,8 +9,8 @@ from datetime import datetime
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.case_search import CaseSearchES
 from corehq.apps.es.cases import case_type
-from corehq.apps.data_interfaces.models import CaseRuleActionResult, AUTO_UPDATE_XMLNS
-from corehq.apps.hqcase.utils import update_case
+from corehq.apps.data_interfaces.models import CaseRuleActionResult
+from corehq.apps.hqcase.utils import update_case, AUTO_UPDATE_XMLNS
 from corehq.apps.es import filters
 
 

--- a/custom/gcc_sangath/rules/custom_actions.py
+++ b/custom/gcc_sangath/rules/custom_actions.py
@@ -1,8 +1,5 @@
-from corehq.apps.data_interfaces.models import (
-    AUTO_UPDATE_XMLNS,
-    CaseRuleActionResult,
-)
-from corehq.apps.hqcase.utils import update_case
+from corehq.apps.data_interfaces.models import CaseRuleActionResult
+from corehq.apps.hqcase.utils import update_case, AUTO_UPDATE_XMLNS
 from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 from custom.gcc_sangath.const import (
     DATE_OF_PEER_REVIEW_CASE_PROP,


### PR DESCRIPTION
## Technical Summary
Small change to make it easier to identify which case update rule a form came from.

This is the first part of a set of changes for https://dimagi-dev.atlassian.net/browse/USH-958. The next step will be making the UI display the rule name instead of the XMLNS.

## Safety Assurance

### Safety story
Minor refactor and non-functional changes.

### Automated test coverage
Auto-update rules are covered by tests already.

### QA Plan
None


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
