### PR TITLE
Add starts-with filter to elasticsearch query

### DIFF
--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -107,39 +107,30 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
 
     def test_starts_with(self):
         parsed = parse_xpath("starts-with(ssn, '100')")
-        expected_filter_single = {
+        expected_filter = {
             "nested": {
                 "path": "case_properties",
                 "query": {
                     "bool": {
-                        "filter": [
+                        "filter": (
                             {
-                                "bool": {
-                                    "filter": (
-                                        {
-                                            "term": {
-                                                "case_properties.key.exact": "ssn"
-                                            }
-                                        },
-                                        {
-                                            "prefix": {
-                                                "case_properties.value.exact": "100"
-                                            }
-                                        }
-                                    )
+                                "term": {
+                                    "case_properties.key.exact": "ssn"
+                                }
+                            },
+                            {
+                                "prefix": {
+                                    "case_properties.value.exact": "100"
                                 }
                             }
-                        ],
-                        "must": {
-                            "match_all": {}
-                        }
+                        )
                     }
                 }
             }
         }
 
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
-        self.checkQuery(built_filter, expected_filter_single, is_raw_query=True)
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_date_comparison(self):
         parsed = parse_xpath("dob >= '2017-02-12'")
@@ -168,6 +159,7 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         }
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, query, is_raw_query=True)
+
 
     @freeze_time('2021-08-02')
     def test_date_comparison__today(self):

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -4,6 +4,7 @@ from .query_functions import (
     selected_all,
     selected_any,
     within_distance,
+    starts_with
 )
 from .subcase_functions import subcase
 from .value_functions import date, date_add, today
@@ -25,4 +26,5 @@ XPATH_QUERY_FUNCTIONS = {
     'selected-all': selected_all,
     'within-distance': within_distance,
     'fuzzy-match': fuzzy_match,
+    'starts-with': starts_with,
 }

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -12,7 +12,7 @@ from corehq.apps.es.queries import DISTANCE_UNITS
 from corehq.apps.es.case_search import (
     case_property_geo_distance,
     case_property_query,
-    case_property_starts_with_query,
+    case_property_starts_with,
 )
 
 from .utils import confirm_args_count
@@ -27,7 +27,7 @@ def not_(node, context):
 def starts_with(node, context):
     property_name, search_value = node.args
     property_name = _property_name_to_string(property_name, node)
-    return case_property_starts_with_query(property_name, search_value)
+    return case_property_starts_with(property_name, search_value)
 
 
 def selected_any(node, context):

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -12,6 +12,7 @@ from corehq.apps.es.queries import DISTANCE_UNITS
 from corehq.apps.es.case_search import (
     case_property_geo_distance,
     case_property_query,
+    case_property_starts_with_query,
 )
 
 from .utils import confirm_args_count
@@ -22,6 +23,11 @@ def not_(node, context):
     confirm_args_count(node, 1)
     return filters.NOT(build_filter_from_ast(node.args[0], context))
 
+
+def starts_with(node, context):
+    property_name, search_value = node.args
+    property_name = _property_name_to_string(property_name, node)
+    return case_property_starts_with_query(property_name, search_value)
 
 def selected_any(node, context):
     return _selected_query(node, context, operator='or')

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -29,6 +29,7 @@ def starts_with(node, context):
     property_name = _property_name_to_string(property_name, node)
     return case_property_starts_with_query(property_name, search_value)
 
+
 def selected_any(node, context):
     return _selected_query(node, context, operator='or')
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -221,19 +221,16 @@ def case_property_text_query(case_property_name, value, operator=None):
     )
 
 
-def case_property_starts_with_query(case_property_name, value):
+def case_property_starts_with(case_property_name, value):
     """Filter by case_properties.key and do a text search in case_properties.value that
        matches starting substring.
 
     """
     return queries.nested(
         CASE_PROPERTIES_PATH,
-        queries.filtered(
-            queries.match_all(),
-            filters.AND(
-                filters.term(PROPERTY_KEY, case_property_name),
-                filters.prefix(PROPERTY_VALUE_EXACT, value),
-            )
+        filters.AND(
+            filters.term(PROPERTY_KEY, case_property_name),
+            filters.prefix(PROPERTY_VALUE_EXACT, value),
         )
     )
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -221,6 +221,23 @@ def case_property_text_query(case_property_name, value, operator=None):
     )
 
 
+def case_property_starts_with_query(case_property_name, value):
+    """Filter by case_properties.key and do a text search in case_properties.value that
+       matches starting substring.
+
+    """
+    return queries.nested(
+        CASE_PROPERTIES_PATH,
+        queries.filtered(
+            queries.match_all(),
+            filters.AND(
+                filters.term(PROPERTY_KEY, case_property_name),
+                filters.prefix(PROPERTY_VALUE_EXACT, value),
+            )
+        )
+    )
+
+
 def case_property_range_query(case_property_name, gt=None, gte=None, lt=None, lte=None):
     """Returns cases where case property `key` fall into the range provided.
 

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -22,6 +22,9 @@ def match_all():
     return {"match_all": {}}
 
 
+def prefix(field, value):
+    return {"prefix": {field: value}}
+
 def term(field, value):
     """
     Filter docs by a field

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -25,6 +25,7 @@ def match_all():
 def prefix(field, value):
     return {"prefix": {field: value}}
 
+
 def term(field, value):
     """
     Filter docs by a field

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -13,7 +13,7 @@ from corehq.apps.case_search.models import CaseSearchConfig
 from corehq.apps.es import queries
 from corehq.apps.es.case_search import (
     CaseSearchES,
-    case_property_starts_with_query,
+    case_property_starts_with,
     case_property_geo_distance,
     case_property_missing,
     case_property_query,
@@ -556,9 +556,8 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
                 {'_id': 'c5', 'ssn': '1001'},
                 {'_id': 'c6', 'ssn': '100-1'},
             ],
-            CaseSearchES().domain(self.domain).add_query(
-                case_property_starts_with_query('ssn', '100'),
-                clause=queries.MUST
+            CaseSearchES().domain(self.domain).filter(
+                case_property_starts_with('ssn', '100'),
             ),
             "starts-with(ssn, '100')",
             ['c5', 'c6', 'c2']


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Support for doing starts-with queries in Case Search via 'XPATH' queries.

query example:
`starts-with(ssn, '100)`

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[https://dimagi-dev.atlassian.net/browse/USH-2150](url)
New feature is built to match design pattern of selected_many and selected_all query feature.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case-Search
[https://confluence.dimagi.com/display/saas/Case+Search+Query+Language](url)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Code changes are covered by tests.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Checking expected elasticsearch query is constructed:
[corehq/apps/case_search/tests/test_filter_dsl.py](url)
`def test_starts_with(self):` 

Checking expected elastisearch query returns expected matching case search items:
[corehq/apps/es/tests/test_case_search_es.py](url)
`def test_starts_with_query(self):`
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
