### PR TITLE
Allow Django-style value-displayname pairs in commcare-*-settings.yml

### DIFF
--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -48,9 +48,9 @@ def _load_custom_commcare_settings():
         if not setting.get('widget'):
             setting['widget'] = 'select'
         if 'values' in setting:
-            values, value_names = unpack_value_names(setting['values'])
-            setting['values'] = values
-            setting['value_names'] = value_names
+            values = setting.pop('values')
+            setting['values'] = [v[0] for v in values]
+            setting['value_names'] = [v[1] for v in values]
         for prop in PROFILE_SETTINGS_TO_TRANSLATE:
             if prop in setting:
                 setting[prop] = _translate_setting(setting, prop)
@@ -176,53 +176,3 @@ def circular_dependencies(settings, yaml_lookup):
         if check_setting_for_circular_dependency(s, yaml_lookup):
             return True
     return False
-
-
-def unpack_value_names(value_list):
-    """
-    Returns a list of values and a list of value names.
-
-    If ``value_list`` is a list of value-value_name pairs, they are
-    unpacked. If ``value_list`` is just a list of values, value names
-    are their values in title case.
-
-    >>> unpack_value_names([
-    ...     ['foo-bar', 'Foozle'],
-    ...     ['baz', 'Bazinga'],
-    ... ])
-    (['foo-bar', 'baz'], ['Foozle', 'Bazinga'])
-
-    >>> unpack_value_names(['foo-bar', 'baz'])
-    (['foo-bar', 'baz'], ['Foo Bar', 'Baz'])
-
-    """
-    values = []
-    value_names = []
-    for item in value_list:
-        if isinstance(item, list) and len(item) == 2:
-            value, value_name = item
-        else:
-            value = item
-            value_name = titleslug(item)
-        values.append(value)
-        value_names.append(value_name)
-    return values, value_names
-
-
-def titleslug(slug):
-    """
-    Returns ``slug`` as title case. Non-strings are returned unchanged.
-
-    >>> titleslug('foo-bar')
-    'Foo Bar'
-    >>> titleslug(5)
-    5
-
-    """
-    if isinstance(slug, str):
-        table = {
-            ord('-'): ord(' '),
-            ord('_'): ord(' '),
-        }
-        return slug.translate(table).title()
-    return slug

--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -38,16 +38,17 @@ def _load_custom_commcare_settings():
             if not setting.get('type'):
                 setting['type'] = 'properties'
             settings.append(setting)
-
     with open(os.path.join(path, 'commcare-app-settings.yml'), encoding='utf-8') as f:
         for setting in yaml.safe_load(f):
             if not setting.get('type'):
                 setting['type'] = 'hq'
             settings.append(setting)
+
     for setting in settings:
         if not setting.get('widget'):
             setting['widget'] = 'select'
-
+        if 'values' in setting and 'value_names' not in setting:
+            setting['value_names'] = [titleslug(v) for v in setting['values']]
         for prop in PROFILE_SETTINGS_TO_TRANSLATE:
             if prop in setting:
                 setting[prop] = _translate_setting(setting, prop)
@@ -173,3 +174,22 @@ def circular_dependencies(settings, yaml_lookup):
         if check_setting_for_circular_dependency(s, yaml_lookup):
             return True
     return False
+
+
+def titleslug(slug):
+    """
+    Returns ``slug`` as title case. Non-strings are returned unchanged.
+
+    >>> titleslug('foo-bar')
+    'Foo Bar'
+    >>> titleslug(5)
+    5
+
+    """
+    if isinstance(slug, str):
+        table = {
+            ord('-'): ord(' '),
+            ord('_'): ord(' '),
+        }
+        return slug.translate(table).title()
+    return slug

--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -49,6 +49,10 @@ def _load_custom_commcare_settings():
             setting['widget'] = 'select'
         if 'values' in setting and 'value_names' not in setting:
             setting['value_names'] = [titleslug(v) for v in setting['values']]
+        if 'value_pairs' in setting:
+            value_pairs = setting.pop('value_pairs')
+            setting['values'] = [v[0] for v in value_pairs]
+            setting['value_names'] = [v[1] for v in value_pairs]
         for prop in PROFILE_SETTINGS_TO_TRANSLATE:
             if prop in setting:
                 setting[prop] = _translate_setting(setting, prop)

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -1,8 +1,10 @@
 - id: application_version
   name: "App Version"
   description: ""
-  values: ["1.0", "2.0"]
-  value_names: ["1.x", "2.x"]
+  value_pairs:
+    # [values, value_names]
+    - ['1.0', '2.0']
+    - ['2.0', '2.x']
   default: "2.0"
   disabled: true
   disabled_txt: "We suggest moving to CommCare 2.0 and above, unless your project is using referrals"
@@ -26,16 +28,22 @@
 - id: platform
   name: "Java Phone Platform"
   description: "The kind of Java phone you want to run the application on"
-  values: ['nokia/s40', 'nokia/s60', 'winmo', 'generic']
-  value_names: ['Nokia S40 (default)', 'Nokia S60', 'WinMo', 'Generic']
+  value_pairs:
+    - ['nokia/s40', 'Nokia S40 (default)']
+    - ['nokia/s60', 'Nokia S60']
+    - ['winmo', 'WinMo']
+    - ['generic', 'Generic']
   default: 'nokia/s40'
 
 - id: text_input
   name: "Text Input"
   description: "What characters to allow users to input"
   widget: text_input
-  values: ['roman', 'native', 'custom-keys', 'qwerty']
-  value_names: [Roman, Native (International), Custom Keys, Full Keyboard]
+  value_pairs:
+    - ['roman', 'Roman']
+    - ['native', 'Native (International)']
+    - ['custom-keys', 'Custom Keys']
+    - ['qwerty', 'Full Keyboard']
   default: roman
   since: {qwerty: '2.6', 'custom-keys': '1.3'}
   requires: "{hq.platform}='nokia/s40'||{hq.platform}='nokia/s60'"
