### PR TITLE
Fix bug on upload zero tables

### DIFF
--- a/corehq/apps/fixtures/tests/test_upload.py
+++ b/corehq/apps/fixtures/tests/test_upload.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from io import BytesIO
 from unittest.mock import patch
 
@@ -559,7 +560,6 @@ class TestFixtureUpload(TestCase):
         self.assertEqual(self.get_rows(), ['orange'])
 
     def test_upload_progress_and_result(self):
-        from datetime import timedelta
         task = FakeTask()
         with patch.object(mod, "timedelta", lambda **k: timedelta()):
             result = self.upload([
@@ -577,6 +577,14 @@ class TestFixtureUpload(TestCase):
         ])
         self.assertEqual(result.number_of_fixtures, 1)
         self.assertTrue(result.success)
+
+    def test_upload_progress_with_zero_tables(self):
+        workbook = self.get_workbook_from_data(self.headers, [])
+        task = FakeTask()
+        with patch.object(mod, "timedelta", lambda **k: timedelta()):
+            result = self.upload(workbook, task=task)
+        self.assertEqual(result.errors, [])
+        self.assertIsNone(self.get_table())
 
     def test_table_uid_conflict(self):
         result = self.upload_table_with_uid_conflict()

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -182,6 +182,8 @@ def setup_progress(task, workbook):
     class progress:
         tables = set()
         next_update = datetime.now()
+        row = 0
+        total_rows = 1
 
     return total_tables, update_progress
 


### PR DESCRIPTION
Stack trace:
```
  File "corehq/apps/fixtures/tasks.py", line 23, in fixture_upload_async
    result = upload_fixture_file(domain, download_ref.get_filename(), replace, task, skip_orm)
  File "corehq/apps/fixtures/upload/run_upload.py", line 32, in upload_fixture_file
    return _run_upload(domain, workbook, replace, task, skip_orm)
  File "corehq/apps/fixtures/upload/run_upload.py", line 99, in _run_upload
    update_progress(None)
  File "corehq/apps/fixtures/upload/run_upload.py", line 179, in update_progress
    processed = table_count * 10 + (10 * progress.row / progress.total_rows)
AttributeError: type object 'progress' has no attribute 'row'
```

## Safety Assurance

### Safety story

Small bug fix with automated test.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
