### PR TITLE
Docs for date format in UCR expressions

### DIFF
--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -76,9 +76,11 @@ class ConstantExpressionTest(SimpleTestCase):
             self.assertEqual(valid_constant, getter({'some': 'random stuff'}))
 
     def test_constant_date_conversion(self):
+        # this is due to the type conversion in JsonObject
         self.assertEqual(date(2015, 2, 4), ExpressionFactory.from_spec('2015-02-04')({}))
 
     def test_constant_datetime_conversion(self):
+        # this is due to the type conversion in JsonObject
         self.assertEqual(datetime(2015, 2, 4, 11, 5, 24), ExpressionFactory.from_spec('2015-02-04T11:05:24Z')({}))
 
     def test_legacy_constant_no_type_casting(self):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1162,6 +1162,7 @@ def test_supported_evaluator_statements(self, eq, context, expected_value):
     ("max(a, b)", {"a": 3, "b": 5}),
     # method calls not allowed
     ('"WORD".lower()', {"a": 5}),
+    ('f"{a.lower()}"', {"a": "b"}),
 ])
 def test_unsupported_evaluator_statements(self, eq, context):
     with self.assertRaises(InvalidExpression):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -17,6 +17,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.userreports.decorators import ucr_context_cache
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
+from corehq.apps.userreports.expressions.getters import transform_datetime
 from corehq.apps.userreports.expressions.specs import (
     PropertyNameGetterSpec,
     PropertyPathGetterSpec,
@@ -1142,6 +1143,7 @@ def test_invalid_eval_expression(self, source_doc, statement, context):
     # ranges > 100 items aren't supported
     ("range(200)", {}, None),
     ("a and not b", {"a": 1, "b": 0}, True),
+    ("f'{a:%Y-%m-%d %H:%M}'", {"a": transform_datetime("2022-01-01T14:44:23.123123Z")}, '2022-01-01 14:44'),
 ])
 def test_supported_evaluator_statements(self, eq, context, expected_value):
     self.assertEqual(eval_statements(eq, context), expected_value)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1100,8 +1100,8 @@ class RelatedDocExpressionDbTest(TestCase):
     ({}, "a + b", {"a": Decimal(2.2), "b": Decimal(3.1)}, Decimal(5.3)),
     ({}, "range(3)", {}, [0, 1, 2]),
     (
-        {'dob': "2022-01-01T14:44:23.123689Z"},
-        "f'{d}'[:-6] + str(round(int(f'{d:%f}')/1000)) + 'Z'",
+        {'dob': "2022-01-01T14:44:23.001567Z"},
+        "f'{d}'[:-6] + '%03d' % round(int(f'{d:%f}')/1000) + 'Z'",
         {
             "d": {
                 "type": "property_name",
@@ -1109,7 +1109,7 @@ class RelatedDocExpressionDbTest(TestCase):
                 "datatype": "datetime",
             },
         },
-        '2022-01-01 14:44:23.124Z'),
+        '2022-01-01 14:44:23.002Z'),
 ])
 def test_valid_eval_expression(self, source_doc, statement, context, expected_value):
     expression = ExpressionFactory.from_spec({

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1142,6 +1142,7 @@ def test_invalid_eval_expression(self, source_doc, statement, context):
     ("a and b", {"a": 0, "b": 1}, False),
     # ranges > 100 items aren't supported
     ("range(200)", {}, None),
+    ("f'{a}'[1:3]", {"a": 1234}, "23"),
     ("a and not b", {"a": 1, "b": 0}, True),
     ("f'{a:%Y-%m-%d %H:%M}'", {"a": transform_datetime("2022-01-01T14:44:23.123123Z")}, '2022-01-01 14:44'),
 ])

--- a/docs/ucr/examples.rst
+++ b/docs/ucr/examples.rst
@@ -621,7 +621,7 @@ These examples using `Python f-strings`_ to format the dates.
 
     {
         "type": "evaluator",
-        "statement": "f'{date:%Y-%m-%dT%H:%M:%S}.' + str(round(int(f'{date:%f}')/1000)) + 'Z'",
+        "statement": "f'{date:%Y-%m-%dT%H:%M:%S}.' + '%03d' % round(int(f'{date:%f}')/1000) + 'Z'",
         "context_variables": {
             "date": {
                 "type": "property_name",

--- a/docs/ucr/examples.rst
+++ b/docs/ucr/examples.rst
@@ -613,7 +613,7 @@ These examples using `Python f-strings`_ to format the dates.
     }
 
 
-**Convert a datetime to only show 3 digit microseconds**
+**Convert a datetime to show only 3 digits in the microseconds field**
 
 2022-01-01T15:32:54.109971Z :raw-html:`&rarr;` 2022-01-01T15:32:54.110Z
 

--- a/docs/ucr/examples.rst
+++ b/docs/ucr/examples.rst
@@ -1,3 +1,6 @@
+.. role::  raw-html(raw)
+    :format: html
+
 UCR Examples
 ============
 
@@ -586,6 +589,49 @@ diff_seconds example
 
 This will return the difference in seconds between two times (i.e. start
 and end of form)
+
+Date format
+~~~~~~~~~~~
+These examples using `Python f-strings`_ to format the dates.
+
+**Convert a datetime to a formatted string**
+
+2022-01-01T15:32:54.109971Z :raw-html:`&rarr;` 15:32 on 01 Jan 2022
+
+.. code:: json
+
+    {
+        "type": "evaluator",
+        "statement": "f'{date:%H:%M on %d %b %Y}'",
+        "context_variables": {
+            "date": {
+                "type": "property_name",
+                "property_name": "my_datetime",
+                "datatype": "datetime",
+            }
+        }
+    }
+
+
+**Convert a datetime to only show 3 digit microseconds**
+
+2022-01-01T15:32:54.109971Z :raw-html:`&rarr;` 2022-01-01T15:32:54.110Z
+
+.. code:: json
+
+    {
+        "type": "evaluator",
+        "statement": "f'{date:%Y-%m-%dT%H:%M:%S}.' + str(round(int(f'{date:%f}')/1000)) + 'Z'",
+        "context_variables": {
+            "date": {
+                "type": "property_name",
+                "property_name": "my_datetime",
+                "datatype": "datetime",
+            }
+        }
+    }
+
+.. _Python f-strings: https://docs.python.org/3/reference/lexical_analysis.html#f-strings
 
 Getting forms submitted for a case
 ----------------------------------


### PR DESCRIPTION
## Technical Summary
Some tests a docs to illustrate how to format dates in UCR expressions.

This is useful in [Configurable Repeaters](https://confluence.dimagi.com/display/saas/Configurable+Repeaters) where a specific date format is expected by the target system.

The specific example of a date with only 3 digits in the microsecond field came from a real integration.

## Safety Assurance

### Safety story
Docs + tests only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
