### PR TITLE
[USH-2455] audit generic api models

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -403,7 +403,7 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('translations', 'SMSTranslations', 'domain'),
     ModelDeletion('translations', 'TransifexBlacklist', 'domain'),
     ModelDeletion('translations', 'TransifexProject', 'domain'),
-    ModelDeletion('generic_inbound', 'ConfigurableAPI', 'domain'),
+    ModelDeletion('generic_inbound', 'ConfigurableAPI', 'domain', audit_action=AuditAction.AUDIT),
     ModelDeletion('userreports', 'AsyncIndicator', 'domain'),
     ModelDeletion('userreports', 'DataSourceActionLog', 'domain'),
     ModelDeletion('userreports', 'InvalidUCRData', 'domain'),

--- a/corehq/motech/generic_inbound/models.py
+++ b/corehq/motech/generic_inbound/models.py
@@ -37,6 +37,7 @@ class ConfigurableAPI(models.Model):
             if self.url_key:
                 raise FieldError("'url_key' is auto-assigned")
             self.url_key = make_url_key()
+            self.__original_url_key = self.url_key
         elif self.url_key != self.__original_url_key:
             raise FieldError("'url_key' can not be changed")
         super().save(*args, **kwargs)

--- a/corehq/motech/generic_inbound/models.py
+++ b/corehq/motech/generic_inbound/models.py
@@ -1,6 +1,8 @@
 from django.core.exceptions import FieldError
 from django.core.validators import validate_slug
 from django.db import models
+from field_audit import audit_fields
+from field_audit.models import AuditingManager
 
 from memoized import memoized
 
@@ -10,6 +12,7 @@ from corehq.motech.generic_inbound.utils import make_url_key
 from corehq.util import reverse
 
 
+@audit_fields("domain", "url_key", "name", "transform_expression", audit_special_queryset_writes=True)
 class ConfigurableAPI(models.Model):
     domain = models.CharField(max_length=255)
     url_key = models.CharField(max_length=32, validators=[validate_slug])
@@ -18,6 +21,8 @@ class ConfigurableAPI(models.Model):
     name = models.CharField(max_length=255)
     description = models.TextField(blank=True, null=True)
     transform_expression = models.ForeignKey(UCRExpression, on_delete=models.PROTECT)
+
+    objects = AuditingManager()
 
     class Meta:
         unique_together = ('domain', 'url_key')

--- a/corehq/motech/generic_inbound/tests/test_models.py
+++ b/corehq/motech/generic_inbound/tests/test_models.py
@@ -1,5 +1,7 @@
 from django.core.exceptions import FieldError
 from django.test import TestCase
+from field_audit.models import AuditEvent
+from nose.tools import nottest
 
 from corehq.apps.userreports.const import UCR_NAMED_EXPRESSION
 from corehq.apps.userreports.models import UCRExpression
