### PR TITLE
Fix misc lookup table bugs

### DIFF
--- a/corehq/apps/fixtures/tests/test_upload.py
+++ b/corehq/apps/fixtures/tests/test_upload.py
@@ -552,6 +552,21 @@ class TestFixtureUpload(TestCase):
         self.upload(self.get_workbook_from_data(headers, data))
         self.assertEqual(self.get_rows(part), ['branch'])
 
+    def test_upload_sheet_with_missing_UID_column(self):
+        self.upload([(None, 'N', 'apple')])
+
+        headers = (
+            self.headers[0],
+            ('things', ('Delete(Y/N)', 'field: name')),
+        )
+        data = [
+            ('types', [('N', 'things', 'yes', 'name', 'yes')]),
+            ('things', [('N', 'apple')]),
+            ('things', [('N', 'orange')]),
+        ]
+        self.upload(self.get_workbook_from_data(headers, data))
+        self.assertEqual(self.get_rows(), ['apple', 'orange'])
+
     def test_delete_row(self):
         self.upload([(None, 'N', 'apple'), (None, 'N', 'orange')])
         ids = {row_name(r): r._id for r in self.get_rows(None)}

--- a/corehq/apps/fixtures/upload/workbook.py
+++ b/corehq/apps/fixtures/upload/workbook.py
@@ -132,10 +132,12 @@ class _FixtureWorkbook(object):
         type_fields = data_type.fields
         sort_key = -1
         for i, di in enumerate(self.get_data_sheet(data_type.tag)):
+            uid = di.get('UID')
             if _is_deleted(di):
-                yield Deleted(di['UID'])
+                if uid:
+                    yield Deleted(uid)
                 continue
-            sort_key = max(sort_keys.get(di['UID'], i), sort_key + 1)
+            sort_key = max(sort_keys.get(uid, i), sort_key + 1)
             item = FixtureDataItem(
                 _id=uuid4().hex,
                 domain=data_type.domain,
@@ -147,7 +149,8 @@ class _FixtureWorkbook(object):
                 item_attributes=di.get('property', {}),
                 sort_key=sort_key,
             )
-            self.item_keys[item] = di['UID']
+            if uid:
+                self.item_keys[item] = uid
             self.ownership[item] = ownership = {}
             for owner_type in ["user", "group", "location"]:
                 owner_names = di.get(owner_type)

--- a/corehq/sql_db/jsonops.py
+++ b/corehq/sql_db/jsonops.py
@@ -45,6 +45,9 @@ class JsonDelete(Func):
     arity = 1
 
     def __init__(self, expression, *items):
+        if isinstance(expression, JsonDelete):
+            items = (expression.extra["items"],) + items
+            expression, = expression.source_expressions
         items = ",".join(items)
         if "'" in items:
             raise ValueError(f"invalid items: {items!r}")

--- a/corehq/sql_db/tests/test_jsonops.py
+++ b/corehq/sql_db/tests/test_jsonops.py
@@ -67,6 +67,11 @@ def test_nested_operations():
     eq(as_sql(expr), "jsonb_set(data::jsonb - '{things}'::text[], ('{items}'), data->'things', true)")
 
 
+def test_nested_delete():
+    expr = ops.JsonDelete(ops.JsonDelete(data_ref, "one"), "two", "three")
+    eq(as_sql(expr), "data::jsonb - '{one,two,three}'::text[]")
+
+
 class TestJsonOpsEvaluation(TestCase):
 
     def test_JsonDelete(self):


### PR DESCRIPTION
3db1f8bad4339c109434470f05d517e74642a6cd - https://sentry.io/organizations/dimagi/issues/3506415653/
```
KeyError: 'UID'
  ...
  File "corehq/apps/fixtures/upload/workbook.py", line 138, in iter_rows
    sort_key = max(sort_keys.get(di['UID'], i), sort_key + 1)
```

3d296b3cc0990c3cd5a03533038e767cbd8563ee - https://sentry.io/organizations/dimagi/issues/3496030118/
```
ProgrammingError: cannot cast type text[] to jsonb
LINE 1: ...lookuptablerow"."fields"::jsonb - '{type}'::text[]::jsonb - ...
                                                             ^
  ...
  File "dimagi/utils/couch/bulk.py", line 120, in _commit
    self.sql_save_actions[cls]()
  File "corehq/apps/fixtures/views.py", line 254, in update_sql_objects
    LookupTableRow.objects.filter(
```

:blowfish: Review by commit.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
