### PR TITLE
Clear login attempts for mobile users after syncs

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -272,7 +272,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
         return HttpResponse('Could not find user', status=404), None
 
     # successful sync, reset login attempts for mobile user
-    clear_login_attempts(restore_user)
+    clear_login_attempts(as_user_obj or couch_user)
 
     project = Domain.get_by_name(domain)
     async_restore_enabled = (

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -75,6 +75,7 @@ from .utils import (
     handle_401_response,
     is_permitted_to_restore,
 )
+from ..hqwebapp.signals import clear_login_attempts
 
 PROFILE_PROBABILITY = float(os.getenv('COMMCARE_PROFILE_RESTORE_PROBABILITY', 0))
 PROFILE_LIMIT = os.getenv('COMMCARE_PROFILE_RESTORE_LIMIT')
@@ -269,6 +270,9 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     restore_user = get_restore_user(domain, couch_user, as_user_obj)
     if not restore_user:
         return HttpResponse('Could not find user', status=404), None
+
+    # successful sync, reset login attempts for mobile user
+    clear_login_attempts(restore_user)
 
     project = Domain.get_by_name(domain)
     async_restore_enabled = (


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13520

I first want to make sure this is the right spot to make this change before proceeding. If it is, I could attempt to add a test to verify this, but there is a lot going on in this method so I don't anticipate it to be trivial. The idea behind the change is that every time users login via the web interface, their login attempts are cleared. This mirrors that behavior but for mobile users. Since a mobile user could login offline, the point at which to clear login attempts would be upon a successful sync. This ensures that if a mobile user goes years without a password reset, they won't slowly accumulate login_attempts for failed attempts.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is a safe change since it is just clearing login attempts when a user syncs.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
