### PR TITLE
updating Kafka command based on the new version, which supports 2.x and 3.x

### DIFF
--- a/corehq/ex-submodules/pillowtop/management/commands/add_kafka_partition.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/add_kafka_partition.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
             print("then stop them")
 
         kafka_command = (
-            "./kafka-topics.sh --alter --zookeeper <zk IP>:2181 --partitions={} --topic={}"
+            "./kafka-topics.sh --alter --bootstrap-server <kafka IP>:9092 --partitions={} --topic={}"
             .format(num_partitions, topic)
         )
         print(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

https://dimagi-dev.atlassian.net/browse/SAAS-13630
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I have tested this change in both Kafka versions 2.6.1 and 3.2.0. 
From 3.x version the argument `--zookeeper` is removed completely. 

Related Commcare-cloud #PR https://github.com/dimagi/commcare-cloud/pull/5403

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/11612356/185603766-a229ce8b-1044-423b-bddd-1911b0ae2933.png">

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations~

(Reverting this PR after Kafka is upgraded to 3.x would cause this command not to work anymore.)

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
