### PR TITLE
Do not log ignored ids as missing in SQL

### DIFF
--- a/corehq/apps/fixtures/management/commands/populate_lookuptables.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptables.py
@@ -53,9 +53,10 @@ class Command(PopulateSQLCommand):
             return cls.diff_value(field, couch.get(field), getattr(sql, field))
 
     def _migrate_docs(self, docs, logfile, fixup_diffs):
-        super()._migrate_docs(docs, logfile, fixup_diffs)
+        ignored = super()._migrate_docs(docs, logfile, fixup_diffs)
         if fixup_diffs:
             self.find_and_fix_duplicates(docs, logfile)
+        return ignored
 
     def find_and_fix_duplicates(self, docs, logfile):
         sql_class = self.sql_class()

--- a/corehq/apps/fixtures/tests/test_couchsqlmigration.py
+++ b/corehq/apps/fixtures/tests/test_couchsqlmigration.py
@@ -617,6 +617,7 @@ class TestLookupTableRowCouchToSQLMigration(TestCase):
         with templog() as log, patch.object(transaction, "atomic", atomic_check):
             call_command('populate_lookuptablerows', log_path=log.path)
             self.assertIn(f"Ignored model for FixtureDataItem with id {doc_id}\n", log.content)
+            self.assertNotIn(f'Doc "{doc_id}" has diff', log.content)
 
     def create_row(self):
         doc, obj = create_lookup_table_row(unwrap_doc=False)


### PR DESCRIPTION
Previous behavior was overly conservative, logging all ignored items as diffs in addition to logging them as ignored.

## Safety Assurance

### Safety story

Affects Couch to SQL migration management commands only.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
