### PR TITLE
Improve safety of `delete_domain` command

### DIFF
--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -3,6 +3,7 @@ import textwrap
 from django.core.management.base import BaseCommand
 
 from corehq.apps.domain.dbaccessors import iter_all_domains_and_deleted_domains_with_name
+from corehq.apps.domain.utils import is_domain_in_use
 
 
 class Command(BaseCommand):
@@ -19,8 +20,20 @@ class Command(BaseCommand):
             default=False,
             help='Skip important confirmation warnings.',
         )
+        parser.add_argument(
+            '--ignore-domain-in-use-check',
+            action='store_true',
+            dest='ignore_domain_in_use',
+            default=False,
+            help='Allow deleting a domain that is in use.',
+        )
 
     def handle(self, domain_name, **options):
+        if not options['ignore_domain_in_use'] and is_domain_in_use(domain_name):
+            print(f'WARNING: Domain {domain_name} is currently in use. If you are sure you want to delete'
+                  f'this domain, use the "--ignore_domain_in_use" argument.')
+            return
+
         domain_objs = list(iter_all_domains_and_deleted_domains_with_name(domain_name))
         if not domain_objs:
             print('domain with name "{}" not found'.format(domain_name))

--- a/corehq/apps/domain/management/commands/hard_delete_forms_and_cases_in_domain.py
+++ b/corehq/apps/domain/management/commands/hard_delete_forms_and_cases_in_domain.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
             action='store_true',
             dest='ignore_domain_in_use',
             default=False,
-            help='Allow deleting a domain that is in use.',
+            help='Allow deleting forms and cases for a domain that is in use.',
         )
 
     def handle(self, domain, **options):

--- a/corehq/apps/domain/management/commands/hard_delete_forms_and_cases_in_domain.py
+++ b/corehq/apps/domain/management/commands/hard_delete_forms_and_cases_in_domain.py
@@ -3,7 +3,7 @@ import logging
 from django.core.management import BaseCommand
 
 from ...deletion import delete_all_cases, delete_all_forms
-from ...models import Domain
+from ...utils import is_domain_in_use
 
 logger = logging.getLogger(__name__)
 
@@ -20,19 +20,19 @@ class Command(BaseCommand):
             help='Skip important confirmation warnings.',
         )
         parser.add_argument(
-            '--allow-active-domain',
+            '--ignore-domain-in-use-check',
             action='store_true',
-            dest='allow_active_domain',
+            dest='ignore_domain_in_use',
             default=False,
-            help='Override deleted domain check.',
+            help='Allow deleting a domain that is in use.',
         )
 
     def handle(self, domain, **options):
