### PR TITLE
Fix timeout on conditional alerts page

### DIFF
--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -141,7 +141,7 @@ hqDefine("scheduling/js/conditional_alert_list", [
             }, 10000);
         };
 
-        self.reloadPageSoon()
+        self.reloadPageSoon();
         return self;
     };
 

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -93,7 +93,7 @@ hqDefine("scheduling/js/conditional_alert_list", [
     };
 
     var ruleList = function (options) {
-        assertProperties.assert(options, ['listUrl']);
+        assertProperties.assert(options, ['refreshUrl']);
         var self = {};
 
         self.rules = ko.observableArray();
@@ -111,7 +111,7 @@ hqDefine("scheduling/js/conditional_alert_list", [
             self.showPaginationSpinner(true);
             self.currentPage(page);
             $.ajax({
-                url: options.listUrl,
+                url: options.refreshUrl,
                 data: {
                     action: 'list_conditional_alerts',
                     page: page,
@@ -147,7 +147,7 @@ hqDefine("scheduling/js/conditional_alert_list", [
 
     $(function () {
         $("#conditional-alert-list").koApplyBindings(ruleList({
-            listUrl: initialPageData.reverse("conditional_alert_list"),
+            refreshUrl: initialPageData.reverse("conditional_alert_list_refresh"),
         }));
     });
 });

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -14,6 +14,7 @@
 
 {% block page_content %}
   {% registerurl 'conditional_alert_list' domain %}
+  {% registerurl 'conditional_alert_list_refresh' domain %}
   {% registerurl 'edit_conditional_alert' domain '---' %}
   {% initial_page_data 'limit_rule_restarts' limit_rule_restarts %}
 

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -13,7 +13,6 @@
 {% endblock %}
 
 {% block page_content %}
-  {% registerurl 'conditional_alert_list' domain %}
   {% registerurl 'conditional_alert_list_refresh' domain %}
   {% registerurl 'edit_conditional_alert' domain '---' %}
   {% initial_page_data 'limit_rule_restarts' limit_rule_restarts %}

--- a/corehq/messaging/scheduling/urls.py
+++ b/corehq/messaging/scheduling/urls.py
@@ -19,6 +19,9 @@ urlpatterns = [
     url(r'^broadcasts/edit/(?P<broadcast_type>[\w-]+)/(?P<broadcast_id>[\w-]+)/$', EditScheduleView.as_view(),
         name=EditScheduleView.urlname),
     url(r'^conditional/$', ConditionalAlertListView.as_view(), name=ConditionalAlertListView.urlname),
+    # System URL only, to enabling data refresh without logging as user activity
+    url(r'^conditional/refresh/$', ConditionalAlertListView.as_view(),
+        name=ConditionalAlertListView.refresh_urlname),
     url(r'^conditional/add/$', CreateConditionalAlertView.as_view(), name=CreateConditionalAlertView.urlname),
     url(r'^conditional/edit/(?P<rule_id>[\w-]+)/$', EditConditionalAlertView.as_view(),
         name=EditConditionalAlertView.urlname),

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -605,6 +605,7 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
 
     template_name = 'scheduling/conditional_alert_list.html'
     urlname = 'conditional_alert_list'
+    refresh_urlname = 'conditional_alert_list_refresh'
     page_title = gettext_lazy('Conditional Alerts')
 
     LIST_CONDITIONAL_ALERTS = 'list_conditional_alerts'

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -298,6 +298,7 @@ class SelectiveSessionMiddleware(SessionMiddleware):
             '/downloads/temp/heartbeat/',  # soil status
             '/a/{domain}/apps/view/[A-Za-z0-9-]+/current_version/$'  # app manager new changes polling
             '/hq/notifications/service/$',  # background request for notification (bell menu in top nav)
+            '/a/{domain}/messaging/conditional/refresh/*'  # conditional alerts list refresh polling
         ]
         if settings.BYPASS_SESSIONS_FOR_MOBILE:
             regexes.extend(getattr(settings, 'SESSION_BYPASS_URLS', []))

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -298,7 +298,7 @@ class SelectiveSessionMiddleware(SessionMiddleware):
             '/downloads/temp/heartbeat/',  # soil status
             '/a/{domain}/apps/view/[A-Za-z0-9-]+/current_version/$'  # app manager new changes polling
             '/hq/notifications/service/$',  # background request for notification (bell menu in top nav)
-            '/a/{domain}/messaging/conditional/refresh/*'  # conditional alerts list refresh polling
+            '/a/{domain}/messaging/conditional/refresh/$'  # conditional alerts list refresh polling
         ]
         if settings.BYPASS_SESSIONS_FOR_MOBILE:
             regexes.extend(getattr(settings, 'SESSION_BYPASS_URLS', []))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Jira: [USH-2416](https://dimagi-dev.atlassian.net/browse/USH-2416).

You can set a custom timeout for user inactivity on a domain using a feature flag. Unfortunately, this feature didn't work on the conditional alerts page. This PR resolves that issue.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Jenny noticed that there was a poll every 10 seconds to refresh the data on the conditional alerts page. These requests were seen as user activity by our timeout code, undesirably delaying the timeout. This PR modifies that poll to use a special URL with an added `/refresh` path, and adds this URL to a list of regexed URLs marked as "don't interpret requests to these URLs as user activity".

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

SECURE_SESSION_TIMEOUT

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

I think the biggest risk is perhaps the refresh data not getting back to the conditional alerts page somehow, but I've tested this locally and on staging and the list seems like it loads every 10 seconds without issue.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

I don't think so? Please let me know if you're aware of any.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

I don't think this is a big enough issue to deserve QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
