### PR TITLE
upgrade pyOpenSSL to 22.0.0

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -86,7 +86,7 @@ contextlib2==21.6.0
     #   schema
 coverage==5.5
     # via -r test-requirements.in
-cryptography==3.4.8
+cryptography==37.0.4
     # via
     #   jwcrypto
     #   oic
@@ -460,7 +460,7 @@ pyjwt==2.4.0
     #   twilio
 pynacl==1.5.0
     # via pygithub
-pyopenssl==20.0.1
+pyopenssl==22.0.0
     # via -r sso-requirements.in
 pyparsing==2.4.7
     # via
@@ -594,7 +594,6 @@ six==1.16.0
     #   packaging
     #   protobuf
     #   pyjwkest
-    #   pyopenssl
     #   python-dateutil
     #   pyzxcvbn
     #   qrcode

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -69,7 +69,7 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
-cryptography==3.4.8
+cryptography==37.0.4
     # via
     #   -r prod-requirements.in
     #   jwcrypto
@@ -389,7 +389,7 @@ pyjwt==2.4.0
     #   twilio
 pynacl==1.5.0
     # via pygithub
-pyopenssl==20.0.1
+pyopenssl==22.0.0
     # via
     #   -r prod-requirements.in
     #   -r sso-requirements.in
@@ -510,7 +510,6 @@ six==1.16.0
     #   jsonschema
     #   protobuf
     #   pyjwkest
-    #   pyopenssl
     #   python-dateutil
     #   pyzxcvbn
     #   qrcode

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -63,7 +63,7 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
-cryptography==3.4.8
+cryptography==37.0.4
     # via
     #   jwcrypto
     #   oic
@@ -348,7 +348,7 @@ pyjwt==2.4.0
     #   twilio
 pynacl==1.5.0
     # via pygithub
-pyopenssl==20.0.1
+pyopenssl==22.0.0
     # via -r sso-requirements.in
 pyparsing==3.0.7
     # via httplib2
@@ -462,7 +462,6 @@ six==1.16.0
     #   jsonschema
     #   protobuf
     #   pyjwkest
-    #   pyopenssl
     #   python-dateutil
     #   pyzxcvbn
     #   qrcode

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -70,7 +70,7 @@ contextlib2==21.6.0
     # via schema
 coverage==5.5
     # via -r test-requirements.in
-cryptography==3.4.8
+cryptography==37.0.4
     # via
     #   jwcrypto
     #   oic
@@ -380,7 +380,7 @@ pyjwt==2.4.0
     #   twilio
 pynacl==1.5.0
     # via pygithub
-pyopenssl==20.0.1
+pyopenssl==22.0.0
     # via -r sso-requirements.in
 pyparsing==3.0.7
     # via httplib2
@@ -501,7 +501,6 @@ six==1.16.0
     #   mando
     #   protobuf
     #   pyjwkest
-    #   pyopenssl
     #   python-dateutil
     #   pyzxcvbn
     #   qrcode


### PR DESCRIPTION
## Technical Summary
This upgrades `pyOpenSSL` to `22.0.0`. Yes, it's the `x.0.0` of a major release, but it looks like it's been around since January with no issues / updates.

Will be timing QA of this upgrade along with QA of additional SSO support of another IdP.

## Safety Assurance

### Safety story
Will be QA'd

### Automated test coverage
Yes, we do have some usage tests at least for `cryptography`'s usage in our `SSO` tests.

### QA Plan
Test both `SAML` and `OIDC` support.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
