### PR TITLE
`case.search.title` migration script for apps 2.53 and later

### DIFF
--- a/corehq/apps/app_manager/management/commands/migrate_apps.py
+++ b/corehq/apps/app_manager/management/commands/migrate_apps.py
@@ -28,8 +28,8 @@ class Command(BaseCommand):
                     if errors:
                         # do something here with unvalidated app
                         continue
-                except XMLSyntaxError as e:
-                    print(e)
+                except XMLSyntaxError:
+                    pass
                 # current_app.save()
 
     def needs_to_be_migrated(self, version):
@@ -41,18 +41,17 @@ class Command(BaseCommand):
             return
         try:
             translations = app.translations
-        except ResourceNotFound:
-            return
-
-        for module in app.modules:
-            search_config = getattr(module, 'search_config')
-            default_label_dict = getattr(search_config, 'title_label')
-            label_dict = {lang: label.get('case.search.title')
-                for lang, label in translations.items() if label and not default_label_dict[lang]}
-            label_dict.update(default_label_dict)
-            print(f"Old: {default_label_dict}")
-            print(f"New: {label_dict}")
-            # setattr(search_config, 'title_label', label_dict)
+            for module in app.modules:
+                search_config = getattr(module, 'search_config')
+                default_label_dict = getattr(search_config, 'title_label')
+                label_dict = {lang: label.get('case.search.title')
+                    for lang, label in translations.items() if label and not default_label_dict[lang]}
+                label_dict.update(default_label_dict)
+                print(f"Old: {default_label_dict}")
+                print(f"New: {label_dict}")
+                # setattr(search_config, 'title_label', label_dict)
+        except (ResourceNotFound, AttributeError):
+            pass
         return
 
     def progress_bar(self, domain, current, total):

--- a/corehq/apps/app_manager/management/commands/migrate_apps.py
+++ b/corehq/apps/app_manager/management/commands/migrate_apps.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
             app_ids = get_all_app_ids(domain)
             total_apps = len(app_ids)
             for i, app_id in enumerate(app_ids):
-                self.progress_bar(domain, i, total_apps)
+                # self.progress_bar(domain, i, total_apps)
                 current_app = Application.get(app_id)
                 try:
                     self.migrate(current_app)
@@ -47,15 +47,15 @@ class Command(BaseCommand):
 
     def _migrate_module(self, translations, module):
         search_config = getattr(module, 'search_config')
-        default_label_dict = getattr(search_config, 'title_label')
-        label_dict = {lang: label.get('case.search.title')
-            for lang, label in translations.items() if label and not default_label_dict[lang]}
-        label_dict.update(default_label_dict)
-        setattr(search_config, 'title_label', label_dict)
+        print(search_config.title_label)
+        # label_dict = {lang: label.get('case.search.title')
+        #     for lang, label in translations.items() if label and not default_label_dict[lang]}
+        # label_dict.update(default_label_dict)
+        # setattr(search_config, 'title_label', label_dict)
 
-    def progress_bar(self, domain, current, total):
-        print("   Migrating apps in %s %d/%d [%-20s] %d%%" %
-            (domain, current + 1, total,
-            '=' * int((20 * (current / total))),
-            (current / total) * 100), end="\r")
-        print()  # prevents the progress bar from deleting from the console, needed for debugging
+    # def progress_bar(self, domain, current, total):
+    #     print("   Migrating apps in %s %d/%d [%-20s] %d%%" %
+    #         (domain, current + 1, total,
+    #         '=' * int((20 * (current / total))),
+    #         (current / total) * 100), end="\r")
+    #     print()  # prevents the progress bar from deleting from the console, needed for debugging

--- a/corehq/apps/app_manager/management/commands/migrate_apps.py
+++ b/corehq/apps/app_manager/management/commands/migrate_apps.py
@@ -1,52 +1,59 @@
-from corehq.apps.builds.models import BuildSpec
 from corehq.toggles import SYNC_SEARCH_CASE_CLAIM
-
 from django.core.management.base import BaseCommand
 from corehq.apps.app_manager.models import Application
-
 from corehq.apps.app_manager.management.commands.helpers import get_all_app_ids
+from couchdbkit.exceptions import ResourceNotFound
 
 
 class Command(BaseCommand):
     """
-    Migrates any app to latest version
+    Migrates case.search.title translation value
+    to case.search_config.title model attribute
+    for all 2.53 apps and later
     """
 
-    def add_arguments(self, parser):
-        parser.add_argument('version')
-        # parser.add_argument('')
-
-    def handle(self, version, **options):
-        new_build_spec = BuildSpec.from_string(f"{version}/latest")
+    def handle(self, **options):
         domains = sorted(SYNC_SEARCH_CASE_CLAIM.get_enabled_domains())
         for domain in domains:
-            print(f"Current domain: {domain}")
             app_ids = get_all_app_ids(domain)  # , include_builds=True)
-            print(f"Apps found: {len(app_ids)}")
+            total_apps = len(app_ids)
+            for i, app_id in enumerate(app_ids):
+                self.progress_bar(domain, i, total_apps)
 
