### PR TITLE
Add global lookup table to case restore

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -7,7 +7,6 @@ from casexml.apps.phone.fixtures import FixtureProvider
 from casexml.apps.phone.utils import (
     GLOBAL_USER_ID,
     get_or_cache_global_fixture,
-    get_or_cache_global_fixture_for_case
 )
 from corehq.apps.fixtures.dbaccessors import iter_fixture_items_for_data_type
 from corehq.apps.fixtures.exceptions import FixtureTypeCheckError
@@ -101,7 +100,7 @@ def get_global_items_by_domain(domain, case_id):
             global_types[data_type._id] = data_type
     if global_types:
         data_fn = partial(ItemListsProvider()._get_global_items, global_types, domain)
-        return get_or_cache_global_fixture_for_case(domain, case_id, FIXTURE_BUCKET, '', data_fn)
+        return get_or_cache_global_fixture(domain, case_id, FIXTURE_BUCKET, '', data_fn)
 
 
 class ItemListsProvider(FixtureProvider):
@@ -140,7 +139,12 @@ class ItemListsProvider(FixtureProvider):
     def get_global_items(self, global_types, restore_state):
         domain = restore_state.restore_user.domain
         data_fn = partial(self._get_global_items, global_types, domain)
-        return get_or_cache_global_fixture(restore_state, FIXTURE_BUCKET, '', data_fn)
+        return get_or_cache_global_fixture(restore_state.restore_user.domain,
+                                           restore_state.restore_user.user_id,
+                                           FIXTURE_BUCKET,
+                                           '',
+                                           data_fn,
+                                           restore_state.overwrite_cache)
 
     def _get_global_items(self, global_types, domain):
         def get_items_by_type(data_type):

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -7,6 +7,7 @@ from casexml.apps.phone.fixtures import FixtureProvider
 from casexml.apps.phone.utils import (
     GLOBAL_USER_ID,
     get_or_cache_global_fixture,
+    get_or_cache_global_fixture_for_case
 )
 from corehq.apps.fixtures.dbaccessors import iter_fixture_items_for_data_type
 from corehq.apps.fixtures.exceptions import FixtureTypeCheckError
@@ -91,6 +92,16 @@ def item_lists_by_app(app, module):
             legacy_item['name'] = f"{item['name']} (legacy)"
             ret.append(legacy_item)
     return lookup_lists + ret
+
+
+def get_global_items_by_domain(domain, case_id):
+    global_types = {}
+    for data_type in FixtureDataType.by_domain(domain):
+        if data_type.is_global:
+            global_types[data_type._id] = data_type
+    if global_types:
+        data_fn = partial(ItemListsProvider()._get_global_items, global_types, domain)
+        return get_or_cache_global_fixture_for_case(domain, case_id, FIXTURE_BUCKET, '', data_fn)
 
 
 class ItemListsProvider(FixtureProvider):

--- a/corehq/apps/ota/case_restore.py
+++ b/corehq/apps/ota/case_restore.py
@@ -6,6 +6,7 @@ from casexml.apps.phone.xml import (
     get_case_element,
     get_registration_element_for_case,
 )
+from corehq.apps.fixtures.fixturegenerators import get_global_items_by_domain
 from corehq.apps.locations.fixtures import (
     FlatLocationSerializer
 )
@@ -49,3 +50,5 @@ def _add_limited_fixtures(domain, case_id, content):
     locations = get_domain_locations(domain)
     nodes = serializer.get_xml_nodes(domain, 'locations', case_id, locations)
     content.extend(nodes)
+    lookuptable = get_global_items_by_domain(domain, case_id)
+    content.extend(lookuptable)

--- a/corehq/apps/ota/case_restore.py
+++ b/corehq/apps/ota/case_restore.py
@@ -51,4 +51,5 @@ def _add_limited_fixtures(domain, case_id, content):
     nodes = serializer.get_xml_nodes(domain, 'locations', case_id, locations)
     content.extend(nodes)
     lookuptable = get_global_items_by_domain(domain, case_id)
-    content.extend(lookuptable)
+    if lookuptable:
+        content.extend(lookuptable)

--- a/corehq/apps/ota/tests/test_case_restore.py
+++ b/corehq/apps/ota/tests/test_case_restore.py
@@ -76,7 +76,6 @@ class TestRelatedCases(TestCase, TestXmlMixin):
 
         domain_obj = create_domain(self.domain)
 
-        self.addCleanup(delete_all_users)
         self.addCleanup(domain_obj.delete)
 
         location_type = LocationType.objects.create(domain=self.domain, name="Top", code="top")

--- a/corehq/apps/ota/tests/test_case_restore.py
+++ b/corehq/apps/ota/tests/test_case_restore.py
@@ -184,7 +184,11 @@ location_fixture_content = """
 lookup_table_fixture_content = """
 <partial>
     <ns0:fixture xmlns:ns0="http://openrosa.org/http/response" id="item-list:{table_tag}" user_id="{user_id}">
