### PR TITLE
register index and add adapter when using custom pillow

### DIFF
--- a/corehq/apps/es/transient_util.py
+++ b/corehq/apps/es/transient_util.py
@@ -78,16 +78,16 @@ def populate_doc_adapter_map():
 
     if settings.UNIT_TESTING:
         from pillowtop.tests.utils import TEST_INDEX_INFO
-        _add_test_adapter("PillowTop", TEST_INDEX_INFO.index,
-                        TEST_INDEX_INFO.type, TEST_INDEX_INFO.mapping,
-                        TEST_INDEX_INFO.alias)
+        add_dynamic_es_adapter("PillowTop", TEST_INDEX_INFO.index,
+                               TEST_INDEX_INFO.type, TEST_INDEX_INFO.mapping,
+                               TEST_INDEX_INFO.alias)
 
         from corehq.apps.es.tests.utils import TEST_ES_INFO, TEST_ES_MAPPING
-        _add_test_adapter("UtilES", TEST_ES_INFO.alias, TEST_ES_INFO.type,
-                        TEST_ES_MAPPING, TEST_ES_INFO.alias)
+        add_dynamic_es_adapter("UtilES", TEST_ES_INFO.alias, TEST_ES_INFO.type,
+                               TEST_ES_MAPPING, TEST_ES_INFO.alias)
 
 
-def _add_test_adapter(descriptor, index_, type_, mapping_, alias):
+def add_dynamic_es_adapter(descriptor, index_, type_, mapping_, alias):
 
     class Adapter(ElasticDocumentAdapter):
         index_name = index_  # override the classproperty

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -234,6 +234,12 @@ def get_case_search_to_elasticsearch_pillow(pillow_id='CaseSearchToElasticsearch
         index_info = ElasticsearchIndexInfo.wrap(raw_info)
         index_info.index = kwargs['index_name']
         index_info.alias = kwargs['index_alias']
+        from corehq.apps.es.registry import register
+        from corehq.apps.es.transient_util import add_dynamic_es_adapter
+        register(index_info, index_info.alias)
+        add_dynamic_es_adapter(
+            "CaseSearchBackfill", index_info.index, index_info.type, index_info.mapping, index_info.alias
+        )
 
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, index_info, topics.CASE_TOPICS)
     case_processor = CaseSearchPillowProcessor(


### PR DESCRIPTION
## Technical Summary
This is necessary when running the 'backfill' pillow which has a different index and alias: https://github.com/dimagi/commcare-cloud/pull/5521

This avoids the `invalid index alias` error.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
