### PR TITLE
Set param defaults

### DIFF
--- a/custom/onse/tasks.py
+++ b/custom/onse/tasks.py
@@ -74,7 +74,11 @@ def update_facility_cases_from_dhis2_data_elements():
 
 
 @task(bind=True, max_retries=MAX_RETRY_ATTEMPTS)
-def _update_facility_cases_from_dhis2_data_elements(self, period, print_notifications):
+def _update_facility_cases_from_dhis2_data_elements(
+    self,
+    period=None,
+    print_notifications=False,
+):
     if not domain_exists(DOMAIN):
         return
     dhis2_server = get_dhis2_server(print_notifications)


### PR DESCRIPTION
## Technical Summary

Fixes a bug in the way that `custom.onse.tasks.update_facility_cases_from_dhis2_data_elements()` calls `_update_facility_cases_from_dhis2_data_elements()`.

`update_facility_cases_from_dhis2_data_elements()`  calls `_update_facility_cases_from_dhis2_data_elements()` without passing any parameters. `execute_update_facility_cases_from_dhis2_data_elements()` defaults the `period` param to `None` and the `print_notifications` param to `False`. So this commit just reuses those defaults.

## Feature Flag
N/A

## Safety Assurance

### Safety story

* Custom code
* Only called once a quarter
* Tested locally

### Automated test coverage

`_update_facility_cases_from_dhis2_data_elements()` is called in tests, but calling it without parameters is not covered.

### QA Plan

No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
