### PR TITLE
Fix potential indefinite block on acquire

### DIFF
--- a/corehq/tests/locks.py
+++ b/corehq/tests/locks.py
@@ -72,14 +72,14 @@ class ReentrantTestLock:
     lock = attr.ib(factory=RLock, init=False, repr=False)
 
     def acquire(self, **kw):
-        no_timeout = "timeout" not in kw
-        kw.setdefault("timeout", 10)
+        timeout_added = kw.get("blocking", True) and "timeout" not in kw
+        if timeout_added:
+            kw["timeout"] = 10
         self.level += 1
         try:
             acquired = self.lock.acquire(**kw)
-            if not acquired and no_timeout and kw.get("blocking", True):
+            if not acquired and timeout_added:
                 # caller expected to block indefinitely,
-                # may not be checking for failed acquire
                 raise RuntimeError(f"could not acquire lock: {self.name}")
             return acquired
         finally:

--- a/corehq/tests/test_locks.py
+++ b/corehq/tests/test_locks.py
@@ -54,15 +54,15 @@ def test_unreleased_lock():
     with assert_raises(AssertionError, msg=msg):
         with reentrant_redis_locks():
             lock = get_redis_lock("unreleased", timeout=0.5, name="test")
-            assert lock.acquire(blocking_timeout=1)
+            assert lock.acquire()
     lock.release()
 
 
 @timelimit(0.1)
 def test_extra_lock_release():
     with reentrant_redis_locks():
-        lock = get_redis_lock("unreleased", timeout=0.5, name="test")
-        assert lock.acquire(blocking_timeout=1)
+        lock = get_redis_lock("extra_release", timeout=0.5, name="test")
+        assert lock.acquire()
         lock.release()
         with assert_raises(RuntimeError):
             lock.release()

--- a/corehq/tests/test_locks.py
+++ b/corehq/tests/test_locks.py
@@ -12,10 +12,10 @@ from .noseplugins.redislocks import TestLock, TimeoutError
 def test_redislocks_nose_plugin():
     lock1 = get_redis_lock(__name__, timeout=0.2, name="test")
     assert isinstance(lock1.lock, TestLock), lock1.lock
-    lock1.acquire()
+    assert lock1.acquire(blocking_timeout=1)
     lock2 = get_redis_lock(__name__, timeout=0.2, name="test")
     with assert_raises(TimeoutError):
-        lock2.acquire()
+        assert lock2.acquire(blocking_timeout=1)
     with assert_raises(LockError, msg="Cannot release a lock that's no longer owned"):
         lock1.release()
 
@@ -54,7 +54,7 @@ def test_unreleased_lock():
     with assert_raises(AssertionError, msg=msg):
         with reentrant_redis_locks():
             lock = get_redis_lock("unreleased", timeout=0.5, name="test")
-            lock.acquire()
+            assert lock.acquire(blocking_timeout=1)
     lock.release()
 
 
@@ -62,7 +62,7 @@ def test_unreleased_lock():
 def test_extra_lock_release():
     with reentrant_redis_locks():
         lock = get_redis_lock("unreleased", timeout=0.5, name="test")
-        lock.acquire()
+        assert lock.acquire(blocking_timeout=1)
         lock.release()
         with assert_raises(RuntimeError):
             lock.release()


### PR DESCRIPTION
Because `test_extra_lock_release` seems to be intermittently hanging indefinitely.

## Safety Assurance

### Safety story

Tests only.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
