### PR TITLE
Only open dependabot PRs for major version upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
   open-pull-requests-limit: 7
   labels:
   - product/invisible
+  # Focus on major versions only
+  # Todo: remove once we're in steady-state on major versions
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-patch"
+        - "version-update:semver-minor"
+
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -17,3 +25,10 @@ updates:
   labels:
   - product/invisible
   - dependencies/javascript
+  # Focus on major versions only
+  # Todo: remove once we're in steady-state on major versions
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-patch"
+        - "version-update:semver-minor"


### PR DESCRIPTION
## Technical Summary
Until we are done with the low-hanging fruit when it comes to major upgrades, I'm proposing these changes to our dependabot configuration to filter out the chattier minor and patch upgrade PRs. I'm hoping this will let our team work on this set of highest priority (most out of date) upgrades first and get through those quicker, after which we can add back the minor / patch upgrades in steady-state.

## Safety Assurance

### Safety story
My main concern was whether we'd still get security updates, but https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/ is explicit about this:

> Note: this feature only applies to version updates. If you have security updates enabled, you will still get pull requests updating you to the minimum patched version.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
