### PR TITLE
Allow users to remove case indices via the v0.6 Case API

### DIFF
--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -32,8 +32,9 @@ class JsonIndex(jsonobject.JsonObject):
         if ids_specified > 1:
             raise BadValueError("Indices must specify case_id, external_id, or temporary ID, and only one")
         if ids_specified == 1:
-            self.properties()['case_type'].required = True
-            self.properties()['relationship'].required = True
+            for prop in ['case_type', 'relationship']:
+                if not self[prop]:
+                    raise BadValueError(f"Property '{prop}' is required when creating or updating case indices")
         super().validate(*args, **kwargs)
 
     def get_id(self, case_db):

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -344,7 +344,7 @@ class TestCaseAPI(TestCase):
                 },
             },
         }).json()
-        self.assertEqual(res['error'], "Property relationship is required.")
+        self.assertEqual(res['error'], "Property relationship is required when creating or updating case indices")
 
     def test_delete_index(self):
         # aka remove child case


### PR DESCRIPTION
## Product Description
Allow users to remove case indices via the v0.6 Case API

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2101
Merge base is https://github.com/dimagi/commcare-hq/pull/31961, just so I don't conflict with myself.

## Feature Flag
Enable the v0.6 Case API

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Unreleased feature, automated tests included

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
