### PR TITLE
Check if location_filter_definition have valid information

### DIFF
--- a/corehq/apps/data_interfaces/forms.py
+++ b/corehq/apps/data_interfaces/forms.py
@@ -707,14 +707,16 @@ class CaseRuleCriteriaForm(forms.Form):
 
             if self.cleaned_data['location_filter_definition']:
                 definition_data = self.cleaned_data['location_filter_definition']
-                definition = LocationFilterDefinition.objects.create(
-                    location_id=definition_data['location_id'],
-                    include_child_locations=definition_data.get('include_child_locations', False),
-                )
 
-                criteria = CaseRuleCriteria(rule=rule)
-                criteria.definition = definition
-                criteria.save()
+                if definition_data and definition_data['location_id']:
+                    definition = LocationFilterDefinition.objects.create(
+                        location_id=definition_data['location_id'],
+                        include_child_locations=definition_data.get('include_child_locations', False),
+                    )
+
+                    criteria = CaseRuleCriteria(rule=rule)
+                    criteria.definition = definition
+                    criteria.save()
 
 
 class CaseRuleActionsForm(forms.Form):


### PR DESCRIPTION
## Product Description
[This](https://sentry.io/organizations/dimagi/issues/3262300213/?project=136860) error was reported. This PR aims to fix the cause of this error.

## Technical Summary
Upon investigating the error it was found that the location_id of the specific location_filter_definition on the rule was blank (i.e. `''`), which means that there's some process which creates a LocationFilterDefinition on a rule without checking for valid information (an "accidental" create). This PR puts a sanity check in place before creating the LocationFilterDefinition on a rule.

## Feature Flag
None specific

## Safety Assurance

### Safety story
Tested locally. Don't think such a simple change requires any more elaborate testing.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
