### PR TITLE
Fix migration race to create items in SQL

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import os
-import re
 import sys
 import traceback
 from contextlib import nullcontext
@@ -12,7 +11,7 @@ from attrs import define, field
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
-from django.db import IntegrityError, transaction
+from django.db import transaction
 
 from corehq.apps.domain.dbaccessors import iterate_doc_ids_in_domain_by_type
 from corehq.dbaccessors.couchapps.all_docs import (
@@ -364,41 +363,14 @@ Run the following commands to run the migration and get up to date:
                 creates.append(obj)
             couch_class.wrap(doc)._migration_sync_to_sql(obj, save=False)
         if creates or updates:
-            self._save(sql_class, creates, updates)
+            with transaction.atomic(), disable_sync_to_couch(sql_class):
+                sql_class.objects.bulk_create(creates, ignore_conflicts=True)
+                for obj in updates:
+                    obj.save()
         update_log("Created", [obj._migration_couch_id for obj in creates])
         update_log("Updated", [obj._migration_couch_id for obj in updates])
         update_log("Ignored", [doc["_id"] for doc in ignored])
         self.ignored_count += len(ignored)
-
-    def _save(self, sql_class, creates, updates):
-        def attempt_save():
-            with transaction.atomic(), disable_sync_to_couch(sql_class):
-                sql_class.objects.bulk_create(creates)
-                for obj in updates:
-                    obj.save()
-
-        def remove_concurrently_created_items(err):
-            match = DUPLICATE_KEY.search(str(err))
-            if match and match.group("table") == sql_class._meta.db_table:
-                exclude_pks = set(
-                    sql_class.objects.filter(pk__in=[x.pk for x in creates])
-                    .values_list("pk", flat=True)
-                )
-                if exclude_pks:
-                    creates[:] = [x for x in creates if x.pk not in exclude_pks]
-                    print("Concurrently created:", exclude_pks)
-                    return True
-            return False
-
-        max_attempts = 10
-        for i in range(max_attempts + 1):
-            try:
-                attempt_save()
-            except IntegrityError as err:
-                if i < max_attempts and remove_concurrently_created_items(err):
-                    continue  # try again
-                raise
-            break
 
     def _verify_docs(self, docs, logfile, verify_only):
         sql_class = self.sql_class()
@@ -482,7 +454,6 @@ Run the following commands to run the migration and get up to date:
         return open(log_path, mode)
 
 
-DUPLICATE_KEY = re.compile(r'duplicate key value violates unique constraint "(?P<table>.+)_pkey"')
 DIFF_HEADER = "Doc {} has differences:\n"
 
 

--- a/corehq/apps/fixtures/tests/test_couchsqlmigration.py
+++ b/corehq/apps/fixtures/tests/test_couchsqlmigration.py
@@ -383,6 +383,57 @@ class TestLookupTableCouchToSQLMigration(TestCase):
             [],
         )
 
+    def test_migration_race(self):
+        def migration_runner():
+            # use the same connection as main test thread
+            connections[DEFAULT_DB_ALIAS] = test_connection
+            call_command('populate_lookuptables')
+
+        def migration_blocker(self, doc):
+            concurrent_save.set()
+            if not allow_migration.wait(timeout=10):
+                raise RuntimeError("allow_migration timeout")
+            return False
+
+        def diff(doc):
+            return self.diff(doc.to_json(), LookupTable.objects.get(id=doc._id))
+
+        from threading import Thread, Event
+        from django.db import DEFAULT_DB_ALIAS, connections
+        test_connection = connections[DEFAULT_DB_ALIAS]
+        test_connection.inc_thread_sharing()
+        try:
+            concurrent_save = Event()
+            allow_migration = Event()
+
+            # save documents to Couch only (not SQL)
+            price, obj = create_lookup_table(unwrap_doc=False)
+            color, obj = create_lookup_table(unwrap_doc=False, tag="color")
+            shape, obj = create_lookup_table(unwrap_doc=False, tag="shape")
+            price.save(sync_to_sql=False)
+            color.save(sync_to_sql=False)
+            shape.save(sync_to_sql=False)
+
+            with patch.object(LookupTableCommand, "should_ignore", migration_blocker):
+                migration = Thread(target=migration_runner)
+                migration.start()  # loads Couch docs, blocks on should_ignore
+
+                if not concurrent_save.wait(timeout=10):
+                    raise RuntimeError("concurrent_save timeout")
+                # Save some SQL records before migration has a chance.
+                # Should not cause migration to fail with IntegrityError.
+                price.save()
+                color.save()
+
+                allow_migration.set()
+                migration.join()
+
+                self.assertEqual(diff(price), [])
+                self.assertEqual(diff(color), [])
+                self.assertEqual(diff(shape), [])
+        finally:
+            test_connection.dec_thread_sharing()
+
     def diff(self, doc, obj):
         return do_diff(LookupTableCommand, doc, obj)
 
@@ -631,7 +682,7 @@ class TestLookupTableRowOwnerCouchToSQLMigration(TestCase):
         return do_diff(LookupTableRowOwnerCommand, doc, obj)
 
 
-def create_lookup_table(unwrap_doc=True):
+def create_lookup_table(unwrap_doc=True, **extra):
     def fields_data(name="name"):
         return [
             {
@@ -654,10 +705,11 @@ def create_lookup_table(unwrap_doc=True):
             'item_attributes': ['name'],
             **extra,
         }
-    obj = jsonattrify(LookupTable, data())
+    obj = jsonattrify(LookupTable, data(**extra))
     doc = FixtureDataType.wrap(data(
         doc_type="FixtureDataType",
         fields=fields_data("field_name"),
+        **extra
     ))
     if unwrap_doc:
         doc = doc.to_json()


### PR DESCRIPTION
Race description:
- HQ process saves a Couch doc
- migration loads batch of Couch docs including that doc
- HQ process saves SQL doc corresponding to the Couch doc
- migration attempts to save batch of SQL docs, crash on duplicate
- resolution: remove that doc from the SQL batch and try again

## Safety Assurance

### Safety story

Only affects Couch to SQL migration management commands. Tests added for lookup tables migration.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
