### PR TITLE
Delete orphaned SQL rows in Lookup Tables migration

### DIFF
--- a/corehq/apps/fixtures/management/commands/base.py
+++ b/corehq/apps/fixtures/management/commands/base.py
@@ -1,0 +1,94 @@
+import json
+from uuid import UUID
+
+from django.db.models import Q
+
+from dimagi.utils.chunked import chunked
+
+from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import (
+    DiffDocs,
+    PopulateSQLCommand,
+)
+
+
+class PopulateLookupTableCommand(PopulateSQLCommand):
+
+    def handle(self, *, chunk_size, fixup_diffs, **kw):
+        self._id_sets_only_in_sql = []
+        result = super().handle(chunk_size=chunk_size, fixup_diffs=fixup_diffs, **kw)
+        if fixup_diffs:
+            with self.open_log(self.log_path, "a") as logfile:
+                self.delete_rows_only_in_sql(fixup_diffs, logfile, chunk_size)
+        return result
+
+    def _verify_docs(self, docs, logfile, verify_only):
+        super()._verify_docs(docs, logfile, verify_only)
+        self.log_only_in_sql(logfile)
+
+    def log_only_in_sql(self, logfile):
+        while self._id_sets_only_in_sql:
+            ids = self._id_sets_only_in_sql.pop()
+            self.diff_count += len(ids)
+            for sql_id in ids:
+                logfile.write(MISSING_IN_COUCH.format(json.dumps(sql_id)))
+
+    def _iter_couch_docs_for_domains(self, *args, **kw):
+        print("WARNING scan for orphaned SQL is not supported with --domains")
+        return super()._iter_couch_docs_for_domains(*args, **kw)
+
+    def _get_all_couch_docs_for_model(self, chunk_size):
+        first_id = None
+        couch_ids = []
+        for doc in super()._get_all_couch_docs_for_model(chunk_size):
+            yield doc
+            couch_ids.append(doc["_id"])
+            if len(couch_ids) >= chunk_size:
+                self.find_rows_only_in_sql(first_id, couch_ids)
+                first_id = couch_ids[-1]
+                couch_ids = []
+        if couch_ids:
+            self.find_rows_only_in_sql(first_id, couch_ids, end=True)
+
+    def find_rows_only_in_sql(self, first_id, couch_ids, end=False):
+        if len(couch_ids) > 1:
+            assert couch_ids[0] < couch_ids[-1], (couch_ids[0], couch_ids[-1])
+        id_name = self.sql_class()._migration_couch_id_name
+        bounds = {} if end else {f"{id_name}__lt": couch_ids[-1]}
+        if first_id is not None:
+            assert first_id < couch_ids[0], (first_id, couch_ids[0])
+            bounds[f"{id_name}__gt"] = first_id
+        ids_only_in_sql = list(
+            self.sql_class().objects
+            .filter(~Q(**{f"{id_name}__in": couch_ids}), **bounds)
+            .values_list(id_name, flat=True)
+        )
+        if ids_only_in_sql:
+            if isinstance(ids_only_in_sql[0], UUID):
+                ids_only_in_sql = [x.hex for x in ids_only_in_sql]
+            self._id_sets_only_in_sql.append(ids_only_in_sql)
+
+    def delete_rows_only_in_sql(self, diffs_file, logfile, chunk_size):
+        couch = self.couch_db()
+        sql_ids = DiffDocs(diffs_file, None, chunk_size, MISSING_IN_COUCH)
+        id_name = self.sql_class()._migration_couch_id_name
+        ignored_count = deleted_count = 0
+        for ids in chunked(sql_ids.iter_doc_ids(), chunk_size, list):
+            to_delete = ids
+            couch_status = couch.view("_all_docs", keys=ids, reduce=False)
+            to_delete = []
+            for res in couch_status:
+                if "value" in res and res["value"].get("deleted"):
+                    to_delete.append(res["id"])
+                else:
+                    ignored_count += 1
+                    print("Unexpected: SQL record not deleted in Couch:", res, file=logfile)
+            print("Removed orphaned SQL rows:", to_delete, file=logfile)
+            self.sql_class().objects.filter(**{f"{id_name}__in": to_delete}).delete()
+            deleted_count += len(to_delete)
+        if deleted_count:
+            print(f"Removed {deleted_count} orphaned SQL rows")
+        if ignored_count:
+            print(f"Ignored {ignored_count} orphaned SQL rows (not deleted in Couch)")
+
+
+MISSING_IN_COUCH = "SQL row {} is missing in Couch\n"