@@ -128,11 +136,10 @@
 
 - id: translation_strategy
   name: 'Translations Strategy'
-  values: ['dump-known', 'select-known', 'simple']
-  value_names:
-   - 'Version 1 translations (old)'
-   - 'Version 2 translations (recommended)'
-   - 'Simple (FOR TESTING ONLY: crashes with any unrecognized user-defined translations)'
+  value_pairs:
+    - ['dump-known', 'Version 1 translations (old)']
+    - ['select-known', 'Version 2 translations (recommended)']
+    - ['simple', 'Simple (FOR TESTING ONLY: crashes with any unrecognized user-defined translations)']
   default: 'select-known'
   requires: "{$parent.doc_type}='Application'"
   preview: true
@@ -150,16 +157,19 @@
 - id: use_grid_menus
   name: Modules Menu Display
   description: Display root menu as a list or grid. Read more on the <a target="_blank" href="https://help.commcarehq.org/display/commcarepublic/Grid+View+for+Form+and+Module+Screens">Help Site</a>.
-  values: [false, true]
-  value_names: ['List', 'Grid']
+  value_pairs:
+    - ['false', 'List']
+    - ['true', 'Grid']
   default: false
   since: "2.24"
 
 - id: grid_form_menus
   name: Forms Menu Display
   description: Configure form menus display. For per-module option turn on grid view for the form's menu in a module under module's settings page. Read more on the <a target="_blank" href="https://help.commcarehq.org/display/commcarepublic/Grid+View+for+Form+and+Module+Screens">Help Site</a>.
-  values: ['none', 'all', 'some']
-  value_names: ['List', 'Grid', 'Enable Menu Display Setting Per-Module']
+  value_pairs:
+    - ['none', 'List']
+    - ['all', 'Grid']
+    - ['some', 'Enable Menu Display Setting Per-Module']
   default: 'none'
   since: '2.24'
 
@@ -167,8 +177,10 @@
   name: Target CommCare Flavor
   description: "Restrict this app to the selected CommCare flavor"
   toggles: TARGET_COMMCARE_FLAVOR
-  values: ['none', 'commcare', 'commcare_lts']
-  value_names: ['None', 'CommCare', 'CommCare LTS']
+  value_pairs:
+    - ['none', 'None']
+    - ['commcare', 'CommCare']
+    - ['commcare_lts', 'CommCare LTS']
   supports_linked_app: true
   default: 'none'
   since: '2.43'
@@ -184,14 +196,9 @@
   name: App Aware Location Fixture Format
   description: Location Fixture format that is provided in the restore for this app
   toggle: HIERARCHICAL_LOCATION_FIXTURE
-  values:
-    - 'project_default'
-    - 'both_fixtures'
-    - 'only_flat_fixture'
-    - 'only_hierarchical_fixture'
-  value_names:
-    - 'Project Default'
-    - 'Both Hierarchical and Flat Fixture'
-    - 'Only Flat Fixture'
-    - 'Only Hierarchical Fixture'
+  value_pairs:
+    - ['project_default', 'Project Default']
+    - ['both_fixtures', 'Both Hierarchical and Flat Fixture']
+    - ['only_flat_fixture', 'Only Flat Fixture']
+    - ['only_hierarchical_fixture', 'Only Hierarchical Fixture']
   default: 'project_default'

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -1,8 +1,9 @@
 - id: application_version
   name: "App Version"
   description: ""
-  value_pairs:
-    # [values, value_names]
+  values:
+    # A list of value-value_name pairs, or just a list of values. Value
+    # names default to their values in title case.
     - ['1.0', '1.x']
     - ['2.0', '2.x']
   default: "2.0"
@@ -28,7 +29,7 @@
 - id: platform
   name: "Java Phone Platform"
   description: "The kind of Java phone you want to run the application on"
-  value_pairs:
+  values:
     - ['nokia/s40', 'Nokia S40 (default)']
     - ['nokia/s60', 'Nokia S60']
     - ['winmo', 'WinMo']
@@ -39,7 +40,7 @@
   name: "Text Input"
   description: "What characters to allow users to input"
   widget: text_input
-  value_pairs:
+  values:
     - ['roman', 'Roman']
     - ['native', 'Native (International)']
     - ['custom-keys', 'Custom Keys']
@@ -136,7 +137,7 @@
 
 - id: translation_strategy
   name: 'Translations Strategy'
-  value_pairs:
+  values:
     - ['dump-known', 'Version 1 translations (old)']
     - ['select-known', 'Version 2 translations (recommended)']
     - ['simple', 'Simple (FOR TESTING ONLY: crashes with any unrecognized user-defined translations)']
@@ -157,7 +158,7 @@
 - id: use_grid_menus
   name: Modules Menu Display
   description: Display root menu as a list or grid. Read more on the <a target="_blank" href="https://help.commcarehq.org/display/commcarepublic/Grid+View+for+Form+and+Module+Screens">Help Site</a>.
-  value_pairs:
+  values:
     - ['false', 'List']
     - ['true', 'Grid']
   default: false
@@ -166,7 +167,7 @@
 - id: grid_form_menus
   name: Forms Menu Display
   description: Configure form menus display. For per-module option turn on grid view for the form's menu in a module under module's settings page. Read more on the <a target="_blank" href="https://help.commcarehq.org/display/commcarepublic/Grid+View+for+Form+and+Module+Screens">Help Site</a>.
-  value_pairs:
+  values:
     - ['none', 'List']
     - ['all', 'Grid']
     - ['some', 'Enable Menu Display Setting Per-Module']
@@ -177,7 +178,7 @@
   name: Target CommCare Flavor
   description: "Restrict this app to the selected CommCare flavor"
   toggles: TARGET_COMMCARE_FLAVOR
