### PR TITLE
Revert sqlalchemy pool changes

### DIFF
--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -30,12 +30,10 @@ def create_engine(connection_url: str, connect_args: dict = None):
     # paramstyle='format' allows you to use column names that include the ')' character
     # otherwise queries will sometimes be misformated/error when formatting
     # https://github.com/zzzeek/sqlalchemy/blob/ff20903/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L173
-    # Turn off sqlalchemy connection pooling since we use pgbouncer for connection pooling already
     connect_args = connect_args or {}
     return sqlalchemy.create_engine(
         connection_url,
         paramstyle='format',
-        poolclass=NullPool,
         connect_args=connect_args
     )
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Reverts https://github.com/dimagi/commcare-hq/pull/32248 and https://github.com/dimagi/commcare-hq/pull/32242 because they appear to have caused an increase in connection errors on unrelated dbs in the case pillow

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just a revert to previous settings

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
