### PR TITLE
Fix lookup table is_global diff

### DIFF
--- a/corehq/apps/fixtures/management/commands/populate_lookuptables.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptables.py
@@ -30,8 +30,12 @@ class Command(PopulateSQLCommand):
         differences, or None if the two are equivalent. The list may
         contain `None` or empty strings.
         """
-        fields = ["domain", "is_global", "tag"]
-        diffs = [cls.diff_attr(name, couch, sql) for name in fields]
+        diffs = [cls.diff_attr(name, couch, sql) for name in ["domain", "tag"]]
+        diffs.append(cls.diff_value(
+            "is_global",
+            couch.get("is_global") or False,
+            sql.is_global,
+        ))
         for field in ["item_attributes", "description"]:
             diffs.append(cls.diff_maybe_empty_field(field, couch, sql))
         diffs.append(cls.diff_value(

--- a/corehq/apps/fixtures/tests/test_couchsqlmigration.py
+++ b/corehq/apps/fixtures/tests/test_couchsqlmigration.py
@@ -50,6 +50,17 @@ class TestLookupTableCouchToSQLDiff(SimpleTestCase):
             ["is_global: couch value True != sql value False"],
         )
 
+    def test_diff_null_is_global(self):
+        doc, obj = create_lookup_table(is_global=None)
+        obj.is_global = False
+        self.assertEqual(self.diff(doc, obj), [])
+
+    def test_diff_missing_is_global(self):
+        doc, obj = create_lookup_table()
+        obj.is_global = False
+        del doc["is_global"]
+        self.assertEqual(self.diff(doc, obj), [])
+
     def test_diff_tag(self):
         doc, obj = create_lookup_table()
         obj.tag = 'cost'
@@ -116,8 +127,8 @@ class TestLookupTableCouchToSQLDiff(SimpleTestCase):
         self.assertEqual(
             self.diff(doc, obj),
             [
-                "is_global: couch value True != sql value False",
                 "tag: couch value 'cost' != sql value 'price'",
+                "is_global: couch value True != sql value False",
             ],
         )
 


### PR DESCRIPTION
Resolves unexpected diff logs: `is_global: couch value None != sql value False`

Also include missing SQL docs in diff log so they can be more easily identified and reprocessed.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Changes in the [first commit](https://github.com/dimagi/commcare-hq/commit/c7dc2ad50c4f4b213726aa5fe980ce898e563d99) are covered by automated tests. The [second commit](https://github.com/dimagi/commcare-hq/commit/ec3dc687ecfa68081423b3e3c72c5cdc314ccbfd) is a low-risk change to management command logging and output.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
