### PR TITLE
Stabilize output of get_csv_details_for_partner

### DIFF
--- a/corehq/apps/analytics/tests/test_partner_analytics_utils.py
+++ b/corehq/apps/analytics/tests/test_partner_analytics_utils.py
@@ -353,18 +353,18 @@ class TestPartnerAnalyticsReportUtils(TestCase):
         headers, body = get_csv_details_for_partner(self.contact, self.year, self.month)
         self.assertListEqual(headers, ['Title', 'Project Space', 'Value'])
         self.assertListEqual(body, [
-            ['OData Access', 'test-001', 2],
-            ['OData Access', 'test-002', 1],
-            ['OData Access', 'test-003', 3],
+            ['Number of Mobile Workers', 'test-001', 10],
+            ['Number of Mobile Workers', 'test-002', 20],
+            ['Number of Mobile Workers', 'test-003', 30],
             ['Number of Submissions', 'test-001', 11],
             ['Number of Submissions', 'test-002', 22],
             ['Number of Submissions', 'test-003', 33],
             ['Number of Web Users', 'test-001', 11],
             ['Number of Web Users', 'test-002', 21],
             ['Number of Web Users', 'test-003', 31],
-            ['Number of Mobile Workers', 'test-001', 10],
-            ['Number of Mobile Workers', 'test-002', 20],
-            ['Number of Mobile Workers', 'test-003', 30],
+            ['OData Access', 'test-001', 2],
+            ['OData Access', 'test-002', 1],
+            ['OData Access', 'test-003', 3],
         ])
         self.assertEqual(mock_send_HTML_email.call_count, 1)
         email_args = mock_send_HTML_email.call_args_list

--- a/corehq/apps/analytics/utils/partner_analytics.py
+++ b/corehq/apps/analytics/utils/partner_analytics.py
@@ -143,7 +143,7 @@ def get_csv_details_for_partner(contact, year, month):
                     domain,
                     data_point.first().value,
                 ])
-    return headers, body
+    return headers, sorted(body)
 
 
 def send_partner_emails(year, month):


### PR DESCRIPTION
Previously the results were unsorted, and postgres does not guarantee that results will be returned in any particular order (unless ORDER BY is specified, of course).

The test was failing when run on Postgres 14.

## Safety Assurance

### Safety story

Minor change to output of report content function and associated test.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
