### PR TITLE
Fix linked lookup tables caching

### DIFF
--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -31,8 +31,8 @@ def get_fixture_data_types(domain, bypass_cache=False):
     ))
 
 
-def get_fixture_data_type_by_tag(domain, tag):
-    data_types = get_fixture_data_types(domain)
+def get_fixture_data_type_by_tag(domain, tag, **kw):
+    data_types = get_fixture_data_types(domain, **kw)
     for data_type in data_types:
         if data_type.tag == tag:
             return data_type

--- a/corehq/apps/linked_domain/local_accessors.py
+++ b/corehq/apps/linked_domain/local_accessors.py
@@ -78,11 +78,11 @@ def get_custom_data_models(domain, limit_types=None):
     return fields
 
 
-def get_fixture(domain, tag):
-    data_type = get_fixture_data_type_by_tag(domain, tag)
+def get_fixture(domain, tag, **kw):
+    data_type = get_fixture_data_type_by_tag(domain, tag, **kw)
     return {
         "data_type": data_type,
-        "data_items": get_fixture_items_for_data_type(domain, data_type._id),
+        "data_items": get_fixture_items_for_data_type(domain, data_type._id, **kw),
     }
 
 

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -210,7 +210,7 @@ def update_fixture(domain_link, tag):
     if domain_link.is_remote:
         master_results = remote_fixture(domain_link, tag)
     else:
-        master_results = local_fixture(domain_link.master_domain, tag)
+        master_results = local_fixture(domain_link.master_domain, tag, bypass_cache=True)
 
     master_data_type = master_results["data_type"]
     if not master_data_type.is_global:

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -1,4 +1,3 @@
-from copy import copy
 from corehq.apps.linked_domain.ucr_expressions import update_linked_ucr_expression
 from corehq.apps.reports.models import TableauVisualization, TableauServer
 from functools import partial
@@ -368,6 +367,7 @@ def update_tableau_server_and_visualizations(domain_link):
         vis.view_url = master_vis['view_url']
         vis.title = master_vis['title']
         vis.save()
+
 
 def update_dialer_settings(domain_link):
     if domain_link.is_remote:

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -230,7 +230,6 @@ def update_fixture(domain_link, tag):
     linked_data_type["domain"] = domain_link.linked_domain
     linked_data_type = FixtureDataType.wrap(linked_data_type)
     linked_data_type.save()
-    clear_fixture_quickcache(domain_link.linked_domain, [linked_data_type])
 
     # Re-create relevant data items
     delete_fixture_items_for_data_type(domain_link.linked_domain, linked_data_type._id)
@@ -242,6 +241,7 @@ def update_fixture(domain_link, tag):
         doc["data_type_id"] = linked_data_type._id
         FixtureDataItem.wrap(doc).save()
 
+    clear_fixture_quickcache(domain_link.linked_domain, [linked_data_type])
     clear_fixture_cache(domain_link.linked_domain)
 
 


### PR DESCRIPTION
Fixes two issues:
- Potentially stale lookup tables caches from source domain were used to populate linked domain.
- A race condition existed because the caches were cleared before linked domain items (rows) were synced.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Changes are covered by automated tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
