### PR TITLE
Log transient bounced invites as Delivered 

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2584,6 +2584,9 @@ class Invitation(models.Model):
     program = models.CharField(max_length=126, null=True)   # couch id of a Program
     supply_point = models.CharField(max_length=126, null=True)  # couch id of a Location
 
+    def __repr__(self):
+        return f"Invitation(domain='{self.domain}', email='{self.email})"
+
     @classmethod
     def by_domain(cls, domain, is_accepted=False, **filters):
         return Invitation.objects.filter(domain=domain, is_accepted=is_accepted, **filters)

--- a/corehq/util/email_event_utils.py
+++ b/corehq/util/email_event_utils.py
@@ -107,7 +107,7 @@ def record_transient_bounce(aws_meta):
 def get_relevant_aws_meta(message_info):
     """
     Creates a list of AwsMeta objects from the Message portion of an AWS
-    SNS Notification message.
+    SNS Notification message.  One per recipient.
     :param message_info: (dict) the "Message" portion of an SNS notification
     :return: (list) AwsMeta objects
     """


### PR DESCRIPTION
## Product Description
If you send a domain invite to a web user whose email account has a vacation autoresponder on, it'll show up as "bounced", even though it does get delivered.  This PR changes that to show "delivered".

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-2285

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The change is fairly innocuous.  Biggest risk is false matches here - I'm not certain what other scenarios might register as transient bounces.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