-        <ns0:atable_list/>
+        <ns0:atable_list>
+            <ns0:atable>
+                <ns0:wing says="quack">duck</ns0:wing>
+            </ns0:atable>
+        </ns0:atable_list>
     </ns0:fixture>
 </partial>
 """

--- a/corehq/apps/ota/tests/test_case_restore.py
+++ b/corehq/apps/ota/tests/test_case_restore.py
@@ -107,7 +107,6 @@ class TestRelatedCases(TestCase, TestXmlMixin):
 
         domain_obj = create_domain(self.domain)
 
-        self.addCleanup(delete_all_users)
         self.addCleanup(domain_obj.delete)
 
         table_tag = "atable"

--- a/corehq/apps/ota/tests/test_case_restore.py
+++ b/corehq/apps/ota/tests/test_case_restore.py
@@ -16,6 +16,7 @@ from corehq.apps.users.models import WebUser
 from corehq.form_processor.models import CommCareCase
 from corehq.util.hmac_request import get_hmac_digest
 from corehq.util.test_utils import flag_enabled
+from corehq.apps.fixtures.models import LookupTable, LookupTableRow, Field, TypeField
 
 
 class TestRelatedCases(TestCase, TestXmlMixin):
@@ -103,6 +104,43 @@ class TestRelatedCases(TestCase, TestXmlMixin):
         self.assertXmlPartialEqual(locations_content, response_content,
                                    '{http://openrosa.org/http/response}fixture[@id="locations"]')
 
+    @flag_enabled('ADD_LIMITED_FIXTURES_TO_CASE_RESTORE')
+    def test_lookup_table_in_restore(self):
+        case_id = self.dad.case_id
+
+        domain_obj = create_domain(self.domain)
+        user = WebUser.create(self.domain, 'test-user', 'passmein', created_by=None, created_via=None)
+
+        self.addCleanup(delete_all_users)
+        self.addCleanup(domain_obj.delete)
+
+        table_tag = "atable"
+
+        table = LookupTable(domain=self.domain,
+                            tag=table_tag,
+                            description="A Table",
+                            is_global=True,
+                            fields=[TypeField(name="wing")])
+        table.save()
+        row = LookupTableRow(
+            table_id=table.id,
+            domain=self.domain,
+            fields={
+                "wing": [Field(value="duck", properties={"says": "quack"})],
+            },
+            sort_key=0,
+        )
+        row.save()
+
+        response = self._generate_restore(case_id, user)
+        self.assertEqual(response.status_code, 200)
+
+        response_content = next(response.streaming_content)
+
+        lookup_table_content = lookup_table_fixture_content.format(table_tag=table_tag, user_id=case_id)
+        xpath = '{h}fixture[@id="item-list:{tag}"]'.format(h='{http://openrosa.org/http/response}', tag=table_tag)
+        self.assertXmlPartialEqual(lookup_table_content, response_content, xpath)
+
     def _generate_restore(self, case_id, user):
         self.client.login(username=user.username, password=user.password)
         url = reverse("case_restore", args=[self.domain, case_id])
@@ -139,6 +177,14 @@ location_fixture_content = """
                 <ns0:location_data/>
             </ns0:location>
         </ns0:locations>
+    </ns0:fixture>
+</partial>
+"""
+
+lookup_table_fixture_content = """
+<partial>
+    <ns0:fixture xmlns:ns0="http://openrosa.org/http/response" id="item-list:{table_tag}" user_id="{user_id}">
+        <ns0:atable_list/>
     </ns0:fixture>
 </partial>
 """

--- a/corehq/apps/ota/tests/test_case_restore.py
+++ b/corehq/apps/ota/tests/test_case_restore.py
@@ -135,7 +135,7 @@ class TestRelatedCases(TestCase, TestXmlMixin):
         response_content = next(response.streaming_content)
 
         lookup_table_content = lookup_table_fixture_content.format(table_tag=table_tag, user_id=case_id)
-        xpath = '{h}fixture[@id="item-list:{tag}"]'.format(h='{http://openrosa.org/http/response}', tag=table_tag)
+        xpath = f'{{http://openrosa.org/http/response}}fixture[@id="item-list:{table_tag}"]'
         self.assertXmlPartialEqual(lookup_table_content, response_content, xpath)
 
     def _generate_restore(self, case_id):

--- a/corehq/apps/programs/fixtures.py
+++ b/corehq/apps/programs/fixtures.py
@@ -1,10 +1,4 @@
-from functools import partial
-
 from casexml.apps.phone.fixtures import FixtureProvider
-from casexml.apps.phone.utils import (
-    GLOBAL_USER_ID,
-    get_or_cache_global_fixture,
-)
 
 from corehq.apps.commtrack.fixtures import simple_fixture_generator
 from corehq.apps.programs.models import Program
@@ -38,7 +32,11 @@ class ProgramFixturesProvider(FixtureProvider):
         # disable caching temporarily
         # https://dimagi-dev.atlassian.net/browse/IIO-332
         # data_fn = partial(self._get_fixture_items, restore_state)
-        # return get_or_cache_global_fixture(restore_state, PROGRAM_FIXTURE_BUCKET, self.id, data_fn)
+        # domain = restore_state.restore_user.domain
+        # user_id = restore_state.restore_user.user_id
+        # overwrite_cache = restore_state.overwrite_cache
+        # return:
+        # get_or_cache_global_fixture(domain, user_id, cache_bucket_prefix, self.id, data_fn, overwrite_cache)
         return self._get_fixture_items(restore_state)
 
     def _get_fixture_items(self, restore_state):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Ticket: [USH-1371](https://dimagi-dev.atlassian.net/browse/USH-1371)
Adding global look up table to case restore. Global tables are ones where the user has checked the ‘Visible to all users’ box.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[This PR](https://github.com/dimagi/commcare-hq/pull/29482/) added the location fixture to the restore, set an example for me.
I extended that feature flag as well as `_add_limited_fixtures()` created by that PR.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Allow limited fixtures to be available in case restore for SMS workflows

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- test both locally and on staging.
- the changes happens behind a FF

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

[Test here](https://github.com/dimagi/commcare-hq/blob/47427775b8e47e76bbdb458210bf31cce91b7c8b/corehq/apps/ota/tests/test_case_restore.py#L108-L142)

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[QA-4454](https://dimagi-dev.atlassian.net/browse/QA-4454)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
