### PR TITLE
Fixed date range treatment of single value

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -323,7 +323,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
                 if (_.every(parts, function (part) { return part.isValid(); }))  {
                     if (parts.length === 1) { // condition where only one valid date is typed in rather than a range
-                        $input.val(oldValue + separator + oldValue).trigger('change');
+                        newValue = oldValue + separator + oldValue;
                     } else if (parts.length === 2) {
                         newValue = parts[0].format(dateFormat) + separator + parts[1].format(dateFormat);
                     }


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2305

## Technical Summary
This broke in https://github.com/dimagi/commcare-hq/pull/31906, though I'm not sure exactly how. Prior to that PR, entering a single date range caused the change event to be fired twice, but the correct value ended up getting rendered after those two changes. I think the new logic is clearer.

## Feature Flag
Case search

## Safety Assurance

### Safety story
Despite this being a web apps UI change, it's limited to the if block for single-date inputs to date range widgets, which is already broken, so I'm leaning against QA.

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