-  value_pairs:
+  values:
     - ['none', 'None']
     - ['commcare', 'CommCare']
     - ['commcare_lts', 'CommCare LTS']
@@ -196,7 +197,7 @@
   name: App Aware Location Fixture Format
   description: Location Fixture format that is provided in the restore for this app
   toggle: HIERARCHICAL_LOCATION_FIXTURE
-  value_pairs:
+  values:
     - ['project_default', 'Project Default']
     - ['both_fixtures', 'Both Hierarchical and Flat Fixture']
     - ['only_flat_fixture', 'Only Flat Fixture']

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -178,7 +178,6 @@
   description: Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR+V2">Help Site</a>
   toggle: MOBILE_UCR
   values: ['1.0', '1.5', '2.0']
-  value_names: ['1.0', '1.5', '2.0']
   default: '1.0'
 
 - id: location_fixture_restore

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -2,8 +2,7 @@
   name: "App Version"
   description: ""
   values:
-    # A list of value-value_name pairs, or just a list of values. Value
-    # names default to their values in title case.
+    # [value, value name]
     - ['1.0', '1.x']
     - ['2.0', '2.x']
   default: "2.0"
@@ -190,7 +189,10 @@
   name: Mobile UCR Restore Version
   description: Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR+V2">Help Site</a>
   toggle: MOBILE_UCR
-  values: ['1.0', '1.5', '2.0']
+  values:
+    - ['1.0', '1.0']
+    - ['1.5', '1.5']
+    - ['2.0', '2.0']
   default: '1.0'
 
 - id: location_fixture_restore

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -3,7 +3,7 @@
   description: ""
   value_pairs:
     # [values, value_names]
-    - ['1.0', '2.0']
+    - ['1.0', '1.x']
     - ['2.0', '2.x']
   default: "2.0"
   disabled: true

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
@@ -43,7 +43,6 @@
   description: "Whether logging of incidents should be activated on the client."
   id: "logenabled"
   values: ["Enabled", "Disabled"]
-  value_names: ["Enabled", "Disabled"]
   default: "Enabled"
   group: "log"
   force: true
@@ -126,7 +125,6 @@
   description: "Whether users registered on the phone need to be registered with the submission server."
   id: "user_reg_server"
   values: ["required", "skip"]
-  value_names: ["Required", "Skip"]
   values_txt: "Set to skip if your deployment does not require users to register with the server. Note that this will likely result in OTA Restore and other features being unavailable."
   default: "required"
   force: true
@@ -156,7 +154,6 @@
   description: "Whether OTA Restore is tolerant of failures, ambiguity, duplicate registrations, etc (and proceeds as best it can), or whether it fails immediately in these cases."
   id: "restore-tolerance"
   values: ["strict", "loose"]
-  value_names: ["Strict", "Loose"]
   default: "loose"
   force: true
 
@@ -247,7 +244,6 @@
   description: "Whether CommCare should search for alternative formats of incompatible media files."
   id: "loose_media"
   values: ["yes", "no"]
-  value_names: ["Yes", "No"]
   default: "no"
   values_txt: "When loose media mode is set to yes, CommCare will search for alternative media formats for any media that it cannot play. If CommCare attempts to play a file at jr://file/media/prompt_one.mp3 and mp3 files are not supported, the media directory will be searched for other files named prompt_one with alternative extensions which may be supported, for instance prompt_one.wav, and play that instead."
   since: "1.3"
@@ -268,7 +264,6 @@
   description: "Number of unsent forms on phone before triggering warning text"
   id: "unsent-number-limit"
   values: ["5", "10", "20", "40", "80", "160"]
-  value_names: ["5", "10", "20", "40", "80", "160"]
   default: "5"
   values_txt: "When the phone has this number of unsynced forms stored locally CommCare will trigger a warning"
   since: "2.1"
@@ -335,7 +330,6 @@
   description: "Whether searches on the phone will match similar strings. IE: 'Jhon' will match 'John'"
   id: "cc-fuzzy-search-enabled"
   values: ["yes", "no"]
-  value_names: ["Yes", "No"]
   default: "yes"
   disabled_default: "no"
   values_txt: "Whether searches can match similar strings"
@@ -375,8 +369,7 @@
 - name: "Default Map Tileset"
   description: "For mobile map displays, chooses a base tileset for the underlying map layer"
   id: "cc-maps-default-layer"
-  values: ["normal", "satellite","terrain","hybrid"]
-  value_names: ["Normal","Satellite","Terrain","Hybrid"]
+  values: ["normal", "satellite", "terrain", "hybrid"]
   default: "normal"
   since: "2.48"
   force: false
@@ -385,7 +378,6 @@
   description: "Adds a text to speech button for all questions to read out the question text aloud."
   id: "cc-enable-tts"
   values: ["yes", "no"]
-  value_names: ["Yes", "No"]
   default: "no"
   since: "2.51"
   force: true
@@ -394,7 +386,6 @@
   description: "Adds a red asterisk to denote mandatory questions in a form. This setting only works in mobile."
   id: "cc-label-required-questions-with-asterisk"
   values: ["yes", "no"]
-  value_names: ["Yes", "No"]
   default: "no"
   since: "2.49"
   force: true

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
@@ -2,8 +2,7 @@
   description: "How often CommCare mobile should attempt to check for a new, released application version."
   id: "cc-autoup-freq"
   values:
-    # A list of value-value_name pairs, or just a list of values. Value
-    # names default to their values in title case.
+    # [value, value name]
     - ['freq-never', 'Never']
     - ['freq-daily', 'Daily']
     - ['freq-weekly', 'Weekly']
@@ -56,7 +55,9 @@
 - name: "Logging Enabled"
   description: "Whether logging of incidents should be activated on the client."
   id: "logenabled"
-  values: ["Enabled", "Disabled"]
+  values:
+    - ['Enabled', 'Enabled']
+    - ['Disabled', 'Disabled']
   default: "Enabled"
   group: "log"
   force: true
