### PR TITLE
Always clear cache, even when the upload fails

### DIFF
--- a/corehq/apps/fixtures/tests/test_upload.py
+++ b/corehq/apps/fixtures/tests/test_upload.py
@@ -675,6 +675,28 @@ class TestFixtureUpload(TestCase):
         self.assertIsNotNone(get_table())
         self.assertTrue(did_check)
 
+    def test_upload_should_clear_cache_on_error(self):
+        def error_tx():
+            def error():
+                raise Exception("cannot save")
+            tx = CouchTransaction()
+            tx.add_post_commit_action(error)
+            return tx
+        CouchTransaction = mod.CouchTransaction
+
+        self.upload([(None, 'N', 'apple')])  # create lookup table
+        apple_id = self.get_rows(None)[0]._id
+
+        upload_error = patch.object(mod, "CouchTransaction", error_tx)
+        with upload_error, self.assertRaises(Exception):
+            # failed upload, previously resulted in stale cache
+            self.upload([(apple_id, 'N', 'orange')])
+        orange_id = self.get_rows(None)[0]._id
+
+        # previously failed with BulkSaveError due to stale cache
+        self.upload([(orange_id, 'N', 'banana')])
+        self.assertEqual(self.get_rows(), ['banana'])
+
     def test_upload_rows_without_sql_table(self):
         with disable_save_to_sql():  # simulate save prior to start of migration
             self.upload([(None, 'N', 'apple')])

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -103,20 +103,22 @@ def _run_upload(domain, workbook, replace=False, task=None, skip_orm=False):
     tables = Mutation()
     rows = Mutation()
     owners = Mutation()
-    tables.process(
-        workbook,
-        old_tables,
-        workbook.iter_tables(domain),
-        table_key,
-        process_table,
-        delete_missing=False,
-        deleted_key=attrgetter("tag"),
-    )
+    try:
+        tables.process(
+            workbook,
+            old_tables,
+            workbook.iter_tables(domain),
+            table_key,
+            process_table,
+            delete_missing=False,
+            deleted_key=attrgetter("tag"),
+        )
 
-    update_progress(None)
-    flush(tables, rows, owners)
-    clear_fixture_quickcache(domain, old_tables)
-    clear_fixture_cache(domain)
+        update_progress(None)
+        flush(tables, rows, owners)
+    finally:
+        clear_fixture_quickcache(domain, old_tables)
+        clear_fixture_cache(domain)
     return result
 
 


### PR DESCRIPTION
Cache invalidation is necessary because an upload failure could occur after some documents have been created and/or deleted in Couch. Couch will raise `BulkSaveError` when a subsequent upload attempts to save a stale/cached document to Couch.

Fixes https://sentry.io/organizations/dimagi/issues/3454845141/

## Safety Assurance

### Safety story

Changes in this PR only affect the lookup table uploader, which is well covered by tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
