### PR TITLE
Location API v6 - Read

### DIFF
--- a/corehq/apps/api/tests/utils.py
+++ b/corehq/apps/api/tests/utils.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 
 from django.test import TestCase
 from django.urls import reverse
-from django.utils.http import urlencode
 
 from django_prbac.models import Role
 

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -83,6 +83,9 @@ API_LIST = (
         LookupTableResource,
         LookupTableItemResource,
     )),
+    ((0, 6), (
+        locations.v0_6.LocationResource,
+    ))
 )
 
 

--- a/corehq/apps/locations/resources/__init__.py
+++ b/corehq/apps/locations/resources/__init__.py
@@ -1,1 +1,1 @@
-from . import v0_1, v0_5
+from . import v0_1, v0_5, v0_6

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -13,6 +13,7 @@ class LocationResource(v0_5.LocationResource):
         detail_uri_name = 'location_id'
         authentication = RequirePermissionAuthentication(HqPermissions.edit_locations)
         allowed_methods = ['get']
+        include_resource_uri = False
         fields = {
             'domain',
             'location_id',
@@ -28,7 +29,6 @@ class LocationResource(v0_5.LocationResource):
         }
 
     def dehydrate(self, bundle):
-        del bundle.data['resource_uri']
         if bundle.obj.parent:
             bundle.data['parent_location_id'] = bundle.obj.parent.location_id
         else:

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -1,0 +1,38 @@
+from corehq.apps.api.resources.auth import RequirePermissionAuthentication
+from corehq.apps.locations.models import SQLLocation
+from corehq.apps.users.models import HqPermissions
+
+from corehq.apps.locations.resources import v0_5
+
+
+class LocationResource(v0_5.LocationResource):
+    resource_name = 'location'
+
+    class Meta:
+        queryset = SQLLocation.objects.filter(is_archived=False).all()
+        detail_uri_name = 'location_id'
+        authentication = RequirePermissionAuthentication(HqPermissions.edit_locations)
+        allowed_methods = ['get']
+        fields = {
+            'domain',
+            'location_id',
+            'name',
+            'site_code',
+            'last_modified',
+            'latitude',
+            'longitude',
+            'location_data',
+        }
+        filtering = {
+            "domain": ('exact',),
+        }
+
+    def dehydrate(self, bundle):
+        del bundle.data['resource_uri']
+        if bundle.obj.parent:
+            bundle.data['parent_location_id'] = bundle.obj.parent.location_id
+        else:
+            bundle.data['parent_location_id'] = ''
+        bundle.data['location_type_name'] = bundle.obj.location_type.name
+        bundle.data['location_type_code'] = bundle.obj.location_type.code
+        return bundle

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -9,7 +9,7 @@ class LocationResource(v0_5.LocationResource):
     resource_name = 'location'
 
     class Meta:
-        queryset = SQLLocation.objects.filter(is_archived=False).all()
+        queryset = SQLLocation.active_objects.all()
         detail_uri_name = 'location_id'
         authentication = RequirePermissionAuthentication(HqPermissions.edit_locations)
         allowed_methods = ['get']

