### PR TITLE
turn off sqlalchemy connection pooling

### DIFF
--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -9,6 +9,7 @@ from memoized import memoized
 from urllib.parse import urlencode
 from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.orm.session import sessionmaker
+from sqlalchemy.pool import NullPool
 
 from corehq.util.test_utils import unit_testing_only
 
@@ -29,13 +30,12 @@ def create_engine(connection_url: str, connect_args: dict = None):
     # paramstyle='format' allows you to use column names that include the ')' character
     # otherwise queries will sometimes be misformated/error when formatting
     # https://github.com/zzzeek/sqlalchemy/blob/ff20903/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L173
-    # Pool recycle set smaller than NLB idle timeout (non-configurable 350s) to prevent reusing connections
-    # that have been closed by the NLB
+    # Turn off sqlalchemy connection pooling since we use pgbouncer for connection pooling already
     connect_args = connect_args or {}
     return sqlalchemy.create_engine(
         connection_url,
         paramstyle='format',
-        pool_recycle=300,
+        pool_class=NullPool,
         connect_args=connect_args
     )
 

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -35,7 +35,7 @@ def create_engine(connection_url: str, connect_args: dict = None):
     return sqlalchemy.create_engine(
         connection_url,
         paramstyle='format',
-        pool_class=NullPool,
+        poolclass=NullPool,
         connect_args=connect_args
     )
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
More aggressive followup to https://github.com/dimagi/commcare-hq/pull/32242. This time we are turning off connection pooling completely as per the instructions in https://docs.sqlalchemy.org/en/14/core/pooling.html#switching-pool-implementations. SQLAlchemy is the only place we use connection pooling on the django side, and pgbouncer covers those needs on the db side.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This changes no application behavior, just connection settings.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests cover whether connections work.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
