### PR TITLE
Tell stickler to use Python 3.9

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -6,7 +6,7 @@ files:
 
 linters:
   flake8:
-    python: 3
+    python: 3.9
     config: .flake8
   eslint:
     config: ./.eslintrc.js


### PR DESCRIPTION
## Technical Summary

Duplicate of #32176, this time targeting a merge into `master` (previous PR merged into a branch that was abandoned).

CI checks only: Tell stickler-ci bot to use Python 3.9 (instead of just Python 3).

## Safety Assurance

### Safety story

CI checks only.

### Automated test coverage

CI checks only.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
