### PR TITLE
Cs/sc 2079 form view ff

### DIFF
--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -24,7 +24,7 @@ from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.standard.cases.case_data import can_view_attachments
 from corehq.apps.reports.views import (
     get_form_attachment_response,
-    require_form_view_permission,
+    augmented_form_view_permissions,
 )
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CaseAttachment, CommCareCase
@@ -129,7 +129,7 @@ class CaseAttachmentAPI(View):
 
 
 @api_auth
-@require_form_view_permission
+@augmented_form_view_permissions
 @location_safe
 def view_form_attachment(request, domain, instance_id, attachment_id):
     return get_form_attachment_response(request, domain, instance_id, attachment_id)

--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -24,7 +24,7 @@ from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.standard.cases.case_data import can_view_attachments
 from corehq.apps.reports.views import (
     get_form_attachment_response,
-    augmented_form_view_permissions,
+    can_view_form_attachment,
 )
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CaseAttachment, CommCareCase
@@ -128,8 +128,7 @@ class CaseAttachmentAPI(View):
                                      content_type=mime_type)
 
 
-@api_auth
-@augmented_form_view_permissions
+@can_view_form_attachment
 @location_safe
 def view_form_attachment(request, domain, instance_id, attachment_id):
     return get_form_attachment_response(request, domain, instance_id, attachment_id)

--- a/corehq/apps/api/tests/form_resources.py
+++ b/corehq/apps/api/tests/form_resources.py
@@ -417,3 +417,12 @@ class TestViewFormAttachment(TestCase):
         # 404 status code means the request is successful, but resource is
         # not found which is OK for the purposes of this test
         self.assertEqual(response.status_code, 404)
+
+    def test_user_has_no_permission(self):
+        self.user.set_role(self.domain.name, 'none')
+        self.user.save()
+
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get(self.view_form_endpoint)
+
+        self.assertEqual(response.status_code, 403)

--- a/corehq/apps/api/tests/form_resources.py
+++ b/corehq/apps/api/tests/form_resources.py
@@ -391,13 +391,14 @@ class TestViewFormAttachment(TestCase):
         super(TestViewFormAttachment, self).tearDown()
 
     def _get_view_form_endpoint(self):
