### PR TITLE
add decorators for permissions and csrf to generic inbound API view

### DIFF
--- a/corehq/motech/generic_inbound/tests/test_api.py
+++ b/corehq/motech/generic_inbound/tests/test_api.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 from django.test import TestCase
 from django.urls import reverse
 
+from corehq import privileges
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.userreports.const import UCR_NAMED_EXPRESSION
 from corehq.apps.userreports.models import UCRExpression
@@ -14,8 +15,10 @@ from corehq.motech.generic_inbound.models import (
     ProcessingAttempt,
     RequestLog,
 )
+from corehq.util.test_utils import privilege_enabled
 
 
+@privilege_enabled(privileges.API_ACCESS)
 class TestGenericInboundAPIView(TestCase):
     domain_name = 'ucr-api-test'
     example_post_data = {'name': 'cricket', 'is_team_sport': True}
@@ -24,7 +27,7 @@ class TestGenericInboundAPIView(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.domain = create_domain(cls.domain_name)
-        cls.user = WebUser.create(cls.domain_name, 'test@dimagi.com', 'secret', None, None)
+        cls.user = WebUser.create(cls.domain_name, 'test@dimagi.com', 'secret', None, None, is_admin=True)
         cls.addClassCleanup(cls.domain.delete)
 
         cls.api_key, _ = HQApiKey.objects.get_or_create(user=cls.user.get_django_user())
@@ -116,8 +119,8 @@ class TestGenericInboundAPIView(TestCase):
             HTTP_AUTHORIZATION=f"apikey {self.user.username}:{self.api_key.key}",
             HTTP_USER_AGENT="user agent string",
         )
+        self.assertEqual(response.status_code, 200, response.content)
         response_json = response.json()
-        self.assertEqual(response.status_code, 200, response_json)
         self.assertItemsEqual(response_json.keys(), ['cases', 'form_id'])
         self.assertEqual(response_json['cases'][0]['owner_id'], self.user.get_id)
         return response_json

--- a/corehq/motech/generic_inbound/utils.py
+++ b/corehq/motech/generic_inbound/utils.py
@@ -21,12 +21,7 @@ def get_context_from_request(request):
         raise GenericInboundUserError(_("Payload must be valid JSON"))
 
     couch_user = request.couch_user
-    if couch_user.is_commcare_user():
-        restore_user = couch_user.to_ota_restore_user(couch_user)
-    elif couch_user.is_web_user():
-        restore_user = couch_user.to_ota_restore_user(request.domain, couch_user)
-    else:
-        raise GenericInboundUserError(_("Unknown user type"))
+    restore_user = couch_user.to_ota_restore_user(couch_user, request_user=couch_user)
 
     query = dict(request.GET.lists())
     return get_evaluation_context(

--- a/corehq/motech/generic_inbound/utils.py
+++ b/corehq/motech/generic_inbound/utils.py
@@ -21,7 +21,7 @@ def get_context_from_request(request):
         raise GenericInboundUserError(_("Payload must be valid JSON"))
 
     couch_user = request.couch_user
-    restore_user = couch_user.to_ota_restore_user(couch_user, request_user=couch_user)
+    restore_user = couch_user.to_ota_restore_user(request.domain, request_user=couch_user)
 
     query = dict(request.GET.lists())
     return get_evaluation_context(

--- a/corehq/util/view_utils.py
+++ b/corehq/util/view_utils.py
@@ -96,7 +96,7 @@ def _get_json_exception_response(code, request, exception, log_message=None):
 
 
 def _json_exception_response_data(code, exception):
-    if isinstance(exception.args[0], bytes):
+    if exception.args and isinstance(exception.args[0], bytes):
         message = exception.args[0].decode('utf-8')
     else:
         message = str(exception)


### PR DESCRIPTION
## Technical Summary
These should have been applied earlier to restrict access based on subscription plan and user permissions.

Also making the view `csrf_exempt` since it's an API view.

The last commit is a tiny cleanup.

## Feature Flag
Generic inbound API

## Safety Assurance

### Safety story
Standard decorators applied to APIs.

### Automated test coverage
Test updated in the PR

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
