### PR TITLE
Annotate location import view with waf allow

### DIFF
--- a/corehq/apps/locations/urls.py
+++ b/corehq/apps/locations/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import re_path as url
 
+from corehq.apps.hqwebapp.decorators import waf_allow
+
 from .views import (
     DowngradeLocationsView,
     DownloadLocationStatusView,
@@ -30,7 +32,7 @@ settings_urls = [
     url(r'^list/$', LocationsListView.as_view(), name=LocationsListView.urlname),
     url(r'^location_search/$', LocationsSearchView.as_view(), name='location_search'),
     url(r'^location_types/$', LocationTypesView.as_view(), name=LocationTypesView.urlname),
-    url(r'^import/$', LocationImportView.as_view(), name=LocationImportView.urlname),
+    url(r'^import/$', waf_allow('XSS_BODY')(LocationImportView.as_view()), name=LocationImportView.urlname),
     url(r'^import_status/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$', LocationImportStatusView.as_view(),
         name=LocationImportStatusView.urlname),
     url(r'^location_importer_job_poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Some of the location uploads were blocked by AWS WAF because the binary file had some characteristics which looked suspicious to AWS. This PR annotates the location import endpoint so that AWS allows the files. 
https://github.com/dimagi/commcare-hq/pull/32190 is the commcare-cloud PR to update the url patterns in WAF config.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12315
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
No code changes as such, just a deocrator added to a view in `urls.py` and have been tested on local that location imports work.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

The PR can be reverted but make sure to revert https://github.com/dimagi/commcare-hq/pull/32190 and run apply the changes on commcare cloud.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
