### PR TITLE
UserRole change auditing

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -415,7 +415,7 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('users', 'UserReportingMetadataStaging', 'domain'),
     ModelDeletion('users', 'UserRole', 'domain', [
         'RolePermission', 'RoleAssignableBy', 'Permission'
-    ], {"audit_action": AuditAction.AUDIT}),
+    ], audit_action=AuditAction.AUDIT),
     ModelDeletion('user_importer', 'UserUploadRecord', 'domain'),
     ModelDeletion('zapier', 'ZapierSubscription', 'domain'),
     ModelDeletion('dhis2', 'SQLDataValueMap', 'dataset_map__domain'),

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -69,13 +69,30 @@ class CustomDeletion(BaseDeletion):
 
 class ModelDeletion(BaseDeletion):
 
-    def __init__(self, app_label, model_name, domain_filter_kwarg, extra_models=None, delete_kwargs=None):
+    def __init__(self, app_label, model_name, domain_filter_kwarg, extra_models=None, audit_action=None):
+        """Deletes all records of an app model matching the provided domain
+        filter.
+
+        :param app_label: label of the app containing the model(s)
+        :param model_name: name of the model in the app
+        :param domain_filter_kwarg: name of the model field to filter by domain
+        :param extra_models: (optional) a collection of other models in the same
+            app to be filtered and deleted in the same way as ``model_name``.
+            The default (``None``) results in only instances of ``model_name``
+            being deleted.
+        :param audit_action: (optional) an audit action to be provided as a
+            keyword argument when deleting records (e.g.
+            ``<QuerySet>.delete(audit_action=audit_action)``). Necessary for
+            models whose manager is an instance of
+            ``field_audit.models.AuditingManager``. The default (``None``)
+            results in ``<QuerySet>.delete()`` being called without parameters.
+        """
         models = extra_models or []
         models.append(model_name)
         super(ModelDeletion, self).__init__(app_label, models)
         self.domain_filter_kwarg = domain_filter_kwarg
         self.model_name = model_name
-        self.delete_kwargs = delete_kwargs or {}
+        self.delete_kwargs = {} if audit_action is None else {"audit_action": audit_action}
 
     def get_model_class(self):
         return apps.get_model(self.app_label, self.model_name)

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -69,13 +69,13 @@ class CustomDeletion(BaseDeletion):
 
 class ModelDeletion(BaseDeletion):
 
-    def __init__(self, app_label, model_name, domain_filter_kwarg, extra_models=None, delete_kwargs={}):
+    def __init__(self, app_label, model_name, domain_filter_kwarg, extra_models=None, delete_kwargs=None):
         models = extra_models or []
         models.append(model_name)
         super(ModelDeletion, self).__init__(app_label, models)
         self.domain_filter_kwarg = domain_filter_kwarg
         self.model_name = model_name
-        self.delete_kwargs = delete_kwargs
+        self.delete_kwargs = delete_kwargs or {}
 
     def get_model_class(self):
         return apps.get_model(self.app_label, self.model_name)

