### PR TITLE
Add command to delete orphaned ucrs for a deleted domain

### DIFF
--- a/corehq/apps/userreports/management/commands/drop_orphaned_ucrs_in_deleted_domain.py
+++ b/corehq/apps/userreports/management/commands/drop_orphaned_ucrs_in_deleted_domain.py
@@ -1,0 +1,59 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from sqlalchemy.exc import ProgrammingError
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.userreports.models import (
+    DataSourceConfiguration,
+    StaticDataSourceConfiguration,
+)
+from corehq.apps.userreports.util import (
+    get_domain_for_ucr_table_name,
+    get_tables_for_data_sources,
+    get_tables_without_data_sources,
+)
+from corehq.sql_db.connections import connection_manager
+
+
+class Command(BaseCommand):
+    help = "Drop orphaned UCR tables for the specified deleted domain"
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+
+    def handle(self, domain, **options):
+        deleted_domains = Domain.get_deleted_domain_names()
+        active_domains = set(Domain.get_all_names())
+        is_deleted = domain in deleted_domains and domain not in active_domains
+        if not is_deleted:
+            raise CommandError(
+                f'The domain {domain} is not deleted or has an active conflict. Resolve before trying again.')
+
+        data_sources = list(DataSourceConfiguration.all())
+        data_sources.extend(list(StaticDataSourceConfiguration.all()))
+        tables_by_engine_id = get_tables_for_data_sources(data_sources, engine_id=None)
+        orphaned_tables_by_engine_id = get_tables_without_data_sources(tables_by_engine_id)
+        drop_tables_for_domain(domain, orphaned_tables_by_engine_id)
+
+
+def drop_tables_for_domain(domain, tables_by_engine_id):
+    for engine_id, tablenames in tables_by_engine_id.items():
+        engine = connection_manager.get_engine(engine_id)
+
+        for tablename in tablenames:
+            # double check that table belongs to domain
+            if domain != get_domain_for_ucr_table_name(tablename):
+                continue
+
+            with engine.begin() as connection:
+                try:
+                    result = connection.execute(f'SELECT COUNT(*), MAX(inserted_at) FROM "{tablename}"')
+                except ProgrammingError:
+                    print(f"\t{tablename}: no inserted_at column, probably not UCR")
+                except Exception as e:
+                    print(f"\tAn error was encountered when attempting to read from {tablename}: {e}")
+                else:
+                    row_count, idle_since = result.fetchone()
+                    print(f"\t{tablename}: {row_count} rows")
+                    connection.execute(f'DROP TABLE "{tablename}"')
+                    print(f'\t^-- deleted {tablename}')

--- a/corehq/apps/userreports/management/commands/prune_old_datasources.py
+++ b/corehq/apps/userreports/management/commands/prune_old_datasources.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from django.core.management.base import BaseCommand
 
 from sqlalchemy.exc import ProgrammingError
@@ -9,9 +7,8 @@ from corehq.apps.userreports.models import (
     StaticDataSourceConfiguration,
 )
 from corehq.apps.userreports.util import (
-    LEGACY_UCR_TABLE_PREFIX,
-    UCR_TABLE_PREFIX,
-    get_table_name,
+    get_tables_for_data_sources,
+    get_tables_without_data_sources,
 )
 from corehq.sql_db.connections import connection_manager
 
@@ -39,8 +36,8 @@ class Command(BaseCommand):
     def handle(self, **options):
         data_sources = list(DataSourceConfiguration.all())
         data_sources.extend(list(StaticDataSourceConfiguration.all()))
-        tables_by_engine_id = get_tables_by_engine_id(data_sources, options.get('engine_id'))
-        tables_to_remove_by_engine = get_tables_to_remove_by_engine(tables_by_engine_id)
+        tables_by_engine_id = get_tables_for_data_sources(data_sources, options.get('engine_id'))
+        tables_to_remove_by_engine = get_tables_without_data_sources(tables_by_engine_id)
         prune_tables(tables_to_remove_by_engine, options['drop_empty_tables'])
 
 
@@ -68,40 +65,3 @@ def prune_tables(tables_to_remove_by_engine, drop_empty_tables):
                         print(f'\t^-- deleted {tablename}')
                     else:
                         print(f"\t{tablename}: {row_count} rows, idle since {idle_since}")
-
-
-def get_tables_by_engine_id(data_sources, engine_id):
-    tables_by_engine_id = defaultdict(set)
-    for data_source in data_sources:
-        if engine_id and data_source.engine_id != engine_id:
-            continue
-
-        table_name = get_table_name(data_source.domain, data_source.table_id)
-        tables_by_engine_id[data_source.engine_id].add(table_name)
-
-    return tables_by_engine_id
-
-
-def get_tables_to_remove_by_engine(tables_by_engine_id):
-    tables_to_remove_by_engine = defaultdict(list)
-    for engine_id, expected_tables in tables_by_engine_id.items():
-        engine = connection_manager.get_engine(engine_id)
-        with engine.begin() as connection:
-            # Using string formatting rather than execute with %s syntax
-            # is acceptable here because the strings we're inserting are static
-            # and only templated for DRYness
-            results = connection.execute(f"""
-            SELECT table_name
-              FROM information_schema.tables
-            WHERE table_schema='public'
-              AND table_type='BASE TABLE'
-              AND (
-                table_name LIKE '{UCR_TABLE_PREFIX}%%'
-                OR
-                table_name LIKE '{LEGACY_UCR_TABLE_PREFIX}%%'
-            );
-            """).fetchall()
-            tables_in_db = {r[0] for r in results}
-
-        tables_to_remove_by_engine[engine_id] = tables_in_db - expected_tables
-    return tables_to_remove_by_engine

--- a/corehq/apps/userreports/tests/test_prune_old_datasources.py
+++ b/corehq/apps/userreports/tests/test_prune_old_datasources.py
@@ -35,42 +35,6 @@ class TestPruneOldDatasources(TestCase):
 
         self.assertFalse(adapter.table_exists)
 
-    def test_tables_for_deleted_domains_are_not_dropped(self):
-        config = self._create_data_source_config(self.deleted_domain.name)
-        adapter = get_indicator_adapter(config, raise_errors=True)
-        adapter.build_table()
-
-        call_command('prune_old_datasources')
-
-        self.assertTrue(adapter.table_exists)
-
-    def test_tables_for_deleted_domains_are_dropped(self):
-        config = self._create_data_source_config(self.deleted_domain.name)
-        adapter = get_indicator_adapter(config, raise_errors=True)
-        adapter.build_table()
-
-        call_command('prune_old_datasources', '--drop-deleted-tables')
-
-        self.assertFalse(adapter.table_exists)
-
-    def test_tables_for_active_domains_are_not_dropped(self):
-        config = self._create_data_source_config(self.active_domain.name)
-        adapter = get_indicator_adapter(config, raise_errors=True)
-        adapter.build_table()
-
-        call_command('prune_old_datasources', '--drop-deleted-tables')
-
-        self.assertTrue(adapter.table_exists)
-
-    def test_tables_for_missing_domains_are_not_dropped(self):
-        config = self._create_data_source_config('unknown-domain')
-        adapter = get_indicator_adapter(config, raise_errors=True)
-        adapter.build_table()
-
-        call_command('prune_old_datasources', '--drop-deleted-tables')
-
-        self.assertTrue(adapter.table_exists)
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The implementation to delete tables for deleted domains in `prune_old_datasources` was risky because it ran on all deleted domains at once, rather than only a specified domain. It also felt more appropriate to have a separate command for this tak, which is what I've done here
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
