### PR TITLE
Bump pip-tools from 6.5.0 to 6.8.0 in /requirements

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -38,6 +38,8 @@ botocore==1.27.28
     # via
     #   boto3
     #   s3transfer
+build==0.8.0
+    # via pip-tools
 cachetools==5.0.0
     # via google-auth
 celery==5.2.7
@@ -378,13 +380,15 @@ openpyxl==3.0.9
     #   -r base-requirements.in
     #   commcaretranslationchecker
 packaging==20.4
-    # via sphinx
+    # via
+    #   build
+    #   sphinx
 parso==0.8.3
     # via jedi
 pathspec==0.9.0
     # via black
 pep517==0.10.0
-    # via pip-tools
+    # via build
 pexpect==4.8.0
     # via ipython
 phonenumberslite==8.12.48
@@ -397,7 +401,7 @@ pillow==9.0.1
     # via
     #   -r base-requirements.in
     #   reportlab
-pip-tools==6.6.0
+pip-tools==6.8.0
     # via -r test-requirements.in
 platformdirs==2.4.1
     # via black
@@ -659,7 +663,9 @@ text-unidecode==1.3
 toml==0.10.2
     # via pep517
 tomli==2.0.1
-    # via black
+    # via
+    #   black
+    #   build
 toposort==1.7
     # via -r base-requirements.in
 traitlets==5.1.1

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -5,7 +5,7 @@ django-nose @ https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/relea
 fakecouch
 nose
 nose-exclude
-pip-tools>6.4.0
+pip-tools>=6.8.0
 testil
 requests-mock
 sqlalchemy-postgres-copy

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -28,6 +28,8 @@ botocore==1.27.28
     # via
     #   boto3
     #   s3transfer
+build==0.8.0
+    # via pip-tools
 cachetools==5.0.0
     # via google-auth
 celery==5.2.7
@@ -323,8 +325,10 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
+packaging==21.3
+    # via build
 pep517==0.10.0
-    # via pip-tools
+    # via build
 phonenumberslite==8.12.48
     # via -r base-requirements.in
 pickle5==0.0.11
@@ -333,7 +337,7 @@ pillow==9.0.1
     # via
     #   -r base-requirements.in
     #   reportlab
-pip-tools==6.6.0
+pip-tools==6.8.0
     # via -r test-requirements.in
 ply==3.11
     # via
@@ -385,7 +389,9 @@ pynacl==1.5.0
 pyopenssl==20.0.1
     # via -r sso-requirements.in
 pyparsing==3.0.7
-    # via httplib2
+    # via
+    #   httplib2
+    #   packaging
 pyphonetics==0.5.3
     # via -r base-requirements.in
 pyrsistent==0.17.3
@@ -537,6 +543,8 @@ text-unidecode==1.3
     # via -r base-requirements.in
 toml==0.10.2
     # via pep517
+tomli==2.0.1
+    # via build
 toposort==1.7
     # via -r base-requirements.in
 tropo-webapi-python==0.1.3


### PR DESCRIPTION
## Technical Summary

Currently, dependabot PRs are breaking our `.txt` requirements files by altering the dependency chain for the `markdown` package (`markdown` --> :x: `importlib-metadata` --> :x: `zipp`, for example, see [this commit](https://github.com/dimagi/commcare-hq/pull/32163/commits/e19b45799771d3f5c924b06e9108fa250dcb22fc)).  This PR is a blind attempt at hoping that depending on the latest version of `pip-tools` might resolve this issue.

Ticket: [SAAS-13961](https://dimagi-dev.atlassian.net/browse/SAAS-13961)

## Safety Assurance

### Safety story

Test requirements only. Change is not production-facing.

### Automated test coverage

Test requirements only.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
