### PR TITLE
Discard node ending with @False

### DIFF
--- a/corehq/apps/hqadmin/corrupt_couch.py
+++ b/corehq/apps/hqadmin/corrupt_couch.py
@@ -379,7 +379,7 @@ def _get_couch_node_databases(db, node_port=COUCH_NODE_PORT):
     resp = db.server._request_session.get(urljoin(db.server.uri, '/_membership'))
     resp.raise_for_status()
     membership = resp.json()
-    nodes = [node.split("@")[1] for node in membership["cluster_nodes"]]
+    nodes = [node.split("@")[1] for node in membership["cluster_nodes"] if not node.endswith("@False")]
     proxy_url = urlparse(settings.COUCH_DATABASE)._replace(path=f"/{db.dbname}")
     auth = proxy_url.netloc.split('@')[0]
     return [Database(node_url(proxy_url, node)) for node in nodes]


### PR DESCRIPTION
Minor fix. Not sure why such an entry would be present in the membership nodes list, but it was observed.

## Safety Assurance

### Safety story

Minor change to rarely used management command.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
