### PR TITLE
Fix bug on upload new rows to existing table

### DIFF
--- a/corehq/apps/fixtures/tests/test_upload.py
+++ b/corehq/apps/fixtures/tests/test_upload.py
@@ -1,7 +1,9 @@
+from contextlib import contextmanager
 from datetime import timedelta
 from io import BytesIO
 from unittest.mock import patch
 
+from django.db import connection
 from django.test import SimpleTestCase, TestCase
 
 import openpyxl
@@ -19,6 +21,7 @@ from corehq.apps.fixtures.models import (
     FixtureItemField,
     FixtureTypeField,
     LookupTable,
+    LookupTableRow,
 )
 from corehq.apps.fixtures.upload import validate_fixture_file_format
 from corehq.apps.fixtures.upload.failure_messages import FAILURE_MESSAGES
@@ -672,6 +675,14 @@ class TestFixtureUpload(TestCase):
         self.assertIsNotNone(get_table())
         self.assertTrue(did_check)
 
+    def test_upload_rows_without_sql_table(self):
+        with disable_save_to_sql():  # simulate save prior to start of migration
+            self.upload([(None, 'N', 'apple')])
+
+        self.upload([(None, 'N', 'orange'), (None, 'N', 'banana')])
+        connection.check_constraints()  # should not raise
+        self.assertEqual(self.get_rows(), ['apple', 'orange', 'banana'])
+
 
 class TestFixtureOwnershipUpload(TestCase):
     do_upload = _run_upload
@@ -804,6 +815,14 @@ class TestFixtureOwnershipUpload(TestCase):
         result = self.upload([(None, 'N', 'apple', 3, 3, 3)], check_result=False)
         self.assertEqual(self.get_rows(), [('apple', {'3'}, {'3'}, {'3'})])
         self.assertFalse(result.errors)
+
+    def test_row_ownership_without_sql_row(self):
+        with disable_save_to_sql():  # simulate save prior to start of migration
+            self.upload([(None, 'N', 'apple')])
+
+        self.upload([(None, 'N', 'apple', 'user1', 'G1', 'loc1')])
+        connection.check_constraints()  # should not raise
+        self.assertEqual(self.get_rows(), [('apple', {'user1'}, {'G1'}, {'loc1'})])
 
     def upload(self, rows, *, check_result=True, **kw):
         data = self.make_rows(rows)
@@ -1035,3 +1054,11 @@ class TestOwnerKey(SimpleTestCase):
 
         t3 = FixtureOwnership(owner_id="def")
         self.assertNotEqual(mod.owner_key(t1), mod.owner_key(t3))
+
+
+@contextmanager
+def disable_save_to_sql():
+    p1 = patch.object(LookupTable.objects, "bulk_create", lambda x: None)
+    p2 = patch.object(LookupTableRow.objects, "bulk_create", lambda x: None)
+    with p1, p2:
+        yield

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -14,7 +14,13 @@ from dimagi.utils.couch.bulk import CouchTransaction
 from dimagi.utils.couch.database import retry_on_couch_error as retry
 from soil import DownloadBase
 
-from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType, FixtureOwnership
+from corehq.apps.fixtures.models import (
+    FixtureDataItem,
+    FixtureDataType,
+    FixtureOwnership,
+    LookupTable,
+    LookupTableRow,
+)
 from corehq.apps.fixtures.upload.definitions import FixtureUploadResult
 from corehq.apps.fixtures.upload.const import INVALID, MULTIPLE
 from corehq.apps.fixtures.upload.workbook import Deleted, get_workbook
@@ -47,6 +53,8 @@ def _run_upload(domain, workbook, replace=False, task=None, skip_orm=False):
             update_progress(table)
             if skip_orm:
                 return  # fast upload does not do ownership
