### PR TITLE
base implementation of hq project limits for APIs

### DIFF
--- a/corehq/apps/api/odata/tests/test_feed.py
+++ b/corehq/apps/api/odata/tests/test_feed.py
@@ -20,9 +20,11 @@ from corehq.apps.export.models import (
 from corehq.apps.es.tests.utils import es_test
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.util.elastic import reset_es_index
+from corehq.util.test_utils import flag_enabled
 
 
 @es_test
+@flag_enabled('API_THROTTLE_WHITELIST')
 class TestODataCaseFeed(TestCase, CaseOdataTestMixin):
 
     @classmethod
@@ -110,6 +112,7 @@ class TestODataCaseFeed(TestCase, CaseOdataTestMixin):
 
 
 @es_test
+@flag_enabled('API_THROTTLE_WHITELIST')
 class TestODataFormFeed(TestCase, FormOdataTestMixin):
 
     @classmethod

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -4,6 +4,7 @@ from functools import wraps
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseForbidden
 
+from attrs import define, field
 from tastypie.authentication import Authentication
 
 from corehq.apps.api.odata.views import odata_permissions_check
@@ -36,11 +37,20 @@ def wrap_4xx_errors_for_apis(view_func):
     return _inner
 
 
+@define
+class ApiIdentifier:
+    username = field()
+    domain = field()
+
+
 def get_rate_limit_identifier(request):
-    username = request.couch_user.username
-    if API_THROTTLE_WHITELIST.enabled(username):
-        return username
-    return f"{getattr(request, 'domain', '')}_{username}"
+    couch_user = getattr(request, 'couch_user', None)
+    if couch_user is not None:
+        username = couch_user.username
+    else:
+        username = ''
+    domain = getattr(request, 'domain', '')
+    return ApiIdentifier(username=username, domain=domain)
 
 
 class HQAuthenticationMixin:
@@ -51,6 +61,10 @@ class HQAuthenticationMixin:
 
     def get_identifier(self, request):
         return get_rate_limit_identifier(request)
+
+
+class SSOAuthentication(HQAuthenticationMixin, Authentication):
+    pass
 
 
 class LoginAuthentication(HQAuthenticationMixin, Authentication):

--- a/corehq/apps/api/resources/meta.py
+++ b/corehq/apps/api/resources/meta.py
@@ -1,11 +1,38 @@
 from django.conf import settings
 
 from tastypie.authorization import ReadOnlyAuthorization
-from tastypie.throttle import CacheDBThrottle
+from tastypie.throttle import BaseThrottle
 
 from corehq.apps.api.resources.auth import LoginAndDomainAuthentication
 from corehq.apps.api.serializers import CustomXMLSerializer
+from corehq.project_limits.rate_limiter import (
+    PerUserRateDefinition,
+    RateDefinition,
+    RateLimiter,
+    get_dynamic_rate_definition,
+)
+from corehq.project_limits.shortcuts import get_standard_ratio_rate_definition
 from corehq.toggles import API_THROTTLE_WHITELIST
+
+
+
+api_rate_limiter = RateLimiter(
+    feature_key='api',
+    get_rate_limits=lambda domain: _get_per_user_api_rate_definition(domain)
+)
+
+
+def _get_per_user_api_rate_definition(domain):
+    return PerUserRateDefinition(
+        per_user_rate_definition=get_standard_ratio_rate_definition(events_per_day=1000),
+        constant_rate_definition=RateDefinition(
+                per_week=100,
+                per_day=50,
+                per_hour=30,
+                per_minute=10,
+                per_second=1,
+            ),
+    ).get_rate_limits(domain)
 
 
 def get_hq_throttle():
@@ -15,13 +42,14 @@ def get_hq_throttle():
     )
 
 
-class HQThrottle(CacheDBThrottle):
+class HQThrottle(BaseThrottle):
 
     def should_be_throttled(self, identifier, **kwargs):
-        if API_THROTTLE_WHITELIST.enabled(identifier):
+        if API_THROTTLE_WHITELIST.enabled(identifier.username):
             return False
 
