### PR TITLE
Updated error handling in template tags that expect JSON

### DIFF
--- a/corehq/apps/hqwebapp/exceptions.py
+++ b/corehq/apps/hqwebapp/exceptions.py
@@ -4,3 +4,7 @@ class AlreadyRenderedException(Exception):
 
 class ResourceVersionsNotFoundException(Exception):
     pass
+
+
+class TemplateTagJSONException(Exception):
+    pass

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -23,10 +23,9 @@ from django_prbac.utils import has_privilege
 from dimagi.utils.web import json_handler
 
 from corehq import privileges
-from corehq.apps.hqwebapp.exceptions import AlreadyRenderedException
+from corehq.apps.hqwebapp.exceptions import AlreadyRenderedException, TemplateTagJSONException
 from corehq.apps.hqwebapp.models import MaintenanceAlert
 from corehq.motech.utils import pformat_json
-from corehq.util.soft_assert import soft_assert
 
 register = template.Library()
 
@@ -39,11 +38,9 @@ def JSON(obj):
     try:
         return escape_script_tags(json.dumps(obj, default=json_handler))
     except TypeError as e:
-        msg = ("Unserializable data was sent to the `|JSON` template tag.  "
-               "If DEBUG is off, Django will silently swallow this error.  "
+        msg = ("Unserializable data was sent to a template tag that expectes JSON. "
                "{}".format(str(e)))
-        soft_assert(notify_admins=True)(False, msg)
-        raise e
+        raise TemplateTagJSONException(msg)
 
 
 def escape_script_tags(unsafe_str):
@@ -595,10 +592,19 @@ def _create_page_data(parser, token, node_slug):
     value = parser.compile_filter(split_contents[2])
 
     class FakeNode(template.Node):
+        # must mock token or error handling code will fail and not reveal real error
+        token = Token(TokenType.TEXT, '', (0, 0), 0)
+
         def render(self, context):
             resolved = value.resolve(context)
+            try:
+                resolved_json = html_attr(resolved)
+            except TemplateTagJSONException as e:
+                msg = ("Error in initial page data key '{}'. "
+                       "{}".format(name, str(e)))
+                raise TemplateTagJSONException(msg)
             return ("<div data-name=\"{}\" data-value=\"{}\"></div>"
-                    .format(name, html_attr(resolved)))
+                    .format(name, resolved_json))
 
     nodelist = NodeList([FakeNode()])
 


### PR DESCRIPTION
## Technical Summary
Better surface dev-facing errors in the `initial_page_data`, `html_attr`, and `trans_html_attr` tags.

Before, errors in initial page data tended to look like this:
![Screen Shot 2022-09-27 at 4 56 06 PM](https://user-images.githubusercontent.com/1486591/192634604-a1dcc81b-6cdf-4f64-90cb-882cde0a2083.png)

Now they identify that they're a problem with a specific piece of initial page data:
![Screen Shot 2022-09-27 at 4 56 12 PM](https://user-images.githubusercontent.com/1486591/192634677-df890ee8-611b-428d-9986-26eb632711db.png)

Errors in `html_attr` or `trans_html_attr` looked like this:
![Screen Shot 2022-09-27 at 4 56 01 PM](https://user-images.githubusercontent.com/1486591/192634195-41547778-e899-43a1-8b54-e1e45d725b71.png)

Now they at least give you a more specific error:
![Screen Shot 2022-09-27 at 4 56 09 PM](https://user-images.githubusercontent.com/1486591/192634319-a7bc99dc-b15b-426a-a61b-ac6964e15e6d.png)


## Safety Assurance

### Safety story
I think local testing is sufficient for this one. Tested an `initial_page_data` and an `html_attr` tag locally, passing both JSON-serializable and non-JSON-serializable data.

### Automated test coverage
There are some templatetags tests.

### QA Plan
Not requesting QA for this.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
