### PR TITLE
permit string values in UCR evaluator expression context

### DIFF
--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -727,45 +727,77 @@ class EvalExpressionSpec(JsonObject):
            "context_variables": {
                "a": 1,
                "b": 20,
-               "c": 2
+               "c": {
+                   "type": "property_name",
+                   "property_name": "the_number_two"
+               }
            }
        }
 
-    This returns 25 (1 + 20 - 2 + 6).
+    This returns **25** (1 + 20 - 2 + 6).
 
-    ``statement`` can be any statement that returns a valid number. All
-    python math
-    `operators <https://en.wikibooks.org/wiki/Python_Programming/Basic_Math#Mathematical_Operators>`__
-    except power operator are available for use.
+    ``statement``
 
-    ``context_variables`` is a dictionary of Expressions where keys are
-    names of variables used in the ``statement`` and values are expressions
-    to generate those variables. Variables can be any valid numbers (Python
-    datatypes ``int``, ``float`` and ``long`` are considered valid numbers.)
-    or also expressions that return numbers. In addition to numbers the
-    following types are supported:
+        The expression statement to be evaluated.
 
-    -  ``date``
-    -  ``datetime``
+    ``context_variables``
 
-    Only the following functions are permitted:
+        A dictionary of Expressions where keys are names of variables used in the ``statement``
+        and values are expressions to generate those variables.
 
-    -  ``rand()``: generate a random number between 0 and 1
-    -  ``randint(max)``: generate a random integer between 0 and ``max``
-    -  ``int(value)``: convert ``value`` to an int. Value can be a number or
-       a string representation of a number
-    -  ``float(value)``: convert ``value`` to a floating point number
-    -  ``str(value)``: convert ``value`` to a string
-    -  ``timedelta_to_seconds(time_delta)``: convert a TimeDelta object into
-       seconds. This is useful for getting the number of seconds between two
-       dates.
+        Variable types must be one of:
 
-       -  e.g. ``timedelta_to_seconds(time_end - time_start)``
+        -  ``str``
+        -  ``int``
+        -  ``float``
+        -  ``bool``
+        -  ``date``
+        -  ``datetime``
 
-    -  ``range(start, [stop], [skip])``: the same as the python ```range``
-       function <https://docs.python.org/2/library/functions.html#range>`__.
-       Note that for performance reasons this is limited to 100 items or
-       less.
+    **Expression limitations**
+
+        Only a single expression is permitted.
+
+        Available operators:
+
+        - `math operators`_ (except the power operator)
+        - `modulus`_
+        - `negation`_
+        - `comparison operators`_
+        - `logical operators`_
+
+        In addition, expressions can perform index and slice operations as well as simple ``if else`` statements.
+
+        Most function calls are disabled except for the following:
+
+        -  ``rand()``: generate a random number between 0 and 1
+        -  ``randint(max)``: generate a random integer between 0 and ``max``
+        -  ``int(value)``: convert ``value`` to an int. Value can be a number or
+           a string representation of a number
+        -  ``float(value)``: convert ``value`` to a floating point number
+        -  ``str(value)``: convert ``value`` to a string
+        -  ``round(value, [ndigits])``: round a number to the nearest integer or ``ndigits``
+           after the decimal point. See `round`_.
+        -  ``timedelta_to_seconds(time_delta)``: convert a TimeDelta object into
+           seconds. This is useful for getting the number of seconds between two
+           dates.
+
+           -  e.g. ``timedelta_to_seconds(time_end - time_start)``
+
+        -  ``range(start, [stop], [skip])``: the same as the Python `range function`_.
+           Note that for performance reasons this is limited to 100 items or
+           less.
+        -  ``today()``: return the current UTC date
+
+    .. _math operators: https://en.wikibooks.org/wiki/Python_Programming/Basic_Math#Mathematical_Operators
+    .. _modulus: https://en.wikibooks.org/wiki/Python_Programming/Operators#Modulus
+    .. _negation: https://en.wikibooks.org/wiki/Python_Programming/Operators#Negation
+    .. _comparison operators: https://en.wikibooks.org/wiki/Python_Programming/Operators#Comparison
+    .. _logical operators: https://en.wikibooks.org/wiki/Python_Programming/Operators#Logical_Operators
+    .. _round: https://docs.python.org/3/library/functions.html?#round
+    .. _range function: https://docs.python.org/3/library/functions.html?#range
+
+    See also :ref:`ucr-evaluator-examples`.
     """
     type = TypeProperty('evaluator')
     statement = StringProperty(required=True)

--- a/corehq/apps/userreports/expressions/utils.py
+++ b/corehq/apps/userreports/expressions/utils.py
@@ -25,6 +25,8 @@ def safe_range(start, *args):
     return None
 
 
+SAFE_TYPES = {float, Decimal, date, datetime, type(None), bool, int, str}
+
 SAFE_OPERATORS = copy.copy(DEFAULT_OPERATORS)
 SAFE_OPERATORS[ast.Pow] = safe_pow_fn  # don't allow power operations
 SAFE_OPERATORS[ast.Not] = operator.not_
@@ -58,7 +60,7 @@ def eval_statements(statement, variable_context):
     """
     # variable values should be numbers
     var_types = set(type(value) for value in variable_context.values())
-    if not var_types.issubset({float, Decimal, date, datetime, type(None), bool}.union(set(six.integer_types))):
+    if not var_types.issubset(SAFE_TYPES):
         raise InvalidExpression('Context contains disallowed types')
 
     evaluator = EvalNoMethods(operators=SAFE_OPERATORS, names=variable_context, functions=FUNCTIONS)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1161,14 +1161,13 @@ def test_invalid_eval_expression(self, source_doc, statement, context):
     ("int(a)", {"a": 1.23}, 1),
     ("round(a)", {"a": 1.23}, 1),
     ("f'{a:%Y-%m-%d %H:%M}'", {"a": transform_datetime("2022-01-01T14:44:23.123123Z")}, '2022-01-01 14:44'),
+    ("a + b", {"a": 'this is ', "b": 'text'}, 'this is text'),
 ])
 def test_supported_evaluator_statements(self, eq, context, expected_value):
     self.assertEqual(eval_statements(eq, context), expected_value)
 
 
 @generate_cases([
-    # variables can't be strings
-    ("a + b", {"a": 2, "b": 'text'}),
     # missing context, b not defined
     ("a + (a*b)", {"a": 2}),
     # power function not supported

--- a/docs/ucr/examples.rst
+++ b/docs/ucr/examples.rst
@@ -510,6 +510,9 @@ change in this scenario.
        }
    }
 
+
+.. _ucr-evaluator-examples:
+
 Evaluator Examples
 ------------------
 


### PR DESCRIPTION
## Product Description
Allow UCR `evaluator` expressions to accept strings in the input context.

## Technical Summary
I don't see a good reason to restrict strings in the input and permitting makes the expressions useful for things other than just math, string formatting for example. While this may not be useful for UCR reports, expressions are now also used by repeaters and potentially other integration features soon.

## Safety Assurance

### Safety story
The expressions are well covered by tests.

### Automated test coverage
Updated

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
