### PR TITLE
Default Mobile Worker Roles: Use better default permissions

### DIFF
--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -20,7 +20,11 @@ class AuthenticationTestBase(TestCase):
         cls.project = Domain.get_or_create_with_name(cls.domain, is_active=True)
         cls.username = 'alice@example.com'
         cls.password = '***'
-        cls.user = WebUser.create(cls.domain, cls.username, cls.password, None, None)
+        cls.api_user_role = UserRole.create(
+            cls.domain, 'api-user', permissions=HqPermissions(access_api=True)
+        )
+        cls.user = WebUser.create(cls.domain, cls.username, cls.password, None, None,
+                                  role_id=cls.api_user_role.get_id)
         cls.api_key, _ = HQApiKey.objects.get_or_create(user=WebUser.get_django_user(cls.user))
         cls.domain_api_key, _ = HQApiKey.objects.get_or_create(user=WebUser.get_django_user(cls.user),
                                                                name='domain-scoped',
@@ -160,10 +164,10 @@ class RequirePermissionAuthenticationTest(AuthenticationTestBase):
     def setUpClass(cls):
         super().setUpClass()
         cls.role_with_permission = UserRole.create(
-            cls.domain, 'edit-data', permissions=HqPermissions(edit_data=True)
+            cls.domain, 'edit-data', permissions=HqPermissions(edit_data=True, access_api=True)
         )
         cls.role_without_permission = UserRole.create(
-            cls.domain, 'no-edit-data', permissions=HqPermissions(edit_data=False)
+            cls.domain, 'no-edit-data', permissions=HqPermissions(edit_data=False, access_api=True)
         )
         cls.role_with_permission_but_no_api_access = UserRole.create(
             cls.domain, 'no-api-access', permissions=HqPermissions(edit_data=True, access_api=False)

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -13,7 +13,7 @@ from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ValidationError
-from django.core.validators import MinValueValidator, MaxValueValidator
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import transaction
 from django.forms.fields import (
     BooleanField,
@@ -96,30 +96,38 @@ from corehq.apps.callcenter.views import (
 from corehq.apps.domain.auth import get_active_users_by_email
 from corehq.apps.domain.extension_points import validate_password_rules
 from corehq.apps.domain.models import (
-    RESTRICTED_UCR_EXPRESSIONS,
     AREA_CHOICES,
     BUSINESS_UNITS,
     DATA_DICT,
     LOGO_ATTACHMENT,
+    RESTRICTED_UCR_EXPRESSIONS,
     SUB_AREA_CHOICES,
-    SMSAccountConfirmationSettings,
+    AllowedUCRExpressionSettings,
     OperatorCallLimitSettings,
+    SMSAccountConfirmationSettings,
     TransferDomainRequest,
     all_restricted_ucr_expressions,
-    AllowedUCRExpressionSettings
 )
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.crispy import HQFormHelper
 from corehq.apps.hqwebapp.fields import MultiCharField
 from corehq.apps.hqwebapp.tasks import send_html_email_async
-from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2Ajax, GeoCoderInput
+from corehq.apps.hqwebapp.widgets import (
+    BootstrapCheckboxInput,
+    GeoCoderInput,
+    Select2Ajax,
+)
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.users.models import CouchUser, WebUser
-from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR, \
-    SECURE_SESSION_TIMEOUT, RESTRICT_MOBILE_ACCESS, TWO_STAGE_USER_PROVISIONING_BY_SMS
+from corehq.toggles import (
+    HIPAA_COMPLIANCE_CHECKBOX,
+    MOBILE_UCR,
+    RESTRICT_MOBILE_ACCESS,
+    SECURE_SESSION_TIMEOUT,
+    TWO_STAGE_USER_PROVISIONING_BY_SMS,
+)
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
-
 
 mark_safe_lazy = lazy(mark_safe, str)  # TODO: Use library method
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -122,7 +122,6 @@ from corehq.apps.users.models import CouchUser, WebUser
 from corehq.toggles import (
     HIPAA_COMPLIANCE_CHECKBOX,
     MOBILE_UCR,
-    RESTRICT_MOBILE_ACCESS,
     SECURE_SESSION_TIMEOUT,
     TWO_STAGE_USER_PROVISIONING_BY_SMS,
 )
@@ -757,8 +756,6 @@ class PrivacySecurityForm(forms.Form):
         super(PrivacySecurityForm, self).__init__(*args, **kwargs)
 
         excluded_fields = []
-        if not RESTRICT_MOBILE_ACCESS.enabled(domain):
-            excluded_fields.append('restrict_mobile_access')
         if not domain_has_privilege(domain, privileges.ADVANCED_DOMAIN_SECURITY):
             excluded_fields.append('ga_opt_out')
             excluded_fields.append('strong_mobile_passwords')
@@ -808,8 +805,7 @@ class PrivacySecurityForm(forms.Form):
         domain_obj.secure_submissions = secure_submissions
         domain_obj.hipaa_compliant = self.cleaned_data.get('hipaa_compliant', False)
         domain_obj.ga_opt_out = self.cleaned_data.get('ga_opt_out', False)
-        if RESTRICT_MOBILE_ACCESS.enabled(domain_obj.name):
-            domain_obj.restrict_mobile_access = self.cleaned_data.get('restrict_mobile_access', False)
+        domain_obj.restrict_mobile_access = self.cleaned_data.get('restrict_mobile_access', False)
 
         domain_obj.disable_mobile_login_lockout = self.cleaned_data.get('disable_mobile_login_lockout', False)
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -730,19 +730,6 @@ class PrivacySecurityForm(forms.Form):
         label=gettext_lazy("Disable Google Analytics"),
         required=False,
     )
-    # Enabled by a specific feature flag:
-    # https://confluence.dimagi.com/display/saas/COVID%3A+Require+explicit+permissions+to+access+mobile+app+endpoints
-    restrict_mobile_access = BooleanField(
-        label=gettext_lazy("Restrict Mobile Endpoint Access"),
-        required=False,
-        help_text=mark_safe_lazy(gettext_lazy(
-            "When this setting is turned on, the Roles and Permissions page will display a new "
-            "\"Mobile App Access\" option under \"Other Settings.\" With this permission disabled, "
-            "the user account will be unable to login or sync from a mobile application, and will only "
-            "be able to use apps via the Web Apps interface."
-            "<a href='https://help.commcarehq.org/display/commcarepublic/Project+Space+Settings'> "
-            "Read more about restricting mobile endpoint access here.</a>")),
-    )
     disable_mobile_login_lockout = BooleanField(
         label=gettext_lazy("Disable Mobile Worker Lockout"),
         required=False,
@@ -805,8 +792,6 @@ class PrivacySecurityForm(forms.Form):
         domain_obj.secure_submissions = secure_submissions
         domain_obj.hipaa_compliant = self.cleaned_data.get('hipaa_compliant', False)
         domain_obj.ga_opt_out = self.cleaned_data.get('ga_opt_out', False)
-        domain_obj.restrict_mobile_access = self.cleaned_data.get('restrict_mobile_access', False)
-
         domain_obj.disable_mobile_login_lockout = self.cleaned_data.get('disable_mobile_login_lockout', False)
 
         domain_obj.save()

--- a/corehq/apps/domain/migrations/0009_restrict_mob_access_from_FF.py
+++ b/corehq/apps/domain/migrations/0009_restrict_mob_access_from_FF.py
@@ -1,19 +1,5 @@
 from django.db import migrations
 
-from corehq.apps.domain.models import Domain
-from corehq.util.django_migrations import skip_on_fresh_install
-
-from corehq.toggles import RESTRICT_MOBILE_ACCESS
-
-
-@skip_on_fresh_install
-def _enable_restrict_mobile_access(apps, schema_editor):
-    for domain in RESTRICT_MOBILE_ACCESS.get_enabled_domains():
-        domain_obj = Domain.get_by_name(domain)
-        if domain_obj and not domain_obj.restrict_mobile_access:
-            domain_obj.restrict_mobile_access = True
-            domain_obj.save()
-
 
 class Migration(migrations.Migration):
 
@@ -21,6 +7,4 @@ class Migration(migrations.Migration):
         ('domain', '0008_use_livequery'),
     ]
 
-    operations = [
-        migrations.RunPython(_enable_restrict_mobile_access, migrations.RunPython.noop)
-    ]
+    operations = []

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -445,8 +445,6 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     ga_opt_out = BooleanProperty(default=False)
 
-    restrict_mobile_access = BooleanProperty(default=False)
-
     @classmethod
     def wrap(cls, data):
         # for domains that still use original_doc

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -24,14 +24,9 @@ class PrivacySecurityFormTests(SimpleTestCase):
             'restrict_superusers',
             'secure_submissions',
             'allow_domain_requests',
+            'restrict_mobile_access',
             'disable_mobile_login_lockout'
         ])
-
-    @patch.object(forms.RESTRICT_MOBILE_ACCESS, 'enabled', return_value=True)
-    def test_restrict_mobile_access_toggle(self, mock_toggle):
-        form = self.create_form()
-        visible_field_names = self.get_visible_fields(form)
-        self.assertIn('restrict_mobile_access', visible_field_names)
 
     @patch.object(forms.HIPAA_COMPLIANCE_CHECKBOX, 'enabled', return_value=True)
     def test_hippa_compliance_toggle(self, mock_toggle):

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -24,7 +24,6 @@ class PrivacySecurityFormTests(SimpleTestCase):
             'restrict_superusers',
             'secure_submissions',
             'allow_domain_requests',
-            'restrict_mobile_access',
             'disable_mobile_login_lockout'
         ])
 

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -309,6 +309,7 @@ class EditPrivacySecurityView(BaseAdminProjectSettingsView):
         if self.privacy_form.is_valid():
             self.privacy_form.save(self.domain_object)
             messages.success(request, _("Your project settings have been saved!"))
