### PR TITLE
Disable horizontal resizing for textarea across hq

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -841,7 +841,7 @@ class ChangeSubscriptionForm(forms.Form):
     subscription_change_note = forms.CharField(
         label=gettext_lazy("Note"),
         required=True,
-        widget=forms.Textarea,
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
     )
     new_plan_edition = forms.ChoiceField(
         label=gettext_lazy("Edition"), initial=SoftwarePlanEdition.ENTERPRISE,
@@ -925,7 +925,7 @@ class BulkUpgradeToLatestVersionForm(forms.Form):
     upgrade_note = forms.CharField(
         label="Note",
         required=True,
-        widget=forms.Textarea,
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
     )
 
     def __init__(self, old_plan_version, web_user, *args, **kwargs):
@@ -1322,7 +1322,7 @@ class SoftwarePlanVersionForm(forms.Form):
     new_role_description = forms.CharField(
         required=False,
         label="New Role Description",
-        widget=forms.Textarea,
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
     )
     upgrade_subscriptions = forms.BooleanField(
         label="Automatically upgrade all subscriptions on the "
@@ -1880,7 +1880,7 @@ class EnterprisePlanContactForm(forms.Form):
     message = forms.CharField(
         required=False,
         label=gettext_noop("Message"),
-        widget=forms.Textarea
+        widget=forms.Textarea(attrs={"style": "resize:vertical"})
     )
 
     def __init__(self, domain, web_user, data=None, *args, **kwargs):
@@ -1944,7 +1944,7 @@ class AnnualPlanContactForm(forms.Form):
     message = forms.CharField(
         required=False,
         label=gettext_noop("Message"),
-        widget=forms.Textarea
+        widget=forms.Textarea(attrs={"style": "resize:vertical"})
     )
 
     def __init__(self, domain, web_user, on_annual_plan, data=None, *args, **kwargs):
@@ -2347,7 +2347,7 @@ class AdjustBalanceForm(forms.Form):
 
     note = forms.CharField(
         required=True,
-        widget=forms.Textarea,
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
     )
 
     invoice_id = forms.CharField(

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -841,7 +841,7 @@ class ChangeSubscriptionForm(forms.Form):
     subscription_change_note = forms.CharField(
         label=gettext_lazy("Note"),
         required=True,
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
     )
     new_plan_edition = forms.ChoiceField(
         label=gettext_lazy("Edition"), initial=SoftwarePlanEdition.ENTERPRISE,
@@ -925,7 +925,7 @@ class BulkUpgradeToLatestVersionForm(forms.Form):
     upgrade_note = forms.CharField(
         label="Note",
         required=True,
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
     )
 
     def __init__(self, old_plan_version, web_user, *args, **kwargs):
@@ -1322,7 +1322,7 @@ class SoftwarePlanVersionForm(forms.Form):
     new_role_description = forms.CharField(
         required=False,
         label="New Role Description",
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
     )
     upgrade_subscriptions = forms.BooleanField(
         label="Automatically upgrade all subscriptions on the "
@@ -1880,7 +1880,7 @@ class EnterprisePlanContactForm(forms.Form):
     message = forms.CharField(
         required=False,
         label=gettext_noop("Message"),
-        widget=forms.Textarea(attrs={"style": "resize:vertical"})
+        widget=forms.Textarea(attrs={"class": "vertical-resize"})
     )
 
     def __init__(self, domain, web_user, data=None, *args, **kwargs):
@@ -1944,7 +1944,7 @@ class AnnualPlanContactForm(forms.Form):
     message = forms.CharField(
         required=False,
         label=gettext_noop("Message"),
-        widget=forms.Textarea(attrs={"style": "resize:vertical"})
+        widget=forms.Textarea(attrs={"class": "vertical-resize"})
     )
 
     def __init__(self, domain, web_user, on_annual_plan, data=None, *args, **kwargs):
@@ -2347,7 +2347,7 @@ class AdjustBalanceForm(forms.Form):
 
     note = forms.CharField(
         required=True,
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
     )
 
     invoice_id = forms.CharField(

--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -151,7 +151,7 @@
               <div class="col-sm-9">
                               <textarea rows="5"
                                         data-bind="value: comment"
-                                        class="form-control"></textarea>
+                                        class="form-control vertical-resize"></textarea>
               </div>
             </div>
           </div>

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -167,7 +167,7 @@
           <i class="fa fa-plus"></i> {% trans "Add filter" %}
         </button>
         <input type="text" class="form-control" data-bind="value: nodesetFilter, visible: showFilter" placeholder="{% trans_html_attr "referral = 'y'" %}" />
-        <textarea class="form-control" data-bind="value: nodeset, visible: showXpath" /></textarea>
+        <textarea class="form-control vertical-resize" data-bind="value: nodeset, visible: showXpath" /></textarea>
         {% if request|toggle_enabled:"SYNC_SEARCH_CASE_CLAIM" %}
           <p data-bind="visible: showXpath() && nodeset()" class="help-block">{% trans "This data will not be shown for case search results." %}</p>
         {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -128,7 +128,7 @@
                           placeholder="XPath Expression"
                           rows="1"
                           data-bind="text: xpath, value: xpath"
-                          class="form-control"
+                          class="form-control vertical-resize"
                           spellcheck="false">
                 </textarea>
               </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -17,7 +17,7 @@
     <div class="panel-body">
       <div class="row">
         <div class="col-sm-6">
-          <textarea class="form-control" data-bind="value: xml"></textarea>
+          <textarea class="form-control vertical-resize" data-bind="value: xml"></textarea>
         </div>
       </div>
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/custom_detail_variables.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/custom_detail_variables.html
@@ -11,7 +11,7 @@
       <p>{% trans "Add custom variables to the variables node." %}</p>
       <div class="row">
         <div class="col-sm-8">
-          <textarea class="form-control"
+          <textarea class="form-control vertical-resize"
                     data-bind="value: xml"
                     placeholder="<variable-name function='some(xpath_expression)' />"
                     spellcheck="false">

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_deploy_modal_sms.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_deploy_modal_sms.html
@@ -21,7 +21,7 @@
                data-bind="multiTypeahead: $root.recipients" />
       </div>
       <div class="form-group">
-                <textarea class="bitly form-control" name="message"
+                <textarea class="bitly form-control vertical-resize" name="message"
                           data-bind="text: 'Update to CommCare: ' + {% if is_odk %}sms_odk_url(){% else %}sms_url(){% endif %} + ' (&quot;' + short_name() + '&quot; v. ' + version() + ')'">
                 </textarea>
       </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -125,7 +125,7 @@
 
 <script type="text/html" id="CommcareSettings.widgets.textarea">
   <span>
-        <textarea type="text" data-bind="value: value, attr: {id: inputId}" class="form-control" />
+        <textarea type="text" data-bind="value: value, attr: {id: inputId}" class="form-control vertical-resize" />
     </span>
 </script>
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/xpathValidator.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/xpathValidator.html
@@ -11,7 +11,7 @@
 {% endcompress %}
 <script type="text/html" id="XPathValidator.template">
   <div class="js-xpath-input-target control-group" data-bind="css: {error: xpathValidator.error}">
-    <textarea class="form-control" spellcheck="false"
+    <textarea class="form-control vertical-resize" spellcheck="false"
               data-bind="attr: {name: input.getAttribute('name'), placeholder: input.getAttribute('placeholder')},
                       value: xpathValidator.xpathText"></textarea>
     <!--ko if: xpathValidator.error()-->

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -88,7 +88,7 @@
               </div>
               <div class="panel-body">
                 <div class="form-group" style="width:100%">
-                  <textarea style="min-width: 50%" spellcheck="false" class="form-control" name="xpath" type="text" placeholder="e.g: name = 'tyrion' or nickname='the imp'" data-bind="value: xpath"> </textarea>
+                  <textarea style="min-width: 50%" spellcheck="false" class="form-control vertical-resize" name="xpath" type="text" placeholder="e.g: name = 'tyrion' or nickname='the imp'" data-bind="value: xpath"> </textarea>
                 </div>
               </div>
             </div>

--- a/corehq/apps/cloudcare/templates/formplayer/debugger.html
+++ b/corehq/apps/cloudcare/templates/formplayer/debugger.html
@@ -133,7 +133,7 @@
       <div class="form-group">
                 <textarea
                   id="xpath"
-                  class="form-control debugger-code at-who-input"
+                  class="form-control vertical-resize debugger-code at-who-input"
                   name="xpath"
                   placeholder="XPath Expression"
                   autocomplete="off"

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -74,7 +74,7 @@
                       {% trans "Description" %}
                   </label>
                   <div class="col-xs-12 col-sm-6 col-md-6 col-lg-8 controls">
-                    <textarea name="description" class="form-control"></textarea>
+                    <textarea name="description" class="form-control vertical-resize"></textarea>
                   </div>
                 </div>
               </fieldset>

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -311,7 +311,7 @@ class DomainGlobalSettingsForm(forms.Form):
     )
     project_description = forms.CharField(
         label=gettext_lazy("Project Description"),
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
         required=False,
         max_length=1000,
         help_text=gettext_lazy(
@@ -855,7 +855,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
         required=False,
         help_text="Quick 1-2 sentence summary of the project.",
     )
-    notes = CharField(label="Notes*", required=False, widget=forms.Textarea(attrs={"style": "resize:vertical"}))
+    notes = CharField(label="Notes*", required=False, widget=forms.Textarea(attrs={"class": "vertical-resize"}))
     phone_model = CharField(
         label="Device Model",
         help_text="Add Web Apps, if this project is using Web Apps as well",
@@ -969,7 +969,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
     )
     app_design_comments = CharField(
         label="App Design Comments",
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
         required=False,
         help_text=(
             "Unusual workflows or design decisions for others to watch out for."
@@ -1776,12 +1776,14 @@ class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):
 class ProBonoForm(forms.Form):
     contact_email = MultiCharField(label=gettext_lazy("Email To"), widget=forms.Select(choices=[]))
     organization = forms.CharField(label=gettext_lazy("Organization"))
-    project_overview = forms.CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}),
-    label="Project overview")
+    project_overview = forms.CharField(
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}), label="Project overview"
+    )
     airtime_expense = forms.CharField(label=gettext_lazy("Estimated annual expenditures on airtime:"))
     device_expense = forms.CharField(label=gettext_lazy("Estimated annual expenditures on devices:"))
-    pay_only_features_needed = forms.CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}),
-    label="Pay only features needed")
+    pay_only_features_needed = forms.CharField(
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}), label="Pay only features needed"
+    )
     duration_of_project = forms.CharField(help_text=gettext_lazy(
         "We grant pro-bono subscriptions to match the duration of your "
         "project, up to a maximum of 12 months at a time (at which point "

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -311,7 +311,7 @@ class DomainGlobalSettingsForm(forms.Form):
     )
     project_description = forms.CharField(
         label=gettext_lazy("Project Description"),
-        widget=forms.Textarea,
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
         required=False,
         max_length=1000,
         help_text=gettext_lazy(
@@ -855,7 +855,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
         required=False,
         help_text="Quick 1-2 sentence summary of the project.",
     )
-    notes = CharField(label="Notes*", required=False, widget=forms.Textarea)
+    notes = CharField(label="Notes*", required=False, widget=forms.Textarea(attrs={"style": "resize:vertical"}))
     phone_model = CharField(
         label="Device Model",
         help_text="Add Web Apps, if this project is using Web Apps as well",
@@ -969,7 +969,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
     )
     app_design_comments = CharField(
         label="App Design Comments",
-        widget=forms.Textarea,
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
         required=False,
         help_text=(
             "Unusual workflows or design decisions for others to watch out for."
@@ -1776,10 +1776,12 @@ class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):
 class ProBonoForm(forms.Form):
     contact_email = MultiCharField(label=gettext_lazy("Email To"), widget=forms.Select(choices=[]))
     organization = forms.CharField(label=gettext_lazy("Organization"))
-    project_overview = forms.CharField(widget=forms.Textarea, label="Project overview")
+    project_overview = forms.CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+    label="Project overview")
     airtime_expense = forms.CharField(label=gettext_lazy("Estimated annual expenditures on airtime:"))
     device_expense = forms.CharField(label=gettext_lazy("Estimated annual expenditures on devices:"))
-    pay_only_features_needed = forms.CharField(widget=forms.Textarea, label="Pay only features needed")
+    pay_only_features_needed = forms.CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+    label="Pay only features needed")
     duration_of_project = forms.CharField(help_text=gettext_lazy(
         "We grant pro-bono subscriptions to match the duration of your "
         "project, up to a maximum of 12 months at a time (at which point "

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -127,7 +127,7 @@
               {% blocktrans %}
                 Could you indicate which new tool you’re using?
               {% endblocktrans %}
-              <textarea class="form-control"
+              <textarea class="form-control vertical-resize"
                         data-bind="textInput: oNewTool"></textarea>
             </p>
             <p>
@@ -146,7 +146,7 @@
               {% blocktrans %}
                 Please specify
               {% endblocktrans %}
-              <textarea class="form-control"
+              <textarea class="form-control vertical-resize"
                         data-bind="textInput: oOtherNewToolReason"></textarea>
             </p>
           <!-- /ko -->
@@ -155,7 +155,7 @@
             {% blocktrans %}
               Please let us know any other feedback you have
             {% endblocktrans %}
-            <textarea class="form-control"
+            <textarea class="form-control vertical-resize"
                       data-bind="textInput: oFeedback"></textarea>
           </p>
 

--- a/corehq/apps/domain/views/tombstone.py
+++ b/corehq/apps/domain/views/tombstone.py
@@ -73,7 +73,7 @@ def create_tombstone(request):
 class TombstoneManagementForm(forms.Form):
     csv_domain_list = forms.CharField(
         label="Comma separated domains",
-        widget=forms.Textarea()
+        widget=forms.Textarea(attrs={"style": "resize:vertical"})
     )
 
     @staticmethod

--- a/corehq/apps/domain/views/tombstone.py
+++ b/corehq/apps/domain/views/tombstone.py
@@ -73,7 +73,7 @@ def create_tombstone(request):
 class TombstoneManagementForm(forms.Form):
     csv_domain_list = forms.CharField(
         label="Comma separated domains",
-        widget=forms.Textarea(attrs={"style": "resize:vertical"})
+        widget=forms.Textarea(attrs={"class": "vertical-resize"})
     )
 
     @staticmethod

--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -31,7 +31,7 @@ class EnterpriseSettingsForm(forms.Form):
         label="Signup Restriction Message",
         required=False,
         help_text=gettext_lazy("Message to display to users who attempt to sign up for an account"),
-        widget=forms.Textarea(attrs={'rows': 2, 'maxlength': 512, "style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={'rows': 2, 'maxlength': 512, "class": "vertical-resize"}),
     )
 
     forms_filetype = forms.ChoiceField(

--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -31,7 +31,7 @@ class EnterpriseSettingsForm(forms.Form):
         label="Signup Restriction Message",
         required=False,
         help_text=gettext_lazy("Message to display to users who attempt to sign up for an account"),
-        widget=forms.Textarea(attrs={'rows': 2, 'maxlength': 512}),
+        widget=forms.Textarea(attrs={'rows': 2, 'maxlength': 512, "style": "resize:vertical"}),
     )
 
     forms_filetype = forms.ChoiceField(

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -78,7 +78,7 @@
           <div class="col-sm-9 col-md-8 col-lg-6">
             <textarea data-bind="value: description"
                       id="export-description"
-                      class="form-control"
+                      class="form-control vertical-resize"
                       rows="3">
             </textarea>
           </div>

--- a/corehq/apps/hqadmin/forms.py
+++ b/corehq/apps/hqadmin/forms.py
@@ -24,7 +24,7 @@ class EmailForm(forms.Form):
     real_email = forms.BooleanField(required=False)
 
 class ReprocessMessagingCaseUpdatesForm(forms.Form):
-    case_ids = forms.CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}))
+    case_ids = forms.CharField(widget=forms.Textarea(attrs={"class": "vertical-resize"}))
 
     def clean_case_ids(self):
         value = self.cleaned_data.get('case_ids', '')
@@ -60,7 +60,7 @@ class ReprocessMessagingCaseUpdatesForm(forms.Form):
 class SuperuserManagementForm(forms.Form):
     csv_email_list = forms.CharField(
         label="Comma or new-line separated email addresses",
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
         required=True
     )
     privileges = forms.MultipleChoiceField(
@@ -101,7 +101,7 @@ class SuperuserManagementForm(forms.Form):
 class OffboardingUserListForm(forms.Form):
     csv_email_list = forms.CharField(
         label="Comma/new-line seperated email addresses",
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
         required=False
     )
 

--- a/corehq/apps/hqadmin/forms.py
+++ b/corehq/apps/hqadmin/forms.py
@@ -24,7 +24,7 @@ class EmailForm(forms.Form):
     real_email = forms.BooleanField(required=False)
 
 class ReprocessMessagingCaseUpdatesForm(forms.Form):
-    case_ids = forms.CharField(widget=forms.Textarea)
+    case_ids = forms.CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}))
 
     def clean_case_ids(self):
         value = self.cleaned_data.get('case_ids', '')
