### PR TITLE
tweaks to MM upload in web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -127,7 +127,7 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
                 newData.append("file", requestParams.file);
                 newData.append("answer", JSON.stringify(_.omit(requestParams, "file")));
                 contentParams = {
-                    contentType: "multipart/form-data",
+                    contentType: false,
                     data: newData,
                 };
             } else {
@@ -140,7 +140,6 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
                 type: 'POST',
                 url: self.urls.xform + "/" + requestParams.action,
                 processData: false,
-                dataType: "json",
                 crossDomain: {
                     crossDomain: true,
                 },

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -125,7 +125,14 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
             if (requestParams.action === Const.ANSWER_MEDIA) {
                 var newData = new FormData();
                 newData.append("file", requestParams.file);
-                newData.append("answer", JSON.stringify(_.omit(requestParams, "file")));
+
+                // use a blob here so that we can set the content type
+                let answerData = new Blob(
+                    [JSON.stringify(_.omit(requestParams, "file"))],
+                    {type: 'application/json'}
+                );
+                newData.append("answer", answerData);
+
                 contentParams = {
                     contentType: false,
                     data: newData,


### PR DESCRIPTION
## Technical Summary
Small tweaks to how the request is sent for MM uploads.

See discussion on https://github.com/dimagi/formplayer/pull/1198

Example request (the relevant parts):
```
POST /answer_media HTTP/1.1
Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryC1BkE3mJj9ttZDK8

------WebKitFormBoundaryC1BkE3mJj9ttZDK8
Content-Disposition: form-data; name="file"; filename="Screenshot from 2022-08-23 15-24-13.png"
Content-Type: image/png


------WebKitFormBoundaryC1BkE3mJj9ttZDK8
Content-Disposition: form-data; name="answer"; filename="blob"
Content-Type: application/json

{"action":"answer_media","ix":"0","answer":"Screenshot from 2022-08-23 15-24-13.png","answersToValidate":{},"oneQuestionPerScreen":false,"domain":"skelly","username":"skelly@dimagi.com","restoreAs":null,"session-id":"1137b02c-3563-4884-8cc9-dfaca4cd89b2","session_id":"1137b02c-3563-4884-8cc9-dfaca4cd89b2","debuggerEnabled":true,"tz_offset_millis":7200000,"tz_from_browser":"Africa/Johannesburg"}
------WebKitFormBoundaryC1BkE3mJj9ttZDK8--
```

## Feature Flag
WEB_APPS_UPLOAD_QUESTIONS

## Safety Assurance

### Safety story
Mostly impacts a FF feature. Also tested answering other questions locally.

### Automated test coverage
NA

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
