### PR TITLE
[couch-to-sql][Repeaters][Phase-2] Repeat records use sql repeater

### DIFF
--- a/corehq/apps/registry/models.py
+++ b/corehq/apps/registry/models.py
@@ -329,7 +329,7 @@ class RegistryAuditHelper:
         )
 
     def data_accessed(self, user, domain, related_object, filters=None):
-        is_repeater = True if hasattr(related_object, 'repeater_type') else False
+        is_repeater = True if hasattr(related_object, 'pk') else False
         if (
             not (related_object and hasattr(related_object, "doc_type"))
             and not is_repeater
@@ -350,12 +350,14 @@ class RegistryAuditHelper:
         except KeyError:
             raise ValueError(f"Unexpected related object type: {related_object.doc_type}")
 
+        related_object_id = related_object.repeater_id if is_repeater else related_object.get_id
+
         return RegistryAuditLog.objects.create(
             registry=self.registry,
             user=user,
             action=RegistryAuditLog.ACTION_DATA_ACCESSED,
             domain=domain,
-            related_object_id=related_object.get_id,
+            related_object_id=related_object_id,
             related_object_type=related_object_type,
             detail=filters
         )

--- a/corehq/apps/registry/models.py
+++ b/corehq/apps/registry/models.py
@@ -329,10 +329,17 @@ class RegistryAuditHelper:
         )
 
     def data_accessed(self, user, domain, related_object, filters=None):
-        if not related_object or not hasattr(related_object, "doc_type"):
+        is_repeater = True if hasattr(related_object, 'repeater_type') else False
+        if (
+            not (related_object and hasattr(related_object, "doc_type"))
+            and not is_repeater
+        ):
             raise ValueError("Unexpected related object")
 
