### PR TITLE
Save ignored count for automatic django migration

### DIFF
--- a/corehq/apps/fixtures/tests/test_couchsqlmigration.py
+++ b/corehq/apps/fixtures/tests/test_couchsqlmigration.py
@@ -516,6 +516,7 @@ class TestLookupTableRowCouchToSQLMigration(TestCase):
 
     def tearDown(self):
         docs = list(get_all_docs_with_doc_types(self.db, ['FixtureDataItem']))
+        docs.append(LookupTableRowCommand.get_migration_status())
         self.db.bulk_delete(docs)
         super().tearDown()
 
@@ -618,6 +619,7 @@ class TestLookupTableRowCouchToSQLMigration(TestCase):
             call_command('populate_lookuptablerows', log_path=log.path)
             self.assertIn(f"Ignored model for FixtureDataItem with id {doc_id}\n", log.content)
             self.assertNotIn(f'Doc "{doc_id}" has diff', log.content)
+        self.assertEqual(LookupTableRowCommand.count_items_to_be_migrated(), 0)
 
     def create_row(self):
         doc, obj = create_lookup_table_row(unwrap_doc=False)


### PR DESCRIPTION
Allows migrations to record ignored documents so the Couch document count (including ignored docs) can be compared to the number of records in SQL, an operation that is performed by `migrate_from_migration` to determine if the migration is completed.

## Safety Assurance

### Safety story

Changes only affect Couch to SQL management commands.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
