### PR TITLE
Add `indexed_on` to new v0.6 case API

### DIFF
--- a/corehq/apps/hqcase/api/core.py
+++ b/corehq/apps/hqcase/api/core.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from dimagi.utils.parsing import json_format_datetime
 from corehq.apps.case_search.const import SPECIAL_CASE_PROPERTIES
 
@@ -14,6 +15,9 @@ def serialize_case(case):
         "date_opened": _isoformat(case.opened_on),
         "last_modified": _isoformat(case.modified_on),
         "server_last_modified": _isoformat(case.server_modified_on),
+        # This is used for cases that were just created, which haven't yet been indexed
+        # Providing this maintains compatibility with the es response
+        "indexed_on": _isoformat(datetime.utcnow()),
         "closed": case.closed,
         "date_closed": _isoformat(case.closed_on),
         "properties": dict(case.dynamic_case_properties()),
@@ -44,6 +48,7 @@ def serialize_es_case(case_doc):
         "date_opened": case_doc['opened_on'],
         "last_modified": case_doc['modified_on'],
         "server_last_modified": case_doc['server_modified_on'],
+        "indexed_on": case_doc['@indexed_on'],
         "closed": case_doc['closed'],
         "date_closed": case_doc['closed_on'],
         "properties": {

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -76,6 +76,21 @@ class TestCaseAPIBulkGet(TestCase):
             external_id=external_id,
         )
 
+    def test_get_single_case(self):
+        res = self.client.get(reverse('case_api', args=(self.domain, self.case_ids[0])))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json()['case_id'], self.case_ids[0])
+
+    def test_get_single_case_not_found(self):
+        res = self.client.get(reverse('case_api', args=(self.domain, 'fake_id')))
+        self.assertEqual(res.status_code, 404)
+        self.assertEqual(res.json()['error'], "Case 'fake_id' not found")
+
+    def test_get_single_case_on_other_domain(self):
+        res = self.client.get(reverse('case_api', args=(self.domain, self.other_domain_case_id)))
+        self.assertEqual(res.status_code, 404)
+        self.assertEqual(res.json()['error'], f"Case '{self.other_domain_case_id}' not found")
+
     def test_bulk_get(self):
         case_ids = self.case_ids[0:2]
         self._call_get_api_check_results(case_ids, matching=2, missing=0)

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -91,35 +91,11 @@ class TestCaseAPI(TestCase):
         # for the time being, the implementation is the same
         return self._create_case(body)
 
-    def test_simple_get(self):
-        case_id = self._make_case().case_id
-        res = self.client.get(reverse('case_api', args=(self.domain, case_id)))
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json()['case_id'], case_id)
-
     def test_basic_get_list(self):
         with patch('corehq.apps.hqcase.views.get_list', lambda *args: {'example': 'result'}):
             res = self.client.get(reverse('case_api', args=(self.domain,)))
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.json(), {'example': 'result'})
-
-    def test_case_not_found(self):
-        res = self.client.get(reverse('case_api', args=(self.domain, 'fake_id')))
-        self.assertEqual(res.status_code, 404)
-        self.assertEqual(res.json()['error'], "Case 'fake_id' not found")
-
-    def test_case_on_other_domain(self):
-        case_id = str(uuid.uuid4())
-        submit_case_blocks([CaseBlock(
-            case_id=case_id,
-            case_type='player',
-            case_name='Judit Polgár',
-            create=True,
-            update={}
-        ).as_text()], domain='other_domain')
-        res = self.client.get(reverse('case_api', args=(self.domain, case_id)))
-        self.assertEqual(res.status_code, 404)
-        self.assertEqual(res.json()['error'], f"Case '{case_id}' not found")
 
     def test_create_case(self):
         res = self._create_case({


### PR DESCRIPTION
## Product Description
Adds in an `indexed_on` property to the serialization format in the new case API

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2319
Adds the `indexed_on` property and switches the individual GET endpoint to pull from ES like the other read endpoints

## Feature Flag
Enable the v0.6 Case API

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested and it's feature-flagged anyways

### Automated test coverage

Included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
