### PR TITLE
Fix sync issue with FixtureDataItem and improve --verify-only command option

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -310,7 +310,7 @@ Run the following commands to run the migration and get up to date:
                 if not verify_only:
                     migrate(item, logfile)
                 if not skip_verify:
-                    verify(item, logfile, exit=not verify_only)
+                    verify(item, logfile, verify_only)
                 if not is_bulk:
                     doc_index += 1
                     if doc_index % 1000 == 0:
@@ -373,7 +373,7 @@ Run the following commands to run the migration and get up to date:
         update_log("Ignored", [doc["_id"] for doc in ignored])
         self.ignored_count += len(ignored)
 
-    def _verify_docs(self, docs, logfile, exit=True):
+    def _verify_docs(self, docs, logfile, verify_only):
         sql_class = self.sql_class()
         couch_id_name = getattr(sql_class, '_migration_couch_id_name', 'couch_id')
         couch_ids = [doc["_id"] for doc in docs]
@@ -382,13 +382,16 @@ Run the following commands to run the migration and get up to date:
         self.missing_in_sql_count += len(couch_ids) - len(objs_by_couch_id)
         diff_count = self.diff_count
         for doc in docs:
+            if verify_only and self.should_ignore(doc):
+                self.ignored_count += 1
+                continue
             obj = objs_by_couch_id.get(doc["_id"])
             if obj is not None:
-                self._do_diff(doc, obj, logfile, exit=False)
+                self._do_diff(doc, obj, logfile)
         if diff_count != self.diff_count:
             print(f"Diff count: {self.diff_count}")
 
-    def _do_diff(self, doc, obj, logfile, exit):
+    def _do_diff(self, doc, obj, logfile, exit=False):
         diff = self.get_diff_as_string(doc, obj)
         if diff:
             logfile.write(DIFF_HEADER.format(json.dumps(doc['_id'])))
@@ -398,11 +401,14 @@ Run the following commands to run the migration and get up to date:
             if exit:
                 raise CommandError(f"Doc verification failed for {doc['_id']!r}. Exiting.")
 
-    def _verify_doc(self, doc, logfile, exit=True):
+    def _verify_doc(self, doc, logfile, verify_only):
+        if verify_only and self.should_ignore(doc):
+            self.ignored_count += 1
+            return
         try:
             couch_id_name = getattr(self.sql_class(), '_migration_couch_id_name', 'couch_id')
             obj = self.sql_class().objects.get(**{couch_id_name: doc["_id"]})
-            self._do_diff(doc, obj, logfile, exit)
+            self._do_diff(doc, obj, logfile, exit=not verify_only)
         except self.sql_class().DoesNotExist:
             self.missing_in_sql_count += 1
 

--- a/corehq/apps/fixtures/management/commands/populate_lookuptablerows.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptablerows.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from uuid import UUID
 from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
 
@@ -49,7 +50,7 @@ class Command(PopulateSQLCommand):
             ),
             cls.diff_value(
                 "item_attributes",
-                couch.get("item_attributes") or {},
+                transform_item_attributes(couch.get("item_attributes") or {}),
                 sql.item_attributes,
             ),
             cls.diff_value(
@@ -84,3 +85,11 @@ def couch_to_sql_fields(data):
         ]
         for name, field in data.items()
     }
+
+
+def transform_item_attributes(data):
+    def convert(value):
+        if isinstance(value, Decimal):
+            return str(value)
+        return value
+    return {name: convert(value) for name, value in data.items()}

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -169,11 +169,7 @@ class LookupTableRow(SyncSQLToCouchMixin, models.Model):
 
     @classmethod
     def _migration_get_fields(cls):
-        return [
-            "domain",
-            "item_attributes",
-            "sort_key",
-        ]
+        return ["domain", "sort_key"]
 
     def _migration_sync_to_couch(self, couch_object):
         if couch_object.data_type_id is None or UUID(couch_object.data_type_id) != self.table_id:
@@ -187,6 +183,8 @@ class LookupTableRow(SyncSQLToCouchMixin, models.Model):
                     ) for val in values
                 ]) for name, values in self.fields.items()
             }
+        if self.item_attributes != couch_object._sql_item_attributes:
+            couch_object.item_attributes = self.item_attributes
         super()._migration_sync_to_couch(couch_object)
 
     @classmethod

--- a/corehq/apps/fixtures/tests/test_couchsqlmigration.py
+++ b/corehq/apps/fixtures/tests/test_couchsqlmigration.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from decimal import Decimal
 from unittest.mock import patch
 from uuid import UUID
 from pathlib import Path
@@ -172,6 +173,12 @@ class TestLookupTableRowCouchToSQLDiff(SimpleTestCase):
             self.diff(doc, obj),
             ["item_attributes: couch value {'name': 'Andy'} != sql value {'age': '4'}"],
         )
+
+    def test_diff_decimal_item_attribute(self):
+        doc, obj = create_lookup_table_row()
+        doc["item_attributes"] = {"height": Decimal("3.2")}
+        obj.item_attributes = {"height": "3.2"}
+        self.assertEqual(self.diff(doc, obj), [])
 
     def test_diff_doc_without_item_attributes(self):
         doc, obj = create_lookup_table_row()
@@ -430,11 +437,11 @@ class TestLookupTableRowCouchToSQLMigration(TestCase):
         )
 
         doc.fields['amount']['field_list'][0]['field_value'] = '1000'
-        doc.item_attributes = {'name': 'Andy', 'age': '4'}
+        doc.item_attributes = {'name': 'Andy', 'age': '4', 'height': Decimal('3.2')}
         doc.sort_key = None
         doc.save()
         obj = LookupTableRow.objects.get(id=UUID(doc._id))
-        self.assertEqual(obj.item_attributes, {'name': 'Andy', 'age': '4'})
+        self.assertEqual(obj.item_attributes, {'name': 'Andy', 'age': '4', 'height': '3.2'})
         self.assertEqual(obj.fields['amount'], [Field('1000', {})])
         self.assertEqual(obj.sort_key, 0)
 


### PR DESCRIPTION
The most important change is the second commit, which handles `Decimal` objects in `FixtureDataItem.item_attributes`. JsonObject automatically converts strings that look like floating point numbers to `Decimal`, and these values cannot be serialized as JSON without additional conversion. This issue was discovered while running `./manage.py populate_lookuptablerows` on a live environment.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

All changes except for the `--verify-only` management command option are covered by automated tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
