### PR TITLE
Secure cookies in middleware

### DIFF
--- a/corehq/apps/analytics/ab_tests.py
+++ b/corehq/apps/analytics/ab_tests.py
@@ -1,7 +1,6 @@
 import logging
 import random
 
-from django.conf import settings
 from django.core.cache import cache
 
 from memoized import memoized
@@ -95,7 +94,7 @@ class SessionAbTest(object):
         version = self.version()
         self._debug_message("storing cookie value '{}' in '{}'".format(
             version, self._cookie_id))
-        response.set_cookie(self._cookie_id, version, secure=settings.SECURE_COOKIES)
+        response.set_cookie(self._cookie_id, version)
 
     def _clear_response(self, response):
         self._debug_message("clearing cookies '{}'".format(self._cookie_id))

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 from functools import partial
 from distutils.version import LooseVersion
 
-from django.conf import settings
 from django.contrib import messages
 from django.http import (
     Http404,
@@ -781,7 +780,7 @@ def _new_advanced_module(request, domain, app, name, lang):
 
     app.save()
     response = back_to_main(request, domain, app_id=app.id, module_id=module_id)
-    response.set_cookie('suppress_build_errors', 'yes', secure=settings.SECURE_COOKIES)
+    response.set_cookie('suppress_build_errors', 'yes')
     return response
 
 
@@ -1416,7 +1415,7 @@ def new_module(request, domain, app_id):
 
         response = back_to_main(request, domain, app_id=app_id,
                                 module_id=enroll_module.id, form_id=0)
-        response.set_cookie('suppress_build_errors', 'yes', secure=settings.SECURE_COOKIES)
+        response.set_cookie('suppress_build_errors', 'yes')
         return response
     elif module_type == 'case' or module_type == 'survey':  # survey option added for V2
         if module_type == 'case':
@@ -1455,7 +1454,7 @@ def new_module(request, domain, app_id):
         app.save()
         response = back_to_main(request, domain, app_id=app_id,
                                 module_id=module_id, form_id=form_id)
-        response.set_cookie('suppress_build_errors', 'yes', secure=settings.SECURE_COOKIES)
+        response.set_cookie('suppress_build_errors', 'yes')
         return response
     elif module_type in MODULE_TYPE_MAP:
         fn = MODULE_TYPE_MAP[module_type][FN]

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from copy import deepcopy
 from functools import partial
 
-from django.conf import settings
 from django.contrib import messages
 from django.http import Http404, HttpResponseRedirect
 from django.template.loader import render_to_string
@@ -123,7 +122,7 @@ def get_langs(request, app):
 
 
 def set_lang_cookie(response, lang):
-    response.set_cookie('lang', lang, secure=settings.SECURE_COOKIES)
+    response.set_cookie('lang', lang)
 
 
 def bail(request, domain, app_id, not_found=""):

--- a/corehq/apps/cloudcare/middleware.py
+++ b/corehq/apps/cloudcare/middleware.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
 
@@ -28,5 +27,4 @@ class CloudcareMiddleware(MiddlewareMixin):
         couch_user = getattr(request, 'couch_user', None)
         if couch_user:
             if request.COOKIES.get(FORMPLAYER_SESSION_COOKIE_NAME) != couch_user.user_id:
-                response.set_cookie(FORMPLAYER_SESSION_COOKIE_NAME, couch_user.user_id,
-                                    secure=settings.SECURE_COOKIES)
+                response.set_cookie(FORMPLAYER_SESSION_COOKIE_NAME, couch_user.user_id)

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -160,7 +160,7 @@ class FormplayerMain(View):
             ).run()
             if login_as_users.total == 1:
                 def set_cookie(response):
-                    response.set_cookie(cookie_name, user.raw_username, secure=settings.SECURE_COOKIES)
+                    response.set_cookie(cookie_name, user.raw_username)
                     return response
 
                 user = CouchUser.get_by_username(login_as_users.hits[0]['username'])

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -412,7 +412,7 @@ def _login(req, domain_name, custom_login_page, extra_context=None):
     if 'auth-username' in req.POST:
         couch_user = CouchUser.get_by_username(req.POST['auth-username'].lower())
         if couch_user:
-            response.set_cookie(settings.LANGUAGE_COOKIE_NAME, couch_user.language, secure=settings.SECURE_COOKIES)
+            response.set_cookie(settings.LANGUAGE_COOKIE_NAME, couch_user.language)
             activate(couch_user.language)
 
     return response

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -252,8 +252,7 @@ class MyAccountSettingsView(BaseMyAccountView):
             self.settings_form.update_user()
 
             res = redirect(reverse(MyAccountSettingsView.urlname))
-            res.set_cookie(settings.LANGUAGE_COOKIE_NAME, self.request.couch_user.language,
-                           secure=settings.SECURE_COOKIE)
+            res.set_cookie(settings.LANGUAGE_COOKIE_NAME, self.request.couch_user.language)
             return res
 
         return self.get(request, *args, **kwargs)

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -343,5 +343,5 @@ class SecureCookiesMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if hasattr(response, 'cookies') and response.cookies:
             for cookie in response.cookies:
-                response.cookies[cookie]['secure'] = settings.SECURE_COOKIES
+                response.cookies[cookie]['secure'] = settings.SECURE_COOKIES or response.cookies[cookie]['secure']
         return response

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -336,3 +336,12 @@ def get_view_func(view_fn, view_kwargs):
         return view_fn.view_class
 
     return view_fn
