### PR TITLE
Add rich metrics for outdated JS dependencies

### DIFF
--- a/scripts/outdated-dependency-metrics.py
+++ b/scripts/outdated-dependency-metrics.py
@@ -85,10 +85,10 @@ def package_list(stream, stream_parser, labels=True):
         if labels:
             print_line("Behind", "Package", "Latest", "Version")
         for delta, name, current, latest in records:
-            if delta is None:
-                behind = "n/a"
-            else:
+            if delta:
                 behind = ".".join(str(v) for v in delta)
+            else:
+                behind = "n/a"
             print_line(behind, name, current, latest)
     except IOError:
         pass
@@ -110,9 +110,7 @@ def package_stats(stream, stream_parser, labels=True):
         "Exotic": 0,
     }
     for delta, name, current, latest in stream_parser(stream):
-        if delta is None:
-            key = "Exotic"
-        else:
+        if delta:
             major, minor, patch = delta
             if major:
                 assert not minor and not patch, delta
@@ -126,6 +124,8 @@ def package_stats(stream, stream_parser, labels=True):
             else:
                 assert patch and not major and not minor, delta
                 key = "Patch"
+        else:
+            key = "Exotic"
         stats[key] += 1
         stats["Outdated"] += 1
     # NOTE: subtle detail: we're depending on Python 3's ordered dict to
@@ -165,7 +165,7 @@ def parse_yarn(stream):
         latest = pkg["Latest"]
         current = pkg["Current"]
         if latest == "exotic":
-            delta = None
+            delta = []
         else:
             delta = behind(latest, current)
         yield delta, name, latest, current

--- a/scripts/outdated-dependency-metrics.py
+++ b/scripts/outdated-dependency-metrics.py
@@ -30,7 +30,6 @@ Enjoy!
 import argparse
 import json
 import sys
-from functools import cmp_to_key
 
 
 def main():
@@ -81,10 +80,7 @@ def package_list(stream, stream_parser, labels=True):
     def print_line(behind, name, current, latest):
         print(f"{behind:8s} {name:28s} {current:12s} {latest}")
 
-    records = sorted(
-        stream_parser(stream),
-        key=cmp_to_key(compare_yarn_versions) if stream_parser == parse_yarn else None
-    )
+    records = sorted(stream_parser(stream))
     try:
         if labels:
             print_line("Behind", "Package", "Latest", "Version")
@@ -143,23 +139,6 @@ def parse_pip(stream):
         latest = pkg["latest_version"]
         current = pkg["version"]
         yield behind(latest, current), pkg["name"], latest, current
-
-
-def compare_yarn_versions(x, y):
-    try:
-        if x < y:
-            return -1
-        elif y > x:
-            return 1
-        else:
-            return 0
-    except TypeError:
-        if isinstance(x[0], list) and y[0] is None:
-            return -1
-        elif isinstance(y[0], list) and x[0] is None:
-            return 1
-        else:
-            return 0
 
 
 def parse_yarn(stream):

--- a/scripts/outdated-dependency-metrics.py
+++ b/scripts/outdated-dependency-metrics.py
@@ -18,9 +18,9 @@ Behind   Package                  Latest       Version
 
 
 $ yarn outdated --json | ./scripts/outdated-dependency-metrics.py yarn
-WARNING: skipping exotic package: knockout-validation
-...
 Behind   Package                      Latest       Version
+n/a      At.js                        exotic       1.5.3
+...
 0.0.1    bootstrap-timepicker         0.5.2        0.5.1
 ...
 12.0.0   sinon                        14.0.0       2.3.2

--- a/scripts/outdated-dependency-metrics.py
+++ b/scripts/outdated-dependency-metrics.py
@@ -13,7 +13,7 @@ TODO:
 
 USAGE:
 
-$ pip list --format json --outdated | ./scripts/pip-dep-debt.py
+$ pip list --format json --outdated | ./scripts/outdated-dependency-metrics.py
 Behind   Package                  Latest       Version
 0.0.1    colorama                 0.4.4        0.4.3
 0.0.1    django-appconf           1.0.5        1.0.4
@@ -23,7 +23,7 @@ Behind   Package                  Latest       Version
 21.0.0   contextlib2              21.6.0       0.6.0.post1
 
 # quiet down, pip!
-$ pip list --format json --outdated 2>/dev/null | ./scripts/pip-dep-debt.py
+$ pip list --format json --outdated 2>/dev/null | ./scripts/outdated-dependency-metrics.py
 ...
 
 Enjoy!

