### PR TITLE
[USH-2253] [USH-2296] [bugfix] fix case detail tabs mode not loading correctly

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -55,7 +55,8 @@ hqDefine("app_manager/js/details/column", function () {
             relevant: "",
         };
         self.original = _.defaults(self.original, tabDefaults);
-        if (!self.original.nodeset && screen.childCaseTypes && screen.childCaseTypes.length) {
+        let screenHasChildCaseTypes = screen.childCaseTypes && screen.childCaseTypes.length;
+        if (!self.original.nodeset && !self.original.nodesetCaseType && screenHasChildCaseTypes) {
             // If there's no nodeset but there are child case types, default to showing a case type
             self.original.nodesetCaseType = screen.childCaseTypes[0];
         }


### PR DESCRIPTION
## Technical Summary
This fixes a bug that was introduced during another fix for the same UI component: https://github.com/dimagi/commcare-hq/pull/31808

The fix is to only apply a default value if the field does not already have a value.

https://dimagi-dev.atlassian.net/browse/USH-2253
https://dimagi-dev.atlassian.net/browse/USH-2296

## Feature Flag
Associate a nodeset with a case detail tab (detail-list-tab-nodesets)

## Safety Assurance

### Safety story
I tested this locally with detail tabs that use subcases as well as custom nodesets. Reloading the page correctly set the dropdowns in all cases.

### Automated test coverage
NA

### QA Plan
None (Considering this is the 2nd bug on the same feature I could be persuaded that this should go through QA)


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
