### PR TITLE
Use ubuntu-22.04 for tests on Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
     - cron: '47 12 * * *'
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
The [ubuntu-18.04 image is being deprecated](https://github.com/actions/runner-images/issues/6002). Our build probably doesn’t depend on anything specific to 18.04. The test runner and backing services are containerized.

## Safety Assurance

### Safety story

Only affects the test runner, so it should be safe if the tests pass.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
