### PR TITLE
Set appropriate workflows when creating `DomainCaseRuleRun`s

### DIFF
--- a/corehq/apps/data_interfaces/deduplication.py
+++ b/corehq/apps/data_interfaces/deduplication.py
@@ -154,6 +154,7 @@ def backfill_deduplicate_rule(domain, rule):
             started_on=now,
             status=DomainCaseRuleRun.STATUS_RUNNING,
             case_type=rule.case_type,
+            workflow=AutomaticUpdateRule.WORKFLOW_DEDUPLICATE,
         )
         action = CaseDeduplicationActionDefinition.from_rule(rule)
         case_iterator = AutomaticUpdateRule.iter_cases(

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -145,7 +145,8 @@ def run_case_update_rules_for_domain(domain, now=None):
             domain=domain,
             started_on=datetime.utcnow(),
             status=DomainCaseRuleRun.STATUS_RUNNING,
-            case_type=case_type
+            case_type=case_type,
+            workflow=AutomaticUpdateRule.WORKFLOW_CASE_UPDATE,
         )
 
         for db in get_db_aliases_for_partitioned_query():


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup to https://github.com/dimagi/commcare-hq/pull/32220

The intention was to decouple the migration from the code that makes use of the new `workflow` field. This simply sets the appropriate workflow when creating a `DomainCaseRuleRun` based on the context.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The `workflow` field is brand new and unused, so this is a very safe change.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
