### PR TITLE
Use default scroll size for analytics `scroll_case_names()`

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -99,7 +99,6 @@ FORM_EXPORT = 'form'
 CASE_EXPORT = 'case'
 SMS_EXPORT = 'sms'
 MAX_EXPORTABLE_ROWS = 100000
-CASE_SCROLL_SIZE = 10000
 
 # When a question is missing completely from a form/case this should be the value
 MISSING_VALUE = '---'

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -29,10 +29,7 @@ from corehq.apps.es.cases import closed_range as closed_range_filter
 from corehq.apps.es.forms import completed as completed_filter
 from corehq.apps.es.forms import submitted as submitted_filter
 from corehq.apps.es.forms import xmlns as xmlns_filter
-from corehq.apps.export.const import (
-    CASE_SCROLL_SIZE,
-    MAX_MULTIMEDIA_EXPORT_SIZE,
-)
+from corehq.apps.export.const import MAX_MULTIMEDIA_EXPORT_SIZE
 from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS_MAP
 from corehq.util.quickcache import quickcache
 
@@ -609,8 +606,7 @@ def scroll_case_names(domain, case_ids):
     query = (CaseES()
             .domain(domain)
             .case_ids(case_ids)
-            .source(['name', '_id'])
-            .size(CASE_SCROLL_SIZE))
+            .source(['name', '_id']))
     return query.scroll()
 
 

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -21,6 +21,7 @@ from corehq.apps.domain.calculations import cases_in_last, inactive_cases_in_las
 from corehq.apps.enterprise.tests.utils import create_enterprise_permissions
 from corehq.apps.es import CaseES, UserES
 from corehq.apps.es.aggregations import MISSING_KEY
+from corehq.apps.es.const import SCROLL_SIZE
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.groups.models import Group
 from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS, get_case_by_identifier
@@ -1215,6 +1216,13 @@ class TestCaseESAccessors(BaseESAccessorsTest):
             len(list(scroll_case_names(self.domain, [case_one.case_id]))),
             1
         )
+
+    def test_scroll_case_names_uses_default_scroll_size(self):
+        def test_scroll(index, raw_query, **kw):
+            self.assertEqual(SCROLL_SIZE, raw_query["size"])
+            return []
+        with patch("corehq.apps.es.es_query.scroll_query", test_scroll):
+            list(scroll_case_names("test", []))
 
     def test_get_active_case_counts(self):
         datespan = DateSpan(datetime(2013, 7, 1), datetime(2013, 7, 30))


### PR DESCRIPTION
## Technical Summary

The helper function `corehq.apps.reports.analytics.esaccessors.scroll_case_names()` was using a custom scroll size of 10000 (maximum Elasticsearch response size), which isn't a good value to use in this scenario. The function now uses the default scroll size (1000).

Found while researching uses of `ESQuery.scroll()` for #31935.

## Safety Assurance

### Safety story

Default scroll size is safe.

### Automated test coverage

Test added.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
