### PR TITLE
[USH-2005] mobile worker default role

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -99,6 +99,9 @@ from .models_role import (  # noqa
     UserRole,
 )
 
+WEB_USER = 'web'
+COMMCARE_USER = 'commcare'
+
 MAX_WEB_USER_LOGIN_ATTEMPTS = 5
 MAX_COMMCARE_USER_LOGIN_ATTEMPTS = 500
 
@@ -327,7 +330,7 @@ class DomainMembership(Membership):
     """
     Each user can have multiple accounts on individual domains
     """
-    _get_default_role = None
+    _user_type = None
 
     domain = StringProperty()
     timezone = StringProperty(default=getattr(settings, "TIME_ZONE", "UTC"))
@@ -372,12 +375,8 @@ class DomainMembership(Membership):
             return self.get_default_role()
 
     def get_default_role(self):
-        """Delegates to the ``_get_default_role`` attribute which is set
-        just in time by 'user.get_domain_membership' and varies based on the
-        type of user (Web / Mobile).
-        """
-        if self._get_default_role:
-            return self._get_default_role(self.domain)
+        if self._user_type == COMMCARE_USER:
+            return UserRole.commcare_user_default(self.domain)
         return None
 
     def has_permission(self, permission, data=None):
@@ -432,9 +431,6 @@ class _AuthorizableMixin(IsMemberOfMixin):
         Use either SingleMembershipMixin or MultiMembershipMixin instead of this
     """
 
-    # see ``DomainMembership.get_default_role``
-    _get_default_role = None
-
     def get_domain_membership(self, domain, allow_enterprise=True):
         domain_membership = None
         try:
@@ -455,7 +451,8 @@ class _AuthorizableMixin(IsMemberOfMixin):
             self.domains = [d.domain for d in self.domain_memberships]
 
         if domain_membership:
-            domain_membership._get_default_role = self._get_default_role
+            # set user type on membership to support default roles for 'commcare' users
+            domain_membership._user_type = self._get_user_type()
         return domain_membership
 
     def add_domain_membership(self, domain, timezone=None, **kwargs):
@@ -993,16 +990,16 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         return self.email
 
     def is_commcare_user(self):
-        return self._get_user_type() == 'commcare'
+        return self._get_user_type() == COMMCARE_USER
 
     def is_web_user(self):
-        return self._get_user_type() == 'web'
+        return self._get_user_type() == WEB_USER
 
     def _get_user_type(self):
         if self.doc_type == 'WebUser':
-            return 'web'
+            return WEB_USER
         elif self.doc_type == 'CommCareUser':
-            return 'commcare'
+            return COMMCARE_USER
         else:
             raise NotImplementedError(f'Unrecognized user type {self.doc_type!r}')
 
@@ -1560,8 +1557,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
 
 class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin):
-    _get_default_role = UserRole.commcare_user_default
-
     domain = StringProperty()
     registering_device_id = StringProperty()
     # used by loadtesting framework - should typically be empty

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -368,7 +368,7 @@ class DomainMembership(Membership):
                 })
                 return None
         else:
-            return None
+            return UserRole.commcare_user_default(self.domain)
 
     def has_permission(self, permission, data=None):
         return self.is_admin or self.permissions.has(permission, data)

--- a/corehq/apps/users/models_role.py
+++ b/corehq/apps/users/models_role.py
@@ -8,6 +8,7 @@ from django.db import models, transaction
 from corehq.apps.users.landing_pages import ALL_LANDING_PAGES
 from corehq.util.models import ForeignValue, foreign_value_init
 from corehq.util.quickcache import quickcache
+from dimagi.utils.logging import notify_error
 
 
 @attr.s(frozen=True)
@@ -118,7 +119,13 @@ class UserRole(models.Model):
     @classmethod
     @quickcache(['domain'])
     def commcare_user_default(cls, domain):
-        return UserRole.objects.get_commcare_user_default(domain)
+        try:
+            return UserRole.objects.get_commcare_user_default(domain)
+        except UserRole.DoesNotExist:
+            notify_error("Domain is missing default commcare user role", {
+                "domain": domain
+            })
+        return None
 
     @property
     def get_id(self):

--- a/corehq/apps/users/models_role.py
+++ b/corehq/apps/users/models_role.py
@@ -67,7 +67,7 @@ class UserRoleManager(models.Manager):
         return query.get(couch_id=couch_id)
 
     def get_commcare_user_default(self, domain):
-        return self.filter(domain=domain, is_commcare_user_default=True).first()
+        return self.get(domain=domain, is_commcare_user_default=True)
 
 
 def _uuid_str():

--- a/corehq/apps/users/tests/test_authorization.py
+++ b/corehq/apps/users/tests/test_authorization.py
@@ -8,6 +8,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, WebUser, DomainMembershipError, HqPermissions
 from corehq.apps.users.models_role import UserRole
+from corehq.apps.users.role_utils import UserRolePresets
 
 
 @nottest
@@ -21,6 +22,11 @@ class BaseAuthorizationTest(TestCase):
         cls.test_role = UserRole.create(cls.domain, 'test role', permissions=HqPermissions(
             edit_web_users=True
         ))
+        cls.mobile_worker_default_role = UserRole.create(
+            cls.domain,
+            UserRolePresets.MOBILE_WORKER,
+            is_commcare_user_default=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -30,6 +36,7 @@ class BaseAuthorizationTest(TestCase):
         super().tearDownClass()
 
     def setUp(self):
+        UserRole.commcare_user_default.clear(UserRole.__class__, self.domain)
         self.user.has_permission.reset_cache(self.user)
         try:
             self.user.is_domain_admin.reset_cache(self.user)
@@ -146,6 +153,11 @@ class TestMobileUserAuthorizationFunctions(BaseAuthorizationTest):
             created_by=None,
             created_via=None,
         )
+
+    def test_get_role__not_set(self):
+        """Mobile workers have a default role"""
+        role = self.user.get_role(self.domain)
+        self.assertEqual(role.name, UserRolePresets.MOBILE_WORKER)
 
     def test_is_domain_admin__admin_role(self):
         with self._set_role(self.domain, self.user, is_admin=True):

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -8,9 +8,10 @@ from corehq.apps.custom_data_fields.models import (
     Field,
     PROFILE_SLUG,
 )
+from corehq.apps.users.models_role import UserRole
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.users.models import CommCareUser, DeviceAppMeta, WebUser
+from corehq.apps.users.models import CommCareUser, DeviceAppMeta, WebUser, CouchUser
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.form_processor.utils import (
     TestFormMetadata,
@@ -307,3 +308,97 @@ class UserDeviceTest(SimpleTestCase):
 
         m1.merge(m2)
         self.assertEqual(m1.last_sync, m2.last_sync)
+
+
+class TestCommCareUserRoles(TestCase):
+    user_class = CommCareUser
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestCommCareUserRoles, cls).setUpClass()
+        cls.domain = 'test-user-role'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.get_db().delete_doc, cls.domain_obj)
+
+        cls.role1 = UserRole.create(domain=cls.domain, name="role1")
+        cls.role2 = UserRole.create(domain=cls.domain, name="role2")
+
+    def test_create_user_without_role(self):
+        user = self._create_user('scotch game')
+        self.assertIsNone(user.get_role(self.domain))
+
+    def test_create_user_with_role(self):
+        user = self._create_user('vienna game', role_id=self.role1.get_id)
+        self.check_role(user, self.role1)
+
+    def test_set_role(self):
+        user = self._create_user("bird's opening")
+
+        user.set_role(self.domain, self.role1.get_qualified_id())
+        user.save()
+
+        # check that the role is applied to the current user object
+        self.check_role(user, self.role1)
+
+        # check that a fresh object from the DB is correct
+        user = CouchUser.get_by_username(user.username)
+        self.check_role(user, self.role1)
+
+    def test_update_role(self):
+        user = self._create_user("alekhine's defense", role_id=self.role1.get_id)
+
+        user.set_role(self.domain, self.role2.get_qualified_id())
+        user.save()
+
+        # check that the role is applied to the current user object
+        self.check_role(user, self.role2)
+
+        # check that a fresh object from the DB is correct
+        user = CouchUser.get_by_username(user.username)
+        self.check_role(user, self.role2)
+
+    def test_role_deleted(self):
+        role = UserRole.create(self.domain, 'new')
+        user = self._create_user("king's gambit", role_id=role.get_id)
+        self.check_role(user, role)
+
+        role.delete()
+
+        user = CouchUser.get_by_username(user.username)
+        self.assertIsNone(user.get_role(self.domain))
+
+    def check_role(self, user, expected, domain=None):
+        role = user.get_role(domain or self.domain)
+        self.assertIsNotNone(role)
+        self.assertEqual(role.get_qualified_id(), expected.get_qualified_id())
+
+    def _create_user(self, username, role_id=None):
+        user = self.user_class.create(
+            domain=self.domain,
+            username=username,
+            password='***',
+            created_by=None,
+            created_via=None,
+            role_id=role_id
+        )
+        self.addCleanup(user.delete, None, None)
+        return user
+
+
+class TestWebUserRoles(TestCommCareUserRoles):
+    user_class = WebUser
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain2 = 'test-user-role2'
+        cls.domain_obj2 = create_domain(cls.domain2)
+        cls.addClassCleanup(cls.domain_obj2.get_db().delete_doc, cls.domain_obj2)
+
+    def test_roles_multiple_domains(self):
+        user = self._create_user("alekhine's defense")
+        user.add_as_web_user(self.domain, self.role1.get_qualified_id())
+        user.add_as_web_user(self.domain2, self.role2.get_qualified_id())
+
+        self.check_role(user, self.role1, self.domain)
+        self.check_role(user, self.role2, self.domain2)

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -335,6 +335,8 @@ class TestCommCareUserRoles(TestCase):
 
     def test_create_user_without_role(self):
         user = self._create_user('scotch game')
+
+        # expect that a CommCareUser without a role will get the default role
         self.check_role(user, self.mobile_worker_default_role)
 
     def test_create_user_with_role(self):
@@ -404,6 +406,12 @@ class TestWebUserRoles(TestCommCareUserRoles):
         cls.domain2 = 'test-user-role2'
         cls.domain_obj2 = create_domain(cls.domain2)
         cls.addClassCleanup(cls.domain_obj2.get_db().delete_doc, cls.domain_obj2)
+
+    def test_create_user_without_role(self):
+        user = self._create_user('scotch game')
+
+        # web users don't have default roles
+        self.assertIsNone(user.get_role(self.domain))
 
     def test_roles_multiple_domains(self):
         user = self._create_user("alekhine's defense")

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -9,6 +9,7 @@ from corehq.apps.custom_data_fields.models import (
     PROFILE_SLUG,
 )
 from corehq.apps.users.models_role import UserRole
+from corehq.apps.users.role_utils import UserRolePresets
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, DeviceAppMeta, WebUser, CouchUser
@@ -322,10 +323,19 @@ class TestCommCareUserRoles(TestCase):
 
         cls.role1 = UserRole.create(domain=cls.domain, name="role1")
         cls.role2 = UserRole.create(domain=cls.domain, name="role2")
+        cls.mobile_worker_default_role = UserRole.create(
+            cls.domain,
+            UserRolePresets.MOBILE_WORKER,
+            is_commcare_user_default=True,
+        )
+
+    def setUp(self):
+        # clear cache
+        UserRole.commcare_user_default.clear(UserRole.__class__, self.domain)
 
     def test_create_user_without_role(self):
         user = self._create_user('scotch game')
-        self.assertIsNone(user.get_role(self.domain))
+        self.check_role(user, self.mobile_worker_default_role)
 
     def test_create_user_with_role(self):
         user = self._create_user('vienna game', role_id=self.role1.get_id)


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-2005

## Product Description
This changes the way mobile user roles work when no role has been assigned. Prior to this PR a mobile user with no role set would get a default set of permissions defined in code.

After this change all domains created prior to 2022-06-15 will maintain the same set of permissions for users with no assigned role. Domains created after that point in time will have a different set of permissions for mobile users with no role assigned.

The difference in permissions is that after this change the following permissions will be removed for new domains and domains created since the migration: `access_api`, `download_reports`.

## Technical Summary
If no role is set in domain membership then return a default role. Web users should always have a role set since you can't create them without a role and can't remove the role after that. Despite that I did try to ensure that the default role is only used for mobile users. I'm not thrilled with the approach so I'd appreciate feedback on that particularly.

## Safety Assurance

### Safety story
This will change the permissions for a small set of users (mobile users with no role set who belong to domains created since 2022-06-15) however since the permissions being removed are  `access_api`, `download_reports` I think it is safe to roll this out without any further data migrations.

In terms of the code changes. I have added some tests to cover the changes and general user role management at the data model level. 

The code to apply the default only for mobile workers uses a just-in-time attribute set on the domain membership object when it is fetched from the user. All (almost) role and permission access on users go through `get_domain_membership` to get the membership object which is where the role is set so I think this approach is safe. The places that do not use `get_domain_membership` do things that would not apply to the default role anyway:

https://github.com/dimagi/commcare-hq/blob/7d5cc76c0a6231ac98cfcf8e36ec5b9bea11f6cb/corehq/apps/settings/views.py#L454-L461

### Automated test coverage
There are some existing tests which cover authorization and I've added more tests for setting and updating roles specifically.

### QA Plan
I don't think this needs QA but I could put it on staging for a while for the sake of caution.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