+            if row is not new_row and row._id not in sql_row_ids:
+                rows.to_sync.append(row)
             owners.process(
                 workbook,
                 old_owners.get(row._id, []),
@@ -57,9 +65,15 @@ def _run_upload(domain, workbook, replace=False, task=None, skip_orm=False):
         old_rows = retry(FixtureDataItem.get_item_list)(domain, table.tag)
         sort_keys = {r._id: r.sort_key for r in old_rows}
         if not skip_orm:
+            sql_row_ids = {id.hex for id in LookupTableRow.objects
+                .filter(id__in=list(sort_keys))
+                .values_list("id", flat=True)}
             old_owners = defaultdict(list)
             for owner in retry(FixtureOwnership.for_all_item_ids)(list(sort_keys), domain):
                 old_owners[owner.data_item_id].append(owner)
+
+        if table is not new_table and table._id not in sql_table_ids:
+            tables.to_sync.append(table)
 
         rows.process(
             workbook,
@@ -83,6 +97,9 @@ def _run_upload(domain, workbook, replace=False, task=None, skip_orm=False):
         owner_ids = load_owner_ids(workbook.get_owners(), domain)
     result.number_of_fixtures, update_progress = setup_progress(task, workbook)
     old_tables = FixtureDataType.by_domain(domain)
+    sql_table_ids = {id.hex for id in LookupTable.objects
+        .filter(id__in=[t._id for t in old_tables])
+        .values_list("id", flat=True)}
     tables = Mutation()
     rows = Mutation()
     owners = Mutation()
@@ -107,6 +124,7 @@ def _run_upload(domain, workbook, replace=False, task=None, skip_orm=False):
 class Mutation:
     to_delete = field(factory=list)
     to_create = field(factory=list)
+    to_sync = field(factory=list)
 
     def process(
         self,
@@ -146,6 +164,13 @@ class Mutation:
 
 
 def flush(tables, rows, owners):
+    def sync_docs_to_sql():
+        if tables.to_sync:
+            FixtureDataType._migration_bulk_sync_to_sql(tables.to_sync)
+        if rows.to_sync:
+            FixtureDataItem._migration_bulk_sync_to_sql(rows.to_sync)
+        assert not owners.to_sync, owners.to_sync
+
     with CouchTransaction() as couch:
         for table in tables.to_delete:
             table.recursive_delete(couch)
@@ -154,6 +179,7 @@ def flush(tables, rows, owners):
         couch.delete_all(d for d in to_delete if d._id not in deleted_ids)
         for doc in chain(tables.to_create, rows.to_create, owners.to_create):
             couch.save(doc)
+        couch.add_post_commit_action(sync_docs_to_sql)
     tables.clear()
     rows.clear()
     owners.clear()

--- a/corehq/ex-submodules/dimagi/utils/couch/bulk.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/bulk.py
@@ -127,15 +127,7 @@ class CouchTransaction(object):
                             "set_sql_save_action() to update objects in bulk.")
                     cls.bulk_save(chunk)
                     start_sql_transaction()
-                    sql_class = cls._migration_get_sql_model_class()
-                    id_name = sql_class._migration_couch_id_name
-                    new_sql_docs = []
-                    for doc in chunk:
-                        assert doc._id, doc
-                        obj = sql_class(**{id_name: doc._id})
-                        doc._migration_sync_to_sql(obj, save=False)
-                        new_sql_docs.append(obj)
-                    sql_class.objects.bulk_create(new_sql_docs)
+                    cls._migration_bulk_sync_to_sql(chunk)
             else:
                 save = cls.bulk_save
             for chunk in chunked(docs, 1000, list):

--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -150,6 +150,18 @@ class SyncCouchToSQLMixin(object):
         if save:
             sql_object.save(sync_to_couch=False)
 
+    @classmethod
+    def _migration_bulk_sync_to_sql(cls, couch_docs):
+        sql_class = cls._migration_get_sql_model_class()
+        id_name = sql_class._migration_couch_id_name
+        new_sql_docs = []
+        for doc in couch_docs:
+            assert doc._id, doc
+            obj = sql_class(**{id_name: doc._id})
+            doc._migration_sync_to_sql(obj, save=False)
+            new_sql_docs.append(obj)
+        sql_class.objects.bulk_create(new_sql_docs)
+
     def _migration_sync_submodels_to_sql(self, sql_object):
         """Migrate submodels from the Couch model to the SQL model. This is called
         as part of ``_migration_sync_to_sql``"""


### PR DESCRIPTION
Lookup table rows could not be saved to SQL if the corresponding lookup table had not been synced to SQL first. The same was true for ownership records with unsynced rows.

Users may notice an error on lookup table upload, but if they download the table everything will look fine (unless there were >1000 lookup table rows in the upload). For uploads with <1000 rows the Couch documents are all saved correctly, but the corresponding SQL rows cannot be saved unless the table has been created since https://github.com/dimagi/commcare-hq/pull/31920 was merged. For uploads with >1000 rows it is possible that the error caused the upload to be aborted before all rows were processed.

Resolves errors in Sentry:

[IntegrityError](https://sentry.io/organizations/dimagi/issues/3454844481/)
```
insert or update on table "fixtures_lookuptablerow" violates foreign key constraint "fixtures_lookuptable_table_id_580508a8_fk_fixtures_"
DETAIL:  Key (table_id)=(...) is not present in table "fixtures_lookuptable".
```

[TaskFailedError](https://sentry.io/organizations/dimagi/issues/2754074608/) with `task_status` reflecting above error.

## Safety Assurance

### Safety story

Changes in this PR only affect the lookup table uploader, which is well covered by tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
