### PR TITLE
ignore django-celery-results models

### DIFF
--- a/corehq/apps/dump_reload/tests/test_dump_models.py
+++ b/corehq/apps/dump_reload/tests/test_dump_models.py
@@ -71,6 +71,8 @@ IGNORE_MODELS = {
     "dhis2.SQLDataSetMap",
     "dhis2.SQLDataValueMap",
     "django_celery_results.TaskResult",
+    "django_celery_results.ChordCounter",
+    "django_celery_results.GroupResult",
     "django_digest.PartialDigest",
     "django_digest.UserNonce",
     "django_prbac.Grant",


### PR DESCRIPTION
## Technical Summary
The new models came from https://github.com/dimagi/commcare-hq/pull/31713.

## Safety Assurance

### Safety story
Test only changes

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
