### PR TITLE
SQL Lookup Tables - Part 1

### DIFF
--- a/corehq/apps/cleanup/management/commands/multi_populate.py
+++ b/corehq/apps/cleanup/management/commands/multi_populate.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from .populate_sql_model_from_couch_model import PopulateSQLCommand
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'commands',
+            metavar="COMMAND",
+            nargs="+",
+            help="""
+                One or more Couch to SQL migration management commands to run.
+                Intended for running multiple subclasses of PopulateSQLCommand
+                in series.
+            """
+        )
+        parser.add_argument(
+            '--verify-only',
+            action='store_true',
+            dest='verify_only',
+            default=False,
+            help="""
+                Don't migrate anything, instead check if couch and sql data is identical.
+            """,
+        )
+        parser.add_argument(
+            '--skip-verify',
+            action='store_true',
+            dest='skip_verify',
+            default=False,
+            help="""
+                Migrate even if verifcation fails. This is intended for usage only with
+                models that don't support verification.
+            """,
+        )
+        parser.add_argument(
+            '--domains',
+            nargs='+',
+            help="Only migrate documents in the specified domains",
+        )
+        parser.add_argument(
+            '--log-path',
+            default="-" if settings.UNIT_TESTING else None,
+            help="File path to write logs to. If not provided a default will be used."
+        )
+
+    def handle(self, **options):
+        if not options["log_path"]:
+            date = datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%S.%f')
+            command_name = self.__class__.__module__.split('.')[-1]
+            options["log_path"] = f"{command_name}_{date}.log"
+        options["append_log"] = True
+        for command in options.pop("commands"):
+            print(f"\n\n{command}...")
+            with PopulateSQLCommand.open_log(options["log_path"], True) as log:
+                print(f"\n{command} logs:", file=log)
+            call_command(command, **options)

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -203,9 +203,15 @@ class PopulateSQLCommand(BaseCommand):
             default="-" if settings.UNIT_TESTING else None,
             help="File path to write logs to. If not provided a default will be used."
         )
+        parser.add_argument(
+            '--append-log',
+            action="store_true",
+            help="Append to log file if it already exists."
+        )
 
     def handle(self, **options):
         log_path = options.get("log_path")
+        append_log = options.get("append_log", False)
         verify_only = options.get("verify_only", False)
         skip_verify = options.get("skip_verify", False)
 
@@ -214,7 +220,7 @@ class PopulateSQLCommand(BaseCommand):
             command_name = self.__class__.__module__.split('.')[-1]
             log_path = f"{command_name}_{date}.log"
 
-        if log_path != "-" and os.path.exists(log_path):
+        if log_path != "-" and os.path.exists(log_path) and not append_log:
             raise CommandError(f"Log file already exists: {log_path}")
 
         if verify_only and skip_verify:
@@ -241,7 +247,7 @@ class PopulateSQLCommand(BaseCommand):
             self.sql_class().__name__,
         ))
 
-        with self._open_log(log_path) as logfile:
+        with self.open_log(log_path, append_log) as logfile:
             for doc in with_progress_bar(docs, length=doc_count, oneline=False):
                 doc_index += 1
                 if not verify_only:
@@ -298,7 +304,9 @@ class PopulateSQLCommand(BaseCommand):
     def _get_couch_doc_count_for_type(self):
         return get_doc_count_by_type(self.couch_db(), self.couch_doc_type())
 
-    def _open_log(self, log_path):
+    @staticmethod
+    def open_log(log_path, append_log):
         if log_path == "-":
             return nullcontext(sys.stdout)
-        return open(log_path, 'w')
+        mode = "a" if append_log else "w"
+        return open(log_path, mode)

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -412,6 +412,7 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('repeaters', 'SQLRepeatRecordAttempt', 'repeat_record__domain'),
     ModelDeletion('couchforms', 'UnfinishedSubmissionStub', 'domain'),
     ModelDeletion('couchforms', 'UnfinishedArchiveStub', 'domain'),
