### PR TITLE
Upload multimedia and signature files in Web Apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -55,6 +55,7 @@ hqDefine("cloudcare/js/form_entry/const", function () {
         // XForm Actions
         NEW_FORM: 'new-form',
         ANSWER: 'answer',
+        ANSWER_MEDIA: 'answer_media',
         CURRENT: 'current',
         EVALUATE_XPATH: 'evaluate-xpath',
         NEW_REPEAT: 'new-repeat',

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -17,6 +17,7 @@ hqDefine("cloudcare/js/form_entry/const", function () {
         GEO: 'geo',
         INFO: 'info',
         BARCODE: 'barcode',
+        BINARY: 'binary',
 
         // Appearance attributes
         NUMERIC: 'numeric',
@@ -32,6 +33,7 @@ hqDefine("cloudcare/js/form_entry/const", function () {
         COLLAPSIBLE_CLOSED: 'collapse-closed',
         TIME_12_HOUR: '12-hour',
         ETHIOPIAN: 'ethiopian',
+        SIGNATURE: 'signature',
 
         // Note it's important to differentiate these two
         NO_PENDING_ANSWER: undefined,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -84,11 +84,13 @@ hqDefine("cloudcare/js/form_entry/const", function () {
         //knockout timeouts
         KO_ENTRY_TIMEOUT: 500,
 
+        // Entry-specific constants
         INT_LENGTH_LIMIT: 10,
         INT_VALUE_LIMIT: Math.pow(2, 31) - 1,
         LONGINT_LENGTH_LIMIT: 15,
         LONGINT_VALUE_LIMIT: Math.pow(2, 63) - 1,
         FLOAT_LENGTH_LIMIT: 15,
         FLOAT_VALUE_LIMIT: +("9".repeat(14)),
+        FILE_PREFIX: "C:\\fakepath\\",
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1333,18 +1333,23 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     return {
         getEntry: getEntry,
         AddressEntry: AddressEntry,
+        AudioEntry: AudioEntry,
         ComboboxEntry: ComboboxEntry,
         DateEntry: DateEntry,
         DropdownEntry: DropdownEntry,
         EthiopianDateEntry: EthiopianDateEntry,
         FloatEntry: FloatEntry,
         FreeTextEntry: FreeTextEntry,
+        ImageEntry: ImageEntry,
         InfoEntry: InfoEntry,
         IntEntry: IntEntry,
         MultiSelectEntry: MultiSelectEntry,
         MultiDropdownEntry: MultiDropdownEntry,
         PhoneEntry: PhoneEntry,
         SingleSelectEntry: SingleSelectEntry,
+        SignatureEntry: SignatureEntry,
         TimeEntry: TimeEntry,
+        UnsupportedEntry: UnsupportedEntry,
+        VideoEntry: VideoEntry,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1243,14 +1243,13 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             case Const.INFO:
                 entry = new InfoEntry(question, {});
                 break;
-            case Const.BINARY:      // needs to be last case so that anything unrecognized display as unsupported
+            case Const.BINARY:
                 if (!toggles.toggleEnabled('WEB_APPS_UPLOAD_QUESTIONS')) {
                     // do nothing, fall through to unsupported
                 } else if (style === Const.SIGNATURE) {
                     entry = new SignatureEntry(question, {});
                     break;
                 } else {
-                    var missing = false;
                     switch (question.control()) {
                         case Const.CONTROL_IMAGE_CHOOSE:
                             entry = new ImageEntry(question, {});
@@ -1261,16 +1260,13 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                         case Const.CONTROL_VIDEO_CAPTURE:
                             entry = new VideoEntry(question, {});
                             break;
-                        default:
-                            missing = true;
+                        // any other control types are unsupported
                     }
-                    if (!missing) {
-                        break;
-                    }   // otherwise, fall through to unsupported
                 }
-            default:
-                window.console.warn('No active entry for: ' + question.datatype());
-                entry = new UnsupportedEntry(question, options);
+        }
+        if (!entry) {
+            window.console.warn('No active entry for: ' + question.datatype());
+            entry = new UnsupportedEntry(question, options);
         }
         return entry;
     }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -983,7 +983,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.accept = "image/*,.pdf,.doc,.docx";
 
         self.helpText = function () {
-            return gettext( "Upload signature file");
+            return gettext("Upload signature file");
         };
 
     }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -893,6 +893,37 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     EthiopianDateEntry.prototype = Object.create(EntrySingleAnswer.prototype);
     EthiopianDateEntry.prototype.constructor = EntrySingleAnswer;
 
+    /**
+     * Represents blah blah blah
+     */
+    function FileEntry(question, options) {
+        var self = this;
+        EntrySingleAnswer.call(this, question, options);
+        self.templateType = 'file';
+
+        self.accept = "image/*,.pdf";
+        self.file = ko.observable();
+
+        self.helpText = function () {
+            return "";      // file input is already pretty helpful
+        };
+
+    }
+    FileEntry.prototype = Object.create(EntrySingleAnswer.prototype);
+    FileEntry.prototype.constructor = EntrySingleAnswer;
+    FileEntry.prototype.onAnswerChange = function (newValue) {
+        var self = this;
+        if (newValue !== Const.NO_ANSWER) {
+            var $input = $('#' + self.entryId);
+            self.answer(newValue.replace(Const.FILE_PREFIX, ""));
+            self.file($input[0].files[0]);
+        } else {
+            self.answer(newValue);
+            self.file(null);
+        }
+        this.question.onchange();
+    };
+
     function GeoPointEntry(question, options) {
         var self = this;
         EntryArrayAnswer.call(self, question, options);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -3,7 +3,8 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     var kissmetrics = hqImport("analytix/js/kissmetrix");
     var Const = hqImport("cloudcare/js/form_entry/const"),
         Utils = hqImport("cloudcare/js/form_entry/utils"),
-        initialPageData = hqImport("hqwebapp/js/initial_page_data");
+        initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+        toggles = hqImport("hqwebapp/js/toggles");
 
     /**
      * The base Object for all entries. Each entry takes a question object

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1146,6 +1146,12 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             case Const.INFO:
                 entry = new InfoEntry(question, {});
                 break;
+            case Const.BINARY:
+                if (style === Const.SIGNATURE) {
+                    entry = new FileEntry(question, {});
+                    break;
+                }
+                // otherwise, deliberately fall through to default (unsupported)
             default:
                 window.console.warn('No active entry for: ' + question.datatype());
                 entry = new UnsupportedEntry(question, options);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -15,6 +15,8 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.answer = question.answer;
         self.datatype = question.datatype();
         self.entryId = _.uniqueId(this.datatype);
+        self.xformAction = Const.ANSWER;
+        self.xformParams = function () { return {}; };
 
         // Returns true if the rawAnswer is valid, false otherwise
         self.isValid = function (rawAnswer) {
@@ -900,6 +902,10 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         var self = this;
         EntrySingleAnswer.call(this, question, options);
         self.templateType = 'file';
+        self.xformAction = Const.ANSWER_MEDIA;
+        self.xformParams = function () {
+            return { file: self.file() };
+        };
 
         self.accept = "image/*,.pdf";
         self.file = ko.observable();

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -896,7 +896,8 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     EthiopianDateEntry.prototype.constructor = EntrySingleAnswer;
 
     /**
-     * Represents blah blah blah
+     * TODO: Represents blah blah blah
+     * TODO: Add other entries, which will have different help text and different accept values
      */
     function FileEntry(question, options) {
         var self = this;
@@ -907,7 +908,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             return { file: self.file() };
         };
 
-        self.accept = "image/*,.pdf";
+        self.accept = "image/*,.pdf,.doc,.docx";
         self.file = ko.observable();
 
         self.helpText = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -12,6 +12,12 @@ describe('Entries', function () {
             "has_geocoder_privs",
             true
         );
+        hqImport("hqwebapp/js/initial_page_data").register(
+            "toggles_dict",
+            {
+                WEB_APPS_UPLOAD_QUESTIONS: true,
+            }
+        );
     });
 
     beforeEach(function () {
@@ -430,5 +436,50 @@ describe('Entries', function () {
 
         entry.rawAnswer('...123');
         assert.isOk(entry.question.error());
+    });
+
+    it('Should return ImageEntry', function () {
+        var entry;
+        questionJSON.datatype = Const.BINARY;
+        questionJSON.control = Const.CONTROL_IMAGE_CHOOSE;
+
+        entry = UI.Question(questionJSON).entry;
+        assert.isTrue(entry instanceof Controls.ImageEntry);
+    });
+
+    it('Should return AudioEntry', function () {
+        var entry;
+        questionJSON.datatype = Const.BINARY;
+        questionJSON.control = Const.CONTROL_AUDIO_CAPTURE;
+
+        entry = UI.Question(questionJSON).entry;
+        assert.isTrue(entry instanceof Controls.AudioEntry);
+    });
+
+    it('Should return VideoEntry', function () {
+        var entry;
+        questionJSON.datatype = Const.BINARY;
+        questionJSON.control = Const.CONTROL_VIDEO_CAPTURE;
+
+        entry = UI.Question(questionJSON).entry;
+        assert.isTrue(entry instanceof Controls.VideoEntry);
+    });
+
+    it('Should return SignatureEntry', function () {
+        var entry;
+        questionJSON.datatype = Const.BINARY;
+        questionJSON.style = { raw: Const.SIGNATURE };
+
+        entry = UI.Question(questionJSON).entry;
+        assert.isTrue(entry instanceof Controls.SignatureEntry);
+    });
+
+    it('Should return UnsuportedEntry when binary question has an unsupported control', function () {
+        var entry;
+        questionJSON.datatype = Const.BINARY;
+        questionJSON.control = Const.CONTROL_UPLOAD;
+
+        entry = UI.Question(questionJSON).entry;
+        assert.isTrue(entry instanceof Controls.UnsupportedEntry);
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/web_form_session_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/web_form_session_spec.js
@@ -185,6 +185,10 @@ describe('WebForm', function () {
                         },
                     };
                 },
+                entry: {
+                    xformAction: Const.ANSWER,
+                    xformParams: function () { return {}; },
+                },
             };
 
             // First blocking request

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -121,15 +121,24 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
             requestParams['tz_offset_millis'] = (new Date()).getTimezoneOffset() * 60 * 1000 * -1;
             requestParams['tz_from_browser'] = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-            var newData = new FormData();
-            _.each(requestParams, function (value, key) {
-                newData.append(key, value);
-            });
-            return $.ajax({
+            var contentParams = {};
+            if (requestParams.action === Const.ANSWER_MEDIA) {
+                var newData = new FormData();
+                newData.append("file", requestParams.file);
+                newData.append("answer", JSON.stringify(_.omit(requestParams, "file")));
+                contentParams = {
+                    contentType: "multipart/form-data",
+                    data: newData,
+                };
+            } else {
+                contentParams = {
+                    contentType: "application/json",
+                    data: JSON.stringify(requestParams),
+                };
+            }
+            return $.ajax(_.extend({
                 type: 'POST',
                 url: self.urls.xform + "/" + requestParams.action,
-                data: newData,
-                contentType: false,     // or "multipart"? right now formplayer is 403ing either way, it wants json
                 processData: false,
                 dataType: "json",
                 crossDomain: {
@@ -144,7 +153,7 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
                 error: function (resp, textStatus) {
                     self.handleFailure(resp, requestParams.action, textStatus, failureCallback);
                 },
-            });
+            }, contentParams));
         };
 
         /*

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -121,11 +121,16 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
             requestParams['tz_offset_millis'] = (new Date()).getTimezoneOffset() * 60 * 1000 * -1;
             requestParams['tz_from_browser'] = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
+            var newData = new FormData();
+            _.each(requestParams, function (value, key) {
+                newData.append(key, value);
+            });
             return $.ajax({
                 type: 'POST',
                 url: self.urls.xform + "/" + requestParams.action,
-                data: JSON.stringify(requestParams),
-                contentType: "application/json",
+                data: newData,
+                contentType: false,     // or "multipart"? right now formplayer is 403ing either way, it wants json
+                processData: false,
                 dataType: "json",
                 crossDomain: {
                     crossDomain: true,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -305,6 +305,9 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
             // We revalidate any errored labels while answering any of the questions
             var erroredLabels = form.erroredLabels();
 
+            // get files from entry
+            var file = ko.utils.unwrapObservable(q.entry.file);
+
             this.serverRequest(
                 {
                     'action': Const.ANSWER,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -305,17 +305,14 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
             // We revalidate any errored labels while answering any of the questions
             var erroredLabels = form.erroredLabels();
 
-            // get files from entry
-            var file = ko.utils.unwrapObservable(q.entry.file);
-
             this.serverRequest(
-                {
-                    'action': Const.ANSWER,
+                _.extend({
+                    'action': q.entry.xformAction,
                     'ix': ix,
                     'answer': answer,
                     'answersToValidate': erroredLabels,
                     'oneQuestionPerScreen': oneQuestionPerScreen,
-                },
+                }, q.entry.xformParams()),
                 function (resp) {
                     $.publish('session.reconcile', [resp, q]);
                     if (self.answerCallback !== undefined) {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -383,9 +383,24 @@
     </div>
   </div>
 </script>
+
+<script type="text/html" id="file-entry-ko-template">
+  <span class="help-block type sr-only" data-bind="text: helpText()"></span>
+  <input type="file" data-bind="
+        value: $data.rawAnswer,
+        attr: {
+            id: entryId,
+            'aria-required': $parent.required() ? 'true' : 'false',
+            accept: accept,
+        },
+    "/>
+  <span class="help-block type" aria-hidden="true" data-bind="text: helpText()"></span>
+</script>
+
 <script type="text/html" id="address-entry-ko-template">
   <div data-bind="attr: { id: entryId }"></div>
 </script>
+
 <script type="text/html" id="geo-entry-ko-template">
   <table width="100%" cellpadding="0" cellspacing="0" border="0">
     <tbody>

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -901,11 +901,12 @@ WEB_APPS_DOMAIN_BANNER = StaticToggle(
     help_link='https://confluence.dimagi.com/display/saas/USH%3A+Show+current+domain+in+web+apps+Login+As+banner',
 )
 
-WEB_APPS_UPLOAD_QUESTIONS = StaticToggle(
+WEB_APPS_UPLOAD_QUESTIONS = FeatureRelease(
     'web_apps_upload_questions',
     'USH: Support signature, image, audio, and video questions in Web Apps',
     TAG_RELEASE,
     namespaces=[NAMESPACE_DOMAIN],
+    owner='Jenny Schweers',
 )
 
 SYNC_SEARCH_CASE_CLAIM = StaticToggle(

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -901,6 +901,13 @@ WEB_APPS_DOMAIN_BANNER = StaticToggle(
     help_link='https://confluence.dimagi.com/display/saas/USH%3A+Show+current+domain+in+web+apps+Login+As+banner',
 )
 
+WEB_APPS_UPLOAD_QUESTIONS = StaticToggle(
+    'web_apps_upload_questions',
+    'USH: Support signature, image, audio, and video questions in Web Apps',
+    TAG_RELEASE,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 SYNC_SEARCH_CASE_CLAIM = StaticToggle(
     'search_claim',
     'Enable synchronous mobile searching and case claiming',


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2069

![Screen Shot 2022-08-16 at 12 06 04 PM](https://user-images.githubusercontent.com/1486591/184927761-c89836d0-8ff2-461d-8f07-5b4ed22c01eb.png)

Opening for review. As visible in the screenshot, there's an outstanding issue with sending these questions to formplayer.

## Technical Summary
This adds web apps support for signature, image, audio, and video questions. All of these are implemented as file uploads - you can't, say, record audio.

## Feature Flag
USH: Support signature, image, audio, and video questions in Web Apps

## Safety Assurance

### Safety story
This is gated behind a new feature flag in case it gets merged before the formplayer side is ready (see below). My intent is to remove the flag when this feature is complete.

### Automated test coverage

There are tests for the new entry logic in this PR.

### QA Plan

Not sure yet. Depending on when the formplayer side of this feature is likely to be ready, I might wait on it or might just merge this and then QA when formplayer is ready.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
