### PR TITLE
Delete SQL lookup table rows on update linked app

### DIFF
--- a/corehq/apps/linked_domain/tests/test_update_fixtures.py
+++ b/corehq/apps/linked_domain/tests/test_update_fixtures.py
@@ -10,6 +10,7 @@ from corehq.apps.fixtures.models import (
     FixtureDataType,
     FixtureItemField,
     FixtureTypeField,
+    LookupTableRow,
 )
 from corehq.apps.fixtures.upload.run_upload import clear_fixture_quickcache
 from corehq.apps.fixtures.utils import clear_fixture_cache
@@ -140,6 +141,12 @@ class TestUpdateFixtures(BaseLinkedDomainTest):
         ], sorted([
             i.fields[field_name].field_list[0].field_value for i in items for field_name in i.fields.keys()
         ]))
+        # Linked SQL rows should have been deleted
+        rows = LookupTableRow.objects.filter(table_id=linked_types[0]._id)
+        self.assertEqual(
+            ['Europa', 'Io', 'Jupiter', 'Jupiter', 'Naiad', 'Neptune', 'Neptune', 'Thalassa'],
+            sorted(field[0].value for i in rows for field in i.fields.values()),
+        )
 
     def test_update_global_only(self):
         other_table = FixtureDataType(


### PR DESCRIPTION
I had previously missed converting `delete_fixture_items_for_data_type` to delete items in both Couch and SQL, which means extra rows have been accumulating in SQL after they are deleted in Couch.

## Safety Assurance

### Safety story

Change is covered by automated tests. A new `paginate_view` call was added to replace `iter_fixture_items_for_data_type` because the latter uses `include_docs=True`, which is unnecessary since the items are immediately deleted.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
