### PR TITLE
Management command to get deleted cases

### DIFF
--- a/custom/covid/management/commands/fetch_deleted_cases.py
+++ b/custom/covid/management/commands/fetch_deleted_cases.py
@@ -1,7 +1,11 @@
-
 import csv
+from casexml.apps.case.xform import get_case_updates
 from datetime import datetime
-from corehq.form_processor.models.cases import CommCareCase
+from django.core.management.base import BaseCommand
+
+
+from corehq.apps.es import FormES
+from corehq.form_processor.models.cases import CommCareCase, XFormInstance
 from corehq.util.argparse_types import date_type
 from django.core.management.base import BaseCommand
 
@@ -20,6 +24,7 @@ class Command(BaseCommand):
         filename = "deleted_cases_pull_{}.csv".format(datetime.utcnow().strftime("%Y-%m-%d_%H.%M.%S"))
         domains = options['domains']
 
+        print(f"Outputting to: {filename}...")
         with open(filename, 'w', encoding='utf-8') as csv_file:
             field_names = ['domain', 'case_id', 'case_type', 'date_of_deletion']
             csv_writer = csv.DictWriter(csv_file, field_names)
@@ -28,11 +33,55 @@ class Command(BaseCommand):
                 deleted_case_ids = CommCareCase.objects.get_deleted_case_ids_in_domain(domain)
                 deleted_cases = CommCareCase.objects.get_cases(deleted_case_ids)
                 for case in deleted_cases:
-                    row = {
-                        'domain': domain,
-                        'case_id': case.case_id,
-                        'case_type': case.type,
-                        'date_of_deletion': case.deleted_on
-                    }
+                    # Should be true if a case was deleted because an associated mobile worker was removed.
+                    if case.deleted_on:
+                        row = {
+                            'domain': domain,
+                            'case_id': case.case_id,
+                            'case_type': case.type,
+                            'date_of_deletion': case.deleted_on
+                        }
+                    # Otherwise, case was deleted due to form achival, and we can get the case type through a
+                    # more lengthy process.
+                    else:
+                        # Getting the form that created the case via ES fails sometimes.
+                        case_type = _find_case_type_ES(domain, case.case_id)
+                        if not case_type:
+                            # If it does, try to get the case type via case transactions.
+                            case_type = _find_case_type_reg(case)
+                        if not case_type:
+                            print(f"Could not find case type for case {case.case_id}")
+                            case_type = "ERR"
+                        row = {
+                            'domain': domain,
+                            'case_id': case.case_id,
+                            'case_type': case_type,
+                            'date_of_deletion': case.modified_on
+                        }
+
                     csv_writer.writerow(row)
             print(f"Result saved to {filename}")
+
+
+def _get_case_type_if_form_creates_case(form, case_id):
+    updates = get_case_updates(form)
+    for update in updates:
+        if update.creates_case() and update.id == case_id:
+            return update.get_create_action().type
+
+
+def _find_case_type_ES(domain, case_id):
+    forms_that_touched_case = FormES().domain(domain).updating_cases([case_id]).run().raw['hits']['hits']
+    for form in forms_that_touched_case:
+        case_type = _get_case_type_if_form_creates_case(form, case_id)
+        if case_type:
+            return case_type
+
+
+def _find_case_type_reg(case):
+    for transaction in case.transactions:
+        if transaction.details.get('archived', False):
+            form = XFormInstance.get_obj_by_id(transaction.details['form_id'])
+            case_type = _get_case_type_if_form_creates_case(form, case.case_id)
+            if case_type:
+                return case_type

--- a/custom/covid/management/commands/fetch_deleted_cases.py
+++ b/custom/covid/management/commands/fetch_deleted_cases.py
@@ -1,0 +1,38 @@
+
+import csv
+from datetime import datetime
+from corehq.form_processor.models.cases import CommCareCase
+from corehq.util.argparse_types import date_type
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--domains', nargs="*",
+            help='Domains to check, will include enterprise-controlled child domains.'
+        )
+        parser.add_argument('--start', type=date_type, help='Start date (inclusive)')
+        parser.add_argument('--end', type=date_type, help='End date (inclusive)')
+
+    def handle(self, **options):
+        filename = "deleted_cases_pull_{}.csv".format(datetime.utcnow().strftime("%Y-%m-%d_%H.%M.%S"))
+        domains = options['domains']
+
+        with open(filename, 'w', encoding='utf-8') as csv_file:
+            field_names = ['domain', 'case_id', 'case_type', 'date_of_deletion']
+            csv_writer = csv.DictWriter(csv_file, field_names)
+            csv_writer.writeheader()
+            for domain in domains:
+                deleted_case_ids = CommCareCase.objects.get_deleted_case_ids_in_domain(domain)
+                deleted_cases = CommCareCase.objects.get_cases(deleted_case_ids)
+                for case in deleted_cases:
+                    row = {
+                        'domain': domain,
+                        'case_id': case.case_id,
+                        'case_type': case.type,
+                        'date_of_deletion': case.deleted_on
+                    }
+                    csv_writer.writerow(row)
+            print(f"Result saved to {filename}")

--- a/custom/covid/management/commands/fetch_deleted_cases.py
+++ b/custom/covid/management/commands/fetch_deleted_cases.py
@@ -3,19 +3,17 @@ from casexml.apps.case.xform import get_case_updates
 from datetime import datetime
 from django.core.management.base import BaseCommand
 
-
 from corehq.apps.es import FormES
 from corehq.form_processor.models.cases import CommCareCase, XFormInstance
 from corehq.util.argparse_types import date_type