@@ -144,7 +145,9 @@
   name: "Server User Registration"
   description: "Whether users registered on the phone need to be registered with the submission server."
   id: "user_reg_server"
-  values: ["required", "skip"]
+  values:
+    - ['required', 'Required']
+    - ['skip', 'Skip']
   values_txt: "Set to skip if your deployment does not require users to register with the server. Note that this will likely result in OTA Restore and other features being unavailable."
   default: "required"
   force: true
@@ -176,7 +179,9 @@
   name: "OTA Restore Tolerance"
   description: "Whether OTA Restore is tolerant of failures, ambiguity, duplicate registrations, etc (and proceeds as best it can), or whether it fails immediately in these cases."
   id: "restore-tolerance"
-  values: ["strict", "loose"]
+  values:
+    - ['strict', 'Strict']
+    - ['loose', 'Loose']
   default: "loose"
   force: true
 
@@ -273,7 +278,9 @@
   name: "Loose Media Mode"
   description: "Whether CommCare should search for alternative formats of incompatible media files."
   id: "loose_media"
-  values: ["yes", "no"]
+  values:
+    - ['yes', 'Yes']
+    - ['no', 'No']
   default: "no"
   values_txt: "When loose media mode is set to yes, CommCare will search for alternative media formats for any media that it cannot play. If CommCare attempts to play a file at jr://file/media/prompt_one.mp3 and mp3 files are not supported, the media directory will be searched for other files named prompt_one with alternative extensions which may be supported, for instance prompt_one.wav, and play that instead."
   since: "1.3"
@@ -294,7 +301,13 @@
 - name: "Unsent Form Limit"
   description: "Number of unsent forms on phone before triggering warning text"
   id: "unsent-number-limit"
-  values: ["5", "10", "20", "40", "80", "160"]
+  values:
+    - ['5', '5']
+    - ['10', '10']
+    - ['20', '20']
+    - ['40', '40']
+    - ['80', '80']
+    - ['160', '160']
   default: "5"
   values_txt: "When the phone has this number of unsynced forms stored locally CommCare will trigger a warning"
   since: "2.1"
@@ -371,7 +384,9 @@
 - name: "Fuzzy Search"
   description: "Whether searches on the phone will match similar strings. IE: 'Jhon' will match 'John'"
   id: "cc-fuzzy-search-enabled"
-  values: ["yes", "no"]
+  values:
+    - ['yes', 'Yes']
+    - ['no', 'No']
   default: "yes"
   disabled_default: "no"
   values_txt: "Whether searches can match similar strings"
@@ -423,7 +438,11 @@
 - name: "Default Map Tileset"
   description: "For mobile map displays, chooses a base tileset for the underlying map layer"
   id: "cc-maps-default-layer"
-  values: ["normal", "satellite", "terrain", "hybrid"]
+  values:
+    - ['normal', 'Normal']
+    - ['satellite', 'Satellite']
+    - ['terrain', 'Terrain']
+    - ['hybrid', 'Hybrid']
   default: "normal"
   since: "2.48"
   force: false
@@ -431,7 +450,9 @@
 - name: "Enable Text To Speech"
   description: "Adds a text to speech button for all questions to read out the question text aloud."
   id: "cc-enable-tts"
-  values: ["yes", "no"]
+  values:
+    - ['yes', 'Yes']
+    - ['no', 'No']
   default: "no"
   since: "2.51"
   force: true
@@ -439,7 +460,9 @@
 - name: "Enable asterisk on required question"
   description: "Adds a red asterisk to denote mandatory questions in a form. This setting only works in mobile."
   id: "cc-label-required-questions-with-asterisk"
-  values: ["yes", "no"]
+  values:
+    - ['yes', 'Yes']
+    - ['no', 'No']
   default: "no"
   since: "2.49"
   force: true

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
@@ -1,8 +1,9 @@
 - name: "Auto Update Frequency"
   description: "How often CommCare mobile should attempt to check for a new, released application version."
   id: "cc-autoup-freq"
-  value_pairs:
-    # [values, value_names]
+  values:
+    # A list of value-value_name pairs, or just a list of values. Value
+    # names default to their values in title case.
     - ['freq-never', 'Never']
     - ['freq-daily', 'Daily']
     - ['freq-weekly', 'Weekly']
@@ -15,7 +16,7 @@
   description: "Make OTA app updates skip download for video files at app update time."
   id: "lazy-load-video-files"
   toggle: LAZY_LOAD_MULTIMEDIA
-  value_pairs:
+  values:
     - ['true', 'Yes']
     - ['false', 'No']
   default: "false"
@@ -26,7 +27,7 @@
   name: "Purge Frequency"
   description: "How often the phone should attempt to purge any cached storage which may have expired"
   id: "purge-freq"
-  value_pairs:
+  values:
     - ['0', 'Whenever Possible']
     - ['1', 'Daily']
     - ['7', 'Once a Week']
@@ -39,7 +40,7 @@
 - name: "Days for Review"
   description: "Amount of time previously submitted forms remain accessible in the CommCare app."
   id: "cc-days-form-retain"
-  value_pairs:
+  values:
     - ['1', 'Just One Day']
     - ['7', 'One Week']
     - ['31', 'One Month']
@@ -67,7 +68,7 @@
   requires: "{properties.logenabled}='Enabled'"
   commcare_default: "log_never"
   default: "log_short"
-  value_pairs:
+  values:
     - ['log_never', 'Never']
     - ['log_short', 'Short']
     - ['log_full', 'Full']
@@ -80,7 +81,7 @@
   requires_txt: "Logging to be Enabled"
   default: "log_never"
   requires: "{properties.logenabled}='Enabled'"
-  value_pairs:
+  values:
     - ['log_never', 'Never']
     - ['log_short', 'Short']
     - ['log_full', 'Full']
