### PR TITLE
Updated _.map call in case search config UI

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -189,18 +189,18 @@ hqDefine("app_manager/js/details/case_claim", function () {
     };
 
     var searchConfigKeys = [
-        'autoLaunch', 'blacklistedOwnerIdsExpression', 'defaultSearch', 'searchAgainLabel',
-        'searchButtonDisplayCondition', 'searchLabel', 'searchFilter',
-        'searchAdditionalRelevant', 'dataRegistry', 'dataRegistryWorkflow', 'additionalRegistryCases',
-        'customRelatedCaseProperty', 'inlineSearch',
+        'auto_launch', 'blacklisted_owner_ids_expression', 'default_search', 'search_again_label',
+        'search_button_display_condition', 'search_label', 'search_filter',
+        'additional_relevant', 'data_registry', 'data_registry_workflow', 'additional_registry_cases',
+        'custom_related_case_property', 'inline_search',
     ];
     var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
         hqImport("hqwebapp/js/assert_properties").assertRequired(options, searchConfigKeys);
 
-        options.searchLabel = options.searchLabel[lang] || "";
-        options.searchAgainLabel = options.searchAgainLabel[lang] || "";
+        options.search_label = options.search_label[lang] || "";
+        options.search_again_label = options.search_again_label[lang] || "";
         var mapping = {
-            'additionalRegistryCases': {
+            'additional_registry_cases': {
                 create: function(options) {
                     return additionalRegistryCaseModel(options.data, saveButton);
                 },
@@ -209,32 +209,32 @@ hqDefine("app_manager/js/details/case_claim", function () {
         var self = ko.mapping.fromJS(options, mapping);
 
         self.restrictWorkflowForDataRegistry = ko.pureComputed(() => {
-            return self.dataRegistry() && self.dataRegistryWorkflow() === 'load_case';
+            return self.data_registry() && self.data_registry_workflow() === 'load_case';
         });
 
         self.workflow = ko.computed({
             read: function () {
                 if (self.restrictWorkflowForDataRegistry()) {
-                    if (self.autoLaunch()) {
-                        if (self.defaultSearch()) {
+                    if (self.auto_launch()) {
+                        if (self.default_search()) {
                             return "es_only";
                         }
                     }
                     return "auto_launch";
                 }
-                if (self.autoLaunch()) {
-                    if (self.defaultSearch()) {
+                if (self.auto_launch()) {
+                    if (self.default_search()) {
                         return "es_only";
                     }
                     return "auto_launch";
-                } else if (self.defaultSearch()) {
+                } else if (self.default_search()) {
                     return "see_more";
                 }
                 return "classic";
             },
             write: function (value) {
-                self.autoLaunch(_.contains(["es_only", "auto_launch"], value));
-                self.defaultSearch(_.contains(["es_only", "see_more"], value));
+                self.auto_launch(_.contains(["es_only", "auto_launch"], value));
+                self.default_search(_.contains(["es_only", "see_more"], value));
             },
         });
 
@@ -243,7 +243,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         });
 
         self.inlineSearchActive = ko.computed(() => {
-            return self.inlineSearchVisible() && self.inlineSearch();
+            return self.inlineSearchVisible() && self.inline_search();
         });
 
         // Allow search filter to be copied from another part of the page
@@ -251,10 +251,10 @@ hqDefine("app_manager/js/details/case_claim", function () {
             return searchFilterObservable && searchFilterObservable();
         });
         self.setSearchFilterEnabled = ko.computed(function () {
-            return self.setSearchFilterVisible() && searchFilterObservable() !== self.searchFilter();
+            return self.setSearchFilterVisible() && searchFilterObservable() !== self.search_filter();
         });
         self.setSearchFilter = function () {
-            self.searchFilter(searchFilterObservable());
+            self.search_filter(searchFilterObservable());
         };
 
         subscribeToSave(self, searchConfigKeys, saveButton);
@@ -268,47 +268,25 @@ hqDefine("app_manager/js/details/case_claim", function () {
         });
 
         self.addRegistryQuery = function () {
-            self.additionalRegistryCases.push(additionalRegistryCaseModel('', saveButton));
+            self.additional_registry_cases.push(additionalRegistryCaseModel('', saveButton));
         };
 
         self.removeRegistryQuery = function (model) {
-            self.additionalRegistryCases.remove(model);
+            self.additional_registry_cases.remove(model);
         };
 
         self.serialize = function () {
-            return {
-                auto_launch: self.autoLaunch(),
-                default_search: self.defaultSearch(),
-                search_additional_relevant: self.searchAdditionalRelevant(),
-                search_button_display_condition: self.searchButtonDisplayCondition(),
-                data_registry: self.dataRegistry(),
-                data_registry_workflow: self.dataRegistryWorkflow(),
-                search_label: self.searchLabel(),
-                search_label_image:
-                    $("#case_search-search_label_media_media_image input[type=hidden][name='case_search-search_label_media_media_image']").val() || null,
-                search_label_image_for_all:
-                    $("#case_search-search_label_media_media_image input[type=hidden][name='case_search-search_label_media_use_default_image_for_all']").val() || null,
-                search_label_audio:
-                    $("#case_search-search_label_media_media_audio input[type=hidden][name='case_search-search_label_media_media_audio']").val() || null,
-                search_label_audio_for_all:
-                    $("#case_search-search_label_media_media_audio input[type=hidden][name='case_search-search_label_media_use_default_audio_for_all']").val() || null,
-                search_again_label: self.searchAgainLabel(),
-                search_again_label_image:
-                    $("#case_search-search_again_label_media_media_image input[type=hidden][name='case_search-search_again_label_media_media_image']").val() || null,
-                search_again_label_image_for_all:
-                    $("#case_search-search_again_label_media_media_image input[type=hidden][name='case_search-search_again_label_media_use_default_image_for_all']").val() || null,
-                search_again_label_audio:
-                    $("#case_search-search_again_label_media_media_audio input[type=hidden][name='case_search-search_again_label_media_media_audio']").val() || null,
-                search_again_label_audio_for_all:
-                    $("#case_search-search_again_label_media_media_audio input[type=hidden][name='case_search-search_again_label_media_use_default_audio_for_all']").val() || null,
-                search_filter: self.searchFilter(),
-                blacklisted_owner_ids_expression: self.blacklistedOwnerIdsExpression(),
-                additional_registry_cases: self.dataRegistryWorkflow() === "load_case" ?  self.additionalRegistryCases().map((query) => {
-                    return query.caseIdXpath();
-                }) : [],
-                custom_related_case_property: self.customRelatedCaseProperty(),
-                inline_search: self.inlineSearch(),
-            };
+            var data = ko.mapping.toJS(self);
+            data.additional_registry_cases = data.data_registry_workflow === "load_case" ?  _.pluck(data.additional_registry_cases, 'caseIdXpath') : [];
+            _.each(['search_label', 'search_again_label'], function (label) {
+                _.each(['image', 'audio'], function (media) {
+                    var key = label + "_" + media,
+                        selector = "#case_search-" + label + "_media_media_" + media + " input[type='hidden']";
+                    data[key] = $(selector + "[name='case_search-" + label + "_media_media_" + media + "']").val();
+                    data[key + "_for_all"] = $(selector + "[name='case_search-" + label + "_media_use_default_" + media + "_for_all']").val();
+                });
+            });
+            return data;
         };
 
         return self;
@@ -339,7 +317,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         var self = {};
 
         self.searchConfig = searchConfigModel(searchConfigOptions, lang, searchFilterObservable, saveButton);
-        self.defaultProperties = ko.observableArray();
+        self.default_properties = ko.observableArray();
 
         // searchProperties is a list of CaseSearchProperty objects
         var wrappedSearchProperties = _.map(searchProperties, function (searchProperty) {
@@ -360,32 +338,25 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 defaultValue: searchProperty.default_value,
                 hidden: searchProperty.hidden,
                 receiverExpression: searchProperty.receiver_expression,
-                itemsetOptions: {
-                    instance_id: searchProperty.itemset.instance_id,
-                    instance_uri: searchProperty.itemset.instance_uri,
-                    nodeset: searchProperty.itemset.nodeset,
-                    label: searchProperty.itemset.label,
-                    value: searchProperty.itemset.value,
-                    sort: searchProperty.itemset.sort,
-                },
+                itemsetOptions: searchProperty.itemset,
             }, saveButton);
         });
 
-        self.searchProperties = ko.observableArray(
+        self.search_properties = ko.observableArray(
             wrappedSearchProperties.length > 0 ? wrappedSearchProperties : [searchPropertyModel({}, saveButton)]
         );
 
         self.addProperty = function () {
-            self.searchProperties.push(searchPropertyModel({}, saveButton));
+            self.search_properties.push(searchPropertyModel({}, saveButton));
         };
         self.removeProperty = function (property) {
-            self.searchProperties.remove(property);
+            self.search_properties.remove(property);
         };
         self._getProperties = function () {
-            // i.e. [{'name': p.name, 'label': p.label} for p in self.searchProperties if p.name]
+            // i.e. [{'name': p.name, 'label': p.label} for p in self.search_properties if p.name]
             return _.map(
                 _.filter(
-                    self.searchProperties(),
+                    self.search_properties(),
                     function (p) { return p.name().length > 0; }  // Skip properties where name is blank
                 ),
                 function (p) {
@@ -411,42 +382,33 @@ hqDefine("app_manager/js/details/case_claim", function () {
             );
         };
 
-        if (defaultProperties.length > 0) {
-            for (var k = 0; k < defaultProperties.length; k++) {
-                self.defaultProperties.push(defaultPropertyModel({
-                    property: defaultProperties[k].property,
-                    defaultValue: defaultProperties[k].defaultValue,
-                }, saveButton));
-            }
-        } else {
-            self.defaultProperties.push(defaultPropertyModel({}, saveButton));
-        }
         self.addDefaultProperty = function () {
-            self.defaultProperties.push(defaultPropertyModel({}, saveButton));
+            self.default_properties.push(defaultPropertyModel({}, saveButton));
         };
         self.removeDefaultProperty = function (property) {
-            self.defaultProperties.remove(property);
+            self.default_properties.remove(property);
         };
         self._getDefaultProperties = function () {
             return _.map(
                 _.filter(
-                    self.defaultProperties(),
+                    self.default_properties(),
                     function (p) { return p.property().length > 0; }  // Skip properties where property is blank
                 ),
-                function (p) {
-                    return {
-                        property: p.property(),
-                        defaultValue: p.defaultValue(),
-                    };
-                }
+                ko.mapping.toJS
             );
         };
 
+        if (defaultProperties.length > 0) {
+            self.default_properties(_.map(defaultProperties, function (p) {
+                return defaultPropertyModel(p, saveButton);
+            }));
+        } else {
+            self.addDefaultProperty();
+        }
+
         self.commonProperties = ko.computed(function () {
-            var defaultProperties = _.map(self._getDefaultProperties(), function (p) {
-                return p.property;
-            });
-            var commonProperties = self.searchProperties().filter(function (n) {
+            var defaultProperties = _.pluck(self._getDefaultProperties(), 'property');
+            var commonProperties = self.search_properties().filter(function (n) {
                 return n.name().length > 0 && defaultProperties.indexOf(n.name()) !== -1;
             });
             return _.map(
@@ -473,7 +435,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             }, self.searchConfig.serialize());
         };
 
-        subscribeToSave(self, ['searchProperties', 'defaultProperties'], saveButton);
+        subscribeToSave(self, ['search_properties', 'default_properties'], saveButton);
 
         return self;
     };

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -394,7 +394,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     self.default_properties(),
                     function (p) { return p.property().length > 0; }  // Skip properties where property is blank
                 ),
-                ko.mapping.toJS
+                function (prop) { return ko.mapping.toJS(prop); }
             );
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -108,8 +108,8 @@ hqDefine('app_manager/js/details/screen_config', function () {
             // Set up case search
             var caseClaimModels = hqImport("app_manager/js/details/case_claim");
             self.search = caseClaimModels.searchViewModel(
-                spec.searchProperties || [],
-                spec.defaultProperties,
+                spec.search_properties || [],
+                spec.default_properties,
                 _.pick(spec, caseClaimModels.searchConfigKeys),
                 spec.lang,
                 self.shortScreen.saveButton,

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -15,7 +15,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
             var details = initial_page_data('details');
             for (var i = 0; i < details.length; i++) {
                 var detail = details[i];
-                var detailScreenConfig = hqImport("app_manager/js/details/screen_config")({
+                var detailScreenConfigOptions = {
                     module_id: moduleBrief.id,
                     moduleUniqueId: moduleBrief.unique_id,
                     state: {
@@ -36,22 +36,9 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     parentSelect: detail.parent_select,
                     fixtureSelect: detail.fixture_select,
                     multimedia: initial_page_data('multimedia_object_map'),
-                    searchProperties: options.search_properties || [],
-                    searchAdditionalRelevant: options.search_additional_relevant,
-                    autoLaunch: options.auto_launch,
-                    defaultSearch: options.default_search,
-                    defaultProperties: options.default_properties || [],
-                    searchButtonDisplayCondition: options.search_button_display_condition,
-                    searchLabel: options.search_label,
-                    searchAgainLabel: options.search_again_label,
-                    searchFilter: options.search_filter,
-                    blacklistedOwnerIdsExpression: options.blacklisted_owner_ids_expression,
-                    dataRegistry: options.data_registry || "",
-                    dataRegistryWorkflow: options.data_registry_workflow,
-                    additionalRegistryCases: options.additional_registry_cases,
-                    customRelatedCaseProperty: options.custom_related_case_property,
-                    inlineSearch: options.inline_search,
-                });
+                };
+                _.extend(detailScreenConfigOptions, options.search_config);
+                var detailScreenConfig = hqImport("app_manager/js/details/screen_config")(detailScreenConfigOptions);
 
                 var $list_home = $("#" + detail.type + "-detail-screen-config-tab");
                 $list_home.koApplyBindings(detailScreenConfig);

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -18,7 +18,7 @@
       <div class="panel-body">
         <p>{% trans "Search against the following case properties." %}</p>
         <table class="table table-condensed">
-          <thead data-bind="visible: searchProperties().length > 0">
+          <thead data-bind="visible: search_properties().length > 0">
           <tr>
             <th class="col-sm-1"></th>
             <th class="col-sm-4">{% trans "Case Property" %}</th>
@@ -29,7 +29,7 @@
             <th class="col-sm-1"></th>
           </tr>
           </thead>
-          <tbody data-bind="foreach: searchProperties, sortableList: searchProperties">
+          <tbody data-bind="foreach: search_properties, sortableList: search_properties">
             {% include "app_manager/partials/modules/case_search_property.html" %}
           </tbody>
         </table>
@@ -49,14 +49,14 @@
       <div class="panel-body">
         <p>{% trans "Filter based on a specific value of any case property. These are applied to every search and are hidden from the user." %}</p>
         <table class="table table-condensed">
-          <thead data-bind="visible: defaultProperties().length > 0">
+          <thead data-bind="visible: default_properties().length > 0">
           <tr>
             <th class="col-sm-5">{% trans "Case Property" %}</th>
             <th class="col-sm-6">{% trans "Value (XPath expression)" %}</th>
             <th class="col-sm-1">&nbsp;</th>
           </tr>
           </thead>
-          <tbody data-bind="foreach: defaultProperties">
+          <tbody data-bind="foreach: default_properties">
           <tr>
             <td class="col-sm-4" data-bind="css: {'has-error': $parent.isCommon(ko.unwrap(property()))}">
 
@@ -131,8 +131,8 @@
             </label>
             <div class="{% css_field_class %} checkbox">
               <label>
-                <input type="checkbox" data-bind="checked: inlineSearch" />
-                <input type="hidden" name="search-input" data-bind="value: inlineSearch"/>
+                <input type="checkbox" data-bind="checked: inline_search" />
+                <input type="hidden" name="search-input" data-bind="value: inline_search"/>
               </label>
             </div>
           </div>
@@ -145,7 +145,7 @@
                     data-content="{% trans_html_attr "This text is for the button to enter case search. It is also the header on the search results screen." %}">
             </label>
             <div class="{% css_field_class %}">
-              {% input_trans module.search_config.search_label.label langs input_name='search_label' input_id='search_label' data_bind="value: searchLabel" %}
+              {% input_trans module.search_config.search_label.label langs input_name='search_label' input_id='search_label' data_bind="value: search_label" %}
             </div>
           </div>
           <div class="case-search-multimedia-input" data-bind="hidden: inlineSearchActive">
@@ -162,7 +162,7 @@
                     data-content="{% trans_html_attr "This text is for the search button displayed at the bottom of search results, so users can search again." %}">
             </label>
             <div class="{% css_field_class %}">
-              {% input_trans module.search_config.search_again_label.label langs input_name='search_again_label' input_id='search_again_label' data_bind="value: searchAgainLabel" %}
+              {% input_trans module.search_config.search_again_label.label langs input_name='search_again_label' input_id='search_again_label' data_bind="value: search_again_label" %}
             </div>
           </div>
           <div class="case-search-multimedia-input" data-bind="hidden: inlineSearchActive">
@@ -173,7 +173,7 @@
             <!-- /ko -->
           </div>
           {% endif %}
-          <div class="form-group" data-bind="slideVisible: !autoLaunch()">
+          <div class="form-group" data-bind="slideVisible: !auto_launch()">
             <label for="search-display-condition" class="control-label {% css_label_class %}">
               {% trans "Display Condition" %}
               <span class="hq-help-template" data-title="{% trans "Display Condition" %}"
@@ -184,7 +184,10 @@
               <textarea class="form-control vertical-resize"
                        id="search-display-condition"
                        spellcheck="false"
-                       data-bind="value: searchButtonDisplayCondition, xpathValidator: {text: searchButtonDisplayCondition, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}"
+                       data-bind="
+                         value: search_button_display_condition,
+                         xpathValidator: {text: search_button_display_condition, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}
+                       "
               ></textarea>
             </div>
           </div>
@@ -196,7 +199,7 @@
                     data-content="{% trans_html_attr "An XPath expression to filter the search results." %}">
             </label>
             <div class="{% css_field_class %}">
-              <textarea data-bind="value: searchFilter, xpathValidator: {text: searchFilter, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}"
+              <textarea data-bind="value: search_filter, xpathValidator: {text: search_filter, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}"
                         class="form-control vertical-resize"
                         id="search-filter"
                         spellcheck="false"
@@ -219,7 +222,7 @@
               </span>
             </label>
             <div class="{% css_field_class %}">
-              <textarea data-bind="value: searchAdditionalRelevant, xpathValidator: {text: searchAdditionalRelevant, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}"
+              <textarea data-bind="value: additional_relevant, xpathValidator: {text: additional_relevant, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}"
                         class="form-control vertical-resize"
                         id="claim-relevant-condition"
                         spellcheck="false"
@@ -234,7 +237,10 @@
               </span>
             </label>
             <div class="{% css_field_class %}">
-              <textarea data-bind="value: blacklistedOwnerIdsExpression, xpathValidator: {text: blacklistedOwnerIdsExpression, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}"
+              <textarea data-bind="
+                value: blacklisted_owner_ids_expression,
+                xpathValidator: {text: blacklisted_owner_ids_expression, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}
+              "
                         class="form-control vertical-resize"
                         id="blacklisted-user-ids"
                         spellcheck="false"
@@ -254,7 +260,7 @@
                         data-content="{% trans_html_attr "Select a Data Registry to use for searching.  Users with access will see results from the registry when performing this search." %}">
               </label>
               <div class="{% css_field_class %}">
-                  <select class="form-control" id="data-registry" data-bind="value: dataRegistry">
+                  <select class="form-control" id="data-registry" data-bind="value: data_registry">
                       <option value/>
                       {% for registry in data_registries %}
                           <option value="{{ registry.slug }}">{{ registry.name }}</option>
@@ -262,19 +268,19 @@
                   </select>
               </div>
           </div>
-          <div class="form-group" data-bind="slideVisible: dataRegistry()">
+          <div class="form-group" data-bind="slideVisible: data_registry()">
               <label for="data-registry" class="{% css_label_class %} control-label">
                   {% trans "Data Registry Workflow" %}
               </label>
               <div class="{% css_field_class %}">
-                  <select class="form-control" data-bind="value: dataRegistryWorkflow">
+                  <select class="form-control" data-bind="value: data_registry_workflow">
                     {% for slug, name in data_registry_workflow_choices %}
                       <option value="{{ slug }}">{{ name }}</option>
                     {% endfor %}
                   </select>
               </div>
           </div>
-          <div class="form-group" data-bind="visible: dataRegistryWorkflow() == 'load_case'">
+          <div class="form-group" data-bind="visible: data_registry_workflow() == 'load_case'">
               <label for="data-registry" class="{% css_label_class %} control-label">
                   {% trans "Load Additional Data Registry Cases" %}
                   <span class="hq-help-template" data-title="{% trans "Data Registry" %}"
@@ -287,13 +293,13 @@
               </label>
               <div class="{% css_field_class %}">
                   <table class="table table-condensed">
-                    <thead data-bind="visible: additionalRegistryCases().length > 0">
+                    <thead data-bind="visible: additional_registry_cases().length > 0">
                     <tr>
                       <th class="col-sm-12">{% trans "Case ID XPath" %}</th>
                       <th class="col-sm-1"></th>
                     </tr>
                     </thead>
-                    <tbody data-bind="foreach: additionalRegistryCases, sortableList: additionalRegistryCases">
+                    <tbody data-bind="foreach: additional_registry_cases, sortableList: additional_registry_cases">
                       <tr>
                         <td>
                           <textarea data-bind="
@@ -335,7 +341,7 @@
                   <input id="custom-related-case-property"
                          type="text"
                          class="form-control"
-                         data-bind="value: customRelatedCaseProperty"/>
+                         data-bind="value: custom_related_case_property"/>
               </div>
           </div>
           {% endif %}

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -227,28 +227,32 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             'item_lists': item_lists,
             'has_lookup_tables': bool([i for i in item_lists if i['fixture_type'] == LOOKUP_TABLE_FIXTURE]),
             'has_mobile_ucr': bool([i for i in item_lists if i['fixture_type'] == REPORT_FIXTURE]),
-            'search_properties': module.search_config.properties if module_offers_search(module) else [],
-            'auto_launch': module.search_config.auto_launch if module_offers_search(module) else False,
-            'default_search': module.search_config.default_search if module_offers_search(module) else False,
-            'default_properties': module.search_config.default_properties if module_offers_search(module) else [],
-            'search_filter': module.search_config.search_filter if module_offers_search(module) else "",
-            'search_button_display_condition':
-                module.search_config.search_button_display_condition if module_offers_search(module) else "",
-            'search_additional_relevant':
-                module.search_config.additional_relevant if module_offers_search(module) else "",
-            'blacklisted_owner_ids_expression': (
-                module.search_config.blacklisted_owner_ids_expression if module_offers_search(module) else ""),
             'default_value_expression_enabled': app.enable_default_value_expression,
-            # populate these even if module_offers_search is false because search_config might just not exist yet
-            'search_label':
-                module.search_config.search_label.label if hasattr(module, 'search_config') else "",
-            'search_again_label':
-                module.search_config.search_again_label.label if hasattr(module, 'search_config') else "",
-            'data_registry': module.search_config.data_registry,
-            'data_registry_workflow': module.search_config.data_registry_workflow,
-            'additional_registry_cases': module.search_config.additional_registry_cases,
-            'custom_related_case_property': module.search_config.custom_related_case_property,
-            'inline_search': module.search_config.inline_search,
+            'search_config': {
+                'search_properties':
+                    module.search_config.properties if module_offers_search(module) else [],
+                'default_properties':
+                    module.search_config.default_properties if module_offers_search(module) else [],
+                'auto_launch': module.search_config.auto_launch if module_offers_search(module) else False,
+                'default_search': module.search_config.default_search if module_offers_search(module) else False,
+                'search_filter': module.search_config.search_filter if module_offers_search(module) else "",
+                'search_button_display_condition':
+                    module.search_config.search_button_display_condition if module_offers_search(module) else "",
+                'additional_relevant':
+                    module.search_config.additional_relevant if module_offers_search(module) else "",
+                'blacklisted_owner_ids_expression': (
+                    module.search_config.blacklisted_owner_ids_expression if module_offers_search(module) else ""),
+                # populate labels even if module_offers_search is false - search_config might just not exist yet
+                'search_label':
+                    module.search_config.search_label.label if hasattr(module, 'search_config') else "",
+                'search_again_label':
+                    module.search_config.search_again_label.label if hasattr(module, 'search_config') else "",
+                'data_registry': module.search_config.data_registry if module.search_config.data_registry else "",
+                'data_registry_workflow': module.search_config.data_registry_workflow,
+                'additional_registry_cases': module.search_config.additional_registry_cases,
+                'custom_related_case_property': module.search_config.custom_related_case_property,
+                'inline_search': module.search_config.inline_search,
+            },
         },
     }
     if toggles.CASE_DETAIL_PRINT.enabled(app.domain):
@@ -1254,7 +1258,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 return HttpResponseBadRequest(e)
             xpath_props = [
                 "search_filter", "blacklisted_owner_ids_expression",
-                "search_button_display_condition", "search_additional_relevant"
+                "search_button_display_condition", "additional_relevant"
             ]
 
             def _check_xpath(xpath, location):
@@ -1295,7 +1299,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 search_again_label=search_again_label,
                 properties=properties,
                 additional_case_types=module.search_config.additional_case_types,
-                additional_relevant=search_properties.get('search_additional_relevant', ''),
+                additional_relevant=search_properties.get('additional_relevant', ''),
                 auto_launch=force_auto_launch or bool(search_properties.get('auto_launch')),
                 default_search=bool(search_properties.get('default_search')),
                 search_filter=search_properties.get('search_filter', ""),


### PR DESCRIPTION
## Technical Summary
First commit reverts https://github.com/dimagi/commcare-hq/pull/32009

Second commit is the real fix for https://dimagi-dev.atlassian.net/browse/USH-2341

[_.map](https://underscorejs.org/#map) passes three arguments to the iteree: the value, its index, and the full list. `toJS` will interpret that second parameter as a mapping specification, which causes intermittent, varied errors. Fix by explicitly calling `toJS` with only the single param.

## Safety Assurance

### Safety story
Targeted fix for an issue in a flagged feature, only reported by one project. I can reproduce similar js errors from the ticket locally in a slightly different scenario than reported and verified that this fix addresses them. I'm reasonably confident this will fix all js errors related to this `toJS` call.

### Automated test coverage

nope

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
