### PR TITLE
Cs/update pages titles

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -4,6 +4,10 @@
 
 {% requirejs_main "case_importer/js/main" %}
 
+{% block page_title %}
+  {{ current_page.title }}
+{% endblock %}
+
 {% block page_content %}
   {% registerurl 'case_importer_uploads' domain %}
   {% registerurl 'case_importer_upload_file_download' domain '---' %}

--- a/corehq/apps/data_interfaces/templates/data_interfaces/find_by_id.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/find_by_id.html
@@ -4,13 +4,16 @@
 
 {% requirejs_main "data_interfaces/js/find_by_id" %}
 
+{% block page_title %}
+  {{ current_page.title }}
+{% endblock %}
+
 {% block page_content %}
   {% registerurl 'global_quick_find' %}
   {% registerurl 'list_case_exports' domain %}
   {% registerurl 'list_form_exports' domain %}
 
   {% blocktrans %}
-    <p class="lead">Find Data by ID</p>
     <p>
       This page allows you to directly access a specific form data or case data page.
       Read more on our <a href='https://confluence.dimagi.com/display/commcarepublic/Find+Data+by+ID'>help site</a>.

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -4,14 +4,13 @@
 
 {% requirejs_main 'data_interfaces/js/list_automatic_update_rules' %}
 
+{% block page_title %}
+  {{ current_page.title }}
+{% endblock %}
+
 {% block pagination_header %}
   <div class="row">
     <div class="col-sm-8">
-      <p class="lead">
-        {% blocktrans %}
-          Automatically update or close cases from CommCare HQ
-        {% endblocktrans %}
-      </p>
       <p>
         {% blocktrans %}
           Create rules for updating or closing cases from CommCare HQ.

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_deduplication_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_deduplication_rules.html
@@ -4,14 +4,13 @@
 
 {% requirejs_main 'data_interfaces/js/list_automatic_update_rules' %}
 
+{% block page_title %}
+  {{ current_page.title }}
+{% endblock %}
+
 {% block pagination_header %}
   <div class="row">
     <div class="col-sm-8">
-      <p class="lead">
-        {% blocktrans %}
-          Automatically find and update duplicate cases
-        {% endblocktrans %}
-      </p>
       <p>
         {% blocktrans %}
           Create rules for finding and updating duplicate cases.

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -614,7 +614,7 @@ def find_by_id(request, domain):
     if not can_view_cases and not can_view_forms:
         raise Http403()
 
-    name = _("Find Case or Form Submission by ID")
+    name = _("Find Data by ID")
     return render(request, 'data_interfaces/find_by_id.html', {
         'domain': domain,
         'current_page': {

--- a/corehq/apps/export/templates/export/download_export.html
+++ b/corehq/apps/export/templates/export/download_export.html
@@ -36,6 +36,10 @@
 
 {% requirejs_main 'export/js/download_export' %}
 
+{% block page_title %}
+  {{ current_page.title }}
+{% endblock %}
+
 {% block page_content %}
   {% initial_page_data 'export_list' export_list %}
   {% initial_page_data 'form_or_case' form_or_case %}

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -6,6 +6,10 @@
 
 {% requirejs_main 'export/js/export_list_main' %}
 
+{% block page_title %}
+  {{ current_page.title }}
+{% endblock %}
+
 {% block page_content %}
   {% initial_page_data 'bulk_download_url' bulk_download_url %}
   {% initial_page_data 'exports' exports %}

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -497,7 +497,7 @@ class BaseExportListView(BaseProjectDataView):
         for use in third-party data analysis tools.
     '''))
     is_odata = False
-    page_title = "Export Form Data"
+    page_title = gettext_lazy("Export Form Data")
 
     @method_decorator(login_and_domain_required)
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -497,6 +497,7 @@ class BaseExportListView(BaseProjectDataView):
         for use in third-party data analysis tools.
     '''))
     is_odata = False
+    page_title = "Export Form Data"
 
     @method_decorator(login_and_domain_required)
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/hqwebapp/templates/hqwebapp/full_screen.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/full_screen.html
@@ -9,7 +9,7 @@
       {% captureas page_title_block %}{% block page_title %}{% endblock page_title %}{% endcaptureas %}
       {% if page_title_block %}
         <div class="page-header" style="margin-top: 0;">
-          <h1 style="font-size: 1.8em;">{{ page_title_block }}</h1>
+          <h1 class="lead" style="font-size: 1.8em;">{{ page_title_block }}</h1>
         </div>
       {% else %}
         {% block pre_page_content %}<div class="spacer"></div>{% endblock %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/two_column.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/two_column.html
@@ -15,7 +15,7 @@
         {% captureas page_title_block %}{% block page_title %}{% endblock page_title %}{% endcaptureas %}
         {% if page_title_block %}
           <div class="page-header" style="margin-top: 0;">
-            <h1 style="font-size: 1.8em;">{{ page_title_block }}</h1>
+            <h1 class="lead" style="font-size: 1.8em;">{{ page_title_block }}</h1>
           </div>
         {% else %}
           {% block pre_page_content %}


### PR DESCRIPTION
## Product Description
Adds titles to some pages that didn't have or didn't show. 

([This slack](https://dimagi.slack.com/archives/C02QG63MU/p1663139964679989) chat can also be reviewed for reference)

## Technical Summary
It was noticed that there exist a few discrepancies between pages when navigating to different pages under the Data tab. Some pages showed titles and others not. Furthermore, between the pages that did have a title, different styles was observed. 

This PR does 2 things:
1) Adds the `lead` class to the `page_title` block
2) Use the `page_title` block on some pages so that their respective titles actually show.

Note: this PR only "fix" _some_ pages, but chances are that there's a bunch more that need changing/conforming to use the `page_title` block as the standard and not the "to-each-his-own" philosophy.  

Some before-and-after screenshots:

Before:
![image](https://user-images.githubusercontent.com/44245062/191468182-6f958a4c-ffe2-444f-92ce-16eecdbd4bd6.png)

After:
![image](https://user-images.githubusercontent.com/44245062/191468396-bf05cc63-3a5a-4f62-8a36-d7f2c38fa86c.png)

One instance I do want to highlight is the following page, which I'm not sure what to do with the second title's ("Upload Lookup Tables") styling:
![image](https://user-images.githubusercontent.com/44245062/191468648-ce365d48-7b27-49a5-8434-87ca3c8e58e5.png)


## Feature Flag
Not a specific FF

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
Automated testing not necessary

### QA Plan
Only tested locally as this is styling

### Migrations
No migrations

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
