### PR TITLE
Catch keyerror and skip engine id if necessary

### DIFF
--- a/corehq/apps/userreports/management/commands/delete_orphaned_ucrs.py
+++ b/corehq/apps/userreports/management/commands/delete_orphaned_ucrs.py
@@ -192,7 +192,11 @@ def get_tables_without_data_sources(tables_by_engine_id):
     """
     tables_without_data_sources = defaultdict(list)
     for engine_id, expected_tables in tables_by_engine_id.items():
-        engine = connection_manager.get_engine(engine_id)
+        try:
+            engine = connection_manager.get_engine(engine_id)
+        except KeyError:
+            print(f"Engine id {engine_id} does not exist anymore. Skipping.")
+            continue
         with engine.begin() as connection:
             # Using string formatting rather than execute with %s syntax
             # is acceptable here because the strings we're inserting are static


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
In the event that the engine id associated with the datasources/tables no longer exists, we should let the operator know and skip that engine id.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This only introduces skipping a bad engine id if encountered, so no additional risk is added.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
