### PR TITLE
Remove ability to set is_superuser/is_staff via Django Admin

### DIFF
--- a/corehq/apps/users/admin.py
+++ b/corehq/apps/users/admin.py
@@ -30,10 +30,32 @@ class ApiKeyInline(admin.TabularInline):
         return False
 
 
+def _copy_fieldsets(fieldsets, excluding_fields=()):
+    """
+    Return a deep copy of ModelAdmin `fieldsets` property, removing certain fields
+
+    :param: fieldsets - fieldsets property to copy
+    :param: excluding_fields - fields to remove
+
+    """
+    # fieldsets is structured like ((display_name, {'fields': fields}), ...)
+    return tuple(
+        # deep copy based on its known structure...
+        (display_name, dict(fields_dict, fields=tuple(
+            field for field in fields_dict["fields"]
+            # ...removing excluded fields
+            if field not in excluding_fields
+        )))
+        for display_name, fields_dict in fieldsets
+    )
+
+
 class CustomUserAdmin(UserAdmin):
     inlines = [
         ApiKeyInline,
     ]
+
+    fieldsets = _copy_fieldsets(UserAdmin.fieldsets, excluding_fields=("is_superuser", "is_staff"))
 
     def has_add_permission(self, request):
         return False

--- a/corehq/apps/users/tests/test_admin.py
+++ b/corehq/apps/users/tests/test_admin.py
@@ -1,0 +1,24 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.users.admin import CustomUserAdmin
+
+
+class CustomUserAdminTest(SimpleTestCase):
+
+    def test_fieldsets(self):
+        """
+        Test that the value of CustomUserAdmin.fieldsets,
+        dynamically calculated by removing fields from UserAdmin,
+        matches hard-coded value.
+
+        This will alert us of any changes to Django's own UserAdmin that affect this,
+        and allow us to make any changes necessitated by that.
+        This is probably over-careful, but might help us quickly avoid a surprise.
+
+        """
+        self.assertEqual(CustomUserAdmin.fieldsets, (
+            (None, {'fields': ('username', 'password')}),
+            ('Personal info', {'fields': ('first_name', 'last_name', 'email')}),
+            ('Permissions', {'fields': ('is_active', 'groups', 'user_permissions')}),
+            ('Important dates', {'fields': ('last_login', 'date_joined')}),
+        ))


### PR DESCRIPTION
## Product Description
Nothing externally user-facing, but staff will no longer be able to change `is_superuser` and `is_staff` properties of any user through the Django Admin interface. (There are other interfaces we already have that we prefer to use to do that.)

## Technical Summary
This changes was inspired by this comment: https://github.com/dimagi/commcare-hq/pull/31917#pullrequestreview-1046255612.

## Safety Assurance

### Safety story
Only affects Django Admin interface, and in a way that just reduces the "mistake surface area".

### Automated test coverage

Added a test that makes sure the calculation works to achieve the result you'd get by copying `fieldsets` from UserAdmin and editing out the desired fields by hand.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