-from django.core.management.base import BaseCommand
+from dimagi.utils.chunked import chunked
 
 
 class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--domains', nargs="*",
-            help='Domains to check, will include enterprise-controlled child domains.'
+            '--domains', nargs="*"
         )
         parser.add_argument('--start', type=date_type, help='Start date (inclusive)')
         parser.add_argument('--end', type=date_type, help='End date (inclusive)')
@@ -26,40 +24,41 @@ class Command(BaseCommand):
 
         print(f"Outputting to: {filename}...")
         with open(filename, 'w', encoding='utf-8') as csv_file:
-            field_names = ['domain', 'case_id', 'case_type', 'date_of_deletion']
+            field_names = ['domain', 'case_id', 'case_type', 'date_of_deletion', 'deletion_type']
             csv_writer = csv.DictWriter(csv_file, field_names)
             csv_writer.writeheader()
             for domain in domains:
                 deleted_case_ids = CommCareCase.objects.get_deleted_case_ids_in_domain(domain)
-                deleted_cases = CommCareCase.objects.get_cases(deleted_case_ids)
-                for case in deleted_cases:
-                    # Should be true if a case was deleted because an associated mobile worker was removed.
-                    if case.deleted_on:
-                        row = {
-                            'domain': domain,
-                            'case_id': case.case_id,
-                            'case_type': case.type,
-                            'date_of_deletion': case.deleted_on
-                        }
-                    # Otherwise, case was deleted due to form achival, and we can get the case type through a
-                    # more lengthy process.
-                    else:
-                        # Getting the form that created the case via ES fails sometimes.
-                        case_type = _find_case_type_ES(domain, case.case_id)
-                        if not case_type:
-                            # If it does, try to get the case type via case transactions.
-                            case_type = _find_case_type_reg(case)
-                        if not case_type:
-                            print(f"Could not find case type for case {case.case_id}")
-                            case_type = "ERR"
-                        row = {
-                            'domain': domain,
-                            'case_id': case.case_id,
-                            'case_type': case_type,
-                            'date_of_deletion': case.modified_on
-                        }
-
-                    csv_writer.writerow(row)
+                for ids_chunk in chunked(deleted_case_ids, 500):
+                    for case in CommCareCase.objects.get_cases(list(ids_chunk)):
+                        # Should be true if a case was deleted because an associated mobile worker was removed.
+                        if case.deleted_on:
+                            row = {
+                                'domain': domain,
+                                'case_id': case.case_id,
+                                'case_type': case.type,
+                                'date_of_deletion': case.server_modified_on,
+                                'deletion_type': 'Mobile worker deleted'
+                            }
+                        # Otherwise, case was deleted due to form achival, and we can get the case type through a
+                        # more lengthy process.
+                        else:
+                            # Getting the form that created the case via ES fails sometimes.
+                            case_type = _find_case_type_using_ES(domain, case.case_id)
+                            if not case_type:
+                                # If it does, try to get the case type via case transactions.
+                                case_type = _find_case_type_from_transactions(case)
+                            if not case_type:
+                                print(f"Could not find case type for case {case.case_id}")
+                                case_type = None
+                            row = {
+                                'domain': domain,
+                                'case_id': case.case_id,
+                                'case_type': case_type,
+                                'date_of_deletion': case.modified_on,
+                                'deletion_type': 'Forms archived' if case_type else 'Unknown'
+                            }
+                        csv_writer.writerow(row)
             print(f"Result saved to {filename}")
 
 
@@ -70,15 +69,22 @@ def _get_case_type_if_form_creates_case(form, case_id):
             return update.get_create_action().type
 
 
-def _find_case_type_ES(domain, case_id):
-    forms_that_touched_case = FormES().domain(domain).updating_cases([case_id]).run().raw['hits']['hits']
+def _find_case_type_using_ES(domain, case_id):
+    forms_that_touched_case = (
+        FormES()
+        .domain(domain)
+        .updating_cases([case_id])
+        .sort('received_on', desc=False)
+        .run()
+        .raw['hits']['hits']
+    )
     for form in forms_that_touched_case:
         case_type = _get_case_type_if_form_creates_case(form, case_id)
         if case_type:
             return case_type
 
 
-def _find_case_type_reg(case):
+def _find_case_type_from_transactions(case):
     for transaction in case.transactions:
         if transaction.details.get('archived', False):
             form = XFormInstance.get_obj_by_id(transaction.details['form_id'])


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This is a management to pull all deleted cases from a set of domains. It will be used as part of [USH-2306](https://dimagi-dev.atlassian.net/jira/software/c/projects/USH/boards/143?modal=detail&selectedIssue=USH-2306) to pull all deleted cases from CICT domains into a CSV file.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Per Simon there seem to be two categories of deleted cases: one category where the associated mobile worker for a case was deleted, and another category in which all the forms attached to a case were deleted.

This command pulls cases from both categories. The latter was a bit trickier, as the case type is not on the case but is only accessible per the form that created the case. You'll notice I pulled forms that touch a case via the ES field `__retrieved_case_ids` (using the `updating_cases` method) per Simon's guidance. That wasn't enough, however, as this field was empty for some of the deleted cases. For those cases, I instead got the case type by using a list of forms from the case's `transactions`. 

I'm open to feedback about whether this seems the right way to do it. This command still couldn't grab the case types for a dozen or so cases, but I think I can grab the case types of those manually by looking through the raw docs if needed. Or if they can't be found we can just consider those case types lost in the context of this data pull.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Purely used for pulling data, doesn't edit anything.

### Automated test coverage

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
