### PR TITLE
Removing title_label logic from Application.wrap

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4826,16 +4826,6 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
                            if module.get('doc_type') != 'CareplanModule']
         self = super(Application, cls).wrap(data)
 
-        translations = data.get('translations')
-        for module in self.modules:
-            if hasattr(module, 'search_config'):
-                label_dict = {lang: label.get('case.search.title')
-                    for lang, label in translations.items() if label}
-                search_config = getattr(module, 'search_config')
-                default_label_dict = getattr(search_config, 'title_label') or {}
-                label_dict.update(default_label_dict)
-                setattr(search_config, 'title_label', label_dict)
-
         # make sure all form versions are None on working copies
         if not self.copy_of:
             for form in self.get_forms():


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira](https://dimagi-dev.atlassian.net/browse/USH-1826?atlOrigin=eyJpIjoiNWNkOGQ1NDFmMDExNGFhNDgxNTA5OWY5N2EwNGNjOTkiLCJwIjoiaiJ9)

`title_label` is an attribute added to the `Case_Search` model to enable case search title configuration on a per module basis for apps version 2.53+. The block of code being deleted was a stop gap solution meant to fetch the value from `case.search.title` app translation and assign it to `title_label` whenever `Application.wrap()` was called. After a recent migration this code is no longer necessary as all apps version 2.53+ now have a `title_label` value. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CASE_CLAIM

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
