### PR TITLE
Update minimatch to ^3.0.5 (3.1.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "lodash": "^4.17.19",
         "mem": "^4.0.0",
         "minimist": "^1.2.6",
-        "minimatch": "^3.0.2",
+        "minimatch": "^3.0.5",
         "moment-timezone": "^0.5.35",
         "normalize-url": "^4.5.1",
         "set-value": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3399,10 +3399,10 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-"minimatch@2 || 3", minimatch@3.0.4, minimatch@4.2.1, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2, minimatch@^5.0.1, minimatch@~3.0.2, minimatch@~3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@4.2.1, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2, minimatch@^5.0.1, minimatch@~3.0.2, minimatch@~3.0.4:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 


### PR DESCRIPTION
## Product Description
No change

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-14055

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

The diff is fairly small https://github.com/isaacs/minimatch/compare/v3.0.4...v3.1.2, nothing looks that concerning. This is a low profile sub-dependency, and there aren't any big changes in its spec'd behavior between these versions.

### Automated test coverage

There likely isn't any meaningful test coverage.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
