### PR TITLE
Strip "/" from Application.url_base

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4411,7 +4411,9 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
     @property
     def url_base(self):
         custom_base_url = getattr(self, 'custom_base_url', None)
-        return custom_base_url or get_url_base()
+        base_url = custom_base_url or get_url_base()
+        # Other code assumes that the base URL does not end in a "/"
+        return base_url.rstrip('/')
 
     @absolute_url_property
     def post_url(self):

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -51,7 +51,10 @@
 
 - id: custom_base_url
   name: "Custom Base URL"
-  description: 'Use a different base URL for all app URLs. This makes the phone send forms, sync and look for updates from a differnent URL. Main use case is to allow migrating ICDS to a new cluster.'
+  description: >
+    Use a different base URL for all app URLs. This makes the phone send forms,
+    sync, and look for updates from a different URL. The main use case is to
+    allow migrating project spaces to a new environment.'
   hide_if_not_enabled: true
   widget: text
   toggle: CUSTOM_APP_BASE_URL

--- a/corehq/apps/app_manager/tests/test_apps.py
+++ b/corehq/apps/app_manager/tests/test_apps.py
@@ -2,7 +2,8 @@ import json
 import os
 import uuid
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
+from django.test.utils import override_settings
 
 from collections import namedtuple
 from memoized import memoized
@@ -367,3 +368,16 @@ class AppManagerTest(TestCase, TestXmlMixin):
         unlinked_doc = linked_app.convert_to_application().to_json()
         self.assertEqual(unlinked_doc['doc_type'], 'Application')
         self.assertFalse(hasattr(unlinked_doc, 'linked_app_attrs'))
+
+
+class TestURLBase(SimpleTestCase):
+
+    def test_custom_base_url(self):
+        app = Application.new_app('test-domain', 'TestApp')
+        app.custom_base_url = 'https://commcare.example.com/'
+        self.assertEqual(app.url_base, 'https://commcare.example.com')
+
+    @override_settings(BASE_ADDRESS='example.com/commcare/')
+    def test_base_address(self):
+        app = Application.new_app('test-domain', 'TestApp')
+        self.assertEqual(app.url_base, 'http://example.com/commcare')


### PR DESCRIPTION
## Technical Summary

This fixes a bug that I discovered when investigating [SC-2206](https://dimagi-dev.atlassian.net/browse/SC-2206). I am opening two PRs, each with a possible solution. I can't decide. I'm hoping the best choice will become clear when these PRs are reviewed.

The nice thing about this solution is that it has a small footprint.


## Safety Assurance

### Safety Story

This is a small change that strips the final "/" of `Application.url_base`, because downstream code (naively?) relies on it.

In Dimagi environments, `settings.BASE_ADDRESS` never ends in a "/". So in our environments this bug can only occur when `custom_base_url` is set for an app, and ends in "/".

### Automated test coverage

Includes tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
