### PR TITLE
[bugfix] USH-2211 incomplete form with EOF nav looses app ID

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -85,7 +85,7 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
             } else if (response.tree) {
                 // form entry time, doggy
                 _.extend(this, _.pick(response, this.formProperties));
-                FormplayerFrontend.trigger('startForm', response, this.appId);
+                FormplayerFrontend.trigger('startForm', response);
             }
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -54,11 +54,21 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
         parse: function (response) {
             _.extend(this, _.pick(response, this.commonProperties));
 
+            var urlObject = Util.currentUrlToObject(),
+                updateUrl = false;
+            if (!urlObject.appId && response.appId) {
+                // will be undefined on urlObject when coming from an incomplete form
+                urlObject.appId = response.appId;
+                this.appId = urlObject.appId;
+                updateUrl = true;
+            }
             if (response.selections) {
-                var urlObject = Util.currentUrlToObject();
                 urlObject.setSelections(response.selections);
-                Util.setUrlToObject(urlObject, true);
                 sessionStorage.removeItem('selectedValues');
+                updateUrl = true;
+            }
+            if (updateUrl) {
+                Util.setUrlToObject(urlObject, true);
             }
 
             if (response.commands) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -85,7 +85,7 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
             } else if (response.tree) {
                 // form entry time, doggy
                 _.extend(this, _.pick(response, this.formProperties));
-                FormplayerFrontend.trigger('startForm', response, this.app_id);
+                FormplayerFrontend.trigger('startForm', response, this.appId);
             }
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -91,7 +91,10 @@ hqDefine("cloudcare/js/formplayer/router", function () {
 
             currentFragment = Backbone.history.getFragment();
             urlObject = Util.CloudcareUrl.fromJson(Util.encodedUrlToObject(currentFragment));
-            response.appId = urlObject.appId;
+            if (urlObject.appId) {
+                // will be undefined on urlObject when coming from an incomplete form
+                response.appId = urlObject.appId;
+            }
 
              if (response.notification) {
                 FormplayerFrontend.trigger("handleNotification", response.notification);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_test.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_test.js
@@ -68,6 +68,8 @@ describe('Render a case list', function () {
         beforeEach(function () {
             window.gettext = sinon.spy();
 
+            sinon.stub(Backbone.history, 'getFragment').callsFake(sinon.spy());
+
             FormplayerFrontend.regions = {
                 getRegion: function (name) {
                     return {
@@ -100,6 +102,7 @@ describe('Render a case list', function () {
         afterEach(function () {
             server.restore();
             clock.restore();
+            Backbone.history.getFragment.restore();
         });
 
         it('Should execute an async restore using sync db', function () {


### PR DESCRIPTION
## Technical Summary
When completing an 'incomplete' form in Web Apps that has EOF nav, the very next screen is correct but navigation after that fails since the App ID has been lost.

This PR re-sets the app ID in the URL based on the response for formplayer (only if the URL does not have an appId param already).

Jira: https://dimagi-dev.atlassian.net/browse/USH-2211

## Safety Assurance

### Safety story
Fairly small changes that are easy to follow and tested locally.

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
