### PR TITLE
Multi-select case list case selection persist between page count change

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -416,7 +416,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         onPerPageLimitChange: function (e) {
             e.preventDefault();
             var casesPerPage = this.ui.casesPerPageLimit.val();
-            FormplayerFrontend.trigger("menu:perPageLimit", casesPerPage);
+            FormplayerFrontend.trigger("menu:perPageLimit", casesPerPage, this.selectedCaseIds);
         },
 
         paginationGoAction: function (e) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -164,9 +164,10 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         API.listMenus();
     });
 
-    FormplayerFrontend.on("menu:perPageLimit", function (casesPerPage) {
+    FormplayerFrontend.on("menu:perPageLimit", function (casesPerPage, selections) {
         var urlObject = Util.currentUrlToObject();
         urlObject.setCasesPerPage(casesPerPage);
+        Util.setSelectedValues(selections);
         Util.setUrlToObject(urlObject);
         Util.savePerPageLimitCookie('cases', casesPerPage);
         API.listMenus();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -157,11 +157,9 @@ hqDefine("cloudcare/js/formplayer/router", function () {
     });
 
     FormplayerFrontend.on("menu:paginate", function (page, selections) {
-        var selectedValues = (sessionStorage.selectedValues !== undefined) ? JSON.parse(sessionStorage.selectedValues) : {};
-        selectedValues[sessionStorage.queryKey] = selections.join(',');
-        sessionStorage.selectedValues = JSON.stringify(selectedValues);
         var urlObject = Util.currentUrlToObject();
         urlObject.setPage(page);
+        Util.setSelectedValues(selections);
         Util.setUrlToObject(urlObject);
         API.listMenus();
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -126,6 +126,12 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         this.stickyQueryInputs[sessionStorage.queryKey] = inputs;
     };
 
+    Util.setSelectedValues = function (selections) {
+        let selectedValues = (sessionStorage.selectedValues !== undefined) ? JSON.parse(sessionStorage.selectedValues) : {};
+        selectedValues[sessionStorage.queryKey] = selections.join(',');
+        sessionStorage.selectedValues = JSON.stringify(selectedValues);
+    }
+
     Util.CloudcareUrl = function (options) {
         this.appId = options.appId;
         this.copyOf = options.copyOf;
@@ -151,9 +157,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             }
             // Selections only deal with strings, because formplayer will send them back as strings
             if (_.isArray(selection)) {
-                var selectedValues = (sessionStorage.selectedValues !== undefined) ? JSON.parse(sessionStorage.selectedValues) : {};
-                selectedValues[sessionStorage.queryKey] = selection.join(',');
-                sessionStorage.selectedValues = JSON.stringify(selectedValues);
+                hqImport("cloudcare/js/formplayer/utils/util").setSelectedValues(selection)
                 this.selections.push(String('use_selected_values'));
             } else {
                 this.selections.push(String(selection));

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -127,9 +127,11 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
     };
 
     Util.setSelectedValues = function (selections) {
-        let selectedValues = (sessionStorage.selectedValues !== undefined) ? JSON.parse(sessionStorage.selectedValues) : {};
-        selectedValues[sessionStorage.queryKey] = selections.join(',');
-        sessionStorage.selectedValues = JSON.stringify(selectedValues);
+        if (selections !== undefined) {
+            let selectedValues = (sessionStorage.selectedValues !== undefined) ? JSON.parse(sessionStorage.selectedValues) : {};
+            selectedValues[sessionStorage.queryKey] = selections.join(',');
+            sessionStorage.selectedValues = JSON.stringify(selectedValues);
+        }
     };
 
     Util.CloudcareUrl = function (options) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/util.js
@@ -130,7 +130,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
         let selectedValues = (sessionStorage.selectedValues !== undefined) ? JSON.parse(sessionStorage.selectedValues) : {};
         selectedValues[sessionStorage.queryKey] = selections.join(',');
         sessionStorage.selectedValues = JSON.stringify(selectedValues);
-    }
+    };
 
     Util.CloudcareUrl = function (options) {
         this.appId = options.appId;
@@ -157,7 +157,7 @@ hqDefine("cloudcare/js/formplayer/utils/util", function () {
             }
             // Selections only deal with strings, because formplayer will send them back as strings
             if (_.isArray(selection)) {
-                hqImport("cloudcare/js/formplayer/utils/util").setSelectedValues(selection)
+                hqImport("cloudcare/js/formplayer/utils/util").setSelectedValues(selection);
                 this.selections.push(String('use_selected_values'));
             } else {
                 this.selections.push(String(selection));


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
followup to [31997](https://github.com/dimagi/commcare-hq/pull/31997)-- this allows case selections to be saves between  the number of cases per page changing

Review by commit, the first commit is "prefactoring" and the second is the main change

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
MULTI_SELECT_CASE_LIST

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
This was flagged by QA so they will do a quick pass

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
