### PR TITLE
Bump email-validator from 1.1.3 to 1.3.0

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -6,7 +6,7 @@ files:
 
 linters:
   flake8:
-    python: 3
+    python: 3.9
     config: .flake8
   eslint:
     config: ./.eslintrc.js

--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -36,8 +36,8 @@ class Command(BaseCommand):
         from corehq.apps.users.models import WebUser
         try:
             validate_email(username)
-        except EmailSyntaxError:
-            raise CommandError('Your username must be an email address')
+        except EmailSyntaxError as exc:
+            raise CommandError('The username must be a valid email address') from exc
         couch_user = WebUser.get_by_username(username)
         if couch_user:
             if not isinstance(couch_user, WebUser):

--- a/corehq/apps/domain/management/commands/tests/test_make_superuser.py
+++ b/corehq/apps/domain/management/commands/tests/test_make_superuser.py
@@ -17,10 +17,12 @@ class TestEmailValidation(SimpleTestCase):
         with patch_fake_webuser():
             call_command("make_superuser", "test@dimagi.com")  # does not raise
 
-    def test_make_superuser_allows_special_domains(self):
-        # as-built with email_validator version 1.1.3
-        with patch_fake_webuser():
-            call_command("make_superuser", "test@example.com")  # does not raise
+    def test_make_superuser_rejects_special_domains(self):
+        # as of email_validator 1.3.0, special domains raise EmailSyntaxError
+        # see: https://github.com/JoshData/python-email-validator/blob/10c34e6/CHANGELOG.md#version-130-september-18-2022  # noqa: E501
+        with (patch_fake_webuser(), self.assertRaises(CommandError) as test):
+            call_command("make_superuser", "test@example.com")
+        self.assertIsInstance(test.exception.__cause__, EmailSyntaxError)
 
     def test_make_superuser_rejects_invalid_email_syntax(self):
         with (patch_fake_webuser(), self.assertRaises(CommandError) as test):

--- a/corehq/apps/domain/management/commands/tests/test_make_superuser.py
+++ b/corehq/apps/domain/management/commands/tests/test_make_superuser.py
@@ -1,0 +1,43 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from django.core.management import CommandError, call_command
+from django.test import SimpleTestCase
+from email_validator import EmailSyntaxError
+
+from corehq.apps.users.models import FakeUser
+
+
+class TestEmailValidation(SimpleTestCase):
+    """Tests the expected behavior of the management command's use of the
+    `email_validator` library.
+    """
+
+    def test_make_superuser(self):
+        with patch_fake_webuser():
+            call_command("make_superuser", "test@dimagi.com")  # does not raise
+
+    def test_make_superuser_allows_special_domains(self):
+        # as-built with email_validator version 1.1.3
+        with patch_fake_webuser():
+            call_command("make_superuser", "test@example.com")  # does not raise
+
+    def test_make_superuser_rejects_invalid_email_syntax(self):
+        with (patch_fake_webuser(), self.assertRaises(CommandError) as test):
+            call_command("make_superuser", "somebody_at_dimagi.com")
+        self.assertIsInstance(test.exception.__cause__, EmailSyntaxError)
+
+
+@contextmanager
+def patch_fake_webuser():
+    with patch("corehq.apps.users.models.WebUser.get_by_username",
+               side_effect=get_fake_superuser) as mock:
+        yield mock
+
+
+def get_fake_superuser(username):
+    fake_user = FakeUser(username=username)
+    # set these to True so Command.handle() doesn't call couch_user.save()
+    fake_user.is_superuser = True
+    fake_user.is_staff = True
+    return fake_user

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -40,7 +40,7 @@ djangorestframework
 dropbox
 elasticsearch2>=2.0.0,<3.0.0  # we will be deprecating support for ES2 soon
 elasticsearch5>=5.0.0,<6.0.0  # ES5 support is currently in development
-email_validator
+email-validator
 ethiopian-date-converter
 eulxml
 gevent

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -212,7 +212,7 @@ elasticsearch2==2.5.1
     # via -r base-requirements.in
 elasticsearch5==5.5.6
     # via -r base-requirements.in
-email-validator==1.1.3
+email-validator==1.3.0
     # via -r base-requirements.in
 et-xmlfile==1.0.1
     # via openpyxl

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -189,7 +189,7 @@ elasticsearch2==2.5.1
     # via -r base-requirements.in
 elasticsearch5==5.5.6
     # via -r base-requirements.in
-email-validator==1.1.3
+email-validator==1.3.0
     # via -r base-requirements.in
 et-xmlfile==1.0.1
     # via openpyxl

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -184,7 +184,7 @@ elasticsearch2==2.5.1
     # via -r base-requirements.in
 elasticsearch5==5.5.6
     # via -r base-requirements.in
-email-validator==1.1.3
+email-validator==1.3.0
     # via -r base-requirements.in
 et-xmlfile==1.0.1
     # via openpyxl

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -176,7 +176,7 @@ elasticsearch2==2.5.1
     # via -r base-requirements.in
 elasticsearch5==5.5.6
     # via -r base-requirements.in
-email-validator==1.1.3
+email-validator==1.3.0
     # via -r base-requirements.in
 et-xmlfile==1.0.1
     # via openpyxl

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -187,7 +187,7 @@ elasticsearch2==2.5.1
     # via -r base-requirements.in
 elasticsearch5==5.5.6
     # via -r base-requirements.in
-email-validator==1.1.3
+email-validator==1.3.0
     # via -r base-requirements.in
 et-xmlfile==1.0.1
     # via openpyxl


### PR DESCRIPTION
## Technical Summary

**Update**: this PR is a work in progress. I've decided the current updates are not an acceptable as-is. Will push changes and provide an update soon.

----

Bumps `email-validator` from 1.1.3 to 1.3.0.

I reviewed the full CHANGELOG and have concluded that the upgrade will not break existing HQ behavior _except_ one "implied" scenario: using the Django manage command to create a superuser at a "special domain". For example:

```sh
./manage.py make_superuser test@example.com
```

Using `email-validator<1.3.0`, this would pass a validation test (although fail a _deliverable_ test, which HQ doesn't perform). Using `email-validator>=1.3.0`, this email address now fails validation (see [changelog](https://github.com/JoshData/python-email-validator/blob/10c34e6/CHANGELOG.md#version-130-september-18-2022)).

Tests were added prior to the upgrade (as-designed) and updated post-upgrade to test that the behavior has changed (special domains are now indeed prohibited from becoming admins).

It is unknown to me why an HQ admin would wish to create a superuser using an email at a "special" domain, however, I have two concerns, and I could be convinced that this PR should be updated to retain the old behavior:

- The `email_validation` library (as of 1.3.0) raises a `EmailSyntaxError` exception for "special" domains, which seems semantically incorrect to me.
- There _may be_ downstream HQ admins who have been using this "existing behavior" (making superusers with special domains), and this change will break that behavior.

Feedback is welcome.

Ticket: [SAAS-13968](https://dimagi-dev.atlassian.net/browse/SAAS-13968)

Review commit-by-commit :tropical_fish: 

## Safety Assurance

### Safety story

As-designed tests added pre-upgrade (and updated post-upgrade).

### Automated test coverage

New tests added around how this library is used (specifically, the areas that changed due to the upgrade).

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