-        return super(HQThrottle, self).should_be_throttled(identifier, **kwargs)
+        return api_rate_limiter.allow_usage(identifier.domain)
+
 
     def accessed(self, identifier, **kwargs):
         """
@@ -34,16 +62,13 @@ class HQThrottle(CacheDBThrottle):
         # only required when using this throttling mechanism.
         from tastypie.models import ApiAccess
 
-        # only record in redis if we need the throttle, otherwise skip
-        # and just leave the db logging
-        if not API_THROTTLE_WHITELIST.enabled(identifier):
-            super(CacheDBThrottle, self).accessed(identifier, **kwargs)
+        api_rate_limiter.report_usage(identifier.domain)
         # Write out the access to the DB for logging purposes.
         url = kwargs.get('url', '')
         if len(url) > 255:
             url = url[:251] + '...'
         ApiAccess.objects.create(
-            identifier=identifier,
+            identifier=identifier.username,
             url=url,
             request_method=kwargs.get('request_method', '')
         )

--- a/corehq/apps/api/resources/meta.py
+++ b/corehq/apps/api/resources/meta.py
@@ -42,7 +42,7 @@ class HQThrottle(BaseThrottle):
         if API_THROTTLE_WHITELIST.enabled(identifier.username):
             return False
 
-        return api_rate_limiter.allow_usage(identifier.domain)
+        return not api_rate_limiter.allow_usage(identifier.domain)
 
 
     def accessed(self, identifier, **kwargs):

--- a/corehq/apps/api/resources/meta.py
+++ b/corehq/apps/api/resources/meta.py
@@ -9,30 +9,24 @@ from corehq.project_limits.rate_limiter import (
     PerUserRateDefinition,
     RateDefinition,
     RateLimiter,
-    get_dynamic_rate_definition,
 )
 from corehq.project_limits.shortcuts import get_standard_ratio_rate_definition
 from corehq.toggles import API_THROTTLE_WHITELIST
 
 
-
 api_rate_limiter = RateLimiter(
     feature_key='api',
-    get_rate_limits=lambda domain: _get_per_user_api_rate_definition(domain)
-)
-
-
-def _get_per_user_api_rate_definition(domain):
-    return PerUserRateDefinition(
+    get_rate_limits=PerUserRateDefinition(
         per_user_rate_definition=get_standard_ratio_rate_definition(events_per_day=1000),
         constant_rate_definition=RateDefinition(
-                per_week=100,
-                per_day=50,
-                per_hour=30,
-                per_minute=10,
-                per_second=1,
-            ),
-    ).get_rate_limits(domain)
+            per_week=100,
+            per_day=50,
+            per_hour=30,
+            per_minute=10,
+            per_second=1,
+        ),
+    ).get_rate_limits
+)
 
 
 def get_hq_throttle():

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -36,6 +36,7 @@ from corehq.apps.api.resources.auth import (
     DomainAdminAuthentication,
     LoginAndDomainAuthentication,
     RequirePermissionAuthentication,
+    SSOAuthentication,
 )
 from corehq.apps.api.resources.meta import CustomResourceMeta
 from corehq.apps.api.resources.v0_1 import _safe_bool
@@ -361,7 +362,7 @@ class SingleSignOnResource(HqBaseResource, DomainSpecificResourceMixin):
         return HttpResponseForbidden()
 
     class Meta(CustomResourceMeta):
-        authentication = Authentication()
+        authentication = SSOAuthentication()
         resource_name = 'sso'
         detail_allowed_methods = []
         list_allowed_methods = ['post']

--- a/corehq/apps/api/tests/core_api.py
+++ b/corehq/apps/api/tests/core_api.py
@@ -714,8 +714,8 @@ class TestApiThrottle(APIResourceTest):
     def test_throttle_allowlist(self):
         """Test that the allowlist toggle allows all traffic through
         """
-        with patch('corehq.apps.api.resources.meta.BaseThrottle.should_be_throttled') as should_be_throttled:
-            should_be_throttled.return_value = True
+        with patch('corehq.apps.api.resources.meta.api_rate_limiter.allow_usage') as allow_access:
+            allow_access.return_value = False
 
             response = self.client.get(self.endpoint)
             self.assertEqual(response.status_code, 429)

--- a/corehq/apps/api/tests/core_api.py
+++ b/corehq/apps/api/tests/core_api.py
@@ -25,6 +25,7 @@ from corehq.apps.api.fields import (
     UseIfRequested,
 )
 from corehq.apps.api.resources import v0_4, v0_5
+from corehq.apps.api.resources.auth import ApiIdentifier
 from corehq.apps.api.util import get_obj
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
@@ -713,7 +714,7 @@ class TestApiThrottle(APIResourceTest):
     def test_throttle_allowlist(self):
         """Test that the allowlist toggle allows all traffic through
         """
-        with patch('corehq.apps.api.resources.meta.CacheDBThrottle.should_be_throttled') as should_be_throttled:
+        with patch('corehq.apps.api.resources.meta.BaseThrottle.should_be_throttled') as should_be_throttled:
             should_be_throttled.return_value = True
 
             response = self.client.get(self.endpoint)
@@ -732,11 +733,11 @@ class TestApiThrottle(APIResourceTest):
         with patch('corehq.apps.api.resources.meta.HQThrottle.should_be_throttled') as hq_should_be_throttled:
 
             self.client.get(self.endpoint)
-            hq_should_be_throttled.assert_called_with(f"{self.domain}_{self.user.username}")
+            hq_should_be_throttled.assert_called_with(ApiIdentifier(domain=self.domain.name, username=self.user.username))
 
             with patch('corehq.apps.api.resources.meta.API_THROTTLE_WHITELIST.enabled') as toggle_patch:
                 toggle_patch.return_value = True
 
                 self.client.get(self.endpoint)
 
-                hq_should_be_throttled.assert_called_with(self.user.username)
+                hq_should_be_throttled.assert_called_with(ApiIdentifier(domain=self.domain.name, username=self.user.username))

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -300,11 +300,5 @@ class HQApiKeyAuthentication(ApiKeyAuthentication):
 
         """
         username = self.extract_credentials(request)[0]
