### PR TITLE
Add privilege for accessing global sms gateway

### DIFF
--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1388,7 +1388,7 @@ class GlobalSmsGatewayListView(CRUDPaginatedViewMixin, BaseAdminSectionView):
 
     @method_decorator(require_superuser)
     def dispatch(self, request, *args, **kwargs):
-        if not request.couch_user.is_staff:
+        if not has_privilege(request, privileges.DEV_SUPPORT_TEAM):
             return HttpResponseRedirect(
                 reverse(
                     SMSAdminInterfaceDispatcher.name(),
@@ -1542,7 +1542,7 @@ class AddGlobalGatewayView(AddGatewayViewMixin, BaseAdminSectionView):
 
     @method_decorator(require_superuser)
     def dispatch(self, request, *args, **kwargs):
-        if not request.couch_user.is_staff:
+        if not has_privilege(request, privileges.DEV_SUPPORT_TEAM):
             return HttpResponseRedirect(reverse("no_permissions"))
         return super(AddGlobalGatewayView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1388,7 +1388,7 @@ class GlobalSmsGatewayListView(CRUDPaginatedViewMixin, BaseAdminSectionView):
 
     @method_decorator(require_superuser)
     def dispatch(self, request, *args, **kwargs):
-        if not has_privilege(request, privileges.DEV_SUPPORT_TEAM):
+        if not has_privilege(request, privileges.GLOBAL_SMS_GATEWAY):
             return HttpResponseRedirect(
                 reverse(
                     SMSAdminInterfaceDispatcher.name(),
@@ -1542,7 +1542,7 @@ class AddGlobalGatewayView(AddGatewayViewMixin, BaseAdminSectionView):
 
     @method_decorator(require_superuser)
     def dispatch(self, request, *args, **kwargs):
-        if not has_privilege(request, privileges.DEV_SUPPORT_TEAM):
+        if not has_privilege(request, privileges.GLOBAL_SMS_GATEWAY):
             return HttpResponseRedirect(reverse("no_permissions"))
         return super(AddGlobalGatewayView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/smsbillables/management/commands/add_sms_gateway_permissions.py
+++ b/corehq/apps/smsbillables/management/commands/add_sms_gateway_permissions.py
@@ -18,13 +18,13 @@ class Command(BaseCommand):
             '--remove-user',
             action='store_true',
             default=False,
-            help='Remove the users specified from the DEV_SUPPORT_TEAM privilege',
+            help='Remove the users specified from the Global SMS Gateway privilege',
         )
 
     def handle(self, usernames, **options):
 
         global_sms_gateway_access = Role.objects.get_or_create(
-            name="Accounting Admin",
+            name="Global SMS Gateway",
             slug=privileges.GLOBAL_SMS_GATEWAY,
         )[0]
 

--- a/corehq/apps/smsbillables/management/commands/add_sms_gateway_permissions.py
+++ b/corehq/apps/smsbillables/management/commands/add_sms_gateway_permissions.py
@@ -1,0 +1,79 @@
+from django.contrib.auth.models import User
+from django.core.management import BaseCommand
+
+from django_prbac.models import Grant, Role, UserRole
+
+from corehq import privileges
+
+
+class Command(BaseCommand):
+    help = 'Grants the user(s) specified the privilege to access global sms gateways'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'usernames',
+            nargs="*",
+        )
+        parser.add_argument(
+            '--remove-user',
+            action='store_true',
+            default=False,
+            help='Remove the users specified from the DEV_SUPPORT_TEAM privilege',
+        )
+
+    def handle(self, usernames, **options):
+        dev_support_role = Role.objects.get_or_create(
+            name="Dimagi Dev and Support Team",
+            slug=privileges.DEV_SUPPORT_TEAM,
+        )[0]
+        global_sms_gateway_access = Role.objects.get_or_create(
+            name="Accounting Admin",
+            slug=privileges.GLOBAL_SMS_GATEWAY,
+        )[0]
+        if not dev_support_role.has_privilege(global_sms_gateway_access):
+            Grant.objects.create(
+                from_role=dev_support_role,
+                to_role=global_sms_gateway_access,
+            )
+        remove_user = options['remove_user']
+
+        for username in usernames:
+            try:
+                user = User.objects.get(username=username)
+                try:
+                    user_role = UserRole.objects.get(user=user)
+                except UserRole.DoesNotExist:
+                    user_privs = Role.objects.get_or_create(
+                        name="Privileges for %s" % user.username,
+                        slug="%s_privileges" % user.username,
+                    )[0]
+                    user_role = UserRole.objects.create(
+                        user=user,
+                        role=user_privs,
+                    )
+
+                if remove_user:
+                    try:
+                        # remove grant object
+                        grant = Grant.objects.get(
+                            from_role=user_role.role,
+                            to_role=dev_support_role
+                        )
+                        grant.delete()
+                        print("Removed %s from the operations team"
+                              % user.username)
+                    except Grant.DoesNotExist:
+                        print("The user %s was never part of the operations "
+                              "team. Leaving alone." % user.username)
+                elif not user_role.has_privilege(dev_support_role):
+                    Grant.objects.create(
+                        from_role=user_role.role,
+                        to_role=dev_support_role,
+                    )
+                    print("Added %s to the Dev and Support team" % user.username)
+                else:
+                    print("User %s is already part of the Dev and Support team"
+                          % user.username)
+
+            except User.DoesNotExist:
+                print("User %s does not exist" % username)

--- a/corehq/apps/smsbillables/management/commands/add_sms_gateway_permissions.py
+++ b/corehq/apps/smsbillables/management/commands/add_sms_gateway_permissions.py
@@ -22,19 +22,12 @@ class Command(BaseCommand):
         )
 
     def handle(self, usernames, **options):
-        dev_support_role = Role.objects.get_or_create(
-            name="Dimagi Dev and Support Team",
-            slug=privileges.DEV_SUPPORT_TEAM,
-        )[0]
+
         global_sms_gateway_access = Role.objects.get_or_create(
             name="Accounting Admin",
             slug=privileges.GLOBAL_SMS_GATEWAY,
         )[0]
-        if not dev_support_role.has_privilege(global_sms_gateway_access):
-            Grant.objects.create(
-                from_role=dev_support_role,
-                to_role=global_sms_gateway_access,
-            )
+
         remove_user = options['remove_user']
 
         for username in usernames:
@@ -44,8 +37,8 @@ class Command(BaseCommand):
                     user_role = UserRole.objects.get(user=user)
                 except UserRole.DoesNotExist:
                     user_privs = Role.objects.get_or_create(
-                        name="Privileges for %s" % user.username,
-                        slug="%s_privileges" % user.username,
+                        name=f"Privileges for {user.username}",
+                        slug=f"{user.username}_privileges",
                     )[0]
                     user_role = UserRole.objects.create(
                         user=user,
@@ -57,22 +50,20 @@ class Command(BaseCommand):
                         # remove grant object
                         grant = Grant.objects.get(
                             from_role=user_role.role,
-                            to_role=dev_support_role
+                            to_role=global_sms_gateway_access
                         )
                         grant.delete()
-                        print("Removed %s from the operations team"
-                              % user.username)
+                        print(f"Removed Global SMS Gateway Edit Access Privilege for {user.username}")
                     except Grant.DoesNotExist:
-                        print("The user %s was never part of the operations "
-                              "team. Leaving alone." % user.username)
-                elif not user_role.has_privilege(dev_support_role):
+                        print(f"The user {user.username} did not have the Privilege. Doing nothing here.")
+                elif not user_role.has_privilege(global_sms_gateway_access):
                     Grant.objects.create(
                         from_role=user_role.role,
-                        to_role=dev_support_role,
+                        to_role=global_sms_gateway_access,
                     )
-                    print("Added %s to the Dev and Support team" % user.username)
+                    print("Enabled privilege to Edit Global SMS Gateways for the user {user.username}")
                 else:
-                    print("User %s is already part of the Dev and Support team"
+                    print("User %s already have the requested privilege"
                           % user.username)
 
             except User.DoesNotExist:

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -6,8 +6,6 @@ API_ACCESS = 'api_access'
 CLOUDCARE = 'cloudcare'
 GEOCODER = 'geocoder'
 
-GLOBAL_SMS_GATEWAY = 'global_sms_gateway'
-
 ACTIVE_DATA_MANAGEMENT = 'active_data_management'
 CUSTOM_BRANDING = 'custom_branding'
 
@@ -136,7 +134,6 @@ MAX_PRIVILEGES = [
     RELEASE_MANAGEMENT,
     LITE_RELEASE_MANAGEMENT,
     LOADTEST_USERS,
-    GLOBAL_SMS_GATEWAY,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -145,6 +142,9 @@ MOBILE_WORKER_CREATION = 'mobile_worker_creation'
 # Other privileges related specifically to accounting processes
 ACCOUNTING_ADMIN = 'accounting_admin'
 OPERATIONS_TEAM = 'dimagi_ops'
+
+# This is a special privilege that is meant for Dev and Support team which allows access to Global SMS Gateway Page
+GLOBAL_SMS_GATEWAY = 'global_sms_gateway'
 
 
 class Titles(object):
@@ -196,5 +196,4 @@ class Titles(object):
             RELEASE_MANAGEMENT: _("Enterprise Release Management"),
             LITE_RELEASE_MANAGEMENT: _("Multi-Environment Release Management"),
             LOADTEST_USERS: _('Loadtest Users'),
-            GLOBAL_SMS_GATEWAY: _('Global SMS Gateway Settings'),
         }.get(privilege, privilege)

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -6,7 +6,6 @@ API_ACCESS = 'api_access'
 CLOUDCARE = 'cloudcare'
 GEOCODER = 'geocoder'
 
-DEV_SUPPORT_TEAM = 'dev_support'
 GLOBAL_SMS_GATEWAY = 'global_sms_gateway'
 
 ACTIVE_DATA_MANAGEMENT = 'active_data_management'

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -6,6 +6,8 @@ API_ACCESS = 'api_access'
 CLOUDCARE = 'cloudcare'
 GEOCODER = 'geocoder'
 
+GLOBAL_SMS_GATEWAY = 'global_sms_gateway'
+
 ACTIVE_DATA_MANAGEMENT = 'active_data_management'
 CUSTOM_BRANDING = 'custom_branding'
 
@@ -134,6 +136,7 @@ MAX_PRIVILEGES = [
     RELEASE_MANAGEMENT,
     LITE_RELEASE_MANAGEMENT,
     LOADTEST_USERS,
+    GLOBAL_SMS_GATEWAY,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -193,4 +196,5 @@ class Titles(object):
             RELEASE_MANAGEMENT: _("Enterprise Release Management"),
             LITE_RELEASE_MANAGEMENT: _("Multi-Environment Release Management"),
             LOADTEST_USERS: _('Loadtest Users'),
+            GLOBAL_SMS_GATEWAY: _('Global SMS Gateway Settings'),
         }.get(privilege, privilege)

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -6,6 +6,7 @@ API_ACCESS = 'api_access'
 CLOUDCARE = 'cloudcare'
 GEOCODER = 'geocoder'
 
+DEV_SUPPORT_TEAM = 'dev_support'
 GLOBAL_SMS_GATEWAY = 'global_sms_gateway'
 
 ACTIVE_DATA_MANAGEMENT = 'active_data_management'

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -2242,7 +2242,7 @@ class SMSAdminTab(UITab):
         from corehq.apps.sms.views import (GlobalSmsGatewayListView,
             AddGlobalGatewayView, EditGlobalGatewayView)
         items = SMSAdminInterfaceDispatcher.navigation_sections(request=self._request, domain=self.domain)
-        if self.couch_user.is_staff:
+        if has_privilege(self._request, privileges.DEV_SUPPORT_TEAM):
             items.append((_('SMS Connectivity'), [
                 {'title': _('Gateways'),
                 'url': reverse(GlobalSmsGatewayListView.urlname),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SAAS-13649
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is a followup of https://github.com/dimagi/commcare-hq/pull/31750 where we are restricting Global SMS Gateways page to the user who have `GLOBAL_SMS_GATEWAY`
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
Has been tested on local and would be putting it on staging to test it.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
