### PR TITLE
Embed tableau report by user instead of role

### DIFF
--- a/corehq/apps/reports/standard/tableau.py
+++ b/corehq/apps/reports/standard/tableau.py
@@ -78,8 +78,12 @@ def tableau_visualization_ajax(request, domain):
     validate_hostname = visualiation_data.pop('validate_hostname')
     target_site = visualiation_data.pop('target_site')
 
-    # An equivalent Tableau user with the username "HQ/{role name}" and proper permissions must exist.
-    tableau_username = f"HQ/{request.couch_user.get_role(domain).name}"
+    if toggles.EMBED_TABLEAU_REPORT_BY_USER.enabled(domain):
+        # An equivalent Tableau user with the username "HQ/{username}" must exist.
+        tableau_username = f"HQ/{request.couch_user.username}"
+    else:
+        # An equivalent Tableau user with the username "HQ/{role name}" must exist.
+        tableau_username = f"HQ/{request.couch_user.get_role(domain).name}"
     tabserver_url = 'https://{}/trusted/'.format(server_name)
     post_arguments = {'username': tableau_username}
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2345,3 +2345,13 @@ FORMPLAYER_INCLUDE_STATE_HASH = FeatureRelease(
     namespaces=[NAMESPACE_DOMAIN],
     owner='Simon Kelly'
 )
+
+EMBED_TABLEAU_REPORT_BY_USER = StaticToggle(
+    'embed_tableau_report_by_user',
+    'Use a Tableau username "HQ/{username}" to embed reports instead of "HQ/{role name}"',
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+    description='By default, a Tableau username "HQ/{role name}" is sent to Tableau to get the embedded report. '
+                'Turn on this flag to instead send "HQ/{the user\'s HQ username}", i.e. "HQ/jdoe@dimagi.com", '
+                'to Tableau to get the embedded report.',
+)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Currently an HQ user's role is sent as the Tableau username in the request to Tableau for embedded report, i.e. "HQ/Admin". This PR modifies that request to use the HQ user's _username_ instead, i.e. "HQ/adunn@dimagi.com", when a feature flag is turned on. This means that after appropriate Tableau config, the report will be embedded with permissions restrictions or data filtering linked to the HQ username, instead of the HQ role.

We have a deadline with the BHA to get data filtering live by Oct 13th and the goal is the get this change deployed this Thursday before the deploy freeze begins.

JIra: [2352](https://dimagi-dev.atlassian.net/browse/USH-2352?atlOrigin=eyJpIjoiYWIwYzM3NzVjMDBhNDgyYmJlNzQ5OTM2MDYyNjVjNzMiLCJwIjoiaiJ9). 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The feature flag will allow analytics/delivery to make the jump to username-based embedding when they like, instead of having to rush to make Tableau config changes before the deploy freeze. This will also make the change to username-based embedding easily revertable in case there is something wrong with the Tableau configuration.

I think it made more sense to add this under a feature flag instead of a feature release toggle because future projects may want to use the user's role name for emebedding to make their Tableau permissions easier to manage, as we almost did with the BHA project before the data filtering need arose. But given that the BHA project is likely to permanently move to user-based embedding instead of role-based, I'm very open to thoughts there.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

New feature flag added, [EMBED_TABLEAU_REPORT_BY_USER](https://staging.commcarehq.org/hq/flags/edit/embed_tableau_report_by_user/), which is behind another feature flag, EMBEDDED_TABLEAU.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested manually and likely to be tested further on staging by the analytics team to make sure this works as expected before this Thursday.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

To be QA'd by the analytics team.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
