### PR TITLE
Use Django's email validation function in make_superuser command

### DIFF
--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -3,8 +3,7 @@ import logging
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-
-from email_validator import EmailSyntaxError, validate_email
+from django.core.validators import ValidationError, validate_email
 
 from corehq.apps.hqadmin.views.users import send_email_notif
 from corehq.util.signals import signalcommand
@@ -36,7 +35,7 @@ class Command(BaseCommand):
         from corehq.apps.users.models import WebUser
         try:
             validate_email(username)
-        except EmailSyntaxError as exc:
+        except ValidationError as exc:
             raise CommandError('The username must be a valid email address') from exc
         couch_user = WebUser.get_by_username(username)
         if couch_user:

--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -36,8 +36,8 @@ class Command(BaseCommand):
         from corehq.apps.users.models import WebUser
         try:
             validate_email(username)
-        except EmailSyntaxError:
-            raise CommandError('Your username must be an email address')
+        except EmailSyntaxError as exc:
+            raise CommandError('The username must be a valid email address') from exc
         couch_user = WebUser.get_by_username(username)
         if couch_user:
             if not isinstance(couch_user, WebUser):

--- a/corehq/apps/domain/management/commands/tests/test_make_superuser.py
+++ b/corehq/apps/domain/management/commands/tests/test_make_superuser.py
@@ -2,8 +2,8 @@ from contextlib import contextmanager
 from unittest.mock import patch
 
 from django.core.management import CommandError, call_command
+from django.core.validators import ValidationError
 from django.test import SimpleTestCase
-from email_validator import EmailSyntaxError
 
 from corehq.apps.users.models import FakeUser
 
@@ -25,7 +25,7 @@ class TestEmailValidation(SimpleTestCase):
     def test_make_superuser_rejects_invalid_email_syntax(self):
         with patch_fake_webuser(), self.assertRaises(CommandError) as test:
             call_command("make_superuser", "somebody_at_dimagi.com")
-        self.assertIsInstance(test.exception.__cause__, EmailSyntaxError)
+        self.assertIsInstance(test.exception.__cause__, ValidationError)
 
 
 @contextmanager

--- a/corehq/apps/domain/management/commands/tests/test_make_superuser.py
+++ b/corehq/apps/domain/management/commands/tests/test_make_superuser.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from unittest.mock import patch
 
 from django.core.management import CommandError, call_command
@@ -28,11 +27,9 @@ class TestEmailValidation(SimpleTestCase):
         self.assertIsInstance(test.exception.__cause__, ValidationError)
 
 
-@contextmanager
 def patch_fake_webuser():
-    with patch("corehq.apps.users.models.WebUser.get_by_username",
-               side_effect=get_fake_superuser) as mock:
-        yield mock
+    return patch("corehq.apps.users.models.WebUser.get_by_username",
+                 side_effect=get_fake_superuser)
 
 
 def get_fake_superuser(username):

--- a/corehq/apps/domain/management/commands/tests/test_make_superuser.py
+++ b/corehq/apps/domain/management/commands/tests/test_make_superuser.py
@@ -1,0 +1,43 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from django.core.management import CommandError, call_command
+from django.test import SimpleTestCase
+from email_validator import EmailSyntaxError
+
+from corehq.apps.users.models import FakeUser
+
+
+class TestEmailValidation(SimpleTestCase):
+    """Tests the expected behavior of the management command's use of the
+    `email_validator` library.
+    """
+
+    def test_make_superuser(self):
+        with patch_fake_webuser():
+            call_command("make_superuser", "test@dimagi.com")  # does not raise
+
+    def test_make_superuser_allows_special_domains(self):
+        # as-built with email_validator version 1.1.3
+        with patch_fake_webuser():
+            call_command("make_superuser", "test@example.com")  # does not raise
+
+    def test_make_superuser_rejects_invalid_email_syntax(self):
+        with patch_fake_webuser(), self.assertRaises(CommandError) as test:
+            call_command("make_superuser", "somebody_at_dimagi.com")
+        self.assertIsInstance(test.exception.__cause__, EmailSyntaxError)
+
+
+@contextmanager
+def patch_fake_webuser():
+    with patch("corehq.apps.users.models.WebUser.get_by_username",
+               side_effect=get_fake_superuser) as mock:
+        yield mock
+
+
+def get_fake_superuser(username):
+    fake_user = FakeUser(username=username)
+    # set these to True so Command.handle() doesn't call couch_user.save()
+    fake_user.is_superuser = True
+    fake_user.is_staff = True
+    return fake_user


### PR DESCRIPTION
## Technical Summary

Use Django's `validate_email` function for validating email syntax (the `email-validator` library is optimized for checking email _deliverability_).

Ticket: [SAAS-13968](https://dimagi-dev.atlassian.net/browse/SAAS-13968)

## Safety Assurance

### Safety story

Django's validation function is perfectly suited for this purpose.

### Automated test coverage

New tests added to verify behavior and guard against regressions.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
