### PR TITLE
Use "force" instead of "skip-checks"

### DIFF
--- a/corehq/apps/hqadmin/management/commands/update_site_setup.py
+++ b/corehq/apps/hqadmin/management/commands/update_site_setup.py
@@ -11,14 +11,14 @@ class Command(BaseCommand):
                  "and domain."
         )
         parser.add_argument(
-            '--skip-checks',
+            '--force',
             action='store_true',
             default=False,
             help="If you are sure of what you are doing and want to skip checks to ensure safe update."
         )
 
     def handle(self, site_address, *args, **options):
-        if not options['skip_checks']:
+        if not options['force']:
             if settings.SITE_ID != 1:
                 raise CommandError("SITE ID under settings expected to have value 1 since only one object is "
                                    "expected")


### PR DESCRIPTION
## Technical Summary

Fixes "argparse.ArgumentError: argument --skip-checks: conflicting option string: --skip-checks".

The error is caused by the fact that "--skip-checks" is already an argument of the `parser` instance passed to the `add_arguments()` method.

This command is needed by the admin who posted [this question to the Forum](https://forum.dimagi.com/t/unable-to-deploy-code-updates-due-to-deploy-fail/9260).

## Safety Assurance

### Safety story

Tested in a local monolith environment.

### Automated test coverage

Not covered by tests

### QA Plan

No QA planned


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
