### PR TITLE
Fix ESQuery scroll size bugs

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -99,7 +99,7 @@ from corehq.elastic import (
 )
 
 from . import aggregations, filters, queries
-from .const import SIZE_LIMIT
+from .const import SCROLL_SIZE, SIZE_LIMIT
 from .registry import verify_registered
 from .utils import flatten_field_dict, values_list
 
@@ -210,7 +210,16 @@ class ESQuery(object):
         Run the query against the scroll api. Returns an iterator yielding each
         document that matches the query.
         """
-        result = scroll_query(self.index, self.raw_query, for_export=self.for_export)
+        # FIXME: we should crash if someone tries this:
+        # if self.uses_aggregations():
+        #     raise Error("aggregation scroll queries will yield invalid hits "
+        #                 "if the scroll requires more than one request.")
+        raw_query = self.raw_query
+        raw_query["size"] = SCROLL_SIZE if self._size is None else self._size
+        # The '_assemble()' method sets size=SIZE_LIMIT when no query size is
+        # configured, and overrides that with size=0 for aggregation queries,
+        # neither of which are acceptable for a scroll query.
+        result = scroll_query(self.index, raw_query, for_export=self.for_export)
         for r in result:
             yield ESQuerySet.normalize_result(self, r)
 
@@ -346,7 +355,10 @@ class ESQuery(object):
         return query
 
     def size(self, size):
-        """Restrict number of results returned.  Analagous to SQL limit."""
+        """Restrict number of results returned. Analagous to SQL limit, except
+        when performing a scroll, in which case this value becomes the number of
+        results to fetch per scroll request.
+        """
         query = deepcopy(self)
         query._size = size
         return query
@@ -459,7 +471,7 @@ class ESQuery(object):
 
     def scroll_ids(self):
         """Returns a generator of all matching ids"""
-        return self.exclude_source().size(5000).scroll()
+        return self.exclude_source().scroll()
 
 
 class ESQuerySet(object):

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -286,6 +286,20 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
         query = HQESQuery('forms').domain('test-exclude').exclude_source()
         self.checkQuery(query, json_output)
 
+    def test_scroll_uses_scroll_size_from_query(self):
+        query = HQESQuery('forms').size(1)
+        self.assertEqual(1, query._size)
+        scroll_query_testfunc = self._scroll_query_mock_assert(size=1)
+        with patch("corehq.apps.es.es_query.scroll_query", scroll_query_testfunc):
+            list(query.scroll())
+
+    def test_scroll_without_query_size_uses_default_scroll_size(self):
+        query = HQESQuery('forms')
+        self.assertIsNone(query._size)
+        scroll_query_testfunc = self._scroll_query_mock_assert(size=SCROLL_SIZE)
+        with patch("corehq.apps.es.es_query.scroll_query", scroll_query_testfunc):
+            list(query.scroll())
+
     def test_scroll_ids_uses_scroll_size_from_query(self):
         query = HQESQuery('forms').size(1)
         self.assertEqual(1, query._size)

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from django.test import SimpleTestCase
 
 from corehq.apps.es import filters, forms, users
-from corehq.apps.es.const import SIZE_LIMIT
+from corehq.apps.es.const import SCROLL_SIZE, SIZE_LIMIT
 from corehq.apps.es.es_query import HQESQuery
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 
@@ -285,3 +285,25 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
         }
         query = HQESQuery('forms').domain('test-exclude').exclude_source()
         self.checkQuery(query, json_output)
+
+    def test_scroll_ids_uses_scroll_size_from_query(self):
+        query = HQESQuery('forms').size(1)
+        self.assertEqual(1, query._size)
+        scroll_query_testfunc = self._scroll_query_mock_assert(size=1)
+        with patch("corehq.apps.es.es_query.scroll_query", scroll_query_testfunc):
+            list(query.scroll_ids())
+
+    def test_scroll_ids_without_query_size_uses_default_scroll_size(self):
+        query = HQESQuery('forms')
+        self.assertIsNone(query._size)
+        scroll_query_testfunc = self._scroll_query_mock_assert(size=SCROLL_SIZE)
+        with patch("corehq.apps.es.es_query.scroll_query", scroll_query_testfunc):
+            list(query.scroll_ids())
+
+    def _scroll_query_mock_assert(self, **raw_query_assertions):
+        def scroll_query_tester(index, raw_query, **kw):
+            for key, value in raw_query_assertions.items():
+                self.assertEqual(value, raw_query[key])
+            return []
+        self.assertNotEqual({}, raw_query_assertions)
+        return scroll_query_tester


### PR DESCRIPTION
## Technical Summary

Possible fix for ticket: [SAAS-13736](https://dimagi-dev.atlassian.net/browse/SAAS-13736) (hopeful thinking :crossed_fingers:, still a valuable change if not).

- Use `size=SCROLL_SIZE` instead of `size=SIZE_LIMIT` for size-undefined scroll queries.
- Do not hard-code `.scroll_ids()` method to a scroll size of 5000.

## Safety Assurance

### Safety story

Side-effects:
1. Drops `.scroll_ids()` scroll request "page size" from hard-coded 5k to configured query size (1k by default) -- safe because 1k is an existing "sensible default" size for scroll requests. This change is hoped to resolve the linked ticket.
2. Drops the default (queries that do not specify a size) scroll request "page size" from 10k to 1k -- advantageous since we have evidence of 5k-size scroll requests timing out, so defaulting to 10k (maximum allowed for a single request) is nonsensical for pagination.

### Automated test coverage

New tests around `ESQuery` scroll request size behavior.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