@@ -10,9 +12,119 @@ from corehq.motech.generic_inbound.models import ConfigurableAPI
 class TestGenericInboundModels(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.expression = UCRExpression.objects.create(
+        cls.api = _make_api_for_test('test', 'test api')
+
+    def test_key_created(self):
+        self.assertIsNotNone(self.api.url_key)
+        self.assertTrue(len(self.api.url_key) > 0)
+
+    def test_key_read_only(self):
+        self.assertIsNotNone(self.api.url_key)
+        self.api.url_key = 'new key'
+        with self.assertRaisesRegex(FieldError, "'url_key' can not be changed"):
+            self.api.save()
+
+    def test_transform(self):
+        body = {'name': 'cricket', 'is_team_sport': True}
+        result = self.api.parsed_expression(body, EvaluationContext(body))
+        self.assertEqual(result, {'case_type': 'sport', 'case_name': 'cricket', 'is_team_sport': True})
+
+
+class TestConfigurableApiAuditing(TestCase):
+    domain = "test-api-auditing"
+    qualified_model_name = "corehq.motech.generic_inbound.models.ConfigurableAPI"
+    audit_fields = {
+        "domain",
+        "name",
+        "url_key",
+        "transform_expression",
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.expression1 = UCRExpression.objects.create(
             name='create_sport',
-            domain='test',
+            domain=cls.domain,
+            expression_type=UCR_NAMED_EXPRESSION,
+            definition={
+                'type': 'dict',
+                'properties': {
+                    'case_type': 'sport',
+                }
+            },
+        )
+
+        cls.expression2 = UCRExpression.objects.create(
+            name='create_sport_beta',
+            domain=cls.domain,
+            expression_type=UCR_NAMED_EXPRESSION,
+            definition={
+                'type': 'dict',
+                'properties': {
+                    'case_type': 'sport',
+                }
+            },
+        )
+
+    def setUp(self):
+        self.api_config = _make_api_for_test(self.domain, "Sports", self.expression1)
+
+        self.setup_audit_events = AuditEvent.objects.all()
+        self.setup_event_ids = set(self.setup_audit_events.values_list("id", flat=True))
+
+    @nottest
+    def get_test_audit_events(self):
+        return AuditEvent.objects.exclude(id__in=self.setup_event_ids)
+
+    def test_audit_fields_for_api_create(self):
+        setup_event, = self.setup_audit_events
+        self.assertEqual(self.qualified_model_name, setup_event.object_class_path)
+        self.assertEqual(self.api_config.pk, setup_event.object_pk)
+        self.assertTrue(setup_event.is_create)
+        self.assertEqual(self.audit_fields, set(setup_event.delta))
+        self.assertEqual({"new": self.domain}, setup_event.delta["domain"])
+        self.assertEqual({"new": self.api_config.name}, setup_event.delta["name"])
+        self.assertEqual({"new": self.expression1.pk}, setup_event.delta["transform_expression"])
+
+    def test_audit_fields_for_api_update(self):
+        previous_name = self.api_config.name
+        previous_expression = self.api_config.transform_expression
+        self.api_config.name = "Sport API Test"
+        self.api_config.transform_expression = self.expression2
+        self.api_config.save()
+
+        event, = self.get_test_audit_events()
+        self.assertEqual(self.qualified_model_name, event.object_class_path)
+        self.assertEqual(self.api_config.pk, event.object_pk)
+        self.assertFalse(event.is_create)
+        self.assertFalse(event.is_delete)
+        self.assertEqual(
+            {
+                "name": {"old": previous_name, "new": "Sport API Test"},
+                "transform_expression": {"old": previous_expression.pk, "new": self.expression2.pk}
+            },
+            event.delta,
+        )
+
+    def test_audit_fields_for_api_delete(self):
+        api_pk = self.api_config.pk
+        self.api_config.delete()
+        event, = self.get_test_audit_events()
+        self.assertEqual(self.qualified_model_name, event.object_class_path)
+        self.assertEqual(api_pk, event.object_pk)
+        self.assertTrue(event.is_delete)
+        self.assertEqual(self.audit_fields, set(event.delta))
+        self.assertEqual({"old": self.api_config.domain}, event.delta["domain"])
+        self.assertEqual({"old": self.api_config.url_key}, event.delta["url_key"])
+        self.assertEqual({"old": self.api_config.name}, event.delta["name"])
+        self.assertEqual({"old": self.expression1.pk}, event.delta["transform_expression"])
+
+
+def _make_api_for_test(domain, name, expression=None):
+    if not expression:
+        expression = UCRExpression.objects.create(
+            name='create_sport',
+            domain=domain,
             expression_type=UCR_NAMED_EXPRESSION,
             definition={
                 'type': 'dict',
@@ -30,22 +142,8 @@ class TestGenericInboundModels(TestCase):
             },
         )
 
-        cls.api = ConfigurableAPI.objects.create(
-            domain='test',
-            transform_expression=cls.expression
-        )
-
-    def test_key_created(self):
-        self.assertIsNotNone(self.api.url_key)
-        self.assertTrue(len(self.api.url_key) > 0)
-
-    def test_key_read_only(self):
-        self.assertIsNotNone(self.api.url_key)
-        self.api.url_key = 'new key'
-        with self.assertRaisesRegex(FieldError, "'url_key' can not be changed"):
-            self.api.save()
-
-    def test_transform(self):
-        body = {'name': 'cricket', 'is_team_sport': True}
-        result = self.api.parsed_expression(body, EvaluationContext(body))
-        self.assertEqual(result, {'case_type': 'sport', 'case_name': 'cricket', 'is_team_sport': True})
+    return ConfigurableAPI.objects.create(
+        domain=domain,
+        name=name,
+        transform_expression=expression
+    )

--- a/corehq/motech/generic_inbound/tests/test_models.py
+++ b/corehq/motech/generic_inbound/tests/test_models.py
@@ -42,6 +42,8 @@ class TestConfigurableApiAuditing(TestCase):
 
     @classmethod
     def setUpTestData(cls):
+        AuditEvent.objects.all().delete()
+
         cls.expression1 = UCRExpression.objects.create(
             name='create_sport',
             domain=cls.domain,
@@ -77,7 +79,7 @@ class TestConfigurableApiAuditing(TestCase):
         return AuditEvent.objects.exclude(id__in=self.setup_event_ids)
 
     def test_audit_fields_for_api_create(self):
-        setup_event, = self.setup_audit_events
+        setup_event = self.setup_audit_events[0]
         self.assertEqual(self.qualified_model_name, setup_event.object_class_path)
         self.assertEqual(self.api_config.pk, setup_event.object_pk)
         self.assertTrue(setup_event.is_create)


### PR DESCRIPTION
## Technical Summary
Add field level auditing for the generic API model

## Feature Flag
GENERIC_INBOUND_API (configurable_api)

## Safety Assurance

### Safety story
Adding the auditing is tested. Also this feature is not in use yet.

### Automated test coverage
Added in PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
