### PR TITLE
Ignore missing parent table or row when migrating

### DIFF
--- a/corehq/apps/cachehq/mixins.py
+++ b/corehq/apps/cachehq/mixins.py
@@ -29,10 +29,10 @@ class _InvalidateCacheMixin(object):
 
     bulk_save = save_docs
 
-    def delete(self):
+    def delete(self, *args, **kw):
         id = self._id
         try:
-            super(_InvalidateCacheMixin, self).delete()
+            super(_InvalidateCacheMixin, self).delete(*args, **kw)
         except ResourceNotFound:
             # it was already deleted. this isn't a problem, but might be a caching bug
             logging.exception('Tried to delete cached doc %s but it was already deleted', id)

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -48,7 +48,8 @@ class PopulateSQLCommand(BaseCommand):
         """
         This should find and update the sql object that corresponds to the given doc,
         or create it if it doesn't yet exist. This method is responsible for saving
-        the sql object.
+        the sql object. May return ``(None, False)`` to cause the document to be
+        ignored by the migration.
         """
         raise NotImplementedError()
 
@@ -277,7 +278,7 @@ class PopulateSQLCommand(BaseCommand):
     def _migrate_doc(self, doc, logfile):
         with transaction.atomic(), disable_sync_to_couch(self.sql_class()):
             model, created = self.update_or_create_sql_object(doc)
-            action = "Creating" if created else "Updated"
+            action = "Ignored" if model is None else ("Creating" if created else "Updated")
             logfile.write(f"{action} model for {self.couch_doc_type()} with id {doc['_id']}\n")
 
     def _get_couch_doc_count_for_domains(self, domains):


### PR DESCRIPTION
Necessary if a `FixtureDataType` or `FixtureDataItem` was deleted but its child records (`FixtureDataItem` or `FixtureOwnership` respectively) were not deleted.

## Safety Assurance

### Safety story

Fixing errors found while testing migration on staging. This only affects the SQL Lookup Table Row and Ownership data migration management commands.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
