### PR TITLE
Add raw_doc support for SQL Lookup Tables

### DIFF
--- a/corehq/apps/hqadmin/tests/test_raw_doc.py
+++ b/corehq/apps/hqadmin/tests/test_raw_doc.py
@@ -40,8 +40,6 @@ class TestRawDocLookup(TestCase):
 
         data = raw_doc_lookup(str(table.id))
         self.assertEqual(json.loads(data["doc"]), expected_doc)
-        results = {r.dbname: r for r in data["db_results"]}
-        self.assertEqual(results["test_commcarehq__fixtures"].result, "missing")
 
     def test_lookuptablerow_raw_doc(self):
         table = make_lookuptable()
@@ -76,8 +74,6 @@ class TestRawDocLookup(TestCase):
 
         data = raw_doc_lookup(str(row.id))
         self.assertEqual(json.loads(data["doc"]), expected_doc)
-        results = {r.dbname: r for r in data["db_results"]}
-        self.assertEqual(results["test_commcarehq__fixtures"].result, "missing")
 
 
 def make_lookuptable():

--- a/corehq/apps/hqadmin/tests/test_raw_doc.py
+++ b/corehq/apps/hqadmin/tests/test_raw_doc.py
@@ -1,0 +1,90 @@
+import json
+
+from django.test import TestCase
+
+from corehq.apps.fixtures.models import Field, LookupTable, LookupTableRow, TypeField
+
+from ..views.data import raw_doc_lookup
+
+
+class TestRawDockLookup(TestCase):
+    maxDiff = None
+
+    def test_lookuptable_raw_doc(self):
+        table = make_lookuptable()
+        table.save()
+        self.addCleanup(table._migration_get_couch_object().delete)
+        expected_doc = {
+            "model": "fixtures.lookuptable",
+            "pk": str(table.id),
+            "fields": {
+                "domain": "test-domain",
+                "is_global": True,
+                "tag": "item",
+                "fields": [
+                    {
+                        "name": "qty",
+                        "properties": [],
+                        "is_indexed": False,
+                    }
+                ],
+                "item_attributes": ["name"],
+                "description": "",
+            },
+        }
+
+        data = raw_doc_lookup(table.id.hex)
+        self.assertEqual(json.loads(data["doc"]), expected_doc)
+        results = {r.dbname: r for r in data["db_results"]}
+        self.assertEqual(results["test_commcarehq__fixtures"].result, "found")
+
+        data = raw_doc_lookup(str(table.id))
+        self.assertEqual(json.loads(data["doc"]), expected_doc)
+        results = {r.dbname: r for r in data["db_results"]}
+        self.assertEqual(results["test_commcarehq__fixtures"].result, "missing")
+
+    def test_lookuptablerow_raw_doc(self):
+        table = make_lookuptable()
+        table.save(sync_to_couch=False)
+        row = LookupTableRow(
+            domain="test-domain",
+            table=table,
+            fields={"qty": [Field(value="2")]},
+            item_attributes={"name": "iron"},
+            sort_key=0,
+        )
+        row.save()
+        self.addCleanup(row._migration_get_couch_object().delete)
+        expected_doc = {
+            "model": "fixtures.lookuptablerow",
+            "pk": str(row.id),
+            "fields": {
+                "table": str(table.id),
+                "domain": "test-domain",
+                "fields": {
+                    "qty": [{"value": "2", "properties": {}}],
+                },
+                "item_attributes": {"name": "iron"},
+                "sort_key": 0,
+            },
+        }
+
+        data = raw_doc_lookup(row.id.hex)
+        self.assertEqual(json.loads(data["doc"]), expected_doc)
+        results = {r.dbname: r for r in data["db_results"]}
+        self.assertEqual(results["test_commcarehq__fixtures"].result, "found")
+
+        data = raw_doc_lookup(str(row.id))
+        self.assertEqual(json.loads(data["doc"]), expected_doc)
+        results = {r.dbname: r for r in data["db_results"]}
+        self.assertEqual(results["test_commcarehq__fixtures"].result, "missing")
+
+
+def make_lookuptable():
+    return LookupTable(
+        domain='test-domain',
+        is_global=True,
+        tag='item',
+        fields=[TypeField(name='qty')],
+        item_attributes=['name'],
+    )

--- a/corehq/apps/hqadmin/tests/test_raw_doc.py
+++ b/corehq/apps/hqadmin/tests/test_raw_doc.py
@@ -7,7 +7,7 @@ from corehq.apps.fixtures.models import Field, LookupTable, LookupTableRow, Type
 from ..views.data import raw_doc_lookup
 
 
-class TestRawDockLookup(TestCase):
+class TestRawDocLookup(TestCase):
     maxDiff = None
 
     def test_lookuptable_raw_doc(self):

--- a/corehq/util/jsonattrs.py
+++ b/corehq/util/jsonattrs.py
@@ -101,6 +101,13 @@ class JsonAttrsField(JSONField):
         value = super().from_db_value(value, expression, connection)
         return self.builder.attrify(value)
 
+    def value_to_string(self, obj):
+        # Returns a JSON-serializable object for compatibility with
+        # django.core.serializers.python.Serializer. Obviously this is
+        # not strictly a string, but it's closer than the collection of
+        # attrs instances returned by the default implementation.
+        return self.builder.jsonify(self.value_from_object(obj))
+
     def deconstruct(self):
         # Returns a JSONField deconstruction to be used in migrations,
         # which do not need to know anything about attrs builders.

--- a/corehq/util/tests/test_jsonattrs.py
+++ b/corehq/util/tests/test_jsonattrs.py
@@ -104,6 +104,18 @@ def test_jsonattrs_from_json():
     eq(check.events, [Event(day=date(2022, 7, 20))])
 
 
+def test_value_to_string_returns_json_serializable():
+    @unregistered_django_model
+    class Check(models.Model):
+        events = AttrsList(Event)
+
+    check = Check(events=[Event()])
+    eq(
+        Check._meta.get_field("events").value_to_string(check),
+        [{"day": "2022-07-19"}],
+    )
+
+
 def get_json_value(model, field_name):
     """Get the JSON value of a field as it would be stored in the database
 


### PR DESCRIPTION
## Safety Assurance

### Safety story

Adds a new feature to an admin view. `jsonattrs` is thoroughly tested, so changes there should be safe.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
