### PR TITLE
Prohibit ESQuery aggregations with scroll queries

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -104,6 +104,10 @@ from .registry import verify_registered
 from .utils import flatten_field_dict, values_list
 
 
+class InvalidQueryError(Exception):
+    """Query parameters cannot be assembled into a valid search."""
+
+
 class ESQuery(object):
     """
     This query builder only outputs the following query structure::
@@ -210,10 +214,11 @@ class ESQuery(object):
         Run the query against the scroll api. Returns an iterator yielding each
         document that matches the query.
         """
-        # FIXME: we should crash if someone tries this:
-        # if self.uses_aggregations():
-        #     raise Error("aggregation scroll queries will yield invalid hits "
-        #                 "if the scroll requires more than one request.")
+        if self.uses_aggregations():
+            raise InvalidQueryError(
+                "aggregation scroll queries will yield invalid hits if the "
+                "scroll requires more than one request."
+            )
         raw_query = self.raw_query
         raw_query["size"] = SCROLL_SIZE if self._size is None else self._size
         # The '_assemble()' method sets size=SIZE_LIMIT when no query size is

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -4,7 +4,7 @@ from django.test import SimpleTestCase
 
 from corehq.apps.es import filters, forms, users
 from corehq.apps.es.const import SCROLL_SIZE, SIZE_LIMIT
-from corehq.apps.es.es_query import HQESQuery
+from corehq.apps.es.es_query import HQESQuery, InvalidQueryError
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 
 
@@ -313,6 +313,14 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
         scroll_query_testfunc = self._scroll_query_mock_assert(size=SCROLL_SIZE)
         with patch("corehq.apps.es.es_query.scroll_query", scroll_query_testfunc):
             list(query.scroll_ids())
+
+    def test_scroll_with_aggregations_raises(self):
+        query = HQESQuery('forms').terms_aggregation('domain.exact', 'domain')
+        with (
+            patch("corehq.apps.es.es_query.scroll_query"),
+            self.assertRaises(InvalidQueryError),
+        ):
+            list(query.scroll())
 
     def _scroll_query_mock_assert(self, **raw_query_assertions):
         def scroll_query_tester(index, raw_query, **kw):

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -316,10 +316,7 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
 
     def test_scroll_with_aggregations_raises(self):
         query = HQESQuery('forms').terms_aggregation('domain.exact', 'domain')
-        with (
-            patch("corehq.apps.es.es_query.scroll_query"),
-            self.assertRaises(InvalidQueryError),
-        ):
+        with self.assertRaises(InvalidQueryError):
             list(query.scroll())
 
     def _scroll_query_mock_assert(self, **raw_query_assertions):

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -74,19 +74,6 @@ from corehq.util.es.elasticsearch import ConnectionError
 from corehq.util.test_utils import make_es_ready_form, trap_extra_setup
 
 
-def _forms_with_attachments(es_query):
-    query = es_query.source(['_id', 'external_blobs'])
-
-    for form in query.scroll():
-        try:
-            for attachment in form.get('external_blobs', {}).values():
-                if attachment['content_type'] != "text/xml":
-                    yield form
-                    continue
-        except AttributeError:
-            pass
-
-
 @es_test
 class BaseESAccessorsTest(TestCase):
 

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -391,6 +391,7 @@ class IndicatorPillowTest(TestCase):
     def tearDown(self):
         self.adapter.clear_table()
 
+    @flaky_slow
     @mock.patch('corehq.apps.userreports.specs.datetime')
     def _check_sample_doc_state(self, expected_indicators, datetime_mock):
         datetime_mock.utcnow.return_value = self.fake_time_now


### PR DESCRIPTION
## Technical Summary

Prohibit aggregated scroll queries as per [recommendation](https://github.com/dimagi/commcare-hq/pull/31931#discussion_r929263803) in #31931.

## Safety Assurance

### Safety story

Risk is medium because if there are aggregated scroll queries in the wild, they will now begin to crash. This would be a good result (albeit, interruption) because such queries are likely yielding invalid results.

This will be deployed to staging and sentry monitored for `InvalidQueryError`s.

**Update**: per the App Infrastructure meeting today: I checked to ensure aggregations are not used where existing scroll queries are performed. Here are the results of my research:

- `ESQuery.scroll()`:

  - :heavy_check_mark: `corehq/pillows/groups_to_user.py`
  - :heavy_check_mark: `corehq/apps/dump_reload/management/commands/dump_domain_data_raw.py`
  - :heavy_check_mark: `corehq/apps/reports/tests/test_esaccessors.py` -- Removed use of `.scroll()` in a dead helper function (no longer used), see 8a88d013.
  - :question: `corehq/apps/reports/standard/deployments.py` -- Calls `.scroll()` on an ESQuery object with complicated setup. I did not track down if there is any scenario where this query can have aggregations applied to it.
  - :question: `corehq/apps/reports/analytics/esaccessors.py` -- Calls `.scroll()` inside two different helper functions that accept ESQuery objects passed from the caller. I tried tracing them but found these helper functions being used in other helper functions and gave up trying to trace them all.
  - :heavy_check_mark: `corehq/apps/data_pipeline_audit/dbacessors.py`
  - :heavy_check_mark: `corehq/apps/data_interfaces/models.py`
  - :heavy_check_mark: `corehq/apps/data_analytics/esaccessors.py`
  - :heavy_check_mark: `corehq/apps/es/tests/test_esquery.py`
  - :heavy_check_mark: `corehq/apps/es/fake/es_query_fake.py`
  - :heavy_check_mark: `corehq/apps/es/es_query.py`

- `ESQuery.values_list(..., scroll=True)`:
  - :heavy_check_mark: `corehq/pillows/tasks.py`
  - :heavy_check_mark: `corehq/apps/reports/tasks.py`
  - :question: `corehq/apps/userreports/reports/filters/choice_providers.py` -- I think I reviewed all the queries this gets called on and they don't use aggregations, but it's possible I missed something.

### Automated test coverage

New test added for change.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