@@ -91,7 +92,7 @@
   description: "Whether or not the phone collects, saves, and sends data."
   id: "cc-send-procedure"
   default: "cc-send-http"
-  value_pairs:
+  values:
     - ['cc-send-http', 'Yes']
     - ['cc-send-none', 'No (NOT RECOMMENDED)']
   "//values": ["cc-send-file"]
@@ -101,7 +102,7 @@
 - name: "Password Format"
   description: "Determines whether phone keys will type letters or numbers by default when typing in the password field."
   id: "password_format"
-  value_pairs:
+  values:
     - ['a', 'Alphanumeric']
     - ['n', 'Numeric']
   default: "a"
@@ -151,7 +152,7 @@
 - name: "Sync Mode"
   description: "Determines if the server automatically attempts to send data to the phone (Two-Way), or only attempt to send data on demand (Push Only); projects using Case Sharing should choose Two-Way. If set to Push Only, the Auto-Sync Frequency and Unsynced Time Limit settings will have no effect."
   id: "server-tether"
-  value_pairs:
+  values:
     - ['push-only', 'Push Only']
     - ['sync', 'Two-Way Sync']
   default: "push-only"
@@ -162,7 +163,7 @@
 - name: "Auto-Sync Frequency"
   description: "Automatically trigger a two-way sync on a regular schedule"
   id: "cc-autosync-freq"
-  value_pairs:
+  values:
     - ['freq-never', disabled]
     - ['freq-daily', 'Daily']
     - ['freq-weekly', 'Weekly']
@@ -182,7 +183,7 @@
 - name: "Form Entry Style"
   description: "What user interface style should be used during form entry."
   id: "ViewStyle"
-  value_pairs:
+  values:
     - ['v_chatterbox', 'Multiple Questions per Screen']
     - ['v_singlequestionscreen', 'One Question per Screen']
   values_txt: "Multiple Questions per Screen displays a running list of questions on the screen at the same time. One Question per Screen displays each question independently. Note: OQPS does not support some features"
@@ -194,7 +195,7 @@
   type: "features"
   name: "No Users Mode"
   description: "Whether to show the user login screen"
-  value_pairs:
+  values:
     - ['true', 'Off']
     - ['false', 'On']
   default: "true"
@@ -206,7 +207,7 @@
   type: "features"
   name: "CommCare Sense"
   description: "Configure for low-literate users, J2ME only"
-  value_pairs:
+  values:
     - ['true', 'Yes']
     - ['false', 'No']
   default: "false"
@@ -216,7 +217,7 @@
 
 - id: "cc-user-mode"
   name: "User Login Mode"
-  value_pairs:
+  values:
     - ['cc-u-normal', 'Normal']
     - ['cc-u-auto', 'Auto-login']
   default: "cc-u-normal"
@@ -231,7 +232,7 @@
   description: "Whether form entry is optimized for speed, or for new users."
   id: "cc-entry-mode"
   requires: "{features.sense}='false'"
-  value_pairs:
+  values:
     - ['cc-entry-quick', 'Normal Scrolling']
     - ['cc-entry-review', 'Numeric Selection']
   values_txt: "Numeric Selection mode will display information about questions for longer and require more input from the user. Normal Scrolling will proceed to the next question whenever enough information is provided."
@@ -244,7 +245,7 @@
   description: "How Send All Unsent functionality is presented to the user"
   id: "cc-send-unsent"
   requires: "{features.sense}='false'"
-  value_pairs:
+  values:
     - ['cc-su-auto', 'Automatic']
     - ['cc-su-man', 'Manual']
   values_txt: "If automatic is enabled, forms will attempt to send on their own without intervention from the user. If manual is enabled, the user must manually decide when to attempt to send forms."
@@ -258,7 +259,7 @@
   description: "What the 'Extra Key' (# on Nokia Phones) does when pressed"
   id: "extra_key_action"
   requires: "{features.sense}='false'"
-  value_pairs:
+  values:
     - ['cycle', 'Languages']
     - ['audio', 'Audio']
   values_txt: "Language cycles through any available translations. Audio plays the question's audio if available. NOTE: If audio is selected, a question's audio will not be played by default when the question is displayed."
@@ -282,7 +283,7 @@
 - name: "Multimedia Validation"
   description: "Whether CommCare should validate that all external multimedia is installed before letting the user run the app."
   id: "cc-content-valid"
-  value_pairs:
+  values:
     - ['yes', 'No Validation']
     - ['no', 'Validate Multimedia']
   default: "yes"
@@ -302,7 +303,7 @@
 - name: "Unsynced Time Limit"
   description: "Days allowed without syncing before triggering a warning"
   id: "unsent-time-limit"
-  value_pairs:
+  values:
     - ['-1', 'Never']
     - ['1', '1 Day']
     - ['5', '5 Days']
@@ -317,7 +318,7 @@
 - name: "Login Buttons"
   description: "Choose to label the login buttons with Icons or Text"
   id: "cc-login-images"
-  value_pairs:
+  values:
     - ['Yes', 'Icons']
     - ['No', 'Text']
   default: "No"
@@ -329,7 +330,7 @@
 - name: "Saved Forms"
   description: "Choose whether or not mobile workers can view previously submitted forms."
   id: "cc-show-saved"
-  value_pairs:
+  values:
     - ['yes', 'Enable']
     - ['no', 'Disable']
   default: "no"
@@ -342,7 +343,7 @@
 - name: "Incomplete Forms"
   description: "Choose whether or not to display the 'Incomplete' button on the ODK home screen"
   id: "cc-show-incomplete"
-  value_pairs:
+  values:
     - ['yes', 'Enable']
     - ['no', 'Disable']
   default: "no"
@@ -357,7 +358,7 @@
   <a href='https://confluence.dimagi.com/display/commcarepublic/Auto-Resize+Images+on+Android'>
   the instructions here</a> to determine which value to use."
   id: "cc-resize-images"
