### PR TITLE
Filter by tracked entity type

### DIFF
--- a/corehq/motech/dhis2/finders.py
+++ b/corehq/motech/dhis2/finders.py
@@ -70,6 +70,7 @@ class TrackedEntityInstanceFinder:
         if not query_filters:
             return []
         params = {
+            "trackedEntityType": self.case_config.te_type_id,
             "ou": get_value(self.case_config.org_unit_id, case_trigger_info),
             "filter": query_filters,
             "ouMode": "DESCENDANTS",


### PR DESCRIPTION
## Technical Summary

Fixes a "409 Conflict" error in recent versions of DHIS2.

DHIS2 >= 2.37 returns a "409 Conflict" response if the tracked entity type is not specified when searching for tracked entities. (CommCare can perform this search when creating a new tracked entity instance, to ensure that the CommCare case does not already exist in DHIS2.)

This change has been tested all supported versions of DHIS2: 2.35, 2.36, 2.37 & 2.38.

## Feature Flag

DHIS2 integration

## Safety Assurance

### Safety story

* Tested manually with all supported versions of DHIS2. (DHIS2 documentation suggests that this change has been supported at least since DHIS2 2.30, and probably earlier.)
* Small change on a feature that is only used by some DHIS2 integrations

### Automated test coverage

Not covered by automated tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
