### PR TITLE
Fix websockets process after celery upgrade

### DIFF
--- a/deployment/gunicorn/commcarehq_wsgi.py
+++ b/deployment/gunicorn/commcarehq_wsgi.py
@@ -1,13 +1,10 @@
 # flake8: noqa: E402
 import os
-from manage import _set_source_root_parent, _set_source_root, run_patches
+from manage import init_hq_python_path, run_patches
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
-_set_source_root_parent('submodules')
-_set_source_root(os.path.join('corehq', 'ex-submodules'))
-_set_source_root(os.path.join('custom', '_legacy'))
-
+init_hq_python_path()
 # patch gevent
 from gevent.monkey import patch_all
 from psycogreen.gevent import patch_psycopg

--- a/deployment/websocket_wsgi.py
+++ b/deployment/websocket_wsgi.py
@@ -1,13 +1,12 @@
 import os
 import gevent.socket
 import redis.connection
-from manage import _set_source_root_parent, _set_source_root
+from manage import init_hq_python_path, run_patches
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
-_set_source_root_parent('submodules')
-_set_source_root(os.path.join('corehq', 'ex-submodules'))
-_set_source_root(os.path.join('custom', '_legacy'))
+init_hq_python_path()
+run_patches()
 
 redis.connection.socket = gevent.socket
 from ws4redis.uwsgi_runserver import uWSGIWebsocketServer

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -134,6 +134,7 @@ function run_tests {
         argv_str=$(printf ' %q' "$TEST" "$@")
         su cchq -c "/bin/bash ../run_tests $argv_str" 2>&1
         log_group_end  # only log group end on success (notice: `set -e`)
+        [ "$TEST" == "python-sharded-and-javascript" ] && scripts/test-prod-entrypoints.sh
         [ "$TEST" == "python-sharded-and-javascript" ] && scripts/test-make-requirements.sh
         [ "$TEST" == "python-sharded-and-javascript" ] && scripts/test-serializer-pickle-files.sh
         [ "$TEST" == "python-sharded-and-javascript" -o "$TEST_MIGRATIONS" ] && scripts/test-django-migrations.sh

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -698,6 +698,8 @@ urllib3==1.26.5
     #   sentry-sdk
 user-agents==2.2.0
     # via django-user-agents
+uwsgi==2.0.20
+    # via -r test-requirements.in
 vine==5.0.0
     # via
     #   amqp

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -13,3 +13,4 @@ flaky
 freezegun
 radon>=5.0  # v5 no longer depends on flake8-polyfill
 coverage
+uWSGI

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -572,6 +572,8 @@ urllib3==1.26.5
     #   sentry-sdk
 user-agents==2.2.0
     # via django-user-agents
+uwsgi==2.0.20
+    # via -r test-requirements.in
 vine==5.0.0
     # via
     #   amqp

--- a/scripts/test-prod-entrypoints.sh
+++ b/scripts/test-prod-entrypoints.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+echo "Testing gunciron entrypoint"
+python -c 'import deployment.gunicorn.commcarehq_wsgi'
+
+echo "Testing websockets entrypoint"
+uwsgi --http-socket web.socket --test deployment.websocket_wsgi
+
+echo "Testing celery entrypoint"
+python -c 'import corehq.celery'


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-13854

## Safety Assurance

### Safety story
Right now the websockets feature is entirely broken, so this could only improve it or keep it the same.

### Automated test coverage

One major reason the bug was introduced in the first place is that there is nothing testing the uwsgi bootstrapping process. If our tests ran `deployment/websocket_wsgi.py` at all, it would have been obvious it wasn't starting up properly.

In this PR I have added those tests. Amit also pointed out that he stumbled on the same issue for gunicorn on staging initially, which uses `deployement/gunicorn/commcarehq_wsgi.py`. There's also `corehq/celery.py` that I found that does similar bootstrapping. So I added a test that executes each of those entrypoint modules (without actually starting a daemon process) and will fail if there are any errors.

### QA Plan

I'll put this on staging and just make sure it works.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

(the only consideration is that it would undo this fix)

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
