### PR TITLE
Use correct Python version for Stickler

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -6,7 +6,7 @@ files:
 
 linters:
   flake8:
-    python: 3.9
+    python: 3
     config: .flake8
   eslint:
     config: ./.eslintrc.js


### PR DESCRIPTION
From Stickler support: `3.9` isn't a valid value. Try using `python: 3`

Reverts https://github.com/dimagi/commcare-hq/pull/32176

## Safety Assurance

### Safety story

Changes Stickler CI config only.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
