### PR TITLE
Removed unused datatables dependencies from web apps

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -11,8 +11,6 @@
 
 {% block head %}
   {{ block.super }}
-  <script src="{% static 'datatables.net/js/jquery.dataTables.min.js' %}"></script>
-  <script src="{% static 'datatables-bootstrap3/BS3/assets/js/datatables.js' %}"></script>
   <style id="persistent-cell-layout-style"></style>
   <style id="persistent-cell-grid-style"></style>
   <style id="list-cell-layout-style"></style>
@@ -35,10 +33,6 @@
   {% compress css %}
     <link rel="stylesheet" href="{% static 'nprogress/nprogress.css' %}">
     <link rel="stylesheet" href="{% static 'At.js/dist/css/jquery.atwho.min.css' %}">
-    <link type="text/css"
-          rel="stylesheet"
-          media="all"
-          href="{% static 'datatables.net-dt/css/jquery.dataTables.min.css' %}"/>
     <link rel="stylesheet" href="{% static 'cloudcare/css/webforms.css' %}">
     <link rel="stylesheet" href="{% static 'bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css' %}"/>
   {% endcompress %}

--- a/corehq/apps/cloudcare/templates/formplayer-common/base.html
+++ b/corehq/apps/cloudcare/templates/formplayer-common/base.html
@@ -46,10 +46,6 @@
   <link rel="stylesheet" href="{% static 'nprogress/nprogress.css' %}">
   <link rel="stylesheet" href="{% static 'jquery-ui-built-themes/base/jquery-ui.min.css' %}">
   <link rel="stylesheet" href="{% static 'At.js/dist/css/jquery.atwho.min.css' %}">
-  <link type="text/css"
-        rel="stylesheet"
-        media="all"
-        href="{% static 'datatables.net-dt/css/jquery.dataTables.min.css' %}"/>
 
   {% javascript_libraries underscore=True jquery_ui=True ko=True hq=True analytics=True %}
   <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -70,7 +70,6 @@ from corehq.apps.domain.decorators import (
 from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.decorators import (
     use_daterangepicker,
-    use_datatables,
     use_jquery_ui,
     waf_allow,
 )
@@ -100,7 +99,6 @@ class FormplayerMain(View):
     urlname = 'formplayer_main'
 
     @use_daterangepicker
-    @use_datatables
     @use_jquery_ui
     @method_decorator(require_cloudcare_access)
     @method_decorator(requires_privilege_for_commcare_user(privileges.CLOUDCARE))
@@ -243,7 +241,6 @@ class FormplayerPreviewSingleApp(View):
 
     urlname = 'formplayer_single_app'
 
-    @use_datatables
     @use_jquery_ui
     @method_decorator(require_cloudcare_access)
     @method_decorator(requires_privilege_for_commcare_user(privileges.CLOUDCARE))


### PR DESCRIPTION
## Technical Summary
I was thinking about js dependencies in web apps and noticed web apps depends on datatables, though I'm fairly certain it isn't used.

`grep -i datatables corehq/apps/cloudcare` returns nothing (other than the code removed in this PR) - @biyeun that's a reasonable test of datatables usage, right? I also clicked around in web apps locally after removing datatables and didn't run into any issues.

## Safety Assurance

### Safety story
Removing dead code.

### Automated test coverage

Unlikely

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
