### PR TITLE
Remove group limitation on broadcast

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -139,7 +139,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             if (match) {
                 var receiveTopic = match[1];
                 var receiveTopicField = match[2];
-                question.contextPubSub.subscribe(function (message) {
+                question.broadcastPubSub.subscribe(function (message) {
                     if (message === Const.NO_ANSWER) {
                         self.rawAnswer(Const.NO_ANSWER);
                     } else if (message) {
@@ -266,7 +266,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             self.editing = false;
             var broadcastObj = Utils.getBroadcastObject(item);
             self.broadcastTopics.forEach(function (broadcastTopic) {
-                question.contextPubSub.notifySubscribers(broadcastObj, broadcastTopic);
+                question.broadcastPubSub.notifySubscribers(broadcastObj, broadcastTopic);
             });
             if (_.isEmpty(broadcastObj)) {
                 question.answer(Const.NO_ANSWER);
@@ -283,7 +283,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             self.question.error(null);
             self.editing = true;
             self.broadcastTopics.forEach(function (broadcastTopic) {
-                question.contextPubSub.notifySubscribers(Const.NO_ANSWER, broadcastTopic);
+                question.broadcastPubSub.notifySubscribers(Const.NO_ANSWER, broadcastTopic);
             });
         };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -139,7 +139,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             if (match) {
                 var receiveTopic = match[1];
                 var receiveTopicField = match[2];
-                question.formPubSub.subscribe(function (message) {
+                question.contextPubSub.subscribe(function (message) {
                     if (message === Const.NO_ANSWER) {
                         self.rawAnswer(Const.NO_ANSWER);
                     } else if (message) {
@@ -266,7 +266,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             self.editing = false;
             var broadcastObj = Utils.getBroadcastObject(item);
             self.broadcastTopics.forEach(function (broadcastTopic) {
-                question.formPubSub.notifySubscribers(broadcastObj, broadcastTopic);
+                question.contextPubSub.notifySubscribers(broadcastObj, broadcastTopic);
             });
             if (_.isEmpty(broadcastObj)) {
                 question.answer(Const.NO_ANSWER);
@@ -283,7 +283,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             self.question.error(null);
             self.editing = true;
             self.broadcastTopics.forEach(function (broadcastTopic) {
-                question.formPubSub.notifySubscribers(Const.NO_ANSWER, broadcastTopic);
+                question.contextPubSub.notifySubscribers(Const.NO_ANSWER, broadcastTopic);
             });
         };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -139,7 +139,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             if (match) {
                 var receiveTopic = match[1];
                 var receiveTopicField = match[2];
-                question.parentPubSub.subscribe(function (message) {
+                question.formPubSub.subscribe(function (message) {
                     if (message === Const.NO_ANSWER) {
                         self.rawAnswer(Const.NO_ANSWER);
                     } else if (message) {
@@ -266,7 +266,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             self.editing = false;
             var broadcastObj = Utils.getBroadcastObject(item);
             self.broadcastTopics.forEach(function (broadcastTopic) {
-                question.parentPubSub.notifySubscribers(broadcastObj, broadcastTopic);
+                question.formPubSub.notifySubscribers(broadcastObj, broadcastTopic);
             });
             if (_.isEmpty(broadcastObj)) {
                 question.answer(Const.NO_ANSWER);
@@ -283,7 +283,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             self.question.error(null);
             self.editing = true;
             self.broadcastTopics.forEach(function (broadcastTopic) {
-                question.parentPubSub.notifySubscribers(Const.NO_ANSWER, broadcastTopic);
+                question.formPubSub.notifySubscribers(Const.NO_ANSWER, broadcastTopic);
             });
         };
 
@@ -1283,19 +1283,10 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
      * Utility that gets the display options from a parent form of a question.
      * */
     function _getDisplayOptions(question) {
-        var maxIter = 10; // protect against a potential infinite loop
-        var form = question.parent;
-
+        const form = Utils.getRootForm(question);
         if (form === undefined) {
             return {};
         }
-
-        // logic in case the question is in a group or repeat or nested group, etc.
-        while (form.displayOptions === undefined && maxIter > 0) {
-            maxIter--;
-            form = parent.parent;
-        }
-
         return form.displayOptions || {};
     }
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1283,7 +1283,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
      * Utility that gets the display options from a parent form of a question.
      * */
     function _getDisplayOptions(question) {
-        const form = Utils.getRootForm(question);
+        const form = Utils.getRootContainer(question);
         if (form === undefined) {
             return {};
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1283,7 +1283,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
      * Utility that gets the display options from a parent form of a question.
      * */
     function _getDisplayOptions(question) {
-        const form = Utils.getRootContainer(question);
+        const form = Utils.getRootForm(question);
         if (form === undefined) {
             return {};
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -433,9 +433,9 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
      */
     function Group(json, parent) {
         var self = this;
+        self.parent = parent;
         Container.call(self, json);
 
-        self.parent = parent;
         self.groupId = groupNum++;
         self.rel_ix = ko.observable(relativeIndex(self.ix()));
         self.isRepetition = parent instanceof Repeat;
@@ -514,9 +514,10 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
      */
     function Repeat(json, parent) {
         var self = this;
+        self.parent = parent;
+
         Container.call(self, json);
 
-        self.parent = parent;
         self.rel_ix = ko.observable(relativeIndex(self.ix()));
         if (_.has(json, 'domain_meta') && _.has(json, 'style')) {
             self.domain_meta = parseMeta(json.datatype, json.style);
@@ -564,8 +565,9 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         var self = this;
         self.fromJS(json);
         self.parent = parent;
-        // Grab the parent pubsub so questions can interact with other questions on the same form/group.
-        self.parentPubSub = (parent) ? parent.pubsub : new ko.subscribable();
+        // Grab the parent pubsub so questions can interact with other questions on the same form.
+        const form = Utils.getRootForm(self);
+        self.formPubSub = (form) ? form.pubsub : new ko.subscribable();
         self.error = ko.observable(null);
         self.serverError = ko.observable(null);
         self.rel_ix = ko.observable(relativeIndex(self.ix()));

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -569,7 +569,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         const form = Utils.getRootContainer(self, function (container) {
             return container instanceof Repeat;
         });
-        self.contextPubSub = (form) ? form.pubsub : new ko.subscribable();
+        self.broadcastPubSub = (form) ? form.pubsub : new ko.subscribable();
         self.error = ko.observable(null);
         self.serverError = ko.observable(null);
         self.rel_ix = ko.observable(relativeIndex(self.ix()));

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -565,8 +565,10 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         var self = this;
         self.fromJS(json);
         self.parent = parent;
-        // Grab the parent pubsub so questions can interact with other questions on the same form.
-        const form = Utils.getRootForm(self);
+        // Grab the containing pubsub so questions can interact with other questions on the same form.
+        const form = Utils.getRootContainer(self, function (container) {
+            return container instanceof Repeat;
+        });
         self.formPubSub = (form) ? form.pubsub : new ko.subscribable();
         self.error = ko.observable(null);
         self.serverError = ko.observable(null);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -569,7 +569,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         const form = Utils.getRootContainer(self, function (container) {
             return container instanceof Repeat;
         });
-        self.formPubSub = (form) ? form.pubsub : new ko.subscribable();
+        self.contextPubSub = (form) ? form.pubsub : new ko.subscribable();
         self.error = ko.observable(null);
         self.serverError = ko.observable(null);
         self.rel_ix = ko.observable(relativeIndex(self.ix()));

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -566,10 +566,8 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.fromJS(json);
         self.parent = parent;
         // Grab the containing pubsub so questions can interact with other questions on the same form.
-        const form = Utils.getRootContainer(self, function (container) {
-            return container instanceof Repeat;
-        });
-        self.broadcastPubSub = (form) ? form.pubsub : new ko.subscribable();
+        const container = Utils.getBroadcastContainer(self);
+        self.broadcastPubSub = (container) ? container.pubsub : new ko.subscribable();
         self.error = ko.observable(null);
         self.serverError = ko.observable(null);
         self.rel_ix = ko.observable(relativeIndex(self.ix()));
@@ -725,6 +723,5 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         Question: function (json, parent) {
             return new Question(json, parent);
         },
-        RepeatClass: Repeat,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -725,5 +725,6 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         Question: function (json, parent) {
             return new Question(json, parent);
         },
+        RepeatClass: Repeat,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/fixtures.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/fixtures.js
@@ -1,6 +1,6 @@
 hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
     return {
-        textJSON: (options={}) => (_.defaults(options, {
+        textJSON: (options = {}) => (_.defaults(options, {
             "caption_audio": null,
             "caption_video": null,
             "caption_image": null,
@@ -26,7 +26,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
             "add-choice": null
         })),
 
-        selectJSON: (options={}) => (_.defaults(options, {
+        selectJSON: (options = {}) => (_.defaults(options, {
             "caption_audio": null,
             "caption_video": null,
             "caption_image": null,
@@ -52,7 +52,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
             "add-choice": null
         })),
 
-        labelJSON: (options={}) => (_.defaults(options, {
+        labelJSON: (options = {}) => (_.defaults(options, {
             "caption_audio": null,
             "caption_video": null,
             "caption_image": null,
@@ -78,7 +78,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
             "add-choice": null
         })),
 
-        repeatJSON: (options={}) => (_.defaults(options, {
+        repeatJSON: (options = {}) => (_.defaults(options, {
             "caption_audio": null,
             "caption": "Repeater",
             "caption_image": null,
@@ -128,7 +128,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
             "caption_video": null,
         }),
 
-        groupJSON: (options={}) => (_.defaults(options, {
+        groupJSON: (options = {}) => (_.defaults(options, {
             "type": "sub-group",
             "ix": "1",
             "children": [

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/fixtures.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/fixtures.js
@@ -128,7 +128,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
             "caption_video": null,
         }),
 
-        groupJSON: () => ({
+        groupJSON: (options={}) => (_.defaults(options, {
             "type": "sub-group",
             "ix": "1",
             "children": [
@@ -146,7 +146,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
                     ],
                 },
             ],
-        }),
+        })),
 
         noQuestionGroupJSON: () => ({
             "type": "sub-group",

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
@@ -1,6 +1,10 @@
 describe('Formplayer utils', function () {
+    var Fixtures = hqImport("cloudcare/js/form_entry/spec/fixtures"),
+        UI = hqImport("cloudcare/js/form_entry/form_ui"),
+        Utils = hqImport("cloudcare/js/form_entry/utils");
+
     it('Should determine if two answers are equal', function () {
-        var answersEqual = hqImport("cloudcare/js/form_entry/utils").answersEqual,
+        var answersEqual = Utils.answersEqual,
             result;
 
         result = answersEqual('ben', 'bob');
@@ -14,5 +18,43 @@ describe('Formplayer utils', function () {
 
         result = answersEqual(['b', 'e', 'n'], ['b', 'e', 'n']);
         assert.isTrue(result);
+    });
+
+    it('Should get root form for questions', function () {
+        /**
+         *  Form's question tree:
+         *     text
+         *     group
+         *         textInGroup
+         *     repeat
+         *         textInRepeat
+         *         groupInRepeat
+         *             textInNestedGroup
+         */
+        var text = Fixtures.textJSON({ix: "0"}),
+            textInGroup = Fixtures.textJSON({ix: "1,0"}),
+            group = Fixtures.groupJSON({ix: "1", children: [textInGroup]}),
+            textInRepeat = Fixtures.textJSON({ix: "2,0"}),
+            textInNestedGroup = Fixtures.textJSON({ix: "2,1,0"}),
+            groupInRepeat = Fixtures.groupJSON({ix: "2,1", children: [textInNestedGroup]}),
+            repeat = Fixtures.repeatJSON({ix: "2", children: [textInRepeat, groupInRepeat]}),
+            form = UI.Form({
+                tree: [text, group, repeat],
+            });
+
+        [text, group, repeat] = form.children();
+        [textInRepeat, groupInRepeat] = repeat.children();
+        [textInNestedGroup] = groupInRepeat.children();
+
+        assert.equal(Utils.getRootContainer(text), form);
+        assert.equal(Utils.getRootContainer(textInRepeat), form);
+        assert.equal(Utils.getRootContainer(groupInRepeat), form);
+
+        var repeatCallback = function (container) {
+            return container instanceof UI.RepeatClass;
+        }
+        assert.equal(Utils.getRootContainer(text, repeatCallback), form);
+        assert.equal(Utils.getRootContainer(textInRepeat, repeatCallback), repeat);
+        assert.equal(Utils.getRootContainer(textInNestedGroup, repeatCallback), repeat);
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
@@ -27,31 +27,28 @@ describe('Formplayer utils', function () {
          *     group
          *         textInGroup
          *     repeat
-         *         textInRepeat
          *         groupInRepeat
-         *             textInNestedGroup
+         *             textInRepeat
          */
         var text = Fixtures.textJSON({ix: "0"}),
             textInGroup = Fixtures.textJSON({ix: "1,0"}),
             group = Fixtures.groupJSON({ix: "1", children: [textInGroup]}),
-            textInRepeat = Fixtures.textJSON({ix: "2,0"}),
-            textInNestedGroup = Fixtures.textJSON({ix: "2,1,0"}),
-            groupInRepeat = Fixtures.groupJSON({ix: "2,1", children: [textInNestedGroup]}),
-            repeat = Fixtures.repeatJSON({ix: "2", children: [textInRepeat, groupInRepeat]}),
+            textInRepeat = Fixtures.textJSON({ix: "2_0,0"}),
+            groupInRepeat = Fixtures.groupJSON({ix: "2_0", children: [textInRepeat]}),
+            repeat = Fixtures.repeatJSON({ix: "2", children: [groupInRepeat]}),
             form = UI.Form({
                 tree: [text, group, repeat],
             });
 
         [text, group, repeat] = form.children();
-        [textInRepeat, groupInRepeat] = repeat.children();
-        [textInNestedGroup] = groupInRepeat.children();
+        [groupInRepeat] = repeat.children();
+        [textInRepeat] = groupInRepeat.children();
 
         assert.equal(Utils.getRootForm(text), form);
-        assert.equal(Utils.getRootForm(textInRepeat), form);
         assert.equal(Utils.getRootForm(groupInRepeat), form);
+        assert.equal(Utils.getRootForm(textInRepeat), form);
 
         assert.equal(Utils.getBroadcastContainer(text), form);
-        assert.equal(Utils.getBroadcastContainer(textInRepeat), repeat);
-        assert.equal(Utils.getBroadcastContainer(textInNestedGroup), repeat);
+        assert.equal(Utils.getBroadcastContainer(textInRepeat), groupInRepeat);
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
@@ -46,15 +46,12 @@ describe('Formplayer utils', function () {
         [textInRepeat, groupInRepeat] = repeat.children();
         [textInNestedGroup] = groupInRepeat.children();
 
-        assert.equal(Utils.getRootContainer(text), form);
-        assert.equal(Utils.getRootContainer(textInRepeat), form);
-        assert.equal(Utils.getRootContainer(groupInRepeat), form);
+        assert.equal(Utils.getRootForm(text), form);
+        assert.equal(Utils.getRootForm(textInRepeat), form);
+        assert.equal(Utils.getRootForm(groupInRepeat), form);
 
-        var repeatCallback = function (container) {
-            return container instanceof UI.RepeatClass;
-        }
-        assert.equal(Utils.getRootContainer(text, repeatCallback), form);
-        assert.equal(Utils.getRootContainer(textInRepeat, repeatCallback), repeat);
-        assert.equal(Utils.getRootContainer(textInNestedGroup, repeatCallback), repeat);
+        assert.equal(Utils.getBroadcastContainer(text), form);
+        assert.equal(Utils.getBroadcastContainer(textInRepeat), repeat);
+        assert.equal(Utils.getBroadcastContainer(textInNestedGroup), repeat);
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -150,17 +150,23 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
     };
 
     /**
-     * Gets the root form of a question.
+     * Gets the root container of a question.
      * @param {Object} question - The Question Object
+     * @param {Function} predicate - Optional. If provided, stop when this condition is reached.
+     * If not provided, the root Form object will be returned.
     **/
-    module.getRootForm = (question) => {
+    module.getRootContainer = (question, stopCallback) => {
         if (question.parent === undefined) {
             return undefined;
         }
 
+        if (!_.isFunction(stopCallback)) {
+            stopCallback = function (container) { return false; };
+        }
+
         // logic in case the question is in a group or repeat or nested group, etc.
         let curr = question.parent;
-        while (curr.parent) {
+        while (curr.parent && !stopCallback(curr.parent)) {
             curr = curr.parent;
         }
         return curr;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -166,7 +166,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
 
         // logic in case the question is in a group or repeat or nested group, etc.
         let curr = question.parent;
-        while (curr.parent && !stopCallback(curr.parent)) {
+        while (curr.parent && !stopCallback(curr)) {
             curr = curr.parent;
         }
         return curr;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -155,13 +155,9 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
      * @param {Function} predicate - Optional. If provided, stop when this condition is reached.
      * If not provided, the root Form object will be returned.
     **/
-    module.getRootContainer = (question, stopCallback) => {
+    var getRoot = (question, stopCallback) => {
         if (question.parent === undefined) {
             return undefined;
-        }
-
-        if (!_.isFunction(stopCallback)) {
-            stopCallback = function () { return false; };
         }
 
         // logic in case the question is in a group or repeat or nested group, etc.
@@ -170,6 +166,21 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
             curr = curr.parent;
         }
         return curr;
+    };
+
+    module.getRootForm = (question) => {
+        return getRoot(question, function (container) {
+            // Don't stop for any reason, just return topmost container
+            return false;
+        });
+    };
+
+    module.getBroadcastContainer = (question) => {
+        var Const = hqImport("cloudcare/js/form_entry/const");
+        return getRoot(question, function (container) {
+            // Return first containing repeat group, or form if there are no ancestor repeats
+            return container.type && container.type() === Const.REPEAT_TYPE;
+        });
     };
 
     return module;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -161,7 +161,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         }
 
         if (!_.isFunction(stopCallback)) {
-            stopCallback = function (container) { return false; };
+            stopCallback = function () { return false; };
         }
 
         // logic in case the question is in a group or repeat or nested group, etc.

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -149,12 +149,6 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         return broadcastObj;
     };
 
-    /**
-     * Gets the root container of a question.
-     * @param {Object} question - The Question Object
-     * @param {Function} predicate - Optional. If provided, stop when this condition is reached.
-     * If not provided, the root Form object will be returned.
-    **/
     var getRoot = (question, stopCallback) => {
         if (question.parent === undefined) {
             return undefined;
@@ -168,6 +162,9 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         return curr;
     };
 
+    /**
+     * Gets a question's form, which will be the root of the question's tree.
+    **/
     module.getRootForm = (question) => {
         return getRoot(question, function (container) {
             // Don't stop for any reason, just return topmost container
@@ -175,11 +172,17 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         });
     };
 
+    /**
+     * Get the appropriate Container to which a question can broadcast messages.
+     * This is typically the root form, but for questions inside of repeats, it's
+     * the current group (a child of the repeat juncture).
+    **/
     module.getBroadcastContainer = (question) => {
         var Const = hqImport("cloudcare/js/form_entry/const");
         return getRoot(question, function (container) {
             // Return first containing repeat group, or form if there are no ancestor repeats
-            return container.type && container.type() === Const.REPEAT_TYPE;
+            var parent = container.parent;
+            return parent && parent.type && parent.type() === Const.REPEAT_TYPE;
         });
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -166,7 +166,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
      * Gets a question's form, which will be the root of the question's tree.
     **/
     module.getRootForm = (question) => {
-        return getRoot(question, function (container) {
+        return getRoot(question, function () {
             // Don't stop for any reason, just return topmost container
             return false;
         });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -149,5 +149,22 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         return broadcastObj;
     };
 
+    /**
+     * Gets the root form of a question.
+     * @param {Object} question - The Question Object
+    **/
+    module.getRootForm = (question) => {
+        if (question.parent === undefined) {
+            return undefined;
+        }
+
+        // logic in case the question is in a group or repeat or nested group, etc.
+        let curr = question.parent;
+        while (curr.parent) {
+            curr = curr.parent;
+        }
+        return curr;
+    };
+
     return module;
 });


### PR DESCRIPTION
## Product Description
This is https://github.com/dimagi/commcare-hq/pull/31975 with a couple of commits added to handle repeat groups.

https://dimagi-dev.atlassian.net/browse/USH-2396

## Technical Summary
Prior to this work, broadcast messages were only sent out within a group, so receivers couldn't be in a different group. https://github.com/dimagi/commcare-hq/pull/31975 made broadcast messages global. This PR restores the repeat group behavior:
* If a broadcast is inside of a repeat group, it cannot broadcast outside of that repeat group
* If a broadcast is **not** in a repeat group, it can broadcast to any receiver in the form, provided the receiver is not in a repeat group

## Feature Flag
No flag, but the geocoder is behind a privilege that's only used by a few projects.

## Safety Assurance

### Safety story

### Automated test coverage

In PR.

### QA Plan

Continuing to use the QA ticket from the last PR: https://dimagi-dev.atlassian.net/browse/QA-4413

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
