### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,8 +20,15 @@ on:
   schedule:
     - cron: '29 18 * * 0'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   analyze:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      security-events: write #  (github/codeql-action/autobuild)
+
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     # see corehq/apps/hqadmin/management/commands/static_analysis.py
     - cron: '47 12 * * *'
+permissions:
+  contents: read # to fetch code (actions/checkout)
 jobs:
   tests:
     runs-on: ubuntu-18.04

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -4,8 +4,12 @@ on:
     - cron: '0 6 * * 3'  # Every Wed at 06:00 UTC
 
 name: Update transifex translations
+permissions: {}
 jobs:
   update_translations:
+    permissions:
+      contents: write # to create branch (peter-evans/create-pull-request)
+      pull-requests: write # to create a PR (peter-evans/create-pull-request)
     name: Update transifex translations
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.