--- a/corehq/apps/domain/tests/test_deletion_models.py
+++ b/corehq/apps/domain/tests/test_deletion_models.py
@@ -54,6 +54,7 @@ IGNORE_MODELS = {
     'domain.SuperuserProjectEntryRecord',
     'dropbox.DropboxUploadHelper',
     'export.DefaultExportSettings',
+    'field_audit.AuditEvent',
     'fixtures.UserLookupTableStatus',
     'fixtures.LookupTableRow',          # handled by cascading delete
     'fixtures.LookupTableRowOwner',     # handled by cascading delete

--- a/corehq/apps/dump_reload/tests/test_dump_models.py
+++ b/corehq/apps/dump_reload/tests/test_dump_models.py
@@ -1,7 +1,6 @@
 import itertools
 
 from django.apps import apps
-from testil import eq
 
 from corehq.apps.dump_reload.sql.dump import _get_app_list
 from corehq.apps.dump_reload.util import get_model_label
@@ -102,6 +101,7 @@ UNKNOWN_MODELS = {
     "fhir.FHIRImportResourceProperty",
     "fhir.FHIRImportResourceType",
     "fhir.ResourceTypeRelationship",
+    "field_audit.AuditEvent",
     "fixtures.UserLookupTableStatus",
     "form_processor.DeprecatedXFormAttachmentSQL",
     "hqwebapp.HQOauthApplication",

--- a/corehq/apps/users/auditors.py
+++ b/corehq/apps/users/auditors.py
@@ -10,7 +10,13 @@ class HQAuditor(BaseAuditor):
             return None
         info = {}
         if request.user.is_authenticated:
-            user = request.couch_user
+            try:
+                user = request.couch_user
+            except AttributeError:
+                # Fetch the couch user manually if it is not set on the request.
+                # Only known to happen during registration (sign up).
+                from corehq.apps.users.models import CouchUser
+                user = CouchUser.get_by_username(request.user.username)
             info["user_type"] = user.doc_type
             info["username"] = user.username
         domain = getattr(request, "domain", None)

--- a/corehq/apps/users/auditors.py
+++ b/corehq/apps/users/auditors.py
@@ -1,0 +1,19 @@
+from field_audit.auditors import BaseAuditor
+
+
+class HQAuditor(BaseAuditor):
+    """Auditor class for getting HQ information from authenticated requests."""
+
+    def change_context(self, request):
+        if not request:
+            # this auditor only knows how to work with requests
+            return None
+        info = {}
+        if request.user.is_authenticated:
+            user = request.couch_user
+            info["user_type"] = user.doc_type
+            info["username"] = user.username
+        domain = getattr(request, "domain", None)
+        if domain is not None:
+            info["domain"] = domain
+        return info if info else None

--- a/corehq/apps/users/models_role.py
+++ b/corehq/apps/users/models_role.py
@@ -4,6 +4,8 @@ import attr
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models, transaction
+from field_audit import audit_fields
+from field_audit.models import AuditAction, AuditingManager
 
 from corehq.apps.users.landing_pages import ALL_LANDING_PAGES
 from corehq.util.models import ForeignValue, foreign_value_init
@@ -48,7 +50,7 @@ class StaticRole:
         return role_to_dict(self)
 
 
-class UserRoleManager(models.Manager):
+class UserRoleManager(AuditingManager):
 
     def get_by_domain(self, domain, include_archived=False):
         query = self.filter(domain=domain)
@@ -75,6 +77,9 @@ def _uuid_str():
     return uuid.uuid4().hex
 
 
+@audit_fields("domain", "name", "default_landing_page", "is_non_admin_editable",
+              "is_archived", "upstream_id", "couch_id",
+              "is_commcare_user_default", audit_special_queryset_writes=True)
 class UserRole(models.Model):
     domain = models.CharField(max_length=128, null=True)
     name = models.CharField(max_length=128, null=True)
@@ -151,7 +156,7 @@ class UserRole(models.Model):
                 pass
 
         if not permission_infos:
-            RolePermission.objects.filter(role=self).delete()
+            RolePermission.objects.filter(role=self).delete(audit_action=AuditAction.AUDIT)
             _clear_query_cache()
             return
 
@@ -171,7 +176,7 @@ class UserRole(models.Model):
 
         if permissions_by_name:
             old_ids = [old.id for old in permissions_by_name.values()]
-            RolePermission.objects.filter(id__in=old_ids).delete()
+            RolePermission.objects.filter(id__in=old_ids).delete(audit_action=AuditAction.AUDIT)
 
         _clear_query_cache()
 
@@ -198,7 +203,7 @@ class UserRole(models.Model):
                 pass
 
         if not role_ids:
-            self.roleassignableby_set.all().delete()
+            self.roleassignableby_set.all().delete(audit_action=AuditAction.AUDIT)
             _clear_query_cache()
             return
 
@@ -215,7 +220,7 @@ class UserRole(models.Model):
 
         if assignments_by_role_id:
             old_ids = list(assignments_by_role_id.values())
-            RoleAssignableBy.objects.filter(id__in=old_ids).delete()
+            RoleAssignableBy.objects.filter(id__in=old_ids).delete(audit_action=AuditAction.AUDIT)
 
         _clear_query_cache()
 
@@ -237,6 +242,8 @@ class UserRole(models.Model):
         return self.is_non_admin_editable or (role_id and role_id in self.assignable_by)
 
 
+@audit_fields("role", "permission_fk", "allow_all", "allowed_items",
+              audit_special_queryset_writes=True)
 @foreign_value_init
 class RolePermission(models.Model):
     role = models.ForeignKey("UserRole", on_delete=models.CASCADE)
@@ -249,6 +256,8 @@ class RolePermission(models.Model):
 
     # current max len in 119 chars
     allowed_items = ArrayField(models.CharField(max_length=256), blank=True, null=True)
+
+    objects = AuditingManager()
 
     class Meta:
         unique_together = [
@@ -273,8 +282,11 @@ class RolePermission(models.Model):
         return PermissionInfo(self.permission, allow=allow)
 
 
+@audit_fields("value", audit_special_queryset_writes=True)
 class Permission(models.Model):
     value = models.CharField(max_length=255, unique=True)
+
+    objects = AuditingManager()
 
     class Meta:
         db_table = "users_permission"
@@ -286,11 +298,13 @@ class Permission(models.Model):
             Permission.objects.get_or_create(value=name)
 
 
+@audit_fields("role", "assignable_by_role", audit_special_queryset_writes=True)
 class RoleAssignableBy(models.Model):
     role = models.ForeignKey("UserRole", on_delete=models.CASCADE)
     assignable_by_role = models.ForeignKey(
         "UserRole", on_delete=models.CASCADE, related_name="can_assign_roles"
     )
+    objects = AuditingManager()
 
 
 def role_to_dict(role):

--- a/corehq/apps/users/tests/test_auditors.py
+++ b/corehq/apps/users/tests/test_auditors.py
@@ -1,0 +1,62 @@
+from django.test import TestCase
+
+from corehq.apps.users.auditors import HQAuditor
+
+
+class TestHQAudit(TestCase):
+
+    def setUp(self):
+        self.auditor = HQAuditor()
+
+    def test_change_context_returns_none_when_not_authenticated(self):
+        request = MockRequest.without_auth("test@example.com", "WebUser")
+        self.assertIsNone(self.auditor.change_context(request))
+
+    def test_change_context_contains_user_name_and_type(self):
+        request = MockRequest.with_auth("test@example.com", "WebUser")
+        self.assertEqual(
+            {"username": "test@example.com", "user_type": "WebUser"},
+            self.auditor.change_context(request)
+        )
+
+    def test_change_context_contains_domain_when_present(self):
+        request = MockRequest.with_auth_and_domain("test@example.com", "WebUser", "test")
+        self.assertEqual(
+            {"username": "test@example.com", "user_type": "WebUser", "domain": "test"},
+            self.auditor.change_context(request)
+        )
+
+
+class MockRequest:
+
+    def __init__(self, user, couch_user, domain=None):
+        self.user = user
+        self.couch_user = couch_user
+        if domain is not None:
+            self.domain = domain
+
+    @classmethod
+    def without_auth(cls, username, doc_type):
+        return cls(MockDjangoAuthUser(username, False), MockCouchUser(username, doc_type))
+
+    @classmethod
+    def with_auth(cls, username, doc_type):
+        return cls(MockDjangoAuthUser(username), MockCouchUser(username, doc_type))
+
+    @classmethod
+    def with_auth_and_domain(cls, username, doc_type, domain):
+        return cls(MockDjangoAuthUser(username), MockCouchUser(username, doc_type), domain)
+
+
+class MockDjangoAuthUser:
+
+    def __init__(self, username, is_authenticated=True):
+        self.username = username
+        self.is_authenticated = is_authenticated
+
+
+class MockCouchUser:
+
+    def __init__(self, username, doc_type):
+        self.username = username
+        self.doc_type = doc_type

--- a/corehq/apps/users/tests/test_auditors.py
+++ b/corehq/apps/users/tests/test_auditors.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from corehq.apps.users.auditors import HQAuditor
@@ -9,14 +11,25 @@ class TestHQAudit(TestCase):
         self.auditor = HQAuditor()
 
     def test_change_context_returns_none_when_not_authenticated(self):
-        request = MockRequest.without_auth("test@example.com", "WebUser")
+        request = MockRequest.without_auth("test@example.com")
         self.assertIsNone(self.auditor.change_context(request))
 
     def test_change_context_contains_user_name_and_type(self):
-        request = MockRequest.with_auth("test@example.com", "WebUser")
+        request = MockRequest.with_auth_and_couch_user("test@example.com", "WebUser")
         self.assertEqual(
             {"username": "test@example.com", "user_type": "WebUser"},
             self.auditor.change_context(request)
+        )
+
+    def test_change_context_fetches_couch_user_when_missing(self):
+        request = MockRequest.with_auth("test@example.com")
+        couch_user = MockCouchUser(request.user.username, "WebUser")
+        with patch("corehq.apps.users.models.CouchUser.get_by_username", return_value=couch_user) as mock:
+            change_context = self.auditor.change_context(request)
+            mock.assert_called_once_with(request.user.username)
+        self.assertEqual(
+            {"username": "test@example.com", "user_type": "WebUser"},
+            change_context,
         )
 
     def test_change_context_contains_domain_when_present(self):
@@ -29,18 +42,23 @@ class TestHQAudit(TestCase):
 
 class MockRequest:
 
-    def __init__(self, user, couch_user, domain=None):
+    def __init__(self, user, couch_user=None, domain=None):
         self.user = user
-        self.couch_user = couch_user
+        if couch_user is not None:
+            self.couch_user = couch_user
         if domain is not None:
             self.domain = domain
 
     @classmethod
-    def without_auth(cls, username, doc_type):
-        return cls(MockDjangoAuthUser(username, False), MockCouchUser(username, doc_type))
+    def without_auth(cls, username):
+        return cls(MockDjangoAuthUser(username, False))
 
     @classmethod
-    def with_auth(cls, username, doc_type):
+    def with_auth(cls, username):
+        return cls(MockDjangoAuthUser(username))
+
+    @classmethod
+    def with_auth_and_couch_user(cls, username, doc_type):
         return cls(MockDjangoAuthUser(username), MockCouchUser(username, doc_type))
 
     @classmethod

--- a/corehq/apps/users/tests/test_models_role.py
+++ b/corehq/apps/users/tests/test_models_role.py
@@ -1,0 +1,311 @@
+from django.test import TestCase
+from field_audit.models import AuditEvent
+from nose.tools import nottest
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.users.models import HqPermissions
+
+from ..models import PermissionInfo
+from ..models_role import (
+    Permission,
+    # RolePermission,
+    UserRole,
+)
+
+
+class BaseEventSetupCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        AuditEvent.objects.all().delete()
+
+    def setUp(self):
+        super().setUp()
+        self.setup_audited_models()
+        self.setup_audit_events = AuditEvent.objects.all()
+        self.setup_event_ids = set(self.setup_audit_events.values_list("id", flat=True))
+
+    def setup_audited_models(self):
+        raise NotImplementedError("BaseEventSetupCase is abstract")
+
+    @nottest
+    def get_test_audit_events(self, ignore_ids=[]):
+        return AuditEvent.objects.exclude(
+            id__in=self.setup_event_ids.union(ignore_ids),
+        )
+
+
+class CaseWithDomainAndRole(BaseEventSetupCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_name = "pets"
+        cls.role_name = "test-role"
+        cls.domain = Domain(name=cls.domain_name)
+        cls.domain.save()
+        cls.addClassCleanup(cls.domain.delete)
+
+    def setup_audited_models(self):
+        self.role = UserRole.create(
+            self.domain_name,
+            self.role_name,
+            permissions=HqPermissions.min(),  # init with no permissions
+        )
+
+
+class TestUserRole(CaseWithDomainAndRole):
+
+    audit_fields = {
+        "name",
+        "domain",
+        "couch_id",
+        "is_archived",
+        "upstream_id",
+        "default_landing_page",
+        "is_non_admin_editable",
+        "is_commcare_user_default",
+    }
+
+    def test_audit_fields_for_userrole_create(self):
+        setup_event, = self.setup_audit_events
+        self.assertEqual(
+            "corehq.apps.users.models_role.UserRole",
+            setup_event.object_class_path,
+        )
+        self.assertEqual(self.role.pk, setup_event.object_pk)
+        self.assertTrue(setup_event.is_create)
+        self.assertEqual(self.audit_fields, set(setup_event.delta))
+        self.assertEqual({"new": self.role_name}, setup_event.delta["name"])
+        self.assertEqual({"new": self.domain_name}, setup_event.delta["domain"])
+
+    def test_audit_fields_for_userrole_update(self):
+        previous = self.role.is_non_admin_editable
+        self.role.is_non_admin_editable = not previous
+        self.role.save()
+        event, = self.get_test_audit_events()
+        self.assertEqual(
+            "corehq.apps.users.models_role.UserRole",
+            event.object_class_path,
+        )
+        self.assertEqual(self.role.pk, event.object_pk)
+        self.assertFalse(event.is_create)
+        self.assertFalse(event.is_delete)
+        self.assertEqual(
+            {"is_non_admin_editable": {"old": previous, "new": not previous}},
+            event.delta,
+        )
+
+    def test_audit_fields_for_userrole_delete(self):
+        remember = self.role.pk
+        self.role.delete()
+        event, = self.get_test_audit_events()
+        self.assertEqual(
+            "corehq.apps.users.models_role.UserRole",
+            event.object_class_path,
+        )
+        self.assertEqual(remember, event.object_pk)
+        self.assertTrue(event.is_delete)
+        self.assertEqual(self.audit_fields, set(event.delta))
+        self.assertEqual({"old": self.role_name}, event.delta["name"])
+        self.assertEqual({"old": self.domain_name}, event.delta["domain"])
+
+
+class TestRoleAssignableBy(CaseWithDomainAndRole):
+
+    def setup_audited_models(self):
+        super().setup_audited_models()
+        AuditEvent.objects.all().delete()  # discard the UserRole event
+        self.role.set_assignable_by([self.role.id])
+
+    def test_audit_fields_for_assignableby_create(self):
+        setup_event, = self.setup_audit_events
+        self.assertEqual(
+            "corehq.apps.users.models_role.RoleAssignableBy",
+            setup_event.object_class_path,
+        )
+        self.assertTrue(setup_event.is_create)
+        self.assertEqual(
+            {
+                "role": {"new": self.role.id},
+                "assignable_by_role": {"new": self.role.id},
+            },
+            setup_event.delta,
+        )
+
+    def test_audit_fields_for_assignableby_delete(self):
+        assignment, = self.role.get_assignable_by()
+        assignment_pk = assignment.pk  # will be cleared when deleted
+        self.role.set_assignable_by([])  # calls RoleAssignableBy.<QuerySet>.delete()
+        event, = self.get_test_audit_events()
+        self.assertTrue(event.is_delete)
+        self.assertEqual(assignment_pk, event.object_pk)
+        self.assertEqual(
+            "corehq.apps.users.models_role.RoleAssignableBy",
+            event.object_class_path,
+        )
+        self.assertEqual(
+            {
+                "role": {"old": self.role.id},
+                "assignable_by_role": {"old": self.role.id},
+            },
+            event.delta
+        )
+
+
+class TestRolePermission(CaseWithDomainAndRole):
+
+    def setup_audited_models(self):
+        super().setup_audited_models()
+        AuditEvent.objects.all().delete()  # discard the UserRole event
+        self.permission = Permission.objects.first()  # fetch any existing one
+        self.permission_info = PermissionInfo(self.permission.value)
+        self.role.set_permissions([self.permission_info])
+        self.role_permission, = self.role.rolepermission_set.all()
+
+    def test_audit_fields_for_rolepermission_create(self):
+        setup_event, = self.setup_audit_events
+        self.assertEqual(
+            "corehq.apps.users.models_role.RolePermission",
+            setup_event.object_class_path,
+        )
+        self.assertEqual(self.role_permission.pk, setup_event.object_pk)
+        self.assertTrue(setup_event.is_create)
+        # For the sake of this test, we don't care what the default values are
+        # for the `allow_all` and `allowed_items` fields, we just care that they
+        # were recorded correctly.
+        self.assertEqual(
+            {
+                "role": {"new": self.role.id},
+                "allow_all": {"new": self.role_permission.allow_all},
+                "allowed_items": {"new": self.role_permission.allowed_items},
+                "permission_fk": {"new": self.permission.pk},
+            },
+            setup_event.delta,
+        )
+
+    def test_audit_fields_for_rolepermission_direct_edit(self):
+        # This isn't an "HQ practical" test because these values don't get
+        # changed this way in practice, but this test demonstrates that such a
+        # change would be audited if it were to happen.
+        previous = self.role_permission.allow_all
+        self.role_permission.allow_all = not previous
+        self.role_permission.save()
+        event, = self.get_test_audit_events()
+        self.assertEqual(
+            "corehq.apps.users.models_role.RolePermission",
+            event.object_class_path,
+        )
+        self.assertEqual(self.role_permission.pk, event.object_pk)
+        self.assertFalse(event.is_create)
+        self.assertFalse(event.is_delete)
+        self.assertEqual(
+            {"allow_all": {"old": previous, "new": self.role_permission.allow_all}},
+            event.delta,
+        )
+
+    def test_audit_fields_for_rolepermission_set_new(self):
+        # fetch any other existing permission
+        permission_x = Permission.objects.exclude(id=self.permission.id).first()
+        permission_info_x = PermissionInfo(permission_x.value)
+        self.role.set_permissions([permission_info_x])
+        role_permission_x, = self.role.rolepermission_set.all()
+        removed, added = self.get_test_audit_events().order_by("is_create")
+        self.assertEqual(
+            "corehq.apps.users.models_role.RolePermission",
+            removed.object_class_path,
+            added.object_class_path,
+        )
+        # removed
+        self.assertEqual(self.role_permission.pk, removed.object_pk)
+        self.assertTrue(removed.is_delete)
+        self.assertEqual(
+            {
+                "role": {"old": self.role.id},
+                "allow_all": {"old": self.role_permission.allow_all},
+                "allowed_items": {"old": self.role_permission.allowed_items},
+                "permission_fk": {"old": self.permission.pk},
+            },
+            removed.delta,
+        )
+        # added
+        self.assertEqual(role_permission_x.pk, added.object_pk)
+        self.assertTrue(added.is_create)
+        self.assertEqual(
+            {
+                "role": {"new": self.role.id},
+                "allow_all": {"new": role_permission_x.allow_all},
+                "allowed_items": {"new": role_permission_x.allowed_items},
+                "permission_fk": {"new": permission_x.pk},
+            },
+            added.delta,
+        )
+
+    def test_audit_fields_for_rolepermission_delete(self):
+        remember_me = self.role_permission.pk
+        self.role.set_permissions([])
+        event, = self.get_test_audit_events()
+        self.assertEqual(
+            "corehq.apps.users.models_role.RolePermission",
+            event.object_class_path,
+        )
+        self.assertEqual(remember_me, event.object_pk)
+        self.assertTrue(event.is_delete)
+        self.assertEqual(
+            {
+                "role": {"old": self.role.id},
+                "allow_all": {"old": self.role_permission.allow_all},
+                "allowed_items": {"old": self.role_permission.allowed_items},
+                "permission_fk": {"old": self.permission.id},
+            },
+            event.delta,
+        )
+
+
+class TestPermission(BaseEventSetupCase):
+
+    @classmethod
+    def setup_audited_models(cls):
+        cls.permission = Permission.objects.create(value="do_bupkis")
+
+    def test_audit_fields_for_permission_create(self):
+        setup_event, = self.setup_audit_events
+        self.assertEqual(
+            "corehq.apps.users.models_role.Permission",
+            setup_event.object_class_path,
+        )
+        self.assertEqual(self.permission.pk, setup_event.object_pk)
+        self.assertTrue(setup_event.is_create)
+        self.assertEqual({"value": {"new": "do_bupkis"}}, setup_event.delta)
+
+    def test_audit_fields_for_permission_update(self):
+        # This isn't an "HQ practical" test because these values don't get
+        # changed this way in practice, but this test demonstrates that such a
+        # change would be audited if it were to happen.
+        self.permission.value = "do_everything"
+        self.permission.save()
+        event, = self.get_test_audit_events()
+        self.assertEqual(
+            "corehq.apps.users.models_role.Permission",
+            event.object_class_path,
+        )
+        self.assertEqual(self.permission.pk, event.object_pk)
+        self.assertFalse(event.is_create)
+        self.assertFalse(event.is_delete)
+        self.assertEqual(
+            {"value": {"old": "do_bupkis", "new": "do_everything"}},
+            event.delta,
+        )
+
+    def test_audit_fields_for_permission_delete(self):
+        remember = self.permission.pk
+        self.permission.delete()
+        event, = self.get_test_audit_events()
+        self.assertEqual(
+            "corehq.apps.users.models_role.Permission",
+            event.object_class_path,
+        )
+        self.assertEqual(remember, event.object_pk)
+        self.assertTrue(event.is_delete)
+        self.assertEqual({"value": {"old": "do_bupkis"}}, event.delta)

--- a/migrations.lock
+++ b/migrations.lock
@@ -364,6 +364,9 @@ fhir
  0009_resourcetyperelationship_related_resource_is_parent
  0010_fhirimportconfig_frequency_choices
  0011_fhirimportconfig_owner_type
+field_audit
+ 0001_initial
+ 0002_add_is_bootstrap_column
 fixtures
  0001_initial
  0002_rm_blobdb_domain_fixtures

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -19,6 +19,7 @@ django-compressor
 django-countries
 django-crispy-forms
 django-cte
+django-field-audit
 django-formtools
 django-logentry-admin
 django-oauth-toolkit

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -155,7 +155,7 @@ django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3
     # via -r dev-requirements.in
-django-field-audit==1.2.2
+django-field-audit==1.2.3
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -155,6 +155,8 @@ django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3
     # via -r dev-requirements.in
+django-field-audit==1.2.2
+    # via -r base-requirements.in
 django-formtools==2.3
     # via
     #   -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -135,7 +135,7 @@ django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3
     # via -r docs-requirements.in
-django-field-audit==1.2.2
+django-field-audit==1.2.3
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -135,6 +135,8 @@ django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3
     # via -r docs-requirements.in
+django-field-audit==1.2.2
+    # via -r base-requirements.in
 django-formtools==2.3
     # via
     #   -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -136,7 +136,7 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
-django-field-audit==1.2.2
+django-field-audit==1.2.3
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -136,6 +136,8 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
+django-field-audit==1.2.2
+    # via -r base-requirements.in
 django-formtools==2.3
     # via
     #   -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -128,6 +128,8 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
+django-field-audit==1.2.2
+    # via -r base-requirements.in
 django-formtools==2.3
     # via
     #   -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -128,7 +128,7 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
-django-field-audit==1.2.2
+django-field-audit==1.2.3
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -135,6 +135,8 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
+django-field-audit==1.2.2
+    # via -r base-requirements.in
 django-formtools==2.3
     # via
     #   -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -135,7 +135,7 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
-django-field-audit==1.2.2
+django-field-audit==1.2.3
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/settings.py
+++ b/settings.py
@@ -220,6 +220,7 @@ DEFAULT_APPS = (
     'captcha',
     'couchdbkit.ext.django',
     'crispy_forms',
+    'field_audit',
     'gunicorn',
     'compressor',
     'tastypie',

--- a/settings.py
+++ b/settings.py
@@ -170,6 +170,7 @@ MIDDLEWARE = [
     'corehq.apps.cloudcare.middleware.CloudcareMiddleware',
     # middleware that adds cookies must come before SecureCookiesMiddleware
     'corehq.middleware.SecureCookiesMiddleware',
+    'field_audit.middleware.FieldAuditMiddleware',
 ]
 
 X_FRAME_OPTIONS = 'DENY'
@@ -244,6 +245,11 @@ CRISPY_ALLOWED_TEMPLATE_PACKS = (
     'bootstrap',
     'bootstrap3',
 )
+
+FIELD_AUDIT_AUDITORS = [
+    "corehq.apps.users.auditors.HQAuditor",
+    "field_audit.auditors.SystemUserAuditor",
+]
 
 HQ_APPS = (
     'django_digest',


### PR DESCRIPTION
## Technical Summary

Redo of #31732. HQ field auditing using the [django-field-audit](https://github.com/dimagi/django-field-audit) plugin. This PR enables field auditing on `UserRole` and related models.

Ticket: [SAAS-13229](https://dimagi-dev.atlassian.net/browse/SAAS-13229)

Review: commit by commit :tropical_fish: 

**Update**: this change will not include a migration for bootstrapping existing records. That operation will be performed as a post-deploy management command. Changelog entry dimagi/commcare-cloud#5462 will be updated, merged and published after this PR (that change needs the commit SHA from this PR).

## Safety Assurance

### Safety story

The `django-field-audit` plugin was written for this purpose and has 100% test coverage. This change also includes tests around the functionality it provides.

### Automated test coverage

Good test coverage.

### QA Plan

QA Ticket: [QA-4503](https://dimagi-dev.atlassian.net/browse/QA-4503)

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
