### PR TITLE
Revert "Stickler?!"

### DIFF
--- a/custom/hmhb/management/commands/repeat_forms_by_external_id.py
+++ b/custom/hmhb/management/commands/repeat_forms_by_external_id.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
             options['case_type'],
             raise_multiple=True,
         )
-        assert case, 'Case %r not found' % (options["external_id"],)
+        assert case, f'Case {options["external_id"]!r} not found'
 
         form_ids = [tx.form_id for tx in case.get_form_transactions()]
         for form in XFormInstance.objects.get_forms(form_ids, ordered=True):


### PR DESCRIPTION
## Technical Summary

This reverts commit 99d538ecabb643007658882cbea759c778fd9c56 because https://github.com/dimagi/commcare-hq/pull/32184

## Feature Flag
N/A

## Safety Assurance

### Safety story

* Tiny
* Reverts an unnecessary commit
* in custom code
* in a Django management command
* in an assertion error message

### Automated test coverage

Not covered

### QA Plan

QA not planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
