### PR TITLE
Add metric for python deps on outdated major release

### DIFF
--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -1,7 +1,9 @@
 # Get total count of python dependencies and outdated python dependencies
 
-total_python_deps="$(pip list| wc -l)"
-outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/pip-dep-debt.py)"
+# skip 2 header lines (produced by pip list)
+total_python_deps="$(pip list | tail -n +3 | wc -l)"
+# skip 1 header line (produced by pip-dep-debt.py)
+outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/pip-dep-debt.py | tail -n +2)"
 outdated_python_deps=$(echo "${outdated_python_deps_list}" | wc -l)
 major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^[^0]' | wc -l)
 minor_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^0\.[^0]' | wc -l)

--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -1,8 +1,11 @@
 # Get total count of python dependencies and outdated python dependencies
 
 total_python_deps="$(pip list| wc -l)"
-outdated_python_deps="$(pip list --outdated| wc -l)"
-major_outdated_python_deps="$(pip list --format json --outdated | ./scripts/pip-dep-debt.py | grep -v '^0\.' | wc -l)"
+outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/pip-dep-debt.py)"
+outdated_python_deps="$(echo ${outdated_python_deps_list} | wc -l)"
+major_outdated_python_deps="$(echo ${outdated_python_deps_list} | grep '^[^0]' | wc -l)"
+minor_outdated_python_deps="$(echo ${outdated_python_deps_list} | grep '^0\.[^0]' | wc -l)"
+patch_outdated_python_deps="$(echo ${outdated_python_deps_list} | grep '^0\.0\.[^0]' | wc -l)"
 
 # Get outdated JS dependency count
 
@@ -43,6 +46,8 @@ source scripts/datadog-utils.sh
 send_metric_to_datadog "commcare.static_analysis.dependency.python.total" $total_python_deps "gauge"
 send_metric_to_datadog "commcare.static_analysis.dependency.python.outdated" $outdated_python_deps "gauge"
 send_metric_to_datadog "commcare.static_analysis.dependency.python.major_outdated" $major_outdated_python_deps "gauge"
+send_metric_to_datadog "commcare.static_analysis.dependency.python.minor_outdated" $minor_outdated_python_deps "gauge"
+send_metric_to_datadog "commcare.static_analysis.dependency.python.patch_outdated" $patch_outdated_python_deps "gauge"
 
 
 send_metric_to_datadog "commcare.static_analysis.dependency.js.total" $total_js_deps "gauge"

--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -2,10 +2,10 @@
 
 total_python_deps="$(pip list| wc -l)"
 outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/pip-dep-debt.py)"
-outdated_python_deps="$(echo ${outdated_python_deps_list} | wc -l)"
-major_outdated_python_deps="$(echo ${outdated_python_deps_list} | grep '^[^0]' | wc -l)"
-minor_outdated_python_deps="$(echo ${outdated_python_deps_list} | grep '^0\.[^0]' | wc -l)"
-patch_outdated_python_deps="$(echo ${outdated_python_deps_list} | grep '^0\.0\.[^0]' | wc -l)"
+outdated_python_deps=$(echo "${outdated_python_deps_list}" | wc -l)
+major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^[^0]' | wc -l)
+minor_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^0\.[^0]' | wc -l)
+patch_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^0\.0\.[^0]' | wc -l)
 
 # Get outdated JS dependency count
 

--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -2,6 +2,7 @@
 
 total_python_deps="$(pip list| wc -l)"
 outdated_python_deps="$(pip list --outdated| wc -l)"
+major_outdated_python_deps="$(pip list --format json --outdated | ./scripts/pip-dep-debt.py | grep -v '^0\.' | wc -l)"
 
 # Get outdated JS dependency count
 
@@ -41,6 +42,7 @@ source scripts/datadog-utils.sh
 
 send_metric_to_datadog "commcare.static_analysis.dependency.python.total" $total_python_deps "gauge"
 send_metric_to_datadog "commcare.static_analysis.dependency.python.outdated" $outdated_python_deps "gauge"
+send_metric_to_datadog "commcare.static_analysis.dependency.python.major_outdated" $major_outdated_python_deps "gauge"
 
 
 send_metric_to_datadog "commcare.static_analysis.dependency.js.total" $total_js_deps "gauge"


### PR DESCRIPTION
## Technical Summary
Add metric for python deps on outdated major release as opposed to any outdated version

## Safety Assurance

### Safety story
Runs only during tests, metrics only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
