### PR TITLE
fix resource warnings in tests from iter_ids

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -191,13 +191,14 @@ def iter_ids(model_class, field, domain, chunk_size=1000):
         load_source='delete_domain',
         query_size=chunk_size,
     )
-    yield from with_progress_bar(
-        (r[0] for r in rows),
-        estimate_partitioned_row_count(model_class, where),
-        prefix="",
-        oneline="concise",
-        stream=silence_during_tests(),
-    )
+    with silence_during_tests() as stream:
+        yield from with_progress_bar(
+            (r[0] for r in rows),
+            estimate_partitioned_row_count(model_class, where),
+            prefix="",
+            oneline="concise",
+            stream=stream,
+        )
 
 
 def _delete_data_files(domain_name):

--- a/corehq/apps/domain/utils.py
+++ b/corehq/apps/domain/utils.py
@@ -7,6 +7,7 @@ import time
 from collections import Counter
 
 import simplejson
+from decorator import contextmanager
 from django.conf import settings
 
 from memoized import memoized
@@ -124,11 +125,13 @@ def guess_domain_language_for_sms(domain_name):
     return counter.most_common(1)[0][0]
 
 
+@contextmanager
 def silence_during_tests():
     if settings.UNIT_TESTING:
-        return open(os.devnull, 'w')
+        with open(os.devnull, 'w') as out:
+            yield out
     else:
-        return sys.stdout
+        yield sys.stdout
 
 
 @unit_testing_only


### PR DESCRIPTION
## Technical Summary
A small change to reduce the number of resource warnings in test output.

## Safety Assurance

### Safety story
Well covered by tests

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
