### PR TITLE
Fix bools

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -158,8 +158,8 @@
   name: Modules Menu Display
   description: Display root menu as a list or grid. Read more on the <a target="_blank" href="https://help.commcarehq.org/display/commcarepublic/Grid+View+for+Form+and+Module+Screens">Help Site</a>.
   values:
-    - ['false', 'List']
-    - ['true', 'Grid']
+    - [false, 'List']
+    - [true, 'Grid']
   default: false
   since: "2.24"
 


### PR DESCRIPTION
## Technical Summary

PR #32032 introduced a bug when I inadvertently changed two boolean values in a YAML file to strings. This change reverts the values back to booleans.

Details: https://dimagi-dev.atlassian.net/browse/QA-4462

Example error: https://sentry.io/organizations/dimagi/issues/3522875969/?environment=staging&project=136860&query=is%3Aunresolved

Thank you @esoergel for alerting me to this.

## Feature Flag

N/A

## Safety Assurance

### Safety story

The error message, "BadValueError: 'true' not of type <class 'bool'>" clearly points to this change. [The relevant commit](https://github.com/dimagi/commcare-hq/pull/32032/commits/cf5f92fc00e8953b7afd548edc495bebcfcea62b) shows exactly where the bad change occurred. A quick search through the commit shows that this instance is the only place where bools were replaced with strings. (Other instances of "true" and "false" were originally strings.)

### Automated test coverage

This change is not covered by tests, because testing all possible values of settings in a config file by comparing them to another copy of the same settings feels like a bad test. But I'm open to suggestions, if there is a better way to think about this.

### QA Plan

QA caught this bug, and logged it in [QA-4462](https://dimagi-dev.atlassian.net/browse/QA-4462)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
