### PR TITLE
Don't use any login decorator for mobile access

### DIFF
--- a/corehq/apps/ota/decorators.py
+++ b/corehq/apps/ota/decorators.py
@@ -34,7 +34,10 @@ def require_mobile_access(fn):
                 )
                 return HttpResponseForbidden()
 
-        return require_permission(HqPermissions.access_mobile_endpoints, login_decorator=None)(fn)(request, domain, *args, **kwargs)
+        return require_permission(
+            HqPermissions.access_mobile_endpoints,
+            login_decorator=None
+        )(fn)(request, domain, *args, **kwargs)
 
     return _inner
 

--- a/corehq/apps/ota/decorators.py
+++ b/corehq/apps/ota/decorators.py
@@ -21,6 +21,12 @@ ORIGIN_TOKEN_SLUG = 'OriginToken'
 
 
 def require_mobile_access(fn):
+    """
+    This decorator restricts a view to users with the `access_mobile_endpoints`
+    permission.
+    It does not perform any authentication, which must be left to other
+    decorators on the view.
+    """
     @wraps(fn)
     def _inner(request, domain, *args, **kwargs):
         origin_token = request.META.get(ORIGIN_TOKEN_HEADER, None)
@@ -51,10 +57,12 @@ def _test_token_valid(origin_token):
     return False
 
 
-# This decorator should be used for any endpoints used by CommCare mobile
-# It supports basic, session, and apikey auth, but not digest
-# Endpoints with this decorator will not enforce two factor authentication
 def mobile_auth(view_func):
+    """
+    This decorator should be used for any endpoints used by CommCare mobile.
+    It supports basic, session, and apikey auth, but not digest.
+    Endpoints with this decorator will not enforce two factor authentication.
+    """
     return get_multi_auth_decorator(default=BASIC)(
         two_factor_exempt(
             require_mobile_access(view_func)
@@ -62,9 +70,11 @@ def mobile_auth(view_func):
     )
 
 
-# This decorator is used only for anonymous web apps and SMS forms
-# Endpoints with this decorator will not enforce two factor authentication
 def mobile_auth_or_formplayer(view_func):
+    """
+    This decorator is used only for anonymous web apps and SMS forms.
+    Endpoints with this decorator will not enforce two factor authentication.
+    """
     return get_multi_auth_decorator(default=BASIC, allow_formplayer=True)(
         two_factor_exempt(
             require_mobile_access(view_func)

--- a/corehq/apps/ota/decorators.py
+++ b/corehq/apps/ota/decorators.py
@@ -34,7 +34,7 @@ def require_mobile_access(fn):
                 )
                 return HttpResponseForbidden()
 
-        return require_permission(HqPermissions.access_mobile_endpoints)(fn)(request, domain, *args, **kwargs)
+        return require_permission(HqPermissions.access_mobile_endpoints, login_decorator=None)(fn)(request, domain, *args, **kwargs)
 
     return _inner
 

--- a/corehq/apps/ota/tests/test_digest_restore.py
+++ b/corehq/apps/ota/tests/test_digest_restore.py
@@ -14,7 +14,7 @@ from corehq.util.test_utils import flag_enabled
 from python_digest import build_authorization_request, calculate_nonce
 
 
-def mock_require_permission(_):
+def mock_require_permission(*args, **kwargs):
     return lambda fn: fn
 
 


### PR DESCRIPTION
require_mobile_access appears to be incorrectly calling require_permission with the default login_decorator (login_and_domain_required), which should not be needed and instead blocks mobile requests when 2FA is enabled.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-13981

## Safety Assurance

### Safety story

The change has been tested on staging.

### Automated test coverage

Tests already cover the affected code and have been updated to account for the additional parameter.

### QA Plan

No QA needed. The limited scope, test coverage, and manual testing on staging are deemed sufficient.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
