### PR TITLE
Use Django's email validation function in ConnectionSettingsForm

### DIFF
--- a/corehq/motech/tests/test_forms.py
+++ b/corehq/motech/tests/test_forms.py
@@ -1,15 +1,19 @@
 from django.test import SimpleTestCase
 
-from ..forms import ConnectionSettingsForm, UnrecognizedHost
+from corehq.util.urlvalidate.test.mockipinfo import (
+    hostname_resolving_to_ips,
+    unresolvable_hostname,
+)
 
-from corehq.util.urlvalidate.test.mockipinfo import hostname_resolving_to_ips, unresolvable_hostname
+from ..forms import ConnectionSettingsForm, UnrecognizedHost
 
 
 class ConnectionSettingsFormTests(SimpleTestCase):
-    def create_form(self, url=None):
+
+    def create_form(self, url=None, notify_emails='test@user.com'):
         form_data = {
             'name': 'testform',
-            'notify_addresses_str': 'test@user.com',
+            'notify_addresses_str': notify_emails,
             'url': 'http://some.url'
         }
 
@@ -37,3 +41,21 @@ class ConnectionSettingsFormTests(SimpleTestCase):
         first_helper = form.helper
         second_helper = form.helper
         self.assertIs(first_helper, second_helper)
+
+    def test_clean_notify_addresses_str(self):
+        email_addrs = "test1@user.com, test2@user.com"
+        form = self.create_form(notify_emails=email_addrs)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(email_addrs, form.cleaned_data["notify_addresses_str"])
+
+    def test_clean_notify_addresses_str_validation_error(self):
+        for bad_addr in ["invalid&example.com", "<test@example.com>"]:
+            email_addrs = f"valid@example.com, {bad_addr}"
+            form = self.create_form(notify_emails=email_addrs)
+            self.assertEqual(
+                {"notify_addresses_str": [{
+                    "message": "Contains an invalid email address.",
+                    "code": "",
+                }]},
+                form.errors.get_json_data(),
+            )

--- a/corehq/motech/tests/test_forms.py
+++ b/corehq/motech/tests/test_forms.py
@@ -54,7 +54,7 @@ class ConnectionSettingsFormTests(SimpleTestCase):
             form = self.create_form(notify_emails=email_addrs)
             self.assertEqual(
                 {"notify_addresses_str": [{
-                    "message": "Contains an invalid email address.",
+                    "message": f"Invalid email address(es): {bad_addr}",
                     "code": "",
                 }]},
                 form.errors.get_json_data(),


### PR DESCRIPTION
## Technical Summary

Use Django's `validate_email` function for form validation in `ConnectionSettingsForm` (the `email-validator` library is designed for checking email _deliverability_).

Ticket: [SAAS-13968](https://dimagi-dev.atlassian.net/browse/SAAS-13968)

## Safety Assurance

### Safety story

Django's validation function is designed for this purpose.

### Automated test coverage

New tests added to verify behavior and guard against regressions.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
