### PR TITLE
Add new utility `yarn-list.py` for listing yarn packages

### DIFF
--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -31,14 +31,18 @@ function main {
     local total=0
 
     # get total Python dependency count (skip 2 header lines)
+    log_msg_with_time INFO "calculating Python package metrics"
     total=$(pip list 2>/dev/null | tail -n +3 | wc -l)
     # publish python metrics
     pip list --format json --outdated 2>/dev/null | publish_metrics python pip "$total"
 
-    # get total JS dependency count (skip the first and last lines)
-    total=$(yarn list --depth 0 | tail -n+2 | head -n-1 | wc -l)
+    # get total JS dependency count (skip the first header line)
+    log_msg_with_time INFO "calculating JS package metrics"
+    total=$(./scripts/yarn-list.py | tail -n +2 | wc -l)
     # publish javascript metrics
-    yarn outdated --json | publish_metrics js yarn "$total"
+    ./scripts/yarn-list.py --outdated --json | publish_metrics js yarn-list "$total"
+
+    log_msg_with_time INFO "done"
 }
 
 
@@ -81,6 +85,14 @@ function publish_datadog_gauge {
     if $send_to_datadog; then
         send_metric_to_datadog "$metric_path" "$value" gauge
     fi
+}
+
+
+function log_msg_with_time {
+    local level_name="$1"; shift
+    local msg="$*"
+    local now=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[${now}] ${level_name}: $msg" >&2
 }
 
 

--- a/scripts/yarn-list.py
+++ b/scripts/yarn-list.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""A utility that outputs package information _like_ `pip list ...`, but for
+yarn packages.
+
+TODO:
+- dynamically calculate column widths rather than using hard-coded widths
+
+Examples:
+
+$ ./yarn-list.py
+Package                              Version
+colorama                             0.4.3
+...
+
+$ ./yarn-list.py --outdated
+Package                              Version     Latest
+colorama                             0.4.3       0.4.4
+...
+"""
+import argparse
+import json
+import sys
+from subprocess import DEVNULL, check_output
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--json",
+        default=False,
+        action="store_true",
+        help="output in JSON",
+    )
+    parser.add_argument(
+        "--outdated",
+        default=False,
+        action="store_true",
+        help="list outdated packages",
+    )
+    opts = parser.parse_args()
+    packages = package_list(opts.outdated)
+    if opts.json:
+        json.dump(packages, sys.stdout)
+    else:
+        print_table(packages, opts.outdated)
+
+
+def package_list(outdated):
+    yarn = Yarn()
+    all_packages = yarn.list()
+    if not outdated:
+        return all_packages
+    outdated_packages = []
+    for package in all_packages:
+        latest_version = yarn.latest_version(package["name"])
+        if package["version"] != latest_version:
+            package["latest_version"] = latest_version if latest_version else "exotic"
+            outdated_packages.append(package)
+    return outdated_packages
+
+
+def print_table(packages, show_latest=False):
+
+    def print_line(package):
+        line = f"{package['name']:36} {package['version']:8}"
+        if show_latest:
+            line = f"{line} {package['latest_version']}"
+        print(line.rstrip())
+
+    print_line({
+        "name": "Package",
+        "version": "Version",
+        "latest_version": "Latest",
+    })
+    for package in packages:
+        print_line(package)
+
+
+class Yarn:
+
+    def __init__(self):
+        yarn_version = check_output(["yarn", "--version"], text=True).strip()
+        if not yarn_version.startswith("1."):
+            raise Crash(f"Yarn Classic (v1.x) is required, found {yarn_version}")
+
+    def command(self, sub_args):
+        # discard first and last lines (yarn version and timing info)
+        # confirmed safe on subcommands:
+        # - info
+        # - list
+        return check_output(["yarn"] + sub_args, stderr=DEVNULL, text=True).splitlines()[1:-1]
+
+    def list(self):
+        lines = self.command(["list", "--depth", "0"])
+        packages = []
+        for line in lines:
+            line = line.rstrip()
+            if not line:
+                continue
+            # example:
+            # ├─ @ungap/promise-all-settled@1.1.2
+            # ├─ abbrev@1.1.1
+            name, x, version = line.split(None, 2)[1].rpartition("@")
+            packages.append({"name": name, "version": version})
+        return packages
+
+    def latest_version(self, name):
+        lines = self.command(["info", name, "dist-tags.latest"])
+        if not lines:
+            return None
+        assert len(lines) == 1, f"{name}: invalid latest: {lines!r}"
+        return lines[0].strip()
+
+
+class Crash(Exception):
+    pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(2)
+    except BrokenPipeError:
+        # Don't print a traceback (or exit with an error) when tools like 'head'
+        # or 'grep' close the stream early.
+        pass
+    except Crash as exc:
+        print(f"ERROR: {exc!s}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Technical Summary

Supersedes #31938.

Following [discussions on Slack](https://dimagi.slack.com/archives/C01G688ECF9/p1658850690605359) with @dannyroberts  about reporting on outdated packages using yarn, this new utility adds functionality that yarn lacks: reporting outdated _sub-dependencies_.  The new script is equivalent to `pip list` in its behavior.

Example with updated `track-dependency-status.sh` script:

```shell
$ ./scripts/track-dependency-status.sh -n
[DRY RUN] no metrics will be sent to datadog
[2022-07-26 18:56:28] INFO: calculating Python package metrics
commcare.static_analysis.dependency.python.total == 265
<snip>
[2022-07-26 18:56:48] INFO: calculating JS package metrics
commcare.static_analysis.dependency.js.total == 678
<snip>
[2022-07-26 19:00:39] INFO: done
```

Note: acquiring outdated information for JS packages takes a while (~3.75 minutes)

Examples for viewing the "raw" package info:

```shell
./scripts/yarn-list.py
./scripts/yarn-list.py --outdated
```

## Safety Assurance

### Safety story

Metrics only.

### Automated test coverage

No tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