--- a/corehq/apps/fixtures/management/commands/populate_lookuptablerowowners.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptablerowowners.py
@@ -1,10 +1,10 @@
 from uuid import UUID
 
-from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
+from .base import PopulateLookupTableCommand
 from ...models import OwnerType
 
 
-class Command(PopulateSQLCommand):
+class Command(PopulateLookupTableCommand):
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)

--- a/corehq/apps/fixtures/management/commands/populate_lookuptablerows.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptablerows.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
 from uuid import UUID
-from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
 
+from .base import PopulateLookupTableCommand
 from ...models import Field
 
 
-class Command(PopulateSQLCommand):
+class Command(PopulateLookupTableCommand):
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)

--- a/corehq/apps/fixtures/management/commands/populate_lookuptables.py
+++ b/corehq/apps/fixtures/management/commands/populate_lookuptables.py
@@ -1,11 +1,10 @@
 from django.db import transaction
 
-from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
-
+from .base import PopulateLookupTableCommand
 from ...models import FixtureDataType, LookupTable, TypeField
 
 
-class Command(PopulateSQLCommand):
+class Command(PopulateLookupTableCommand):
 
     @classmethod
     def couch_db_slug(cls):

--- a/corehq/apps/fixtures/tests/test_couchsqlmigration.py
+++ b/corehq/apps/fixtures/tests/test_couchsqlmigration.py
@@ -499,6 +499,35 @@ class TestLookupTableCouchToSQLMigration(TestCase):
             for dup_id in dup_ids:
                 self.assertNotIn(f'Doc "{dup_id}" has differences:', log2.content)
 
+    def test_migration_deletes_orphaned_tables_in_sql(self):
+        # SQL rows became orphaned when bulk_delete() raised BulkSaveError (unhandled)
+        docs = []
+        for i in range(9):
+            doc, obj = create_lookup_table(tag=f"price{i}", unwrap_doc=False)
+            doc.save()
+            docs.append(doc)
+        docs.sort(key=lambda d: d._id)
+        deleted = [docs[0], docs[-1]]
+        deleted_ids = [d._id for d in deleted]
+        FixtureDataType.bulk_delete(deleted)
+        _, not_deleted = create_lookup_table(tag="price", unwrap_doc=False)
+        not_deleted.save(sync_to_couch=False)
+
+        with templog() as log, templog() as log2:
+            call_command('populate_lookuptables', chunk_size=3, log_path=log.path)
+            missing = 0
+            for doc_id in deleted_ids + [not_deleted.id.hex]:
+                if f'SQL row "{doc_id}" is missing in Couch\n' in log.content:
+                    missing += 1
+            self.assertEqual(missing, 3, log.content)
+            self.assertEqual(log.content.count("missing in Couch"), 3, log.content)
+
+            call_command('populate_lookuptables', fixup_diffs=log.path, log_path=log2.path)
+            self.assertIn(f"Removed orphaned SQL rows: {deleted_ids}", log2.content)
+            res = {'key': not_deleted.id.hex, 'error': 'not_found'}
+            self.assertIn(f"not deleted in Couch: {res}", log2.content)
+        self.assertFalse(LookupTable.objects.filter(id__in=deleted_ids).exists())
+
     def diff(self, doc, obj):
         return do_diff(LookupTableCommand, doc, obj)
 
@@ -621,6 +650,35 @@ class TestLookupTableRowCouchToSQLMigration(TestCase):
             self.assertNotIn(f'Doc "{doc_id}" has diff', log.content)
         self.assertEqual(LookupTableRowCommand.count_items_to_be_migrated(), 0)
 
