### PR TITLE
Avoid saving empty strings as translations in case search

### DIFF
--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -40,10 +40,13 @@ class ModuleTests(SimpleTestCase):
             CaseSearchProperty(name='name', label={'fr': 'Nom'}),
             CaseSearchProperty(name='age', label={'fr': 'Âge'}),
         ]
+
+        # Update name, add dob, and remove age
         props = list(_update_search_properties(module, [
             {'name': 'name', 'label': 'Name'},
             {'name': 'dob', 'label': 'Date of birth'}
         ], "en"))
+
         self.assertEqual(props[0]['label'], {'en': 'Name', 'fr': 'Nom'})
         self.assertEqual(props[1]['label'], {'en': 'Date of birth'})
 

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -19,6 +19,7 @@ from corehq.apps.app_manager.models import (
     ReportAppConfig,
     ReportModule,
 )
+from corehq.apps.app_manager.views.modules import _update_search_properties
 from corehq.apps.app_manager.util import purge_report_from_mobile_ucr
 from corehq.apps.userreports.models import ReportConfiguration
 from corehq.util.test_utils import flag_enabled
@@ -31,6 +32,19 @@ class ModuleTests(SimpleTestCase):
         self.module = self.app.add_module(Module.new_module('Untitled Module', None))
         self.module.case_type = 'another_case_type'
         self.form = self.module.new_form("Untitled Form", None)
+
+    def test_update_search_properties(self):
+        module = Module()
+        module.search_config.properties = [
+            CaseSearchProperty(name='name', label={'fr': 'Nom'}),
+            CaseSearchProperty(name='age', label={'fr': 'Âge'}),
+        ]
+        props = list(_update_search_properties(module, [
+            {'name': 'name', 'label': 'Name'},
+            {'name': 'dob', 'label': 'Date of birth'}
+        ], "en"))
+        self.assertEqual(props[0]['label'], {'en': 'Name', 'fr': 'Nom'})
+        self.assertEqual(props[1]['label'], {'en': 'Date of birth'})
 
 
 class AdvancedModuleTests(SimpleTestCase):

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -46,6 +46,16 @@ class ModuleTests(SimpleTestCase):
         self.assertEqual(props[0]['label'], {'en': 'Name', 'fr': 'Nom'})
         self.assertEqual(props[1]['label'], {'en': 'Date of birth'})
 
+    def test_update_search_properties_blank(self):
+        module = Module()
+        module.search_config.properties = [
+            CaseSearchProperty(name='name', label={'fr': 'Nom'}),
+        ]
+        props = list(_update_search_properties(module, [
+            {'name': 'name', 'label': ''},
+        ], "fr"))
+        self.assertEqual(props[0]['label'], {})
+
 
 class AdvancedModuleTests(SimpleTestCase):
 

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -50,15 +50,29 @@ class ModuleTests(SimpleTestCase):
         self.assertEqual(props[0]['label'], {'en': 'Name', 'fr': 'Nom'})
         self.assertEqual(props[1]['label'], {'en': 'Date of birth'})
 
-    def test_update_search_properties_blank(self):
+    def test_update_search_properties_blank_same_lang(self):
         module = Module()
         module.search_config.properties = [
             CaseSearchProperty(name='name', label={'fr': 'Nom'}),
         ]
+
+        # Blanking out a translation removes it from dict
         props = list(_update_search_properties(module, [
             {'name': 'name', 'label': ''},
         ], "fr"))
         self.assertEqual(props[0]['label'], {})
+
+    def test_update_search_properties_blank_other_lang(self):
+        module = Module()
+        module.search_config.properties = [
+            CaseSearchProperty(name='name', label={'fr': 'Nom'}),
+        ]
+
+        # Blank translations don't get added to dict
+        props = list(_update_search_properties(module, [
+            {'name': 'name', 'label': ''},
+        ], "en"))
+        self.assertEqual(props[0]['label'], {'fr': 'Nom'})
 
     def test_update_search_properties_required(self):
         module = Module()

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1009,16 +1009,27 @@ def _update_search_properties(module, search_properties, lang='en'):
     True
 
     """
+
+    # Replace translation for current language in a translations dict
+    def _update_translation(old_obj, new_data, attr):
+        values = getattr(old_obj, attr) if old_obj else {}
+        try:
+            values.pop(lang)
+        except KeyError:
+            pass
+        new_value = new_data.get(attr)
+        if new_value:
+            values[lang] = new_value
+        return values
+
     props_by_name = {p.name: p for p in module.search_config.properties}
     for prop in search_properties:
         current = props_by_name.get(prop['name'])
 
-        _current_label = current.label if current else {}
-        _current_hint = current.hint if current else {}
         ret = {
             'name': prop['name'],
-            'label': {**_current_label, lang: prop['label']},
-            'hint': {**_current_hint, lang: prop['hint']},
+            'label': _update_translation(current, prop, 'label'),
+            'hint': _update_translation(current, prop, 'hint'),
         }
         if prop.get('default_value'):
             ret['default_value'] = prop['default_value']

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1011,13 +1011,14 @@ def _update_search_properties(module, search_properties, lang='en'):
     """
 
     # Replace translation for current language in a translations dict
