### PR TITLE
Android app dependencies

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -3,12 +3,16 @@ from distutils.version import LooseVersion
 
 from django.utils.translation import gettext
 
-from memoized import memoized
-
 import commcare_translations
 import langcodes
+from langcodes import langs_by_code
+from memoized import memoized
+
 from corehq import toggles
 from corehq.apps.app_manager import id_strings
+from corehq.apps.app_manager.commcare_settings import (
+    get_commcare_settings_lookup,
+)
 from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
 from corehq.apps.app_manager.util import (
     create_temp_sort_column,
@@ -16,7 +20,6 @@ from corehq.apps.app_manager.util import (
     module_offers_search,
 )
 from corehq.util.translation import localize
-from langcodes import langs_by_code
 
 
 def non_empty_only(dct):
@@ -116,6 +119,8 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
             for_default,
             build_profile_id,
         )
+
+    yield from _create_dependencies_app_strings(app)
 
 
 def _create_module_details_app_strings(module, langs):
@@ -477,6 +482,19 @@ def _create_case_list_form_app_strings(
             yield id_strings.case_list_form_audio_locale(module), audio
 
 
+def _create_dependencies_app_strings(app):
+    dependencies = app.profile.get('features', {}).get('dependencies')
+    if toggles.APP_DEPENDENCIES.enabled(app.domain) and dependencies:
+        settings = get_commcare_settings_lookup()['features']['dependencies']
+        app_id_to_name = {k: v for k, v in zip(
+            settings["values"],
+            settings["value_names"]
+        )}
+        for app_id in dependencies:
+            app_name = app_id_to_name[app_id]
+            yield id_strings.android_package_name(app_id), app_name
+
+
 def _maybe_add_index(text, app):
     if app.build_version and app.build_version >= LooseVersion('2.8'):
         sense_on = app.profile.get('features', {}).get('sense') == 'true'
@@ -553,8 +571,12 @@ class AppStringsBase(object):
                 'Unable to find the selected case after performing a sync. Please try again.'
 
         from corehq.apps.app_manager.models import (
-            AUTO_SELECT_CASE, AUTO_SELECT_FIXTURE, AUTO_SELECT_USER,
-            AUTO_SELECT_LOCATION, AUTO_SELECT_USERCASE, AUTO_SELECT_RAW
+            AUTO_SELECT_CASE,
+            AUTO_SELECT_FIXTURE,
+            AUTO_SELECT_LOCATION,
+            AUTO_SELECT_RAW,
+            AUTO_SELECT_USER,
+            AUTO_SELECT_USERCASE,
         )
 
         mode_text = {

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -345,6 +345,11 @@ def reports_last_updated_on():
     return 'cchq.reports_last_updated_on'
 
 
+@pattern('android.package.name.%s')
+def android_package_name(package_id):
+    return 'android.package.name.{package_id}'.format(package_id=package_id)
+
+
 CUSTOM_APP_STRINGS_RE = _regex_union(REGEXES)
 
 

--- a/corehq/apps/app_manager/static/app_manager/js/settings/commcare_settings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/settings/commcare_settings.js
@@ -227,14 +227,8 @@ hqDefine('app_manager/js/settings/commcare_settings', function () {
             });
 
             // Returns values and value names as select/multiSelect options.
-            // Accepts an array of default values to support multiSelect.
+            // Accepts default values as an array to support multiSelect.
             setting.getOptions = function (values, valueNames, defaults) {
-                if (!values || !valueNames || values.length !== valueNames.length) {
-                    var msg = ("select and multiSelect widgets require values " +
-                        "and value names of equal length");
-                    console.error(msg, values, valueNames);
-                    throw new Error(msg);
-                }
                 var options = [];
                 for (var i = 0; i < values.length; i++) {
                     options.push({

--- a/corehq/apps/app_manager/static/app_manager/js/settings/commcare_settings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/settings/commcare_settings.js
@@ -226,19 +226,20 @@ hqDefine('app_manager/js/settings/commcare_settings', function () {
                 return setting.disabled && setting.visibleValue() !== setting['default'];
             });
 
-            // Returns values and value_names as select/multiSelect options.
+            // Returns values and value names as select/multiSelect options.
             // Accepts an array of default values to support multiSelect.
-            setting.getOptions = function (values, value_names, defaults) {
-                if (!values || !value_names || values.length !== value_names.length) {
-                    console.error("select and multiSelect widgets require values " +
-                        "and value_names of equal length", values, value_names);
-                    throw {};
+            setting.getOptions = function (values, valueNames, defaults) {
+                if (!values || !valueNames || values.length !== valueNames.length) {
+                    var msg = ("select and multiSelect widgets require values " +
+                        "and value names of equal length");
+                    console.error(msg, values, valueNames);
+                    throw new Error(msg);
                 }
                 var options = [];
                 for (var i = 0; i < values.length; i++) {
                     options.push({
                         label: (defaults.includes(values[i]) ? '* ' : '') +
-                            value_names[i],
+                            valueNames[i],
                         value: values[i],
                     });
                 }

--- a/corehq/apps/app_manager/static/app_manager/js/settings/commcare_settings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/settings/commcare_settings.js
@@ -226,6 +226,25 @@ hqDefine('app_manager/js/settings/commcare_settings', function () {
                 return setting.disabled && setting.visibleValue() !== setting['default'];
             });
 
+            // Returns values and value_names as select/multiSelect options.
+            // Accepts an array of default values to support multiSelect.
+            setting.getOptions = function (values, value_names, defaults) {
+                if (!values || !value_names || values.length !== value_names.length) {
+                    console.error("select and multiSelect widgets require values " +
+                        "and value_names of equal length", values, value_names);
+                    throw {};
+                }
+                var options = [];
+                for (var i = 0; i < values.length; i++) {
+                    options.push({
+                        label: (defaults.includes(values[i]) ? '* ' : '') +
+                            value_names[i],
+                        value: values[i],
+                    });
+                }
+                return options;
+            };
+
             // valueToSave is only ever used during serialization/save;
             // different from visibleValue
             // in that you want to save null and not the shown value
@@ -338,26 +357,11 @@ hqDefine('app_manager/js/settings/commcare_settings', function () {
     CommcareSettings.widgets = {};
 
     CommcareSettings.widgets.select = function (self) {
-        self.updateOptions = function () {
-            var values = ko.utils.unwrapObservable(self.values);
-            var value_names = ko.utils.unwrapObservable(self.value_names);
-            if (!values || !value_names || values.length !== value_names.length) {
-                console.error("Widget select requires values " +
-                    "and value_names of equal length", self);
-                throw {};
-            }
-            var options = [];
-            for (var i = 0; i < values.length; i++) {
-                options.push({
-                    label: (self['default'] === values[i] ? '* ' : '') +
-                        value_names[i],
-                    value: values[i],
-                });
-            }
-            self.options(options);
-        };
-        self.options = ko.observable([]);
-        self.updateOptions();
+        self.options = ko.observable(self.getOptions(
+            ko.utils.unwrapObservable(self.values),
+            ko.utils.unwrapObservable(self.value_names),
+            [self['default']]
+        ));
         self.selectOption = function (selectedOption) {
             if (selectedOption) {
                 self.visibleValue(selectedOption.value);
@@ -389,6 +393,45 @@ hqDefine('app_manager/js/settings/commcare_settings', function () {
             var value = self.value();
             return !value || _(self.options()).some(function (option) {
                 return option.value === value;
+            });
+        };
+    };
+
+    CommcareSettings.widgets.multiSelect = function (self) {
+        self.options = ko.observable(self.getOptions(
+            ko.utils.unwrapObservable(self.values),
+            ko.utils.unwrapObservable(self.value_names),
+            self['default']  // multiSelect default is an array
+        ));
+
+        self.selectOptions = function (selectedOptions) {
+            var values = _.map(selectedOptions, function (o) {
+                return o.value;
+            });
+            self.visibleValue(values);
+        };
+
+        self.selectedOptions = ko.computed({
+            read: function () {
+                var visibleValue = self.visibleValue();
+                return _.filter(self.options(), function (o) {
+                    return visibleValue.includes(o.value);
+                });
+            },
+            write: self.selectOptions,
+        });
+
+        self.writeSelectedOptions = ko.computed({
+            read: function () { return []; },
+            write: self.selectOptions,
+        });
+
+        self.valueIsLegal = function () {
+            var optionValues = _.map(self.options(), function (o) {
+                return o.value;
+            });
+            return _.every(self.value(), function (v) {
+                return optionValues.includes(v);
             });
         };
     };

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
@@ -466,3 +466,18 @@
   default: "no"
   since: "2.49"
   force: true
+
+- id: 'dependencies'
+  name: 'Android app dependencies'
+  type: 'features'
+  toggle: APP_DEPENDENCIES
+  description: >
+    Prevents mobile workers from using a CommCare app until the Android
+    apps that it needs have been installed on the device.
+  widget: 'multiSelect'
+  values:
+    - ['org.commcare.dalvik.reminders', 'CommCare Reminders']
+    - ['callout.commcare.org.sendussd', 'CommCare USSD']
+    - ['org.commcare.dalvik.abha', 'CommCare ABHA']
+  default: []  # multiSelect default takes a list
+  since: '2.53'

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
@@ -481,3 +481,4 @@
     - ['org.commcare.dalvik.abha', 'CommCare ABHA']
   default: []  # multiSelect default takes a list
   since: '2.53'
+  force: true

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yml
@@ -75,6 +75,7 @@
     - hq.use_grid_menus
     - hq.grid_form_menus
     - hq.target_commcare_flavor
+    - features.dependencies  # Required Android apps
 
 - title: 'Advanced'
   id: app-settings-advanced

--- a/corehq/apps/app_manager/static_strings.py
+++ b/corehq/apps/app_manager/static_strings.py
@@ -32,6 +32,7 @@ STATICALLY_ANALYZABLE_TRANSLATIONS = [
     gettext_noop('Allow visitors to use this application without a login.'),
     gettext_noop('Alphanumeric'),
     gettext_noop('Amount of time previously submitted forms remain accessible in the CommCare app.'),
+    gettext_noop('Android app dependencies'),
     gettext_noop('Android Settings'),
     gettext_noop('Anonymous Usage'),
     gettext_noop('Any positive integer. Represents period of purging in days.'),
@@ -166,6 +167,9 @@ STATICALLY_ANALYZABLE_TRANSLATIONS = [
     gettext_noop('Oops! This setting has been discontinued. We recommend you change this setting to Version 2, and it will no longer appear on your settings page.'),
     gettext_noop('Password Format'),
     gettext_noop('Practice Mobile Worker'),
+    gettext_noop('Prevents mobile workers from using a CommCare app until the '
+                 'Android apps that it needs have been installed on the '
+                 'device.\n'),
     gettext_noop('Profile URL'),
     gettext_noop('Project Default'),
     gettext_noop('Prompt Updates to Latest CommCare Version'),

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -25,6 +25,34 @@
   </span>
 </script>
 
+<script type="text/html" id="CommcareSettings.widgets.multiSelect">
+  <span>
+    <span data-bind="if: valueIsLegal()">
+      <select multiple="multiple"
+              class="col-sm-3 form-control"
+              data-bind="options: options,
+                         selectedOptions: selectedOptions,
+                         optionsText: 'label',
+                         attr: {
+                           disabled: !enabled(),
+                           id: inputId
+                         }"></select>
+    </span>
+    <span data-bind="if: !valueIsLegal()" >
+      <select multiple="multiple"
+              class="col-sm-3 form-control error"
+              data-bind="options: options,
+                         selectedOptions: writeSelectedOptions,
+                         optionsText: 'label',
+                         attr: {
+                           disabled: !enabled(),
+                           id: inputId
+                         },
+                         optionsCaption: value()"></select>
+    </span>
+  </span>
+</script>
+
 <script type="text/html" id="CommcareSettings.widgets.bool">
   <div class="checkbox-app-settings">
     <input type="checkbox"

--- a/corehq/apps/app_manager/templates/app_manager/profile.xml
+++ b/corehq/apps/app_manager/templates/app_manager/profile.xml
@@ -50,11 +50,20 @@
             <time>0</time>
         </reminders>
         <package active="false"/>
-        {% for feature, value in app_profile.features.items %}{% if value.value != None and feature != 'users'%}
+        {% for feature, value in app_profile.features.items %}{% if value.value != None %}
+        {% if feature != 'users' and feature != 'dependencies' %}
             <{{ feature }} active="{{ value.value }}" />
+        {% endif %}
         {% endif %}{% endfor %}
         <users active="{{ app_profile.features.users.value|default:'true' }}">
         </users>
+        {% if app_profile.features.dependencies.value %}
+        <dependencies active="true">
+            {% for app_id in app_profile.features.dependencies.value %}
+            <android_package id="{{ app_id }}"/>
+            {% endfor %}
+        </dependencies>
+        {% endif %}
     </features>
 
     <suite><resource id="suite" version="{{ app.version }}">

--- a/corehq/apps/app_manager/tests/test_app_strings.py
+++ b/corehq/apps/app_manager/tests/test_app_strings.py
@@ -207,3 +207,21 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
             self.assertEqual(es_app_strings['case_search.m0'], 'Conseguirlos')
             self.assertEqual(es_app_strings['case_search.m0.icon'], 'jr://file/commcare/image/1_es.png')
             self.assertEqual(es_app_strings['case_search.m0.again'], 'Get them all')
+
+    def test_dependencies_app_strings(self):
+        app_id = 'callout.commcare.org.sendussd'
+        app_name = 'CommCare USSD'
+
+        factory = AppFactory(build_version='2.40.0')
+        factory.app.profile['features'] = {'dependencies': [app_id]}
+
+        with flag_disabled('APP_DEPENDENCIES'):
+            default_strings = self._generate_app_strings(factory.app, 'default')
+            self.assertNotIn(f'android.package.name.{app_id}', default_strings)
+
+        with flag_enabled('APP_DEPENDENCIES'):
+            default_strings = self._generate_app_strings(factory.app, 'default')
+            self.assertEqual(
+                default_strings[f'android.package.name.{app_id}'],
+                app_name
+            )

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2285,6 +2285,18 @@ GOOGLE_SHEETS_INTEGRATION = StaticToggle(
     """
 )
 
+APP_DEPENDENCIES = StaticToggle(
+    'app-dependencies',
+    'Set Android app dependencies that must be installed before using a '
+    'CommCare app',
+    TAG_SOLUTIONS_LIMITED,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    Prevents mobile workers from using a CommCare app until the Android apps
+    that it needs have been installed on the device.
+    """,
+)
+
 SUPERSET_ANALYTICS = StaticToggle(
     'superset-analytics',
     'Activates Analytics features to create Superset based reports and dashboards using UCR data',


### PR DESCRIPTION
## Product Description

This feature allows app builders to set one or more Android apps as dependencies of a CommCare app. CommCare users are only able to open the CommCare app once the required Android apps have been installed on their device.

Dependencies are set under app settings > Advanced Settings:

![image](https://user-images.githubusercontent.com/708421/186262826-391ad50a-ff94-4dd3-ae58-d3ee0f12cc83.png)

## Technical Summary

Spec: https://docs.google.com/document/d/1F_nKK8dSvpEKB3QOqq2A8Rb1AcMKZwpg9_TLK_IrhJ4/edit?pli=1#
Jira: https://dimagi-dev.atlassian.net/browse/SC-2161

Easier to review by commit. :blowfish: 

## Feature Flag

"app dependencies"

## Safety Assurance

### Safety story

Tested locally. Currently being tested on Staging.

### Automated test coverage

Includes tests

### QA Plan

No QA planned. Dev testing on staging should be sufficient.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
