### PR TITLE
Change 'Get Free Trial' to 'Request Custom Trial'

### DIFF
--- a/corehq/apps/registration/templates/registration/partials/choose_your_plan.html
+++ b/corehq/apps/registration/templates/registration/partials/choose_your_plan.html
@@ -30,7 +30,7 @@
              data-toggle="modal"
              class="btn btn-primary">
             {% blocktrans %}
-              Get Free Trial
+              Request Custom Trial
             {% endblocktrans %}
           </a>
           <script src="//fast.wistia.com/embed/medias/jzm3ggrinr.jsonp" async></script>


### PR DESCRIPTION
## Product Description
We are changing the "Get Free Trial" text here:
![Screen Shot 2022-08-09 at 6 43 29 PM](https://user-images.githubusercontent.com/716573/183709633-d1a31578-9f8a-4cf5-9277-4817480d647a.png)

To "Request Custom Trial" here:
![Screen Shot 2022-08-09 at 6 43 14 PM](https://user-images.githubusercontent.com/716573/183709682-6a04d23f-a534-417e-949a-007e0ecb7fdd.png)

Here is the requesting ticket:
https://dimagi-dev.atlassian.net/browse/SAAS-13842


## Safety Assurance

### Safety story
just a text change

### Automated test coverage
text only

### QA Plan
N/A


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
