### PR TITLE
[USH-2420] hook up API validation into the view processing

### DIFF
--- a/corehq/motech/generic_inbound/core.py
+++ b/corehq/motech/generic_inbound/core.py
@@ -32,14 +32,21 @@ def execute_generic_api(domain, couch_user, device_id, context, api_model):
 
 
 def _validate_api_request(api, eval_context):
+    """Run any validation expressions against the context.
+
+    :returns: False if no expressions were run or True if all validations passed.
+    :raises: GenericInboundValidationError if any validations fail"""
     validations = api.get_validations()
     if not validations:
-        return
+        return False
 
     errors = []
     for validation in validations:
-        if validation.parsed_expression(eval_context.root_doc, eval_context) is False:
+        expr = validation.parsed_expression
+        if not expr(eval_context.root_doc, eval_context):
             errors.append(validation.get_error_context())
 
     if errors:
         raise GenericInboundValidationError(errors)
+
+    return True

--- a/corehq/motech/generic_inbound/core.py
+++ b/corehq/motech/generic_inbound/core.py
@@ -1,0 +1,45 @@
+from corehq.apps.hqcase.api.core import serialize_case
+from corehq.apps.hqcase.api.updates import handle_case_update
+from corehq.motech.generic_inbound.exceptions import GenericInboundValidationError
+
+
+def execute_generic_api(domain, couch_user, device_id, context, api_model):
+    _validate_api_request(api_model, context)
+
+    data = api_model.parsed_expression(context.root_doc, context)
+
+    if not isinstance(data, list):
+        # the bulk API always requires a list
+        data = [data]
+
+    xform, case_or_cases = handle_case_update(
+        domain=domain,
+        data=data,
+        user=couch_user,
+        device_id=device_id,
+        is_creation=None,
+    )
+
+    if isinstance(case_or_cases, list):
+        return {
+            'form_id': xform.form_id,
+            'cases': [serialize_case(case) for case in case_or_cases],
+        }
+    return {
+        'form_id': xform.form_id,
+        'case': serialize_case(case_or_cases),
+    }
+
+
+def _validate_api_request(api, eval_context):
+    validations = api.get_validations()
+    if not validations:
+        return
+
+    errors = []
+    for validation in validations:
+        if validation.parsed_expression(eval_context.root_doc, eval_context) is False:
+            errors.append(validation.get_error_context())
+
+    if errors:
+        raise GenericInboundValidationError(errors)

--- a/corehq/motech/generic_inbound/exceptions.py
+++ b/corehq/motech/generic_inbound/exceptions.py
@@ -4,3 +4,11 @@ class GenericInboundApiError(Exception):
 
 class GenericInboundUserError(Exception):
     pass
+
+
+class GenericInboundValidationError(GenericInboundApiError):
+    def __init__(self, errors):
+        self.errors = errors
+
+    def __str__(self):
+        return '\n'.join(f"{e['name']}: {e['message']}" for e in self.errors)

--- a/corehq/motech/generic_inbound/models.py
+++ b/corehq/motech/generic_inbound/models.py
@@ -52,6 +52,9 @@ class ConfigurableAPI(models.Model):
     def absolute_url(self):
         return reverse("generic_inbound_api", args=[self.domain, self.url_key], absolute=True)
 
+    def get_validations(self):
+        return list(self.validations.all())
+
 
 class ConfigurableApiValidation(models.Model):
     api = models.ForeignKey(ConfigurableAPI, on_delete=models.CASCADE, related_name="validations")
@@ -63,6 +66,12 @@ class ConfigurableApiValidation(models.Model):
     @memoized
     def parsed_expression(self):
         return self.expression.wrapped_definition(FactoryContext.empty())
