### PR TITLE
Make blobdb s3db default to system credentials

### DIFF
--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -31,11 +31,17 @@ class S3BlobDB(AbstractBlobDB):
         kwargs = {}
         if "config" in config:
             kwargs["config"] = Config(**config["config"])
+        # if access_key and secret_key are falsy
+        # then omit them from kwargs
+        # and allow boto3 to use the system default credentials
+        if config.get("access_key") or config.get("secret_key"):
+            kwargs.update(
+                aws_access_key_id=config.get("access_key", ""),
+                aws_secret_access_key=config.get("secret_key", ""),
+            )
         self.db = boto3.resource(
             's3',
             endpoint_url=config.get("url"),
-            aws_access_key_id=config.get("access_key", ""),
-            aws_secret_access_key=config.get("secret_key", ""),
             **kwargs
         )
         self.bulk_delete_chunksize = config.get("bulk_delete_chunksize", DEFAULT_BULK_DELETE_CHUNKSIZE)

--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -31,17 +31,11 @@ class S3BlobDB(AbstractBlobDB):
         kwargs = {}
         if "config" in config:
             kwargs["config"] = Config(**config["config"])
-        # if access_key and secret_key are falsy
-        # then omit them from kwargs
-        # and allow boto3 to use the system default credentials
-        if config.get("access_key") or config.get("secret_key"):
-            kwargs.update(
-                aws_access_key_id=config.get("access_key", ""),
-                aws_secret_access_key=config.get("secret_key", ""),
-            )
         self.db = boto3.resource(
             's3',
             endpoint_url=config.get("url"),
+            aws_access_key_id=config.get("access_key"),
+            aws_secret_access_key=config.get("secret_key"),
             **kwargs
         )
         self.bulk_delete_chunksize = config.get("bulk_delete_chunksize", DEFAULT_BULK_DELETE_CHUNKSIZE)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-13894

## Technical Summary
Make blobdb s3db default to system credentials when access_key and secret_key aren't set in the config.

## Safety Assurance

### Safety story
The new behavior oath that this opens up (omitting falsy credentials in the `boto3.resource` call) is will initially never be hit on any of our environments, because `access_key` and `secret_key` are set to values in localsettings `S3_BLOB_DB_SETTINGS`. Thus, this PR should initially represent no change at all. It just opens up our ability to use EC2 Role credentials provided by the system by setting these values to `None` in our localsettings in a following change, which is where the heavier testing will be needed.

### Automated test coverage

There isn't any, since this changes behavior on a level lower (S3 connection configuration) than any of our application code tests cover.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

so long as we haven't rolled out any further changes that depend on this.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
