### PR TITLE
Fix docs for add_commcare_build "--build_version" flag

### DIFF
--- a/corehq/apps/builds/README.rst
+++ b/corehq/apps/builds/README.rst
@@ -117,7 +117,7 @@ Using a management command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - `./manage.py add_commcare_build --latest` To fetch the latest released build from github
-- `./manage.py add_commcare_build --version=2.53.0` To manually specify the build number to use
+- `./manage.py add_commcare_build --build_version 2.53.0` To manually specify the build number to use
 - `./manage.py add_commcare_build path/to/build/ 2.53.0 2321` To make a J2ME build from a zip. The args are build_path, version, and build_number
 
 

--- a/corehq/apps/builds/management/commands/add_commcare_build.py
+++ b/corehq/apps/builds/management/commands/add_commcare_build.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
     help = textwrap.dedent("""
         Adds a commcare build, labeled with the version (x.y.z) Usage:
         "./manage.py add_commcare_build --latest" or
-        "./manage.py add_commcare_build --version=2.53.0" see also
+        "./manage.py add_commcare_build --build_version 2.53.0" see also
         https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/builds/README.rst
     """)
 


### PR DESCRIPTION
## Technical Summary
Was adding CommCare version locally and found the command different than listed. Changes .rst doc and internal help that reference `add_commcare_build --version=BUILD` to be `add_commcare_build --build_version BUILD`


## Safety Assurance

### Safety story
Minor change to docs only.

### Automated test coverage


### QA Plan



### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
