### PR TITLE
Fix sql to couch migration for Repeaters with jsonschema attributes

### DIFF
--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -349,7 +349,7 @@ class SQLDhis2Repeater(SQLFormRepeater, SQLDhis2Instance):
         return Dhis2Repeater
 
     def _wrap_schema_attrs(self, couch_object):
-        setattr(couch_object, 'dhis2_config', Dhis2Config.wrap(self.dhis2_config))
+        couch_object.dhis2_config = Dhis2Config.wrap(self.dhis2_config)
 
     @classmethod
     def _migration_get_fields(cls):
@@ -420,7 +420,7 @@ class SQLDhis2EntityRepeater(SQLCaseRepeater, SQLDhis2Instance):
             raise
 
     def _wrap_schema_attrs(self, couch_object):
-        setattr(couch_object, 'dhis2_entity_config', Dhis2EntityConfig.wrap(self.dhis2_entity_config))
+        couch_object.dhis2_entity_config = Dhis2EntityConfig.wrap(self.dhis2_entity_config)
 
     @classmethod
     def _migration_get_fields(cls):

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -349,7 +349,7 @@ class SQLDhis2Repeater(SQLFormRepeater, SQLDhis2Instance):
         return Dhis2Repeater
 
     def _wrap_schema_attrs(self, couch_object):
-        setattr(couch_object, 'dhis2_config', Dhis2Config.wrap(getattr(self, 'dhis2_config')))
+        setattr(couch_object, 'dhis2_config', Dhis2Config.wrap(self.dhis2_config))
 
     @classmethod
     def _migration_get_fields(cls):
@@ -420,7 +420,7 @@ class SQLDhis2EntityRepeater(SQLCaseRepeater, SQLDhis2Instance):
             raise
 
     def _wrap_schema_attrs(self, couch_object):
-        setattr(couch_object, 'dhis2_entity_config', Dhis2EntityConfig.wrap(getattr(self, 'dhis2_entity_config')))
+        setattr(couch_object, 'dhis2_entity_config', Dhis2EntityConfig.wrap(self.dhis2_entity_config))
 
     @classmethod
     def _migration_get_fields(cls):

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -348,9 +348,12 @@ class SQLDhis2Repeater(SQLFormRepeater, SQLDhis2Instance):
     def _migration_get_couch_model_class(cls):
         return Dhis2Repeater
 
+    def _wrap_schema_attrs(self, couch_object):
+        setattr(couch_object, 'dhis2_config', Dhis2Config.wrap(getattr(self, 'dhis2_config')))
+
     @classmethod
     def _migration_get_fields(cls):
-        return super()._migration_get_fields() + ["dhis2_config", "dhis2_version", "dhis2_version_last_modified"]
+        return super()._migration_get_fields() + ["dhis2_version", "dhis2_version_last_modified"]
 
 
 class SQLDhis2EntityRepeater(SQLCaseRepeater, SQLDhis2Instance):
@@ -416,10 +419,12 @@ class SQLDhis2EntityRepeater(SQLCaseRepeater, SQLDhis2Instance):
             )
             raise
 
+    def _wrap_schema_attrs(self, couch_object):
+        setattr(couch_object, 'dhis2_entity_config', Dhis2EntityConfig.wrap(getattr(self, 'dhis2_entity_config')))
+
     @classmethod
     def _migration_get_fields(cls):
         return super()._migration_get_fields() + [
-            "dhis2_entity_config",
             "dhis2_version",
             "dhis2_version_last_modified"
         ]

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -363,13 +363,16 @@ class SQLOpenmrsRepeater(SQLCaseRepeater):
             return RepeaterResponse(400, 'Bad Request', pformat_json(str(err)))
         return response
 
+    def _wrap_schema_attrs(self, couch_object):
+        setattr(couch_object, 'openmrs_config', OpenmrsConfig.wrap(getattr(self, 'openmrs_config')))
+        # setattr(couch_object, 'atom_feed_status', AtomFeedStatus.wrap(getattr(self, 'atom_feed_status')))
+
     @classmethod
     def _migration_get_fields(cls):
         return super()._migration_get_fields() + [
             "location_id",
             "atom_feed_enabled",
             "atom_feed_status",
-            "openmrs_config",
         ]
 
     @classmethod

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -364,8 +364,7 @@ class SQLOpenmrsRepeater(SQLCaseRepeater):
         return response
 
     def _wrap_schema_attrs(self, couch_object):
