### PR TITLE
[USH-2103] case API v0.6 bulk fetch

### DIFF
--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -122,7 +122,7 @@ def api_url_patterns():
     yield url(r'v0.5/messaging-event/$', messaging_events, name="api_messaging_event_list")
     yield url(r'v0.5/messaging-event/(?P<event_id>\d+)/$', messaging_events, name="api_messaging_event_detail")
     # match v0.6/case/ AND v0.6/case/e0ad6c2e-514c-4c2b-85a7-da35bbeb1ff1/ trailing slash optional
-    yield url(r'v0\.6/case(?:/(?P<case_id>[\w-]+))?/?$', case_api, name='case_api')
+    yield url(r'v0\.6/case(?:/(?P<case_id>[\w\-,]+))?/?$', case_api, name='case_api')
     yield from versioned_apis(API_LIST)
     yield url(r'^case/attachment/(?P<case_id>[\w\-:]+)/(?P<attachment_id>.*)$', CaseAttachmentAPI.as_view(),
               name="api_case_attachment")

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -34,7 +34,7 @@ from corehq.apps.fixtures.resources.v0_1 import (
     LookupTableItemResource,
     LookupTableResource,
 )
-from corehq.apps.hqcase.views import case_api
+from corehq.apps.hqcase.views import case_api, case_api_bulk_fetch
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.locations import resources as locations
 
@@ -121,6 +121,7 @@ def api_url_patterns():
               ODataFormMetadataView.as_view(), name=ODataFormMetadataView.urlname)
     yield url(r'v0.5/messaging-event/$', messaging_events, name="api_messaging_event_list")
     yield url(r'v0.5/messaging-event/(?P<event_id>\d+)/$', messaging_events, name="api_messaging_event_detail")
+    yield url(r'v0\.6/case/bulk-fetch/$', case_api_bulk_fetch, name='case_api_bulk_fetch')
     # match v0.6/case/ AND v0.6/case/e0ad6c2e-514c-4c2b-85a7-da35bbeb1ff1/ trailing slash optional
     yield url(r'v0\.6/case(?:/(?P<case_id>[\w\-,]+))?/?$', case_api, name='case_api')
     yield from versioned_apis(API_LIST)

--- a/corehq/apps/es/tests/utils.py
+++ b/corehq/apps/es/tests/utils.py
@@ -252,6 +252,10 @@ def case_search_es_setup(domain, case_blocks):
     # send cases to ES in the same order they were passed in so `indexed_on`
     # order is predictable for TestCaseListAPI.test_pagination and others
     cases = sorted(cases, key=lambda case: order[case.case_id])
+    populate_case_search_index(cases)
+
+
+def populate_case_search_index(cases):
     populate_es_index(cases, 'case_search', transform_case_for_elasticsearch)
 
 

