### PR TITLE
Remove help text for search bar

### DIFF
--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -270,14 +270,6 @@
                         params="value: query,
                                             action: function() { goToPage(1); },
                                             placeholder: '{% trans_html_attr "Search Workers..." %}'"></search-box>
-            <p class="help-block">
-              <i class="fa fa-info-circle"></i>
-              {% blocktrans %}
-                Search any text, or use a targeted query. For more info see the <a
-                      href='https://wiki.commcarehq.org/display/commcarepublic/Create+and+Manage+CommCare+Mobile+Workers#CreateandManageCommCareMobileWorkers-SearchforMobileWorkers'
-                      target='_blank'>Mobile Workers</a> help page
-              {% endblocktrans %}
-            </p>
           </div>
           <div class="col-sm-6">
             <button type="button" class="btn btn-default pull-right"


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Users will no longer see help text telling them to enter queries into the search box. They can still search for matching text.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
In [this ticket](https://dimagi-dev.atlassian.net/browse/SAAS-12433) it is described that the mobile worker search widget returns no users when using queries. This has been broken since 2017 and since the ticket was only created last year, we can safely assume that users don't really use the query functionality. This coupled with the potential security risks of just letting users query our database directly has led us to decide not to support this functionality any further. Therefore I will be removing the help text from the search bar and editing the docs to not mention this functionality.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Did local testing. I'm simply removing some help text so it is pretty safe.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