-        domain_obj = Domain.get_by_name(domain)
-        if not options['allow_active_domain'] and domain_obj and not domain_obj.doc_type.endswith('-Deleted'):
-            print(f'WARNING: Domain {domain} is an active domain. If your intention is to delete the domain, you '
+        if not options['ignore_domain_in_use'] and is_domain_in_use(domain):
+            print(f'WARNING: Domain {domain} is currently in use. If your intention is to delete the domain, you '
                   f'should use the `delete_domain` command instead. If you are sure you want to delete forms and'
-                  f'cases for this domain, use the "--allow-active-domain" argument.')
+                  f'cases for this domain, use the "--ignore_domain_in_use" argument.')
+            return
 
         if not options['noinput']:
             confirm = input(

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -122,7 +122,10 @@ from corehq.apps.zapier.models import ZapierSubscription
 from corehq.blobs import CODES, NotFound, get_blob_db
 from corehq.form_processor.backends.sql.dbaccessors import doc_type_to_state
 from corehq.form_processor.models import CommCareCase, XFormInstance
-from corehq.form_processor.tests.utils import create_form_for_test
+from corehq.form_processor.tests.utils import (
+    create_case,
+    create_form_for_test,
+)
 from corehq.motech.models import ConnectionSettings, RequestLog
 from corehq.motech.repeaters.const import RECORD_SUCCESS_STATE
 from corehq.motech.repeaters.models import (
@@ -1035,84 +1038,92 @@ class TestDeleteDomain(TestCase):
         self.assertEqual(count_lookup_table_row_owners(self.domain2.name), 1)
 
 
-class TestHardDeleteSQLFormsAndCases(TestCase):
+class HardDeleteFormsAndCasesInDomainTests(TestCase):
 
-    def setUp(self):
-        super(TestHardDeleteSQLFormsAndCases, self).setUp()
-        self.domain = Domain(name='test')
-        self.domain.save()
-        self.addCleanup(ensure_deleted, self.domain)
-        self.domain2 = Domain(name='test2')
-        self.domain2.save()
-        self.addCleanup(ensure_deleted, self.domain2)
+    def test_normal_forms_are_deleted(self):
+        create_form_for_test(self.deleted_domain.name)
+        call_command('hard_delete_forms_and_cases_in_domain', self.deleted_domain.name, noinput=True)
+        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.deleted_domain.name)), 0)
+
+    def test_archived_forms_are_deleted(self):
+        create_form_for_test(self.deleted_domain.name, state=XFormInstance.ARCHIVED)
+        call_command('hard_delete_forms_and_cases_in_domain', self.deleted_domain.name, noinput=True)
+        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.deleted_domain.name)), 0)
+
+    def test_soft_deleted_forms_are_deleted(self):
+        create_form_for_test(self.deleted_domain.name, state=XFormInstance.DELETED)
+        call_command('hard_delete_forms_and_cases_in_domain', self.deleted_domain.name, noinput=True)
+        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.deleted_domain.name)), 0)
+
+    def test_forms_are_deleted_for_specified_domain_only(self):
+        create_form_for_test(self.deleted_domain.name)
+        create_form_for_test(self.extra_deleted_domain.name)
+        call_command('hard_delete_forms_and_cases_in_domain', self.deleted_domain.name, noinput=True)
+        self.addCleanup(self._cleanup_forms_and_cases, self.extra_deleted_domain.name)
+        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.deleted_domain.name)), 0)
+        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.extra_deleted_domain.name)), 1)
+
+    def test_cases_are_deleted(self):
+        create_case(self.domain_in_use.name, save=True)
+        call_command('hard_delete_forms_and_cases_in_domain', self.deleted_domain.name, noinput=True)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.deleted_domain.name)), 0)
+
+    def test_soft_deleted_cases_are_deleted(self):
+        case = create_case(self.domain_in_use.name, save=True)
+        CommCareCase.objects.soft_delete_cases(self.deleted_domain.name, [case.case_id])
+        call_command('hard_delete_forms_and_cases_in_domain', self.deleted_domain.name, noinput=True)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.deleted_domain.name)), 0)
+
+    def test_cases_are_deleted_for_specified_domain_only(self):
+        create_case(self.deleted_domain.name, save=True)
+        create_case(self.extra_deleted_domain.name, save=True)
+        call_command('hard_delete_forms_and_cases_in_domain', self.deleted_domain.name, noinput=True)
+        self.addCleanup(self._cleanup_forms_and_cases, self.extra_deleted_domain.name)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.deleted_domain.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.extra_deleted_domain.name)), 1)
+
+    def test_forms_and_cases_are_not_deleted_if_domain_in_use(self):
+        # a form is created as a byproduct of case creation
+        create_case(self.domain_in_use.name, save=True)
+        call_command('hard_delete_forms_and_cases_in_domain', self.domain_in_use.name, noinput=True)
+        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.domain_in_use.name)), 1)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain_in_use.name)), 1)
+        self.assertEqual(len(XFormInstance.objects.get_deleted_form_ids_in_domain(self.domain_in_use.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain_in_use.name)), 0)
+
+    def test_forms_and_cases_are_deleted_if_domain_in_use_but_ignore_flag_is_true(self):
+        # a form is created as a byproduct of case creation
+        create_case(self.domain_in_use.name, save=True)
+        call_command('hard_delete_forms_and_cases_in_domain', self.domain_in_use.name, noinput=True,
+                     ignore_domain_in_use=True)
+        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.domain_in_use.name)), 0)
+        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain_in_use.name)), 0)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.deleted_domain = Domain(name='deleted-domain')
+        cls.deleted_domain.save()
+        cls.deleted_domain.delete(leave_tombstone=True)
+        cls.addClassCleanup(ensure_deleted, cls.deleted_domain)
+
+        cls.extra_deleted_domain = Domain(name='extra-deleted-domain')
+        cls.extra_deleted_domain.save()
+        cls.extra_deleted_domain.delete(leave_tombstone=True)
+        cls.addClassCleanup(ensure_deleted, cls.extra_deleted_domain)
+
+        cls.domain_in_use = Domain(name='domain-in-use')
+        cls.domain_in_use.save()
+        cls.addClassCleanup(ensure_deleted, cls.domain_in_use)
+
+    def _cleanup_forms_and_cases(self, domain_name):
+        call_command('hard_delete_forms_and_cases_in_domain', domain_name, noinput=True, ignore_domain_in_use=True)
 
     def tearDown(self):
