### PR TITLE
Resolve duplicate lookup tables with --fixup-diffs

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -384,6 +384,9 @@ Run the following commands to run the migration and get up to date:
 
     def _do_diff(self, doc, obj, logfile, exit=False):
         if obj is None:
+            couch_class = self.sql_class()._migration_get_couch_model_class()
+            if not couch_class.get_db().doc_exist(doc["_id"]):
+                return  # ignore if also missing in Couch (deleted)
             diff = "Missing in SQL - unique constraint violation?"
         else:
             diff = self.get_diff_as_string(doc, obj)

--- a/corehq/apps/fixtures/management/commands/populate_lookuptables.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptables.py
@@ -1,6 +1,8 @@
+from django.db import transaction
+
 from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
 
-from ...models import TypeField
+from ...models import FixtureDataType, LookupTable, TypeField
 
 
 class Command(PopulateSQLCommand):
@@ -49,6 +51,73 @@ class Command(PopulateSQLCommand):
     def diff_maybe_empty_field(cls, field, couch, sql):
         if couch.get(field) or getattr(sql, field):
             return cls.diff_value(field, couch.get(field), getattr(sql, field))
+
+    def _migrate_docs(self, docs, logfile, fixup_diffs):
+        super()._migrate_docs(docs, logfile, fixup_diffs)
+        if fixup_diffs:
+            self.find_and_fix_duplicates(docs, logfile)
+
+    def find_and_fix_duplicates(self, docs, logfile):
+        sql_class = self.sql_class()
+        couch_class = sql_class._migration_get_couch_model_class()
+        assert sql_class is LookupTable, sql_class
+        assert couch_class is FixtureDataType, couch_class
+
+        couch_by_id = {d["_id"]: d for d in docs}
+        sql_ids = {id.hex for id in LookupTable.objects
+            .filter(id__in=list(couch_by_id))
+            .values_list("id", flat=True)}
+        seen = set()
+        for missing_in_sql in couch_by_id.keys() - sql_ids:
+            if missing_in_sql in seen:
+                continue
+            doc = couch_by_id[missing_in_sql]
+            domain = doc["domain"]
+            tag = doc["tag"]
+            couch_docs = list(FixtureDataType.by_domain_tag(domain, tag))
+            if len(couch_docs) == 1:
+                delete_orphaned_sql_row(couch_docs[0], logfile)
+            elif len(couch_docs) > 1:
+                delete_duplicate_couch_docs(couch_docs, logfile)
+            seen.update(doc._id for doc in couch_docs)
+
+
+def delete_orphaned_sql_row(doc, logfile):
+    with transaction.atomic():
+        try:
+            table = LookupTable.objects.get(domain=doc.domain, tag=doc.tag)
+        except LookupTable.DoesNotExist:
+            print("Unexpected: Orphaned SQL row not found:", doc._id, file=logfile)
+            return
+        if table._migration_couch_id == doc._id:
+            print("Unexpected: SQL row is not orphaned:", doc._id, file=logfile)
+            return
+        LookupTable.objects.filter(id=table.id).delete()
+        doc._migration_do_sync()
+    print("Removed orphaned LookupTable row:", table.id, file=logfile)
+    print(f"Recreated model for {type(doc).__name__} with id {doc._id}", file=logfile)
+
+
+def delete_duplicate_couch_docs(couch_docs, logfile):
+    pairs = {(d.domain, d.tag) for d in couch_docs}
+    assert len(pairs) == 1, pairs
+    (domain, tag), = pairs
+    try:
+        obj = LookupTable.objects.get(domain=domain, tag=tag)
+    except LookupTable.DoesNotExist:
+        print(f"Unexpected: SQL row not found: domain={domain} tag={tag}", file=logfile)
+        return
+    keep_id = obj._migration_couch_id
+    couch_ids = sorted({d._id for d in couch_docs})
+    assert len(couch_ids) > 1, couch_ids
+    if couch_ids[0] != keep_id:
+        print("Unexpected: SQL row does not have lowest id value:", keep_id, couch_ids, file=logfile)
+        return
+    # Rationale for removing all but the doc with the lowest id value:
+    # That one would appear last in a restore payload, and is therefore
+    # the one of most consequence on a mobile device.
+    FixtureDataType.bulk_delete([d for d in couch_docs if d._id != keep_id])
+    print("Removed duplicate FixtureDataTypes:", couch_ids[1:], file=logfile)
 
 
 def transform_field(data):


### PR DESCRIPTION
Adds fixups to the `populate_lookuptables` management command for two different duplicate scenarios:
- SQL row id differs from Couch document id, Couch document cannot be synced to SQL.
- Multiple Couch documents exist for a single `(domain, tag)` pair.

The first scenario can occur as a result of a race condition. The cause of the second is as yet unknown.

## Safety Assurance

### Safety story

Tests added for both fixup scenarios.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
