### PR TITLE
Add migration to truncate authtoken_token table

### DIFF
--- a/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
+++ b/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from corehq.util.django_migrations import add_if_not_exists_raw
+from corehq.util.django_migrations import add_if_exists_raw
 
 
 class Migration(migrations.Migration):
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            add_if_not_exists_raw("TRUNCATE TABLE authtoken_token", name='authtoken_table'),
+            add_if_exists_raw("TRUNCATE TABLE authtoken_token", name='authtoken_table'),
             reverse_sql=migrations.RunSQL.noop
         )
     ]

--- a/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
+++ b/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
@@ -1,5 +1,7 @@
 from django.db import migrations
 
+from corehq.util.django_migrations import add_if_not_exists
+
 
 class Migration(migrations.Migration):
 
@@ -8,8 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL("""
-            DROP TABLE IF EXISTS authtoken_token;
-            DELETE FROM django_migrations WHERE app='authtoken';
-        """, reverse_sql=migrations.RunSQL.noop)
+        migrations.RunSQL(add_if_not_exists("TRUNCATE TABLE authtoken_token"), reverse_sql=migrations.RunSQL.noop)
     ]

--- a/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
+++ b/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from corehq.util.django_migrations import add_if_exists_raw
+from corehq.util.django_migrations import execute_sql_if_exists_raw
 
 
 class Migration(migrations.Migration):
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            add_if_exists_raw("TRUNCATE TABLE authtoken_token", name='authtoken_table'),
+            execute_sql_if_exists_raw("TRUNCATE TABLE authtoken_token", name='authtoken_table'),
             reverse_sql=migrations.RunSQL.noop
         )
     ]

--- a/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
+++ b/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
@@ -5,7 +5,7 @@ def _truncate_authtoken_table(apps, schema_editor):
     # NOTE: truncating to preserve migration records
     from django.db import connection
     cursor = connection.cursor()
-    cursor.execute("TRUNCATE TABLE `authtoken_token`")
+    cursor.execute("TRUNCATE TABLE authtoken_token")
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
+++ b/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from corehq.util.django_migrations import add_if_not_exists
+from corehq.util.django_migrations import add_if_not_exists_raw
 
 
 class Migration(migrations.Migration):
@@ -10,5 +10,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL(add_if_not_exists("TRUNCATE TABLE authtoken_token"), reverse_sql=migrations.RunSQL.noop)
+        migrations.RunSQL(
+            add_if_not_exists_raw("TRUNCATE TABLE authtoken_token", name='authtoken_table'),
+            reverse_sql=migrations.RunSQL.noop
+        )
     ]

--- a/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
+++ b/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
@@ -1,13 +1,6 @@
 from django.db import migrations
 
 
-def _truncate_authtoken_table(apps, schema_editor):
-    # NOTE: truncating to preserve migration records
-    from django.db import connection
-    cursor = connection.cursor()
-    cursor.execute("TRUNCATE TABLE authtoken_token")
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -15,5 +8,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(_truncate_authtoken_table, reverse_code=migrations.RunPython.noop)
+        migrations.RunSQL("TRUNCATE TABLE authtoken_token", reverse_sql=migrations.RunSQL.noop)
     ]

--- a/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
+++ b/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
@@ -9,9 +9,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL("""
-            IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'authtoken_token')
-            begin
-                TRUNCATE TABLE authtoken_token;
-            end
+            DROP TABLE IF EXISTS authtoken_token;
+            DELETE FROM django_migrations WHERE app='authtoken';
         """, reverse_sql=migrations.RunSQL.noop)
     ]

--- a/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
+++ b/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
@@ -1,7 +1,7 @@
 from django.db import migrations
 
 
-def _truncate_authtoken_table():
+def _truncate_authtoken_table(apps, schema_editor):
     # NOTE: truncating to preserve migration records
     from django.db import connection
     cursor = connection.cursor()

--- a/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
+++ b/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
@@ -8,5 +8,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL("TRUNCATE TABLE authtoken_token", reverse_sql=migrations.RunSQL.noop)
+        migrations.RunSQL("""
+            IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'authtoken_token')
+            begin
+                TRUNCATE TABLE authtoken_token;
+            end
+        """, reverse_sql=migrations.RunSQL.noop)
     ]

--- a/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
+++ b/corehq/apps/hqwebapp/migrations/0009_truncate_authtoken_table.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+def _truncate_authtoken_table():
+    # NOTE: truncating to preserve migration records
+    from django.db import connection
+    cursor = connection.cursor()
+    cursor.execute("TRUNCATE TABLE `authtoken_token`")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hqwebapp', '0008_hqoauthapplication'),
+    ]
+
+    operations = [
+        migrations.RunPython(_truncate_authtoken_table, reverse_code=migrations.RunPython.noop)
+    ]

--- a/corehq/util/django_migrations.py
+++ b/corehq/util/django_migrations.py
@@ -56,6 +56,17 @@ def add_if_not_exists_raw(string, name):
     ])
 
 
+def add_if_exists_raw(string, name):
+    """
+    turn a 'TRUNCATE TABLE' template into a 'TRUNCATE TABLE IF EXISTS' template
+    """
+    return ''.join([
+        "DO $do$ BEGIN IF NOT (SELECT to_regclass('{}') is NULL) THEN".format(name),
+        string,
+        "; END IF; END $do$"
+    ])
+
+
 class DatabaseSchemaEditorIfNotExists(DatabaseSchemaEditor):
     sql_create_index = add_if_not_exists(DatabaseSchemaEditor.sql_create_index)
     sql_create_unique = add_if_not_exists(DatabaseSchemaEditor.sql_create_unique)

--- a/corehq/util/django_migrations.py
+++ b/corehq/util/django_migrations.py
@@ -61,7 +61,7 @@ def add_if_exists_raw(string, name):
     turn a 'TRUNCATE TABLE' template into a 'TRUNCATE TABLE IF EXISTS' template
     """
     return ''.join([
-        "DO $do$ BEGIN IF NOT (SELECT to_regclass('{}') is NULL) THEN".format(name),
+        "DO $do$ BEGIN IF NOT (SELECT to_regclass('{}') is NULL) THEN ".format(name),
         string,
         "; END IF; END $do$"
     ])

--- a/corehq/util/django_migrations.py
+++ b/corehq/util/django_migrations.py
@@ -56,7 +56,7 @@ def add_if_not_exists_raw(string, name):
     ])
 
 
-def add_if_exists_raw(string, name):
+def execute_sql_if_exists_raw(string, name):
     """
     turn a 'TRUNCATE TABLE' template into a 'TRUNCATE TABLE IF EXISTS' template
     """

--- a/migrations.lock
+++ b/migrations.lock
@@ -487,6 +487,7 @@ hqwebapp
  0006_create_user_access_log
  0007_user_access_agent
  0008_hqoauthapplication
+ 0009_truncate_authtoken_table
 integration
  0001_initial
  0002_dialersettings


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13728

We no longer reference this table in HQ, and therefore can remove it. ~Rather than drop the table, we are choosing to truncate it to preserve django migrations that were run in the authtoken app.~ ~Update: since there is not straightforward conditional syntax available in postgres for TRUNCATE, we are instead opting to drop the table and delete the migrations. I've also confirmed that this is the only table that exists from the authtoken app.~ Another update: created a utility to effectively have "TRUNCATE IF EXISTS" and using that instead.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
We do not use this table anymore, so it is safe to delete all rows within it. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
This is a migration that does not have a straightforward reversal, so while the PR can be reverted, the migration will not be.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