-  value_pairs:
+  values:
     - ['full', 'Full Resize']
     - ['half', 'Half Resize']
     - ['width', 'Horizontal Resize']
@@ -388,7 +389,7 @@
 - name: "Login Duration"
   description: "Length of time after which you will be logged out automatically"
   id: "cc-login-duration-seconds"
-  value_pairs:
+  values:
     - ['86400', '24 hours']
     - ['43200', '12 hours']
     - ['28800', '8 hours']
@@ -407,7 +408,7 @@
   <a href='https://confluence.dimagi.com/display/commcarepublic/Image+Sizing+with+Multiple+Android+Device+Models'>
   the instructions here</a> to determine which value to use."
   id: "cc-inflation-target-density"
-  value_pairs:
+  values:
     - ['120', 'Low Density']
     - ['160', 'Medium Density']
     - ['240', 'High Density']

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
@@ -1,8 +1,11 @@
 - name: "Auto Update Frequency"
   description: "How often CommCare mobile should attempt to check for a new, released application version."
   id: "cc-autoup-freq"
-  values: ["freq-never", "freq-daily", "freq-weekly"]
-  value_names: ["Never", "Daily", "Weekly"]
+  value_pairs:
+    # [values, value_names]
+    - ['freq-never', 'Never']
+    - ['freq-daily', 'Daily']
+    - ['freq-weekly', 'Weekly']
   default: "freq-never"
   values_txt: "After login, the application will look at the profile's defined reference for the authoritative location of the newest version. This check will occur with some periodicity since the last successful check based on this property. freq-never disables the automatic check."
   since: "1.3"
@@ -12,8 +15,9 @@
   description: "Make OTA app updates skip download for video files at app update time."
   id: "lazy-load-video-files"
   toggle: LAZY_LOAD_MULTIMEDIA
-  values: ["true", "false"]
-  value_names: ["Yes", "No"]
+  value_pairs:
+    - ['true', 'Yes']
+    - ['false', 'No']
   default: "false"
   since: "2.50"
   force: true
@@ -22,8 +26,12 @@
   name: "Purge Frequency"
   description: "How often the phone should attempt to purge any cached storage which may have expired"
   id: "purge-freq"
-  values: ["0", "1", "7", "15", "31"]
-  value_names: ["Whenever Possible", "Daily", "Once a Week", "Twice a Month", "Once a Month"]
+  value_pairs:
+    - ['0', 'Whenever Possible']
+    - ['1', 'Daily']
+    - ['7', 'Once a Week']
+    - ['15', 'Twice a Month']
+    - ['31', 'Once a Month']
   default: "0"
   values_txt: "Any positive integer. Represents period of purging in days."
   force: true
@@ -31,8 +39,13 @@
 - name: "Days for Review"
   description: "Amount of time previously submitted forms remain accessible in the CommCare app."
   id: "cc-days-form-retain"
-  values: ["1", "7",  "31", "92", "365", "-1"]
-  value_names: ["Just One Day", "One Week", "One Month", "Three Months", "One Year", "Forms are Never Removed"]
+  value_pairs:
+    - ['1', 'Just One Day']
+    - ['7', 'One Week']
+    - ['31', 'One Month']
+    - ['92', 'Three Months']
+    - ['365', 'One Year']
+    - ['-1', 'Forms are Never Removed']
   requires: "{features.sense}='false'"
   default: "-1"
   values_txt: "Any positive integer. Represents period of purging in days." 
@@ -54,8 +67,10 @@
   requires: "{properties.logenabled}='Enabled'"
   commcare_default: "log_never"
   default: "log_short"
-  values: ["log_never", "log_short", "log_full"]
-  value_names: ["Never", "Short", "Full"]
+  value_pairs:
+    - ['log_never', 'Never']
+    - ['log_short', 'Short']
+    - ['log_full', 'Full']
   group: "log"
   force: true
 
@@ -65,8 +80,10 @@
   requires_txt: "Logging to be Enabled"
   default: "log_never"
   requires: "{properties.logenabled}='Enabled'"
-  values: ["log_never", "log_short", "log_full"]
-  value_names: ["Never", "Short", "Full"]
+  value_pairs:
+    - ['log_never', 'Never']
+    - ['log_short', 'Short']
+    - ['log_full', 'Full']
   group: "log"
   force: true
 
@@ -74,17 +91,19 @@
   description: "Whether or not the phone collects, saves, and sends data."
   id: "cc-send-procedure"
   default: "cc-send-http"
-  values: ["cc-send-http", "cc-send-none"]
+  value_pairs:
+    - ['cc-send-http', 'Yes']
+    - ['cc-send-none', 'No (NOT RECOMMENDED)']
   "//values": ["cc-send-file"]
-  value_names: ["Yes", "No (NOT RECOMMENDED)"]
   "//value_names": ["Save to the File System"]
   force: true
 
 - name: "Password Format"
   description: "Determines whether phone keys will type letters or numbers by default when typing in the password field."
   id: "password_format"
-  values: ["a", "n"]
-  value_names: ["Alphanumeric", "Numeric"]
+  value_pairs:
+    - ['a', 'Alphanumeric']
+    - ['n', 'Numeric']
   default: "a"
   force: true
 
@@ -132,8 +151,9 @@
 - name: "Sync Mode"
   description: "Determines if the server automatically attempts to send data to the phone (Two-Way), or only attempt to send data on demand (Push Only); projects using Case Sharing should choose Two-Way. If set to Push Only, the Auto-Sync Frequency and Unsynced Time Limit settings will have no effect."
   id: "server-tether"
-  values: ["push-only", "sync"]
-  value_names: ["Push Only", "Two-Way Sync"]
+  value_pairs:
+    - ['push-only', 'Push Only']
+    - ['sync', 'Two-Way Sync']
   default: "push-only"
   requires: "{hq.case_sharing}=false"
   contingent_default: [{"condition": "{hq.case_sharing}=true", "value": "sync"}]