+            return redirect(self.urlname, domain=self.domain)
         return self.get(request, *args, **kwargs)
 
 

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -289,7 +289,6 @@ class EditPrivacySecurityView(BaseAdminProjectSettingsView):
             "two_factor_auth": self.domain_object.two_factor_auth,
             "strong_mobile_passwords": self.domain_object.strong_mobile_passwords,
             "ga_opt_out": self.domain_object.ga_opt_out,
-            "restrict_mobile_access": self.domain_object.restrict_mobile_access,
             "disable_mobile_login_lockout": self.domain_object.disable_mobile_login_lockout,
         }
         if self.request.method == 'POST':

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -366,7 +366,7 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
 
         expected_object_counts = Counter({
             UserRole: 2,
-            RolePermission: 11,
+            RolePermission: 5,
             RoleAssignableBy: 1
         })
 

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -81,7 +81,7 @@ class BaseDumpLoadTest(TestCase):
         self.delete_sql_data()
         super(BaseDumpLoadTest, self).tearDown()
 
-    def _dump_and_load(self, expected_dump_counts, load_filter=None, expected_load_counts=None, dumper_fn=None):
+    def _dump_and_load(self, expected_dump_counts, load_filter=None, expected_load_counts=None):
         expected_load_counts = expected_load_counts or expected_dump_counts
         expected_dump_counts.update(self.default_objects_counts)
 