-        if API_THROTTLE_WHITELIST.enabled(username):
-            return username
-
-        try:
-            api_key = self.extract_credentials(request)[1]
-        except ValueError:
-            api_key = ''
-        return f"{getattr(request, 'domain', '')}_{api_key}"
+        domain = getattr(request, 'domain', '')
+        return ApiIdentifier(username=username, domain=domain)

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -15,7 +15,6 @@ from tastypie.authentication import ApiKeyAuthentication
 from dimagi.utils.django.request import mutable_querydict
 from dimagi.utils.web import get_ip
 
-from corehq.apps.api.resources.auth import ApiIdentifier
 from corehq.apps.receiverwrapper.util import DEMO_SUBMIT_MODE
 from corehq.apps.users.models import CouchUser, HQApiKey
 from corehq.toggles import API_THROTTLE_WHITELIST, TWO_STAGE_USER_PROVISIONING
@@ -300,6 +299,9 @@ class HQApiKeyAuthentication(ApiKeyAuthentication):
         are domain specific.
 
         """
+        # inline to avoid circular import
+        from corehq.apps.api.resources.auth import ApiIdentifier
+
         username = self.extract_credentials(request)[0]
         domain = getattr(request, 'domain', '')
         return ApiIdentifier(username=username, domain=domain)

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -15,6 +15,7 @@ from tastypie.authentication import ApiKeyAuthentication
 from dimagi.utils.django.request import mutable_querydict
 from dimagi.utils.web import get_ip
 
+from corehq.apps.api.resources.auth import ApiIdentifier
 from corehq.apps.receiverwrapper.util import DEMO_SUBMIT_MODE
 from corehq.apps.users.models import CouchUser, HQApiKey
 from corehq.toggles import API_THROTTLE_WHITELIST, TWO_STAGE_USER_PROVISIONING

--- a/corehq/apps/enterprise/tests/test_permissions.py
+++ b/corehq/apps/enterprise/tests/test_permissions.py
@@ -14,6 +14,7 @@ from corehq.apps.users.models import (
     UserRole,
     WebUser,
 )
+from corehq.util.test_utils import flag_enabled
 
 
 class EnterprisePermissionsTest(TestCase):
@@ -86,6 +87,7 @@ class EnterprisePermissionsTest(TestCase):
         self.assertFalse(self.web_user_admin.has_permission(domain, "view_groups"))
         self.assertFalse(self.web_user_admin.has_permission(domain, "edit_groups"))
 
+    @flag_enabled('API_THROTTLE_WHITELIST')
     def test_api_call(self):
         url = reverse('api_dispatch_list', kwargs={
             'domain': 'county',

--- a/corehq/apps/zapier/tests/test_polling.py
+++ b/corehq/apps/zapier/tests/test_polling.py
@@ -11,8 +11,10 @@ from corehq.apps.app_manager.models import Application
 from corehq.apps.api.models import ESXFormInstance
 
 from corehq.apps.zapier.api.v0_5 import ZapierApplicationResource, ZapierXFormInstanceResource
+from corehq.util.test_utils import flag_enabled
 
 
+@flag_enabled('API_THROTTLE_WHITELIST')
 class XFormPollingTests(SimpleTestCase):
     def test_can_poll_with_only_zapier_privilege(self):
         self.forms = [self._create_form(id='7', domain='test-domain')]
@@ -80,6 +82,7 @@ class XFormPollingTests(SimpleTestCase):
         return self.forms
 
 
+@flag_enabled('API_THROTTLE_WHITELIST')
 class ApplicationPollingTests(SimpleTestCase):
     def test_can_poll_with_only_zapier_privilege(self):
         self.applications = [self._create_app('1'), self._create_app('2')]


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This applies standard hq rate limiting (shared across the enterprise rather than per user) to APIs, allowing projects to meaningfully have designated integration users without having to exempt from rate limiting.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13532

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
APIs are relatively well tested and the project limit framework being used is heavily used elsewhere in critical code (including form submissions). Additionally, this should represent increased limits for most API users, so should not disrupt existing workflows. I also plan to test this manually on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
We have automated tests for both APIs and the rate limiter used.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