@@ -142,8 +162,10 @@
 - name: "Auto-Sync Frequency"
   description: "Automatically trigger a two-way sync on a regular schedule"
   id: "cc-autosync-freq"
-  values: ["freq-never", "freq-daily", "freq-weekly"]
-  value_names: [disabled, "Daily","Weekly"]
+  value_pairs:
+    - ['freq-never', disabled]
+    - ['freq-daily', 'Daily']
+    - ['freq-weekly', 'Weekly']
   default: "freq-never"
   values_txt: "When auto-sync is enabled CommCare will attempt to submit forms and synchronize the user's data after logging in with the frequency chosen."
   since: "2.0"
@@ -160,8 +182,9 @@
 - name: "Form Entry Style"
   description: "What user interface style should be used during form entry."
   id: "ViewStyle"
-  values: ["v_chatterbox","v_singlequestionscreen"]
-  value_names: ["Multiple Questions per Screen", "One Question per Screen"]
+  value_pairs:
+    - ['v_chatterbox', 'Multiple Questions per Screen']
+    - ['v_singlequestionscreen', 'One Question per Screen']
   values_txt: "Multiple Questions per Screen displays a running list of questions on the screen at the same time. One Question per Screen displays each question independently. Note: OQPS does not support some features"
   default: "v_chatterbox"
   force: true
@@ -171,8 +194,9 @@
   type: "features"
   name: "No Users Mode"
   description: "Whether to show the user login screen"
-  values: ["true", "false"]
-  value_names: ["Off", "On"]
+  value_pairs:
+    - ['true', 'Off']
+    - ['false', 'On']
   default: "true"
   group: "sense"
   widget: "bool"
@@ -182,8 +206,9 @@
   type: "features"
   name: "CommCare Sense"
   description: "Configure for low-literate users, J2ME only"
-  values: ["true", "false"]
-  value_names: ["Yes", "No"]
+  value_pairs:
+    - ['true', 'Yes']
+    - ['false', 'No']
   default: "false"
   group: "sense"
   widget: "bool"
@@ -191,8 +216,9 @@
 
 - id: "cc-user-mode"
   name: "User Login Mode"
-  values: ["cc-u-normal", "cc-u-auto"]
-  value_names: ["Normal", "Auto-login"]
+  value_pairs:
+    - ['cc-u-normal', 'Normal']
+    - ['cc-u-auto', 'Auto-login']
   default: "cc-u-normal"
   commcare_default: "<-- having this property be different from 'default' forces 'cc-user-mode' to show up in the profile file"
   "//contingent_default": [{"condition": "{features.sense}='true'", "value": "cc-u-auto"}]
@@ -205,8 +231,9 @@
   description: "Whether form entry is optimized for speed, or for new users."
   id: "cc-entry-mode"
   requires: "{features.sense}='false'"
-  values: ["cc-entry-quick", "cc-entry-review"]
-  value_names: ["Normal Scrolling", "Numeric Selection"]
+  value_pairs:
+    - ['cc-entry-quick', 'Normal Scrolling']
+    - ['cc-entry-review', 'Numeric Selection']
   values_txt: "Numeric Selection mode will display information about questions for longer and require more input from the user. Normal Scrolling will proceed to the next question whenever enough information is provided."
   default: "cc-entry-quick"
   contingent_default: [{"condition": "{features.sense}='true'", "value": "cc-entry-review"}]
@@ -217,8 +244,9 @@
   description: "How Send All Unsent functionality is presented to the user"
   id: "cc-send-unsent"
   requires: "{features.sense}='false'"
-  values: ["cc-su-auto", "cc-su-man"]
-  value_names: ["Automatic", "Manual"]
+  value_pairs:
+    - ['cc-su-auto', 'Automatic']
+    - ['cc-su-man', 'Manual']
   values_txt: "If automatic is enabled, forms will attempt to send on their own without intervention from the user. If manual is enabled, the user must manually decide when to attempt to send forms."
   default: "cc-su-auto"
   commcare_default: "cc-su-man"
@@ -230,8 +258,9 @@
   description: "What the 'Extra Key' (# on Nokia Phones) does when pressed"
   id: "extra_key_action"
   requires: "{features.sense}='false'"
-  values: ["cycle", "audio"]
-  value_names: ["Languages", "Audio"]
+  value_pairs:
+    - ['cycle', 'Languages']
+    - ['audio', 'Audio']
   values_txt: "Language cycles through any available translations. Audio plays the question's audio if available. NOTE: If audio is selected, a question's audio will not be played by default when the question is displayed."
   default: "audio"
   commcare_default: "cycle"
@@ -253,8 +282,9 @@
 - name: "Multimedia Validation"
   description: "Whether CommCare should validate that all external multimedia is installed before letting the user run the app."
   id: "cc-content-valid"
-  values: ["yes", "no"]
-  value_names: ["No Validation", "Validate Multimedia"]
+  value_pairs:
+    - ['yes', 'No Validation']
+    - ['no', 'Validate Multimedia']
   default: "yes"
   values_txt: "If multimedia validation is enabled, CommCare will perform an additional check after installing your app to ensure that all of your multimedia is present on the phone before allowing the app to run. It is recommended for deployment, but will make your app unable to run if multimedia is enabled."
   since: "2.0"
@@ -272,8 +302,13 @@
 - name: "Unsynced Time Limit"
   description: "Days allowed without syncing before triggering a warning"
   id: "unsent-time-limit"
-  values: ["-1", "1", "5", "7", "14", "30"]
-  value_names: ["Never", "1 Day", "5 Days", "One Week", "Two Weeks", "One Month"]
+  value_pairs:
+    - ['-1', 'Never']
+    - ['1', '1 Day']
+    - ['5', '5 Days']
+    - ['7', 'One Week']
+    - ['14', 'Two Weeks']
+    - ['30', 'One Month']
   default: "5"
   values_txt: "When this many days have passed without the user syncing CommCare will trigger a warning"
   since: "2.4"
