### PR TITLE
Multi-Select: Remove selections upon form submission

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -221,6 +221,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
         };
 
         this.onSubmit = function () {
+            sessionStorage.removeItem('selectedValues');
             this.page = null;
             this.sortIndex = null;
             this.search = null;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Flagged from [this interrupt ticket ](https://dimagi-dev.atlassian.net/browse/USH-2503)
There was an error triggered fro some dedupe workflows that contained multi-select case lists

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This adds a clear upon form submission of the cases saved in `selectedValues`. This was not here previously because it's also cleared in other functions that are called the same time as onSubmit. However, my guess is this complicated workflow BHA is using does not have the other functions called. This caused the workflow to fail the second time around, but "starting over" (clicking the home button) calls the functions with the selectedValues clearing and lets it succeed again. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
MULTI_SELECT_CASE_LISTS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