@@ -60,7 +60,7 @@ class ReprocessMessagingCaseUpdatesForm(forms.Form):
 class SuperuserManagementForm(forms.Form):
     csv_email_list = forms.CharField(
         label="Comma or new-line separated email addresses",
-        widget=forms.Textarea(),
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
         required=True
     )
     privileges = forms.MultipleChoiceField(
@@ -101,7 +101,7 @@ class SuperuserManagementForm(forms.Form):
 class OffboardingUserListForm(forms.Form):
     csv_email_list = forms.CharField(
         label="Comma/new-line seperated email addresses",
-        widget=forms.Textarea(),
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
         required=False
     )
 

--- a/corehq/apps/hqwebapp/templates/500.html
+++ b/corehq/apps/hqwebapp/templates/500.html
@@ -80,7 +80,7 @@
                 <div class="form-group">
                   <label class="col-sm-3 control-label" for="bug-report-500-message">{% trans "Full Description" %}</label>
                   <div class="col-sm-6">
-                    <textarea class="form-control" name="message" id="bug-report-500-message" rows="5"></textarea>
+                    <textarea class="form-control vertical-resize" name="message" id="bug-report-500-message" rows="5"></textarea>
                   </div>
                 </div>
               </fieldset>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/modal_report_issue.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/modal_report_issue.html
@@ -44,7 +44,7 @@
                                    class="col-sm-3 control-label">{% trans "Full Description" %}</label>
                             <div class="col-sm-9">
                                 <textarea name="message"
-                                          class="form-control"
+                                          class="form-control vertical-resize"
                                           id="bug-report-message"
                                           rows="3"
                                           placeholder="{% trans "Please describe the issue and list any steps you took to see this issue." %}"></textarea>
@@ -78,7 +78,7 @@
                                    class="col-sm-3 control-label">{% trans "Project Description" %}</label>
                             <div class="col-sm-9">
                                 <textarea name="project_description"
-                                          class="form-control"
+                                          class="form-control vertical-resize"
                                           id="bug-report-project-description"
                                           rows="3"
                                           placeholder="{% trans 'Please provide a short description of your organization and the work it is doing.' %}">{% spaceless %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/maintenance_alerts.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/maintenance_alerts.html
@@ -38,7 +38,7 @@
             <div class="col-sm-8">
               <textarea name="alert_text"
                         id="alert_text"
-                        class="form-control"
+                        class="form-control vertical-resize"
                         placeholder="Alert text..."
                         form="alertForm"></textarea>
             </div>
@@ -51,7 +51,7 @@
             <div class="col-sm-8">
               <textarea name="domains"
                         id="domains"
-                        class="form-control"
+                        class="form-control vertical-resize"
                         placeholder="Affected domains (space separated). Leave blank to show to everyone."
                         form="alertForm" ></textarea>
             </div>

--- a/corehq/apps/notifications/forms.py
+++ b/corehq/apps/notifications/forms.py
@@ -17,7 +17,7 @@ class NotificationCreationForm(forms.Form):
     content = forms.CharField(
         label=gettext_lazy('Content'),
         max_length=140,
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
     )
     url = forms.URLField(
         label=gettext_lazy('URL')
@@ -33,7 +33,7 @@ class NotificationCreationForm(forms.Form):
     domains = SimpleArrayField(
         base_field=forms.CharField(),
         label=gettext_lazy("Domains"),
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
         help_text=gettext_lazy("Enter a comma separated list of domains for this notification. "
                                "This is only required if you have checked the box above."),
         required=False

--- a/corehq/apps/notifications/forms.py
+++ b/corehq/apps/notifications/forms.py
@@ -17,7 +17,7 @@ class NotificationCreationForm(forms.Form):
     content = forms.CharField(
         label=gettext_lazy('Content'),
         max_length=140,
-        widget=forms.Textarea,
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
     )
     url = forms.URLField(
         label=gettext_lazy('URL')
@@ -33,7 +33,7 @@ class NotificationCreationForm(forms.Form):
     domains = SimpleArrayField(
         base_field=forms.CharField(),
         label=gettext_lazy("Domains"),
-        widget=forms.Textarea,
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
         help_text=gettext_lazy("Enter a comma separated list of domains for this notification. "
                                "This is only required if you have checked the box above."),
         required=False

--- a/corehq/apps/products/forms.py
+++ b/corehq/apps/products/forms.py
@@ -28,8 +28,9 @@ class CurrencyField(forms.DecimalField):
 class ProductForm(forms.Form):
     name = forms.CharField(max_length=100)
     code = forms.CharField(label=gettext_noop("Product ID"), max_length=100, required=False)
-    description = forms.CharField(max_length=500, required=False,
-    widget=forms.Textarea(attrs={"style": "resize:vertical"}))
+    description = forms.CharField(
+        max_length=500, required=False, widget=forms.Textarea(attrs={"class": "vertical-resize"})
+    )
     unit = forms.CharField(label=gettext_noop("Units"), max_length=100, required=False)
     program_id = forms.ChoiceField(label=gettext_noop("Program"), choices=(), required=True)
     cost = CurrencyField(max_digits=8, decimal_places=2, required=False)

--- a/corehq/apps/products/forms.py
+++ b/corehq/apps/products/forms.py
@@ -28,7 +28,8 @@ class CurrencyField(forms.DecimalField):
 class ProductForm(forms.Form):
     name = forms.CharField(max_length=100)
     code = forms.CharField(label=gettext_noop("Product ID"), max_length=100, required=False)
-    description = forms.CharField(max_length=500, required=False, widget=forms.Textarea)
+    description = forms.CharField(max_length=500, required=False,
+    widget=forms.Textarea(attrs={"style": "resize:vertical"}))
     unit = forms.CharField(label=gettext_noop("Units"), max_length=100, required=False)
     program_id = forms.ChoiceField(label=gettext_noop("Program"), choices=(), required=True)
     cost = CurrencyField(max_digits=8, decimal_places=2, required=False)

--- a/corehq/apps/registry/templates/registry/registry_list.html
+++ b/corehq/apps/registry/templates/registry/registry_list.html
@@ -209,7 +209,7 @@
                       {% trans "Description" %}
                   </label>
                   <div class="col-xs-12 col-sm-8 col-md-8 col-lg-8 controls">
-                    <textarea name="description" class="form-control"></textarea>
+                    <textarea name="description" class="form-control vertical-resize"></textarea>
                   </div>
                 </div>
                 <div class="form-group">

--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -28,7 +28,7 @@ class SavedReportConfigForm(forms.Form):
     name = forms.CharField()
     description = forms.CharField(
         required=False,
-        widget=forms.Textarea(),
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
     )
     start_date = forms.DateField(
         required=False,

--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -28,7 +28,7 @@ class SavedReportConfigForm(forms.Form):
     name = forms.CharField()
     description = forms.CharField(
         required=False,
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
     )
     start_date = forms.DateField(
         required=False,

--- a/corehq/apps/reports/templates/reports/partials/save_reports_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/save_reports_modal.html
@@ -24,7 +24,7 @@
           <div class="form-group">
             <label class="control-label col-xs-3" for="description">{% trans "Description" %}</label>
             <div class="col-xs-9">
-              <textarea rows="3" name="description" data-bind="value: description" class="form-control"></textarea>
+              <textarea rows="3" name="description" data-bind="value: description" class="form-control vertical-resize"></textarea>
             </div>
           </div>
 

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -157,7 +157,7 @@
                             name="recipient_emails"
                             data-bind="value: recipient_emails"
                             aria-describedby="email-report-recipient_emails-help-block"
-                            class="form-control"></textarea>
+                            class="form-control vertical-resize"></textarea>
                   <span id="email-report-recipient_emails-help-block"
                         class="help-block">
                     Separate email addresses with commas
@@ -171,7 +171,7 @@
                             id="email-report-notes"
                             name="notes"
                             data-bind="value: notes"
-                            class="form-control"></textarea>
+                            class="form-control vertical-resize"></textarea>
                 </div>
               </div>
             </div>

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -899,7 +899,7 @@ class BackendForm(Form):
     )
     description = CharField(
         label=gettext_noop("Description"),
-        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+        widget=forms.Textarea(attrs={"class": "vertical-resize"}),
         required=False,
     )
     give_other_domains_access = BooleanField(
@@ -1297,9 +1297,9 @@ class SubscribeSMSForm(Form):
 
 class ComposeMessageForm(forms.Form):
 
-    recipients = forms.CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+    recipients = forms.CharField(widget=forms.Textarea(attrs={"class": "vertical-resize"}),
                                  help_text=gettext_lazy("Type a username, group name or 'send to all'"))
-    message = forms.CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+    message = forms.CharField(widget=forms.Textarea(attrs={"class": "vertical-resize"}),
     help_text=gettext_lazy('0 characters (160 max)'))
 
     def __init__(self, *args, **kwargs):
@@ -1323,7 +1323,7 @@ class ComposeMessageForm(forms.Form):
 class SentTestSmsForm(Form):
     phone_number = CharField(
         required=True, help_text=gettext_lazy("Phone number with country code"))
-    message = CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}), required=True)
+    message = CharField(widget=forms.Textarea(attrs={"class": "vertical-resize"}), required=True)
     backend_id = ChoiceField(
         label=gettext_lazy("Gateway"),
         required=False

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -899,7 +899,7 @@ class BackendForm(Form):
     )
     description = CharField(
         label=gettext_noop("Description"),
-        widget=forms.Textarea,
+        widget=forms.Textarea(attrs={"style": "resize:vertical"}),
         required=False,
     )
     give_other_domains_access = BooleanField(
@@ -1297,9 +1297,10 @@ class SubscribeSMSForm(Form):
 
 class ComposeMessageForm(forms.Form):
 
-    recipients = forms.CharField(widget=forms.Textarea,
+    recipients = forms.CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}),
                                  help_text=gettext_lazy("Type a username, group name or 'send to all'"))
-    message = forms.CharField(widget=forms.Textarea, help_text=gettext_lazy('0 characters (160 max)'))
+    message = forms.CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}),
+    help_text=gettext_lazy('0 characters (160 max)'))
 
     def __init__(self, *args, **kwargs):
         domain = kwargs.pop('domain')
@@ -1322,7 +1323,7 @@ class ComposeMessageForm(forms.Form):
 class SentTestSmsForm(Form):
     phone_number = CharField(
         required=True, help_text=gettext_lazy("Phone number with country code"))
-    message = CharField(widget=forms.Textarea, required=True)
+    message = CharField(widget=forms.Textarea(attrs={"style": "resize:vertical"}), required=True)
     backend_id = ChoiceField(
         label=gettext_lazy("Gateway"),
         required=False

--- a/corehq/apps/userreports/templates/userreports/import_report.html
+++ b/corehq/apps/userreports/templates/userreports/import_report.html
@@ -6,7 +6,7 @@
     <div class="form-group">
       <label for="report_spec" class="control-label col-sm-3 col-md-2 requiredField">{% trans "Report spec" %}<span class="asteriskField">*</span></label>
       <div class="col-sm-9 col-md-8">
-        <textarea cols="100" placeholder="{% trans 'paste report source here' %}" class="form-control" name="report_spec" rows="30">{{ spec }}</textarea>
+        <textarea cols="100" placeholder="{% trans 'paste report source here' %}" class="form-control vertical-resize" name="report_spec" rows="30">{{ spec }}</textarea>
       </div>
     </div>
     <div class="form-actions">

--- a/corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+++ b/corehq/apps/userreports/templates/userreports/partials/filter_panel.html
@@ -73,7 +73,7 @@
                 <div class="form-group">
                   <label class="control-label col-sm-3" for="description">{% trans "Description" %}</label>
                   <div class="controls col-sm-9">
-                    <textarea rows="3" class="form-control" name="description" data-bind="value: description"></textarea>
+                    <textarea rows="3" class="form-control vertical-resize" name="description" data-bind="value: description"></textarea>
                   </div>
                 </div>
                 <div data-bind="visible: has_ucr_datespan">

--- a/corehq/apps/userreports/templates/userreports/ucr_expression.html
+++ b/corehq/apps/userreports/templates/userreports/ucr_expression.html
@@ -47,7 +47,7 @@
                 {% trans "Description" %}
               </label>
               <div class="col-xs-12 col-sm-7 col-md-7 col-lg-7 controls">
-                <textarea name="description" class="form-control" id="description" data-bind="value: description">
+                <textarea name="description" class="form-control vertical-resize" id="description" data-bind="value: description">
                 </textarea>
               </div>
             </div>

--- a/corehq/messaging/scheduling/templates/scheduling/partials/message_configuration.html
+++ b/corehq/messaging/scheduling/templates/scheduling/partials/message_configuration.html
@@ -20,14 +20,14 @@
 </div>
 
 <div class="controls translation-controls" data-bind="visible: !translate()">
-  <textarea data-bind="value: nonTranslatedMessage" rows="10" cols="40" class="textarea form-control">
+  <textarea data-bind="value: nonTranslatedMessage" rows="10" cols="40" class="textarea form-control vertical-resize">
   </textarea>
 </div>
 
 <div data-bind="visible: translate(), foreach: translatedMessages">
   <div class="controls translation-controls">
     <label>{% trans "Translation" %} (<span data-bind="text: language_code"></span>):</label>
-    <textarea data-bind="value: message" rows="10" cols="40" class="textarea form-control">
+    <textarea data-bind="value: message" rows="10" cols="40" class="textarea form-control vertical-resize">
         </textarea>
   </div>
 </div>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Original Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-13281

After consulting other's opinion in #gtd-product, instead of implementing what the original ticket ask for (resize both vertically and horizontally), I disabled horizontally resizing for all textarea.
Related slack discussion: 
https://dimagi.slack.com/archives/C0BGN9LDU/p1658431905764939
https://dimagi.slack.com/archives/C0BGN9LDU/p1658477079788099

Here is a google doc I made to track almost every changes:
https://docs.google.com/document/d/1Hs9oDE_RlX2DmzlriuaQo-xGPX7EGoendUpcd29lRVU/edit?usp=sharing



## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I searched two patterns in our hq codebase:  `<textarea(.|\n)*form-control`, `widget=forms.Textarea` , to find all the textarea might need change. And I either add `vertical-resize` to its class, or add `"style": "resize:vertical"` to its attributes.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
This is not specific to a feature flag. But many feature flags might need to toggle on to see the changes.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I find almost every changes I made.
Also, there is no functionality changed. Just disabling horizontal resizing should be safe.
This change aligns with our [style guide](https://www.commcarehq.org/styleguide/organisms/#:~:text=The%20textarea%20uses,the%20page%27s%20layout)

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Talked with Jenny, no QA for this one. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
