### PR TITLE
Add delete_old_couch_views_from_disk management command

### DIFF
--- a/corehq/apps/hqadmin/management/commands/delete_old_couch_views_from_disk.py
+++ b/corehq/apps/hqadmin/management/commands/delete_old_couch_views_from_disk.py
@@ -1,0 +1,28 @@
+from couchdbkit import Database
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = 'Runs /{db}/_view_cleanup on all dbs'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--noinput',
+            action='store_true',
+            default=False,
+            help='Do not prompt user for input',
+        )
+
+    def handle(self, **options):
+        dbs = [Database(uri) for uri in {value for key, value in settings.COUCHDB_DATABASES}]
+
+        if True or options['noinput'] or input('\n'.join([
+            'This command cannot provide feedback whether there are any files to delete.\n'
+            'See https://docs.couchdb.org/en/stable/api/database/compact.html#db-view-cleanup for documentation\n'
+            'After applying this any previously deleted couch views will not be quickly restorable.\n'
+            'Proceed? [y/N]: ',
+        ])).lower() == 'y':
+            for db in dbs:
+                print(f'Running /{db.dbname}/_view_cleanup')
+                print(db.view_cleanup())

--- a/corehq/apps/hqadmin/management/commands/prune_couch_views.py
+++ b/corehq/apps/hqadmin/management/commands/prune_couch_views.py
@@ -61,6 +61,8 @@ class Command(BaseCommand):
         else:
             print('database already completely pruned!')
 
+        print("To remove from disk any pruned views, use management command `delete_old_couch_views_from_disk`")
+
 
 class MyConflictsDontDie(Exception):
     pass

--- a/manage.py
+++ b/manage.py
@@ -24,6 +24,7 @@ def main():
         GeventCommand('ptop_preindex'),
         GeventCommand('sync_prepare_couchdb_multi'),
         GeventCommand('sync_couch_views'),
+        GeventCommand('delete_old_couch_views_from_disk'),
         GeventCommand('populate_form_date_modified'),
         GeventCommand('run_aggregation_query'),
         GeventCommand('send_pillow_retry_queue_through_pillows'),


### PR DESCRIPTION
## Technical Summary
There's an extra step that I've long known about but which I don't think is documented anywhere required for freeing up space after deleting a couch view.

## Safety Assurance

### Safety story
The way this management command works is to just call /{db}/_view_cleanup for every db, so it's relying on couch's own internal cleanup mechanism, not implementing any new logic that might be error prone.

### QA Plan

I ran this on staging and confirmed it ran through and freed up space on couch machine disks.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
