### PR TITLE
Multi select case list clearing checkbox fix

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -65,7 +65,8 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
             if (response.selections) {
                 urlObject.setSelections(response.selections);
                 updateUrl = true;
-                var currentSelectedValues = sessionStorage.selectedValues === undefined ? null : sessionStorage.selectedValues;
+                var currentSelectedValues = sessionStorage.selectedValues !== undefined && response.multiSelect ?
+                    sessionStorage.selectedValues : null;
                 sessionStorage.removeItem('selectedValues');
             }
             if (updateUrl) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -58,7 +58,6 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
                 var urlObject = Util.currentUrlToObject();
                 urlObject.setSelections(response.selections);
                 Util.setUrlToObject(urlObject, true);
-                sessionStorage.removeItem('selectedValues');
             }
 
             if (response.commands) {
@@ -73,6 +72,9 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
                 _.extend(this, _.pick(response, this.detailProperties));
                 return response.details;
             } else if (response.tree) {
+                if (response.selections) {
+                    sessionStorage.removeItem('selectedValues');
+                }
                 // form entry time, doggy
                 _.extend(this, _.pick(response, this.formProperties));
                 FormplayerFrontend.trigger('startForm', response, this.app_id);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -87,7 +87,7 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
                 _.extend(this, _.pick(response, this.detailProperties));
                 return response.details;
             } else if (response.tree) {
-                // form entry time, doggy
+                // form entry time
                 _.extend(this, _.pick(response, this.formProperties));
                 FormplayerFrontend.trigger('startForm', response);
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -65,6 +65,8 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
             if (response.selections) {
                 urlObject.setSelections(response.selections);
                 updateUrl = true;
+                var currentSelectedValues = sessionStorage.selectedValues === undefined ? null : sessionStorage.selectedValues;
+                sessionStorage.removeItem('selectedValues');
             }
             if (updateUrl) {
                 Util.setUrlToObject(urlObject, true);
@@ -74,6 +76,9 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
                 _.extend(this, _.pick(response, this.commandProperties));
                 return response.commands;
             } else if (response.entities) {
+                if (response.selections && currentSelectedValues) {
+                    sessionStorage.selectedValues = currentSelectedValues;
+                }
                 _.extend(this, _.pick(response, this.entityProperties));
                 return response.entities;
             } else if (response.type === "query") {
@@ -82,9 +87,6 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
                 _.extend(this, _.pick(response, this.detailProperties));
                 return response.details;
             } else if (response.tree) {
-                if (response.selections) {
-                    sessionStorage.removeItem('selectedValues');
-                }
                 // form entry time, doggy
                 _.extend(this, _.pick(response, this.formProperties));
                 FormplayerFrontend.trigger('startForm', response);


### PR DESCRIPTION
Ticket: [USH-2262](https://dimagi-dev.atlassian.net/browse/USH-2262)

https://user-images.githubusercontent.com/36681924/181612156-1ae03346-76fe-4fad-b2be-600dbe6d5b05.mov



## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Checkboxes are not cleared when navigating between pages of results on the case list so a user can select from more than one page. However, it is still cleared if the user nagivated away from the page by either the back button or pressing "Continue"


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This simply moves the code to clear the selections until the continue button is pressed (which triggers `else if (response.tree)`, rather than every time there is `response.selections` which happens with navigation. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
MULTI_SELECT_CASE_LIST

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is tested locally and on staging, I am also requesting QA

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I will request QA on this simply because of visibility of this feature for BHA. This restricts the number of cases that the selection was previously cleared for, but changes like this can be sneaky. 


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
