### PR TITLE
Add requirements.txt/M1 issues section to dev_setup_mac

### DIFF
--- a/DEV_SETUP_MAC.md
+++ b/DEV_SETUP_MAC.md
@@ -125,6 +125,18 @@
   pip install psycopg2-binary
   ```
 
+### M1 Issues
+
+- `gevent` may present errors when installing with Python <3.9. For this reason, you should avoid using an older version of Python unless it is required.
+
+- `pynacl` will likely install but may throw an error `symbol not found in flat namespace '_ffi_prep_closure'` when attempting to run, particularly when setting up CommCare-Cloud.
+
+  This can be fixed by installing a version of `pynacl` specific to the system architecture:
+  ```sh
+  arch -arm64 pip install --upgrade --force-reinstall pynacl
+  ```
+
+
 ## Docker
 
 Docker images that will not run on Mac OS (Intel or M1):


### PR DESCRIPTION
## Product Description

## Technical Summary
Add notes and solutions for issues with `gevent`and `pynacl` on an M1 Mac that were encountered when setting up Commcare-Cloud. It's possible this belongs in that repo instead, but this felt a reasonable place given it is Mac-specific setup info.

## Feature Flag

## Safety Assurance

### Safety story
Changes to docs only.

### Automated test coverage

### QA Plan

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
