### PR TITLE
Have Dependabot open additional PRs for minor and patched versions. Tag with new labels.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,53 @@ updates:
   open-pull-requests-limit: 7
   labels:
   - product/invisible
-  # Focus on major versions only
-  # Todo: remove once we're in steady-state on major versions
+  - dependencies/major
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-patch"
+        - "version-update:semver-minor"
+
+- package-ecosystem: pip
+  directory: "/requirements"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 4
+  labels:
+  - product/invisible
+  - dependencies/minor
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-patch"
+        - "version-update:semver-major"
+
+- package-ecosystem: pip
+  directory: "/requirements"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 7
+  labels:
+  - product/invisible
+  - dependencies/patch
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 5
+  labels:
+  - product/invisible
+  - dependencies/javascript
+  - dependencies/major
   ignore:
     - dependency-name: "*"
       update-types:
@@ -25,10 +70,25 @@ updates:
   labels:
   - product/invisible
   - dependencies/javascript
-  # Focus on major versions only
-  # Todo: remove once we're in steady-state on major versions
+  - dependencies/minor
   ignore:
     - dependency-name: "*"
       update-types:
         - "version-update:semver-patch"
+        - "version-update:semver-major"
+
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 5
+  labels:
+  - product/invisible
+  - dependencies/javascript
+  - dependencies/patch
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
         - "version-update:semver-minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
   schedule:
     interval: daily
     time: "10:00"
-  open-pull-requests-limit: 7
+  open-pull-requests-limit: 4
   labels:
   - product/invisible
   - dependencies/patch

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -71,6 +71,15 @@ labels:
 - name: 'dependencies/javascript'
   color: navy
   description: 'Change in javascript dependency.'
+- name: 'dependencies/major'
+  color: red
+  description: 'Dependency upgrade that is at least one major version behind.'
+- name: 'dependencies/minor'
+  color: yellow
+  description: 'Dependency upgrade that is at least one minor version behind.'
+- name: 'dependencies/patch'
+  color: green
+  description: 'Dependency upgrade that is at least one patched version behind.'
 - name: 'awaiting QA'
   color: light_orange
   description: 'QA in progress. Do not merge'


### PR DESCRIPTION
## Technical Summary
I am hoping to try out a new process for dependapod were we can choose 1-2 major versions, 2-4 minor versions, and 3-6 patched versions for each dependacat rotation. I'm hoping we can get dependabot to open PRs in each of these major, minor, and patch categories that are then labeled differently

## Safety Assurance

### Safety story
Only updates to `dependabot.yml`

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
