### PR TITLE
Pagination widget set firstItem to 0 if 0 totalItems

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
@@ -96,7 +96,7 @@ hqDefine('hqwebapp/js/components/pagination', [
                 return _.template(
                     params.itemsTextTemplate || gettext('Showing <%- firstItem %> to <%- lastItem %> of <%- maxItems %> entries')
                 )({
-                    firstItem: ((self.currentPage() - 1) * self.perPage()) + 1,
+                    firstItem: self.totalItems() > 0 ? ((self.currentPage() - 1) * self.perPage()) + 1 : 0,
                     lastItem: isNaN(lastItem) ? 1 : lastItem,
                     maxItems: self.totalItems(),
                 });


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
In the event that there are no items in a table, the pagination widget currently still sets `firstItem` to 1, which results in confusing text. This just checks if there are 0 `totalItems`, and if so sets `firstItem` to 0 as well.

Before
![Screen Shot 2022-10-18 at 5 45 19 AM](https://user-images.githubusercontent.com/15785053/196438955-75992b1b-4dcb-4e21-9935-fdd85eec20d4.png)

After
![Screen Shot 2022-10-18 at 6 09 55 AM](https://user-images.githubusercontent.com/15785053/196438924-8088ca32-d2c1-40c2-b506-b71af3ed283e.png)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
