### PR TITLE
[USH-2469] include deleted indices in restore

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -102,7 +102,7 @@ class IndexTest(TestCase):
             user_id=self.user.user_id,
             owner_id=self.user.user_id,
             create=True,
-            index={'dad': ('father-case', self.FATHER_CASE_ID)},
+            index={'mom': ('mother-case', ''), 'dad': ('father-case', self.FATHER_CASE_ID)},
             date_modified=now,
             date_opened=now.date()
         ).as_xml()

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -968,8 +968,7 @@ class CommCareCaseIndexManager(RequireDBManager):
         return list(query.filter(case_id=case_id, domain=domain))
 
     def get_related_indices(self, domain, case_ids, exclude_indices):
-        """Get indices (forward and reverse) for the given set of case ids. This will only return
-        'live' indices.
+        """Get indices (forward and reverse) for the given set of case ids.
 
         :param case_ids: A list of case ids.
         :param exclude_indices: A set or dict of index id strings with

--- a/corehq/sql_accessors/migrations/0067_livequery_sql_include_deleted_indices.py
+++ b/corehq/sql_accessors/migrations/0067_livequery_sql_include_deleted_indices.py
@@ -8,7 +8,9 @@ migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {})
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('sql_accessors', '0066_drop_unused_function'),
+        ('sql_accessors', '0067_livequery_sql'),
     ]
 
-    operations = []
+    operations = [
+        migrator.get_migration('get_related_indices.sql'),
+    ]

--- a/corehq/sql_accessors/sql_templates/get_related_indices.sql
+++ b/corehq/sql_accessors/sql_templates/get_related_indices.sql
@@ -19,7 +19,6 @@ BEGIN
     FROM form_processor_commcarecaseindexsql
     JOIN case_ids ON cid = case_id -- case_id points to child/extension
     WHERE domain = domain_name
-        AND referenced_id != '' -- ignore deleted indices
         AND case_id || ' ' || identifier NOT IN (SELECT xid FROM exclude_indices)
 
     UNION

--- a/migrations.lock
+++ b/migrations.lock
@@ -892,6 +892,7 @@ sql_accessors
  0065_get_ledger_values_for_cases_3
  0066_drop_unused_function
  0067_livequery_sql
+ 0067_livequery_sql_include_deleted_indices
 sql_proxy_accessors
  0001_initial
  0002_add_sync_functions


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-2469

## Technical Summary
In fixing a [previous sync bug](https://github.com/dimagi/commcare-hq/pull/32088) the livequery code was updated to ignore deleted indices (to prevent pulling in cases with delete extension indexes).

This inadvertently resulted in deleted indices not being included in the restore since they were not being fetched by livequery (and we don't re-fetch them: https://github.com/dimagi/commcare-hq/blob/cdc8b6708d365839a68cc9944a28f2819a862042/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py#L93).

This PR reverts the previous change so that all indexes are fetched during restore but
adds an additional filter stage to ignore when calculating cases to sync.

## Safety Assurance

### Safety story
Generally this is quite safe in that the code is well tested and the bug is well understood.

### Automated test coverage
Added in this PR

### QA Plan
None

### Migrations
This includes a migration which will be run on all the case databases which will delete and re-create the function. This is safe since the function is backwards compatible with existing code. Also the migration is run inside a transaction so the 'drop and re-create' will be applied atomically.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
