### PR TITLE
Fix raw doc lookup with invalid UUID value

### DIFF
--- a/corehq/apps/hqadmin/tests/test_raw_doc.py
+++ b/corehq/apps/hqadmin/tests/test_raw_doc.py
@@ -75,6 +75,11 @@ class TestRawDocLookup(TestCase):
         data = raw_doc_lookup(str(row.id))
         self.assertEqual(json.loads(data["doc"]), expected_doc)
 
+    def test_raw_doc_with_invalid_uuid(self):
+        data = raw_doc_lookup("abcxyz")
+        self.assertNotIn("doc", data)
+        self.assertEqual({r.result for r in data["db_results"]}, {"missing"})
+
 
 def make_lookuptable():
     return LookupTable(


### PR DESCRIPTION
Just realized that raw_doc has been broken for IDs that are not valid UUIDs since SQL Lookup Tables were added.

## Safety Assurance

### Safety story

Affects internal admin view only.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
