### PR TITLE
[couch-to-sql][Repeaters][Phase-2] Move most of the Repeater.get call to SQL

### DIFF
--- a/corehq/apps/zapier/signals/receivers.py
+++ b/corehq/apps/zapier/signals/receivers.py
@@ -6,7 +6,7 @@ from tastypie.http import HttpBadRequest
 
 from corehq.apps.zapier.consts import CASE_TYPE_REPEATER_CLASS_MAP, EventTypes
 from corehq.apps.zapier.models import ZapierSubscription
-from corehq.motech.repeaters.models import FormRepeater
+from corehq.motech.repeaters.models import FormRepeater, SQLFormRepeater
 
 
 @receiver(pre_save, sender=ZapierSubscription)
@@ -48,7 +48,7 @@ def zapier_subscription_post_delete(sender, instance, *args, **kwargs):
     Deletes the repeater object when the corresponding zap is turned off
     """
     if instance.event_name == EventTypes.NEW_FORM:
-        repeater = FormRepeater.get(instance.repeater_id)
+        repeater = SQLFormRepeater.objects.get(repeater_id=instance.repeater_id)
     elif instance.event_name in CASE_TYPE_REPEATER_CLASS_MAP:
         repeater = CASE_TYPE_REPEATER_CLASS_MAP[instance.event_name].get(instance.repeater_id)
     else:

--- a/corehq/motech/dhis2/tests/data/repeater.py
+++ b/corehq/motech/dhis2/tests/data/repeater.py
@@ -1,3 +1,149 @@
+dhis2_entity_repeater_data = {
+    "dhis2_entity_config":
+    {
+        "case_configs":
+        [
+            {
+                "doc_type": "Dhis2CaseConfig",
+                "case_type": "cps",
+                "te_type_id": "Vz4rOPQJPHW",
+                "tei_id":
+                {
+                    "case_property": "dhis2_tei_id"
+                },
+                "org_unit_id":
+                {
+                    "value": "QVRHaVvDQgD"
+                },
+                "attributes":
+                {
+                    "L94Yck2opZn":
+                    {
+                        "case_property": "first_name"
+                    },
+                    "AAEYzp0EvHi":
+                    {
+                        "case_property": "last_name"
+                    },
+                    "v3bPqw4oA6O":
+                    {
+                        "case_property": "gender"
+                    },
+                    "f3VOrC9HBOm":
+                    {
+                        "case_property": "child_age"
+                    },
+                    "uE8D2CincNr":
+                    {
+                        "case_property": "mother_name"
+                    }
+                },
+                "finder_config":
+                {
+                    "property_weights":
+                    [
+                        {
+                            "case_property": "first_name",
+                            "weight": "0.35",
+                            "match_type": "exact",
+                            "match_params":
+                            [],
+                            "doc_type": "PropertyWeight"
+                        },
+                        {
+                            "case_property": "last_name",
+                            "weight": "0.55",
+                            "match_type": "exact",
+                            "match_params":
+                            [],
+                            "doc_type": "PropertyWeight"
+                        },
+                        {
+                            "case_property": "child_age",
+                            "weight": "0.1",
+                            "match_type": "exact",
+                            "match_params":
+                            [],
+                            "doc_type": "PropertyWeight"
+                        }
+                    ],
+                    "confidence_margin": "0.5",
+                    "doc_type": "FinderConfig"
+                },
+                "form_configs":
+                [
+                    {
+                        "doc_type": "Dhis2FormConfig",
+                        "xmlns": "http://openrosa.org/formdesigner/69A0067F-B757-4EDB-B1FF-470D3BCA3F15",
+                        "program_id": "Jz69xPyCQtD",
+                        "program_stage_id":
+                        {
+                            "value": "YWXud3jESes"
+                        },
+                        "org_unit_id":
+                        {
+                            "value": "QVRHaVvDQgD"
+                        },
+                        "program_status":
+                        {
+                            "value": "ACTIVE"
+                        },
+                        "event_status":
+                        {
+                            "value": "ACTIVE"
+                        },
+                        "datavalue_maps":
+                        [
+                            {
+                                "data_element_id": "XcZFbXk5dqH",
+                                "value":
+                                {
+                                    "form_question": "/data/treatment_provided"
+                                },
+                                "doc_type": "FormDataValueMap"
+                            },
+                            {
+                                "data_element_id": "OWJwRcDOgzx",
+                                "value":
+                                {
+                                    "form_question": "/data/side_effects"
+                                },
+                                "doc_type": "FormDataValueMap"
+                            }
+                        ],
+                        "enrollment_date":
+                        {},
+                        "incident_date":
+                        {},
+                        "event_date":
+                        {
+                            "form_question": "/metadata/received_on",
+                            "external_data_type": "dhis2_date"
+                        },
+                        "completed_date":
+                        {},
+                        "event_location":
+                        {}
+                    }
+                ],
+                "relationships_to_export":
+                []
+            }
+        ],
+        "doc_type": "Dhis2EntityConfig"
+    },
+    "repeater_type": "Dhis2EntityRepeater",
+    "version": "2.0",
+    "white_listed_case_types":
+    [],
+    "black_listed_users":
+    [],
+    "format": "form_json",
+    "is_paused": False,
+    "dhis2_version": "2.33.9",
+    "dhis2_version_last_modified": "2021-11-08T15:56:10.854630Z"
+}
+
 dhis2_repeater_data = {
     "dhis2_config":
     {

--- a/corehq/motech/dhis2/tests/data/repeater.py
+++ b/corehq/motech/dhis2/tests/data/repeater.py
@@ -1,0 +1,89 @@
+dhis2_repeater_data = {
+    "dhis2_config":
+    {
+        "doc_type": "Dhis2Config",
+        "form_configs":
+        [
+            {
+                "doc_type": "Dhis2FormConfig",
+                "xmlns": "http://openrosa.org/formdesigner/3974C41B-0BC4-4B27-B6D2-6FE49E33D961",
+                "datavalue_maps":
+                [
+                    {
+                        "data_element_id": "S9zdlWB1xny",
+                        "value":
+                        {
+                            "doc_type": "FormQuestion",
+                            "form_question": "/data/dhis2_indicators/dhis2_avortement_bovin_ovin_caprin"
+                        },
+                        "doc_type": "FormDataValueMap"
+                    },
+                    {
+                        "data_element_id": "ENxf6cfFlFR",
+                        "categoryOptionCombo": "iaUZ0KXio4m",
+                        "value":
+                        {
+                            "doc_type": "FormQuestion",
+                            "form_question": "/data/dhis2_indicators/dhis2_suscption_rougeole_mort"
+                        },
+                        "doc_type": "FormDataValueMap"
+                    },
+                    {
+                        "data_element_id": "VOpvrwKrAoJ",
+                        "value":
+                        {
+                            "doc_type": "FormQuestion",
+                            "form_question": "/data/dhis2_indicators/dhis2_mention_particuliere"
+                        },
+                        "doc_type": "FormDataValueMap"
+                    }
+                ],
+                "org_unit_id":
+                {
+                    "location_field": "org_unit_id_simr",
+                    "doc_type": "FormUserAncestorLocationField"
+                },
+                "program_id": "lasd4I6jsbl",
+                "event_status":
+                {
+                    "value": "COMPLETED"
+                },
+                "dataSet": "WEu0IGoo8mU",
+                "completeDate":
+                {
+                    "form_question": "/data/dhis2_indicators/dates_calc/date",
+                    "doc_type": "FormQuestion"
+                },
+                'event_location': {},
+                "period":
+                {
+                    "form_question": "/data/dhis2_indicators/dhis2_real_date",
+                    "doc_type": "FormQuestion"
+                },
+                "event_date":
+                {
+                    "form_question": "/data/dhis2_indicators/dhis2_real_date",
+                    "doc_type": "FormQuestion"
+                },
+                "completed_date": None,
+                "enrollment_date":
+                {},
+                "incident_date":
+                {},
+                "program_stage_id":
+                {},
+                "program_status":
+                {
+                    "value": "ACTIVE"
+                }
+            }
+        ]
+    },
+    "format": "form_json",
+    "is_paused": False,
+    "repeater_type": "Dhis2Repeater",
+    "white_listed_form_xmlns":
+    [],
+    "dhis2_version": None,
+    "dhis2_version_last_modified": None,
+}

--- a/corehq/motech/dhis2/tests/test_views.py
+++ b/corehq/motech/dhis2/tests/test_views.py
@@ -7,10 +7,10 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import WebUser
 from corehq.motech.dhis2.models import SQLDataSetMap, SQLDataValueMap
-from corehq.motech.dhis2.repeaters import SQLDhis2Repeater
+from corehq.motech.dhis2.repeaters import SQLDhis2EntityRepeater, SQLDhis2Repeater
 from corehq.motech.models import ConnectionSettings
 from corehq.util.test_utils import flag_enabled
-from corehq.motech.dhis2.tests.data.repeater import dhis2_repeater_data
+from corehq.motech.dhis2.tests.data.repeater import dhis2_repeater_data, dhis2_entity_repeater_data
 
 from ..views import DataSetMapUpdateView
 
@@ -251,3 +251,47 @@ class TestConfigDhis2RepeaterView(BaseViewTest):
         unchanged_repeater = SQLDhis2Repeater.objects.get(id=self.dhis2_repeater.id)
 
         self.assertEqual(unchanged_repeater.dhis2_config, self.dhis2_repeater.dhis2_config)
+
+
+class TestConfigDhis2EntityRepeaterView(BaseViewTest):
+
+    @classmethod
+    def _create_data(cls):
+        conn = ConnectionSettings(
+            domain=cls.domain,
+            name="motech_conn",
+            url="url",
+        )
+        conn.save()
+        cls.connection_setting = conn
+        cls.dhis2_repeater = SQLDhis2EntityRepeater(**deepcopy(dhis2_entity_repeater_data))
+        cls.dhis2_repeater.domain = DOMAIN
+        cls.dhis2_repeater.connection_settings = conn
+        cls.dhis2_repeater.save()
+        cls.url_kwargs = {
+            'domain': cls.domain.name,
+            'repeater_id': cls.dhis2_repeater.repeater_id
+        }
+
+    def test_config_get(self):
+        response = self.client.get(reverse('config_dhis2_entity_repeater', kwargs=self.url_kwargs))
+        self.assertEqual(response.status_code, 200)
+
+    def test_config_post_with_correct_data(self):
+        case_configs = deepcopy(self.dhis2_repeater.dhis2_entity_config['case_configs'])
+        case_configs[0]['te_type_id'] = 'abcd'
+
+        data = {
+            'case_configs': json.dumps(case_configs)
+        }
+
+        response = self.client.post(reverse('config_dhis2_entity_repeater', kwargs=self.url_kwargs), data)
+        self.assertEqual(response.status_code, 200)
+
+        updated_repeater = SQLDhis2EntityRepeater.objects.get(id=self.dhis2_repeater.id)
+
+        self.assertEqual(updated_repeater.dhis2_entity_config['case_configs'], case_configs)
+
+        # restore the state
+        updated_repeater.dhis2_config = dhis2_repeater_data['dhis2_config']
+        updated_repeater.save()

--- a/corehq/motech/dhis2/tests/test_views.py
+++ b/corehq/motech/dhis2/tests/test_views.py
@@ -9,6 +9,7 @@ from corehq.apps.users.models import WebUser
 from corehq.motech.dhis2.models import SQLDataSetMap, SQLDataValueMap
 from corehq.motech.dhis2.repeaters import SQLDhis2EntityRepeater, SQLDhis2Repeater
 from corehq.motech.models import ConnectionSettings
+from ...repeaters.dbaccessors import delete_all_repeaters
 from corehq.util.test_utils import flag_enabled
 from corehq.motech.dhis2.tests.data.repeater import dhis2_repeater_data, dhis2_entity_repeater_data
 
@@ -23,7 +24,6 @@ class BaseViewTest(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        delete_all_users()
         cls.domain = create_domain(DOMAIN)
         cls.user = WebUser.create(DOMAIN, USERNAME, PASSWORD,
                                   created_by=None, created_via=None)
@@ -77,6 +77,7 @@ class BaseViewTest(TestCase):
         cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         cls.connection_setting.delete()
+        delete_all_repeaters()
         super().tearDownClass()
 
 

--- a/corehq/motech/dhis2/tests/test_views.py
+++ b/corehq/motech/dhis2/tests/test_views.py
@@ -1,11 +1,16 @@
+from copy import deepcopy
+import json
 from django.test import TestCase
 from django.urls import reverse
 
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import WebUser
 from corehq.motech.dhis2.models import SQLDataSetMap, SQLDataValueMap
+from corehq.motech.dhis2.repeaters import SQLDhis2Repeater
 from corehq.motech.models import ConnectionSettings
 from corehq.util.test_utils import flag_enabled
+from corehq.motech.dhis2.tests.data.repeater import dhis2_repeater_data
 
 from ..views import DataSetMapUpdateView
 
@@ -18,6 +23,7 @@ class BaseViewTest(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        delete_all_users()
         cls.domain = create_domain(DOMAIN)
         cls.user = WebUser.create(DOMAIN, USERNAME, PASSWORD,
                                   created_by=None, created_via=None)
@@ -71,8 +77,6 @@ class BaseViewTest(TestCase):
         cls.user.delete(cls.domain.name, deleted_by=None)
         cls.domain.delete()
         cls.connection_setting.delete()
-        cls.dataset_map.delete()
-        cls.data_value_map.delete()
         super().tearDownClass()
 
 
@@ -178,3 +182,72 @@ class TestDataSetMapUpdateView(BaseViewTest):
 
         datavalue_map.refresh_from_db()
         self.assertNotEqual(datavalue_map.data_element_id, invalid_data_element_id)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dataset_map.delete()
+        cls.data_value_map.delete()
+        return super().tearDownClass()
+
+
+class TestConfigDhis2RepeaterView(BaseViewTest):
+
+    @classmethod
+    def _create_data(cls):
+        conn = ConnectionSettings(
+            domain=cls.domain,
+            name="motech_conn",
+            url="url",
+        )
+        conn.save()
+        cls.connection_setting = conn
+        cls.dhis2_repeater = SQLDhis2Repeater(**deepcopy(dhis2_repeater_data))
+        cls.dhis2_repeater.domain = DOMAIN
+        cls.dhis2_repeater.connection_settings = conn
+        cls.dhis2_repeater.save()
+        cls.url_kwargs = {
+            'domain': cls.domain.name,
+            'repeater_id': cls.dhis2_repeater.repeater_id
+        }
+
+    def test_config_get(self):
+        response = self.client.get(reverse('config_dhis2_repeater', kwargs=self.url_kwargs))
+        self.assertEqual(response.status_code, 200)
+
+    def test_config_post_with_correct_data(self):
+        form_configs = deepcopy(self.dhis2_repeater.dhis2_config['form_configs'])
+        form_configs[0]['program_id'] = 'abcd'
+
+        data = {
+            'form_configs': json.dumps(form_configs)
+        }
+
+        response = self.client.post(reverse('config_dhis2_repeater', kwargs=self.url_kwargs), data)
+        self.assertEqual(response.status_code, 200)
+
+        updated_repeater = SQLDhis2Repeater.objects.get(id=self.dhis2_repeater.id)
+
+        self.assertEqual(updated_repeater.dhis2_config['form_configs'], form_configs)
+
+        # restore the state
+        updated_repeater.dhis2_config = dhis2_repeater_data['dhis2_config']
+        updated_repeater.save()
+
+    def test_config_post_with_incorrect_data(self):
+        form_configs = deepcopy(dhis2_repeater_data['dhis2_config']['form_configs'])
+
+        # Delete a required Property
+        form_configs[0].pop('program_id')
+
+        data = {
+            'form_configs': json.dumps(form_configs)
+        }
+
+        response = self.client.post(reverse('config_dhis2_repeater', kwargs=self.url_kwargs), data)
+
+        self.assertEqual(response.status_code, 400)
+
+        # No changes in repeater doc when request fails
+        unchanged_repeater = SQLDhis2Repeater.objects.get(id=self.dhis2_repeater.id)
+
+        self.assertEqual(unchanged_repeater.dhis2_config, self.dhis2_repeater.dhis2_config)

--- a/corehq/motech/dhis2/tests/test_views.py
+++ b/corehq/motech/dhis2/tests/test_views.py
@@ -4,7 +4,6 @@ from django.test import TestCase
 from django.urls import reverse
 
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import WebUser
 from corehq.motech.dhis2.models import SQLDataSetMap, SQLDataValueMap
 from corehq.motech.dhis2.repeaters import SQLDhis2EntityRepeater, SQLDhis2Repeater

--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -33,7 +33,7 @@ from .forms import (
     Dhis2EntityConfigForm,
 )
 from .models import SQLDataSetMap, SQLDataValueMap
-from .repeaters import Dhis2EntityRepeater, SQLDhis2Repeater
+from .repeaters import SQLDhis2EntityRepeater, SQLDhis2Repeater
 from .tasks import send_dataset
 
 
@@ -399,7 +399,7 @@ def config_dhis2_repeater(request, domain, repeater_id):
 @login_and_domain_required
 @require_http_methods(["GET", "POST"])
 def config_dhis2_entity_repeater(request, domain, repeater_id):
-    repeater = Dhis2EntityRepeater.get(repeater_id)
+    repeater = SQLDhis2EntityRepeater.objects.get(repeater_id=repeater_id)
     assert repeater.domain == domain
     if request.method == 'POST':
         errors = []
@@ -421,15 +421,12 @@ def config_dhis2_entity_repeater(request, domain, repeater_id):
         else:
             repeater.dhis2_entity_config = Dhis2EntityConfig.wrap({
                 "case_configs": case_configs
-            })
+            }).to_json()
             repeater.save()
             return JsonResponse({'success': _('DHIS2 Tracked Entity configuration saved')})
 
     else:
-        case_configs = [
-            case_config.to_json()
-            for case_config in repeater.dhis2_entity_config.case_configs
-        ]
+        case_configs = repeater.dhis2_entity_config['case_configs']
     return render(request, 'dhis2/dhis2_entity_config.html', {
         'domain': domain,
         'repeater_id': repeater_id,

--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -33,7 +33,7 @@ from .forms import (
     Dhis2EntityConfigForm,
 )
 from .models import SQLDataSetMap, SQLDataValueMap
-from .repeaters import Dhis2EntityRepeater, Dhis2Repeater
+from .repeaters import Dhis2EntityRepeater, SQLDhis2Repeater
 from .tasks import send_dataset
 
 
@@ -371,23 +371,24 @@ def send_dataset_now(request, domain, pk):
 @login_and_domain_required
 @require_http_methods(["GET", "POST"])
 def config_dhis2_repeater(request, domain, repeater_id):
-    repeater = Dhis2Repeater.get(repeater_id)
+    repeater = SQLDhis2Repeater.objects.get(repeater_id=repeater_id)
     assert repeater.domain == domain, f'"{repeater.domain}" != "{domain}"'
 
     if request.method == 'POST':
         form = Dhis2ConfigForm(data=request.POST)
         if form.is_valid():
             data = form.cleaned_data
-            repeater.dhis2_config.form_configs = list(map(Dhis2FormConfig.wrap, data['form_configs']))
+            # wrapping here to ensure schema validation and filling in defaults
+            cleaned_form_configs = list(map(Dhis2FormConfig.wrap, data['form_configs']))
+            # saving back dicts to sql tables
+            repeater.dhis2_config['form_configs'] = [config.to_json() for config in cleaned_form_configs]
             repeater.save()
             return JsonResponse({'success': _('DHIS2 Anonymous Events configuration saved')})
         else:
             errors = [err for errlist in form.errors.values() for err in errlist]
             return JsonResponse({'errors': errors}, status=400)
     else:
-        form_configs = json.dumps([
-            form_config.to_json() for form_config in repeater.dhis2_config.form_configs
-        ])
+        form_configs = json.dumps(repeater.dhis2_config['form_configs'])
     return render(request, 'dhis2/dhis2_events_config.html', {
         'domain': domain,
         'repeater_id': repeater_id,

--- a/corehq/motech/openmrs/tests/data/openmrs_repeater.py
+++ b/corehq/motech/openmrs/tests/data/openmrs_repeater.py
@@ -1,0 +1,119 @@
+test_data = {
+    "location_id": "581fe9d38a2c4eaf8e1fee1420800118",
+    "openmrs_config":
+    {
+        "openmrs_provider": "35711912-13A6-47F9-8D54-655FCAD75895",
+        "case_config":
+        {
+            "patient_identifiers":
+            {
+                "uuid":
+                {
+                    "case_property": "external_id"
+                }
+            },
+            "match_on_ids":
+            [
+                "uuid"
+            ],
+            "person_properties":
+            {},
+            "person_preferred_name":
+            {},
+            "person_preferred_address":
+            {},
+            "person_attributes":
+            {},
+            "doc_type": "OpenmrsCaseConfig",
+            "import_creates_cases": False
+        },
+        "form_configs":
+        [
+            {
+                "__form_name__": "prenatal",
+                "doc_type": "OpenmrsFormConfig",
+                "xmlns": "http://openrosa.org/formdesigner/00822D7D-D6B9-4F02-9067-02AAEA49436F",
+                "openmrs_visit_type": "90973824-1AE9-4E22-B2BB-9CBD56FB3238",
+                "openmrs_observations":
+                [
+                    {
+                        "doc_type": "ObservationMapping",
+                        "concept": "3ce934fa-26fe-102b-80cb-0017a47871b2",
+                        "value":
+                        {
+                            "form_question": "/data/signes_vitaux_de_la_mre/TA_Systolique"
+                        },
+                        "case_property": None
+                    },
+                    {
+                        "doc_type": "ObservationMapping",
+                        "concept": "3ce93694-26fe-102b-80cb-0017a47871b2",
+                        "value":
+                        {
+                            "form_question": "/data/signes_vitaux_de_la_mre/ta_diastolique"
+                        },
+                        "case_property": None
+                    },
+                    {
+                        "doc_type": "ObservationMapping",
+                        "concept": "3ce939d2-26fe-102b-80cb-0017a47871b2",
+                        "value":
+                        {
+                            "form_question": "/data/signes_vitaux_de_la_mre/temp-maternel"
+                        },
+                        "case_property": None
+                    },
+                    {
+                        "doc_type": "ObservationMapping",
+                        "concept": "3cd95a58-26fe-102b-80cb-0017a47871b2",
+                        "value":
+                        {
+                            "form_question": "/data/signes_durgence_de_la_mre/passage_de_liquide",
+                            "value_map":
+                            {
+                                "oui": "148968AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                            }
+                        },
+                        "case_property": None
+                    },
+                    {
+                        "doc_type": "ObservationMapping",
+                        "concept": "164141AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "value":
+                        {
+                            "form_question": "/metadata/username"
+                        },
+                        "case_property": None
+                    }
+                ],
+                "openmrs_start_datetime":
+                {
+                    "form_question": "/data/maternel/date_visite_domicile",
+                    "external_data_type": "omrs_date"
+                },
+                "openmrs_encounter_type": "91DDF969-A2D4-4603-B979-F2D6F777F4AF",
+                "openmrs_form": None,
+                "bahmni_diagnoses":
+                []
+            },
+        ],
+        "doc_type": "OpenmrsConfig"
+    },
+    "atom_feed_enabled": True,
+    "atom_feed_status": {
+        'patient': {
+            'last_polled_at': '2022-06-01T00:00:00.000000Z',
+            'last_page': None,
+            'doc_type': 'AtomFeedStatus'
+        }
+    },
+    "version": "2.0",
+    "white_listed_case_types":
+    [
+        "patient"
+    ],
+    "black_listed_users":
+    [],
+    "format": "form_json",
+    "is_paused": False,
+}

--- a/corehq/motech/openmrs/tests/test_views.py
+++ b/corehq/motech/openmrs/tests/test_views.py
@@ -1,0 +1,73 @@
+from copy import deepcopy
+import json
+
+from django.urls import reverse
+
+from corehq.motech.dhis2.tests.test_views import BaseViewTest
+from corehq.motech.models import ConnectionSettings
+from corehq.motech.openmrs.repeaters import SQLOpenmrsRepeater
+from corehq.motech.openmrs.tests.data.openmrs_repeater import test_data
+
+
+class TestOpenmrsRepeaterViews(BaseViewTest):
+    @classmethod
+    def _create_data(cls):
+        conn = ConnectionSettings(
+            domain=cls.domain,
+            name="motech_conn",
+            url="url",
+        )
+        conn.save()
+        cls.connection_setting = conn
+        cls.repeater = SQLOpenmrsRepeater(**deepcopy(test_data))
+        cls.repeater.domain = cls.domain.name
+        cls.repeater.connection_settings_id = conn.id
+        cls.repeater.save()
+        cls.url_kwargs = {
+            'domain': cls.domain.name,
+            'repeater_id': cls.repeater.repeater_id
+        }
+
+    def test_config_openmrs_repeater_get(self):
+        response = self.client.get(reverse('config_openmrs_repeater', kwargs=self.url_kwargs))
+        self.assertEqual(response.status_code, 200)
+
+    def test_config_openmrs_repeater_post(self):
+        repeater_data = deepcopy(test_data['openmrs_config'])
+        repeater_data['openmrs_provider'] = 'abcd'
+        repeater_data['case_config']['person_properties'] = {
+            'gender': {
+                'value': 'male',
+                'external_data_type': 'omrs_text'
+            }
+        }
+        post_data = {
+            'openmrs_provider': repeater_data['openmrs_provider'],
+            'patient_config': json.dumps(repeater_data['case_config']),
+            'encounters_config': json.dumps(repeater_data['form_configs'])
+        }
+        response = self.client.post(reverse('config_openmrs_repeater', kwargs=self.url_kwargs), data=post_data)
+        self.assertEqual(response.status_code, 200)
+        updated_repeater = SQLOpenmrsRepeater.objects.get(repeater_id=self.repeater.repeater_id)
+        self.assertEqual(updated_repeater.to_json()['openmrs_config'], repeater_data)
+
+    def test_config_openmrs_repeater_post_with_errors(self):
+        repeater_data = deepcopy(test_data['openmrs_config'])
+        repeater_data['openmrs_provider'] = 'abcd'
+        repeater_data['case_config']['person_properties'] = {
+            'blah': {
+                'value': 'blah',
+                'external_data_type': 'omrs_text'
+            }
+        }
+        post_data = {
+            'openmrs_provider': repeater_data['openmrs_provider'],
+            'patient_config': json.dumps(repeater_data['case_config']),
+            'encounters_config': json.dumps(repeater_data['form_configs'])
+        }
+        response = self.client.post(reverse('config_openmrs_repeater', kwargs=self.url_kwargs), data=post_data)
+        self.assertEqual(response.status_code, 200)
+        updated_repeater = SQLOpenmrsRepeater.objects.get(repeater_id=self.repeater.repeater_id)
+
+        # Config should not change
+        self.assertEqual(updated_repeater.to_json(), self.repeater.to_json())

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -33,7 +33,7 @@ from corehq.motech.openmrs.repeater_helpers import (
     get_patient_identifier_types,
     get_person_attribute_types,
 )
-from corehq.motech.openmrs.repeaters import OpenmrsRepeater
+from corehq.motech.openmrs.repeaters import SQLOpenmrsRepeater
 from corehq.motech.openmrs.tasks import import_patients_to_domain
 from corehq.motech.repeaters.models import RepeatRecord
 from corehq.motech.repeaters.views import AddCaseRepeaterView, EditRepeaterView
@@ -50,19 +50,21 @@ def config_openmrs_repeater(request, domain, repeater_id):
         form = OpenmrsConfigForm(data=request.POST)
         if form.is_valid():
             data = form.cleaned_data
-            repeater.openmrs_config.openmrs_provider = data['openmrs_provider']
-            repeater.openmrs_config.case_config = OpenmrsCaseConfig.wrap(data['patient_config'])
-            repeater.openmrs_config.form_configs = list(map(OpenmrsFormConfig.wrap, data['encounters_config']))
+            repeater.openmrs_config['openmrs_provider'] = data['openmrs_provider']
+            # wrapping for schema validation
+            repeater.openmrs_config['case_config'] = OpenmrsCaseConfig.wrap(data['patient_config']).to_json()
+            repeater.openmrs_config['form_configs'] = [
+                OpenmrsFormConfig.wrap(enc).to_json()
+                for enc in data['encounters_config']
+            ]
             repeater.save()
 
     else:
         form = OpenmrsConfigForm(
             data={
-                'openmrs_provider': repeater.openmrs_config.openmrs_provider,
-                'encounters_config': json.dumps([
-                    form_config.to_json()
-                    for form_config in repeater.openmrs_config.form_configs]),
-                'patient_config': json.dumps(repeater.openmrs_config.case_config.to_json()),
+                'openmrs_provider': repeater.openmrs_config['openmrs_provider'],
+                'encounters_config': json.dumps(repeater.openmrs_config['form_configs']),
+                'patient_config': json.dumps(repeater.openmrs_config['case_config']),
             }
         )
     return render(request, 'openmrs/edit_config.html', {
@@ -80,7 +82,7 @@ class OpenmrsModelListViewHelper(object):
     @property
     @memoized
     def repeater(self):
-        repeater = OpenmrsRepeater.get(self.repeater_id)
+        repeater = SQLOpenmrsRepeater.objects.get(repeater_id=self.repeater_id)
         assert repeater.domain == self.domain
         return repeater
 
@@ -112,7 +114,7 @@ def openmrs_person_attribute_types(request, domain, repeater_id):
 def openmrs_raw_api(request, domain, repeater_id, rest_uri):
     get_params = dict(request.GET)
     no_links = get_params.pop('links', None) is None
-    repeater = OpenmrsRepeater.get(repeater_id)
+    repeater = SQLOpenmrsRepeater.objects.get(repeater_id=repeater_id)
     assert repeater.domain == domain
     raw_json = repeater.requests.get('/ws/rest/v1' + rest_uri, get_params).json()
     if no_links:
@@ -122,7 +124,7 @@ def openmrs_raw_api(request, domain, repeater_id, rest_uri):
 
 @login_and_domain_required
 def openmrs_test_fire(request, domain, repeater_id, record_id):
-    repeater = OpenmrsRepeater.get(repeater_id)
+    repeater = SQLOpenmrsRepeater.objects.get(repeater_id=repeater_id)
     record = RepeatRecord.get(record_id)
     assert repeater.domain == domain
     assert record.domain == domain

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -476,7 +476,7 @@ class SQLRepeater(SyncSQLToCouchMixin, RepeaterSuperProxy):
             self.domain, url, payload,
             headers=self.get_headers(repeat_record),
             auth_manager=self.connection_settings.get_auth_manager(),
-            verify=self.verify,
+            verify=not self.connection_settings.skip_cert_verify,
             notify_addresses=self.connection_settings.notify_addresses,
             payload_id=repeat_record.payload_id,
             method=self.request_method,

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -421,15 +421,15 @@ class SQLRepeater(SyncSQLToCouchMixin, RepeaterSuperProxy):
         return True
 
     def pause(self):
-        self.paused = True
+        self.is_paused = True
         self.save()
 
     def resume(self):
-        self.paused = False
+        self.is_paused = False
         self.save()
 
     def retire(self, sync_to_couch=True):
-        self.paused = False
+        self.is_paused = False
         self.is_deleted = True
         self.save(sync_to_couch=False)
         if sync_to_couch:

--- a/corehq/motech/repeaters/tests/test_views.py
+++ b/corehq/motech/repeaters/tests/test_views.py
@@ -51,3 +51,19 @@ class TestRepeaterViews(BaseViewTest):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, f'/a/{self.domain.name}/motech/forwarding/')
         self.assertEqual(SQLFormRepeater.objects.get(id=repeater.id).is_paused, True)
+
+    @privilege_enabled(privileges.DATA_FORWARDING)
+    def test_resume_repeater(self):
+        repeater = SQLFormRepeater.objects.create(
+            domain=self.domain.name,
+            connection_settings=self.connection_setting,
+            is_paused=True
+        )
+        url_kwargs = {
+            'domain': self.domain.name,
+            'repeater_id': repeater.repeater_id
+        }
+        response = self.client.post(reverse('resume_repeater', kwargs=url_kwargs))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, f'/a/{self.domain.name}/motech/forwarding/')
+        self.assertEqual(SQLFormRepeater.objects.get(id=repeater.id).is_paused, False)

--- a/corehq/motech/repeaters/tests/test_views.py
+++ b/corehq/motech/repeaters/tests/test_views.py
@@ -1,0 +1,38 @@
+from django.urls import reverse
+
+from testil import assert_raises
+
+from corehq import privileges
+from corehq.motech.dhis2.tests.test_views import BaseViewTest
+from corehq.motech.models import ConnectionSettings
+from corehq.motech.repeaters.models import SQLFormRepeater
+from corehq.util.test_utils import privilege_enabled
+
+
+class TestRepeaterViews(BaseViewTest):
+
+    @classmethod
+    def _create_data(cls):
+        conn = ConnectionSettings(
+            domain=cls.domain.name,
+            name="motech_conn",
+            url="url",
+        )
+        conn.save()
+        cls.connection_setting = conn
+        cls.repeater = SQLFormRepeater.objects.create(
+            domain=cls.domain.name,
+            connection_settings=conn,
+        )
+        cls.url_kwargs = {
+            'domain': cls.domain.name,
+            'repeater_id': cls.repeater.repeater_id
+        }
+
+    @privilege_enabled(privileges.DATA_FORWARDING)
+    def test_drop_repeater(self):
+        response = self.client.post(reverse('drop_repeater', kwargs=self.url_kwargs))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, f'/a/{self.domain.name}/motech/forwarding/')
+        with assert_raises(SQLFormRepeater.DoesNotExist):
+            SQLFormRepeater.objects.get(id=self.repeater.id)

--- a/corehq/motech/repeaters/tests/test_views.py
+++ b/corehq/motech/repeaters/tests/test_views.py
@@ -36,3 +36,18 @@ class TestRepeaterViews(BaseViewTest):
         self.assertEqual(response.url, f'/a/{self.domain.name}/motech/forwarding/')
         with assert_raises(SQLFormRepeater.DoesNotExist):
             SQLFormRepeater.objects.get(id=repeater.id)
+
+    @privilege_enabled(privileges.DATA_FORWARDING)
+    def test_pause_repeater(self):
+        repeater = SQLFormRepeater.objects.create(
+            domain=self.domain.name,
+            connection_settings=self.connection_setting,
+        )
+        url_kwargs = {
+            'domain': self.domain.name,
+            'repeater_id': repeater.repeater_id
+        }
+        response = self.client.post(reverse('pause_repeater', kwargs=url_kwargs))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, f'/a/{self.domain.name}/motech/forwarding/')
+        self.assertEqual(SQLFormRepeater.objects.get(id=repeater.id).is_paused, True)

--- a/corehq/motech/repeaters/tests/test_views.py
+++ b/corehq/motech/repeaters/tests/test_views.py
@@ -20,19 +20,19 @@ class TestRepeaterViews(BaseViewTest):
         )
         conn.save()
         cls.connection_setting = conn
-        cls.repeater = SQLFormRepeater.objects.create(
-            domain=cls.domain.name,
-            connection_settings=conn,
-        )
-        cls.url_kwargs = {
-            'domain': cls.domain.name,
-            'repeater_id': cls.repeater.repeater_id
-        }
 
     @privilege_enabled(privileges.DATA_FORWARDING)
     def test_drop_repeater(self):
-        response = self.client.post(reverse('drop_repeater', kwargs=self.url_kwargs))
+        repeater = SQLFormRepeater.objects.create(
+            domain=self.domain.name,
+            connection_settings=self.connection_setting,
+        )
+        url_kwargs = {
+            'domain': self.domain.name,
+            'repeater_id': repeater.repeater_id
+        }
+        response = self.client.post(reverse('drop_repeater', kwargs=url_kwargs))
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, f'/a/{self.domain.name}/motech/forwarding/')
         with assert_raises(SQLFormRepeater.DoesNotExist):
-            SQLFormRepeater.objects.get(id=self.repeater.id)
+            SQLFormRepeater.objects.get(id=repeater.id)

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -307,7 +307,7 @@ def drop_repeater(request, domain, repeater_id):
 @require_can_edit_web_users
 @requires_privilege_with_fallback(privileges.DATA_FORWARDING)
 def pause_repeater(request, domain, repeater_id):
-    rep = Repeater.get(repeater_id)
+    rep = SQLRepeater.objects.get(repeater_id=repeater_id)
     rep.pause()
     messages.success(request, "Forwarding paused!")
     return HttpResponseRedirect(

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -25,6 +25,7 @@ from ..forms import CaseRepeaterForm, FormRepeaterForm, GenericRepeaterForm
 from ..models import (
     Repeater,
     RepeatRecord,
+    SQLRepeater,
     are_repeat_records_migrated,
     get_all_repeater_types,
 )
@@ -294,7 +295,7 @@ class EditCaseRepeaterView(EditRepeaterView, AddCaseRepeaterView):
 @require_can_edit_web_users
 @requires_privilege_with_fallback(privileges.DATA_FORWARDING)
 def drop_repeater(request, domain, repeater_id):
-    rep = Repeater.get(repeater_id)
+    rep = SQLRepeater.objects.get(repeater_id=repeater_id)
     rep.retire()
     messages.success(request, "Forwarding stopped!")
     return HttpResponseRedirect(

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -319,7 +319,7 @@ def pause_repeater(request, domain, repeater_id):
 @require_can_edit_web_users
 @requires_privilege_with_fallback(privileges.DATA_FORWARDING)
 def resume_repeater(request, domain, repeater_id):
-    rep = Repeater.get(repeater_id)
+    rep = SQLRepeater.objects.get(repeater_id=repeater_id)
     rep.resume()
     messages.success(request, "Forwarding resumed!")
     return HttpResponseRedirect(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
First PR - https://github.com/dimagi/commcare-hq/pull/32021

This is the Second PR for moving repeater Reads/writes to SQL. This PR moves most of the `Repeater.get()` calls to SQL, most because there were some intricacies in other calls which required moving more parts of the model. So I have deferred them for time being. 
I realized that it would be a better idea to go model-wise rather than function wise so for the next PRs I would be putting up Model level PRs.

This PR also has the tests in the first commit and then the changes to the SQL model. The code has been tested against both couch and SQL models. For the changes that already had tests, the commit message contains info about that test.

Review by commit 🐟 


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Have been tested locally and changes have proper tests.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