-            for app_id in app_ids:
-                apps_to_migrate = []
-                app = Application.get(app_id)
-                if app['build_spec'].version != version:
-                    apps_to_migrate.append(app)
-
-            # if there are no apps in the domain needing to be migrated we skip the domain
-            if len(apps_to_migrate) == 0:
-                print(f"No apps to migrate in domain: {domain}")
-                continue
-
-            print(f"Apps to migrate: {len(apps_to_migrate)}")
-
-            for i, current_app in enumerate(apps_to_migrate):
-                current_app.build_spec = new_build_spec
+                current_app = Application.get(app_id)
+                self.migrate(current_app)
                 errors = current_app.validate_app()
                 if errors:
                     # do something here with unvalidated app
                     continue
-                current_app.save()
+                # current_app.save()
 
-                # progress bar
-                print("   Migrating apps %d/%d [%-20s] %d%%" %
-                    (i + 1, len(apps_to_migrate), '=' * int((20 * (i / len(apps_to_migrate)))),
-                    (i / len(apps_to_migrate)) * 100), end="\r")
-            print()  # prevents the progress bar from deleting from the console, for debugging
+    def needs_to_be_migrated(self, version):
+        major, minor, patch = [int(x) for x in version.split('.')]
+        return major >= 2 and minor >= 53
+
+    def migrate(self, app):
+        if not self.needs_to_be_migrated(app['build_spec'].version):
+            return
+        try:
+            translations = app.translations
+            print(translations)
+        except ResourceNotFound:
+            return
+        for module in app.modules:
+            search_config = getattr(module, 'search_config')
+            default_label_dict = getattr(search_config, 'title_label')
+            label_dict = {lang: label.get('case.search.title')
+                for lang, label in translations.items() if label and not default_label_dict[lang]}
+            label_dict.update(default_label_dict)
+            print(f"Old: {default_label_dict}")
+            print(f"New: {label_dict}")
+            # setattr(search_config, 'title_label', label_dict)
+        return
+
+    def progress_bar(self, domain, current, total):
+        print("   Migrating apps in %s %d/%d [%-20s] %d%%" %
+            (domain, current + 1, total,
+            '=' * int((20 * (current / total))),
+            (current / total) * 100), end="\r")
+        print()  # prevents the progress bar from deleting from the console, needed for debugging

--- a/corehq/apps/app_manager/management/commands/migrate_apps.py
+++ b/corehq/apps/app_manager/management/commands/migrate_apps.py
@@ -1,0 +1,52 @@
+from corehq.apps.builds.models import BuildSpec
+from corehq.toggles import SYNC_SEARCH_CASE_CLAIM
+
+from django.core.management.base import BaseCommand
+from corehq.apps.app_manager.models import Application
+
+from corehq.apps.app_manager.management.commands.helpers import get_all_app_ids
+
+
+class Command(BaseCommand):
+    """
+    Migrates any app to latest version
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('version')
+        # parser.add_argument('')
+
+    def handle(self, version, **options):
+        new_build_spec = BuildSpec.from_string(f"{version}/latest")
+        domains = sorted(SYNC_SEARCH_CASE_CLAIM.get_enabled_domains())
+        for domain in domains:
+            print(f"Current domain: {domain}")
+            app_ids = get_all_app_ids(domain)  # , include_builds=True)
+            print(f"Apps found: {len(app_ids)}")
+
+            for app_id in app_ids:
+                apps_to_migrate = []
+                app = Application.get(app_id)
+                if app['build_spec'].version != version:
+                    apps_to_migrate.append(app)
+
+            # if there are no apps in the domain needing to be migrated we skip the domain
+            if len(apps_to_migrate) == 0:
+                print(f"No apps to migrate in domain: {domain}")
+                continue
+
+            print(f"Apps to migrate: {len(apps_to_migrate)}")
+
+            for i, current_app in enumerate(apps_to_migrate):
+                current_app.build_spec = new_build_spec
+                errors = current_app.validate_app()
+                if errors:
+                    # do something here with unvalidated app
+                    continue
+                current_app.save()
+
+                # progress bar
+                print("   Migrating apps %d/%d [%-20s] %d%%" %
+                    (i + 1, len(apps_to_migrate), '=' * int((20 * (i / len(apps_to_migrate)))),
+                    (i / len(apps_to_migrate)) * 100), end="\r")
+            print()  # prevents the progress bar from deleting from the console, for debugging


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This is a script meant to migrate app data for all apps with versions 2.53 or later. 

An app is migrated by getting the value of `case.search.title` from app translations and then setting that value to the new `title_label` attribute in the `CaseSearch` model. This code mirrors this block from  `apps.app_manager.models.Application.wrap` :
https://github.com/dimagi/commcare-hq/blob/ae759e1fa7da83ca0b26b080696edcce0da50346/corehq/apps/app_manager/models.py#L4823-L4831

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira](https://dimagi-dev.atlassian.net/browse/USH-2322?atlOrigin=eyJpIjoiNGM3N2UzYzNjNmVjNGEzZThjODk4N2ZmYmRkYTVhMDIiLCJwIjoiaiJ9)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CASE_CLAIM

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