--- a/corehq/apps/hqcase/api/get_bulk.py
+++ b/corehq/apps/hqcase/api/get_bulk.py
@@ -81,16 +81,16 @@ def _prepare_result(domain, es_results, doc_ids, es_id_field, serialized_id_fiel
     error_ids = set()
     found_ids = set()
 
-    final_results = [_serialize_doc(doc) for doc in es_results]
+    serialized_results = [_serialize_doc(doc) for doc in es_results]
 
     missing_ids = set(doc_ids) - found_ids
-    final_results.extend([
+    serialized_results.extend([
         _get_error_doc(missing_id) for missing_id in missing_ids
     ])
 
     # This orders the results in the same order as the input IDs. It also has the effect
     # of including duplicate results for duplicate IDs
-    results_by_id = {res[serialized_id_field]: res for res in final_results}
+    results_by_id = {res[serialized_id_field]: res for res in serialized_results}
     ordered_results = [
         results_by_id[doc_id] for doc_id in doc_ids
     ]

--- a/corehq/apps/hqcase/api/get_bulk.py
+++ b/corehq/apps/hqcase/api/get_bulk.py
@@ -2,7 +2,7 @@ import dataclasses
 from dataclasses import dataclass, field
 from operator import itemgetter
 
-from corehq.apps.es.case_search import ElasticCaseSearch
+from corehq.apps.es.case_search import ElasticCaseSearch, CaseSearchES
 from corehq.apps.hqcase.api.core import serialize_es_case, UserError
 from corehq.apps.hqcase.api.get_list import MAX_PAGE_SIZE
 from corehq.form_processor.models.util import sort_with_id_list
@@ -26,6 +26,9 @@ def get_bulk(domain, case_ids=None, external_ids=None):
     This must return a result for each case ID passed in and the results must
     be in the same order as the original list of case IDs.
 
+    If both case IDs and external IDs are passed then results will include
+    cases loaded by ID first followed by cases loaded by external ID.
+
     If the case is not found or belongs to a different domain then
     an error stub is included in the result set.
     """
@@ -45,37 +48,49 @@ def get_bulk(domain, case_ids=None, external_ids=None):
 
 
 def _get_cases_by_id(domain, case_ids):
-    results = ElasticCaseSearch().get_docs(case_ids)
+    es_results = ElasticCaseSearch().get_docs(case_ids)
+    return _prepare_result(
+        domain, es_results, case_ids,
+        es_id_field='_id', serialized_id_field='case_id'
+    )
 
+
+def _get_cases_by_external_id(domain, external_ids):
+    query = CaseSearchES().domain(domain).external_id(external_ids)
+    es_results = query.run().hits
+
+    return _prepare_result(
+        domain, es_results, external_ids,
+        es_id_field='external_id', serialized_id_field='external_id'
+    )
+
+
+def _prepare_result(domain, es_results, doc_ids, es_id_field, serialized_id_field):
     def _serialize_doc(doc):
-        found_ids.add(doc['_id'])
+        found_ids.add(doc[es_id_field])
 
         if doc['domain'] == domain:
             return serialize_es_case(doc)
 
-        error_ids.add(doc['_id'])
-        return _get_error_doc(doc['_id'])
+        error_ids.add(doc[es_id_field])
+        return _get_error_doc(doc[es_id_field], serialized_id_field)
 
     error_ids = set()
     found_ids = set()
 
-    final_results = [_serialize_doc(doc) for doc in results]
+    final_results = [_serialize_doc(doc) for doc in es_results]
 
-    missing_ids = set(case_ids) - found_ids
+    missing_ids = set(doc_ids) - found_ids
     final_results.extend([
-        _get_error_doc(missing_id) for missing_id in missing_ids
+        _get_error_doc(missing_id, serialized_id_field) for missing_id in missing_ids
     ])
 
-    sort_with_id_list(final_results, case_ids, 'case_id', operator=itemgetter)
+    sort_with_id_list(final_results, doc_ids, serialized_id_field, operator=itemgetter)
 
-    total = len(case_ids)
+    total = len(doc_ids)
     not_found = len(error_ids) + len(missing_ids)
     return BulkFetchResults(final_results, total - not_found, not_found)
 
 
-def _get_cases_by_external_id(domain, external_ids):
-    return BulkFetchResults()
-
-
-def _get_error_doc(case_id):
-    return {'case_id': case_id, 'error': 'not found'}
+def _get_error_doc(id_value, id_field):
+    return {id_field: id_value, 'error': 'not found'}

--- a/corehq/apps/hqcase/api/get_bulk.py
+++ b/corehq/apps/hqcase/api/get_bulk.py
@@ -65,6 +65,10 @@ def _get_cases_by_external_id(domain, external_ids):
 
 
 def _prepare_result(domain, es_results, doc_ids, es_id_field, serialized_id_field):
+
+    def _get_error_doc(id_value):
+        return {serialized_id_field: id_value, 'error': 'not found'}
+
     def _serialize_doc(doc):
         found_ids.add(doc[es_id_field])
 
@@ -72,7 +76,7 @@ def _prepare_result(domain, es_results, doc_ids, es_id_field, serialized_id_fiel
             return serialize_es_case(doc)
 
         error_ids.add(doc[es_id_field])
-        return _get_error_doc(doc[es_id_field], serialized_id_field)
+        return _get_error_doc(doc[es_id_field])
 
     error_ids = set()
     found_ids = set()
@@ -81,7 +85,7 @@ def _prepare_result(domain, es_results, doc_ids, es_id_field, serialized_id_fiel
 
     missing_ids = set(doc_ids) - found_ids
     final_results.extend([
-        _get_error_doc(missing_id, serialized_id_field) for missing_id in missing_ids
+        _get_error_doc(missing_id) for missing_id in missing_ids
     ])
 
     # This orders the results in the same order as the input IDs. It also has the effect
@@ -96,7 +100,3 @@ def _prepare_result(domain, es_results, doc_ids, es_id_field, serialized_id_fiel
     total = len(doc_ids)
     not_found = len(error_ids) + len(missing_ids) + len(duplicates_missing)
     return BulkFetchResults(ordered_results, total - not_found, not_found)
-
-
-def _get_error_doc(id_value, id_field):
-    return {id_field: id_value, 'error': 'not found'}

--- a/corehq/apps/hqcase/api/get_bulk.py
+++ b/corehq/apps/hqcase/api/get_bulk.py
@@ -4,18 +4,25 @@ from corehq.apps.hqcase.api.core import serialize_es_case
 
 def get_bulk(domain, case_ids):
     results = ElasticCaseSearch().get_docs(case_ids)
-    missing = 0
+    missing_count = 0
     final_results = []
+    found_ids = set()
     for doc in results:
+        found_ids.add(doc['_id'])
         if doc['domain'] != domain:
             final_results.append(_get_error_doc(doc['_id']))
-            missing += 1
+            missing_count += 1
         else:
             final_results.append(serialize_es_case(doc))
 
+    missing_ids = set(case_ids) - found_ids
+    missing_count += len(missing_ids)
+    for missing_id in missing_ids:
+        final_results.append(_get_error_doc(missing_id))
+
     return {
-        'matching_records': len(final_results) - missing,
-        'missing_records': missing,
+        'matching_records': len(final_results) - missing_count,
+        'missing_records': missing_count,
         'cases': final_results
     }
 

--- a/corehq/apps/hqcase/api/get_bulk.py
+++ b/corehq/apps/hqcase/api/get_bulk.py
@@ -1,7 +1,8 @@
 from operator import itemgetter
 
 from corehq.apps.es.case_search import ElasticCaseSearch
-from corehq.apps.hqcase.api.core import serialize_es_case
+from corehq.apps.hqcase.api.core import serialize_es_case, UserError
+from corehq.apps.hqcase.api.get_list import MAX_PAGE_SIZE
 from corehq.form_processor.models.util import sort_with_id_list
 
 
@@ -14,6 +15,9 @@ def get_bulk(domain, case_ids):
     If the case is not found or belongs to a different domain then
     an error stub is included in the result set.
     """
+    if len(case_ids) > MAX_PAGE_SIZE:
+        raise UserError(f"You cannot request more than {MAX_PAGE_SIZE} cases per request.")
+
     results = ElasticCaseSearch().get_docs(case_ids)
 
     def _serialize_doc(doc):

--- a/corehq/apps/hqcase/api/get_bulk.py
+++ b/corehq/apps/hqcase/api/get_bulk.py
@@ -4,7 +4,21 @@ from corehq.apps.hqcase.api.core import serialize_es_case
 
 def get_bulk(domain, case_ids):
     results = ElasticCaseSearch().get_docs(case_ids)
+    missing = 0
+    final_results = []
+    for doc in results:
+        if doc['domain'] != domain:
+            final_results.append(_get_error_doc(doc['_id']))
+            missing += 1
+        else:
+            final_results.append(serialize_es_case(doc))
+
     return {
-        'matching_records': len(results),
-        'cases': [serialize_es_case(case) for case in results]
+        'matching_records': len(final_results) - missing,
+        'missing_records': missing,
+        'cases': final_results
     }
+
+
+def _get_error_doc(case_id):
+    return {'case_id': case_id, 'error': 'not found'}

--- a/corehq/apps/hqcase/api/get_bulk.py
+++ b/corehq/apps/hqcase/api/get_bulk.py
@@ -1,9 +1,8 @@
 import dataclasses
-from collections import Counter
 from dataclasses import dataclass, field
 
-from corehq.apps.es.case_search import ElasticCaseSearch, CaseSearchES
-from corehq.apps.hqcase.api.core import serialize_es_case, UserError
+from corehq.apps.es.case_search import CaseSearchES, ElasticCaseSearch
+from corehq.apps.hqcase.api.core import UserError, serialize_es_case
 from corehq.apps.hqcase.api.get_list import MAX_PAGE_SIZE
 
 

--- a/corehq/apps/hqcase/api/get_bulk.py
+++ b/corehq/apps/hqcase/api/get_bulk.py
@@ -1,0 +1,10 @@
+from corehq.apps.es.case_search import ElasticCaseSearch
+from corehq.apps.hqcase.api.core import serialize_es_case
+
+
+def get_bulk(domain, case_ids):
+    results = ElasticCaseSearch().get_docs(case_ids)
+    return {
+        'matching_records': len(results),
+        'cases': [serialize_es_case(case) for case in results]
+    }

--- a/corehq/apps/hqcase/api/get_bulk.py
+++ b/corehq/apps/hqcase/api/get_bulk.py
@@ -1,5 +1,8 @@
+from operator import itemgetter
+
 from corehq.apps.es.case_search import ElasticCaseSearch
 from corehq.apps.hqcase.api.core import serialize_es_case
+from corehq.form_processor.models.util import sort_with_id_list
 
 
 def get_bulk(domain, case_ids):
@@ -19,6 +22,8 @@ def get_bulk(domain, case_ids):
     missing_count += len(missing_ids)
     for missing_id in missing_ids:
         final_results.append(_get_error_doc(missing_id))
+
+    sort_with_id_list(final_results, case_ids, 'case_id', operator=itemgetter)
 
     return {
         'matching_records': len(final_results) - missing_count,

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -4,11 +4,23 @@ from django.test import TestCase
 from django.urls import reverse
 
 from casexml.apps.case.mock import CaseBlock
+
 from corehq import privileges
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.es.tests.utils import es_test, case_search_es_setup, case_search_es_teardown
+from corehq.apps.es.tests.utils import (
+    case_search_es_setup,
+    case_search_es_teardown,
+    es_test,
+    populate_case_search_index,
+)
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.models import HqPermissions, UserRole, WebUser
-from corehq.util.test_utils import disable_quickcache, flag_enabled, privilege_enabled
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
+from corehq.util.test_utils import (
+    disable_quickcache,
+    flag_enabled,
+    privilege_enabled,
+)
 
 
 @es_test
@@ -17,7 +29,7 @@ from corehq.util.test_utils import disable_quickcache, flag_enabled, privilege_e
 @flag_enabled('CASE_API_V0_6')
 @flag_enabled('API_THROTTLE_WHITELIST')
 class TestCaseAPIBulkGet(TestCase):
-    domain = 'test-update-cases'
+    domain = 'test-bulk-get-cases'
     maxDiff = None
 
     @classmethod
@@ -36,16 +48,22 @@ class TestCaseAPIBulkGet(TestCase):
         case_search_es_setup(cls.domain, case_blocks)
         cls.case_ids = [b.case_id for b in case_blocks]
 
+        xform, [case] = submit_case_blocks(
+            cls._make_case_block('Vera Menchik', external_id='vera').as_text(), domain='other-domain'
+        )
+        populate_case_search_index([case])
+        cls.other_domain_case_id = case.case_id
+
     def setUp(self):
         self.client.login(username='netflix', password='password')
-
-    def tearDown(self):
-        case_search_es_teardown()
 
     @classmethod
     def tearDownClass(cls):
         cls.web_user.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
+        FormProcessorTestUtils.delete_all_cases(cls.domain)
+        FormProcessorTestUtils.delete_all_xforms(cls.domain)
+        case_search_es_teardown()
         super().tearDownClass()
 
     @classmethod
@@ -59,7 +77,19 @@ class TestCaseAPIBulkGet(TestCase):
 
     def test_bulk_get(self):
         case_ids = self.case_ids[0:2]
+        self._call_api_check_results(case_ids)
+
+    def test_bulk_get_domain_filter(self):
+        case_ids = self.case_ids[0:2] + [self.other_domain_case_id]
+        result = self._call_api_check_results(case_ids)
+        self.assertEqual(result['matching_records'], 2)
+        self.assertEqual(result['missing_records'], 1)
+        self.assertEqual(result['cases'][2]['error'], 'not found')
+
+    def _call_api_check_results(self, case_ids):
         res = self.client.get(reverse('case_api', args=(self.domain, ','.join(case_ids))))
         self.assertEqual(res.status_code, 200)
-        result_case_ids = [case['case_id'] for case in res.json()['cases']]
+        result = res.json()
+        result_case_ids = [case['case_id'] for case in result['cases']]
         self.assertEqual(result_case_ids, case_ids)
+        return result

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -44,7 +44,7 @@ class TestCaseAPIBulkGet(TestCase):
         case_blocks = [
             cls._make_case_block('Vera Menchik', external_id='vera'),
             cls._make_case_block('Nona Gaprindashvili', external_id='nona'),
-            cls._make_case_block('Maia Chiburdanidze', external_id='mia'),
+            cls._make_case_block('Maia Chiburdanidze', external_id='maia'),
         ]
         case_search_es_setup(cls.domain, case_blocks)
         cls.case_ids = [b.case_id for b in case_blocks]

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -77,24 +77,38 @@ class TestCaseAPIBulkGet(TestCase):
 
     def test_bulk_get(self):
         case_ids = self.case_ids[0:2]
-        self._call_api_check_results(case_ids)
+        self._call_get_api_check_results(case_ids)
 
     def test_bulk_get_domain_filter(self):
         case_ids = self.case_ids[0:2] + [self.other_domain_case_id]
-        result = self._call_api_check_results(case_ids)
+        result = self._call_get_api_check_results(case_ids)
         self.assertEqual(result['matching_records'], 2)
         self.assertEqual(result['missing_records'], 1)
         self.assertEqual(result['cases'][2]['error'], 'not found')
 
     def test_bulk_get_not_found(self):
         case_ids = ['missing'] + self.case_ids[0:2]
-        result = self._call_api_check_results(case_ids)
+        result = self._call_get_api_check_results(case_ids)
         self.assertEqual(result['matching_records'], 2)
         self.assertEqual(result['missing_records'], 1)
         self.assertEqual(result['cases'][0]['error'], 'not found')
 
-    def _call_api_check_results(self, case_ids):
+    def test_bulk_post(self):
+        case_ids = self.case_ids[0:2]
+        self._call_post_api_check_results(case_ids)
+
+    def _call_get_api_check_results(self, case_ids):
         res = self.client.get(reverse('case_api', args=(self.domain, ','.join(case_ids))))
+        self.assertEqual(res.status_code, 200)
+        result = res.json()
+        result_case_ids = [case['case_id'] for case in result['cases']]
+        self.assertEqual(result_case_ids, case_ids)
+        return result
+
+    def _call_post_api_check_results(self, case_ids):
+        res = self.client.post(reverse('case_api_bulk_fetch', args=(self.domain,)), data={
+            'case_ids': case_ids
+        }, content_type="application/json")
         self.assertEqual(res.status_code, 200)
         result = res.json()
         result_case_ids = [case['case_id'] for case in result['cases']]

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -1,0 +1,65 @@
+import uuid
+
+from django.test import TestCase
+from django.urls import reverse
+
+from casexml.apps.case.mock import CaseBlock
+from corehq import privileges
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.es.tests.utils import es_test, case_search_es_setup, case_search_es_teardown
+from corehq.apps.users.models import HqPermissions, UserRole, WebUser
+from corehq.util.test_utils import disable_quickcache, flag_enabled, privilege_enabled
+
+
+@es_test
+@disable_quickcache
+@privilege_enabled(privileges.API_ACCESS)
+@flag_enabled('CASE_API_V0_6')
+@flag_enabled('API_THROTTLE_WHITELIST')
+class TestCaseAPIBulkGet(TestCase):
+    domain = 'test-update-cases'
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
+        role = UserRole.create(
+            cls.domain, 'edit-data', permissions=HqPermissions(edit_data=True, access_api=True)
+        )
+        cls.web_user = WebUser.create(cls.domain, 'netflix', 'password', None, None, role_id=role.get_id)
+        case_blocks = [
+            cls._make_case_block('Vera Menchik', external_id='vera'),
+            cls._make_case_block('Nona Gaprindashvili', external_id='nona'),
+            cls._make_case_block('Maia Chiburdanidze', external_id='mia'),
+        ]
+        case_search_es_setup(cls.domain, case_blocks)
+        cls.case_ids = [b.case_id for b in case_blocks]
+
+    def setUp(self):
+        self.client.login(username='netflix', password='password')
+
+    def tearDown(self):
+        case_search_es_teardown()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.web_user.delete(cls.domain, deleted_by=None)
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    @classmethod
+    def _make_case_block(cls, name, external_id=None):
+        return CaseBlock(
+            case_id=str(uuid.uuid4()),
+            case_type='player',
+            case_name=name,
+            external_id=external_id,
+        )
+
+    def test_bulk_get(self):
+        case_ids = self.case_ids[0:2]
+        res = self.client.get(reverse('case_api', args=(self.domain, ','.join(case_ids))))
+        self.assertEqual(res.status_code, 200)
+        result_case_ids = [case['case_id'] for case in res.json()['cases']]
+        self.assertEqual(result_case_ids, case_ids)

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -87,11 +87,11 @@ class TestCaseAPIBulkGet(TestCase):
         self.assertEqual(result['cases'][2]['error'], 'not found')
 
     def test_bulk_get_not_found(self):
-        case_ids = self.case_ids[0:2] + ['missing']
+        case_ids = ['missing'] + self.case_ids[0:2]
         result = self._call_api_check_results(case_ids)
         self.assertEqual(result['matching_records'], 2)
         self.assertEqual(result['missing_records'], 1)
-        self.assertEqual(result['cases'][2]['error'], 'not found')
+        self.assertEqual(result['cases'][0]['error'], 'not found')
 
     def _call_api_check_results(self, case_ids):
         res = self.client.get(reverse('case_api', args=(self.domain, ','.join(case_ids))))

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -80,6 +80,11 @@ class TestCaseAPIBulkGet(TestCase):
         case_ids = self.case_ids[0:2]
         self._call_get_api_check_results(case_ids)
 
+    def test_bulk_get_duplicate(self):
+        """Duplicate case IDs in the request results in duplicates in the response"""
+        case_ids = [self.case_ids[0], self.case_ids[0]]
+        self._call_get_api_check_results(case_ids)
+
     def test_bulk_get_domain_filter(self):
         case_ids = self.case_ids[0:2] + [self.other_domain_case_id]
         result = self._call_get_api_check_results(case_ids)
@@ -98,6 +103,14 @@ class TestCaseAPIBulkGet(TestCase):
         case_ids = self.case_ids[0:2]
         self._call_post_api_check_results(case_ids)
 
+    def test_bulk_post_missing(self):
+        self._call_post_api_check_results(external_ids=['missing1', self.case_ids[1], 'missing2'])
+
+    def test_bulk_post_duplicates(self):
+        """Duplicate case IDs in the request results in duplicates in the response"""
+        case_ids = [self.case_ids[0], 'missing', self.case_ids[0], 'missing']
+        self._call_post_api_check_results(case_ids)
+
     def test_bulk_post_over_limit(self):
         with patch('corehq.apps.hqcase.api.get_bulk.MAX_PAGE_SIZE', 3):
             self._call_post(['1', '2', '3', '4'], expected_status=400)
@@ -108,10 +121,20 @@ class TestCaseAPIBulkGet(TestCase):
     def test_bulk_post_external_ids_missing(self):
         self._call_post_api_check_results(external_ids=['missing', 'vera', 'nona'])
 
+    def test_bulk_post_external_ids_duplicates(self):
+        """Duplicate case IDs in the request results in duplicates in the response"""
+        self._call_post_api_check_results(external_ids=['vera', 'missing', 'nona', 'vera', 'missing'])
+
     def test_bulk_post_case_ids_and_external_ids(self):
         self._call_post_api_check_results(
             case_ids=self.case_ids[0:2],
             external_ids=['vera', 'nona']
+        )
+
+    def test_bulk_post_case_ids_and_external_ids_duplicates(self):
+        self._call_post_api_check_results(
+            case_ids=[self.case_ids[0], self.case_ids[0]],
+            external_ids=['vera', 'vera']
         )
 
     def test_bulk_post_case_ids_and_external_ids_missing(self):

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -86,6 +86,13 @@ class TestCaseAPIBulkGet(TestCase):
         self.assertEqual(result['missing_records'], 1)
         self.assertEqual(result['cases'][2]['error'], 'not found')
 
+    def test_bulk_get_not_found(self):
+        case_ids = self.case_ids[0:2] + ['missing']
+        result = self._call_api_check_results(case_ids)
+        self.assertEqual(result['matching_records'], 2)
+        self.assertEqual(result['missing_records'], 1)
+        self.assertEqual(result['cases'][2]['error'], 'not found')
+
     def _call_api_check_results(self, case_ids):
         res = self.client.get(reverse('case_api', args=(self.domain, ','.join(case_ids))))
         self.assertEqual(res.status_code, 200)

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -108,8 +108,8 @@ class TestCaseAPIBulkGet(TestCase):
 
     def test_bulk_post_duplicates(self):
         """Duplicate case IDs in the request results in duplicates in the response"""
-        case_ids = [self.case_ids[0], 'missing', self.case_ids[0], 'missing']
-        self._call_post_api_check_results(case_ids, matching=2, missing=2)
+        case_ids = [self.case_ids[0], 'missing', self.case_ids[0], 'missing', 'missing']
+        self._call_post_api_check_results(case_ids, matching=2, missing=3)
 
     def test_bulk_post_over_limit(self):
         with patch('corehq.apps.hqcase.api.get_bulk.MAX_PAGE_SIZE', 3):

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -115,13 +115,13 @@ def case_api_bulk_fetch(request, domain):
 
 def _handle_get(request, case_id):
     if ',' in case_id:
-        return _get_bulk_cases(request, case_id.split(','))
+        return _get_bulk_cases(request, case_ids=case_id.split(','))
     return _get_single_case(request, case_id)
 
 
-def _get_bulk_cases(request, case_ids):
+def _get_bulk_cases(request, case_ids=None, external_ids=None):
     try:
-        res = get_bulk(request.domain, case_ids)
+        res = get_bulk(request.domain, case_ids, external_ids)
     except UserError as e:
         return JsonResponse({'error': str(e)}, status=400)
 
@@ -145,10 +145,11 @@ def _handle_bulk_fetch(request):
         return JsonResponse({'error': "Payload must be valid JSON"}, status=400)
 
     case_ids = data.get('case_ids')
-    if not case_ids:
-        return JsonResponse({'error': "Payload must include a 'case_ids' field"}, status=400)
+    external_ids = data.get('external_ids')
+    if not case_ids and not external_ids:
+        return JsonResponse({'error': "Payload must include 'case_ids' or 'external_ids' fields"}, status=400)
 
-    return _get_bulk_cases(request, case_ids)
+    return _get_bulk_cases(request, case_ids=case_ids, external_ids=external_ids)
 
 
 def _handle_list_view(request):

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -100,6 +100,19 @@ def case_api(request, domain, case_id=None):
     return JsonResponse({'error': "Request method not allowed"}, status=405)
 
 
+@waf_allow('XSS_BODY')
+@csrf_exempt
+@allow_cors(['OPTIONS', 'GET', 'POST'])
+@api_auth
+@require_permission(HqPermissions.edit_data)
+@require_permission(HqPermissions.access_api)
+@CASE_API_V0_6.required_decorator()
+@requires_privilege_with_fallback(privileges.API_ACCESS)
+@api_throttle
+def case_api_bulk_fetch(request, domain):
+    return JsonResponse({})
+
+
 def _handle_get(request, case_id):
     if ',' in case_id:
         return _get_bulk_cases(request, case_id.split(','))

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -90,7 +90,7 @@ class ExplodeCasesView(BaseProjectSettingsView, TemplateView):
 @api_throttle
 def case_api(request, domain, case_id=None):
     if request.method == 'GET' and case_id:
-        return _handle_individual_get(request, case_id)
+        return _handle_get(request, case_id)
     if request.method == 'GET' and not case_id:
         return _handle_list_view(request)
     if request.method == 'POST' and not case_id:
@@ -100,7 +100,7 @@ def case_api(request, domain, case_id=None):
     return JsonResponse({'error': "Request method not allowed"}, status=405)
 
 
-def _handle_individual_get(request, case_id):
+def _handle_get(request, case_id):
     if ',' in case_id:
         return _get_bulk_cases(request, case_id.split(','))
     return _get_single_case(request, case_id)

--- a/corehq/form_processor/models/util.py
+++ b/corehq/form_processor/models/util.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from functools import lru_cache
 from itertools import groupby
-from operator import attrgetter
 
 from corehq.util.metrics import metrics_counter
 
@@ -18,7 +17,7 @@ def _get_result_tuple(names):
     return namedtuple('Result', names)
 
 
-def sort_with_id_list(object_list, id_list, id_property, operator=attrgetter):
+def sort_with_id_list(object_list, id_list, id_property):
     """Sort object list in the same order as given list of ids
 
     SQL does not necessarily return the rows in any particular order so
@@ -27,10 +26,8 @@ def sort_with_id_list(object_list, id_list, id_property, operator=attrgetter):
     NOTE: this does not return the sorted list. It sorts `object_list`
     in place using Python's built-in `list.sort`.
     """
-    getter = operator(id_property)
-
     def key(obj):
-        return index_map[getter(obj)]
+        return index_map[getattr(obj, id_property)]
 
     index_map = {id_: index for index, id_ in enumerate(id_list)}
     object_list.sort(key=key)

--- a/corehq/form_processor/models/util.py
+++ b/corehq/form_processor/models/util.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 from functools import lru_cache
 from itertools import groupby
+from operator import attrgetter
 
 from corehq.util.metrics import metrics_counter
 
@@ -17,7 +18,7 @@ def _get_result_tuple(names):
     return namedtuple('Result', names)
 
 
-def sort_with_id_list(object_list, id_list, id_property):
+def sort_with_id_list(object_list, id_list, id_property, operator=attrgetter):
     """Sort object list in the same order as given list of ids
 
     SQL does not necessarily return the rows in any particular order so
@@ -26,8 +27,10 @@ def sort_with_id_list(object_list, id_list, id_property):
     NOTE: this does not return the sorted list. It sorts `object_list`
     in place using Python's built-in `list.sort`.
     """
+    getter = operator(id_property)
+
     def key(obj):
-        return index_map[getattr(obj, id_property)]
+        return index_map[getter(obj)]
 
     index_map = {id_: index for index, id_ in enumerate(id_list)}
     object_list.sort(key=key)


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-2103

## Product Description

Spec: https://docs.google.com/document/d/1upMFrcItnyxVkD2NoBzpO6pTJRMncYVRVQcrvF5Gfj0/edit#heading=h.2ql3p2gjeco

This adds two API features:

#### Bulk fetch via GET
    GET /a/<domain>/api/v0.6/case/case_id,case_id,case_id

This supports up to ~140 cases per request.

#### Bulk fetch via POST (or GET)

    POST /a/<domain>/api/v0.6/case/bulk_fetch/
    {
      "case_id": ["case1", "case2"],
      "external_id": ["id1", "id2"]
    }

This supports up to 5000 cases per request.

#### Response format
The response will include a JSON object for each provided ID, including missing and duplicate IDs. The results
are ordered to match the input.

If both `case_ids` and `external_ids` are provided, case_id results will be in the results first followed by external ID results.

The results are serialized using the same format as the other Case API v0.6 endpoints.

```json
{
  "matching_records": 5,
  "missing_records": 1,
  "cases": [  ]
}
```

If records are missing a stub is included in the result:

* *if searching by case ID*
```json
{"case_id": "case1", "error": "not found"}
```

* *if searching by external ID*
```json
{"external_id": "id2", "error": "not found"}
```

## Feature Flag
Case API v0.6

## Safety Assurance

### Safety story
This is mostly additions. The existing API has good test coverage and the additions are covered by tests. 

The API is still behind a feature flag and not widely used yet.

### Automated test coverage
Added

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
