### PR TITLE
Sort repeat records after getting from couch

### DIFF
--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -122,7 +122,7 @@ def get_paged_couch_repeat_records(domain, skip, limit, repeater_id=None, state=
     kwargs.update(_get_startkey_endkey_all_records(domain, repeater_id, state))
 
     results = RepeatRecord.get_db().view('repeaters/repeat_records', **kwargs).all()
-    results.sort(key=lambda result: result['doc']['registered_on'], reverse=True)
+    results.sort(key=lambda result: (result['doc']['registered_on'] or 0), reverse=True)
 
     return [RepeatRecord.wrap(result['doc']) for result in results]
 

--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -122,6 +122,7 @@ def get_paged_couch_repeat_records(domain, skip, limit, repeater_id=None, state=
     kwargs.update(_get_startkey_endkey_all_records(domain, repeater_id, state))
 
     results = RepeatRecord.get_db().view('repeaters/repeat_records', **kwargs).all()
+    results.sort(key=lambda result: result['doc']['registered_on'], reverse=True)
 
     return [RepeatRecord.wrap(result['doc']) for result in results]
 


### PR DESCRIPTION
## Product Description
Reorders data forwarding records report chronologically, rather than by status, when no record status is selected as a filter.

## Technical Summary
[USH-2509](https://dimagi-dev.atlassian.net/browse/USH-2509?atlOrigin=eyJpIjoiNDRlNDMzMjZlZmQ4NDBlZmI4ZmJjODk2YTUxNGU4NmIiLCJwIjoiaiJ9)
Resolves an issue where records with the status of "cancelled" are sorted to the end of the list and may seem to disappear, especially when there are multiple pages of records. This seems to be because of how the view `repeaters/repeat_records` returns records from Couch.

## Safety Assurance

### Safety story
This change sorts an existing list object only, and has no other interactions.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