-        return reverse('api_form_attachment',
-                kwargs=dict(
-                    domain=self.domain.name,
-                    instance_id='5321',
-                    attachment_id='1234',
-                )
+        return reverse(
+            'api_form_attachment',
+            kwargs=dict(
+                domain=self.domain.name,
+                instance_id='5321',
+                attachment_id='1234',
             )
+        )
 
     @flag_enabled('VIEW_FORM_ATTACHMENT')
     def test_domain_has_feature_flag_enabled(self):

--- a/corehq/apps/api/tests/form_resources.py
+++ b/corehq/apps/api/tests/form_resources.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 from django.test import TestCase
 from django.utils.http import urlencode
+from django.urls import reverse
 
 from casexml.apps.case.mock import CaseBlock
 from dimagi.utils.parsing import json_format_datetime
@@ -17,8 +18,12 @@ from corehq.form_processor.tests.utils import create_form_for_test
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 from corehq.pillows.xform import transform_xform_for_elasticsearch
 from corehq.util.elastic import reset_es_index
+from corehq.apps.users.models import WebUser
+from corehq.apps.domain.models import Domain
+from django_prbac.models import Role
 
 from .utils import APIResourceTest, FakeFormESView
+from corehq.util.test_utils import flag_enabled
 
 
 @es_test
@@ -364,3 +369,54 @@ class TestXFormPillow(TestCase):
         self.assertFalse(isinstance(cleaned['form']['meta']['appVersion'], dict))
         self.assertTrue(isinstance(cleaned['form']['meta']['appVersion'], str))
         self.assertTrue(cleaned['form']['meta']['appVersion'], "CCODK:\"2.5.1\"(11126). v236 CC2.5b[11126] on April-15-2013")
+
+
+class TestViewFormAttachment(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        Role.get_cache().clear()
+        cls.domain = Domain.get_or_create_with_name('qwerty', is_active=True)
+        cls.view_form_endpoint = cls._get_view_form_endpoint()
+        cls.username = 'rudolph@qwerty.commcarehq.org'
+        cls.password = '***'
+        cls.user = WebUser.create(cls.domain.name, cls.username, cls.password, None, None,
+                                  email='rudoph@example.com', first_name='rudolph', last_name='commcare')
+        cls.user.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(deleted_by_domain=cls.domain.name, deleted_by=None)
+        cls.domain.delete()
+        super(TestViewFormAttachment, cls).tearDownClass()
+
+    @classmethod
+    def _get_view_form_endpoint(cls):
+        return reverse('api_form_attachment',
+                kwargs=dict(
+                    domain=cls.domain.name,
+                    instance_id='5321',
+                    attachment_id='1234',
+                )
+            )
+
+    @flag_enabled('VIEW_FORM_ATTACHMENT')
+    def test_domain_has_feature_flag_enabled(self):
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get(self.view_form_endpoint)
+        # 404 status code means the request is successful, but resource is
+        # not found which is OK for the purposes of this test
+        self.assertEqual(response.status_code, 404)
+
+    def test_user_has_permission(self):
+        self.user.set_role(self.domain.name, 'admin')
+        self.user.save()
+
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get(self.view_form_endpoint)
+
+        # 404 status code means the request is successful, but resource is
+        # not found which is OK for the purposes of this test
+        self.assertEqual(response.status_code, 404)

--- a/corehq/apps/api/tests/form_resources.py
+++ b/corehq/apps/api/tests/form_resources.py
@@ -373,30 +373,27 @@ class TestXFormPillow(TestCase):
 
 class TestViewFormAttachment(TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
 
         Role.get_cache().clear()
-        cls.domain = Domain.get_or_create_with_name('qwerty', is_active=True)
-        cls.view_form_endpoint = cls._get_view_form_endpoint()
-        cls.username = 'rudolph@qwerty.commcarehq.org'
-        cls.password = '***'
-        cls.user = WebUser.create(cls.domain.name, cls.username, cls.password, None, None,
+        self.domain = Domain.get_or_create_with_name('qwerty', is_active=True)
+        self.view_form_endpoint = self._get_view_form_endpoint()
+        self.username = 'rudolph@qwerty.commcarehq.org'
+        self.password = '***'
+        self.user = WebUser.create(self.domain.name, self.username, self.password, None, None,
                                   email='rudoph@example.com', first_name='rudolph', last_name='commcare')
-        cls.user.save()
+        self.user.save()
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete(deleted_by_domain=cls.domain.name, deleted_by=None)
-        cls.domain.delete()
-        super(TestViewFormAttachment, cls).tearDownClass()
+    def tearDown(self):
+        self.user.delete(deleted_by_domain=self.domain.name, deleted_by=None)
+        self.domain.delete()
+        super(TestViewFormAttachment, self).tearDown()
 
-    @classmethod
-    def _get_view_form_endpoint(cls):
+    def _get_view_form_endpoint(self):
         return reverse('api_form_attachment',
                 kwargs=dict(
-                    domain=cls.domain.name,
+                    domain=self.domain.name,
                     instance_id='5321',
                     attachment_id='1234',
                 )

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -139,7 +139,6 @@ from .standard import ProjectReport, inspect
 from corehq.apps.domain.utils import domain_restricts_superusers
 from corehq.apps.domain.decorators import api_auth
 
-
 DATE_FORMAT = "%Y-%m-%d %H:%M"
 
 # Number of columns in case property history popup

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -172,19 +172,6 @@ def _can_view_form_attachment():
         @wraps(view_func)
         def _inner(request, domain, *args, **kwargs):
             if VIEW_FORM_ATTACHMENT.enabled(domain):
-                user = request.couch_user
-                user_allowed = False
-
-                domain_membership = user.get_domain_membership(domain, allow_enterprise=True)
-
-                if domain_membership:
-                    user_allowed = True
-                elif user.is_global_admin() and (domain is None or not domain_restricts_superusers(domain)):
-                    user_allowed = True
-
-                if not user_allowed:
-                    return HttpResponseForbidden()
-
                 return view_func(request, domain, *args, **kwargs)
 
             try:

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -136,7 +136,6 @@ from .forms import (
 from .lookup import ReportLookup, get_full_report_name
 from .models import TableauServer, TableauVisualization
 from .standard import ProjectReport, inspect
-from corehq.apps.domain.utils import domain_restricts_superusers
 from corehq.apps.domain.decorators import api_auth
 
 DATE_FORMAT = "%Y-%m-%d %H:%M"

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -164,18 +164,22 @@ require_form_view_permission = require_permission(
 require_can_view_all_reports = require_permission(HqPermissions.view_reports)
 
 
-def _augmented_form_view_permissions():
+def _augmented_form_view_permissions(login_decorator=login_and_domain_required):
     def decorator(view_func):
         @wraps(view_func)
         def _inner(request, domain, *args, **kwargs):
             if VIEW_FORM_ATTACHMENT.enabled(domain):
                 return view_func(request, domain, *args, **kwargs)
             return require_form_view_permission(view_func)(request, domain, *args, **kwargs)
-        return _inner
+
+        if login_decorator:
+            return login_decorator(_inner)
+        else:
+            return _inner
     return decorator
 
 
-augmented_form_view_permissions = _augmented_form_view_permissions()
+augmented_form_view_permissions = _augmented_form_view_permissions(login_decorator=None)
 
 
 @login_and_domain_required

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -175,9 +175,9 @@ def _augmented_form_view_permissions(login_decorator=login_and_domain_required):
 
                 domain_membership = user.get_domain_membership(domain, allow_enterprise=True)
 
-                if user.is_global_admin() and (domain is None or not domain_restricts_superusers(domain)):
+                if domain_membership:
                     user_allowed = True
-                elif domain_membership:
+                elif user.is_global_admin() and (domain is None or not domain_restricts_superusers(domain)):
                     user_allowed = True
 
                 if not user_allowed:

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2298,3 +2298,10 @@ TWO_STAGE_USER_PROVISIONING_BY_SMS = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
 )
+
+VIEW_FORM_ATTACHMENT = StaticToggle(
+    'view_form_attachments',
+    'Allow users on the domain to view form attachments without having to have the report Submit History permission.',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
## Product Description
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2079)
Added a feature flag which, if enabled, allows users on that domain to view form attachments without having the SubmitHistory permission enabled.

## Technical Summary
Added the [augmented_form_view_permissions](https://github.com/dimagi/commcare-hq/blob/1bc480bc704ac412c2725cf3c992c00e6192802c/corehq/apps/reports/views.py#L167) decorator on the [view_form_attachment](https://github.com/dimagi/commcare-hq/blob/1bc480bc704ac412c2725cf3c992c00e6192802c/corehq/apps/api/object_fetch_api.py#L134) endpoint which simply skips the [require_form_view_permission](https://github.com/dimagi/commcare-hq/blob/1bc480bc704ac412c2725cf3c992c00e6192802c/corehq/apps/reports/views.py#L173) permission requirement if the feature flag is enabled on the domain.

## Feature Flag
[view_form_attachments](https://staging.commcarehq.org/hq/flags/edit/view_form_attachments/)

## Safety Assurance

### Safety story
- Automated tests
- Tested this on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
Tested this on staging

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