@@ -89,11 +89,10 @@ class BaseDumpLoadTest(TestCase):
         self._check_signals_handle_raw(models)
 
         # Dump
+        dumper = SqlDataDumper(self.domain_name, [], [])
+        dumper.stdout = None  # silence output
         output_stream = StringIO()
-        if dumper_fn:
-            dumper_fn(output_stream)
-        else:
-            SqlDataDumper(self.domain_name, [], []).dump(output_stream)
+        dumper.dump(output_stream)
         output_stream.seek(0)
 
         self.delete_sql_data()
@@ -767,7 +766,9 @@ class TestSqlLoadWithError(BaseDumpLoadTest):
 
     def _load_with_errors(self, chunk_size):
         output_stream = StringIO()
-        SqlDataDumper(self.domain_name, [], []).dump(output_stream)
+        dumper = SqlDataDumper(self.domain_name, [], [])
+        dumper.stdout = None
+        dumper.dump(output_stream)
         output_stream.seek(0)
         self.delete_sql_data()
         # resave the product to force an error

--- a/corehq/apps/enterprise/tests/test_permissions.py
+++ b/corehq/apps/enterprise/tests/test_permissions.py
@@ -29,6 +29,7 @@ class EnterprisePermissionsTest(TestCase):
 
         # Set up users
         cls.master_role = UserRole.create("state", "role1", permissions=HqPermissions(
+            access_api=True,
             view_web_users=True,
             edit_web_users=False,
             view_groups=True,

--- a/corehq/apps/ota/decorators.py
+++ b/corehq/apps/ota/decorators.py
@@ -23,21 +23,18 @@ ORIGIN_TOKEN_SLUG = 'OriginToken'
 def require_mobile_access(fn):
     @wraps(fn)
     def _inner(request, domain, *args, **kwargs):
-        if Domain.get_by_name(domain).restrict_mobile_access:
-            origin_token = request.META.get(ORIGIN_TOKEN_HEADER, None)
-            if origin_token:
-                if _test_token_valid(origin_token):
-                    return fn(request, domain, *args, **kwargs)
-                else:
-                    auth_logger.info(
-                        "Request rejected domain=%s reason=%s request=%s",
-                        domain, "flag:mobile_access_restricted", request.path
-                    )
-                    return HttpResponseForbidden()
+        origin_token = request.META.get(ORIGIN_TOKEN_HEADER, None)
+        if origin_token:
+            if _test_token_valid(origin_token):
+                return fn(request, domain, *args, **kwargs)
+            else:
+                auth_logger.info(
+                    "Request rejected domain=%s reason=%s request=%s",
+                    domain, "flag:mobile_access_restricted", request.path
+                )
+                return HttpResponseForbidden()
 
-            return require_permission(HqPermissions.access_mobile_endpoints)(fn)(request, domain, *args, **kwargs)
-
-        return fn(request, domain, *args, **kwargs)
+        return require_permission(HqPermissions.access_mobile_endpoints)(fn)(request, domain, *args, **kwargs)
 
     return _inner
 

--- a/corehq/apps/ota/tests/test_auth.py
+++ b/corehq/apps/ota/tests/test_auth.py
@@ -22,9 +22,6 @@ class TestMobileEndpointAccess(TestCase):
         super().setUpClass()
         cls.request_factory = RequestFactory()
         cls.domain_obj = create_domain(cls.domain)
-        cls.domain_obj.restrict_mobile_access = True
-        cls.domain_obj.save()
-
         initialize_domain_with_default_roles(cls.domain)
         app_editor_role = UserRole.objects.get(name=UserRolePresets.APP_EDITOR)
 

--- a/corehq/apps/ota/tests/test_auth.py
+++ b/corehq/apps/ota/tests/test_auth.py
@@ -1,0 +1,58 @@
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.ota.decorators import require_mobile_access
+from corehq.apps.users.models import CommCareUser, UserRole, WebUser
+from corehq.apps.users.role_utils import (
+    UserRolePresets,
+    initialize_domain_with_default_roles,
+)
+from corehq.util.test_utils import flag_enabled
+
+
+@flag_enabled('SYNC_SEARCH_CASE_CLAIM')
+class TestMobileEndpointAccess(TestCase):
+    domain = 'test-update-cases'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.request_factory = RequestFactory()
+        cls.domain_obj = create_domain(cls.domain)
+        cls.domain_obj.restrict_mobile_access = True
+        cls.domain_obj.save()
+
+        initialize_domain_with_default_roles(cls.domain)
+        app_editor_role = UserRole.objects.get(name=UserRolePresets.APP_EDITOR)
+
+        cls.web_user = WebUser.create(cls.domain, 'webuser', 'password', None, None,
+                                      role_id=app_editor_role.get_id)
+        cls.mobile_worker = CommCareUser.create(cls.domain, 'ccuser', 'password', None, None)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def _make_request(self, user):
+        @require_mobile_access
+        def my_view(request, domain):
+            return HttpResponse()
+
+        request = self.request_factory.get('/myview')
+        request.couch_user = user
+        request.user = user.get_django_user()
+        return my_view(request, self.domain)
+
+    def test_mobile_worker_with_access(self):
+        self.assertTrue(self.mobile_worker.has_permission(self.domain, 'access_mobile_endpoints'))
+        res = self._make_request(self.mobile_worker)
+        self.assertEqual(res.status_code, 200)
+
+    def test_web_user_without_access(self):
+        self.assertFalse(self.web_user.has_permission(self.domain, 'access_mobile_endpoints'))
+        with self.assertRaises(PermissionDenied):
+            self._make_request(self.web_user)

--- a/corehq/apps/ota/tests/test_digest_restore.py
+++ b/corehq/apps/ota/tests/test_digest_restore.py
@@ -14,6 +14,11 @@ from corehq.util.test_utils import flag_enabled
 from python_digest import build_authorization_request, calculate_nonce
 
 
+def mock_require_permission(_):
+    return lambda fn: fn
+
+
+@mock.patch('corehq.apps.ota.decorators.require_permission', new=mock_require_permission)
 class DigestOtaRestoreTest(TestCase):
     """
     Integration test for django_digest based ota restore is tested

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -179,13 +179,13 @@ class HqPermissions(DocumentSchema):
     view_apps = BooleanProperty(default=False)
     edit_shared_exports = BooleanProperty(default=False)
     access_all_locations = BooleanProperty(default=True)
-    access_api = BooleanProperty(default=True)
+    access_api = BooleanProperty(default=False)
     access_web_apps = BooleanProperty(default=False)
     edit_messaging = BooleanProperty(default=False)
     access_release_management = BooleanProperty(default=False)
 
     edit_reports = BooleanProperty(default=False)
-    download_reports = BooleanProperty(default=True)
+    download_reports = BooleanProperty(default=False)
     view_reports = BooleanProperty(default=False)
     view_report_list = StringListProperty(default=[])
     edit_ucrs = BooleanProperty(default=False)
@@ -195,7 +195,7 @@ class HqPermissions(DocumentSchema):
     edit_billing = BooleanProperty(default=False)
     report_an_issue = BooleanProperty(default=True)
 
-    access_mobile_endpoints = BooleanProperty(default=True)
+    access_mobile_endpoints = BooleanProperty(default=False)
 
     view_file_dropzone = BooleanProperty(default=False)
     edit_file_dropzone = BooleanProperty(default=False)

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -23,9 +23,7 @@ class UserRolePresets:
         BILLING_ADMIN: lambda: HqPermissions(edit_billing=True),
         MOBILE_WORKER: lambda: HqPermissions(access_mobile_endpoints=True,
                                              report_an_issue=True,
-                                             access_all_locations=True,
-                                             access_api=False,
-                                             download_reports=False)
+                                             access_all_locations=True)
     }
 
 

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -96,6 +96,7 @@ hqDefine('users/js/roles',[
                         };
                     }),
                 };
+                data.permissions.download_reports = true;  // the user must explicitly disable this when visible
 
                 data.tableauPermissions = {
                     all: data.permissions.view_tableau,
@@ -154,6 +155,10 @@ hqDefine('users/js/roles',[
                 self.tableauPermissions.filteredSpecific = filterSpecific(self.tableauPermissions);
                 self.manageRegistryPermission.filteredSpecific = filterSpecific(self.manageRegistryPermission);
                 self.viewRegistryContentsPermission.filteredSpecific = filterSpecific(self.viewRegistryContentsPermission);
+                self.canSeeAnyReports = ko.computed(function () {
+                    return self.reportPermissions.all() || _.any(self.reportPermissions.specific(), (p) => p.value());
+                });
+
                 self.unwrap = function () {
                     return cls.unwrap(self);
                 };
@@ -484,6 +489,11 @@ hqDefine('users/js/roles',[
                 data.permissions.view_report_list = unwrapItemList(data.reportPermissions.specific, 'path');
                 data.permissions.view_tableau = data.tableauPermissions.all;
                 data.permissions.view_tableau_list = unwrapItemList(data.tableauPermissions.specific);
+
+                // Set download_reports to true only if the user can see reports
+                data.permissions.download_reports = data.permissions.download_reports && (
+                    data.permissions.view_reports || data.permissions.view_report_list.length !== 0
+                );
 
                 data.permissions.manage_data_registry = data.manageRegistryPermission.all;
                 data.permissions.manage_data_registry_list = unwrapItemList(data.manageRegistryPermission.specific);

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -391,8 +391,6 @@
               </div>
               </div>
             {% endif %}
-            {% if request.project.restrict_mobile_access %}
-            {# BEGIN MOBILE permission #}
             <div class="form-group">
               <label class="col-sm-4 control-label">
                 {% trans "Mobile App Access" %}
@@ -409,8 +407,6 @@
                 </div>
               </div>
             </div>
-            {# END MOBILE permission #}
-            {% endif %}
             <div class="form-group">
               <label class="col-sm-4 control-label"
                      for="landing-page">

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -167,6 +167,23 @@
                 </div>
               </div>
             </div>
+
+              <div class="form-group" data-bind="visible: canSeeAnyReports">
+              <label class="col-sm-4 control-label">
+                {% trans "Download and Email Reports" %}
+              </label>
+              <div class="col-sm-8 controls">
+                <div class="form-check">
+                  <input type="checkbox"
+                    id="download-and-email-reports-checkbox"
+                    data-bind="checked: permissions.download_reports, disable: !$root.allowEdit" />
+                  <label for="download-and-email-reports-checkbox">
+                    {% trans "Allow role to download and email report data." %}
+                  </label>
+                </div>
+              </div>
+            </div>
+
             {% if request|toggle_enabled:"EMBEDDED_TABLEAU" %}
               <div class="form-group" data-bind="visible: !tableauPermissions.all()">
                 <label class="col-sm-4 control-label">
@@ -460,21 +477,6 @@
                       </label>
                     </div>
                   </div>
-                </div>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="col-sm-4 control-label">
-                {% trans "Download and Email Reports" %}
-              </label>
-              <div class="col-sm-8 controls">
-                <div class="form-check">
-                  <input type="checkbox"
-                         id="download-and-email-reports-checkbox"
-                         data-bind="checked: permissions.download_reports, disable: !$root.allowEdit" />
-                  <label for="download-and-email-reports-checkbox">
-                    {% trans "Allow role to download and email report data." %}
-                  </label>
                 </div>
               </div>
             </div>

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1907,14 +1907,6 @@ SKIP_UPDATING_USER_REPORTING_METADATA = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-RESTRICT_MOBILE_ACCESS = StaticToggle(
-    'restrict_mobile_endpoints',
-    'USH: Displays a security setting option to require explicit permissions to access mobile app endpoints',
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN],
-    help_link="https://confluence.dimagi.com/display/saas/COVID%3A+Require+explicit+permissions+to+access+mobile+app+endpoints",
-)
-
 DOMAIN_PERMISSIONS_MIRROR = StaticToggle(
     'domain_permissions_mirror',
     "USH: Enterprise Permissions: mirror a project space's permissions in other project spaces",


### PR DESCRIPTION
## Product Description
Now that projects have default mobile worker roles (https://github.com/dimagi/commcare-hq/pull/32057), we can set better defaults for new roles without affecting existing roles.  Since these mobile worker roles are user-configurable, we can also finally release the mobile endpoints access permission.  This PR does both of those things.  Specifically, the user-facing changes are:

* Newly created roles will start with no checkboxes checked except "Full organization access" and "Allow this role to report issues".  I believe these two to be reasonable defaults for all roles.  These ones were previously enabled but are now being disabled by default:
  * "Access APIs" is currently checked for all roles unless explicitly removed.  Going forward, users will have to specifically enable API access where desired.
  * There is a "Download and Email Reports" permission that is currently enabled by default.  Conceptually, it's kind of a child of the “Access All/Specific Reports” stuff.  I haven’t been able to find anything that it allows without adding reports permissions too.  I’m moving this to the “Reports” section and making it dependent on the Access All/Specific Reports settings.  If no reports are enabled, the permission will be disabled and hidden from view.  If any reports are enabled, the checkbox will appear, and it will be checked by default.  This should have the same desirable behavior as before, but without the permission being enabled for users who can’t access reports.
* Projects will now see a permission called “Mobile App Access”.  This will be disabled by default for all new roles besides “Mobile Worker Default”.  Currently, this permission is enabled by default for all users, and is hidden behind [this feature flag](https://www.commcarehq.org/hq/flags/edit/restrict_mobile_endpoints/) and a “Restrict Mobile Endpoint Access” domain setting.
  * This does not affect WebApps, but it does mean that anyone assigned to a role (other than Mobile Worker Default) created after this goes live will not be able to use CommCare Android unless the role is explicitly granted that permission.
  * The feature flag and domain setting are removed

Here's the download reports permission in context:
![image](https://user-images.githubusercontent.com/2367539/189957570-310f18f1-b2ab-4dd5-a8bc-38436be987e6.png)

Here's the mobile endpoints permission:
![image](https://user-images.githubusercontent.com/2367539/189957715-a4327ded-9a82-40a8-8d03-a4c222df8f34.png)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-2000
https://dimagi-dev.atlassian.net/browse/USH-1495

read commit-by-commit - messages should explain the changes

## Feature Flag
Releases the feature flag:
> USH: Displays a security setting option to require explicit permissions to access mobile app endpoints

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Simon's previous PR did most of the scary stuff - this PR is pretty straightforward by comparison, and primarily just opens access to things that have already been tested and pushed.  The `download_reports` change is pretty simple, I'm confident with local testing for that one.  The new permission defaults are also pretty straightforward.  I added new tests for the mobile endpoints decorator before removing the domain setting.

I'll also be pushing this to staging for further testing.

### Automated test coverage

included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