-        setattr(couch_object, 'openmrs_config', OpenmrsConfig.wrap(getattr(self, 'openmrs_config')))
-        # setattr(couch_object, 'atom_feed_status', AtomFeedStatus.wrap(getattr(self, 'atom_feed_status')))
+        setattr(couch_object, 'openmrs_config', OpenmrsConfig.wrap(self.openmrs_config))
 
     @classmethod
     def _migration_get_fields(cls):

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -364,7 +364,7 @@ class SQLOpenmrsRepeater(SQLCaseRepeater):
         return response
 
     def _wrap_schema_attrs(self, couch_object):
-        setattr(couch_object, 'openmrs_config', OpenmrsConfig.wrap(self.openmrs_config))
+        couch_object.openmrs_config = OpenmrsConfig.wrap(self.openmrs_config)
 
     @classmethod
     def _migration_get_fields(cls):

--- a/corehq/motech/repeaters/expression/repeaters.py
+++ b/corehq/motech/repeaters/expression/repeaters.py
@@ -92,7 +92,7 @@ class SQLBaseExpressionRepeater(SQLRepeater):
 
     configured_filter = OptionValue(default=dict)
     configured_expression = OptionValue(default=dict)
-    url_template = OptionValue()
+    url_template = OptionValue(default=None)
 
     payload_generator_classes = (ExpressionPayloadGenerator,)
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -353,9 +353,10 @@ class SQLRepeater(SyncSQLToCouchMixin, RepeaterSuperProxy):
     def get_url(self, record):
         return self.repeater.get_url(record)
 
+    @classmethod
     @property
-    def _repeater_type(self):
-        name = type(self).__name__
+    def _repeater_type(cls):
+        name = cls.__name__
         return name[3:] if name.startswith('SQL') else name
 
     @property

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -545,10 +545,14 @@ class SQLRepeater(SyncSQLToCouchMixin, RepeaterSuperProxy):
         """
         return self.__class__.__name__
 
+    def _wrap_schema_attrs(self, couch_object):
+        pass
+
     def _migration_sync_to_couch(self, couch_object):
         for field_name in self._migration_get_fields():
             value = getattr(self, field_name)
             setattr(couch_object, field_name, value)
+        self._wrap_schema_attrs(couch_object)
         setattr(couch_object, 'connection_settings_id', self.connection_settings.id)
         setattr(couch_object, 'paused', self.is_paused)
         couch_object.save(sync_to_sql=False)

--- a/corehq/motech/repeaters/optionvalue.py
+++ b/corehq/motech/repeaters/optionvalue.py
@@ -43,12 +43,19 @@ persisted by their base class, ``SQLRepeater.options``, defined as
 ``JSONField(default=dict)``.
 
 """
-from dimagi.utils.parsing import json_format_datetime, string_to_utc_datetime
+from dimagi.utils.parsing import ISO_DATETIME_FORMAT, json_format_datetime, string_to_utc_datetime
+from datetime import datetime
 
 
 class DateTimeCoder:
 
     def to_json(value):
+        if type(value) == str:
+            try:
+                datetime.strptime(value, ISO_DATETIME_FORMAT)
+                return value
+            except ValueError:
+                raise ValueError(f"{value} should be a valid datetime of Format {ISO_DATETIME_FORMAT}")
         return json_format_datetime(value) if value is not None else None
 
     def from_json(value):

--- a/corehq/motech/repeaters/tests/data/repeaters.py
+++ b/corehq/motech/repeaters/tests/data/repeaters.py
@@ -8,7 +8,6 @@ repeater_test_data = [
         "base_doc": "Repeater",
         "white_listed_form_xmlns":
         [],
-        "notify_addresses_str": "",
         "started_at": "2021-01-07T09:06:47.177274Z",
         "connection_settings_id": 1
     },

--- a/corehq/motech/repeaters/tests/test_optionvalue.py
+++ b/corehq/motech/repeaters/tests/test_optionvalue.py
@@ -1,9 +1,11 @@
+from datetime import datetime
 import doctest
 
 import attr
 from testil import assert_raises, eq
 
-from corehq.motech.repeaters.optionvalue import OptionValue
+from corehq.motech.repeaters.optionvalue import DateTimeCoder, OptionValue
+from dimagi.utils.parsing import json_format_datetime
 
 
 def test_basic_option_value():
@@ -47,6 +49,26 @@ def test_raises_on_invalid_choice():
     eq(order.options, {})
 
 
