### PR TITLE
upgrade django-compressor from 2.4 to 4.1

### DIFF
--- a/corehq/apps/userreports/templates/userreports/partials/column_list_configuration.html
+++ b/corehq/apps/userreports/templates/userreports/partials/column_list_configuration.html
@@ -1,4 +1,4 @@
-{% extends parent %}
+{% extends "userreports/partials/property_list_configuration.html" %}
 {% load i18n %}
 
 {% block property_name_display %}

--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -152,7 +152,7 @@
             <div class="panel-collapse collapse in" id="report-config-columns">
               <div class="panel-body">
                 <div data-bind="with: columnList">
-                  {% include "userreports/partials/column_list_configuration.html" with parent="userreports/partials/property_list_configuration.html" %}
+                  {% include "userreports/partials/column_list_configuration.html" %}
                 </div>
               </div>
             </div>

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -145,7 +145,7 @@ django-bulk-update==2.2.0
     # via -r base-requirements.in
 django-celery-results==2.4.0
     # via -r base-requirements.in
-django-compressor==2.4
+django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
@@ -510,7 +510,7 @@ quickcache==0.5.4
     # via -r base-requirements.in
 radon==5.1.0
     # via -r test-requirements.in
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via django-compressor
 redis==3.5.3
     # via
@@ -546,7 +546,7 @@ requests-oauthlib==1.3.1
     #   google-auth-oauthlib
 requests-toolbelt==0.9.1
     # via -r base-requirements.in
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via django-compressor
 rsa==4.8
     # via google-auth
@@ -572,7 +572,6 @@ six==1.16.0
     #   asttokens
     #   click-repl
     #   django-braces
-    #   django-compressor
     #   django-oauth-toolkit
     #   django-statici18n
     #   django-transfer

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -125,7 +125,7 @@ django-bulk-update==2.2.0
     # via -r base-requirements.in
 django-celery-results==2.4.0
     # via -r base-requirements.in
-django-compressor==2.4
+django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
@@ -415,7 +415,7 @@ qrcode==4.0.4
     #   django-two-factor-auth
 quickcache==0.5.4
     # via -r base-requirements.in
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via django-compressor
 redis==3.5.3
     # via
@@ -448,7 +448,7 @@ requests-oauthlib==1.3.1
     #   google-auth-oauthlib
 requests-toolbelt==0.9.1
     # via -r base-requirements.in
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via django-compressor
 rsa==4.8
     # via google-auth
@@ -471,7 +471,6 @@ six==1.16.0
     #   -r base-requirements.in
     #   click-repl
     #   django-braces
-    #   django-compressor
     #   django-oauth-toolkit
     #   django-statici18n
     #   django-transfer

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -128,7 +128,7 @@ django-bulk-update==2.2.0
     # via -r base-requirements.in
 django-celery-results==2.4.0
     # via -r base-requirements.in
-django-compressor==2.4
+django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
@@ -433,7 +433,7 @@ qrcode==4.0.4
     #   django-two-factor-auth
 quickcache==0.5.4
     # via -r base-requirements.in
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via django-compressor
 redis==3.5.3
     # via
@@ -465,7 +465,7 @@ requests-oauthlib==1.3.1
     #   google-auth-oauthlib
 requests-toolbelt==0.9.1
     # via -r base-requirements.in
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via django-compressor
 rsa==4.8
     # via google-auth
@@ -491,7 +491,6 @@ six==1.16.0
     #   asttokens
     #   click-repl
     #   django-braces
-    #   django-compressor
     #   django-oauth-toolkit
     #   django-statici18n
     #   django-transfer

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -120,7 +120,7 @@ django-bulk-update==2.2.0
     # via -r base-requirements.in
 django-celery-results==2.4.0
     # via -r base-requirements.in
-django-compressor==2.4
+django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
@@ -388,7 +388,7 @@ qrcode==4.0.4
     #   django-two-factor-auth
 quickcache==0.5.4
     # via -r base-requirements.in
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via django-compressor
 redis==3.5.3
     # via
@@ -420,7 +420,7 @@ requests-oauthlib==1.3.1
     #   google-auth-oauthlib
 requests-toolbelt==0.9.1
     # via -r base-requirements.in
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via django-compressor
 rsa==4.8
     # via google-auth
@@ -443,7 +443,6 @@ six==1.16.0
     #   -r base-requirements.in
     #   click-repl
     #   django-braces
-    #   django-compressor
     #   django-oauth-toolkit
     #   django-statici18n
     #   django-transfer

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -127,7 +127,7 @@ django-bulk-update==2.2.0
     # via -r base-requirements.in
 django-celery-results==2.4.0
     # via -r base-requirements.in
-django-compressor==2.4
+django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
@@ -423,7 +423,7 @@ quickcache==0.5.4
     # via -r base-requirements.in
 radon==5.1.0
     # via -r test-requirements.in
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via django-compressor
 redis==3.5.3
     # via
@@ -458,7 +458,7 @@ requests-oauthlib==1.3.1
     #   google-auth-oauthlib
 requests-toolbelt==0.9.1
     # via -r base-requirements.in
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via django-compressor
 rsa==4.8
     # via google-auth
@@ -481,7 +481,6 @@ six==1.16.0
     #   -r base-requirements.in
     #   click-repl
     #   django-braces
-    #   django-compressor
     #   django-oauth-toolkit
     #   django-statici18n
     #   django-transfer

--- a/settings.py
+++ b/settings.py
@@ -907,7 +907,10 @@ COMPRESS_FILTERS = {
     'css': [
         'compressor.filters.css_default.CssAbsoluteFilter',
         'compressor.filters.cssmin.rCSSMinFilter',
-    ]
+    ],
+    'js': [
+        'compressor.filters.jsmin.rJSMinFilter',
+    ],
 }
 
 LESS_B3_PATHS = {


### PR DESCRIPTION
## Technical Summary
This upgrades `django-compressor` from `2.4` to `4.1`

For testing, I'm going to put this on `staging`. An issue with `django-compressor` will most likely manifest in catastrophic ways (if there is an issue to be found). This will either occur in the deploy/build process or when loading stylesheets and javascript on a page. So if the staging deploy succeeds and pages on staging are not immediately throwing 500s, I feel like this will be a safe change to make.

## Safety Assurance

### Safety story
will do a test as described above on `staging`

### Automated test coverage
We do test the CSS and JS builds

### QA Plan
Since issues with this library will manifest almost immediately in catastrophic ways, I feel a deploy and click through on staging should be enough for QAing this.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