+    def test_migration_deletes_orphaned_rows_in_sql(self):
+        # SQL rows became orphaned when bulk_delete() raised BulkSaveError (unhandled)
+        docs = []
+        for i in range(9):
+            doc, obj = self.create_row()
+            doc.save()
+            docs.append(doc)
+        docs.sort(key=lambda d: d._id)
+        deleted = [docs[0], docs[-1]]
+        deleted_ids = [d._id for d in deleted]
+        FixtureDataItem.bulk_delete(deleted)
+        _, not_deleted = self.create_row()
+        not_deleted.save(sync_to_couch=False)
+
+        with templog() as log, templog() as log2:
+            call_command('populate_lookuptablerows', chunk_size=3, log_path=log.path)
+            missing = 0
+            for doc_id in deleted_ids + [not_deleted.id.hex]:
+                if f'SQL row "{doc_id}" is missing in Couch\n' in log.content:
+                    missing += 1
+            self.assertEqual(missing, 3, log.content)
+            self.assertEqual(log.content.count("missing in Couch"), 3, log.content)
+
+            call_command('populate_lookuptablerows', fixup_diffs=log.path, log_path=log2.path)
+            self.assertIn(f"Removed orphaned SQL rows: {deleted_ids}", log2.content)
+            res = {'key': not_deleted.id.hex, 'error': 'not_found'}
+            self.assertIn(f"not deleted in Couch: {res}", log2.content)
+        self.assertFalse(LookupTable.objects.filter(id__in=deleted_ids).exists())
+
     def create_row(self):
         doc, obj = create_lookup_table_row(unwrap_doc=False)
         doc.data_type_id = self.type_doc._id
@@ -737,6 +795,37 @@ class TestLookupTableRowOwnerCouchToSQLMigration(TestCase):
         with templog() as log, patch.object(transaction, "atomic", atomic_check):
             call_command('populate_lookuptablerowowners', log_path=log.path)
             self.assertIn(f"Ignored model for FixtureOwnership with id {doc_id}\n", log.content)
+
+    def test_migration_deletes_orphaned_owners_in_sql(self):
+        # SQL rows became orphaned when bulk_delete() raised BulkSaveError (unhandled)
+        docs = []
+        for i in range(9):
+            doc, obj = self.create_owner()
+            doc.save()
+            docs.append(doc)
+        docs.sort(key=lambda d: d._id)
+        deleted = [docs[0], docs[-1]]
+        deleted_ids = [d._id for d in deleted]
+        FixtureOwnership.bulk_delete(deleted)
+        _, not_deleted = self.create_owner()
+        # unlikely scenario: Couch corruption causes document to be missing, but not deleted
+        not_deleted.couch_id = "6e477e6f73934be5a0f47710d240e3db"
+        not_deleted.save(sync_to_couch=False)
+
+        with templog() as log, templog() as log2:
+            call_command('populate_lookuptablerowowners', chunk_size=3, log_path=log.path)
+            missing = 0
+            for doc_id in deleted_ids + [not_deleted.couch_id]:
+                if f'SQL row "{doc_id}" is missing in Couch\n' in log.content:
+                    missing += 1
+            self.assertEqual(missing, 3, log.content)
+            self.assertEqual(log.content.count("missing in Couch"), 3, log.content)
+
+            call_command('populate_lookuptablerowowners', fixup_diffs=log.path, log_path=log2.path)
+            self.assertIn(f"Removed orphaned SQL rows: {deleted_ids}", log2.content)
+            res = {'key': not_deleted.couch_id, 'error': 'not_found'}
+            self.assertIn(f"not deleted in Couch: {res}", log2.content)
+        self.assertFalse(LookupTable.objects.filter(id__in=deleted_ids).exists())
 
     def create_owner(self):
         doc, obj = create_lookup_table_row_owner(unwrap_doc=False)


### PR DESCRIPTION
SQL rows can become orphaned when `bulk_delete()` raises `BulkSaveError` (unhandled). One bug that caused that to happen has since been fixed in https://github.com/dimagi/commcare-hq/pull/32110

## Safety Assurance

### Safety story

Changes migration management commands only.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
