### PR TITLE
Add waf_allow decorator to `accept_invitation`

### DIFF
--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -33,7 +33,7 @@
                     </p>
                     <p>
                       {% blocktrans with user.username as username %}
-                        Are you sure you want to to accept the invitation
+                        Are you sure you want to accept the invitation
                         to join the CommCare HQ {{ invite_type }}
                         <strong>{{ invite_to }}</strong> as <strong>{{ username }}</strong>?
                       {% endblocktrans %}

--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext_lazy
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_POST
 
+from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.registration.models import AsyncSignupRequest
 from corehq.apps.sso.models import IdentityProvider
 from dimagi.utils.couch import CriticalSection
@@ -219,6 +220,7 @@ class UserInvitationView(object):
             return reverse("domain_homepage", args=[domain])
 
 
+@waf_allow('XSS_BODY')
 @always_allow_project_access
 @location_safe
 @sensitive_post_parameters('password')


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14023

Due to the substring 'on' existing in a user's email address, they are unable to go through the accept invitation workflow and instead get a 403 error raised by the WAF. After reviewing the uses of variables in the `accept_invite.html` template, I didn't see any offending lines that would allow for cross site scripting. Examples of user input being the username itself which needs to be a valid email address (can't contain <script> tags), or the domain which similarly goes through validation.

From what I can tell, that is the only html template I should be concerned about when enabling `waf_allow` on this endpoint, but please correct me if I'm wrong.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Adding a waf_allow decorator only increases flexibility, so there is no risk of breaking anything. The only risk is creating a new security vulnerability since the WAF would no longer attempt to flag XSS issues on this request, but the safety of this change has been vetted as part of this PR.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
