### PR TITLE
formplayer state hash check

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -390,11 +390,22 @@ class RestoreState:
                 self.last_sync_log.error_hash = str(parsed_hash)
                 self.last_sync_log.save()
 
-                raise BadStateException(
-                    server_hash=computed_hash,
-                    phone_hash=parsed_hash,
-                    case_ids=self.last_sync_log.get_footprint_of_cases_on_phone()
-                )
+                if self.params.is_webapps:
+                    # ignore this from webapps for now and just report
+                    notify_error("State hash mistmatch from webapps", details={
+                        'synclog_id': self.params.sync_log_id,
+                        'device_id': self.params.device_id,
+                        'app_id': self.params.app_id,
+                        'user_id': self.restore_user.user_id,
+                        'request_user_id': self.restore_user.request_user_id,
+                        'domain': self.domain,
+                    })
+                else:
+                    raise BadStateException(
+                        server_hash=computed_hash,
+                        phone_hash=parsed_hash,
+                        case_ids=self.last_sync_log.get_footprint_of_cases_on_phone()
+                    )
 
     @property
     def last_sync_log(self):

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -375,22 +375,21 @@ class RestoreState:
 
     def validate_state(self):
         check_version(self.params.version)
-        if self.last_sync_log:
-            if self.params.state_hash:
-                parsed_hash = CaseStateHash.parse(self.params.state_hash)
-                computed_hash = self.last_sync_log.get_state_hash()
-                if computed_hash != parsed_hash:
-                    # log state error on the sync log
-                    self.last_sync_log.had_state_error = True
-                    self.last_sync_log.error_date = datetime.utcnow()
-                    self.last_sync_log.error_hash = str(parsed_hash)
-                    self.last_sync_log.save()
+        if self.last_sync_log and self.params.state_hash:
+            parsed_hash = CaseStateHash.parse(self.params.state_hash)
+            computed_hash = self.last_sync_log.get_state_hash()
+            if computed_hash != parsed_hash:
+                # log state error on the sync log
+                self.last_sync_log.had_state_error = True
+                self.last_sync_log.error_date = datetime.utcnow()
+                self.last_sync_log.error_hash = str(parsed_hash)
+                self.last_sync_log.save()
 
-                    raise BadStateException(
-                        server_hash=computed_hash,
-                        phone_hash=parsed_hash,
-                        case_ids=self.last_sync_log.get_footprint_of_cases_on_phone()
-                    )
+                raise BadStateException(
+                    server_hash=computed_hash,
+                    phone_hash=parsed_hash,
+                    case_ids=self.last_sync_log.get_footprint_of_cases_on_phone()
+                )
 
     @property
     def last_sync_log(self):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -79,3 +79,16 @@ class StateHashTest(TestCase):
             self.assertEqual(set(e.case_ids), {"abc123", "123abc"})
         else:
             self.fail("Call to generate a payload with a bad hash should fail!")
+
+    def testMismatchIgnoredForWebApps(self):
+        sync = self.device.last_sync
+        self.assertEqual(CaseStateHash(EMPTY_HASH), sync.log.get_state_hash())
+
+        c1 = CaseBlock(case_id="abc123", create=True, owner_id=self.user.user_id).as_text()
+        c2 = CaseBlock(case_id="123abc", create=True, owner_id=self.user.user_id).as_text()
+        self.device.case_factory.post_case_blocks([c1, c2])
+
+        bad_hash = CaseStateHash("thisisntright")
+        self.device.id = 'WebAppsLogin'
+        self.device.sync(state_hash=str(bad_hash))
+        self.assertEqual(set(self.device.last_sync.cases), {"abc123", "123abc"})


### PR DESCRIPTION
## Technical Summary
Formplayer does not currently send state hashes to HQ which has resulted in bugs like https://github.com/dimagi/commcare-hq/pull/32088 going unnoticed for long periods of time.

This [Formplayer PR](https://github.com/dimagi/formplayer/pull/1218) adds the state hash to all sync requests from Formplayer. To avoid generating a lot of user facing errors any validation errors will just be logged (for now).

## Safety Assurance

### Safety story
This just adds logging for state hash validation errors from formplayer.

### Automated test coverage
A test was added to check that state hash errors are actually ignored.

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
