### PR TITLE
Fix null title_label values on staging

### DIFF
--- a/corehq/apps/app_manager/management/commands/fix_title_label.py
+++ b/corehq/apps/app_manager/management/commands/fix_title_label.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
                 print(f"Checking Application Modules: {app_id}")
                 for module in app.modules:
                     if hasattr(module, 'search_config'):
-                        print(f"Looking at Module: {module.name[app.default_language]}")
+                        print(f"Looking at Module: {module.name}")
                         title_label = module.search_config.title_label
                         new_title_label = {}
                         for lang, string in title_label.items():

--- a/corehq/apps/app_manager/management/commands/fix_title_label.py
+++ b/corehq/apps/app_manager/management/commands/fix_title_label.py
@@ -1,0 +1,30 @@
+from corehq.toggles import SYNC_SEARCH_CASE_CLAIM
+
+from django.core.management.base import BaseCommand
+
+from corehq.apps.app_manager.dbaccessors import *
+from corehq.apps.app_manager.models import Application
+from corehq.apps.app_manager.management.commands.helpers import get_all_app_ids
+
+
+class Command(BaseCommand):
+
+    def handle(self, **options):
+        domains = sorted(SYNC_SEARCH_CASE_CLAIM.get_enabled_domains())
+        for domain in domains:
+            print(f"Looking at domain: {domain}")
+            app_ids = get_all_app_ids(domain)  # , include_builds=True)
+            for app_id in app_ids:
+                app = Application.get(app_id)
+                print(f"Checking Application Modules: {app_id}")
+                for module in app.modules:
+                    if hasattr(module, 'search_config'):
+                        print(f"Looking at Module: {module.name[app.default_language]}")
+                        search_config = getattr(module, "search_config")
+                        title_label = getattr(search_config, 'title_label')
+                        new_labels = title_label.copy()
+                        for lang, string in title_label.items():
+                            if string is None:
+                                print(f"Fixing translation: {{{lang}: {string}}}")
+                                new_labels[lang] = ""
+                        setattr(search_config, 'title_label', new_labels)

--- a/corehq/apps/app_manager/management/commands/fix_title_label.py
+++ b/corehq/apps/app_manager/management/commands/fix_title_label.py
@@ -19,13 +19,12 @@ class Command(BaseCommand):
                 for module in app.modules:
                     if hasattr(module, 'search_config'):
                         print(f"Looking at Module: {module.name[app.default_language]}")
-                        try:
-                            title_label = module.search_config.title_label
-                            for lang, string in title_label.items():
-                                if string is None:
-                                    print(f"Fixing translation: {{{lang}: {string}}}")
-                                    module.search_config.title_label[lang] = ""
-                                    app.save()
-                        except:
-                            print("Skipping Module.")
-                            pass
+
+                        title_label = module.search_config.title_label
+                        new_title_label = {}
+                        for lang, string in title_label.items():
+                            if string is None:
+                                print(f"Fixing translation: {{{lang}: {string}}}")
+                                new_title_label[lang] = ""
+                            else:
+                                new_title_label[lang] = string

--- a/corehq/apps/app_manager/management/commands/fix_title_label.py
+++ b/corehq/apps/app_manager/management/commands/fix_title_label.py
@@ -14,8 +14,12 @@ class Command(BaseCommand):
             print(f"Looking at domain: {domain}")
             app_ids = get_all_app_ids(domain)  # , include_builds=True)
             for app_id in app_ids:
-                app = Application.get(app_id)
-                print(f"Checking Application Modules: {app_id}")
+                try:
+                    print(f"Checking Application Modules: {app_id}")
+                    app = Application.get(app_id)
+                except Exception as e:
+                    print(f"Skipping Application: {app_id}")
+                    print(e)
                 for module in app.modules:
                     if hasattr(module, 'search_config'):
                         print(f"Looking at Module: {module.name}")

--- a/corehq/apps/app_manager/management/commands/fix_title_label.py
+++ b/corehq/apps/app_manager/management/commands/fix_title_label.py
@@ -19,7 +19,6 @@ class Command(BaseCommand):
                 for module in app.modules:
                     if hasattr(module, 'search_config'):
                         print(f"Looking at Module: {module.name[app.default_language]}")
-
                         title_label = module.search_config.title_label
                         new_title_label = {}
                         for lang, string in title_label.items():
@@ -28,3 +27,5 @@ class Command(BaseCommand):
                                 new_title_label[lang] = ""
                             else:
                                 new_title_label[lang] = string
+                        module.search_config.title_label = new_title_label
+                app.save()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This is a script to manually fix some None values for title_label in staging that is preventing apps from saving when the branch do/case-claim-title is deployed. This isn't planned to be merged to master.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
