### PR TITLE
Fix sync for schemadict attributes

### DIFF
--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -232,7 +232,7 @@ class OpenmrsRepeater(CaseRepeater):
                 value = value.to_json()
             if field_name == 'atom_feed_status':
                 value = {
-                    feed_name: feed.to_json
+                    feed_name: feed.to_json()
                     for feed_name, feed in self.atom_feed_status.items()
                 }
             setattr(sql_object, field_name, value)

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -225,6 +225,19 @@ class OpenmrsRepeater(CaseRepeater):
             "openmrs_config",
         ]
 
+    def _migration_sync_to_sql(self, sql_object):
+        for field_name in self._migration_get_fields():
+            value = getattr(self, field_name)
+            if hasattr(value, 'to_json'):
+                value = value.to_json()
+            if field_name == 'atom_feed_status':
+                value = {
+                    feed_name: feed.to_json
+                    for feed_name, feed in self.atom_feed_status.items()
+                }
+            setattr(sql_object, field_name, value)
+        sql_object.save(sync_to_couch=False)
+
     @classmethod
     def _migration_get_sql_model_class(cls):
         return SQLOpenmrsRepeater
@@ -365,13 +378,14 @@ class SQLOpenmrsRepeater(SQLCaseRepeater):
 
     def _wrap_schema_attrs(self, couch_object):
         couch_object.openmrs_config = OpenmrsConfig.wrap(self.openmrs_config)
+        for feed in self.atom_feed_status.keys():
+            couch_object.atom_feed_status[feed] = AtomFeedStatus.wrap(self.atom_feed_status[feed])
 
     @classmethod
     def _migration_get_fields(cls):
         return super()._migration_get_fields() + [
             "location_id",
             "atom_feed_enabled",
-            "atom_feed_status",
         ]
 
     @classmethod

--- a/corehq/motech/repeaters/tests/data/repeaters.py
+++ b/corehq/motech/repeaters/tests/data/repeaters.py
@@ -1821,8 +1821,13 @@ repeater_test_data = [
             "doc_type": "OpenmrsConfig"
         },
         "atom_feed_enabled": False,
-        "atom_feed_status":
-        {},
+        "atom_feed_status": {
+            'patient': {
+                'last_polled_at': '2022-06-01T00:00:00.000000Z',
+                'last_page': None,
+                'doc_type': 'AtomFeedStatus'
+            }
+        },
         "doc_type": "OpenmrsRepeater",
         "version": "2.0",
         "white_listed_case_types":

--- a/corehq/motech/repeaters/tests/test_repeaters_migration.py
+++ b/corehq/motech/repeaters/tests/test_repeaters_migration.py
@@ -582,8 +582,13 @@ class TestSQLOpenmrsRepeater(RepeaterSyncTestsBase):
         self._assert_common_attrs_are_equal(sql_repeater, couch_repeater)
         self.assertEqual(sql_repeater.location_id, couch_repeater.location_id)
         self.assertEqual(sql_repeater.atom_feed_enabled, couch_repeater.atom_feed_enabled)
-        self.assertEqual(sql_repeater.atom_feed_status, couch_repeater.atom_feed_status)
-        # self.assertEqual(sql_repeater.openmrs_config, couch_repeater.openmrs_config.to_json())
+        self.assertEqual(sql_repeater.atom_feed_status.keys(), couch_repeater.atom_feed_status.keys())
+        for feed in sql_repeater.atom_feed_status:
+            self.assertEqual(
+                sql_repeater.atom_feed_status[feed],
+                couch_repeater.atom_feed_status[feed].to_json()
+            )
+        self.assertEqual(sql_repeater.openmrs_config, couch_repeater.openmrs_config.to_json())
         self.assertEqual(sql_repeater.white_listed_case_types, couch_repeater.white_listed_case_types)
         self.assertEqual(sql_repeater.black_listed_users, couch_repeater.black_listed_users)
 

--- a/corehq/motech/repeaters/tests/test_repeaters_migration.py
+++ b/corehq/motech/repeaters/tests/test_repeaters_migration.py
@@ -123,7 +123,9 @@ class TestMigrationCommand(TestCase):
         for obj in openmrs_objects:
             sql_obj = SQLOpenmrsRepeater.objects.get(repeater_id=obj._id)
             self.assertEqual(sql_obj.openmrs_config, obj.openmrs_config.to_json())
-            self.assertEqual(sql_obj.atom_feed_status, obj.atom_feed_status)
+            self.assertEqual(sql_obj.atom_feed_status.keys(), obj.atom_feed_status.keys())
+            for feed_name, feed in obj.atom_feed_status.items():
+                self.assertEqual(sql_obj.atom_feed_status[feed_name], feed.to_json())
 
         for obj in caseexpression_objects:
             sql_obj = SQLCaseExpressionRepeater.objects.get(repeater_id=obj._id)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
While adding tests for `poll_openmrs_atom_feeds`, I noticed that the `atom_feed_status` does not have a `to_json()` method. The sync logic looks for `to_json` in schema attributes and calls them while syncing. I realized that `SchemaDictProperty` is of type dict with `DocuentSchema` objects wrapped inside it. Till now the syncing logic was relying on native serialization of Django models which was stripping off timezone information while saving to DB. The PR fixes that issue and adds a test to verify it's working.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Pretty safe change, limited to sync logic only which has been covered by tests.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular, consider how existing data may be impacted by this change.
-->
Has been tested locally and has tests surrounding it.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Has tests to cover the change.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
