### PR TITLE
Re-updated app manager intro content

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -214,7 +214,7 @@ def get_releases_context(request, domain, app_id):
         context.update({
             'enable_update_prompts': app.enable_update_prompts,
         })
-        if app.version == 1:
+        if app.version == 1 and len(app.modules) == 0:
             context.update({'intro_only': True})
 
         # Multimedia is not supported for remote applications at this time.


### PR DESCRIPTION
## Product Description
Tweak https://github.com/dimagi/commcare-hq/pull/32035 so the intro content doesn't show when you import or copy an app.

## Safety Assurance

### Safety story
Trivial

### Automated test coverage
no

### QA Plan
no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