--- a/scripts/outdated-dependency-metrics.py
+++ b/scripts/outdated-dependency-metrics.py
@@ -50,14 +50,23 @@ def main():
         help="read package (JSON) information from %(metavar)s, specify a dash "
              "(-) to read from STDIN (the default).",
     )
+    parser.add_argument(
+        "--no-labels",
+        dest="labels",
+        default=True,
+        action="store_false",
+        help="do not print data labels in the output",
+    )
+
     opts = parser.parse_args()
-    package_list(opts.in_file, stream_parsers[opts.format])
+    package_list(opts.in_file, stream_parsers[opts.format], opts.labels)
 
 
-def package_list(stream, stream_parser):
+def package_list(stream, stream_parser, labels=True):
     records = sorted(stream_parser(stream))
     try:
-        print_line("Behind", "Package", "Latest", "Version")
+        if labels:
+            print_line("Behind", "Package", "Latest", "Version")
         for delta, name, current, latest in records:
             print_line(".".join(str(v) for v in delta), name, current, latest)
     except IOError:

--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -3,7 +3,7 @@
 # skip 2 header lines (produced by pip list)
 total_python_deps="$(pip list | tail -n +3 | wc -l)"
 # skip 1 header line (produced by outdated-dependency-metrics.py)
-outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/outdated-dependency-metrics.py | tail -n +2)"
+outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/outdated-dependency-metrics.py pip | tail -n +2)"
 outdated_python_deps=$(echo "${outdated_python_deps_list}" | wc -l)
 multi_major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^[^01]' | wc -l)
 major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^1' | wc -l)

--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -1,57 +1,97 @@
-# Get total count of python dependencies and outdated python dependencies
+#!/usr/bin/env bash
 
-# skip 2 header lines (produced by pip list)
-total_python_deps="$(pip list | tail -n +3 | wc -l)"
-outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/outdated-dependency-metrics.py pip --no-labels)"
-outdated_python_deps=$(echo "${outdated_python_deps_list}" | wc -l)
-multi_major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^[^01]' | wc -l)
-major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^1' | wc -l)
-minor_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^0\.[^0]' | wc -l)
-patch_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^0\.0\.[^0]' | wc -l)
+set -e
 
-# Get outdated JS dependency count
+# import the datadog utils
+source ./scripts/datadog-utils.sh
 
-function outdated_count {
-    python - <(cat -) <<-END
-import json
-import sys
-with open(sys.argv[1], "r") as json_file:
-    dep_arr = json.load(json_file)
-print(len(dep_arr["data"]["body"]))
-END
+send_to_datadog=true
+
+
+function main {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                usage
+                return 0
+                ;;
+            -n|--dry-run)
+                echo "[DRY RUN] no metrics will be sent to datadog" >&2
+                # I would rather not use a global for this, but passing it two
+                # function calls deep feels messier in this case.
+                send_to_datadog=false
+                ;;
+            *)
+                usage "invalid args: $*"
+                return 1
+                ;;
+        esac
+        shift
+    done
+    local total=0
+
+    # get total Python dependency count (skip 2 header lines)
+    total=$(pip list 2>/dev/null | tail -n +3 | wc -l)
+    # publish python metrics
+    pip list --format json --outdated 2>/dev/null | publish_metrics python pip "$total"
+
+    # get total JS dependency count (skip the first and last lines)
+    total=$(yarn list --depth 0 | tail -n+2 | head -n-1 | wc -l)
+    # publish javascript metrics
+    yarn outdated --json | publish_metrics js yarn "$total"
 }
 
-outdated_js_deps="$(yarn outdated --json | sed -n 2p | outdated_count)"
 
