### PR TITLE
Allow docker postgres version to be overridden with environment variable

### DIFF
--- a/docker/hq-compose-os-default.yml
+++ b/docker/hq-compose-os-default.yml
@@ -4,4 +4,4 @@ version: '2.3'
 
 services:
   postgres:
-    image: dimagi/docker-postgresql
+    image: dimagi/docker-postgresql:${DOCKER_HQ_POSTGRES_VERSION:-latest}

--- a/docker/hq-compose-os-macos-m1-12.yml
+++ b/docker/hq-compose-os-macos-m1-12.yml
@@ -4,7 +4,7 @@ version: '2.3'
 
 services:
   postgres:
-    image: dimagi/docker-postgresql
+    image: dimagi/docker-postgresql:${DOCKER_HQ_POSTGRES_VERSION:-latest}
     platform: linux/amd64
   couch:
     platform: linux/amd64


### PR DESCRIPTION
Instructions for running postgres 14 in docker:

1. Before starting a container with postgres 14, follow the [instructions for upgrading postgresql in docker](https://gist.github.com/millerdev/547bac773483402554797e578fbd238f), except do the following two steps instead of the section with the heading **Upgrade docker image and start it**.
2. Tell docker to use version 14 rather than `latest` (which is currently 10) by adding the following line to your HQ shell initialization script (e.g., bash profile). Also run it in your terminal right now:
   ```sh
   export DOCKER_HQ_POSTGRES_VERSION=14
   ```
   NOTE: you will need to checkout a branch that includes https://github.com/dimagi/commcare-hq/pull/32169/commits/3f6aac65865c9a9931b93f9e31f8ecc462c6699c for this to work. Postgres may not start if you checkout an old branch and restart docker services after performing the upgrade. The resolution for that is to checkout a branch that includes that commit (e.g., `master`), get postgres started, then go back to work on the old branch.
3. Stop and start your postgresql docker container:
   ```sh
   ./scripts/docker stop postgres
   ./scripts/docker up postgres
   ```

## Safety Assurance

### Safety story

Minor change to docker compose configuration. Tested locally.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
