### PR TITLE
remove notice that OIDC is still in development from accounting admin edit IdP form

### DIFF
--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -414,7 +414,6 @@ class EditIdentityProviderAdminForm(forms.Form):
                 crispy.Div(*sp_details_form.service_provider_fields),
                 crispy.Div(*sp_details_form.token_encryption_fields),
             )
-            protocol_notice = current_protocol_name
         else:
             rp_details_form = RelyingPartyDetailsForm(identity_provider)
             self.fields.update(rp_details_form.fields)
@@ -422,13 +421,6 @@ class EditIdentityProviderAdminForm(forms.Form):
                 _('Relying Party Settings'),
                 'slug',
                 crispy.Div(*rp_details_form.application_details_fields),
-            )
-            # todo remove when OIDC is active
-            protocol_notice = format_html(
-                "{}<p class='alert alert-warning'>"
-                "<strong>Please Note that OIDC support is still in development!</strong><br/> "
-                "Do not make any Identity Providers live on production.</p>",
-                current_protocol_name
             )
 
         from corehq.apps.accounting.views import ManageBillingAccountView
@@ -453,7 +445,6 @@ class EditIdentityProviderAdminForm(forms.Form):
                 crispy.Div(
                     crispy.Fieldset(
                         _('Primary Configuration'),
-                        protocol_notice,
                         hqcrispy.B3TextField(
                             'owner',
                             format_html(
@@ -464,7 +455,7 @@ class EditIdentityProviderAdminForm(forms.Form):
                         ),
                         hqcrispy.B3TextField(
                             'protocol',
-                            protocol_notice
+                            current_protocol_name
                         ),
                         hqcrispy.B3TextField(
                             'idp_type',


### PR DESCRIPTION
## Technical Summary
Small change that removes the FYI/warning notice on the Accounting Admin edit Identity Provider form that OIDC is in development. We have completed partner testing, so it's good to go.

## Safety Assurance

### Safety story
Minor form change to Accounting Admin. Does not impact general users

### Automated test coverage
Yes

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