+function publish_metrics {
+    local metric_id="$1"
+    local data_format="$2"
+    local total="$3"
 
-# Get total JS dependencies from package.json
+    local metric_prefix="commcare.static_analysis.dependency.${metric_id}"
+    local stats=$(cat - | ./scripts/outdated-dependency-metrics.py "$data_format" --stats)
 
-function dependency_count {
-    local json_path="$1"
-    python - "$json_path" <<-END
-import json
-import sys
+    local outdated=$(outdated_stat Outdated "$stats")
+    local multmajor=$(outdated_stat Multi-Major "$stats")
+    local major=$(outdated_stat Major "$stats")
+    local minor=$(outdated_stat Minor "$stats")
+    local patch=$(outdated_stat Patch "$stats")
+    local exotic=$(outdated_stat Exotic "$stats")
 
-with open(sys.argv[1], "r") as json_file:
-    packages = json.load(json_file)
-
-print(sum(len(packages[k]) for k in ["dependencies", "devDependencies"]))
-END
+    publish_datadog_gauge "${metric_prefix}.total" "$total"
+    publish_datadog_gauge "${metric_prefix}.outdated" "$outdated"
+    publish_datadog_gauge "${metric_prefix}.multi_major_outdated" "$multmajor"
+    publish_datadog_gauge "${metric_prefix}.major_outdated" "$major"
+    publish_datadog_gauge "${metric_prefix}.minor_outdated" "$minor"
+    publish_datadog_gauge "${metric_prefix}.patch_outdated" "$patch"
+    publish_datadog_gauge "${metric_prefix}.exotic_outdated" "$exotic"
 }
 
-total_js_deps=$(dependency_count package.json)
 
-# Publish metrics to Datadog
-
-source scripts/datadog-utils.sh
-
-send_metric_to_datadog "commcare.static_analysis.dependency.python.total" $total_python_deps "gauge"
-send_metric_to_datadog "commcare.static_analysis.dependency.python.outdated" $outdated_python_deps "gauge"
-send_metric_to_datadog "commcare.static_analysis.dependency.python.multi_major_outdated" $multi_major_outdated_python_deps "gauge"
-send_metric_to_datadog "commcare.static_analysis.dependency.python.major_outdated" $major_outdated_python_deps "gauge"
-send_metric_to_datadog "commcare.static_analysis.dependency.python.minor_outdated" $minor_outdated_python_deps "gauge"
-send_metric_to_datadog "commcare.static_analysis.dependency.python.patch_outdated" $patch_outdated_python_deps "gauge"
+function outdated_stat {
+    local label="$1"
+    local stats="$2"
+    echo "$stats" | grep -E "^${label}: " | awk -F': ' '{print $2}'
+}
 
 
-send_metric_to_datadog "commcare.static_analysis.dependency.js.total" $total_js_deps "gauge"
-send_metric_to_datadog "commcare.static_analysis.dependency.js.outdated" $outdated_js_deps "gauge"
+function publish_datadog_gauge {
+    local metric_path="$1"
+    local value="$2"
+    echo "$metric_path == $value"
+    if $send_to_datadog; then
+        send_metric_to_datadog "$metric_path" "$value" gauge
+    fi
+}
+
+
+function usage {
+    local script=$(basename "$0")
+    local msg="$*"
+    echo "USAGE: $script [-h|--help] [-n|--dry-run]" >&2
+    if [ -n "$msg" ]; then
+        echo "ERROR: $msg" >&2
+    fi
+}
+
+
+main "$@"

--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -2,8 +2,8 @@
 
 # skip 2 header lines (produced by pip list)
 total_python_deps="$(pip list | tail -n +3 | wc -l)"
-# skip 1 header line (produced by pip-dep-debt.py)
-outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/pip-dep-debt.py | tail -n +2)"
+# skip 1 header line (produced by outdated-dependency-metrics.py)
+outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/outdated-dependency-metrics.py | tail -n +2)"
 outdated_python_deps=$(echo "${outdated_python_deps_list}" | wc -l)
 multi_major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^[^01]' | wc -l)
 major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^1' | wc -l)

--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -2,8 +2,7 @@
 
 # skip 2 header lines (produced by pip list)
 total_python_deps="$(pip list | tail -n +3 | wc -l)"
-# skip 1 header line (produced by outdated-dependency-metrics.py)
-outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/outdated-dependency-metrics.py pip | tail -n +2)"
+outdated_python_deps_list="$(pip list --format json --outdated | ./scripts/outdated-dependency-metrics.py pip --no-labels)"
 outdated_python_deps=$(echo "${outdated_python_deps_list}" | wc -l)
 multi_major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^[^01]' | wc -l)
 major_outdated_python_deps=$(echo "${outdated_python_deps_list}" | grep '^1' | wc -l)


### PR DESCRIPTION
## Technical Summary

As promised in the Dependency Pod meeting today:
- update `outdated-dependency-metrics.py` (previously `pip-dep-debt.py`) to parse yarn outdated information
- update `track-dependency-status.sh` to publish full outdated metrics for both Python and JS (to datadog)

## Safety Assurance

### Safety story

Developer utilities only, not product-related.

### Automated test coverage

Utils only, no tests.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
