### PR TITLE
Remove tinys3 & allow None in settings.S3_ACCESS_KEY and settings.S3_SECRET_KEY

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -737,7 +737,7 @@ def _track_periodic_data_on_kiss(submit_json):
             ] + [prop['value'] for prop in webuser['properties']]
             csvwriter.writerow(row)
 
-    if settings.S3_ACCESS_KEY and settings.S3_SECRET_KEY and settings.ANALYTICS_IDS.get('KISSMETRICS_KEY', None):
+    if settings.ANALYTICS_IDS.get('KISSMETRICS_KEY', None):
         s3 = boto3.client(
             's3',
             aws_access_key_id=settings.S3_ACCESS_KEY,

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -5,6 +5,7 @@ import os
 import time
 from datetime import date, datetime, timedelta
 
+import boto3
 from django.conf import settings
 
 import csv
@@ -13,7 +14,6 @@ import requests
 import six.moves.urllib.error
 import six.moves.urllib.parse
 import six.moves.urllib.request
-import tinys3
 from celery.schedules import crontab
 from celery.task import periodic_task
 from email_validator import EmailNotValidError, validate_email
@@ -738,14 +738,15 @@ def _track_periodic_data_on_kiss(submit_json):
             csvwriter.writerow(row)
 
     if settings.S3_ACCESS_KEY and settings.S3_SECRET_KEY and settings.ANALYTICS_IDS.get('KISSMETRICS_KEY', None):
-        s3_connection = tinys3.Connection(settings.S3_ACCESS_KEY, settings.S3_SECRET_KEY, tls=True)
-        f = open(filename, 'rb')
-        s3_connection.upload(filename, f, 'kiss-uploads')
+        s3 = boto3.client(
+            's3',
+            aws_access_key_id=settings.S3_ACCESS_KEY,
+            aws_secret_access_key=settings.S3_SECRET_KEY,
+        )
+        with open(filename, 'rb') as f:
+            s3.upload_fileobj(f, 'kiss-uploads', filename)
 
     os.remove(filename)
-
-
-
 
 
 def get_ab_test_properties(user):

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data_raw.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data_raw.py
@@ -41,13 +41,12 @@ class Command(BaseCommand):
             s3_key = settings.S3_ACCESS_KEY
             s3_secret = settings.S3_SECRET_KEY
 
-        if not (s3_key and s3_secret):
-            raise CommandError("S3 credentials not provided.")
-
         self.bucket = options['bucket'] or 'raw-data-{}'.format(domain)
         self.client = boto3.client(
-            's3', region_name=options['region'],
-            aws_access_key_id=s3_key, aws_secret_access_key=s3_secret
+            's3',
+            region_name=options['region'],
+            aws_access_key_id=s3_key,
+            aws_secret_access_key=s3_secret
         )
         self._create_bucket()
 

--- a/manage.py
+++ b/manage.py
@@ -113,10 +113,6 @@ def _set_source_root(source_root):
 
 
 def run_patches():
-    # workaround for https://github.com/smore-inc/tinys3/issues/33
-    import mimetypes
-    mimetypes.init()
-
     patch_jsonfield()
     patch_celery_task()
 

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -105,7 +105,6 @@ SQLAlchemy
 stripe
 suds-py3
 text-unidecode
-tinys3
 toposort
 tropo-webapi-python
 turn-python

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -536,7 +536,6 @@ requests==2.25.1
     #   requests-toolbelt
     #   sphinx
     #   stripe
-    #   tinys3
     #   twilio
 requests-mock==1.9.3
     # via -r test-requirements.in
@@ -658,8 +657,6 @@ text-unidecode==1.3
     # via
     #   -r base-requirements.in
     #   faker
-tinys3==0.1.12
-    # via -r base-requirements.in
 toml==0.10.2
     # via pep517
 tomli==2.0.1

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -440,7 +440,6 @@ requests==2.25.1
     #   requests-toolbelt
     #   sphinx
     #   stripe
-    #   tinys3
     #   twilio
 requests-oauthlib==1.3.1
     # via
@@ -540,8 +539,6 @@ text-unidecode==1.3
     # via
     #   -r base-requirements.in
     #   faker
-tinys3==0.1.12
-    # via -r base-requirements.in
 toposort==1.7
     # via -r base-requirements.in
 tropo-webapi-python==0.1.3

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -457,7 +457,6 @@ requests==2.25.1
     #   requests-oauthlib
     #   requests-toolbelt
     #   stripe
-    #   tinys3
     #   twilio
 requests-oauthlib==1.3.1
     # via
@@ -541,8 +540,6 @@ text-unidecode==1.3
     # via
     #   -r base-requirements.in
     #   faker
-tinys3==0.1.12
-    # via -r base-requirements.in
 toposort==1.7
     # via -r base-requirements.in
 tornado==6.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -412,7 +412,6 @@ requests==2.25.1
     #   requests-oauthlib
     #   requests-toolbelt
     #   stripe
-    #   tinys3
     #   twilio
 requests-oauthlib==1.3.1
     # via
@@ -491,8 +490,6 @@ text-unidecode==1.3
     # via
     #   -r base-requirements.in
     #   faker
-tinys3==0.1.12
-    # via -r base-requirements.in
 toposort==1.7
     # via -r base-requirements.in
 tropo-webapi-python==0.1.3

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -448,7 +448,6 @@ requests==2.25.1
     #   requests-oauthlib
     #   requests-toolbelt
     #   stripe
-    #   tinys3
     #   twilio
 requests-mock==1.9.3
     # via -r test-requirements.in
@@ -539,8 +538,6 @@ text-unidecode==1.3
     # via
     #   -r base-requirements.in
     #   faker
-tinys3==0.1.12
-    # via -r base-requirements.in
 toml==0.10.2
     # via pep517
 toposort==1.7


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-13894

This both gets rid of an unnecessary dependency (`tinys3`, whose functionality we can already get from `boto3` just as easily and more standardly), and allows a `None` value for the S3 credentials to mean "use the system default credentials", following the convention `boto3` uses.

## Safety Assurance

### Safety story
These keys are barely used at all; the only regular use is for analytics. It's not used at all on staging, but (1) I will make sure to test the connection in production in a limited release before making any localsettings changes that take advantage of this and (2) the worst case scenario (kissmetrics uploads failing for a day) is not so severe.

I've also verified on staging that the code pattern used in the small tinys3 => boto3 rewrite works as expected.

### Automated test coverage

I don't think there's much or any existing test coverage for the kissmetrics upload code.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