+    ModelDeletion('fixtures', 'LookupTable', 'domain'),
     CustomDeletion('ucr', delete_all_ucr_tables_for_domain, []),
     ModelDeletion('domain', 'OperatorCallLimitSettings', 'domain'),
     ModelDeletion('domain', 'SMSAccountConfirmationSettings', 'domain'),

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -65,6 +65,7 @@ from corehq.apps.data_interfaces.models import (
 from corehq.apps.domain.deletion import DOMAIN_DELETE_OPERATIONS
 from corehq.apps.domain.models import Domain, TransferDomainRequest
 from corehq.apps.export.models.new import DataFile, EmailExportWhenDoneRequest
+from corehq.apps.fixtures.models import LookupTable
 from corehq.apps.ivr.models import Call
 from corehq.apps.locations.models import (
     LocationFixtureConfiguration,
@@ -1002,6 +1003,17 @@ class TestDeleteDomain(TestCase):
         self.assertIsNotNone(CommtrackConfig.for_domain(self.domain.name))
         self.domain.delete()
         self.assertIsNone(CommtrackConfig.for_domain(self.domain.name))
+
+    def test_lookup_tables(self):
+        def count_lookup_tables(domain):
+            return LookupTable.objects.filter(domain=domain).count()
+        for domain_name in [self.domain.name, self.domain2.name]:
+            LookupTable.objects.create(domain=domain_name, tag="domain-deletion")
+
+        self.domain.delete()
+
+        self.assertEqual(count_lookup_tables(self.domain.name), 0)
+        self.assertEqual(count_lookup_tables(self.domain2.name), 1)
 
 
 class TestHardDeleteSQLFormsAndCases(TestCase):

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -65,7 +65,7 @@ from corehq.apps.data_interfaces.models import (
 from corehq.apps.domain.deletion import DOMAIN_DELETE_OPERATIONS
 from corehq.apps.domain.models import Domain, TransferDomainRequest
 from corehq.apps.export.models.new import DataFile, EmailExportWhenDoneRequest
-from corehq.apps.fixtures.models import LookupTable
+from corehq.apps.fixtures.models import LookupTable, LookupTableRow
 from corehq.apps.ivr.models import Call
 from corehq.apps.locations.models import (
     LocationFixtureConfiguration,
@@ -1007,13 +1007,20 @@ class TestDeleteDomain(TestCase):
     def test_lookup_tables(self):
         def count_lookup_tables(domain):
             return LookupTable.objects.filter(domain=domain).count()
+
+        def count_lookup_table_rows(domain):
+            return LookupTableRow.objects.filter(domain=domain).count()
+
         for domain_name in [self.domain.name, self.domain2.name]:
-            LookupTable.objects.create(domain=domain_name, tag="domain-deletion")
+            table = LookupTable.objects.create(domain=domain_name, tag="domain-deletion")
+            LookupTableRow.objects.create(domain=domain_name, table_id=table.id, sort_key=0)
 
         self.domain.delete()
 
         self.assertEqual(count_lookup_tables(self.domain.name), 0)
+        self.assertEqual(count_lookup_table_rows(self.domain.name), 0)
         self.assertEqual(count_lookup_tables(self.domain2.name), 1)
+        self.assertEqual(count_lookup_table_rows(self.domain2.name), 1)
 
 
 class TestHardDeleteSQLFormsAndCases(TestCase):

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -65,7 +65,12 @@ from corehq.apps.data_interfaces.models import (
 from corehq.apps.domain.deletion import DOMAIN_DELETE_OPERATIONS
 from corehq.apps.domain.models import Domain, TransferDomainRequest
 from corehq.apps.export.models.new import DataFile, EmailExportWhenDoneRequest
-from corehq.apps.fixtures.models import LookupTable, LookupTableRow
+from corehq.apps.fixtures.models import (
+    LookupTable,
+    LookupTableRow,
+    LookupTableRowOwner,
+    OwnerType,
+)
 from corehq.apps.ivr.models import Call
 from corehq.apps.locations.models import (
     LocationFixtureConfiguration,
@@ -1011,16 +1016,27 @@ class TestDeleteDomain(TestCase):
         def count_lookup_table_rows(domain):
             return LookupTableRow.objects.filter(domain=domain).count()
 
+        def count_lookup_table_row_owners(domain):
+            return LookupTableRowOwner.objects.filter(domain=domain).count()
+
         for domain_name in [self.domain.name, self.domain2.name]:
             table = LookupTable.objects.create(domain=domain_name, tag="domain-deletion")
-            LookupTableRow.objects.create(domain=domain_name, table_id=table.id, sort_key=0)
+            row = LookupTableRow.objects.create(domain=domain_name, table_id=table.id, sort_key=0)
+            LookupTableRowOwner.objects.create(
+                domain=domain_name,
+                row_id=row.id,
+                owner_type=OwnerType.User,
+                owner_id="abc",
+            )
 
         self.domain.delete()
 
         self.assertEqual(count_lookup_tables(self.domain.name), 0)
         self.assertEqual(count_lookup_table_rows(self.domain.name), 0)
+        self.assertEqual(count_lookup_table_row_owners(self.domain.name), 0)
         self.assertEqual(count_lookup_tables(self.domain2.name), 1)
         self.assertEqual(count_lookup_table_rows(self.domain2.name), 1)
+        self.assertEqual(count_lookup_table_row_owners(self.domain2.name), 1)
 
 
 class TestHardDeleteSQLFormsAndCases(TestCase):

--- a/corehq/apps/domain/tests/test_deletion_models.py
+++ b/corehq/apps/domain/tests/test_deletion_models.py
@@ -55,6 +55,8 @@ IGNORE_MODELS = {
     'dropbox.DropboxUploadHelper',
     'export.DefaultExportSettings',
     'fixtures.UserLookupTableStatus',
+    'fixtures.LookupTableRow',          # handled by cascading delete
+    'fixtures.LookupTableRowOwner',     # handled by cascading delete
     'sms.MigrationStatus',
     'util.BouncedEmail',
     'util.ComplaintBounceMeta',

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -157,7 +157,8 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('repeaters.SQLRepeatRecordAttempt', SimpleFilter('repeat_record__domain')),
     FilteredModelIteratorBuilder('translations.SMSTranslations', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('translations.TransifexBlacklist', SimpleFilter('domain')),
-    UniqueFilteredModelIteratorBuilder('translations.TransifexOrganization', SimpleFilter('transifexproject__domain')),
+    UniqueFilteredModelIteratorBuilder(
+        'translations.TransifexOrganization', SimpleFilter('transifexproject__domain')),
     FilteredModelIteratorBuilder('translations.TransifexProject', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('zapier.ZapierSubscription', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('domain.OperatorCallLimitSettings', SimpleFilter('domain')),
@@ -171,7 +172,13 @@ class SqlDataDumper(DataDumper):
 
     def dump(self, output_stream):
         stats = Counter()
-        objects = get_objects_to_dump(self.domain, self.excludes, self.includes, stats_counter=stats, stdout=self.stdout)
+        objects = get_objects_to_dump(
+            self.domain,
+            self.excludes,
+            self.includes,
+            stats_counter=stats,
+            stdout=self.stdout,
+        )
         JsonLinesSerializer().serialize(
             objects,
             use_natural_foreign_keys=False,

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -162,6 +162,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('zapier.ZapierSubscription', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('domain.OperatorCallLimitSettings', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('domain.SMSAccountConfirmationSettings', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('fixtures.LookupTable', SimpleFilter('domain')),
 ]]
 
 

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -165,6 +165,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('domain.SMSAccountConfirmationSettings', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('fixtures.LookupTable', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('fixtures.LookupTableRow', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('fixtures.LookupTableRowOwner', SimpleFilter('domain')),
 ]]
 
 

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -164,6 +164,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('domain.OperatorCallLimitSettings', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('domain.SMSAccountConfirmationSettings', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('fixtures.LookupTable', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('fixtures.LookupTableRow', SimpleFilter('domain')),
 ]]
 
 

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -736,10 +736,16 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
         self._dump_and_load(Counter({SQLCreateCaseRepeater: 1, ConnectionSettings: 1, ZapierSubscription: 1}))
 
     def test_lookup_table(self):
-        from corehq.apps.fixtures.models import LookupTable, LookupTableRow
+        from corehq.apps.fixtures.models import LookupTable, LookupTableRow, LookupTableRowOwner, OwnerType
         table = LookupTable.objects.create(domain=self.domain_name, tag="dump-load")
-        LookupTableRow.objects.create(domain=self.domain_name, table_id=table.id, sort_key=0)
-        self._dump_and_load(Counter({LookupTable: 1, LookupTableRow: 1}))
+        row = LookupTableRow.objects.create(domain=self.domain_name, table_id=table.id, sort_key=0)
+        LookupTableRowOwner.objects.create(
+            domain=self.domain_name,
+            row_id=row.id,
+            owner_type=OwnerType.User,
+            owner_id="abc",
+        )
+        self._dump_and_load(Counter({LookupTable: 1, LookupTableRow: 1, LookupTableRowOwner: 1}))
 
 
 @mock.patch("corehq.apps.dump_reload.sql.load.ENQUEUE_TIMEOUT", 1)

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -735,6 +735,11 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
         # connection settings and sqlrepeater instances would be created automatically with sql sync logic in place
         self._dump_and_load(Counter({SQLCreateCaseRepeater: 1, ConnectionSettings: 1, ZapierSubscription: 1}))
 
+    def test_lookup_table(self):
+        from corehq.apps.fixtures.models import LookupTable
+        LookupTable.objects.create(domain=self.domain_name, tag="dump-load")
+        self._dump_and_load(Counter({LookupTable: 1}))
+
 
 @mock.patch("corehq.apps.dump_reload.sql.load.ENQUEUE_TIMEOUT", 1)
 class TestSqlLoadWithError(BaseDumpLoadTest):

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -736,9 +736,10 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
         self._dump_and_load(Counter({SQLCreateCaseRepeater: 1, ConnectionSettings: 1, ZapierSubscription: 1}))
 
     def test_lookup_table(self):
-        from corehq.apps.fixtures.models import LookupTable
-        LookupTable.objects.create(domain=self.domain_name, tag="dump-load")
-        self._dump_and_load(Counter({LookupTable: 1}))
+        from corehq.apps.fixtures.models import LookupTable, LookupTableRow
+        table = LookupTable.objects.create(domain=self.domain_name, tag="dump-load")
+        LookupTableRow.objects.create(domain=self.domain_name, table_id=table.id, sort_key=0)
+        self._dump_and_load(Counter({LookupTable: 1, LookupTableRow: 1}))
 
 
 @mock.patch("corehq.apps.dump_reload.sql.load.ENQUEUE_TIMEOUT", 1)

--- a/corehq/apps/fixtures/apps.py
+++ b/corehq/apps/fixtures/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = 'corehq.apps.fixtures'
+    default_auto_field = 'django.db.models.BigAutoField'

--- a/corehq/apps/fixtures/couchmodels.py
+++ b/corehq/apps/fixtures/couchmodels.py
@@ -111,13 +111,13 @@ class FixtureDataType(QuickCachedDocumentMixin, SyncCouchToSQLMixin, Document):
             "item_attributes",
         ]
 
-    def _migration_sync_to_sql(self, sql_object):
+    def _migration_sync_to_sql(self, sql_object, save=True):
         fields = self._sql_fields
         if sql_object.fields != fields:
             sql_object.fields = fields
         if sql_object.description != (self.description or ""):
             sql_object.description = self.description or ""
-        super()._migration_sync_to_sql(sql_object)
+        super()._migration_sync_to_sql(sql_object, save=save)
 
     @property
     def _sql_fields(self):
@@ -310,14 +310,14 @@ class FixtureDataItem(SyncCouchToSQLMixin, Document):
     def _migration_get_fields(cls):
         return ["domain", "item_attributes"]
 
-    def _migration_sync_to_sql(self, sql_object):
+    def _migration_sync_to_sql(self, sql_object, save=True):
         if sql_object.table_id is None or sql_object.table_id != UUID(self.data_type_id):
             sql_object.table_id = UUID(self.data_type_id)
         fields = self._sql_fields
         if sql_object.fields != fields:
             sql_object.fields = fields
         sql_object.sort_key = self.sort_key or 0
-        super()._migration_sync_to_sql(sql_object)
+        super()._migration_sync_to_sql(sql_object, save=save)
 
     @property
     def _sql_fields(self):
@@ -603,13 +603,13 @@ class FixtureOwnership(SyncCouchToSQLMixin, Document):
             "owner_id",
         ]
 
-    def _migration_sync_to_sql(self, sql_object):
+    def _migration_sync_to_sql(self, sql_object, save=True):
         from .models import OwnerType
         if sql_object.row_id is None or sql_object.row_id != UUID(self.data_item_id):
             sql_object.row_id = UUID(self.data_item_id)
         if OwnerType.from_string(self.owner_type) != sql_object.owner_type:
             sql_object.owner_type = OwnerType.from_string(self.owner_type)
-        super()._migration_sync_to_sql(sql_object)
+        super()._migration_sync_to_sql(sql_object, save=save)
 
     @classmethod
     def _migration_get_sql_model_class(cls):

--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -108,3 +108,32 @@ def delete_all_fixture_data_types():
             pass
         else:
             fixture_data_type.delete()
+
+
+@unit_testing_only
+def delete_all_fixture_data(domain_name=None):
+    from .couchmodels import FixtureDataType, FixtureDataItem, FixtureOwnership
+
+    def delete_all(doc_class):
+        view, key = get_view_and_key(doc_class)
+        db = doc_class.get_db()
+        docs = [r["doc"] for r in db.view(
+            view,
+            startkey=key,
+            endkey=key + [{}],
+            include_docs=True,
+            reduce=False
+        ).all()]
+        if docs:
+            db.bulk_delete(docs, empty_on_delete=False)
+
+    if domain_name:
+        def get_view_and_key(doc_class):
+            return "by_domain_doc_type_date/view", [domain_name, doc_class.__name__]
+    else:
+        def get_view_and_key(doc_class):
+            return "all_docs/by_doc_type", [doc_class.__name__]
+
+    delete_all(FixtureOwnership),
+    delete_all(FixtureDataItem),
+    delete_all(FixtureDataType),

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -199,12 +199,13 @@ class ItemListsProvider(FixtureProvider):
         for attribute in item['_data_type'].item_attributes:
             try:
                 xData.attrib[attribute] = serialize(item['item_attributes'][attribute])
-            except KeyError as e:
+            except KeyError:
                 # This should never occur, buf if it does, the OTA restore on mobile will fail and
                 # this error would have been raised and email-logged.
                 raise FixtureTypeCheckError(
-                    "Table with tag %s has an item with id %s that doesn't have an attribute as defined in its types definition"
-                    % (item['_data_type'].tag, item['_id'])
+                    f"Table with tag {item['_data_type'].tag} has an item with "
+                    f"id {item['_id']} that doesn't have an attribute as "
+                    "defined in its types definition"
                 )
         for field in item['_data_type'].fields:
             escaped_field_name = clean_fixture_field_name(field.field_name)

--- a/corehq/apps/fixtures/management/commands/populate_lookuptablerowowners.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptablerowowners.py
@@ -1,0 +1,66 @@
+from uuid import UUID
+
+from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
+from ...models import OwnerType
+
+
+class Command(PopulateSQLCommand):
+    @classmethod
+    def couch_db_slug(cls):
+        return "fixtures"
+
+    @classmethod
+    def couch_doc_type(self):
+        return 'FixtureOwnership'
+
+    @classmethod
+    def sql_class(self):
+        from corehq.apps.fixtures.models import LookupTableRowOwner
+        return LookupTableRowOwner
+
+    @classmethod
+    def commit_adding_migration(cls):
+        return "TODO: add once the PR adding this file is merged"
+
+    @classmethod
+    def diff_couch_and_sql(cls, couch, sql):
+        """
+        This should compare each attribute of the given couch document and sql object.
+        Return a list of human-reaedable strings describing their differences, or None if the
+        two are equivalent. The list may contain `None` or empty strings which will be filtered
+        out before display.
+
+        Note: `diff_value`, `diff_attr` and `diff_lists` methods of `PopulateSQLCommand` are useful
+        helpers.
+        """
+        fields = ["domain", "owner_id"]
+        diffs = [cls.diff_attr(name, couch, sql) for name in fields]
+        diffs.append(cls.diff_value(
+            "owner_type",
+            OWNER_TYPE_MAP[couch["owner_type"]],
+            sql.owner_type,
+        ))
+        diffs.append(cls.diff_value(
+            "row_id",
+            UUID(couch["data_item_id"]),
+            sql.row_id,
+        ))
+        return diffs
+
+    def update_or_create_sql_object(self, doc):
+        model, created = self.sql_class().objects.update_or_create(
+            couch_id=doc['_id'],
+            defaults={
+                "domain": doc["domain"],
+                "row_id": UUID(doc["data_item_id"]),
+                "owner_type": OWNER_TYPE_MAP[doc["owner_type"]],
+                "owner_id": doc.get("owner_id"),
+            })
+        return model, created
+
+
+OWNER_TYPE_MAP = {
+    "user": OwnerType.User,
+    "group": OwnerType.Group,
+    "location": OwnerType.Location,
+}

--- a/corehq/apps/fixtures/management/commands/populate_lookuptablerowowners.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptablerowowners.py
@@ -37,7 +37,7 @@ class Command(PopulateSQLCommand):
         diffs = [cls.diff_attr(name, couch, sql) for name in fields]
         diffs.append(cls.diff_value(
             "owner_type",
-            OWNER_TYPE_MAP[couch["owner_type"]],
+            OwnerType.from_string(couch["owner_type"]),
             sql.owner_type,
         ))
         diffs.append(cls.diff_value(
@@ -53,14 +53,7 @@ class Command(PopulateSQLCommand):
             defaults={
                 "domain": doc["domain"],
                 "row_id": UUID(doc["data_item_id"]),
-                "owner_type": OWNER_TYPE_MAP[doc["owner_type"]],
+                "owner_type": OwnerType.from_string(doc["owner_type"]),
                 "owner_id": doc.get("owner_id"),
             })
         return model, created
-
-
-OWNER_TYPE_MAP = {
-    "user": OwnerType.User,
-    "group": OwnerType.Group,
-    "location": OwnerType.Location,
-}

--- a/corehq/apps/fixtures/management/commands/populate_lookuptablerows.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptablerows.py
@@ -1,0 +1,85 @@
+from uuid import UUID
+from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
+
+from ...models import Field
+
+
+class Command(PopulateSQLCommand):
+
+    @classmethod
+    def couch_db_slug(cls):
+        return "fixtures"
+
+    @classmethod
+    def couch_doc_type(cls):
+        return 'FixtureDataItem'
+
+    @classmethod
+    def sql_class(cls):
+        from ...models import LookupTableRow
+        return LookupTableRow
+
+    @classmethod
+    def commit_adding_migration(cls):
+        return "TODO: add once the PR adding this file is merged"
+
+    @classmethod
+    def diff_couch_and_sql(cls, couch, sql):
+        """
+        Compare each attribute of the given couch document and sql
+        object. Return a list of human-readable strings describing their
+        differences, or None if the two are equivalent. The list may
+        contain `None` or empty strings.
+        """
+        diffs = [
+            cls.diff_attr("domain", couch, sql),
+            cls.diff_value(
+                "table_id",
+                UUID(couch["data_type_id"]),
+                sql.table_id,
+            ),
+            cls.diff_value(
+                "fields",
+                couch_to_sql_fields(couch["fields"]),
+                sql.fields,
+            ),
+            cls.diff_value(
+                "item_attributes",
+                couch.get("item_attributes") or {},
+                sql.item_attributes,
+            ),
+            cls.diff_value(
+                "sort_key",
+                couch.get("sort_key") or 0,
+                sql.sort_key,
+            ),
+        ]
+        return diffs
+
+    def update_or_create_sql_object(self, doc):
+        return self.sql_class().objects.update_or_create(
+            id=UUID(doc['_id']),
+            defaults={
+                "domain": doc["domain"],
+                "table_id": UUID(doc["data_type_id"]),
+                "fields": couch_to_sql_fields(doc["fields"]),
+                "item_attributes": doc.get("item_attributes") or {},
+                "sort_key": doc.get("sort_key") or 0,
+            },
+        )
+
+
+def couch_to_sql_fields(data):
+    def get_values(field):
+        if isinstance(field, dict):
+            return field["field_list"]
+        # pre-2014 fields format
+        assert isinstance(field, (str, int, float, type(None))), field
+        return [{"field_value": str(field), "properties": {}}]
+    return {
+        name: [
+            Field(val["field_value"], val["properties"])
+            for val in get_values(field)
+        ]
+        for name, field in data.items()
+    }

--- a/corehq/apps/fixtures/management/commands/populate_lookuptables.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptables.py
@@ -1,0 +1,65 @@
+from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
+
+from ...models import TypeField
+
+
+class Command(PopulateSQLCommand):
+
+    @classmethod
+    def couch_db_slug(cls):
+        return "fixtures"
+
+    @classmethod
+    def couch_doc_type(cls):
+        return 'FixtureDataType'
+
+    @classmethod
+    def sql_class(cls):
+        from ...models import LookupTable
+        return LookupTable
+
+    @classmethod
+    def commit_adding_migration(cls):
+        return "TODO: add once the PR adding this file is merged"
+
+    @classmethod
+    def diff_couch_and_sql(cls, couch, sql):
+        """
+        Compare each attribute of the given couch document and sql
+        object. Return a list of human-readable strings describing their
+        differences, or None if the two are equivalent. The list may
+        contain `None` or empty strings.
+        """
+        fields = ["domain", "is_global", "tag", "item_attributes"]
+        diffs = [cls.diff_attr(name, couch, sql) for name in fields]
+        if couch.get("description") or sql.description:
+            diffs.append(cls.diff_value(
+                "description",
+                couch.get("description"),
+                sql.description,
+            ))
+        diffs.append(cls.diff_value(
+            "fields",
+            [transform_field(f) for f in couch["fields"]],
+            sql.fields,
+        ))
+        return diffs
+
+    def update_or_create_sql_object(self, doc):
+        return self.sql_class().objects.update_or_create(
+            id=doc['_id'],
+            defaults={
+                "domain": doc["domain"],
+                "is_global": doc.get("is_global", False),
+                "tag": doc["tag"],
+                "fields": [transform_field(f) for f in doc.get("fields", [])],
+                "item_attributes": doc.get("item_attributes", []),
+                "description": doc.get("description") or ""
+            },
+        )
+
+
+def transform_field(data):
+    copy = data.copy()
+    copy.pop("doc_type")
+    return TypeField(name=copy.pop("field_name"), **copy)

--- a/corehq/apps/fixtures/migrations/0005_lookuptablemodels.py
+++ b/corehq/apps/fixtures/migrations/0005_lookuptablemodels.py
@@ -1,0 +1,30 @@
+import corehq.sql_db.fields
+import dimagi.utils.couch.migration
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fixtures', '0004_userlookuptablestatus'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LookupTable',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
+                ('domain', corehq.sql_db.fields.CharIdField(db_index=True, default=None, max_length=126)),
+                ('is_global', models.BooleanField(default=False)),
+                ('tag', corehq.sql_db.fields.CharIdField(default=None, max_length=32)),
+                ('fields', models.JSONField(default=list)),
+                ('item_attributes', models.JSONField(default=list)),
+                ('description', models.CharField(default='', max_length=255)),
+            ],
+            options={
+                'unique_together': {('domain', 'tag')},
+            },
+            bases=(dimagi.utils.couch.migration.SyncSQLToCouchMixin, models.Model),
+        ),
+    ]

--- a/corehq/apps/fixtures/migrations/0005_lookuptablemodels.py
+++ b/corehq/apps/fixtures/migrations/0005_lookuptablemodels.py
@@ -1,6 +1,7 @@
 import corehq.sql_db.fields
 import dimagi.utils.couch.migration
 from django.db import migrations, models
+import django.db.models.deletion
 import uuid
 
 
@@ -26,5 +27,21 @@ class Migration(migrations.Migration):
                 'unique_together': {('domain', 'tag')},
             },
             bases=(dimagi.utils.couch.migration.SyncSQLToCouchMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name='LookupTableRow',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
+                ('domain', corehq.sql_db.fields.CharIdField(db_index=True, default=None, max_length=126)),
+                ('fields', models.JSONField(default=dict)),
+                ('item_attributes', models.JSONField(default=dict)),
+                ('sort_key', models.IntegerField()),
+                ('table', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='fixtures.lookuptable')),
+            ],
+            bases=(dimagi.utils.couch.migration.SyncSQLToCouchMixin, models.Model),
+        ),
+        migrations.AddIndex(
+            model_name='lookuptablerow',
+            index=models.Index(fields=['domain', 'table_id', 'sort_key', 'id'], name='fixtures_lo_domain_96d65b_idx'),
         ),
     ]

--- a/corehq/apps/fixtures/migrations/0005_lookuptablemodels.py
+++ b/corehq/apps/fixtures/migrations/0005_lookuptablemodels.py
@@ -44,4 +44,20 @@ class Migration(migrations.Migration):
             model_name='lookuptablerow',
             index=models.Index(fields=['domain', 'table_id', 'sort_key', 'id'], name='fixtures_lo_domain_96d65b_idx'),
         ),
+        migrations.CreateModel(
+            name='LookupTableRowOwner',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('domain', corehq.sql_db.fields.CharIdField(default=None, max_length=126)),
+                ('owner_type', models.PositiveSmallIntegerField(choices=[(0, 'User'), (1, 'Group'), (2, 'Location')])),
+                ('owner_id', corehq.sql_db.fields.CharIdField(default=None, max_length=126)),
+                ('couch_id', corehq.sql_db.fields.CharIdField(db_index=True, max_length=126, null=True)),
+                ('row', models.ForeignKey(db_index=False, on_delete=django.db.models.deletion.CASCADE, to='fixtures.lookuptablerow')),
+            ],
+            bases=(dimagi.utils.couch.migration.SyncSQLToCouchMixin, models.Model),
+        ),
+        migrations.AddIndex(
+            model_name='lookuptablerowowner',
+            index=models.Index(fields=['domain', 'owner_type', 'owner_id'], name='fixtures_lo_domain_6a5d50_idx'),
+        ),
     ]

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -1,6 +1,13 @@
 from datetime import datetime
+from uuid import UUID, uuid4
 
+from attrs import define, field
 from django.db import models
+
+from dimagi.utils.couch.migration import SyncSQLToCouchMixin
+
+from corehq.sql_db.fields import CharIdField
+from corehq.util.jsonattrs import AttrsList
 
 from .couchmodels import (  # noqa: F401
     _id_from_doc,
@@ -14,6 +21,96 @@ from .couchmodels import (  # noqa: F401
 )
 
 
+@define
+class Alias:
+    name = field()
+
+    def __get__(self, obj, owner=None):
+        return self if obj is None else getattr(obj, self.name)
+
+    def __set__(self, obj, value):
+        setattr(obj, self.name, value)
+
+
+@define
+class TypeField:
+    name = field()
+    properties = field(factory=list)
+    is_indexed = field(default=False)
+    field_name = Alias("name")
+
+
+class LookupTable(SyncSQLToCouchMixin, models.Model):
+    """Lookup Table
+
+    `fields` structure:
+    ```py
+    [
+        {
+            "name": "country",
+            "properties": [],
+            "is_indexed": True,
+        },
+        {
+            "name": "state_name",
+            "properties": ["lang"],
+            "is_indexed": False,
+        },
+        ...
+    ]
+    ```
+    """
+    id = models.UUIDField(primary_key=True, default=uuid4)
+    domain = CharIdField(max_length=126, db_index=True, default=None)
+    is_global = models.BooleanField(default=False)
+    tag = CharIdField(max_length=32, default=None)
+    fields = AttrsList(TypeField, default=list)
+    item_attributes = models.JSONField(default=list)
+    description = models.CharField(max_length=255, default="")
+
+    class Meta:
+        app_label = 'fixtures'
+        unique_together = [('domain', 'tag')]
+
+    _migration_couch_id_name = "id"
+
+    @property
+    def _migration_couch_id(self):
+        return self.id.hex
+
+    @_migration_couch_id.setter
+    def _migration_couch_id(self, value):
+        self.id = UUID(value)
+
+    @classmethod
+    def _migration_get_fields(cls):
+        return [
+            "domain",
+            "is_global",
+            "tag",
+            "item_attributes",
+        ]
+
+    def _migration_sync_to_couch(self, couch_object):
+        if self.fields != couch_object._sql_fields:
+            couch_object.fields = [FixtureTypeField.from_sql(f) for f in self.fields]
+        if self.description != (couch_object.description or ""):
+            couch_object.description = self.description
+        super()._migration_sync_to_couch(couch_object)
+
+    @classmethod
+    def _migration_get_couch_model_class(cls):
+        return FixtureDataType
+
+    def _migration_get_or_create_couch_object(self):
+        cls = self._migration_get_couch_model_class()
+        obj = self._migration_get_couch_object()
+        if obj is None:
+            obj = cls(_id=self._migration_couch_id)
+            obj.save(sync_to_sql=False)
+        return obj
+
+
 class UserLookupTableType:
     LOCATION = 1
     CHOICES = (
@@ -23,6 +120,7 @@ class UserLookupTableType:
 
 class UserLookupTableStatus(models.Model):
     """Keeps track of when a user needs to re-sync a fixture"""
+    id = models.AutoField(primary_key=True, verbose_name="ID", auto_created=True)
     user_id = models.CharField(max_length=100, db_index=True)
     fixture_type = models.PositiveSmallIntegerField(choices=UserLookupTableType.CHOICES)
     last_modified = models.DateTimeField()

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from enum import IntEnum, unique
 from uuid import UUID, uuid4
 
 from attrs import define, field
@@ -203,8 +202,7 @@ class LookupTableRow(SyncSQLToCouchMixin, models.Model):
         return obj
 
 
-@unique
-class OwnerType(IntEnum):
+class OwnerType(models.IntegerChoices):
     User = 0
     Group = 1
     Location = 2
@@ -213,14 +211,10 @@ class OwnerType(IntEnum):
     def from_string(cls, value):
         return getattr(cls, value.title())
 
-    @classmethod
-    def choices(cls):
-        return [(t.value, t.name) for t in cls]
-
 
 class LookupTableRowOwner(SyncSQLToCouchMixin, models.Model):
     domain = CharIdField(max_length=126, default=None)
-    owner_type = models.PositiveSmallIntegerField(choices=OwnerType.choices())
+    owner_type = models.PositiveSmallIntegerField(choices=OwnerType.choices)
     owner_id = CharIdField(max_length=126, default=None)
     row = models.ForeignKey(LookupTableRow, on_delete=models.CASCADE, db_index=False)
     couch_id = CharIdField(max_length=126, null=True, db_index=True)

--- a/corehq/apps/fixtures/tests/test_couchsqlmigration.py
+++ b/corehq/apps/fixtures/tests/test_couchsqlmigration.py
@@ -1,8 +1,18 @@
+from uuid import UUID
+
 from django.core.management import call_command
 from django.test import SimpleTestCase, TestCase
 
 from ..management.commands.populate_lookuptables import Command as LookupTableCommand
-from ..models import FixtureDataType, LookupTable, TypeField
+from ..management.commands.populate_lookuptablerows import Command as LookupTableRowCommand
+from ..models import (
+    Field,
+    FixtureDataItem,
+    FixtureDataType,
+    LookupTable,
+    LookupTableRow,
+    TypeField,
+)
 from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types
 
 
@@ -101,6 +111,98 @@ class TestLookupTableCouchToSQLDiff(SimpleTestCase):
 
     def diff(self, doc, obj):
         return do_diff(LookupTableCommand, doc, obj)
+
+
+class TestLookupTableRowCouchToSQLDiff(SimpleTestCase):
+
+    def test_no_diff(self):
+        doc, obj = create_lookup_table_row()
+        self.assertEqual(self.diff(doc, obj), [])
+
+    def test_diff_domain(self):
+        doc, obj = create_lookup_table_row()
+        doc['domain'] = 'other-domain'
+        self.assertEqual(
+            self.diff(doc, obj),
+            ["domain: couch value 'other-domain' != sql value 'some-domain'"],
+        )
+
+    def test_diff_table_id(self):
+        doc, obj = create_lookup_table_row()
+        doc['data_type_id'] = couch_id = 'cddc3a035aab444a8ead069c942d7472'
+        sql_id = UUID('0fb6c422115145c0a651bb9a34ca09c4')
+        self.assertEqual(
+            self.diff(doc, obj),
+            [f"table_id: couch value {UUID(couch_id)!r} != sql value {sql_id!r}"],
+        )
+
+    def test_diff_fields(self):
+        doc, obj = create_lookup_table_row()
+        del doc['fields']['qty']
+        error, = self.diff(doc, obj)
+        self.assertRegex(
+            error,
+            r"^fields: couch value \{[^qy]+\} != sql value \{.+\}$",
+        )
+
+    def test_diff_old_style_fields(self):
+        doc, obj = create_lookup_table_row()
+        doc['fields'] = {'amount': '1'}
+        error, = self.diff(doc, obj)
+        self.assertRegex(
+            error,
+            r"^fields: couch value \{[^qy]+\} != sql value \{.+\}$",
+        )
+
+    def test_diff_item_attributes(self):
+        doc, obj = create_lookup_table_row()
+        obj.item_attributes = {'age': '4'}
+        self.assertEqual(
+            self.diff(doc, obj),
+            ["item_attributes: couch value {'name': 'Andy'} != sql value {'age': '4'}"],
+        )
+
+    def test_diff_doc_without_item_attributes(self):
+        doc, obj = create_lookup_table_row()
+
+        del doc["item_attributes"]
+        self.assertEqual(
+            self.diff(doc, obj),
+            ["item_attributes: couch value {} != sql value {'name': 'Andy'}"],
+        )
+
+        obj.item_attributes = {}
+        self.assertEqual(self.diff(doc, obj), [])  # not in Couch == {} in SQL
+
+    def test_diff_sort_key(self):
+        doc, obj = create_lookup_table_row()
+        obj.sort_key = 25
+        self.assertEqual(
+            self.diff(doc, obj),
+            ["sort_key: couch value 2 != sql value 25"],
+        )
+
+    def test_diff_null_sort_key(self):
+        doc, obj = create_lookup_table_row()
+        doc["sort_key"] = None
+        obj.sort_key = 0
+        self.assertEqual(self.diff(doc, obj), [])
+
+    def test_diff_multiple(self):
+        doc, obj = create_lookup_table_row()
+        obj.sort_key = 25
+        doc["data_type_id"] = couch_id = 'cddc3a035aab444a8ead069c942d7472'
+        sql_id = UUID('0fb6c422115145c0a651bb9a34ca09c4')
+        self.assertEqual(
+            self.diff(doc, obj),
+            [
+                f"table_id: couch value {UUID(couch_id)!r} != sql value {sql_id!r}",
+                "sort_key: couch value 2 != sql value 25",
+            ],
+        )
+
+    def diff(self, doc, obj):
+        return do_diff(LookupTableRowCommand, doc, obj)
 
 
 class TestLookupTableCouchToSQLMigration(TestCase):
@@ -206,6 +308,115 @@ class TestLookupTableCouchToSQLMigration(TestCase):
         return do_diff(LookupTableCommand, doc, obj)
 
 
+class TestLookupTableRowCouchToSQLMigration(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.db = FixtureDataItem.get_db()
+        cls.type_doc = create_lookup_table(unwrap_doc=False)[0]
+        cls.type_doc.save()
+        cls.table_obj = LookupTable.objects.get(id=cls.type_doc._id)
+        cls.addClassCleanup(cls.type_doc.delete)
+
+    def tearDown(self):
+        docs = list(get_all_docs_with_doc_types(self.db, ['FixtureDataItem']))
+        self.db.bulk_delete(docs)
+        super().tearDown()
+
+    def test_sync_to_couch(self):
+        doc, obj = self.create_row()
+        obj.save()
+        self.assertEqual(self.diff(self.db.get(obj._migration_couch_id), obj), [])
+
+        obj.fields['amount'][0].value = '42'
+        obj.item_attributes = {'name': 'Andy', 'age': '4'}
+        obj.sort_key = -1
+        obj.save()
+        doc = self.db.get(obj._migration_couch_id)
+        self.assertEqual(doc['item_attributes'], {'name': 'Andy', 'age': '4'})
+        self.assertEqual(doc['fields']['amount']['field_list'][0], {
+            'doc_type': 'FixtureItemField',
+            'field_value': '42',
+            'properties': {},
+        })
+        self.assertEqual(doc['sort_key'], -1)
+
+    def test_sync_to_sql(self):
+        doc, obj = self.create_row()
+        doc.save()
+        self.assertEqual(
+            self.diff(doc.to_json(), LookupTableRow.objects.get(id=UUID(doc._id))),
+            [],
+        )
+
+        doc.fields['amount']['field_list'][0]['field_value'] = '1000'
+        doc.item_attributes = {'name': 'Andy', 'age': '4'}
+        doc.sort_key = None
+        doc.save()
+        obj = LookupTableRow.objects.get(id=UUID(doc._id))
+        self.assertEqual(obj.item_attributes, {'name': 'Andy', 'age': '4'})
+        self.assertEqual(obj.fields['amount'], [Field('1000', {})])
+        self.assertEqual(obj.sort_key, 0)
+
+    def test_migration(self):
+        doc, obj = self.create_row()
+        doc.save(sync_to_sql=False)
+        call_command('populate_lookuptablerows')
+        self.assertEqual(
+            self.diff(doc.to_json(), LookupTableRow.objects.get(id=UUID(doc._id))),
+            [],
+        )
+
+        # Additional call should apply any updates
+        doc = FixtureDataItem.get(doc._id)
+        doc.fields['amount']['field_list'][0]['field_value'] = '1000'
+        doc.item_attributes = {'name': 'Andy', 'age': '4'}
+        doc.sort_key = None
+        doc.save(sync_to_sql=False)
+        call_command('populate_lookuptablerows')
+        self.assertEqual(
+            self.diff(doc.to_json(), LookupTableRow.objects.get(id=UUID(doc._id))),
+            [],
+        )
+
+    def test_migration_with_old_doc_format(self):
+        doc, obj = self.create_row()
+        data = doc.to_json()
+        data['fields'] = {'amount': 1}  # old format
+        del data['item_attributes']
+        doc_id = self.db.save_doc(data)["id"]
+        call_command('populate_lookuptablerows')
+        doc_json = {
+            **data,
+            '_id': doc_id,
+            'fields': {  # new format
+                'amount': {'doc_type': 'FieldList', 'field_list': [
+                    {
+                        'field_value': '1',
+                        'properties': {},
+                        'doc_type': 'FixtureItemField',
+                    }
+                ]}
+            },
+            'item_attributes': {},
+        }
+        self.assertEqual(
+            self.diff(doc_json, LookupTableRow.objects.get(id=UUID(doc_id))),
+            [],
+        )
+
+    def create_row(self):
+        doc, obj = create_lookup_table_row(unwrap_doc=False)
+        doc.data_type_id = self.type_doc._id
+        obj.table = self.table_obj
+        assert obj.table_id == self.table_obj.id, (obj.table_id, self.table_obj.id)
+        return doc, obj
+
+    def diff(self, doc, obj):
+        return do_diff(LookupTableRowCommand, doc, obj)
+
+
 def create_lookup_table(unwrap_doc=True):
     def fields_data(name="name"):
         return [
@@ -233,6 +444,44 @@ def create_lookup_table(unwrap_doc=True):
     doc = FixtureDataType.wrap(data(
         doc_type="FixtureDataType",
         fields=fields_data("field_name"),
+    ))
+    if unwrap_doc:
+        doc = doc.to_json()
+    return doc, obj
+
+
+def create_lookup_table_row(unwrap_doc=True):
+    def data(**extra):
+        return {
+            'domain': 'some-domain',
+            'item_attributes': {'name': 'Andy'},
+            'sort_key': 2,
+            **extra,
+        }
+    obj = jsonattrify(LookupTableRow, data(
+        table_id=UUID('0fb6c422115145c0a651bb9a34ca09c4'),
+        fields={
+            'amount': [
+                {"value": "1", "properties": {}},
+            ],
+            'qty': [
+                {"value": "1", "properties": {"loc": "Boston"}},
+                {"value": "3", "properties": {"loc": "Miami"}},
+            ],
+        },
+    ))
+    doc = FixtureDataItem.wrap(data(
+        doc_type="FixtureDataItem",
+        data_type_id="0fb6c422115145c0a651bb9a34ca09c4",
+        fields={
+            'amount': {'field_list': [
+                {"field_value": "1", "properties": {}},
+            ]},
+            'qty': {'field_list': [
+                {"field_value": "1", "properties": {"loc": "Boston"}},
+                {"field_value": "3", "properties": {"loc": "Miami"}},
+            ]},
+        },
     ))
     if unwrap_doc:
         doc = doc.to_json()

--- a/corehq/apps/fixtures/tests/test_couchsqlmigration.py
+++ b/corehq/apps/fixtures/tests/test_couchsqlmigration.py
@@ -1,0 +1,211 @@
+from django.core.management import call_command
+from django.test import SimpleTestCase, TestCase
+
+from ..management.commands.populate_lookuptables import Command as LookupTableCommand
+from ..models import FixtureDataType, LookupTable, TypeField
+from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types
+
+
+class TestLookupTableCouchToSQLDiff(SimpleTestCase):
+
+    def test_no_diff(self):
+        doc, obj = create_lookup_table()
+        self.assertEqual(self.diff(doc, obj), [])
+
+    def test_diff_domain(self):
+        doc, obj = create_lookup_table()
+        doc['domain'] = 'other-domain'
+        self.assertEqual(
+            self.diff(doc, obj),
+            ["domain: couch value 'other-domain' != sql value 'some-domain'"],
+        )
+
+    def test_diff_is_global(self):
+        doc, obj = create_lookup_table()
+        obj.is_global = False
+        self.assertEqual(
+            self.diff(doc, obj),
+            ["is_global: couch value True != sql value False"],
+        )
+
+    def test_diff_tag(self):
+        doc, obj = create_lookup_table()
+        obj.tag = 'cost'
+        self.assertEqual(
+            self.diff(doc, obj),
+            ["tag: couch value 'price' != sql value 'cost'"],
+        )
+
+    def test_diff_fields(self):
+        doc, obj = create_lookup_table()
+        doc['fields'] = [{
+            'doc_type': 'FixtureTypeField',
+            'field_name': 'amount',
+            'properties': [],
+            'is_indexed': False,
+        }]
+        error, = self.diff(doc, obj)
+        self.assertRegex(
+            error,
+            r"^fields: couch value \[[^q]+\] != sql value \[.+\]$",
+        )
+
+    def test_diff_item_attributes(self):
+        doc, obj = create_lookup_table()
+        obj.item_attributes = ['age']
+        self.assertEqual(
+            self.diff(doc, obj),
+            ["item_attributes: couch value ['name'] != sql value ['age']"],
+        )
+
+    def test_diff_description(self):
+        doc, obj = create_lookup_table()
+        obj.description = 'about that'
+        self.assertEqual(
+            self.diff(doc, obj),
+            ["description: couch value None != sql value 'about that'"],
+        )
+
+    def test_diff_multiple(self):
+        doc, obj = create_lookup_table()
+        obj.is_global = False
+        doc["tag"] = 'cost'
+        self.assertEqual(
+            self.diff(doc, obj),
+            [
+                "is_global: couch value True != sql value False",
+                "tag: couch value 'cost' != sql value 'price'",
+            ],
+        )
+
+    def diff(self, doc, obj):
+        return do_diff(LookupTableCommand, doc, obj)
+
+
+class TestLookupTableCouchToSQLMigration(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.db = FixtureDataType.get_db()
+
+    def tearDown(self):
+        docs = list(get_all_docs_with_doc_types(self.db, ['FixtureDataType']))
+        self.db.bulk_delete(docs)
+        super().tearDown()
+
+    def test_sync_to_couch(self):
+        doc, obj = create_lookup_table()
+        obj.save()
+        couch_obj = self.db.get(obj._migration_couch_id)
+        self.assertIsNone(couch_obj['description'], None)
+        self.assertEqual(self.diff(couch_obj, obj), [])
+
+        obj.tag = 'cost'
+        obj.fields[0].name = 'value'
+        obj.item_attributes = ['name', 'age']
+        obj.description = 'about that'
+        obj.save()
+        doc = self.db.get(obj._migration_couch_id)
+        self.assertEqual(doc['tag'], 'cost')
+        self.assertEqual(doc['description'], 'about that')
+        self.assertEqual(doc['item_attributes'], ['name', 'age'])
+        self.assertEqual(doc['fields'][0], {
+            'doc_type': 'FixtureTypeField',
+            'field_name': 'value',
+            'properties': [],
+            'is_indexed': False,
+        })
+
+    def test_sync_to_sql(self):
+        doc, obj = create_lookup_table(unwrap_doc=False)
+        doc.save()
+        self.assertEqual(
+            self.diff(doc.to_json(), LookupTable.objects.get(id=doc._id)),
+            [],
+        )
+
+        doc.tag = 'cost'
+        doc.fields[0].field_name = 'value'
+        doc.item_attributes = ['name', 'age']
+        doc.save()
+        obj = LookupTable.objects.get(id=doc._id)
+        self.assertEqual(obj.tag, 'cost')
+        self.assertEqual(obj.item_attributes, ['name', 'age'])
+        self.assertEqual(obj.fields[0], TypeField(
+            name='value',
+            properties=[],
+            is_indexed=False,
+        ))
+
+    def test_migration(self):
+        doc, obj = create_lookup_table(unwrap_doc=False)
+        doc.save(sync_to_sql=False)
+        call_command('populate_lookuptables')
+        self.assertEqual(
+            self.diff(doc.to_json(), LookupTable.objects.get(id=doc._id)),
+            [],
+        )
+
+        # Additional call should apply any updates
+        doc = FixtureDataType.get(doc._id)
+        doc.tag = 'cost'
+        doc.fields[0].field_name = 'value'
+        doc.item_attributes = ['name', 'age']
+        doc.save(sync_to_sql=False)
+        call_command('populate_lookuptables')
+        self.assertEqual(
+            self.diff(doc.to_json(), LookupTable.objects.get(id=doc._id)),
+            [],
+        )
+
+    def diff(self, doc, obj):
+        return do_diff(LookupTableCommand, doc, obj)
+
+
+def create_lookup_table(unwrap_doc=True):
+    def fields_data(name="name"):
+        return [
+            {
+                name: 'amount',
+                'properties': [],
+                'is_indexed': False,
+            }, {
+                name: 'qty',
+                'properties': [],
+                'is_indexed': False,
+            },
+        ]
+
+    def data(**extra):
+        return {
+            'domain': 'some-domain',
+            'is_global': True,
+            'tag': 'price',
+            'fields': fields_data(),
+            'item_attributes': ['name'],
+            **extra,
+        }
+    obj = jsonattrify(LookupTable, data())
+    doc = FixtureDataType.wrap(data(
+        doc_type="FixtureDataType",
+        fields=fields_data("field_name"),
+    ))
+    if unwrap_doc:
+        doc = doc.to_json()
+    return doc, obj
+
+
+def do_diff(Command, doc, obj):
+    result = Command.diff_couch_and_sql(doc, obj)
+    return [x for x in result if x is not None]
+
+
+def jsonattrify(model_type, data):
+    obj = model_type()
+    for name, value in data.items():
+        field = model_type._meta.get_field(name)
+        if hasattr(field, "builder"):
+            value = field.builder.attrify(value)
+        setattr(obj, name, value)
+    return obj

--- a/corehq/apps/fixtures/tests/test_models.py
+++ b/corehq/apps/fixtures/tests/test_models.py
@@ -1,6 +1,61 @@
-from django.test import SimpleTestCase
+from django.db import IntegrityError
+from django.test import SimpleTestCase, TestCase
 
-from ..models import FieldList, FixtureItemField, FixtureTypeField
+from corehq.util.test_utils import generate_cases
+from corehq.util.tests.test_jsonattrs import set_json_value
+
+from ..models import (
+    FieldList,
+    FixtureItemField,
+    FixtureTypeField,
+    LookupTable,
+    TypeField,
+)
+
+
+class TestLookupTable(TestCase):
+
+    def test_default_domain_is_not_valid(self):
+        table = LookupTable(tag="x")
+        with self.assertRaises(IntegrityError):
+            table.save()
+
+    def test_default_tag_is_not_valid(self):
+        table = LookupTable(domain="test")
+        with self.assertRaises(IntegrityError):
+            table.save()
+
+    def test_fields(self):
+        table = LookupTable(domain="test", tag="x", fields=[TypeField("vera")])
+        self.assertEqual(table.fields[0].name, "vera")
+        self.assertEqual(table.fields[0].properties, [])
+        table.save(sync_to_couch=False)
+        new = LookupTable.objects.get(id=table.id)
+        self.assertEqual(new.fields, table.fields)
+        self.assertIsNot(new.fields, table.fields)
+
+    @generate_cases([
+        # Detect incompatibilities between the JSON data stored in the
+        # database and LookupTable.fields and/or TypeField type. One or more
+        # of these tests will fail if the field definition changes in an
+        # incompatible way.
+        #
+        # Do not change any of these data formats as long as rows with the
+        # same format may exist in a database somewhere.
+        ([],),
+        ([{"name": "vera", "properties": [], "is_indexed": False}],),
+        ([{"name": "vera", "properties": ["album"], "is_indexed": True}],),
+    ])
+    def test_persistent_formats(self, value):
+        obj = LookupTable()
+        set_json_value(obj, "fields", value)
+        if value:
+            self.assertTrue(
+                all(isinstance(f, TypeField) for f in obj.fields),
+                obj.fields
+            )
+        else:
+            self.assertEqual(obj.fields, value)
 
 
 class TestFieldTypes(SimpleTestCase):

--- a/corehq/apps/fixtures/tests/test_views.py
+++ b/corehq/apps/fixtures/tests/test_views.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -6,6 +7,9 @@ from django.urls import reverse
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
+
+from ..dbaccessors import delete_all_fixture_data
+from ..models import LookupTable, LookupTableRow, Field, TypeField
 
 DOMAIN = "lookup"
 USER = "test@test.com"
@@ -24,6 +28,7 @@ class LookupTableViewsTest(TestCase):
         cls.user.is_superuser = True
         cls.user.save()
         cls.addClassCleanup(cls.user.delete, DOMAIN, deleted_by=None)
+        cls.addClassCleanup(delete_all_fixture_data, DOMAIN)
 
     def test_update_tables_post_without_data_type_id(self):
         data = {
@@ -32,17 +37,145 @@ class LookupTableViewsTest(TestCase):
             "is_global": False,
             "description": ""
         }
+        with self.get_client(data) as client:
+            # should not raise
+            # TypeError: update_tables() missing 1 required positional argument: 'data_type_id'
+            response = client.post(self.url(), data)
+        self.assertEqual(response.status_code, 200, str(response))
+
+    def test_update_tables_put(self):
+        table = self.create_lookup_table()
+        self.create_row(table)
+        data = {
+            'tag': 'atable',
+            'description': 'A Modified Table',
+            'is_global': False,
+            'fields': {'wing': {'update': 'foot'}},
+        }
+        with self.get_client(data) as client:
+            response = client.put(self.url(data_type_id=table.id.hex), data)
+        self.assertEqual(response.status_code, 200)
+        table = LookupTable.objects.get(domain=DOMAIN, tag="atable")
+        self.assertFalse(table.is_global)
+        self.assertEqual(table.description, "A Modified Table")
+        self.assertEqual(table.fields, [TypeField(name="foot")])
+        row = LookupTableRow.objects.get(table_id=table.id)
+        self.assertEqual(row.fields, {
+            "foot": [Field(value="duck", properties={"says": "quack"})]
+        })
+
+        from ..models import FieldList, FixtureItemField
+        couch_row = row._migration_get_couch_object()
+        self.assertEqual(couch_row.fields, {
+            "foot": FieldList(field_list=[
+                FixtureItemField(field_value="duck", properties={"says": "quack"})
+            ])
+        })
+
+    def test_update_tables_put_multiple_field_updates_on_multiple_rows(self):
+        table = self.create_lookup_table(fields=[
+            TypeField("a"),
+            TypeField("b"),
+            TypeField("c"),
+        ])
+        row1 = self.create_row(table, fields={
+            "a": [Field(value="1", properties={"p": "x"})],
+            "b": [Field(value="2", properties={"p": "y"})],
+            "c": [Field(value="3", properties={"p": "z"})],
+        })
+        row2 = self.create_row(table, fields={
+            "a": [Field(value="4", properties={"p": "m"})],
+            "b": [Field(value="5", properties={"p": "n"})],
+            "c": [Field(value="6", properties={"p": "o"})],
+        })
+        data = {
+            'tag': 'atable',
+            'description': 'A Modified Table',
+            'is_global': False,
+            'fields': {
+                'a': {'update': 'd'},
+                'b': {'remove': 1},
+                'c': {},
+                'e': {'is_new': 1},
+            },
+        }
+        with self.get_client(data) as client:
+            response = client.put(self.url(data_type_id=table.id.hex), data)
+        self.assertEqual(response.status_code, 200)
+        table = LookupTable.objects.get(domain=DOMAIN, tag="atable")
+        self.assertFalse(table.is_global)
+        self.assertEqual(table.description, "A Modified Table")
+        self.assertEqual(table.fields, [
+            TypeField("d"),
+            TypeField("c"),
+            TypeField("e"),
+        ])
+        row1 = LookupTableRow.objects.get(id=row1.id)
+        self.assertEqual(row1.fields, {
+            "c": [Field(value="3", properties={"p": "z"})],
+            "d": [Field(value="1", properties={"p": "x"})],
+            "e": [],
+        })
+        row2 = LookupTableRow.objects.get(id=row2.id)
+        self.assertEqual(row2.fields, {
+            "c": [Field(value="6", properties={"p": "o"})],
+            "d": [Field(value="4", properties={"p": "m"})],
+            "e": [],
+        })
+
+        from ..models import FieldList, FixtureItemField
+        couch_row1 = row1._migration_get_couch_object()
+        self.assertEqual(couch_row1.fields, {
+            "c": FieldList(field_list=[FixtureItemField(field_value="3", properties={"p": "z"})]),
+            "d": FieldList(field_list=[FixtureItemField(field_value="1", properties={"p": "x"})]),
+            "e": FieldList(field_list=[]),
+        })
+        couch_row2 = row2._migration_get_couch_object()
+        self.assertEqual(couch_row2.fields, {
+            "c": FieldList(field_list=[FixtureItemField(field_value="6", properties={"p": "o"})]),
+            "d": FieldList(field_list=[FixtureItemField(field_value="4", properties={"p": "m"})]),
+            "e": FieldList(field_list=[]),
+        })
+
+    @contextmanager
+    def get_client(self, data=None):
         client = Client()
         client.login(username=USER, password=PASS)
-        url = reverse("update_lookup_tables", kwargs={'domain': DOMAIN})
         allow_all = patch('django_prbac.decorators.has_privilege', return_value=True)
 
         # Not sure why _to_kwargs doesn't work on a test client request,
         # or maybe why it does work in the real world? Mocking it was
         # the easiest way I could find to work around the issue.
-        json_data = patch('corehq.apps.fixtures.views._to_kwargs', return_value=data)
+        json_data = patch('corehq.apps.fixtures.views._to_kwargs', return_value=data or {})
 
         with allow_all, json_data:
-            response = client.post(url, data)
-        self.assertEqual(response.status_code, 200, str(response))
-        self.assertIn("validation_errors", response.json())
+            yield client
+
+    def url(self, **kwargs):
+        kwargs.setdefault("domain", DOMAIN)
+        return reverse("update_lookup_tables", kwargs=kwargs)
+
+    def create_lookup_table(self, fields=None):
+        table = LookupTable(
+            domain=DOMAIN,
+            tag="atable",
+            description="A Table",
+            is_global=True,
+            fields=fields or [TypeField(name="wing")]
+        )
+        table.save()
+        self.addCleanup(table._migration_get_couch_object().delete)
+        return table
+
+    def create_row(self, table, fields=None):
+        row = LookupTableRow(
+            table_id=table.id,
+            domain=DOMAIN,
+            fields=fields or {
+                "wing": [Field(value="duck", properties={"says": "quack"})],
+            },
+            sort_key=0,
+        )
+        row.save()
+        self.addCleanup(row._migration_get_couch_object().delete)
+        return row

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -48,6 +48,7 @@ from corehq.apps.fixtures.models import (
     FixtureDataItem,
     FixtureDataType,
     FixtureTypeField,
+    LookupTableRow,
 )
 from corehq.apps.fixtures.tasks import (
     async_fixture_download,
@@ -64,6 +65,7 @@ from corehq.apps.fixtures.utils import (
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.util import format_datatables_data
 from corehq.apps.users.models import HqPermissions
+from corehq.sql_db.jsonops import JsonDelete, JsonGet, JsonSet
 from corehq.toggles import SKIP_ORM_FIXTURE_UPLOAD
 from corehq.util.files import file_extention_from_filename
 from corehq import toggles
@@ -198,6 +200,11 @@ def _update_types(patches, domain, data_type_id, data_tag, is_global, descriptio
                 properties=[]
             ))
     data_type.fields = new_fixture_fields
+
+    def update_sql_objects():
+        data_type._migration_do_sync()
+
+    transaction.set_sql_save_action(FixtureDataType, update_sql_objects)
     transaction.save(data_type)
     return data_type
 
@@ -226,6 +233,30 @@ def _update_items(fields_patches, domain, data_type_id, transaction):
                 )
         setattr(item, "fields", updated_fields)
         transaction.save(item)
+
+    fields_json = "fields"
+    for field_name, patch in fields_patches.items():
+        if "update" in patch:
+            new_field_name = patch["update"]
+            fields_json = JsonSet(
+                JsonDelete(fields_json, field_name),
+                [new_field_name],
+                JsonGet("fields", field_name),
+            )
+        elif "remove" in patch:
+            fields_json = JsonDelete(fields_json, field_name)
+    for field_name, patch in fields_patches.items():
+        if "is_new" in patch:
+            fields_json = JsonSet(fields_json, [field_name], [])
+
+    def update_sql_objects():
+        if fields_json != "fields":
+            LookupTableRow.objects.filter(
+                domain=domain,
+                table_id=data_type_id,
+            ).update(fields=fields_json)
+
+    transaction.set_sql_save_action(FixtureDataItem, update_sql_objects)
     transaction.add_post_commit_action(
         lambda: FixtureDataItem.by_data_type(domain, data_type_id, bypass_cache=True)
     )

--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -139,7 +139,7 @@ class SyncCouchToSQLMixin(object):
             obj = cls(**{cls._migration_couch_id_name: self._id})
         return obj
 
-    def _migration_sync_to_sql(self, sql_object):
+    def _migration_sync_to_sql(self, sql_object, save=True):
         """Copy data from the Couch model to the SQL model and save it"""
         for field_name in self._migration_get_fields():
             value = getattr(self, field_name)
@@ -147,7 +147,8 @@ class SyncCouchToSQLMixin(object):
         self._migration_sync_submodels_to_sql(sql_object)
         for custom_func in self._migration_get_custom_couch_to_sql_functions():
             custom_func(self, sql_object)
-        sql_object.save(sync_to_couch=False)
+        if save:
+            sql_object.save(sync_to_couch=False)
 
     def _migration_sync_submodels_to_sql(self, sql_object):
         """Migrate submodels from the Couch model to the SQL model. This is called

--- a/corehq/sql_db/fields.py
+++ b/corehq/sql_db/fields.py
@@ -1,0 +1,24 @@
+import sys
+
+from django.db.models import CharField
+
+
+class CharIdField(CharField):
+    """CharField that does not create varchar_pattern_ops index
+
+    Django automatically creates varchar_pattern_ops indexes for indexed
+    varchar columns to support `LIKE` and regular expression queries. ID
+    fields are not typically quieried with those operators, and
+    therefore the extra index would degrade performance and consume
+    storage for no benefit.
+    """
+
+    def db_type(self, connection):
+        # HACK short circuit index creation based on caller name
+        if _get_caller_name() == "_create_like_index_sql":
+            return None
+        return super().db_type(connection)
+
+
+def _get_caller_name():
+    return sys._getframe(2).f_code.co_name

--- a/corehq/sql_db/jsonops.py
+++ b/corehq/sql_db/jsonops.py
@@ -1,0 +1,69 @@
+import json
+
+from django.db.models.expressions import Expression, Func, RawSQL, Value
+from django.db.models import JSONField
+
+
+class JsonDelete(Func):
+    """Delete item(s) from JSONB value
+
+    :param expression: JSONB field name or value expression.
+    :param *items: Names of items to delete.
+    """
+    function = "-"
+    template = "%(expressions)s::jsonb %(function)s '{%(items)s}'::text[]"
+    arity = 1
+
+    def __init__(self, expression, *items):
+        items = ",".join(items)
+        if "'" in items:
+            raise ValueError(f"invalid items: {items!r}")
+        super().__init__(expression, output_field=JSONField(), items=items)
+
+
+class JsonGet(Func):
+    """Get item from JSON or JSONB value
+
+    :param expression: JSON/JSONB field name or value expression.
+    :param field: Name of item to get.
+    """
+    function = "->"
+    template = "%(expressions)s%(function)s'%(field_name)s'"
+    arity = 1
+
+    def __init__(self, expression, field):
+        if not isinstance(field, str) or "'" in field:
+            raise ValueError(f"invalid field: {field!r}")
+        super().__init__(expression, output_field=JSONField(), field_name=field)
+
+
+class JsonSet(Func):
+    """Replace value at path in JSONB value
+
+    :param expression: JSONB field name or value expression.
+    :param path: Sequence of keys or indexes representing the path of
+        the value in `expression` to be replaced.
+    :param new_value: JSON-serializable value or expression.
+    :param create_missing: Add value if it is missing (default: True).
+    """
+    function = "jsonb_set"
+    template = "%(function)s(%(expressions)s, %(create_missing)s)"
+    arity = 3
+
+    def __init__(self, expression, path, new_value, create_missing=True):
+        path_items = ",".join(_int_str(p) for p in path)
+        if "'" in path_items:
+            raise ValueError(f"invalid path: {path_items!r}")
+        if not isinstance(new_value, Expression):
+            new_value = Value(json.dumps(new_value))
+        super().__init__(
+            expression,
+            RawSQL("'{%s}'" % path_items, ()),
+            new_value,
+            output_field=JSONField(),
+            create_missing="true" if create_missing else "false",
+        )
+
+
+def _int_str(arg):
+    return str(arg) if isinstance(arg, int) else arg

--- a/corehq/sql_db/tests/test_fields.py
+++ b/corehq/sql_db/tests/test_fields.py
@@ -1,0 +1,50 @@
+from django.db import connection
+from django.db import models
+from django.db.backends.postgresql.schema import DatabaseSchemaEditor
+
+from corehq.util.test_utils import unregistered_django_model
+
+from ..fields import CharIdField
+
+
+def test_CharIdField_without_indexes():
+    @unregistered_django_model
+    class Test(models.Model):
+        some_id = CharIdField()
+    field = {f.name: f for f in Test._meta.fields}["some_id"]
+    with schema_editor() as editor:
+        editor.add_field(Test, field)
+        assert_no_pattern_ops_index(editor)
+
+
+def test_CharIdField_primary_key():
+    @unregistered_django_model
+    class Test(models.Model):
+        id = CharIdField(primary_key=True)
+    field = {f.name: f for f in Test._meta.fields}["id"]
+    assert field.unique
+    with schema_editor() as editor:
+        editor.add_field(Test, field)
+        assert_no_pattern_ops_index(editor)
+
+
+def test_CharIdField_with_index():
+    @unregistered_django_model
+    class Test(models.Model):
+        domain = CharIdField(db_index=True, max_length=25)
+    field = {f.name: f for f in Test._meta.fields}["domain"]
+    with schema_editor() as editor:
+        editor.add_field(Test, field)
+        assert_no_pattern_ops_index(editor)
+
+
+def schema_editor():
+    return DatabaseSchemaEditor(connection, collect_sql=True, atomic=False)
+
+
+def assert_no_pattern_ops_index(editor):
+    statements = editor.collected_sql + editor.deferred_sql
+    assert statements, "expected at least one SQL statement"
+    print("\n".join(str(s) for s in statements))
+    for sql in statements:
+        assert "_pattern_ops" not in str(sql), repr(sql)

--- a/corehq/sql_db/tests/test_jsonops.py
+++ b/corehq/sql_db/tests/test_jsonops.py
@@ -1,0 +1,139 @@
+import json
+
+from django.db import DEFAULT_DB_ALIAS, connection
+from django.db import models
+from django.db.models.expressions import RawSQL, Ref
+from django.db.models.sql.compiler import SQLCompiler
+from django.forms import JSONField
+from django.test import TestCase
+
+from django_cte import CTEManager, With
+from django_cte.raw import raw_cte_sql
+
+from testil import assert_raises, eq
+
+from corehq.util.test_utils import unregistered_django_model
+
+from .. import jsonops as ops
+
+
+def test_JsonDelete_sql():
+    expr = ops.JsonDelete(data_ref, "items", "abc")
+    eq(as_sql(expr), "data::jsonb - '{items,abc}'::text[]")
+
+
+def test_JsonDelete_illegal_field():
+    with assert_raises(ValueError):
+        ops.JsonDelete(data_ref, "illegal'field")
+
+
+def test_JsonGet_sql():
+    expr = ops.JsonGet(data_ref, "field")
+    eq(as_sql(expr), "data->'field'")
+
+
+def test_JsonGet_illegal_field():
+    with assert_raises(ValueError):
+        ops.JsonGet(data_ref, "illegal'field")
+
+
+def test_JsonSet_sql():
+    expr = ops.JsonSet(data_ref, ["items", 0, "abc"], [1, 2, 3])
+    eq(as_sql(expr), "jsonb_set(data, ('{items,0,abc}'), [1, 2, 3], true)")
+
+
+def test_JsonSet_do_not_create_missing():
+    expr = ops.JsonSet(data_ref, ["items"], [1, None], create_missing=False)
+    eq(as_sql(expr), "jsonb_set(data, ('{items}'), [1, null], false)")
+
+
+def test_JsonSet_illegal_field():
+    with assert_raises(ValueError):
+        ops.JsonSet(data_ref, ["illegal'field"], 1)
+
+
+def test_JsonSet_with_expression():
+    select = RawSQL("SELECT '{}'::jsonb", [])
+    expr = ops.JsonSet(data_ref, ["field"], select)
+    eq(as_sql(expr), "jsonb_set(data, ('{field}'), (SELECT '{}'::jsonb), true)")
+
+
+def test_nested_operations():
+    expr = ops.JsonSet(
+        ops.JsonDelete(data_ref, "things"),
+        ["items"],
+        ops.JsonGet(data_ref, "things"),
+    )
+    eq(as_sql(expr), "jsonb_set(data::jsonb - '{things}'::text[], ('{items}'), data->'things', true)")
+
+
+class TestJsonOpsEvaluation(TestCase):
+
+    def test_JsonDelete(self):
+        value = eval_json_op(ops.JsonDelete(data_ref, "score"))
+        self.assertEqual(value, {"things": [1, 2, 3], "other": "value"})
+
+    def test_JsonSet(self):
+        value = eval_json_op(ops.JsonSet(data_ref, ["things", 1], {"b": 2}))
+        self.assertEqual(value, {
+            "things": [1, {"b": 2}, 3],
+            "other": "value",
+            "score": 3,
+        })
+
+    def test_JsonGet(self):
+        value = eval_json_op(ops.JsonGet(data_ref, "things"))
+        self.assertEqual(value, [1, 2, 3])
+
+    def test_nested_operations(self):
+        value = eval_json_op(ops.JsonSet(
+            ops.JsonDelete(data_ref, "things"),
+            ["items"],
+            ops.JsonGet(data_ref, "things"),
+        ))
+        self.assertEqual(value, {
+            "items": [1, 2, 3],
+            "other": "value",
+            "score": 3,
+        })
+
+
+class _UnquotedRef(Ref):
+
+    def as_sql(self, compiler, connection):
+        return self.refs, []
+
+
+data_ref = _UnquotedRef("data", None)
+
+
+def as_sql(expression):
+    compiler = SQLCompiler(None, connection, DEFAULT_DB_ALIAS)
+    sql, params = compiler.compile(expression)
+    return sql % tuple(params)
+
+
+def eval_json_op(expression):
+    # raw CTE is a hack to evaluate a query without an existing model
+    data = {"things": [1, 2, 3], "other": "value", "score": 3}
+    cte_sql = "SELECT %s::jsonb AS data"
+    data_cte = raw_cte_sql(cte_sql, [json.dumps(data)], {"data": JSONField()})
+    data_cte.query.model = _JsonModel
+    data_cte.query.default_cols = []
+    data_cte.query.annotations = {}
+    data_cte.query.values_select = []
+    data_cte.query.annotation_select_mask = None
+    cte = With(data_cte)
+    qs = (
+        cte.queryset().with_cte(cte)
+        .annotate(val=expression)
+        .values_list("val", flat=True)
+    )
+    print(qs.query)
+    value, = qs
+    return value
+
+
+@unregistered_django_model
+class _JsonModel(models.Model):
+    objects = CTEManager()

--- a/corehq/util/jsonattrs.py
+++ b/corehq/util/jsonattrs.py
@@ -1,0 +1,235 @@
+"""A Pythonic way to interact with structured JSON in Django models.
+
+Why use this?
+
+Rich object features such as default values, calculated properties, and
+methods can be implemented centrally on an attrs class rather than
+having that logic distributed, and probably duplicated, throughout the
+application in every place where JSON values would be read and/or
+written.
+
+```py
+@define
+class Item:
+    name = field()
+    value = field(default=0)
+    tags = field(factory=list)
+
+    @property
+    def proper_name(self):
+        return self.name.title()
+
+
+class Plane(models.Model):
+    items = AttrsList(Item)
+
+
+plane = Plane(items=[Item("line")])
+plane.save()
+# Saved `items` JSON: `[{"name": "line", "value": 0, "tags": []}]`
+
+assert plane.items[0].proper_name == "Line"  # calculated property
+```
+
+Usage examples:
+
+```py
+@define
+class Point:
+    x = field()
+    y = field()
+
+
+class Plane(models.Model):
+
+    # A dict of `<str>: Point(...)` items
+    # JSON in the database looks like {"north": {"x": 0, "y": 1}, ...}
+    points = AttrsDict(Point)
+
+    # A list of `Point` objects
+    # JSON in the database looks like [{"x": 0, "y": 1}, ...]
+    coords = AttrsList(Point)
+
+    # Nested collections are also possible:
+
+    named_points = AttrsDict(list_of(Point))
+    # JSON: {"north-west": [{"x": 0, "y": 1}, {"x": 1, "y": 0}, ...], ...}
+
+    named_coords = AttrsList(dict_of(Point))
+    # JSON: [{"north": {"x": 0, "y": 1}, "west": {"x": 1, "y": 0}, ...}, ...]
+```
+
+Attrs classes may implement `__jsonattrs_to_json__` (instance method) and
+`__jsonattrs_from_json__` (class method) to perform custom conversions to and
+from JSON. For example, these methods can be used to handle dates, times,
+Decimal, and other non-JSON-serializable value types.
+
+It is also possible to override `__jsonattrs_from_json__` on attrs types or
+custom subclasses of `dict_of` and `list_of` to support lazy migrations of
+legacy data. A note on lazy migrations: running a migration every time a row is
+read is not free. While it may seem trivial for a single row, it adds up when
+aggregated over thousands of rows read day after day. It may be a better long
+term strategy to run the migration once and update all existing rows when the
+data format changes. This allows the migration code to be removed and makes the
+implementation simpler and more performant.
+
+Things that may be added in the future:
+
+- A Django field type that holds a single attrs class instance.
+- Attrs field types for dates, times, Decimal, and other non-JSON-serializable
+  value types.
+- Support for migrating/converting the outer collection of `AttrsDict` and
+  `AttrsList`.
+"""
+from attrs import asdict, define, field
+
+from django.db.models import JSONField
+
+__all__ = ["AttrsDict", "AttrsList", "dict_of", "list_of"]
+
+
+class JsonAttrsField(JSONField):
+
+    def __init__(self, *args, builder, **kw):
+        super().__init__(*args, **kw)
+        self.builder = builder
+
+    def get_prep_value(self, value):
+        return super().get_prep_value(self.builder.jsonify(value))
+
+    def from_db_value(self, value, expression, connection):
+        value = super().from_db_value(value, expression, connection)
+        return self.builder.attrify(value)
+
+    def deconstruct(self):
+        # Returns a JSONField deconstruction to be used in migrations,
+        # which do not need to know anything about attrs builders.
+        name, path, args, kwargs = super().deconstruct()
+        assert not args, (name, path, args, kwargs)
+        assert "builder" not in kwargs, (name, path, args, kwargs)
+        assert isinstance(self, JSONField), type(self).__mro__
+        path = JSONField().deconstruct()[1]
+        return name, path, args, kwargs
+
+    def clone(self):
+        # Assumes `self.builder` is immutable; it is shared by this
+        # field and the clone.
+        name, path, args, kwargs = super().deconstruct()
+        assert not args, (name, path, args, kwargs)
+        assert "builder" not in kwargs, (name, path, args, kwargs)
+        return self.__class__(self.builder, **kwargs)
+
+
+class AttrsDict(JsonAttrsField):
+    """Dict field containing attrs values, saved to the database as JSON
+
+    Dict keys are always strings because that is the only key type
+    allowed in JSON. Dict values are attrs objects of the type specified
+    by `value_type`
+    """
+
+    def __init__(self, value_type, /, **jsonfield_args):
+        super().__init__(builder=AttrsDictBuilder(value_type), **jsonfield_args)
+
+
+class AttrsList(JsonAttrsField):
+    """List field containing attrs items, saved to the database as JSON
+
+    List items are attrs objects of the type specified by `item_type`.
+    """
+
+    def __init__(self, item_type, /, **jsonfield_args):
+        super().__init__(builder=AttrsListBuilder(item_type), **jsonfield_args)
+
+
+@define
+class AttrsListBuilder:
+    attrs_type = field()
+
+    def attrify(self, items):
+        attrs_type = self.attrs_type
+        if items is None:
+            return items
+        if hasattr(attrs_type, "__jsonattrs_from_json__"):
+            from_json = attrs_type.__jsonattrs_from_json__
+            return [from_json(item) for item in items]
+        return [attrs_type(**item) for item in items]
+
+    def jsonify(self, value):
+        if not value:
+            return value
+        if hasattr(self.attrs_type, "__jsonattrs_to_json__"):
+            to_json = self.attrs_type.__jsonattrs_to_json__
+        else:
+            to_json = asdict
+        return [to_json(v) for v in value]
+
+
+@define
+class AttrsDictBuilder:
+    attrs_type = field()
+
+    def attrify(self, values):
+        attrs_type = self.attrs_type
+        if values is None:
+            return values
+        if hasattr(attrs_type, "__jsonattrs_from_json__"):
+            from_json = attrs_type.__jsonattrs_from_json__
+            return {key: from_json(value) for key, value in values.items()}
+        return {key: attrs_type(**value) for key, value in values.items()}
+
+    def jsonify(self, value):
+        if not value:
+            return value
+        if hasattr(self.attrs_type, "__jsonattrs_to_json__"):
+            to_json = self.attrs_type.__jsonattrs_to_json__
+        else:
+            to_json = asdict
+        return {k: to_json(v) for k, v in value.items()}
+
+
+@define
+class dict_of:
+    value_type = field()
+    key_type = field(default=str)
+    builder = field()
+
+    @builder.default
+    def _builder(self):
+        return AttrsDictBuilder(self.value_type)
+
+    def __jsonattrs_from_json__(self, value):
+        self._check_none(value)
+        return self.builder.attrify(value)
+
+    def __jsonattrs_to_json__(self, value):
+        self._check_none(value)
+        return self.builder.jsonify(value)
+
+    def _check_none(self, value):
+        if value is None:
+            typename = self.value_type.__name__
+            raise ValueError(f"expected dict with {typename} values, got None")
+
+
+@define
+class list_of:
+    item_type = field()
+    builder = field()
+
+    @builder.default
+    def _builder(self):
+        return AttrsListBuilder(self.item_type)
+
+    def __jsonattrs_from_json__(self, value):
+        self._check_none(value)
+        return self.builder.attrify(value)
+
+    def __jsonattrs_to_json__(self, value):
+        self._check_none(value)
+        return self.builder.jsonify(value)
+
+    def _check_none(self, value):
+        if value is None:
+            typename = self.item_type.__name__
+            raise ValueError(f"expected list of {typename}, got None")

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -887,10 +887,8 @@ def new_db_connection(alias=DEFAULT_DB_ALIAS):
     connections.prepare_test_settings(alias)
     db = connections.databases[alias]
     backend = load_backend(db['ENGINE'])
-    with (
-        closing(backend.DatabaseWrapper(db, alias)) as cn,
-        mock.patch("django.db.connections._connections.default", cn)
-    ):
+    with closing(backend.DatabaseWrapper(db, alias)) as cn, \
+            mock.patch("django.db.connections._connections.default", cn):
         yield cn
 
 

--- a/corehq/util/tests/test_jsonattrs.py
+++ b/corehq/util/tests/test_jsonattrs.py
@@ -1,0 +1,151 @@
+import json
+from datetime import date
+
+from attrs import asdict, define, field
+from django.db import models
+from testil import assert_raises, eq
+
+from ..jsonattrs import AttrsDict, AttrsList, dict_of, list_of
+from ..test_utils import unregistered_django_model
+
+
+def test_attrsdict():
+    @unregistered_django_model
+    class Check(models.Model):
+        points = AttrsDict(Point)
+
+    points = {}
+    check = Check(points=points)
+    assert check.points is points, (check.points, points)
+
+    check.points = xydict = {"north": Point(0, 1)}
+    eq(get_json_value(check, "points"), {"north": {"x": 0, "y": 1}})
+
+    set_json_value(check, "points", {"north": {"x": 0, "y": 1}})
+    assert check.points is not xydict, xydict
+    eq(check.points, {"north": Point(0, 1)})
+
+
+def test_attrsdict_list_of():
+    @unregistered_django_model
+    class Check(models.Model):
+        point_lists = AttrsDict(list_of(Point))
+
+    points = {}
+    check = Check(point_lists=points)
+    assert check.point_lists is points, (check.point_lists, points)
+
+    check.point_lists = north_points = {"north": [Point(0, 1)]}
+    eq(get_json_value(check, "point_lists"), {"north": [{"x": 0, "y": 1}]})
+
+    set_json_value(check, "point_lists", {"north": [{"x": 0, "y": 1}]})
+    assert check.point_lists is not north_points, north_points
+    eq(check.point_lists, {"north": [Point(0, 1)]})
+
+    check.point_lists = {"null": None}
+    with assert_raises(ValueError, msg="expected list of Point, got None"):
+        get_json_value(check, "point_lists")
+
+
+def test_attrslist():
+    @unregistered_django_model
+    class Check(models.Model):
+        values = AttrsList(Value)
+
+    values = []
+    check = Check(values=values)
+    assert check.values is values, (check.values, values)
+
+    check.values = abbylist = [Value("abby")]
+    eq(get_json_value(check, "values"), [{"name": "abby"}])
+
+    set_json_value(check, "values", [{"name": "abby"}])
+    assert check.values is not abbylist, abbylist
+    eq(check.values, [Value("abby")])
+
+
+def test_attrslist_dict_of():
+    @unregistered_django_model
+    class Check(models.Model):
+        value_items = AttrsList(dict_of(Value))
+
+    values = []
+    check = Check(value_items=values)
+    assert check.value_items is values, (check.value_items, values)
+
+    check.value_items = nomnom = [{"nom": Value("nom")}]
+    eq(get_json_value(check, "value_items"), [{"nom": {"name": "nom"}}])
+
+    set_json_value(check, "value_items", [{"nom": {"name": "nom"}}])
+    assert check.value_items is not nomnom, nomnom
+    eq(check.value_items, [{"nom": Value("nom")}])
+
+    check.value_items = [None]
+    with assert_raises(ValueError, msg="expected dict with Value values, got None"):
+        get_json_value(check, "value_items")
+
+
+def test_jsonattrs_to_json():
+    @unregistered_django_model
+    class Check(models.Model):
+        events = AttrsList(Event)
+
+    check = Check(events=[Event()])
+    eq(get_json_value(check, "events"), [{"day": "2022-07-19"}])
+
+
+def test_jsonattrs_from_json():
+    @unregistered_django_model
+    class Check(models.Model):
+        events = AttrsList(Event)
+
+    check = Check()
+    set_json_value(check, "events", [{"day": "2022-07-20"}])
+    eq(check.events, [Event(day=date(2022, 7, 20))])
+
+
+def get_json_value(model, field_name):
+    """Get the JSON value of a field as it would be stored in the database
+
+    Returns JSON that has been deserialized with `json.loads(value)`.
+    """
+    field = model._meta.get_field(field_name)
+    value = field.pre_save(model, False)
+    return json.loads(field.get_db_prep_save(value, None))
+
+
+def set_json_value(model, field_name, value):
+    """Populate model with JSON data as if it were loaded from a database row
+
+    `value` should be a Python data structure as if it had been read
+    from the database and deserialized with `json.loads()`.
+    """
+    field = model._meta.get_field(field_name)
+    py_value = field.from_db_value(json.dumps(value), None, None)
+    setattr(model, field_name, py_value)
+
+
+@define
+class Point:
+    x = field()
+    y = field()
+
+
+@define
+class Value:
+    name = field()
+
+
+@define
+class Event:
+    day = field(factory=lambda: date(2022, 7, 19))
+
+    def __jsonattrs_to_json__(self):
+        data = asdict(self)
+        data["day"] = data["day"].isoformat()
+        return data
+
+    @classmethod
+    def __jsonattrs_from_json__(cls, data):
+        data["day"] = date.fromisoformat(data["day"])
+        return cls(**data)

--- a/migrations.lock
+++ b/migrations.lock
@@ -358,6 +358,7 @@ fixtures
  0002_rm_blobdb_domain_fixtures
  0003_rm_blobdb_domain_fixtures
  0004_userlookuptablestatus
+ 0005_lookuptablemodels
 form_processor
  0001_initial
  0002_xformattachmentsql


### PR DESCRIPTION
This is the [first PR](https://commcare-hq.readthedocs.io/couch_to_sql_models.html#pr-1-add-sql-model-and-migration-management-command-write-to-sql) in the migration of Lookup Tables (previously known as Fixtures) from Couch to SQL.

Lookup Table performance has been an issue in the past. In general new SQL operations should perform better than the equivalent Couch operations. Bulk operations have been added where the code was previously saving row-by-row. Overall write performance will obviously be at least slightly worse until we can stop writing to Couch (a couple of PRs away). Specifically, performance of the Excel uploader and web interface for editing tables will be impacted while writing to Couch, but other read-only operations such as restores are not expected to be affected.

~A change log entry with instructions for how to migrate external environments will be added to commcare-cloud after this has been merged.~

:tropical_fish: Review by commit.

The full set of changes, including commits to be included in future PRs can be found at https://github.com/dimagi/commcare-hq/compare/dm/sql-lookup-tables - I plan to rebase that branch on this and future PRs as modifications are made, FYI.

## Safety Assurance

### Safety story

Test driven development was used to ensure existing features continue to function with SQL as they did before on Couch.

### Automated test coverage

Yes. New tests have been added in places where they were previously missing.

### QA Plan

Lookup Table features to be tested in QA:

- Excel uploads.
- Excel downloads.
- Updates using the web interface.
- APIs: read and write operations.
- Linked domains: Lookup Table changes in the parent domain should be propagated to child domains.
- Restores containing lookup tables, including
  - global tables
  - tables with user-, group-, and location-owned rows.
- Other Lookup Table features in HQ?

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-4392).

### Migrations
- [x] The migrations in this code can be safely applied first independently of the code.

### Rollback instructions

The migration in this PR adds new SQL tables and indexes. The presence of those entities does not pose a problem for rollback, but subsequent PRs must account for the fact that the migration has been applied. It may be desirable to unapply the migration in a private release after rollback to allow a fresh start.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
