### PR TITLE
Revert "Revert sqlalchemy pool changes"

### DIFF
--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -30,10 +30,12 @@ def create_engine(connection_url: str, connect_args: dict = None):
     # paramstyle='format' allows you to use column names that include the ')' character
     # otherwise queries will sometimes be misformated/error when formatting
     # https://github.com/zzzeek/sqlalchemy/blob/ff20903/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L173
+    # Turn off sqlalchemy connection pooling since we use pgbouncer for connection pooling already
     connect_args = connect_args or {}
     return sqlalchemy.create_engine(
         connection_url,
         paramstyle='format',
+        poolclass=NullPool,
         connect_args=connect_args
     )
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#32250

Now that the UCR dbs have [dedicated pgbouncer machines](https://github.com/dimagi/commcare-cloud/pull/5536), and therefore this change is unlikely to affect any other DB, I would like to roll it out again