### PR TITLE
Add metrics for python deps outdated by more than 1 major version

### DIFF
--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -5,7 +5,8 @@ total_python_deps="$(pip list | tail -n +3 | wc -l)"
 # skip 1 header line (produced by pip-dep-debt.py)
 outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/pip-dep-debt.py | tail -n +2)"
 outdated_python_deps=$(echo "${outdated_python_deps_list}" | wc -l)
-major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^[^0]' | wc -l)
+multi_major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^[^01]' | wc -l)
+major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^1' | wc -l)
 minor_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^0\.[^0]' | wc -l)
 patch_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^0\.0\.[^0]' | wc -l)
 
@@ -47,6 +48,7 @@ source scripts/datadog-utils.sh
 
 send_metric_to_datadog "commcare.static_analysis.dependency.python.total" $total_python_deps "gauge"
 send_metric_to_datadog "commcare.static_analysis.dependency.python.outdated" $outdated_python_deps "gauge"
+send_metric_to_datadog "commcare.static_analysis.dependency.python.multi_major_outdated" $multi_major_outdated_python_deps "gauge"
 send_metric_to_datadog "commcare.static_analysis.dependency.python.major_outdated" $major_outdated_python_deps "gauge"
 send_metric_to_datadog "commcare.static_analysis.dependency.python.minor_outdated" $minor_outdated_python_deps "gauge"
 send_metric_to_datadog "commcare.static_analysis.dependency.python.patch_outdated" $patch_outdated_python_deps "gauge"


### PR DESCRIPTION
## Technical Summary
Follow up to #31927. I realized maybe the best goal would be "have all libraries be on the latest or second latest major version", and so this PR adds a measure for deps more than one major version out of date. Getting that to permanent zero I think _is_ actually a sustainable goal.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