-    def _update_translation(old_obj, new_data, attr):
-        values = getattr(old_obj, attr) if old_obj else {}
+    def _update_translation(old_obj, new_data, old_attr, new_attr=None):
+        new_attr = new_attr or old_attr
+        values = getattr(old_obj, old_attr) if old_obj else {}
         try:
             values.pop(lang)
         except KeyError:
             pass
-        new_value = new_data.get(attr)
+        new_value = new_data.get(new_attr)
         if new_value:
             values[lang] = new_value
         return values
@@ -1040,16 +1041,15 @@ def _update_search_properties(module, search_properties, lang='en'):
         if prop.get('exclude'):
             ret['exclude'] = prop['exclude']
         if prop.get('required_test'):
-            _current_text = current.required.text if current and current.required else {}
             ret['required'] = {
                 'test': prop['required_test'],
-                'text': {**_current_text, lang: prop['required_text']}
+                'text': _update_translation(current.required if current else None, prop, "text", "required_text"),
             }
         if prop.get('validation_test'):
-            _current_text = current.validations[0].text if current and current.validations else {}
             ret['validations'] = [{
                 'test': prop['validation_test'],
-                'text': {**_current_text, lang: prop['validation_text']},
+                'text': _update_translation(current.validations[0] if current and current.validations else None,
+                                            prop, "text", "validation_text"),
             }]
         if prop.get('appearance', '') == 'fixture':
             if prop.get('is_multiselect', False):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1020,21 +1020,21 @@ def _update_search_properties(module, search_properties, lang='en'):
             'label': {**_current_label, lang: prop['label']},
             'hint': {**_current_hint, lang: prop['hint']},
         }
-        if prop['default_value']:
+        if prop.get('default_value'):
             ret['default_value'] = prop['default_value']
-        if prop['hidden']:
+        if prop.get('hidden'):
             ret['hidden'] = prop['hidden']
-        if prop['allow_blank_value']:
+        if prop.get('allow_blank_value'):
             ret['allow_blank_value'] = prop['allow_blank_value']
-        if prop['exclude']:
+        if prop.get('exclude'):
             ret['exclude'] = prop['exclude']
-        if prop['required_test']:
+        if prop.get('required_test'):
             _current_text = current.required.text if current and current.required else {}
             ret['required'] = {
                 'test': prop['required_test'],
                 'text': {**_current_text, lang: prop['required_text']}
             }
-        if prop['validation_test']:
+        if prop.get('validation_test'):
             _current_text = current.validations[0].text if current and current.validations else {}
             ret['validations'] = [{
                 'test': prop['validation_test'],

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1014,10 +1014,7 @@ def _update_search_properties(module, search_properties, lang='en'):
     def _update_translation(old_obj, new_data, old_attr, new_attr=None):
         new_attr = new_attr or old_attr
         values = getattr(old_obj, old_attr) if old_obj else {}
-        try:
-            values.pop(lang)
-        except KeyError:
-            pass
+        values.pop(lang, None)
         new_value = new_data.get(new_attr)
         if new_value:
             values[lang] = new_value


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2335

## Technical Summary
[This change](https://github.com/dimagi/commcare-hq/pull/31871/files#r915186610) had the side effect of causing search properties without a hint to store an empty string in the hint attribute, e.g., `{default_lang: ""}` where it previously would have been an empty dictionary (and similarly for other localizable text properties).

For hints, this meant that [this check](https://github.com/dimagi/commcare-hq/blob/7f4796d4b51fcd98eb6050cf900081173912e49e/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py#L265) started returning true even if there was no real hint text present. That then caused hints to be included in the suite.

Blank translations get replaced by [non-breaking spaces](https://github.com/dimagi/commcare-translations/blob/60e5ce47400d645eee332d8f1ea7a0d8db57767a/commcare_translations.py#L88-L90). Formplayer would pass the non-breaking space along to web apps, which would see a hint and display the hint popup, with no content except that non-breaking space.

This PR updates the save logic so that empty strings will not be stored in the translations dicts for case search properties.

## Feature Flag
Case search & claim

## Safety Assurance

### Safety story
I'm basically relying on test coverage. Open to feedback.

### Automated test coverage

In PR.

### QA Plan

Not requesting QA.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