-        doc_type = getattr(related_object, 'base_doc', related_object.doc_type)
+        doc_type = (
+            getattr(related_object, 'base_doc', related_object.doc_type)
+            if not is_repeater else 'Repeater'
+        )
         try:
             related_object_type = {
                 "ReportConfiguration": RegistryAuditLog.RELATED_OBJECT_UCR,

--- a/corehq/apps/registry/tests/test_logging.py
+++ b/corehq/apps/registry/tests/test_logging.py
@@ -1,10 +1,14 @@
+import uuid
 from django.test import TestCase
+from corehq.apps.app_manager.models import Application
 
 from corehq.apps.domain.shortcuts import create_user
 from corehq.apps.domain.tests.test_utils import test_domain
 from corehq.apps.registry.models import RegistryAuditLog, RegistryInvitation
 from corehq.apps.registry.tests.utils import Invitation, create_registry_for_test
 from corehq.apps.registry.utils import DataRegistryCrudHelper
+from corehq.motech.models import ConnectionSettings
+from corehq.motech.repeaters.models import SQLFormRepeater
 
 
 class RegistryLoggingTests(TestCase):
@@ -101,6 +105,27 @@ class RegistryLoggingTests(TestCase):
         self.helper.remove_grant(self.domain, grant.id)
         self._assertLogs([
             (self.domain, RegistryAuditLog.ACTION_GRANT_REMOVED),
+        ], ignore_actions=[RegistryAuditLog.ACTION_INVITATION_ADDED])
+
+    def test_log_data_access_with_repeater(self):
+        connx = ConnectionSettings.objects.create(domain=self.domain, url='http://fake.com')
+        repeater = SQLFormRepeater(
+            domain=self.domain,
+            connection_settings=connx,
+            repeater_id=uuid.uuid4().hex
+        )
+        repeater.save(sync_to_couch=False)
+        self.registry.logger.data_accessed(self.user, self.domain, repeater)
+        self._assertLogs([
+            (self.domain, RegistryAuditLog.ACTION_DATA_ACCESSED)
+        ], ignore_actions=[RegistryAuditLog.ACTION_INVITATION_ADDED])
+
+    def test_log_data_access_with_application(self):
+        app = Application.new_app(self.domain, 'Test App')
+        app._id = uuid.uuid4().hex
+        self.registry.logger.data_accessed(self.user, self.domain, app)
+        self._assertLogs([
+            (self.domain, RegistryAuditLog.ACTION_DATA_ACCESSED)
         ], ignore_actions=[RegistryAuditLog.ACTION_INVITATION_ADDED])
 
     def _assertLogs(self, expected_actions, ignore_actions=None):

--- a/corehq/apps/reports/filters/select.py
+++ b/corehq/apps/reports/filters/select.py
@@ -22,7 +22,7 @@ from corehq.motech.repeaters.const import (
     RECORD_PENDING_STATE,
     RECORD_SUCCESS_STATE,
 )
-from corehq.motech.repeaters.dbaccessors import get_repeaters_by_domain
+from corehq.motech.repeaters.models import SQLRepeater
 
 
 class GroupFilterMixin(object):
@@ -133,7 +133,7 @@ class RepeaterFilter(BaseSingleOptionFilter):
         return [(r.get_id, str(r)) for r in self._get_repeaters()]
 
     def _get_repeaters(self):
-        return get_repeaters_by_domain(self.domain)
+        return SQLRepeater.objects.by_domain(self.domain)
 
 
 class RepeatRecordStateFilter(BaseSingleOptionFilter):

--- a/corehq/apps/zapier/consts.py
+++ b/corehq/apps/zapier/consts.py
@@ -1,7 +1,7 @@
 from corehq.motech.repeaters.models import (
-    CaseRepeater,
-    CreateCaseRepeater,
-    UpdateCaseRepeater,
+    SQLCaseRepeater,
+    SQLCreateCaseRepeater,
+    SQLUpdateCaseRepeater,
 )
 
 
@@ -13,7 +13,7 @@ class EventTypes(object):
 
 
 CASE_TYPE_REPEATER_CLASS_MAP = {
-    EventTypes.NEW_CASE: CreateCaseRepeater,
-    EventTypes.UPDATE_CASE: UpdateCaseRepeater,
-    EventTypes.CHANGED_CASE: CaseRepeater,
+    EventTypes.NEW_CASE: SQLCreateCaseRepeater,
+    EventTypes.UPDATE_CASE: SQLUpdateCaseRepeater,
+    EventTypes.CHANGED_CASE: SQLCaseRepeater,
 }

--- a/corehq/apps/zapier/signals/receivers.py
+++ b/corehq/apps/zapier/signals/receivers.py
@@ -6,6 +6,7 @@ from tastypie.http import HttpBadRequest
 
 from corehq.apps.zapier.consts import CASE_TYPE_REPEATER_CLASS_MAP, EventTypes
 from corehq.apps.zapier.models import ZapierSubscription
+from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeaters.models import SQLFormRepeater
 
 
@@ -16,20 +17,26 @@ def zapier_subscription_pre_save(sender, instance, *args, **kwargs):
     """
     if instance.pk:
         return
-
+    conn = ConnectionSettings(
+        domain=instance.domain,
+        name=instance.url,
+        url=instance.url,
+    )
     if instance.event_name == EventTypes.NEW_FORM:
+        conn.save()
         repeater = SQLFormRepeater(
             domain=instance.domain,
-            url=instance.url,
+            connection_settings=conn,
             format='form_json',
             include_app_id_param=False,
             white_listed_form_xmlns=[instance.form_xmlns]
         )
 
     elif instance.event_name in CASE_TYPE_REPEATER_CLASS_MAP:
+        conn.save()
         repeater = CASE_TYPE_REPEATER_CLASS_MAP[instance.event_name](
             domain=instance.domain,
-            url=instance.url,
+            connection_settings=conn,
             format='case_json',
             white_listed_case_types=[instance.case_type],
         )
@@ -50,7 +57,7 @@ def zapier_subscription_post_delete(sender, instance, *args, **kwargs):
     if instance.event_name == EventTypes.NEW_FORM:
         repeater = SQLFormRepeater.objects.get(repeater_id=instance.repeater_id)
     elif instance.event_name in CASE_TYPE_REPEATER_CLASS_MAP:
-        repeater = CASE_TYPE_REPEATER_CLASS_MAP[instance.event_name].get(instance.repeater_id)
+        repeater = CASE_TYPE_REPEATER_CLASS_MAP[instance.event_name].objects.get(repeater_id=instance.repeater_id)
     else:
         raise ImmediateHttpResponse(
             HttpBadRequest('The passed event type is not valid.')

--- a/corehq/apps/zapier/signals/receivers.py
+++ b/corehq/apps/zapier/signals/receivers.py
@@ -46,7 +46,7 @@ def zapier_subscription_pre_save(sender, instance, *args, **kwargs):
         )
 
     repeater.save()
-    instance.repeater_id = repeater.get_id
+    instance.repeater_id = repeater.repeater_id
 
 
 @receiver(post_delete, sender=ZapierSubscription)

--- a/corehq/apps/zapier/signals/receivers.py
+++ b/corehq/apps/zapier/signals/receivers.py
@@ -6,7 +6,7 @@ from tastypie.http import HttpBadRequest
 
 from corehq.apps.zapier.consts import CASE_TYPE_REPEATER_CLASS_MAP, EventTypes
 from corehq.apps.zapier.models import ZapierSubscription
-from corehq.motech.repeaters.models import FormRepeater, SQLFormRepeater
+from corehq.motech.repeaters.models import SQLFormRepeater
 
 
 @receiver(pre_save, sender=ZapierSubscription)
@@ -18,7 +18,7 @@ def zapier_subscription_pre_save(sender, instance, *args, **kwargs):
         return
 
     if instance.event_name == EventTypes.NEW_FORM:
-        repeater = FormRepeater(
+        repeater = SQLFormRepeater(
             domain=instance.domain,
             url=instance.url,
             format='form_json',

--- a/corehq/apps/zapier/tests/test_zapier_hooks.py
+++ b/corehq/apps/zapier/tests/test_zapier_hooks.py
@@ -142,8 +142,8 @@ class TestZapierIntegration(TestCase):
             )
             self.assertIsNotNone(subscription.repeater_id)
             self.assertNotEqual(subscription.repeater_id, '')
-            self.assertEqual(repeater_class.get_db().get(subscription.repeater_id)['doc_type'],
-                             repeater_class.__name__)
+            self.assertEqual(repeater_class.objects.get(repeater_id=subscription.repeater_id).repeater_type,
+                             repeater_class._repeater_type)
 
     def test_subscribe_error(self):
         data = {

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -471,11 +471,11 @@ def fetch_metadata(requests):
 
 
 def create_dhis2_event_repeat_records(sender, xform, **kwargs):
-    create_repeat_records(Dhis2Repeater, xform)
+    create_repeat_records(SQLDhis2Repeater, xform)
 
 
 def create_dhis2_entity_repeat_records(sender, xform, **kwargs):
-    create_repeat_records(Dhis2EntityRepeater, xform)
+    create_repeat_records(SQLDhis2EntityRepeater, xform)
 
 
 successful_form_received.connect(create_dhis2_event_repeat_records)

--- a/corehq/motech/fhir/signals.py
+++ b/corehq/motech/fhir/signals.py
@@ -7,5 +7,5 @@ from corehq.motech.repeaters.signals import create_repeat_records
 
 @receiver(successful_form_received, dispatch_uid="create_fhir_repeat_records")
 def create_fhir_repeat_records(sender, xform, **kwargs):
-    from .repeaters import FHIRRepeater
-    create_repeat_records(FHIRRepeater, xform)
+    from .repeaters import SQLFHIRRepeater
+    create_repeat_records(SQLFHIRRepeater, xform)

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -476,7 +476,7 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
 
 
 def create_openmrs_repeat_records(sender, xform, **kwargs):
-    create_repeat_records(OpenmrsRepeater, xform)
+    create_repeat_records(SQLOpenmrsRepeater, xform)
 
 
 successful_form_received.connect(create_openmrs_repeat_records)

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -819,7 +819,7 @@ class VoidedPatientTests(TestCase, TestFileMixin):
 
 
 def test_observation_mappings():
-    repeater = OpenmrsRepeater.wrap({
+    repeater = SQLOpenmrsRepeater(**{
         "openmrs_config": {
             "openmrs_provider": "",
             "case_config": {},
@@ -831,6 +831,7 @@ def test_observation_mappings():
                     {
                         "concept": "397b9631-2911-435a-bf8a-ae4468b9c1d4",
                         "case_property": "abnormal_temperature",
+                        'doc_type': 'ObservationMapping',
                         "value": {
                             "doc_type": "FormQuestionMap",
                             "form_question": "/data/abnormal_temperature",
@@ -843,6 +844,7 @@ def test_observation_mappings():
                     {
                         "concept": "397b9631-2911-435a-bf8a-ae4468b9c1d4",
                         "case_property": "bahmni_abnormal_temperature",
+                        'doc_type': 'ObservationMapping',
                         "value": {
                             "doc_type": "ConstantString",
                             "value": "",
@@ -867,7 +869,7 @@ def test_observation_mappings():
                         'no': 'eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0'
                     }
                 }
-            ),
+            ).to_json(),
             ObservationMapping(
                 concept='397b9631-2911-435a-bf8a-ae4468b9c1d4',
                 case_property='bahmni_abnormal_temperature',
@@ -876,7 +878,7 @@ def test_observation_mappings():
                     "doc_type": "ConstantString",
                     "value": ''
                 }
-            )
+            ).to_json()
         ]
     })
 

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -128,7 +128,7 @@ def openmrs_test_fire(request, domain, repeater_id, record_id):
     record = RepeatRecord.get(record_id)
     assert repeater.domain == domain
     assert record.domain == domain
-    assert record.repeater_id == repeater.get_id
+    assert record.repeater_id == repeater.repeater_id
 
     attempt = repeater.fire_for_record(record)
     return JsonResponse(attempt.to_json())

--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -227,34 +227,6 @@ def get_sql_repeat_records_by_payload_id(domain, payload_id):
             .all())
 
 
-def get_repeaters_by_domain(domain):
-    from .models import Repeater
-
-    results = Repeater.get_db().view('repeaters/repeaters',
-        startkey=[domain],
-        endkey=[domain, {}],
-        include_docs=True,
-        reduce=False,
-    ).all()
-
-    return [Repeater.wrap(result['doc']) for result in results
-            if Repeater.get_class_from_doc_type(result['doc']['doc_type'])
-            ]
-
-
-def _get_repeater_ids_by_domain(domain):
-    from .models import Repeater
-
-    results = Repeater.get_db().view('repeaters/repeaters',
-        startkey=[domain],
-        endkey=[domain, {}],
-        include_docs=False,
-        reduce=False,
-    ).all()
-
-    return [result['id'] for result in results]
-
-
 def iterate_repeat_records_for_ids(doc_ids):
     from .models import RepeatRecord
     return (RepeatRecord.wrap(doc) for doc in iter_docs(RepeatRecord.get_db(), doc_ids))
@@ -308,30 +280,3 @@ def delete_all_repeaters():
     from .models import Repeater
     for repeater in Repeater.get_db().view('repeaters/repeaters', reduce=False, include_docs=True).all():
         Repeater.wrap(repeater['doc']).delete()
-
-
-def get_all_repeater_docs():
-    from .models import Repeater
-    results = Repeater.get_db().view('repeaters/repeaters', reduce=False, include_docs=True).all()
-    return [
-        repeater['doc'] for repeater in results
-        if Repeater.get_class_from_doc_type(repeater['doc']['doc_type'])
-    ]
-
-
-def get_repeater_count_for_domains(domains):
-    from .models import Repeater
-    view_kwargs = {
-        'reduce': True,
-        'include_docs': False,
-    }
-    count = 0
-    for domain in domains:
-        view_kwargs.update({
-            'startkey': [domain],
-            'endkey': [domain, {}]
-        })
-        result = Repeater.get_db().view('repeaters/repeaters', **view_kwargs).first()
-        if result:
-            count += result['value']
-    return count

--- a/corehq/motech/repeaters/expression/repeaters.py
+++ b/corehq/motech/repeaters/expression/repeaters.py
@@ -122,6 +122,16 @@ class SQLBaseExpressionRepeater(SQLRepeater):
             self.parsed_expression,
         )
 
+    def get_url(self, repeat_record):
+        base_url = super().get_url(repeat_record)
+        if self.url_template:
+            return base_url + self.generator.get_url(
+                repeat_record,
+                self.url_template,
+                self.payload_doc(repeat_record),
+            )
+        return base_url
+
     @classmethod
     def _migration_get_couch_model_class(cls):
         return BaseExpressionRepeater

--- a/corehq/motech/repeaters/management/commands/find_missing_repeat_records.py
+++ b/corehq/motech/repeaters/management/commands/find_missing_repeat_records.py
@@ -15,9 +15,9 @@ from corehq.motech.dhis2.repeaters import Dhis2EntityRepeater
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater
 from corehq.motech.repeaters.dbaccessors import (
     get_domains_that_have_repeat_records,
-    get_repeat_records_by_payload_id,
-    get_repeaters_by_domain,
+    get_repeat_records_by_payload_id
 )
+from corehq.motech.repeaters.utils import get_repeaters_by_domain
 from corehq.motech.repeaters.models import FormRepeater, ShortFormRepeater, CaseRepeater, CreateCaseRepeater, \
     UpdateCaseRepeater, RepeatRecord, LocationRepeater, UserRepeater, AppStructureRepeater
 from corehq.util.argparse_types import date_type

--- a/corehq/motech/repeaters/management/commands/migrate_all_repeaters.py
+++ b/corehq/motech/repeaters/management/commands/migrate_all_repeaters.py
@@ -4,8 +4,8 @@ import traceback
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
-from corehq.motech.repeaters.dbaccessors import get_all_repeater_docs
 from corehq.motech.repeaters.models import SQLRepeater
+from corehq.motech.repeaters.utils import get_all_repeater_docs
 from corehq.util.django_migrations import skip_on_fresh_install
 
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1718,8 +1718,8 @@ class RepeatRecord(Document):
     @memoized
     def repeater(self):
         try:
-            return Repeater.get(self.repeater_id)
-        except ResourceNotFound:
+            return SQLRepeater.objects.get(repeater_id=self.repeater_id)
+        except SQLRepeater.DoesNotExist:
             return None
 
     @property

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -391,6 +391,13 @@ class SQLRepeater(SyncSQLToCouchMixin, RepeaterSuperProxy):
             self.next_attempt_at = None
             self.save()
 
+    def get_attempt_info(self, repeat_record):
+        return None
+
+    @property
+    def verify(self):
+        return not self.connection_settings.skip_cert_verify
+
     def register(self, payload, fire_synchronously=False):
         if not self.allowed_to_forward(payload):
             return

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1722,6 +1722,12 @@ class RepeatRecord(Document):
         except SQLRepeater.DoesNotExist:
             return None
 
+    def is_repeater_deleted(self):
+        try:
+            return SQLRepeater.all_objects.get(repeater_id=self.repeater_id).is_deleted
+        except SQLRepeater.DoesNotExist:
+            return True
+
     @property
     def url(self):
         warnings.warn("RepeatRecord.url is deprecated. Use Repeater.get_url instead", DeprecationWarning)

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -352,7 +352,7 @@ class SQLRepeater(SyncSQLToCouchMixin, RepeaterSuperProxy):
                 raise e
 
     def get_url(self, record):
-        return self.repeater.get_url(record)
+        return self.connection_settings.url
 
     @classmethod
     @property
@@ -624,7 +624,7 @@ class SQLFormRepeater(SQLRepeater):
             return urlunparse(url_parts)
 
     def get_headers(self, repeat_record):
-        headers = super(FormRepeater, self).get_headers(repeat_record)
+        headers = super().get_headers(repeat_record)
         headers.update({
             "received-on": json_format_datetime(self.payload_doc(repeat_record).received_on)
         })

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -310,10 +310,6 @@ class SQLRepeater(SyncSQLToCouchMixin, RepeaterSuperProxy):
             if isinstance(attr_tuple[1], OptionValue)
         ]
 
-    @property
-    def get_id(self):
-        return self.repeater_id
-
     def to_json(self):
         repeater_dict = self.__dict__.copy()
         options = repeater_dict.pop('options', None)

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -310,6 +310,10 @@ class SQLRepeater(SyncSQLToCouchMixin, RepeaterSuperProxy):
             if isinstance(attr_tuple[1], OptionValue)
         ]
 
+    @property
+    def get_id(self):
+        return self.repeater_id
+
     def to_json(self):
         repeater_dict = self.__dict__.copy()
         options = repeater_dict.pop('options', None)

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -12,35 +12,35 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.signals import commcare_user_post_save
 from corehq.form_processor.models import CommCareCase
 from corehq.motech.repeaters.models import (
-    CreateCaseRepeater,
-    ReferCaseRepeater,
-    UpdateCaseRepeater,
+    SQLCreateCaseRepeater,
+    SQLDataRegistryCaseUpdateRepeater,
+    SQLReferCaseRepeater,
+    SQLUpdateCaseRepeater,
     domain_can_forward,
-    DataRegistryCaseUpdateRepeater,
 )
 from dimagi.utils.logging import notify_exception
 
 
 def create_form_repeat_records(sender, xform, **kwargs):
-    from corehq.motech.repeaters.models import FormRepeater
+    from corehq.motech.repeaters.models import SQLFormRepeater
     if not xform.is_duplicate:
-        create_repeat_records(FormRepeater, xform)
+        create_repeat_records(SQLFormRepeater, xform)
 
 
 def create_case_repeat_records(sender, case, **kwargs):
-    from corehq.motech.repeaters.models import CaseRepeater
-    from corehq.motech.repeaters.expression.repeaters import CaseExpressionRepeater
-    create_repeat_records(CaseRepeater, case)
-    create_repeat_records(CreateCaseRepeater, case)
-    create_repeat_records(UpdateCaseRepeater, case)
-    create_repeat_records(ReferCaseRepeater, case)
-    create_repeat_records(CaseExpressionRepeater, case)
+    from corehq.motech.repeaters.models import SQLCaseRepeater
+    from corehq.motech.repeaters.expression.repeaters import SQLCaseExpressionRepeater
+    create_repeat_records(SQLCaseRepeater, case)
+    create_repeat_records(SQLCreateCaseRepeater, case)
+    create_repeat_records(SQLUpdateCaseRepeater, case)
+    create_repeat_records(SQLReferCaseRepeater, case)
+    create_repeat_records(SQLCaseExpressionRepeater, case)
 
 
 def create_short_form_repeat_records(sender, xform, **kwargs):
-    from corehq.motech.repeaters.models import ShortFormRepeater
+    from corehq.motech.repeaters.models import SQLShortFormRepeater
     if not xform.is_duplicate:
-        create_repeat_records(ShortFormRepeater, xform)
+        create_repeat_records(SQLShortFormRepeater, xform)
 
 
 def create_repeat_records(repeater_cls, payload):
@@ -80,16 +80,16 @@ def _create_repeat_records(repeater_cls, payload, fire_synchronously=False):
 
 @receiver(commcare_user_post_save, dispatch_uid="create_user_repeat_records")
 def create_user_repeat_records(sender, couch_user, **kwargs):
-    from corehq.motech.repeaters.models import UserRepeater
-    create_repeat_records(UserRepeater, couch_user)
+    from corehq.motech.repeaters.models import SQLUserRepeater
+    create_repeat_records(SQLUserRepeater, couch_user)
 
 
 @receiver(post_save, sender=SQLLocation, dispatch_uid="create_location_repeat_records")
 def create_location_repeat_records(sender, raw=False, **kwargs):
-    from corehq.motech.repeaters.models import LocationRepeater
+    from corehq.motech.repeaters.models import SQLLocationRepeater
     if raw:
         return
-    create_repeat_records(LocationRepeater, kwargs['instance'])
+    create_repeat_records(SQLLocationRepeater, kwargs['instance'])
 
 
 @receiver(sql_case_post_save, sender=CommCareCase, dispatch_uid="fire_synchronous_repeaters")
@@ -97,7 +97,7 @@ def fire_synchronous_case_repeaters(sender, case, **kwargs):
     """These repeaters need to fire synchronously since the changes they make to cases
     must reflect by the end of form submission processing
     """
-    _create_repeat_records(DataRegistryCaseUpdateRepeater, case, fire_synchronously=True)
+    _create_repeat_records(SQLDataRegistryCaseUpdateRepeater, case, fire_synchronously=True)
 
 
 successful_form_received.connect(create_form_repeat_records)

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -73,7 +73,7 @@ def _create_repeat_records(repeater_cls, payload, fire_synchronously=False):
     domain = payload.domain
 
     if domain_can_forward(domain):
-        repeaters = repeater_cls.by_domain(domain, stale_query=True)
+        repeaters = repeater_cls.objects.by_domain(domain)
         for repeater in repeaters:
             repeater.register(payload, fire_synchronously=fire_synchronously)
 

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -181,6 +181,11 @@ def _process_repeat_record(repeat_record):
     if repeat_record.cancelled:
         return
 
+    if repeat_record.is_repeater_deleted():
+        if not repeat_record.doc_type.endswith(DELETED_SUFFIX):
+            repeat_record.doc_type += DELETED_SUFFIX
+            repeat_record.save()
+
     repeater = repeat_record.repeater
     if not repeater:
         repeat_record.cancel()
@@ -188,11 +193,7 @@ def _process_repeat_record(repeat_record):
         return
 
     try:
-        if repeater.doc_type.endswith(DELETED_SUFFIX):
-            if not repeat_record.doc_type.endswith(DELETED_SUFFIX):
-                repeat_record.doc_type += DELETED_SUFFIX
-                repeat_record.save()
-        elif repeater.paused:
+        if repeater.is_paused:
             # postpone repeat record by MAX_RETRY_WAIT so that these don't get picked in each cycle and
             # thus clogging the queue with repeat records with paused repeater
             repeat_record.postpone_by(MAX_RETRY_WAIT)

--- a/corehq/motech/repeaters/tests/test_dbaccessors.py
+++ b/corehq/motech/repeaters/tests/test_dbaccessors.py
@@ -4,11 +4,8 @@ from datetime import datetime, timedelta
 from django.test import TestCase
 
 from corehq.motech.models import ConnectionSettings
-from corehq.motech.repeaters.const import (
-    RECORD_PENDING_STATE,
-)
+from corehq.motech.repeaters.const import RECORD_PENDING_STATE
 from corehq.motech.repeaters.dbaccessors import (
-    get_all_repeater_docs,
     get_domains_that_have_repeat_records,
     get_failure_repeat_record_count,
     get_overdue_repeat_record_count,
@@ -16,13 +13,16 @@ from corehq.motech.repeaters.dbaccessors import (
     get_pending_repeat_record_count,
     get_repeat_record_count,
     get_repeat_records_by_payload_id,
-    get_repeater_count_for_domains,
-    get_repeaters_by_domain,
     get_success_repeat_record_count,
     iter_repeat_records_by_domain,
     iterate_repeat_record_ids,
 )
 from corehq.motech.repeaters.models import CaseRepeater, RepeatRecord
+from corehq.motech.repeaters.utils import (
+    get_all_repeater_docs,
+    get_repeaters_by_domain,
+    get_repeater_count_for_domains,
+)
 
 
 class TestRepeatRecordDBAccessors(TestCase):

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -17,9 +17,9 @@ from corehq.motech.const import ALGO_AES, BASIC_AUTH
 from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeaters.dbaccessors import (
     delete_all_repeaters,
-    get_all_repeater_docs,
     iter_repeat_records_by_domain,
 )
+from corehq.motech.repeaters.utils import get_all_repeater_docs
 from corehq.motech.utils import b64_aes_encrypt
 
 from ..const import (

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -1,7 +1,9 @@
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import timedelta
+from unittest.mock import patch
 from uuid import uuid4
+import uuid
 
 from django.conf import settings
 from django.db.models.deletion import ProtectedError
@@ -10,11 +12,13 @@ from django.utils import timezone
 
 from nose.tools import assert_in, assert_raises
 
+from corehq.util.test_utils import _create_case
 from corehq.motech.const import ALGO_AES, BASIC_AUTH
 from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeaters.dbaccessors import (
     delete_all_repeaters,
     get_all_repeater_docs,
+    iter_repeat_records_by_domain,
 )
 from corehq.motech.utils import b64_aes_encrypt
 
@@ -615,3 +619,42 @@ class TestSQLRepeaterToJSON(TestCase):
             couch_data = self._clean_couch_json(couch_repeater.to_json())
 
             self.assertEqual(sql_data, couch_data)
+
+
+class TestSQLRepeaterModelMethods(RepeaterTestCase):
+
+    def test_register(self):
+        case_id = uuid.uuid4().hex
+        payload, cases = _create_case(
+            domain=DOMAIN, case_id=case_id, case_type='some_case', owner_id='abcd'
+        )
+        repeat_record = self.sql_repeater.register(payload, fire_synchronously=True)
+        self.addCleanup(repeat_record.delete)
+        self.assertEqual(repeat_record.payload_id, payload.get_id)
+        all_records = list(iter_repeat_records_by_domain(DOMAIN))
+        self.assertEqual(len(all_records), 1)
+        self.assertEqual(all_records[0]._id, repeat_record.get_id)
+
+    def test_send_request(self):
+        case_id = uuid.uuid4().hex
+        payload, cases = _create_case(
+            domain=DOMAIN, case_id=case_id, case_type='some_case', owner_id='abcd'
+        )
+        repeat_record = self.sql_repeater.register(payload, fire_synchronously=True)
+        self.addCleanup(repeat_record.delete)
+        from corehq.motech.repeaters.tests.test_models_slow import ResponseMock
+        resp = ResponseMock(status_code=200, reason='OK')
+        # will assert if all the args passed in SQL and couch repeater are same
+        # This also compares various other functions defined in Repeater class
+        with patch('corehq.motech.repeaters.models.simple_request') as simple_request:
+            simple_request.return_value = resp
+            self.sql_repeater.send_request(repeat_record, payload)
+            self.repeater.send_request(repeat_record, payload)
+            first_call, second_call = simple_request.mock_calls
+
+        self.assertEqual(first_call.args, second_call.args)
+        sql_authmanager = first_call.kwargs.pop('auth_manager')
+        couch_authmanager = second_call.kwargs.pop('auth_manager')
+        self.assertEqual(type(sql_authmanager), type(couch_authmanager))
+
+        self.assertEqual(first_call.kwargs, second_call.kwargs)

--- a/corehq/motech/repeaters/tests/test_populate_caserepeater.py
+++ b/corehq/motech/repeaters/tests/test_populate_caserepeater.py
@@ -12,6 +12,7 @@ class TestMigrationDiff(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         domain = 'caserepeater-migration'
         cls.conn = ConnectionSettings(domain=domain, url='http://url.com')
         cls.conn.save()
@@ -42,7 +43,6 @@ class TestMigrationDiff(TestCase):
             format='case_json',
             repeater_id='id_1',
         )
-        super().setUpClass()
 
     def test_diff_couch_and_sql_with_no_diff(self):
         output = MigrationCommand.diff_couch_and_sql(self.couch_repeater_obj.to_json(), self.sql_repeater_obj)
@@ -65,6 +65,7 @@ class TestMigrationCommand(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.domain_1 = 'caserepeater-migration'
         cls.domain_2 = 'migration-caserepeater'
         cls.date = datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%S')
@@ -89,7 +90,6 @@ class TestMigrationCommand(TestCase):
 
         for repeater in cls.repeaters:
             repeater.save(sync_to_sql=False)
-        return super(TestMigrationCommand, cls).setUpClass()
 
     @classmethod
     def tearDownClass(cls):

--- a/corehq/motech/repeaters/tests/test_proxy_models.py
+++ b/corehq/motech/repeaters/tests/test_proxy_models.py
@@ -21,8 +21,8 @@ from corehq.motech.models import ConnectionSettings
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater, SQLOpenmrsRepeater
 from corehq.motech.repeaters.dbaccessors import (
     delete_all_repeaters,
-    get_all_repeater_docs,
 )
+from corehq.motech.repeaters.utils import get_all_repeater_docs
 from corehq.motech.repeaters.expression.repeaters import (
     CaseExpressionRepeater,
     SQLCaseExpressionRepeater,

--- a/corehq/motech/repeaters/tests/test_proxy_models.py
+++ b/corehq/motech/repeaters/tests/test_proxy_models.py
@@ -297,7 +297,6 @@ class TestRepeaterModelsAttrEquality(ModelAttrEqualityHelper):
             # other attrs
             'to_json', '_convert_to_serializable',
             '_optionvalue_fields', '_wrap_schema_attrs',
-            'get_id'
         }
 
 

--- a/corehq/motech/repeaters/tests/test_proxy_models.py
+++ b/corehq/motech/repeaters/tests/test_proxy_models.py
@@ -279,13 +279,11 @@ class TestRepeaterModelsAttrEquality(ModelAttrEqualityHelper):
             'paused',
             # connection setting props
             'plaintext_password', 'username', 'notify_addresses_str', 'create_connection_settings', 'name', 'url',
-            'verify', 'skip_cert_verify', 'password', 'auth_type',
+            'skip_cert_verify', 'password', 'auth_type',
             # not required in sql
             'by_domain', 'base_doc',
             'get_class_from_doc_type', 'started_at', '_get_connection_settings',
             'clear_caches',  # will see if we need it as per requirement
-            # not used
-            'get_attempt_info'
         }
 
     @classmethod
@@ -296,8 +294,10 @@ class TestRepeaterModelsAttrEquality(ModelAttrEqualityHelper):
             'all_objects', 'reset_next_attempt', 'is_deleted', 'PROXY_FIELD_NAME', 'Meta', 'repeater',
             # added by django choicefield in models
             'get_request_method_display',
+            # other attrs
             'to_json', '_convert_to_serializable',
-            '_optionvalue_fields', '_wrap_schema_attrs'
+            '_optionvalue_fields', '_wrap_schema_attrs',
+            'get_id'
         }
 
 

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -42,9 +42,10 @@ from corehq.motech.repeaters.dbaccessors import (
 from corehq.motech.repeaters.models import (
     CaseRepeater,
     FormRepeater,
-    LocationRepeater,
     Repeater,
     RepeatRecord,
+    SQLCaseRepeater,
+    SQLLocationRepeater,
     SQLRepeater,
     ShortFormRepeater,
     UserRepeater,
@@ -704,7 +705,7 @@ class RepeaterFailureTest(BaseRepeaterTest):
     def test_get_payload_exception(self):
         repeat_record = self.repeater.register(CommCareCase.objects.get_case(CASE_ID, self.domain))
         with self.assertRaises(Exception):
-            with patch.object(CaseRepeater, 'get_payload', side_effect=Exception('Boom!')):
+            with patch.object(SQLCaseRepeater, 'get_payload', side_effect=Exception('Boom!')):
                 repeat_record.fire()
 
         self.assertEqual(repeat_record.failure_reason, 'Boom!')
@@ -806,7 +807,7 @@ class TestRepeaterFormat(BaseRepeaterTest):
             def get_payload(self, repeat_record, payload_doc):
                 return cls.payload
 
-        RegisterGenerator.get_collection(CaseRepeater).add_new_format(NewCaseGenerator)
+        RegisterGenerator.get_collection(SQLCaseRepeater).add_new_format(NewCaseGenerator)
         cls.new_generator = NewCaseGenerator
 
     def setUp(self):
@@ -816,16 +817,15 @@ class TestRepeaterFormat(BaseRepeaterTest):
             domain=self.domain,
             url='case-repeater-url',
         )
-        self.repeater = CaseRepeater(
+        self.repeater = SQLCaseRepeater(
             domain=self.domain,
             connection_settings_id=self.connx.id,
             format='new_format',
         )
-        # SQL Repeater Model restricts format and would raise error on unexpected values
-        self.repeater.save(sync_to_sql=False)
+        self.repeater.save()
 
     def tearDown(self):
-        self.repeater.delete(sync_to_sql=False)
+        self.repeater.delete()
         self.connx.delete()
         FormProcessorTestUtils.delete_all_cases_forms_ledgers(self.domain)
         delete_all_repeat_records()
@@ -840,7 +840,7 @@ class TestRepeaterFormat(BaseRepeaterTest):
                 return self.payload
 
         with self.assertRaises(DuplicateFormatException):
-            RegisterGenerator.get_collection(CaseRepeater).add_new_format(NewCaseGenerator)
+            RegisterGenerator.get_collection(SQLCaseRepeater).add_new_format(NewCaseGenerator)
 
     def test_new_format_second_default(self):
         class NewCaseGenerator(BasePayloadGenerator):
@@ -851,7 +851,7 @@ class TestRepeaterFormat(BaseRepeaterTest):
                 return self.payload
 
         with self.assertRaises(DuplicateFormatException):
-            RegisterGenerator.get_collection(CaseRepeater).add_new_format(NewCaseGenerator, is_default=True)
+            RegisterGenerator.get_collection(SQLCaseRepeater).add_new_format(NewCaseGenerator, is_default=True)
 
     def test_new_format_payload(self):
         case = CommCareCase.objects.get_case(CASE_ID, self.domain)
@@ -876,9 +876,9 @@ class TestRepeaterFormat(BaseRepeaterTest):
             )
 
     def test_get_format_by_deprecated_name(self):
-        self.assertIsInstance(CaseRepeater(
+        self.assertIsInstance(SQLCaseRepeater(
             domain=self.domain,
-            url='case-repeater-url',
+            connection_settings=self.connx,
             format='new_format_alias',
         ).generator, self.new_generator)
 
@@ -977,7 +977,7 @@ class LocationRepeaterTest(TestCase, DomainSubscriptionMixin):
             domain=self.domain,
             url='super-cool-url',
         )
-        self.repeater = LocationRepeater(
+        self.repeater = SQLLocationRepeater(
             domain=self.domain,
             connection_settings_id=self.connx.id,
         )
@@ -1107,14 +1107,13 @@ class TestRepeaterDeleted(BaseRepeaterTest):
             domain=self.domain,
             url='case-repeater-url',
         )
-        self.repeater = CaseRepeater(
+        self.repeater = SQLCaseRepeater(
             domain=self.domain,
             connection_settings_id=self.connx.id,
             format='case_json',
         )
         self.repeater.save()
         self.post_xml(self.xform_xml, self.domain)
-        self.repeater = reloaded(self.repeater)
 
     def tearDown(self):
         self.repeater.delete()
@@ -1130,6 +1129,7 @@ class TestRepeaterDeleted(BaseRepeaterTest):
 
         with patch.object(RepeatRecord, 'fire') as mock_fire:
             self.repeat_record = self.repeater.register(CommCareCase.objects.get_case(CASE_ID, self.domain))
+            self.repeat_record = reloaded(self.repeat_record)
             _process_repeat_record(self.repeat_record)
             self.assertEqual(mock_fire.call_count, 0)
             self.assertEqual(self.repeat_record.doc_type, "RepeatRecord-Deleted")
@@ -1140,6 +1140,7 @@ class TestRepeaterDeleted(BaseRepeaterTest):
 
         with patch.object(RepeatRecord, 'fire') as mock_fire:
             self.repeat_record = self.repeater.register(CommCareCase.objects.get_case(CASE_ID, self.domain))
+            self.repeat_record = reloaded(self.repeat_record)
             _process_repeat_record(self.repeat_record)
             self.assertEqual(mock_fire.call_count, 0)
             self.assertEqual(self.repeat_record.doc_type, "RepeatRecord-Deleted")

--- a/corehq/motech/repeaters/tests/test_repeaters_migration.py
+++ b/corehq/motech/repeaters/tests/test_repeaters_migration.py
@@ -50,6 +50,7 @@ class TestMigrationCommand(TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
+        super().setUpClass()
         cls.conn = ConnectionSettings(url="http://url.com", domain='rtest')
         cls.conn.save()
         cls.couch_repeaters = []
@@ -58,7 +59,6 @@ class TestMigrationCommand(TestCase):
             r.connection_settings_id = cls.conn.id
             r.save(sync_to_sql=False)
             cls.couch_repeaters.append(r)
-        return super().setUpClass()
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/custom/cowin/signals.py
+++ b/custom/cowin/signals.py
@@ -4,12 +4,12 @@ from corehq.form_processor.signals import sql_case_post_save
 
 from corehq.motech.repeaters.signals import create_repeat_records
 from custom.cowin.repeaters import (
-    BeneficiaryRegistrationRepeater,
-    BeneficiaryVaccinationRepeater,
+    SQLBeneficiaryRegistrationRepeater,
+    SQLBeneficiaryVaccinationRepeater,
 )
 
 
 @receiver(sql_case_post_save, dispatch_uid="create_cowin_repeat_records")
 def create_cowin_repeat_records(sender, case, **kwargs):
-    create_repeat_records(BeneficiaryRegistrationRepeater, case)
-    create_repeat_records(BeneficiaryVaccinationRepeater, case)
+    create_repeat_records(SQLBeneficiaryRegistrationRepeater, case)
+    create_repeat_records(SQLBeneficiaryVaccinationRepeater, case)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
PR 1 https://github.com/dimagi/commcare-hq/pull/32021
PR 2 https://github.com/dimagi/commcare-hq/pull/32042

This is 3rd PR for Phase 2 of Repeater migrations. Majorly this moves Repeat Records to use SQLRepeaters. The changes that I have made were already tested by multiple components in HQ so very few new tests were added.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tests have been added and changes have been tried to be tested on local env wherever possible.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Tests have been added where required.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

QA will be triggered when entire Phase 2 will be complete 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