+def test_datetime_coder_with_datetime():
+    order = FoodOptions()
+    ordered_on = datetime.now()
+    order.ordered_on = ordered_on
+    eq(order.options['ordered_on'], json_format_datetime(ordered_on))
+
+
+def test_datetime_coder_with_str_datetime():
+    order = FoodOptions()
+    ordered_on = json_format_datetime(datetime.now())
+    order.ordered_on = ordered_on
+    eq(order.options['ordered_on'], ordered_on)
+
+
+def test_datetime_coder_with_invalid_str():
+    order = FoodOptions()
+    with assert_raises(ValueError):
+        order.ordered_on = 'blah_blah'
+
+
 def test_instance_of_optionvalue():
     assert isinstance(FoodOptions.dish, OptionValue), repr(FoodOptions.dish)
 
@@ -81,6 +103,7 @@ class FoodOptions:
     dish = OptionValue()
     food_option = OptionValue(default="veg", choices=["veg", "non-veg"])
     condiments = OptionValue(default=list)
+    ordered_on = OptionValue(coder=DateTimeCoder)
 
 
 class BadFoodOptions:

--- a/corehq/motech/repeaters/tests/test_proxy_models.py
+++ b/corehq/motech/repeaters/tests/test_proxy_models.py
@@ -297,7 +297,7 @@ class TestRepeaterModelsAttrEquality(ModelAttrEqualityHelper):
             # added by django choicefield in models
             'get_request_method_display',
             'to_json', '_convert_to_serializable',
-            '_optionvalue_fields'
+            '_optionvalue_fields', '_wrap_schema_attrs'
         }
 
 

--- a/corehq/motech/repeaters/tests/test_repeaters_migration.py
+++ b/corehq/motech/repeaters/tests/test_repeaters_migration.py
@@ -171,7 +171,24 @@ class RepeaterSyncTestsBase(TestCase):
         return [couch_cls.wrap(r) for r in self.test_data if r['doc_type'] == couch_cls.__name__]
 
     def get_sql_objects(self, sql_cls):
-        return [sql_cls(**r) for r in self.test_data if r['doc_type'] == sql_cls()._repeater_type]
+        all_objects = []
+        for r_obj in deepcopy(self.test_data):
+
+            r_obj.pop('base_doc')
+            r_obj.pop('started_at', None)
+            r_obj.pop('last_success_at', None)
+            r_obj.pop('failure_streak', None)
+
+            r_obj['is_paused'] = r_obj.pop('paused', False)
+            repeater_type = r_obj.pop('doc_type')
+
+            if 'include_app_id_param' not in set(sql_cls()._optionvalue_fields):
+                r_obj.pop('include_app_id_param', None)
+            if repeater_type == sql_cls()._repeater_type:
+                all_objects.append(
+                    sql_cls(**r_obj)
+                )
+        return all_objects
 
 
 class TestSQLCaseRepeater(RepeaterSyncTestsBase):

--- a/corehq/motech/repeaters/tests/test_repeaters_migration.py
+++ b/corehq/motech/repeaters/tests/test_repeaters_migration.py
@@ -171,7 +171,7 @@ class RepeaterSyncTestsBase(TestCase):
         return [couch_cls.wrap(r) for r in self.test_data if r['doc_type'] == couch_cls.__name__]
 
     def get_sql_objects(self, sql_cls):
-        return [sql_cls(**r) for r in self.test_data if r['doc_type'] == sql_cls._repeater_type]
+        return [sql_cls(**r) for r in self.test_data if r['doc_type'] == sql_cls()._repeater_type]
 
 
 class TestSQLCaseRepeater(RepeaterSyncTestsBase):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A part of couch to SQL migration.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
While moving reads from couch to SQL, I encountered the scenario where the repeaters with `jsonschema` attributes did not play nice with the Repeater operations. On investigation I figured that the error was coming during the sync process. We are storing all the JSONSchema attributes as dicts in SQL. But when we were not wrapping the dicts in the sync logic.

We have tests for all the Repeaters sync logic and it was weird that all the tests are passing without any issue. Then on further looking I came across f6561f1c251c2a66bd1d5b36d43ad3eb9b10077c. This cute little mistake which was making sure that the tests don't complain.

So this PR fixes the issue and updates the sync logic to support wrapping of these docs.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Tested on local and has tests in place. The changes will only come into action when we have moved writes to SQL and for now they won't have any effect.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
The changes have tests for them.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