-        call_command('hard_delete_forms_and_cases_in_domain', self.domain2.name, noinput=True)
-        call_command('hard_delete_forms_and_cases_in_domain', self.domain.name, noinput=True)
-        super(TestHardDeleteSQLFormsAndCases, self).tearDown()
-
-    def test_forms_are_hard_deleted(self):
-        for domain_name in [self.domain.name, self.domain2.name]:
-            create_form_for_test(domain_name)
-            create_form_for_test(domain_name, state=XFormInstance.ARCHIVED)
-            self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(domain_name)), 1)
-
-        call_command('hard_delete_forms_and_cases_in_domain', self.domain.name, noinput=True)
-
-        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.domain.name)), 0)
-        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.domain2.name)), 1)
-
-        self.assertEqual(len(XFormInstance.objects.get_deleted_form_ids_in_domain(self.domain.name)), 0)
-        self.assertEqual(len(XFormInstance.objects.get_deleted_form_ids_in_domain(self.domain2.name)), 0)
-
-    def test_soft_deleted_forms_are_hard_deleted(self):
-        for domain_name in [self.domain.name, self.domain2.name]:
-            create_form_for_test(domain_name)
-            create_form_for_test(domain_name, state=XFormInstance.DELETED)
-            self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(domain_name)), 1)
-
-        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.domain.name)), 1)
-        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.domain2.name)), 1)
-
-        self.assertEqual(len(XFormInstance.objects.get_deleted_form_ids_in_domain(self.domain.name)), 1)
-        self.assertEqual(len(XFormInstance.objects.get_deleted_form_ids_in_domain(self.domain2.name)), 1)
-
-        call_command('hard_delete_forms_and_cases_in_domain', self.domain.name, noinput=True)
-
-        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.domain.name)), 0)
-        self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.domain2.name)), 1)
-
-        self.assertEqual(len(XFormInstance.objects.get_deleted_form_ids_in_domain(self.domain.name)), 0)
-        self.assertEqual(len(XFormInstance.objects.get_deleted_form_ids_in_domain(self.domain2.name)), 1)
-
-    def test_cases_are_hard_deleted(self):
-        for domain_name in [self.domain.name, self.domain2.name]:
-            CaseFactory(domain_name).create_case()
-            self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(domain_name)), 1)
-
-        call_command('hard_delete_forms_and_cases_in_domain', self.domain.name, noinput=True)
-
-        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
-        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
-
-        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain.name)), 0)
-        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
-
-    def test_soft_deleted_cases_are_hard_deleted(self):
-        for domain_name in [self.domain.name, self.domain2.name]:
-            CaseFactory(domain_name).create_case()
-            self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(domain_name)), 1)
-
-        case_ids_to_soft_delete = CommCareCase.objects.get_case_ids_in_domain(self.domain.name)
-        CommCareCase.objects.soft_delete_cases(self.domain.name, case_ids_to_soft_delete)
-
-        call_command('hard_delete_forms_and_cases_in_domain', self.domain.name, noinput=True)
-
-        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain.name)), 0)
-        self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(self.domain2.name)), 1)
-
-        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain.name)), 0)
-        self.assertEqual(len(CommCareCase.objects.get_deleted_case_ids_in_domain(self.domain2.name)), 0)
+        for domain in [self.deleted_domain, self.extra_deleted_domain, self.domain_in_use]:
+            self._cleanup_forms_and_cases(domain.name)
+        super().tearDown()
 
 
 def ensure_deleted(domain):

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -13,7 +13,6 @@ from django.test import TestCase
 from dateutil.relativedelta import relativedelta
 from unittest.mock import patch
 
-from casexml.apps.case.mock import CaseFactory
 from casexml.apps.phone.models import SyncLogSQL
 from couchforms.models import UnfinishedSubmissionStub
 
@@ -302,7 +301,7 @@ class TestDeleteDomain(TestCase):
 
     def _test_case_deletion(self):
         for domain_name in [self.domain.name, self.domain2.name]:
