### PR TITLE
Updated app manager intro content to only show when app is brand new

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -214,7 +214,7 @@ def get_releases_context(request, domain, app_id):
         context.update({
             'enable_update_prompts': app.enable_update_prompts,
         })
-        if len(app.modules) == 0:
+        if app.version == 1:
             context.update({'intro_only': True})
 
         # Multimedia is not supported for remote applications at this time.


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/SAAS-13789

The help content this flag controls is aimed at users who are brand new to HQ and don’t know what to do first. If someone has added and deleted menus (or made a different app change, like updating a setting), they know enough that those hints aren’t valuable.

## Safety Assurance

### Safety story
Minor UI-level change to help content.

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
