### PR TITLE
Multi-select detail popup fixes

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -141,7 +141,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var tabListView = hqImport("cloudcare/js/formplayer/menus/views").DetailTabListView({
             collection: tabCollection,
             showDetail: function (detailTabIndex) {
-                showDetail(model, detailTabIndex, caseId);
+                showDetail(model, detailTabIndex, caseId, isMultiSelect);
             },
         });
         var detailFooterView = hqImport("cloudcare/js/formplayer/menus/views").CaseDetailFooterView({

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -140,7 +140,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
 
         var tabListView = hqImport("cloudcare/js/formplayer/menus/views").DetailTabListView({
             collection: tabCollection,
-            showDetail: function (detailTabIndex) {
+            onTabClick: function (detailTabIndex) {
                 showDetail(model, detailTabIndex, caseId, isMultiSelect);
             },
         });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -159,6 +159,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
     var getDetailList = function (detailObject) {
         var i;
         if (detailObject.get('entities')) {
+            // This is a data tab, displaying a table
             var entities = detailObject.get('entities');
             var listModel = [];
             // we need to map the details and headers JSON to a list for a Backbone Collection
@@ -179,6 +180,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             return hqImport("cloudcare/js/formplayer/menus/views").CaseListDetailView(menuData);
         }
 
+        // This is a regular detail, displaying name-value pairs
         var headers = detailObject.get('headers');
         var details = detailObject.get('details');
         var styles = detailObject.get('styles');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -161,7 +161,11 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
                 });
             }
             if (menuResponse.tiles === null || menuResponse.tiles === undefined) {
-                return hqImport("cloudcare/js/formplayer/menus/views").CaseListView(menuData);
+                if (menuData.isMultiSelect) {
+                    return hqImport("cloudcare/js/formplayer/menus/views").MultiSelectCaseListView(menuData);
+                } else {
+                    return hqImport("cloudcare/js/formplayer/menus/views").CaseListView(menuData);
+                }
             } else {
                 if (menuResponse.numEntitiesPerRow > 1) {
                     return hqImport("cloudcare/js/formplayer/menus/views").GridCaseTileListView(menuData);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -328,18 +328,18 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         initialize: function (options) {
-            this.styles = options.styles;
-            this.hasNoItems = options.collection.length === 0;
-            this.redoLast = options.redoLast;
+            var self = this;
+            self.styles = options.styles;
+            self.hasNoItems = options.collection.length === 0;
+            self.redoLast = options.redoLast;
             if (sessionStorage.selectedValues !== undefined) {
                 let parsedSelectedValues = JSON.parse(sessionStorage.selectedValues)[sessionStorage.queryKey];
-                this.selectedCaseIds = parsedSelectedValues !== undefined && parsedSelectedValues !== '' ? parsedSelectedValues.split(',') : [];
+                self.selectedCaseIds = parsedSelectedValues !== undefined && parsedSelectedValues !== '' ? parsedSelectedValues.split(',') : [];
             } else {
-                this.selectedCaseIds = [];
+                self.selectedCaseIds = [];
             }
-            this.isMultiSelect = options.isMultiSelect;
+            self.isMultiSelect = options.isMultiSelect;
 
-            var self = this;
             FormplayerFrontend.on("multiSelect:updateCases", function (action, caseIds) {
                 if (action === Constants.MULTI_SELECT_ADD) {
                     self.selectedCaseIds = _.union(self.selectedCaseIds, caseIds);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -510,7 +510,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         initialize: function (options) {    // eslint-disable-line no-unused-vars
             MultiSelectCaseListView.__super__.initialize.apply(this, arguments);
             var self = this;
-            FormplayerFrontend.on("multiSelect:updateCases", function (action, caseIds) {
+            // Remove any event handling left over from previous instances of MultiSelectCaseListView.
+            // Only one of these views is supporteed on the page at any given time.
+            FormplayerFrontend.off("multiSelect:updateCases").on("multiSelect:updateCases", function (action, caseIds) {
                 if (action === Constants.MULTI_SELECT_ADD) {
                     self.selectedCaseIds = _.union(self.selectedCaseIds, caseIds);
                 } else {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -338,6 +338,16 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 this.selectedCaseIds = [];
             }
             this.isMultiSelect = options.isMultiSelect;
+
+            var self = this;
+            FormplayerFrontend.on("multiSelect:updateCases", function (action, caseIds) {
+                if (action === Constants.MULTI_SELECT_ADD) {
+                    self.selectedCaseIds = _.union(self.selectedCaseIds, caseIds);
+                } else {
+                    self.selectedCaseIds = _.difference(self.selectedCaseIds, caseIds);
+                }
+                self.reconcileMultiSelectUI();
+            });
         },
 
         ui: {
@@ -372,15 +382,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         onRender: function () {
-            var self = this;
-            FormplayerFrontend.off("multiSelect:updateCases").on("multiSelect:updateCases", function (action, caseIds) {
-                if (action === Constants.MULTI_SELECT_ADD) {
-                    self.selectedCaseIds = _.union(self.selectedCaseIds, caseIds);
-                } else {
-                    self.selectedCaseIds = _.difference(self.selectedCaseIds, caseIds);
-                }
-                self.reconcileMultiSelectUI();
-            });
             this.reconcileMultiSelectUI();
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -314,6 +314,34 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
     });
 
+    var CaseListViewUI = function () {
+        return {
+            actionButton: '.case-list-action-button button',
+            searchButton: '#case-list-search-button',
+            searchTextBox: '.module-search-container',
+            paginators: '.js-page',
+            paginationGoButton: '#pagination-go-button',
+            paginationGoTextBox: '.module-go-container',
+            columnHeader: '.header-clickable',
+            paginationGoText: '#goText',
+            casesPerPageLimit: '.per-page-limit',
+        };
+    };
+
+    var CaseListViewEvents = function () {
+        return {
+            'click @ui.actionButton': 'caseListAction',
+            'click @ui.searchButton': 'caseListSearch',
+            'click @ui.paginators': 'paginateAction',
+            'click @ui.paginationGoButton': 'paginationGoAction',
+            'click @ui.columnHeader': 'columnSortAction',
+            'change @ui.casesPerPageLimit': 'onPerPageLimitChange',
+            'keypress @ui.searchTextBox': 'searchTextKeyAction',
+            'keypress @ui.paginationGoTextBox': 'paginationGoKeyAction',
+            'keypress @ui.paginators': 'paginateKeyAction',
+        };
+    };
+
     var CaseListView = Marionette.CollectionView.extend({
         tagName: "div",
         template: _.template($("#case-view-list-template").html() || ""),
@@ -340,29 +368,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             }
         },
 
-        ui: {
-            actionButton: '.case-list-action-button button',
-            searchButton: '#case-list-search-button',
-            searchTextBox: '.module-search-container',
-            paginators: '.js-page',
-            paginationGoButton: '#pagination-go-button',
-            paginationGoTextBox: '.module-go-container',
-            columnHeader: '.header-clickable',
-            paginationGoText: '#goText',
-            casesPerPageLimit: '.per-page-limit',
-        },
+        ui: CaseListViewUI(),
 
-        events: {
-            'click @ui.actionButton': 'caseListAction',
-            'click @ui.searchButton': 'caseListSearch',
-            'click @ui.paginators': 'paginateAction',
-            'click @ui.paginationGoButton': 'paginationGoAction',
-            'click @ui.columnHeader': 'columnSortAction',
-            'change @ui.casesPerPageLimit': 'onPerPageLimitChange',
-            'keypress @ui.searchTextBox': 'searchTextKeyAction',
-            'keypress @ui.paginationGoTextBox': 'paginationGoKeyAction',
-            'keypress @ui.paginators': 'paginateKeyAction',
-        },
+        events: CaseListViewEvents(),
 
         caseListAction: function (e) {
             var index = $(e.currentTarget).data().index,
@@ -480,22 +488,18 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
     });
 
     var MultiSelectCaseListView = CaseListView.extend({
-        ui: function () {
-            return _.extend(MultiSelectCaseListView.__super__.ui, {
-                selectAllCheckbox: "#select-all-checkbox",
-                continueButton: "#multi-select-continue-btn",
-                continueButtonText: "#multi-select-btn-text",
-            });
-        },
+        ui: _.extend(CaseListViewUI(), {
+            selectAllCheckbox: "#select-all-checkbox",
+            continueButton: "#multi-select-continue-btn",
+            continueButtonText: "#multi-select-btn-text",
+        }),
 
-        events: function () {
-            return _.extend(MultiSelectCaseListView.__super__.events, {
-                'click @ui.selectAllCheckbox': 'selectAllAction',
-                'keypress @ui.selectAllCheckbox': 'selectAllAction',
-                'click @ui.continueButton': 'continueAction',
-                'keypress @ui.continueButton': 'continueAction',
-            });
-        },
+        events: _.extend(CaseListViewEvents(), {
+            'click @ui.selectAllCheckbox': 'selectAllAction',
+            'keypress @ui.selectAllCheckbox': 'selectAllAction',
+            'click @ui.continueButton': 'continueAction',
+            'keypress @ui.continueButton': 'continueAction',
+        }),
 
         childViewOptions: function () {
             var options = MultiSelectCaseListView.__super__.childViewOptions.apply(this);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -503,7 +503,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             return options;
         },
 
-        initialize: function (options) {
+        initialize: function (options) {    // eslint-disable-line no-unused-vars
             MultiSelectCaseListView.__super__.initialize.apply(this, arguments);
             var self = this;
             FormplayerFrontend.on("multiSelect:updateCases", function (action, caseIds) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -747,11 +747,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         initialize: function (options) {
             this.index = options.model.get('id');
             this.active = options.model.get('active');
-            this.showDetail = options.showDetail;
+            this.onTabClick = options.onTabClick;
         },
         tabClick: function (e) {
             e.preventDefault();
-            this.options.showDetail(this.index);
+            this.options.onTabClick(this.index);
         },
     });
 
@@ -762,7 +762,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         childViewContainer: "ul",
         childViewOptions: function () {
             return {
-                showDetail: this.options.showDetail,
+                onTabClick: this.options.onTabClick,
             };
         },
     });

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -151,7 +151,6 @@
 
 <script type="text/template" id="case-view-list-detail-template">
   <div class="module-case-list-container">
-    <div class="page-header menu-header"><h1 class="page-title"><%- title %></h1></div>
     <div class="module-case-list-table-container">
       <table class="table module-table module-table-case-list">
         <thead>


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2522

## Technical Summary
This fixes two bugs in multiselect case lists
1. https://github.com/dimagi/commcare-hq/commit/748a35a648e43a3890f130220fcb0afc6aeeade8 fixes an issue where when you're on a multiselect case list, pop up case details, then click on a detail tab, the UI switches from the multiselect Select + Cancel buttons to the single select Continue button.
1. https://github.com/dimagi/commcare-hq/commit/d61daadd4a38b56252e5ec94fde1897d7627590e fixes the main issue in the linked ticket, where the "Select" button doesn't work and the checkboxes stop responding after the first time you look at a case detail popup.
   * The [event handler for selecting multiple cases](https://github.com/dimagi/commcare-hq/blob/a6a25f2d1b77ae04eecc4cc0f554ccb93adf58ac/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js#L376-L383) is in `CaseListView.onRender` (CaseListView is the view for the entire case list). It uses the pattern of calling `off` and then `on`, so the event doesn't get attached multiple times as the view is repeatedly rendered.
   * The bug happens when you have a detail popup with a data tab to display a table of child cases. This table uses the `CaseListDetailView`, which is a [subclass of CaseListView](https://github.com/dimagi/commcare-hq/blob/a6a25f2d1b77ae04eecc4cc0f554ccb93adf58ac/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js#L647-L650).
   * When the `CaseListDetailView` is rendered, the `off` call in `onRender` removes the `multiSelect:updateCases` handler that the `CaseListView` had added. It then attaches a new handler, with itself as the `self` referenced in the handler. When that new handler is called, it doesn't update the UI, because its call to `reconcileMultiSelectUI` returns early due to [this check](https://github.com/dimagi/commcare-hq/blob/a6a25f2d1b77ae04eecc4cc0f554ccb93adf58ac/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js#L475-L477). `CaseListDetailView` doesn't define `isMultiSelect`, that flag isn't relevant to it.
   * Moving the event handler to `initialize` fixes this because it lets me remove the `off`, since initialize isn't called multiple times. So now the handler gets called twice: first by the `CaseListView`, which does the update, and then by the `CaseListDetailView`, which does nothing.

I'm not in love with the handler being called twice, thinking about moving the event attaching into a helper function in `CaseListView` and then having subclasses override that helper to do nothing. A cleaner option could be to pull the multiselect logic into a new MultiselectCaseList class, which would subclass CaseListView. Open to feedback.

The other commits are little refactors.

This PR also removes the all-caps header here, because it's redundant with the tab name and it's ugly:
![Screen Shot 2022-10-11 at 4 07 08 PM](https://user-images.githubusercontent.com/1486591/195188272-4e0ac602-0feb-4015-ac71-98e5fa53dd5f.png)

## Feature Flag
USH: Allow selecting multiple cases from the case list

## Safety Assurance

### Safety story
This is somewhat risky, since we have poor view-level test coverage in web apps.

On the bright side, this feature is only used by one client, so the impact is limited.

### Automated test coverage

None

### QA Plan
https://dimagi-dev.atlassian.net/browse/QA-4597

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
