### PR TITLE
add pool_recycle to sqlalchemy engine

### DIFF
--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -29,7 +29,7 @@ def create_engine(connection_url: str, connect_args: dict = None):
     # paramstyle='format' allows you to use column names that include the ')' character
     # otherwise queries will sometimes be misformated/error when formatting
     # https://github.com/zzzeek/sqlalchemy/blob/ff20903/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L173
-    # Pool recycle set smaller than NLB idle timeout to prevent reusing connections
+    # Pool recycle set smaller than NLB idle timeout (non-configurable 350s) to prevent reusing connections
     # that have been closed by the NLB
     connect_args = connect_args or {}
     return sqlalchemy.create_engine(

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -29,8 +29,15 @@ def create_engine(connection_url: str, connect_args: dict = None):
     # paramstyle='format' allows you to use column names that include the ')' character
     # otherwise queries will sometimes be misformated/error when formatting
     # https://github.com/zzzeek/sqlalchemy/blob/ff20903/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L173
+    # Pool recycle set smaller than NLB idle timeout to prevent reusing connections
+    # that have been closed by the NLB
     connect_args = connect_args or {}
-    return sqlalchemy.create_engine(connection_url, paramstyle='format', connect_args=connect_args)
+    return sqlalchemy.create_engine(
+        connection_url,
+        paramstyle='format',
+        pool_recycle=300,
+        connect_args=connect_args
+    )
 
 
 class SessionHelper(object):


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This adds a timeout to connections in the sqlalchemy connection pool, replacing them if they are older than 300 seconds. That ensures sqlalchemy will not reuse a connection that has already been closed by the network load balancer, which has a non-configurable idle timeout of 350 seconds. Use of already closed connections is the suspected cause of the hanging queries referenced in https://dimagi-dev.atlassian.net/browse/USH-2498 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This changes no behavior other than how often sqlalchemy makes new connections.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Connection code is well tested and if this breaks the ability to make connections to the UCR db, that will be found in tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
