### PR TITLE
Add conditional for 'completed case search' Kissmetrics events

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -463,9 +463,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         continueAction: function () {
             FormplayerFrontend.trigger("menu:select", this.selectedCaseIds);
-            kissmetrics.track.event('Completed Case Search', {
-                'Split Screen Case Search': hqImport('hqwebapp/js/toggles').toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
-            });
+            if (/search_command\.m\d+/.test(sessionStorage.queryKey)) {
+                kissmetrics.track.event('Completed Case Search', {
+                    'Split Screen Case Search': hqImport('hqwebapp/js/toggles').toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
+                });
+            };
         },
 
         reconcileMultiSelectUI: function () {
@@ -790,9 +792,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 FormplayerFrontend.trigger("multiSelect:updateCases", Constants.MULTI_SELECT_ADD, [this.caseId]);
             } else {
                 FormplayerFrontend.trigger("menu:select", this.caseId);
-                kissmetrics.track.event('Completed Case Search', {
-                    'Split Screen Case Search': hqImport('hqwebapp/js/toggles').toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
-                });
+                if (/search_command\.m\d+/.test(sessionStorage.queryKey)) {
+                    kissmetrics.track.event('Completed Case Search', {
+                        'Split Screen Case Search': hqImport('hqwebapp/js/toggles').toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
+                    });
+                };
             }
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -467,7 +467,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 kissmetrics.track.event('Completed Case Search', {
                     'Split Screen Case Search': hqImport('hqwebapp/js/toggles').toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
                 });
-            };
+            }
         },
 
         reconcileMultiSelectUI: function () {
@@ -796,7 +796,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     kissmetrics.track.event('Completed Case Search', {
                         'Split Screen Case Search': hqImport('hqwebapp/js/toggles').toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
                     });
-                };
+                }
             }
         },
     });


### PR DESCRIPTION
## Product Description

## Technical Summary
Revision to 'Completed Case Search' Kissmetrics events added in [PR #32164](https://github.com/dimagi/commcare-hq/pull/32164) to improve metric data quality.

As is, certain edge cases will give incorrect data in Kissmetrics. e.g. if a user begins a case search, leaves that screen without selecting a case, then later using their local caseDB search selects a case, that would be incorrectly counted as a Started Case Search => Completed Case Search action. Adding a conditional test to the 'Completed Case Search' events to check if case search was used solves this.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
This is a minor change that only affects events being sent to Kissmetrics.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
