### PR TITLE
add timeout to offline warnings

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -345,6 +345,7 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         }
 
         const reconnectTimingWindow = 2000;
+        // if user's offline time is longer than the reconnect timing window, it's considered as truly offline
         let trulyOffline;
 
         window.addEventListener(

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -345,15 +345,13 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         }
 
         const reconnectTimingWindow = 2000;
-        // if user's offline time is longer than the reconnect timing window, it's considered as truly offline
-        let trulyOffline;
+        let offlineTime;
 
         window.addEventListener(
             'offline',function () {
-                trulyOffline = false;
+                offlineTime = new Date();
                 _.delay(function () {
-                    if (!this.navigator.onLine) {
-                        trulyOffline = true;
+                    if (!this.navigator.onLine && (new Date() - offlineTime) > reconnectTimingWindow) {
                         showError(gettext("You are now offline. Web Apps is not optimized " +
                             "for offline use. Please reconnect to the Internet before " +
                             "continuing."), $("#cloudcare-notifications"));
@@ -365,7 +363,7 @@ hqDefine("cloudcare/js/formplayer/app", function () {
 
         window.addEventListener(
             'online', function () {
-                if (trulyOffline) {
+                if ((new Date() - offlineTime) > reconnectTimingWindow) {
                     showSuccess(gettext("You are are back online."), $("#cloudcare-notifications"));
                     $('.submit').prop('disabled', false);
                     $('.form-control').prop('disabled', false);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -343,20 +343,35 @@ hqDefine("cloudcare/js/formplayer/app", function () {
                 false
             );
         }
+
+        const pendingErrors = [];
+
         window.addEventListener(
-            'offline', function () {
-                showError(gettext("You are now offline. Web Apps is not optimized " +
-                    "for offline use. Please reconnect to the Internet before " +
-                    "continuing."), $("#cloudcare-notifications"));
-                $('.submit').prop('disabled', 'disabled');
-                $('.form-control').prop('disabled', 'disabled');
-            }
-        );
+            'offline',function () {
+                const offlineHandler = () => {
+                    showError(gettext("You are now offline. Web Apps is not optimized " +
+                        "for offline use. Please reconnect to the Internet before " +
+                        "continuing."), $("#cloudcare-notifications"));
+                    $('.submit').prop('disabled', 'disabled');
+                    $('.form-control').prop('disabled', 'disabled');
+                    pendingErrors.pop();
+                };
+                if (pendingErrors.length) {
+                    offlineHandler();
+                } else {
+                    pendingErrors.push(setTimeout(offlineHandler,2000));
+                }
+            });
+
         window.addEventListener(
             'online', function () {
-                showSuccess(gettext("You are are back online."), $("#cloudcare-notifications"));
-                $('.submit').prop('disabled', false);
-                $('.form-control').prop('disabled', false);
+                if (pendingErrors.length) {
+                    clearTimeout(pendingErrors.pop());
+                } else {
+                    showSuccess(gettext("You are are back online."), $("#cloudcare-notifications"));
+                    $('.submit').prop('disabled', false);
+                    $('.form-control').prop('disabled', false);
+                }
             }
         );
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -344,30 +344,27 @@ hqDefine("cloudcare/js/formplayer/app", function () {
             );
         }
 
-        const pendingErrors = [];
+        const reconnectTimingWindow = 2000;
+        let trulyOffline;
 
         window.addEventListener(
             'offline',function () {
-                const offlineHandler = () => {
-                    showError(gettext("You are now offline. Web Apps is not optimized " +
-                        "for offline use. Please reconnect to the Internet before " +
-                        "continuing."), $("#cloudcare-notifications"));
-                    $('.submit').prop('disabled', 'disabled');
-                    $('.form-control').prop('disabled', 'disabled');
-                    pendingErrors.pop();
-                };
-                if (pendingErrors.length) {
-                    offlineHandler();
-                } else {
-                    pendingErrors.push(setTimeout(offlineHandler,2000));
-                }
+                trulyOffline = false;
+                _.delay(function () {
+                    if (!this.navigator.onLine) {
+                        trulyOffline = true;
+                        showError(gettext("You are now offline. Web Apps is not optimized " +
+                            "for offline use. Please reconnect to the Internet before " +
+                            "continuing."), $("#cloudcare-notifications"));
+                        $('.submit').prop('disabled', 'disabled');
+                        $('.form-control').prop('disabled', 'disabled');
+                    }
+                },reconnectTimingWindow);
             });
 
         window.addEventListener(
             'online', function () {
-                if (pendingErrors.length) {
-                    clearTimeout(pendingErrors.pop());
-                } else {
+                if (trulyOffline) {
                     showSuccess(gettext("You are are back online."), $("#cloudcare-notifications"));
                     $('.submit').prop('disabled', false);
                     $('.form-control').prop('disabled', false);


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Ticket: [USH-2261](https://dimagi-dev.atlassian.net/browse/USH-2261)
As long as user get back online quickly in 2 seconds, the web app won't show an error message as well as won't send sentry error.

https://user-images.githubusercontent.com/39149002/181629648-4e8980c1-c74e-49ae-8f48-e10ce49209fb.mov



## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I simply added a setTimeout to delay the error function 2 seconds. If user get back online quickly, I'll just clearTimeout.


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is tested locally and on staging. Will also request QA.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will ask QA to test:

-  There won't be any offline/online message, if user get back online in 2 seconds
-  There will be offline/online message if user get back online longer than 2 seconds

Will create a QA ticket and paste the link here soon.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