+
+
+class SecureCookiesMiddleware(MiddlewareMixin):
+
+    def process_response(self, request, response):
+        if hasattr(response, 'cookies') and response.cookies:
+            for cookie in response.cookies:
+                response.cookies[cookie]['secure'] = settings.SECURE_COOKIES
+        return response

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -102,12 +102,31 @@ class NoDomainReport(BaseReport):
     slug = 'admin_report'
 
 
+def cookie_view(request):
+    response = HttpResponse()
+    response.set_cookie('test-cookie', 'abc123')
+    return response
+
+
+def secure_cookie_view(request):
+    response = HttpResponse()
+    response.set_cookie('test-cookie', 'abc123', secure=True)
+    return response
+
+
+def no_cookie_view(request):
+    return HttpResponse()
+
+
 urlpatterns = [
     path('slow_class', SlowClassView.as_view()),
     path('slow_function', slow_function_view),
     TestNoDomainReportDispatcher.url_pattern(),
     path('<domain>/', include([TestReportDispatcher.url_pattern()])),
     path('<domain>/custom/', include([TestCustomReportDispatcher.url_pattern()])),
+    path('cookie', cookie_view),
+    path('secure_cookie', secure_cookie_view),
+    path('no_cookie', no_cookie_view),
 ]
 
 
@@ -180,3 +199,34 @@ class TestLogLongRequestMiddlewareReports(TestCase):
         res = self.client.get('/domain2/custom/custom_report/')
         self.assertEqual(res.status_code, 200)
         notify_exception.assert_not_called()
+
+
+@override_settings(
+    ROOT_URLCONF='corehq.tests.test_middleware',
+    MIDDLEWARE=('corehq.middleware.SecureCookiesMiddleware',),
+)
+class TestSecureCookiesMiddleware(SimpleTestCase):
+
+    def test_secure_if_SECURE_COOKIES_is_true(self):
+        with override_settings(SECURE_COOKIES=True):
+            response = self.client.get('/cookie')
+        self.assertTrue(response.cookies['test-cookie']['secure'])
+
+    def test_not_secure_if_SECURE_COOKIES_is_false(self):
+        with override_settings(SECURE_COOKIES=False):
+            response = self.client.get('/cookie')
+        self.assertFalse(response.cookies['test-cookie']['secure'])
+
+    def test_already_secure_cookie_remains_secure_if_SECURE_COOKIES_is_true(self):
+        with override_settings(SECURE_COOKIES=True):
+            response = self.client.get('/secure_cookie')
+        self.assertTrue(response.cookies['test-cookie']['secure'])
+
+    def test_already_secure_cookie_overridden_if_SECURE_COOKIES_is_false(self):
+        with override_settings(SECURE_COOKIES=False):
+            response = self.client.get('/secure_cookie')
+        self.assertFalse(response.cookies['test-cookie']['secure'])
+
+    def test_ignores_if_no_cookies_set(self):
+        response = self.client.get('/no_cookie')
+        self.assertFalse(response.cookies)

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -222,10 +222,10 @@ class TestSecureCookiesMiddleware(SimpleTestCase):
             response = self.client.get('/secure_cookie')
         self.assertTrue(response.cookies['test-cookie']['secure'])
 
-    def test_already_secure_cookie_overridden_if_SECURE_COOKIES_is_false(self):
+    def test_already_secure_cookie_remains_secure_if_SECURE_COOKIES_is_false(self):
         with override_settings(SECURE_COOKIES=False):
             response = self.client.get('/secure_cookie')
-        self.assertFalse(response.cookies['test-cookie']['secure'])
+        self.assertTrue(response.cookies['test-cookie']['secure'])
 
     def test_ignores_if_no_cookies_set(self):
         response = self.client.get('/no_cookie')

--- a/settings.py
+++ b/settings.py
@@ -168,6 +168,7 @@ MIDDLEWARE = [
     'no_exceptions.middleware.NoExceptionsMiddleware',
     'corehq.apps.locations.middleware.LocationAccessMiddleware',
     'corehq.apps.cloudcare.middleware.CloudcareMiddleware',
+    # middleware that adds cookies must come before SecureCookiesMiddleware
     'corehq.middleware.SecureCookiesMiddleware',
 ]
 

--- a/settings.py
+++ b/settings.py
@@ -168,6 +168,7 @@ MIDDLEWARE = [
     'no_exceptions.middleware.NoExceptionsMiddleware',
     'corehq.apps.locations.middleware.LocationAccessMiddleware',
     'corehq.apps.cloudcare.middleware.CloudcareMiddleware',
+    'corehq.middleware.SecureCookiesMiddleware',
 ]
 
 X_FRAME_OPTIONS = 'DENY'


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13823

This ensures cookies that are set on the HttpResponse object are set as secure before passing back to the client. We exclusively serve requests over HTTPS which is why we want to have this functionality. This prevents us from adding future cookies and forgetting to mark them as secure.

### Concerns

1) I'm unsure of the cookies that are set in JS as this would be client side and out of scope of our middleware. Need to look more into this, but figured I'd get the initial part of the PR up.

2) Maybe the downside of middleware, but order does matter. We have other middleware that sets cookies, so we need to be sure that this middleware is always run after those run (`CloudcareMiddleware` is an example). Is there a standard approach to prevent this from happening? Or should I just add a comment to this middleware/where it is added in settings?

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Will test on staging.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests in `corehq.tests.middleware` to ensure this behaves as expected.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
