### PR TITLE
Ignore conflicts on sync to SQL

### DIFF
--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -168,9 +168,9 @@ class Mutation:
 def flush(tables, rows, owners):
     def sync_docs_to_sql():
         if tables.to_sync:
-            FixtureDataType._migration_bulk_sync_to_sql(tables.to_sync)
+            FixtureDataType._migration_bulk_sync_to_sql(tables.to_sync, ignore_conflicts=True)
         if rows.to_sync:
-            FixtureDataItem._migration_bulk_sync_to_sql(rows.to_sync)
+            FixtureDataItem._migration_bulk_sync_to_sql(rows.to_sync, ignore_conflicts=True)
         assert not owners.to_sync, owners.to_sync
 
     with CouchTransaction() as couch:

--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -151,7 +151,7 @@ class SyncCouchToSQLMixin(object):
             sql_object.save(sync_to_couch=False)
 
     @classmethod
-    def _migration_bulk_sync_to_sql(cls, couch_docs):
+    def _migration_bulk_sync_to_sql(cls, couch_docs, **kw):
         sql_class = cls._migration_get_sql_model_class()
         id_name = sql_class._migration_couch_id_name
         new_sql_docs = []
@@ -160,7 +160,7 @@ class SyncCouchToSQLMixin(object):
             obj = sql_class(**{id_name: doc._id})
             doc._migration_sync_to_sql(obj, save=False)
             new_sql_docs.append(obj)
-        sql_class.objects.bulk_create(new_sql_docs)
+        sql_class.objects.bulk_create(new_sql_docs, **kw)
 
     def _migration_sync_submodels_to_sql(self, sql_object):
         """Migrate submodels from the Couch model to the SQL model. This is called


### PR DESCRIPTION
While the race condition is certainly there, the frequency of this error in production (a couple per day) makes it seem unlikely that concurrent table edits are actually causing the issue and it's not a bug in the uploader itself. However, that bug has thus far avoided detection. Using concurrency with threads in a test was a last resort to show that the bug exists and the fix is effective. In any case ignoring conflicts is fine here because the sole purpose of syncing to SQL is to create parent records that are required for foreign key references by child records.

Fix for [Sentry error](https://sentry.io/organizations/dimagi/issues/3503731391/):
```
IntegrityError: duplicate key value violates unique constraint "fixtures_lookuptable_pkey"
DETAIL:  Key (id)=(...) already exists.

  File "corehq/apps/fixtures/tasks.py", line 23, in fixture_upload_async
    result = upload_fixture_file(domain, download_ref.get_filename(), replace, task, skip_orm)
  File "corehq/apps/fixtures/upload/run_upload.py", line 38, in upload_fixture_file
    return _run_upload(domain, workbook, replace, task, skip_orm)
  File "corehq/apps/fixtures/upload/run_upload.py", line 118, in _run_upload
    flush(tables, rows, owners)
  File "corehq/apps/fixtures/upload/run_upload.py", line 184, in flush
    couch.add_post_commit_action(sync_docs_to_sql)
  File "dimagi/utils/couch/bulk.py", line 146, in __exit__
    self.commit()
  File "dimagi/utils/couch/bulk.py", line 100, in commit
    self._commit(start_sql_transaction)
  File "dimagi/utils/couch/bulk.py", line 137, in _commit
    action()
  File "corehq/apps/fixtures/upload/run_upload.py", line 171, in sync_docs_to_sql
    FixtureDataType._migration_bulk_sync_to_sql(tables.to_sync)
  File "dimagi/utils/couch/migration.py", line 163, in _migration_bulk_sync_to_sql
    sql_class.objects.bulk_create(new_sql_docs)
  File "django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "django/db/models/query.py", line 502, in bulk_create
    returned_columns = self._batched_insert(
  File "django/db/models/query.py", line 1287, in _batched_insert
    inserted_rows.extend(self._insert(
  File "django/db/models/query.py", line 1270, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "django/db/models/sql/compiler.py", line 1416, in execute_sql
    cursor.execute(sql, params)
  File "django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
```

## Safety Assurance

### Safety story

A minor surgical change to the lookup table uploader, which is well covered by tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
