### PR TITLE
Fix 500 error when deleting assigned role

### DIFF
--- a/corehq/apps/users/analytics.py
+++ b/corehq/apps/users/analytics.py
@@ -84,6 +84,6 @@ def get_search_users_in_domain_es_query(domain, search_string, limit, offset):
 
 def get_role_user_count(domain, role_id):
     from corehq.apps.es.users import UserES
-    users = UserES().is_active().domain(domain).role_id(role_id).count()
-    users += Invitation.objects.filter(role="user-role:" + role_id, is_accepted=False).count()
-    return users
+    users_count = UserES().is_active().domain(domain).role_id(role_id).count()
+    users_count += Invitation.objects.filter(role="user-role:" + role_id, is_accepted=False).count()
+    return users_count

--- a/corehq/apps/users/analytics.py
+++ b/corehq/apps/users/analytics.py
@@ -1,5 +1,5 @@
 from corehq.apps.es import UserES, users, queries
-from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.models import CommCareUser, Invitation
 from corehq.elastic import get_es_new
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.toggles import RESTRICT_LOGIN_AS
@@ -84,4 +84,6 @@ def get_search_users_in_domain_es_query(domain, search_string, limit, offset):
 
 def get_role_user_count(domain, role_id):
     from corehq.apps.es.users import UserES
-    return UserES().is_active().domain(domain).role_id(role_id).count()
+    users = UserES().is_active().domain(domain).role_id(role_id).count()
+    users += Invitation.objects.filter(role="user-role:" + role_id, is_accepted=False).count()
+    return users

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -950,10 +950,10 @@ def delete_user_role(request, domain):
         return JsonResponse({
             "message": ngettext(
                 "Unable to delete role '{role}'. "
-                "It has one user and pending invitations still assigned to it. "
+                "It has one user and/or invitation still assigned to it. "
                 "Remove all users assigned to the role before deleting it.",
                 "Unable to delete role '{role}'. "
-                "It has {user_count} users and pending invitations still assigned to it. "
+                "It has {user_count} users and/or invitations still assigned to it. "
                 "Remove all users assigned to the role before deleting it.",
                 user_count,
             ).format(role=role_data["name"], user_count=user_count)

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -946,6 +946,7 @@ def delete_user_role(request, domain):
         return JsonResponse({})
     role_data = json.loads(request.body.decode('utf-8'))
     user_count = get_role_user_count(domain, role_data["_id"])
+    Invitation.objects.filter(role="user-role:" + role_data["_id"]).delete()
     if user_count:
         return JsonResponse({
             "message": ngettext(

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -523,7 +523,11 @@ class BaseRoleAccessView(BaseUserSettingsView):
 
             try:
                 user_count = get_role_user_count(role.domain, role.couch_id)
-                role_data["hasUsersAssigned"] = bool(user_count)
+                invitations = Invitation.objects.filter(role="user-role:" + role_data["_id"])
+                if user_count or invitations:
+                    role_data["hasUsersAssigned"] = True
+                else:
+                    role_data["hasUsersAssigned"] = False
             except TypeError:
                 # when query_result['hits'] returns None due to an ES issue
                 show_es_issue = True
@@ -946,16 +950,19 @@ def delete_user_role(request, domain):
         return JsonResponse({})
     role_data = json.loads(request.body.decode('utf-8'))
     user_count = get_role_user_count(domain, role_data["_id"])
-    Invitation.objects.filter(role="user-role:" + role_data["_id"]).delete()
-    if user_count:
+    invitations = Invitation.objects.filter(role="user-role:" + role_data["_id"])
+    if user_count or invitations:
         return JsonResponse({
             "message": ngettext(
-                "Unable to delete role '{role}'. It has one user still assigned to it. "
+                "Unable to delete role '{role}'. "
+                "It has one user and {invite_count} invitations still assigned to it. "
                 "Remove all users assigned to the role before deleting it.",
-                "Unable to delete role '{role}'. It has {user_count} users still assigned to it. "
+                "Unable to delete role '{role}'. "
+                "It has {user_count} users and {invite_count} invitations still assigned to it. "
                 "Remove all users assigned to the role before deleting it.",
-                user_count
-            ).format(role=role_data["name"], user_count=user_count)
+                user_count,
+                invitations.count(),
+            ).format(role=role_data["name"], user_count=user_count, invite_count=invitations.count())
         }, status=400)
     try:
         role = UserRole.objects.by_couch_id(role_data["_id"], domain=domain)

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -523,7 +523,7 @@ class BaseRoleAccessView(BaseUserSettingsView):
 
             try:
                 user_count = get_role_user_count(role.domain, role.couch_id)
-                invitations = Invitation.objects.filter(role="user-role:" + role_data["_id"])
+                invitations = Invitation.objects.filter(role="user-role:" + role_data["_id"], is_accepted=False)
                 if user_count or invitations:
                     role_data["hasUsersAssigned"] = True
                 else:
@@ -950,7 +950,7 @@ def delete_user_role(request, domain):
         return JsonResponse({})
     role_data = json.loads(request.body.decode('utf-8'))
     user_count = get_role_user_count(domain, role_data["_id"])
-    invitations = Invitation.objects.filter(role="user-role:" + role_data["_id"])
+    invitations = Invitation.objects.filter(role="user-role:" + role_data["_id"], is_accepted=False)
     if user_count or invitations:
         return JsonResponse({
             "message": ngettext(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When a new role is created and is assigned to the web user and then the role is deleted, the web user starts throwing a 500 error. This will fix that by deleting sent invites linked to the role.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Link to ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12415).
I've decided to delete invites linked to the role because it makes sense to me that we want users linked to the role reassigned to new roles or deleted before deleting the role itself. We can probably reassign the invitation but it is way less work to just delete the invitation. I am open to changing this to actually reassign the invitation to some default role.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
local testing and I will test on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I couldn't identify tests for this specific function so I will write them.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
