### PR TITLE
Add case_id filter to forms API

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -474,18 +474,19 @@ def _validate_and_get_es_filter(search_param):
 
 
 def es_query_from_get_params(search_params, domain, reserved_query_params=None, doc_type='form'):
-    # doc_type can be form or case
-    assert doc_type in ['form', 'case']
-    es = FormES() if doc_type == 'form' else CaseES()
-
-    query = es.remove_default_filters().domain(domain)
-
     if doc_type == 'form':
+        query = FormES().remove_default_filters().domain(domain)
         if 'include_archived' in search_params:
-            query = query.filter(
-                filters.OR(filters.term('doc_type', 'xforminstance'), filters.term('doc_type', 'xformarchived')))
+            query = query.filter(filters.OR(
+                filters.term('doc_type', 'xforminstance'),
+                filters.term('doc_type', 'xformarchived'),
+            ))
         else:
             query = query.filter(filters.term('doc_type', 'xforminstance'))
+    elif doc_type == 'case':
+        query = CaseES().domain(domain)
+    else:
+        raise AssertionError("unknown doc type")
 
     if '_search' in search_params:
         # This is undocumented usecase by Data export tool and one custom project

--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -429,6 +429,7 @@ class XFormServerModifiedParams:
 xform_param_consumers = [
     TermParam('xmlns', 'xmlns.exact'),
     TermParam('xmlns.exact'),
+    TermParam('case_id', '__retrieved_case_ids'),
     DateRangeParams('received_on'),
     DateRangeParams('server_modified_on'),
     DateRangeParams('server_date_modified', 'server_modified_on'),

--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -19,8 +19,6 @@ from corehq.apps.user_importer.helpers import UserChangeLogger
 from corehq.apps.users.models import CommCareUser, HqPermissions, WebUser
 from corehq.const import USER_CHANGE_VIA_API
 
-TASTYPIE_RESERVED_GET_PARAMS = ['api_key', 'username', 'format']
-
 
 class UserResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMixin):
     type = "user"

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -148,7 +148,7 @@ class XFormInstanceResource(SimpleSortableResourceMixin, HqBaseResource, DomainS
 
     def obj_get_list(self, bundle, domain, **kwargs):
         try:
-            es_query = es_query_from_get_params(bundle.request.GET, domain, ['include_archived'])
+            es_query = es_query_from_get_params(bundle.request.GET, domain)
         except Http400 as e:
             raise BadRequest(str(e))
 


### PR DESCRIPTION
## Product Description
This adds a filter to the forms API which allows you to return only forms that touch a specific case

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-2104
The first few commits are cleanup/refactor stuff that I couldn't resist.

The actual change is quite simple, it just wraps the existing `__retrieved_case_ids` value in the xform_mapping.  I believe this change is safe enough to apply as-is, and undocumented.  Then we can give the AEs a chance to play around with it on real project data before we make it official.  The main risk I anticipate is that `__retrieved_case_ids` might not be comprehensive, though that seems unlikely, as it's populated by `get_case_updates`, which appears to be widely relied upon.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I tested this locally, and added an automated test.  The refactors should have no behavior changes.  I did split the available filters - forms here, cases there.  I'll comment on why I think that's save in-line for ease of reply.

### Automated test coverage

included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
