### PR TITLE
First arg is request or None, not string

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -231,7 +231,8 @@ def _rebuild_case_with_retries(self, domain, case_id, detail):
             self.retry(exc=exc)
         except MaxRetriesExceededError:
             notify_exception(
-                "Maximum Retries Exceeded while rebuilding case {} during deletion.".format(case_id)
+                None,
+                f"Maximum Retries Exceeded while rebuilding case {case_id} during deletion.",
             )
 
 

--- a/corehq/util/signals.py
+++ b/corehq/util/signals.py
@@ -11,7 +11,7 @@ from dimagi.utils.logging import notify_exception
 
 @task_failure.connect
 def log_celery_task_exception(task_id, exception, traceback, einfo, *args, **kwargs):
-    notify_exception('Celery task failure', exec_info=einfo.exc_info)
+    notify_exception(None, 'Celery task failure', exec_info=einfo.exc_info)
 
 
 class SignalHandlerContext(object):


### PR DESCRIPTION
Resolves `AttributeError: 'str' object has no attribute 'path'`

More details from Sentry:
`Signal handler "<function log_celery_task_exception at 0x7ff4fd06c790>" raised: "AttributeError(\"'str' object has no attribute 'path'\")"`

## Safety Assurance

### Safety story

Minor fix for error observed on sentry.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
