### PR TITLE
Disable horizontal resizing in webapp and app preview

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -313,7 +313,7 @@
   <span class="help-block type sr-only" data-bind="
         text: helpText()
     "></span>
-  <textarea class="textfield form-control" data-bind="
+  <textarea class="textfield form-control vertical-resize" data-bind="
         value: $data.rawAnswer,
         valueUpdate: valueUpdate,
         attr: {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This is related to this [PR](https://github.com/dimagi/commcare-hq/pull/31964)
This change will affect all text entry in App Preview and Web App:
App Review:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/39149002/182234682-9811f513-7472-4b26-b71f-bf782f1b6c20.png">
Web App:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/39149002/182234742-e6b4813a-5464-400b-8cae-183c0d60062e.png">


Making this specific change in a separate PR, because Web apps UI is an area where clients are very sensitive to changes, and it would be good to be able to change/revert it separately if we need to.


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Just add `vertical-resize` class to text entry template

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA for this.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