@@ -282,8 +317,9 @@
 - name: "Login Buttons"
   description: "Choose to label the login buttons with Icons or Text"
   id: "cc-login-images"
-  values: ["Yes", "No"]
-  value_names: ["Icons", "Text"]
+  value_pairs:
+    - ['Yes', 'Icons']
+    - ['No', 'Text']
   default: "No"
   contingent_default: [{"condition": "{features.sense}='true'", "value": "Yes"}]
   values_txt: "This value will set whether the login screen uses customizable icons for login and demo mode options or uses the standard buttons with labels."
@@ -293,8 +329,9 @@
 - name: "Saved Forms"
   description: "Choose whether or not mobile workers can view previously submitted forms."
   id: "cc-show-saved"
-  values: ["yes", "no"]
-  value_names: ["Enable", "Disable"]
+  value_pairs:
+    - ['yes', 'Enable']
+    - ['no', 'Disable']
   default: "no"
   commcare_default: "yes"
   contingent_default: [{"condition": "{features.sense}='true'", "value": "no"}]
@@ -305,8 +342,9 @@
 - name: "Incomplete Forms"
   description: "Choose whether or not to display the 'Incomplete' button on the ODK home screen"
   id: "cc-show-incomplete"
-  values: ["yes", "no"]
-  value_names: ["Enable", "Disable"]
+  value_pairs:
+    - ['yes', 'Enable']
+    - ['no', 'Disable']
   default: "no"
   commcare_default: "yes"
   contingent_default: [{"condition": "{features.sense}='true'", "value": "no"}]
@@ -319,8 +357,11 @@
   <a href='https://confluence.dimagi.com/display/commcarepublic/Auto-Resize+Images+on+Android'>
   the instructions here</a> to determine which value to use."
   id: "cc-resize-images"
-  values: ["full", "half", "width", "none"]
-  value_names: ["Full Resize", "Half Resize", "Horizontal Resize","None"]
+  value_pairs:
+    - ['full', 'Full Resize']
+    - ['half', 'Half Resize']
+    - ['width', 'Horizontal Resize']
+    - ['none', 'None']
   default: "none"
   values_txt: "This will determine how images you select for your questions will be resized to fit the screen. Horizontal will stretch/compress the image to fit perfectly horizontally while scaling to height to maintain the aspect ratio. Full Resize will try to be clever and find the ideal vertical/horizontal scaling for the screen. Half Resize will do the same but with half the area."
   since: "2.11"
@@ -347,8 +388,14 @@
 - name: "Login Duration"
   description: "Length of time after which you will be logged out automatically"
   id: "cc-login-duration-seconds"
-  values:      [   "86400",    "43200",   "28800",    "7200",   "3600",       "1800",        "900"]
-  value_names: ["24 hours", "12 hours", "8 hours", "2 hours", "1 hour", "30 minutes", "15 minutes"]
+  value_pairs:
+    - ['86400', '24 hours']
+    - ['43200', '12 hours']
+    - ['28800', '8 hours']
+    - ['7200', '2 hours']
+    - ['3600', '1 hour']
+    - ['1800', '30 minutes']
+    - ['900', '15 minutes']
   default: "86400"
   values_txt: "This will set the amount of time you will remain logged in before automatically being logged out."
   since: "2.21"
@@ -360,8 +407,14 @@
   <a href='https://confluence.dimagi.com/display/commcarepublic/Image+Sizing+with+Multiple+Android+Device+Models'>
   the instructions here</a> to determine which value to use."
   id: "cc-inflation-target-density"
-  values: ["120", "160", "240", "320", "480", "640", "none"]
-  value_names: ["Low Density", "Medium Density", "High Density", "X-High Density", "XX-High Density", "XXX-High Density", "None"]
+  value_pairs:
+    - ['120', 'Low Density']
+    - ['160', 'Medium Density']
+    - ['240', 'High Density']
+    - ['320', 'X-High Density']
+    - ['480', 'XX-High Density']
+    - ['640', 'XXX-High Density']
+    - ['none', 'None']
   default: "none"
   since: "2.24"
   force: true

--- a/corehq/apps/app_manager/tests/test_commcare_settings.py
+++ b/corehq/apps/app_manager/tests/test_commcare_settings.py
@@ -1,4 +1,3 @@
-import doctest
 import os
 from collections import defaultdict
 
@@ -135,10 +134,3 @@ class CommCareSettingsTest(SimpleTestCase):
                                 static_strings,
                                 'You need to add "{}" to static_strings.py'.format(value)
                             )
-
-
-def test_doctests():
-    import corehq.apps.app_manager.commcare_settings
-
-    results = doctest.testmod(corehq.apps.app_manager.commcare_settings)
-    assert results.failed == 0

--- a/corehq/apps/app_manager/tests/test_commcare_settings.py
+++ b/corehq/apps/app_manager/tests/test_commcare_settings.py
@@ -1,3 +1,4 @@
+import doctest
 import os
 from collections import defaultdict
 
@@ -134,3 +135,10 @@ class CommCareSettingsTest(SimpleTestCase):
                                 static_strings,
                                 'You need to add "{}" to static_strings.py'.format(value)
                             )
+
+
+def test_doctests():
+    import corehq.apps.app_manager.commcare_settings
+
+    results = doctest.testmod(corehq.apps.app_manager.commcare_settings)
+    assert results.failed == 0


### PR DESCRIPTION
## Technical Summary

We are expecting a new CommCare profile setting that has a long(ish?) list of values. This change allows lists of values to be more readable.

(Also, in the case of values whose value names are just their title case, the value names can be omitted.)

:blowfish: 

## Feature Flag
N/A

## Safety Assurance

### Safety story

Small code change

### Automated test coverage

Includes tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
