### PR TITLE
Revert check for deleted domain in delete_domain command

### DIFF
--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -3,7 +3,6 @@ import textwrap
 from django.core.management.base import BaseCommand
 
 from corehq.apps.domain.dbaccessors import iter_all_domains_and_deleted_domains_with_name
-from corehq.apps.domain.utils import is_domain_in_use
 
 
 class Command(BaseCommand):
@@ -20,20 +19,8 @@ class Command(BaseCommand):
             default=False,
             help='Skip important confirmation warnings.',
         )
-        parser.add_argument(
-            '--ignore-domain-in-use-check',
-            action='store_true',
-            dest='ignore_domain_in_use',
-            default=False,
-            help='Allow deleting a domain that is in use.',
-        )
 
     def handle(self, domain_name, **options):
-        if not options['ignore_domain_in_use'] and is_domain_in_use(domain_name):
-            print(f'WARNING: Domain {domain_name} is currently in use. If you are sure you want to delete'
-                  f'this domain, use the "--ignore_domain_in_use" argument.')
-            return
-
         domain_objs = list(iter_all_domains_and_deleted_domains_with_name(domain_name))
         if not domain_objs:
             print('domain with name "{}" not found'.format(domain_name))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Cal pointed out how non-sensical this was 🤦🏻. As part of deleting a domain, a domain's doc is set to `Domain-Deleted`. So to check that the doc is already `Domain-Deleted` prior to deleting doesn't make sense, and would require using the --ignore flag every time we want to use `delete_domain`. Reverting the change that impacted the `delete_domain` command, but keeping the rest of the changes from https://github.com/dimagi/commcare-hq/pull/32247.

In the original ticket I read
> The project space linked below was deleted as per our offboarding process and it turns out it was actually active.

And got carried away thinking we should have a check in code that makes sure the domain isn't active, without thinking about what that really meant for this command.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
