### PR TITLE
SQL Lookup Table cache invalidation and bypasses

### DIFF
--- a/corehq/apps/fixtures/couchmodels.py
+++ b/corehq/apps/fixtures/couchmodels.py
@@ -168,12 +168,13 @@ class FixtureDataType(QuickCachedDocumentMixin, SyncCouchToSQLMixin, Document):
 
     def recursive_delete(self, transaction):
         item_ids = []
-        for item in FixtureDataItem.by_data_type(self.domain, self.get_id):
+        for item in FixtureDataItem.by_data_type(self.domain, self.get_id, bypass_cache=True):
             transaction.delete(item)
             item_ids.append(item.get_id)
         for item_id_chunk in chunked(item_ids, 1000):
             transaction.delete_all(FixtureOwnership.for_all_item_ids(item_id_chunk, self.domain))
         transaction.delete(self)
+        # NOTE cache must be invalidated after transaction commit
 
     @classmethod
     def delete_fixtures_by_domain(cls, domain, transaction):

--- a/corehq/apps/fixtures/couchmodels.py
+++ b/corehq/apps/fixtures/couchmodels.py
@@ -144,9 +144,9 @@ class FixtureDataType(QuickCachedDocumentMixin, SyncCouchToSQLMixin, Document):
         return count_fixture_data_types(domain)
 
     @classmethod
-    def by_domain(cls, domain):
+    def by_domain(cls, domain, **kw):
         from corehq.apps.fixtures.dbaccessors import get_fixture_data_types
-        return get_fixture_data_types(domain)
+        return get_fixture_data_types(domain, **kw)
 
     @classmethod
     def by_domain_tag(cls, domain, tag):
@@ -569,9 +569,9 @@ class FixtureDataItem(SyncCouchToSQLMixin, Document):
                         reduce=False, include_docs=True)
 
     @classmethod
-    def get_item_list(cls, domain, tag):
+    def get_item_list(cls, domain, tag, **kw):
         data_type = FixtureDataType.by_domain_tag(domain, tag).one()
-        return cls.by_data_type(domain, data_type)
+        return cls.by_data_type(domain, data_type, **kw)
 
     @classmethod
     def get_indexed_items(cls, domain, tag, index_field):

--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -17,8 +17,8 @@ def count_fixture_data_types(domain):
     return num_fixtures['value'] if num_fixtures is not None else 0
 
 
-@quickcache(['domain'], timeout=30 * 60)
-def get_fixture_data_types(domain):
+@quickcache(['domain'], timeout=30 * 60, skip_arg='bypass_cache')
+def get_fixture_data_types(domain, bypass_cache=False):
     from corehq.apps.fixtures.models import FixtureDataType
     return list(FixtureDataType.view(
         'by_domain_doc_type_date/view',

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -62,7 +62,7 @@ def _run_upload(domain, workbook, replace=False, task=None, skip_orm=False):
                 owner_key,
             )
 
-        old_rows = retry(FixtureDataItem.get_item_list)(domain, table.tag)
+        old_rows = retry(FixtureDataItem.get_item_list)(domain, table.tag, bypass_cache=True)
         sort_keys = {r._id: r.sort_key for r in old_rows}
         if not skip_orm:
             sql_row_ids = {id.hex for id in LookupTableRow.objects
@@ -96,7 +96,7 @@ def _run_upload(domain, workbook, replace=False, task=None, skip_orm=False):
     else:
         owner_ids = load_owner_ids(workbook.get_owners(), domain)
     result.number_of_fixtures, update_progress = setup_progress(task, workbook)
-    old_tables = FixtureDataType.by_domain(domain)
+    old_tables = FixtureDataType.by_domain(domain, bypass_cache=True)
     sql_table_ids = {id.hex for id in LookupTable.objects
         .filter(id__in=[t._id for t in old_tables])
         .values_list("id", flat=True)}

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -37,6 +37,7 @@ WHITELIST = [
     ("tastypie", "django.conf.urls.url() is deprecated"),
     ("tastypie", "request.is_ajax() is deprecated"),
     ("nose.suite", "'collections.abc'"),
+    ("nose.plugins.collect", "'collections.abc'"),
 
     # warnings that can be resolved with HQ code changes
     ("", "json_response is deprecated.  Use django.http.JsonResponse instead."),


### PR DESCRIPTION
There have been a small but steady stream of `BulkSaveError`s in Sentry. My best guess at this point is that they are mainly due to stale caches. This is not surprising since we have not been clearing caches consistently for write operations. Hopefully this PR covers all of them.

The second to last commit is an unrelated deprecation warning whitelist.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Lookup Table write operations are relatively low volume. Most changes in this PR are covered by automated tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
