### PR TITLE
[USH-2037] extension sync bug

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/cleanup.py
+++ b/corehq/ex-submodules/casexml/apps/case/cleanup.py
@@ -15,7 +15,7 @@ from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CommCareCase
 
 
-def close_cases(case_ids, domain, user, device_id, case_db=None):
+def close_cases(case_ids, domain, user, device_id, case_db=None, synctoken_id=None):
     """
     Close cases by submitting a close forms.
 
@@ -39,6 +39,11 @@ def close_cases(case_ids, domain, user, device_id, case_db=None):
         close=True,
     ).as_xml(), encoding='utf-8').decode('utf-8') for case_id in case_ids]
 
+    submission_extras = {}
+    if synctoken_id:
+        submission_extras = {
+            "last_sync_token": synctoken_id
+        }
     return submit_case_blocks(
         case_blocks,
         domain,
@@ -46,6 +51,7 @@ def close_cases(case_ids, domain, user, device_id, case_db=None):
         user_id,
         device_id=device_id,
         case_db=case_db,
+        submission_extras=submission_extras
     )[0].form_id
 
 

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -130,7 +130,7 @@ def _is_change_of_ownership(previous_owner_id, next_owner_id):
     )
 
 
-def close_extension_cases(case_db, cases, device_id):
+def close_extension_cases(case_db, cases, device_id, synctoken_id):
     from casexml.apps.case.cleanup import close_cases
     extensions_to_close = get_all_extensions_to_close(case_db.domain, cases)
     extensions_to_close = case_db.filter_closed_extensions(list(extensions_to_close))
@@ -141,6 +141,7 @@ def close_extension_cases(case_db, cases, device_id):
             SYSTEM_USER_ID,
             device_id,
             case_db,
+            synctoken_id
         )
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -82,7 +82,11 @@ def do_livequery(timing_context, restore_state, response, async_task=None):
                 sync_ids = discard_already_synced_cases(live_ids, restore_state)
         else:
             sync_ids = live_ids
+
+        dependent_ids = live_ids - set(owned_ids)
+        debug('updating synclog: live=%r dependent=%r', live_ids, dependent_ids)
         restore_state.current_sync_log.case_ids_on_phone = live_ids
+        restore_state.current_sync_log.dependent_case_ids_on_phone = dependent_ids
 
         total_cases = len(sync_ids)
         with timing_context("compile_response(%s cases)" % total_cases):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -2011,17 +2011,13 @@ class DeleteExtensionIndexTest(BaseSyncTest):
         )
         self.device.change_cases([claim, client])
         self.device.sync()
-        return host, claim, client
 
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
     def test_break_index(self):
-        host, claim, client = self._create_cases()
+        self._create_cases()
 
         synclog = self.device.last_sync.log
         self.assertEqual(synclog.case_ids_on_phone, {"host", "claim", "client"})
-        client = CommCareCase.objects.partitioned_get('client')
-        print(self.device.user_id)
-        print(client.owner_id)
 
         # remove the index on 'client' & close 'host'
         # this should result in all cases being purged since host is now closed

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -2046,6 +2046,15 @@ class TestUpdatesToSynclog(BaseSyncTest):
         result = self.device.sync()
         self.assertNotIn("client", result.cases)
 
+        # claiming the case again should result in it being synced to the device
+        ferrel.change_cases(CaseBlock(case_id="claim2", owner_id=self.user_id, create=True, index={
+            "host": ("client", "client")
+        }))
+        ferrel.post_changes()
+
+        result = self.device.sync()
+        self.assertIn("client", result.cases)
+
     @flag_enabled('EXTENSION_CASES_SYNC_ENABLED')
     def test_close_host(self):
         self._create_cases()

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -438,7 +438,8 @@ class SubmissionPost(object):
             close_extension_cases(
                 case_db,
                 case_stock_result.case_models,
-                "SubmissionPost-%s-close_extensions" % instance.form_id
+                "SubmissionPost-%s-close_extensions" % instance.form_id,
+                instance.last_sync_token
             )
         except PostSaveError:
             raise


### PR DESCRIPTION
## Technical Summary
Jira: https://dimagi-dev.atlassian.net/browse/USH-2307

The above ticket describes an issue where a case should be 'on the device' but it is not.

Starting point:

```
host <--ext-- claim (owned)
     <--ext-- client
```

* Removing the extension index from 'client' should remove the case from the phone
* Closing the 'host' case should remove the 'claim' case from the phone

Both of these should result in the synclog being updated to remove the case ID so that future incremental syncs are correct.

This PR fixes both of these issues:

1. Closing extension cases after closing a host case wasn't updating the synclogs
  * I think this is causing this error: https://sentry.io/share/issue/ebca3f40b3fb475e866fe264b892aac1/
2. Removing and index from an extension case prevents it from being purged from the synclog

## Feature Flag
Extension sync

## Safety Assurance

### Safety story
The sync code is well tested and the rules are well understood. There is good test coverage for other scenarios.

### Automated test coverage
Tests added for these edge cases, other tests already exist for other scenarios.

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