--- a/corehq/apps/locations/tests/test_api_v6.py
+++ b/corehq/apps/locations/tests/test_api_v6.py
@@ -1,0 +1,111 @@
+import json
+from corehq.apps.api.tests.utils import APIResourceTest
+from corehq.apps.locations.models import LocationType, SQLLocation
+from corehq.apps.locations.resources.v0_6 import LocationResource
+from corehq.util.view_utils import absolute_reverse
+
+
+class LocationV6Test(APIResourceTest):
+    api_name = 'v0.6'
+    resource = LocationResource
+
+    def setUp(self):
+        self.parent_type = LocationType.objects.create(
+            domain=self.domain.name,
+            name="State",
+            code="state",
+        )
+
+        self.child_type = LocationType.objects.create(
+            domain=self.domain.name,
+            name="City",
+            code="city",
+            parent_type=self.parent_type
+        )
+
+        self.location1 = SQLLocation.objects.create(
+            domain=self.domain.name,
+            id="1234",
+            location_id="1",
+            name="Colorado",
+            site_code="colorado",
+            location_type=self.parent_type
+        )
+
+        self.location2 = SQLLocation.objects.create(
+            domain=self.domain.name,
+            id="1235",
+            location_id="2",
+            name="Denver",
+            site_code="denver",
+            longitude=10.1234567891,
+            latitude=11.1234567891,
+            location_type=self.child_type,
+            parent=self.location1,
+            metadata={"population": "715,522"}
+        )
+
+    def single_endpoint(self, id):
+        return absolute_reverse('api_dispatch_detail', kwargs=dict(domain=self.domain.name,
+                                                          api_name=self.api_name,
+                                                          resource_name=self.resource._meta.resource_name,
+                                                          location_id=id))
+
+    # Disregards order of fields in output.
+    def _validate_obj_output(self, desired_output, actual_output):
+        for key in desired_output.keys():
+            self.assertEqual(desired_output[key], actual_output[key])
+
+    def test_list(self):
+        response = self._assert_auth_get_resource(self.list_endpoint)
+        self.assertEqual(response.status_code, 200)
+
+        self._validate_obj_output({
+            "domain": self.domain.name,
+            "last_modified": self.location1.last_modified.isoformat(),
+            "latitude": None,
+            "location_data": {},
+            "location_id": "1",
+            "location_type_code": "state",
+            "location_type_name": "State",
+            "longitude": None,
+            "name": "Colorado",
+            "parent_location_id": "",
+            "site_code": "colorado"
+        }, json.loads(response.content.decode('utf-8'))['objects'][0])
+
+        self._validate_obj_output({
+            "domain": self.domain.name,
+            "last_modified": self.location2.last_modified.isoformat(),
+            "latitude": "11.1234567891",
+            "location_data": {
+                "population": "715,522"
+            },
+            "location_id": "2",
+            "location_type_code": "city",
+            "location_type_name": "City",
+            "longitude": "10.1234567891",
+            "name": "Denver",
+            "parent_location_id": "1",
+            "site_code": "denver"
+        }, json.loads(response.content.decode('utf-8'))['objects'][1])
+
+    def test_detail(self):
+        response = self._assert_auth_get_resource(self.single_endpoint(self.location2.location_id))
+        self.assertEqual(response.status_code, 200)
+
+        self._validate_obj_output({
+            "domain": self.domain.name,
+            "last_modified": self.location2.last_modified.isoformat(),
+            "latitude": "11.1234567891",
+            "location_data": {
+                "population": "715,522"
+            },
+            "location_id": "2",
+            "location_type_code": "city",
+            "location_type_name": "City",
+            "longitude": "10.1234567891",
+            "name": "Denver",
+            "parent_location_id": "1",
+            "site_code": "denver"
+        }, json.loads(response.content.decode('utf-8')))

--- a/corehq/apps/locations/tests/test_api_v6.py
+++ b/corehq/apps/locations/tests/test_api_v6.py
@@ -54,7 +54,7 @@ class LocationV6Test(APIResourceTest):
         response = self._assert_auth_get_resource(self.list_endpoint)
         self.assertEqual(response.status_code, 200)
 
-        self.assertDictEqual({
+        location_1_dict = {
             "domain": self.domain.name,
             "last_modified": self.location1.last_modified.isoformat(),
             "latitude": None,
@@ -66,9 +66,9 @@ class LocationV6Test(APIResourceTest):
             "name": "Colorado",
             "parent_location_id": "",
             "site_code": "colorado"
-        }, response.json()['objects'][0])
+        }
 
-        self.assertDictEqual({
+        location_2_dict = {
             "domain": self.domain.name,
             "last_modified": self.location2.last_modified.isoformat(),
             "latitude": "11.1234567891",
@@ -82,7 +82,15 @@ class LocationV6Test(APIResourceTest):
             "name": "Denver",
             "parent_location_id": "1",
             "site_code": "denver"
-        }, response.json()['objects'][1])
+        }
+
+        try:
+            self.assertDictEqual(location_1_dict, response.json()['objects'][0])
+            self.assertDictEqual(location_2_dict, response.json()['objects'][1])
+        # Order of results doesn't matter, and order varies between envs.
+        except AssertionError:
+            self.assertDictEqual(location_1_dict, response.json()['objects'][1])
+            self.assertDictEqual(location_2_dict, response.json()['objects'][0])
 
     def test_detail(self):
         response = self._assert_auth_get_resource(self.single_endpoint(self.location2.location_id))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Jira: [USH-2359](https://dimagi-dev.atlassian.net/browse/USH-2359?atlOrigin=eyJpIjoiNTkwNjY5OTgzMjY2NDVjMTk5ODViNmQyNmRjMjA1ZWUiLCJwIjoiaiJ9). The linked spec there gives a good overview of what I'm trying to implement here.

This PR is just for reading (to get a list of locations or just a single individual location).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I tried different Tastypie methods to add custom fields/remove a field as part of the response, but landed on dehydrate which seems to be the most commonly supported with Tastypie and resulted in the most succinct code.

If you're familiar with the APIs and Tastypie I think you'll have enough context to review this.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

I don't think there's one for the generic API. Should the location API have one?

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

This is purely an additional feature, so it shouldn't break anything. There might be some kind of an authorization risk but for the most part I think I followed existed syntaxes in HQ.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added as part of this PR.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

To be done at the end of Location API work after this is all released (see all the tickets [here](https://dimagi-dev.atlassian.net/browse/USH-2355?jql=issueKey%20in%20(USH-2355%2CUSH-2359%2C%20USH-2360%2C%20USH-2363))).


### Migrations

No migrations.

<!-- Please link to any past code changes that are coordinated with this migration -->
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
