### PR TITLE
disable api throttle in tests

### DIFF
--- a/corehq/motech/generic_inbound/tests/test_api.py
+++ b/corehq/motech/generic_inbound/tests/test_api.py
@@ -15,10 +15,11 @@ from corehq.motech.generic_inbound.models import (
     ProcessingAttempt,
     RequestLog,
 )
-from corehq.util.test_utils import privilege_enabled
+from corehq.util.test_utils import privilege_enabled, flag_enabled
 
 
 @privilege_enabled(privileges.API_ACCESS)
+@flag_enabled('API_THROTTLE_WHITELIST')
 class TestGenericInboundAPIView(TestCase):
     domain_name = 'ucr-api-test'
     example_post_data = {'name': 'cricket', 'is_team_sport': True}


### PR DESCRIPTION
## Technical Summary
Enable the 'throttle whitelist' flag for Generic API tests.

## Safety Assurance

### Safety story
Change to tests only 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
