### PR TITLE
Make it possible to update cases by external ID

### DIFF
--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -32,8 +32,9 @@ class JsonIndex(jsonobject.JsonObject):
         if ids_specified > 1:
             raise BadValueError("Indices must specify case_id, external_id, or temporary ID, and only one")
         if ids_specified == 1:
-            self.properties()['case_type'].required = True
-            self.properties()['relationship'].required = True
+            for prop in ['case_type', 'relationship']:
+                if not self[prop]:
+                    raise BadValueError(f"Property '{prop}' is required when creating or updating case indices")
         super().validate(*args, **kwargs)
 
     def get_id(self, case_db):

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -34,14 +34,14 @@ class JsonIndex(jsonobject.JsonObject):
         if ids_specified == 1:
             for prop in ['case_type', 'relationship']:
                 if not self[prop]:
-                    raise BadValueError(f"Property '{prop}' is required when creating or updating case indices")
+                    raise BadValueError(f"Property {prop} is required when creating or updating case indices")
         super().validate(*args, **kwargs)
 
     def get_id(self, case_db):
         if self.temporary_id:
-            return case_db.lookup_id(self.temporary_id, 'temporary_id')
+            return case_db.get_by_temporary_id(self.temporary_id)
         if self.external_id:
-            return case_db.lookup_id(self.external_id, 'external_id')
+            return case_db.get_by_external_id(self.external_id)
         # case_id may be unspecified, which is fine - that's how deletions work
         return self.case_id
 

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -25,8 +25,8 @@ class JsonIndex(jsonobject.JsonObject):
     case_type = jsonobject.StringProperty(required=True)
     relationship = jsonobject.StringProperty(required=True, choices=('child', 'extension'))
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def validate(self, *args, **kwargs):
+        super().validate(*args, **kwargs)
         if len(list(filter(None, [self.case_id, self.external_id, self.temporary_id]))) != 1:
             raise BadValueError("Indices must specify case_id, external_id, or temporary ID, and only one")
 
@@ -49,9 +49,9 @@ class BaseJsonCaseChange(jsonobject.JsonObject):
         string_conversions = ()
 
     @classmethod
-    def wrap(self, obj):
+    def wrap(cls, obj):
         for attr, _ in obj.items():
-            if attr not in self._properties_by_key:
+            if attr not in cls._properties_by_key:
                 # JsonObject will raise an exception here anyways, but we need
                 # a user-friendly error message
                 raise BadValueError(f"'{attr}' is not a valid field.")

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -111,7 +111,7 @@ class JsonCaseCreation(BaseJsonCaseChange):
     @classmethod
     def wrap(cls, data):
         if 'case_id' in data:
-            raise UserError(f"You cannot specify 'case_id' when creating a new case")
+            raise UserError("You cannot specify case_id when creating a new case")
         data['case_id'] = str(uuid.uuid4())
         return super().wrap(data)
 

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -106,6 +106,8 @@ class JsonCaseCreation(BaseJsonCaseChange):
 
     @classmethod
     def wrap(cls, data):
+        if 'case_id' in data:
+            raise UserError(f"You cannot specify 'case_id' when creating a new case")
         data['case_id'] = str(uuid.uuid4())
         return super().wrap(data)
 

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -170,11 +170,9 @@ def _get_bulk_updates(domain, all_data, user):
     errors = []
     for i, data in enumerate(all_data, start=1):
         try:
-            is_creation = data.pop('create')
-        except KeyError:
-            raise UserError("A 'create' flag is required for each update.")
-
-        try:
+            is_creation = data.pop('create', None)
+            if is_creation is None:
+                raise UserError("A 'create' flag is required for each update.")
             updates.append(_get_individual_update(domain, data, user, is_creation))
         except UserError as e:
             errors.append(f'Error in row {i}: {e}')

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -387,7 +387,8 @@ class TestCaseAPI(TestCase):
             'owner_id': 'methuen_home',
         }])
         self.assertEqual(res.status_code, 400)
-        self.assertEqual(res.json(), {'error': "A 'create' flag is required for each update."})
+        self.assertIn("A 'create' flag is required for each update.",
+                      res.json()['error'])
 
     def test_attempt_create_with_case_id(self):
         res = self._bulk_update_cases([{

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -389,6 +389,18 @@ class TestCaseAPI(TestCase):
         self.assertEqual(res.status_code, 400)
         self.assertEqual(res.json(), {'error': "A 'create' flag is required for each update."})
 
+    def test_attempt_create_with_case_id(self):
+        res = self._bulk_update_cases([{
+            'create': True,
+            'case_type': 'player',
+            'case_name': 'Jolene',
+            'owner_id': 'methuen_home',
+            'case_id': 'somethingmalicious',
+        }])
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("You cannot specify 'case_id' when creating a new case",
+                      res.json()['error'])
+
     def test_bulk_update_too_big(self):
         res = self._bulk_update_cases([
             {'create': True, 'case_name': f'case {i}', 'case_type': 'player'}

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -424,7 +424,7 @@ class TestCaseAPI(TestCase):
             'case_id': 'somethingmalicious',
         }])
         self.assertEqual(res.status_code, 400)
-        self.assertIn("You cannot specify 'case_id' when creating a new case",
+        self.assertIn("You cannot specify case_id when creating a new case",
                       res.json()['error'])
 
     def test_bulk_update_too_big(self):

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -522,7 +522,6 @@ class TestCaseAPI(TestCase):
         self.assertEqual(case.dynamic_case_properties().get('champion'), 'true')
 
     def test_update_by_external_id_doesnt_exist(self):
-        case = self._make_case()
         res = self.client.put(
             reverse('case_api', args=(self.domain,)),
             {

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -344,7 +344,7 @@ class TestCaseAPI(TestCase):
                 },
             },
         }).json()
-        self.assertEqual(res['error'], "Property relationship is required.")
+        self.assertEqual(res['error'], "Property relationship is required when creating or updating case indices")
 
     def test_delete_index(self):
         # aka remove child case


### PR DESCRIPTION
## Product Description
Make it possible to update cases by external ID in the v0.6 Case API, without knowing the case ID

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2274
https://docs.google.com/document/d/1upMFrcItnyxVkD2NoBzpO6pTJRMncYVRVQcrvF5Gfj0/edit?disco=AAAAUj_F3X0

I had a bit of trouble splitting this into meaningful commits - honestly you might as well just review everything together.  The big thing is a restructure.  This PR introduces a `CaseIDLookerUpper` class that handles DB interaction in bulk.  Now anything with an implicit dependency on DB lookups requires an instance of that class.  This let me move enrichment and validation into the `BaseJsonCaseChange` class, in methods that accept that class.

## Feature Flag
Enable the v0.6 Case API

## Safety Assurance

### Safety story
Heavily tested, plus it's unreleased

### Automated test coverage
included
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
