### PR TITLE
Reapplies case search "required" message changes

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -275,11 +275,10 @@ class RemoteRequestFactory(object):
             if prop.exclude:
                 kwargs['exclude'] = "true()"
             if prop.required.test:
-                kwargs['required_attr'] = interpolate_xpath(prop.required.test)
-                # kwargs['required'] = Required(
-                #     test=interpolate_xpath(prop.required.test),
-                #     text=[Text(locale_id=id_strings.search_property_required_text(self.module, prop.name))],
-                # )
+                kwargs['required'] = Required(
+                    test=interpolate_xpath(prop.required.test),
+                    text=[Text(locale_id=id_strings.search_property_required_text(self.module, prop.name))],
+                )
             if prop.validations:
                 kwargs['validations'] = [
                     Validation(

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -520,7 +520,6 @@ class QueryPrompt(DisplayNode):
     default_value = StringField('@default', required=False)
     allow_blank_value = BooleanField('@allow_blank_value', required=False)
     exclude = StringField('@exclude', required=False)
-    required_attr = StringField('@required', required=False)  # Temporary addition
     required = NodeField('required', Required, required=False)
     validations = NodeListField('validation', Validation)
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -186,7 +186,7 @@
                               <textarea class="form-control vertical-resize" data-bind="value: requiredTest" placeholder="true()"></textarea>
                             </div>
                           </div>
-                          <div class="form-group" data-bind="visible: false">
+                          <div class="form-group" data-bind="visible: requiredTest">
                               <label class="control-label col-xs-12 col-sm-3">
                                   {% trans "Required Message" %}
                               </label>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -849,12 +849,17 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         suite = self.app.create_suite()
         expected = """
         <partial>
-          <prompt key="name" required="instance('commcaresession')/session/user/data/is_supervisor = 'n'">
+          <prompt key="name">
             <display>
               <text>
                 <locale id="search_property.m0.name"/>
               </text>
             </display>
+            <required test="instance('commcaresession')/session/user/data/is_supervisor = 'n'">
+              <text>
+                <locale id="search_property.m0.name.required.text"/>
+              </text>
+            </required>
           </prompt>
         </partial>
         """


### PR DESCRIPTION
## Product Description
Reverts the reverts from https://github.com/dimagi/commcare-hq/pull/31959 - making case search required messages editable in the UI

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
To be coordinated with rollout of https://github.com/dimagi/formplayer/pull/1180

## Feature Flag
USH case search additions

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change