-            CaseFactory(domain_name).create_case()
+            create_case(domain_name, save=True)
             self.assertEqual(len(CommCareCase.objects.get_case_ids_in_domain(domain_name)), 1)
 
         self.domain.delete()

--- a/corehq/apps/domain/tests/test_utils.py
+++ b/corehq/apps/domain/tests/test_utils.py
@@ -1,6 +1,7 @@
 import json
 from contextlib import contextmanager
 from random import randint
+from unittest.mock import patch
 
 from django.test import SimpleTestCase, TestCase
 
@@ -12,6 +13,7 @@ from corehq.apps.domain.utils import (
     get_serializable_wire_invoice_general_credit,
     guess_domain_language,
     guess_domain_language_for_sms,
+    is_domain_in_use,
 )
 from corehq.apps.users.models import CommCareUser
 from corehq.motech.utils import b64_aes_decrypt
@@ -174,3 +176,41 @@ class TestGetDomainURLSlug(SimpleTestCase):
     ])
     def test_stop_words_excluded(self, hr_name, max_length, expected):
         self.assertEqual(expected, get_domain_url_slug(hr_name, max_length=max_length))
+
+
+class IsDomainInUseTests(SimpleTestCase):
+
+    def test_domain_in_use_returns_true(self):
+        self.mock_get_by_name.return_value = self.domain_actively_in_use
+        self.assertTrue(is_domain_in_use(self.domain_actively_in_use.name))
+
+    def test_paused_domain_returns_true(self):
+        self.mock_get_by_name.return_value = self.paused_domain
+        self.assertTrue(is_domain_in_use(self.paused_domain.name))
+
+    def test_deleted_domain_returns_false(self):
+        self.mock_get_by_name.return_value = self.deleted_domain
+        self.assertFalse(is_domain_in_use(self.deleted_domain.name))
+
+    def test_active_deleted_domain_returns_false(self):
+        # should not be possible to get into this state (active + deleted)
+        self.mock_get_by_name.return_value = self.active_deleted_domain
+        self.assertFalse(is_domain_in_use(self.active_deleted_domain.name))
+
+    def test_non_existent_domain_returns_false(self):
+        self.mock_get_by_name.return_value = None
+        self.assertFalse(is_domain_in_use('non-existent-domain'))
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_actively_in_use = Domain(doc_type="Domain", name="domain-in-use", is_active=True)
+        cls.paused_domain = Domain(doc_type="Domain", name="domain-paused", is_active=False)
+        cls.deleted_domain = Domain(doc_type="Domain-Deleted", name="domain-deleted", is_active=False)
+        # should not be possible to get into this state
+        cls.active_deleted_domain = Domain(doc_type="Domain-Deleted", name="domain-deleted", is_active=True)
+
+    def setUp(self):
+        self.get_by_name_patcher = patch('corehq.apps.domain.utils.Domain.get_by_name')
+        self.mock_get_by_name = self.get_by_name_patcher.start()
+        self.addCleanup(self.get_by_name_patcher.stop)

--- a/corehq/apps/domain/utils.py
+++ b/corehq/apps/domain/utils.py
@@ -158,3 +158,8 @@ def log_domain_changes(user, domain, new_obj, old_obj):
 def encrypt_account_confirmation_info(commcare_user):
     data = {"user_id": commcare_user.get_id, "time": int(time.time())}
     return b64_aes_encrypt(json.dumps(data))
+
+
+def is_domain_in_use(domain_name):
+    domain_obj = Domain.get_by_name(domain_name)
+    return domain_obj and not domain_obj.doc_type.endswith('-Deleted')


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
**Review by commit**


One cause of https://dimagi-dev.atlassian.net/browse/SAAS-14021 was the lack of a check in the `delete_domain` command to ensure the domain is no longer in use before deleting. I added this logic to `hard_delete_forms_and_cases` earlier this year, but should have included this command in that as well. I've made some slight modifications to the existing logic/flag name, wrapped the logic into a separate helper with tests, and added it to the `delete_domain` command.

My reasoning for changing the language from "is active" to "is in use" is because there is a specific `is_active` flag on a Domain object that is not directly related to whether or not the domain is eligible to be deleted. If there are better suggestions for clear naming here, I'm open to it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The logic added here is for commands that deal with deleting data which is inherently risky. However with the tests on the helper method, and the simple logic to check if the results of the helper should be ignored or not, this seems safe after going through peer review.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests for the helper method `is_domain_in_use`.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