+
+    def get_error_context(self):
+        return {
+            "name": self.name,
+            "message": self.message,
+        }
 
     def to_json(self):
         return {

--- a/corehq/motech/generic_inbound/tests/test_api_processing.py
+++ b/corehq/motech/generic_inbound/tests/test_api_processing.py
@@ -3,9 +3,11 @@ from datetime import datetime
 
 from django.test import SimpleTestCase
 
+from corehq.apps.userreports.const import UCR_NAMED_FILTER
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.models import UCRExpression
-from corehq.motech.generic_inbound.models import ConfigurableAPI
+from corehq.motech.generic_inbound.exceptions import GenericInboundValidationError
+from corehq.motech.generic_inbound.models import ConfigurableAPI, ConfigurableApiValidation
 from corehq.motech.generic_inbound.utils import get_evaluation_context
 from corehq.motech.generic_inbound.views import _execute_case_api
 
@@ -31,3 +33,40 @@ class TestGenericInboundAPI(SimpleTestCase):
         context = get_evaluation_context(user, 'post', {}, {}, {})
         with self.assertRaises(BadSpecError):
             _execute_case_api(self.domain_name, user, "device_id", context, api_model)
+
+    def test_validation_errors(self):
+
+        validation_expression = UCRExpression(
+            expression_type=UCR_NAMED_FILTER,
+            definition={
+                "type": "boolean_expression",
+                "expression": {"type": "jsonpath", "jsonpath": "resource.type"},
+                "operator": "eq",
+                "property_value": "patient"
+            })
+        validations = [
+            ConfigurableApiValidation(
+                name="is patient", message="must be patient", expression=validation_expression
+            ),
+            ConfigurableApiValidation(
+                name="is also patient", message="must be patient again", expression=validation_expression
+            ),
+        ]
+        api_model = ConfigurableAPI(
+            domain=self.domain_name,
+            transform_expression=UCRExpression(definition={
+                'type': 'dict', 'properties': {'case_type': 'patient'}
+            }),
+        )
+
+        # mock 'get_validations'
+        api_model.get_validations = lambda: validations
+        user = MockUser()
+        context = get_evaluation_context(user, 'post', {}, {}, {})
+        with self.assertRaises(GenericInboundValidationError) as cm:
+            _execute_case_api(self.domain_name, user, "device_id", context, api_model)
+
+        self.assertEqual(cm.exception.errors, [
+            {"name": "is patient", "message": "must be patient"},
+            {"name": "is also patient", "message": "must be patient again"},
+        ])

--- a/corehq/motech/generic_inbound/tests/test_api_processing.py
+++ b/corehq/motech/generic_inbound/tests/test_api_processing.py
@@ -9,7 +9,7 @@ from corehq.apps.userreports.models import UCRExpression
 from corehq.motech.generic_inbound.exceptions import GenericInboundValidationError
 from corehq.motech.generic_inbound.models import ConfigurableAPI, ConfigurableApiValidation
 from corehq.motech.generic_inbound.utils import get_evaluation_context
-from corehq.motech.generic_inbound.views import _execute_case_api
+from corehq.motech.generic_inbound.core import execute_generic_api
 
 
 @dataclasses.dataclass
@@ -32,7 +32,7 @@ class TestGenericInboundAPI(SimpleTestCase):
         user = MockUser()
         context = get_evaluation_context(user, 'post', {}, {}, {})
         with self.assertRaises(BadSpecError):
-            _execute_case_api(self.domain_name, user, "device_id", context, api_model)
+            execute_generic_api(self.domain_name, user, "device_id", context, api_model)
 
     def test_validation_errors(self):
 
@@ -64,7 +64,7 @@ class TestGenericInboundAPI(SimpleTestCase):
         user = MockUser()
         context = get_evaluation_context(user, 'post', {}, {}, {})
         with self.assertRaises(GenericInboundValidationError) as cm:
-            _execute_case_api(self.domain_name, user, "device_id", context, api_model)
+            execute_generic_api(self.domain_name, user, "device_id", context, api_model)
 
         self.assertEqual(cm.exception.errors, [
             {"name": "is patient", "message": "must be patient"},

--- a/corehq/motech/generic_inbound/tests/test_api_processing.py
+++ b/corehq/motech/generic_inbound/tests/test_api_processing.py
@@ -9,7 +9,7 @@ from corehq.apps.userreports.models import UCRExpression
 from corehq.motech.generic_inbound.exceptions import GenericInboundValidationError
 from corehq.motech.generic_inbound.models import ConfigurableAPI, ConfigurableApiValidation
 from corehq.motech.generic_inbound.utils import get_evaluation_context
-from corehq.motech.generic_inbound.core import execute_generic_api
+from corehq.motech.generic_inbound.core import execute_generic_api, _validate_api_request
 
 
 @dataclasses.dataclass
@@ -34,39 +34,57 @@ class TestGenericInboundAPI(SimpleTestCase):
         with self.assertRaises(BadSpecError):
             execute_generic_api(self.domain_name, user, "device_id", context, api_model)
 
-    def test_validation_errors(self):
+    def test_validation_pass(self):
+        api_model = _get_api_with_validation(self.domain_name)
+        user = MockUser()
+        context = get_evaluation_context(user, 'post', {}, {}, {"resource": {"type": "patient"}})
+        self.assertTrue(_validate_api_request(api_model, context))
 
-        validation_expression = UCRExpression(
+    def test_validation_errors(self):
+        api_model = _get_api_with_validation(self.domain_name)
+        validations = api_model.get_validations()
+        client_validation_expression = UCRExpression(
             expression_type=UCR_NAMED_FILTER,
             definition={
                 "type": "boolean_expression",
-                "expression": {"type": "jsonpath", "jsonpath": "resource.type"},
-                "operator": "eq",
-                "property_value": "patient"
+                "expression": {"type": "jsonpath", "jsonpath": "body.resource.type"},
+                "operator": "not_eq",
+                "property_value": "client"
             })
-        validations = [
-            ConfigurableApiValidation(
-                name="is patient", message="must be patient", expression=validation_expression
-            ),
-            ConfigurableApiValidation(
-                name="is also patient", message="must be patient again", expression=validation_expression
-            ),
-        ]
-        api_model = ConfigurableAPI(
-            domain=self.domain_name,
-            transform_expression=UCRExpression(definition={
-                'type': 'dict', 'properties': {'case_type': 'patient'}
-            }),
-        )
-
-        # mock 'get_validations'
-        api_model.get_validations = lambda: validations
+        validations.append(ConfigurableApiValidation(
+            name="is also patient", message="must be patient again", expression=client_validation_expression
+        ))
         user = MockUser()
-        context = get_evaluation_context(user, 'post', {}, {}, {})
+        # 1st validation should fail, 2nd should succeed
+        context = get_evaluation_context(user, 'post', {}, {}, {"resource": {"type": "employee"}})
         with self.assertRaises(GenericInboundValidationError) as cm:
             execute_generic_api(self.domain_name, user, "device_id", context, api_model)
 
         self.assertEqual(cm.exception.errors, [
             {"name": "is patient", "message": "must be patient"},
-            {"name": "is also patient", "message": "must be patient again"},
         ])
+
+
+def _get_api_with_validation(domain_name):
+    validation_expression = UCRExpression(
+        expression_type=UCR_NAMED_FILTER,
+        definition={
+            "type": "boolean_expression",
+            "expression": {"type": "jsonpath", "jsonpath": "body.resource.type"},
+            "operator": "eq",
+            "property_value": "patient"
+        })
+    validations = [
+        ConfigurableApiValidation(
+            name="is patient", message="must be patient", expression=validation_expression
+        )
+    ]
+    api_model = ConfigurableAPI(
+        domain=domain_name,
+        transform_expression=UCRExpression(definition={
+            'type': 'dict', 'properties': {'case_type': 'patient'}
+        }),
+    )
+    # mock 'get_validations'
+    api_model.get_validations = lambda: validations
+    return api_model


### PR DESCRIPTION
## Product Description
Uses the validation configurations provided for the API to validate incoming requests.

See https://github.com/dimagi/commcare-hq/pull/32185

## Technical Summary
Run all validations against the evaluation context and error if any fail.

Spec: https://docs.google.com/document/d/1lpGyVzur2G2lFOQJJ2nNiNQzasZFMccJiFtRxS5CSPo/edit#heading=h.nwsih2qjefwy

## Feature Flag
Generic inbound API

## Safety Assurance

### Safety story
Changes covered by tests. Also the feature is not yet released.

### Automated test coverage
Added in the PR

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
