### PR TITLE
Lookup Table Owners Issue

### DIFF
--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -92,10 +92,10 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
 
     now = datetime.utcnow
     last_update = [now()]
-    upate_period = timedelta(seconds=1)  # do not update progress more than once a second
+    update_period = timedelta(seconds=1)  # do not update progress more than once a second
 
     def _update_progress(event_count, item_count, items_in_table):
-        if task and now() - last_update[0] > upate_period:
+        if task and now() - last_update[0] > update_period:
             last_update[0] = now()
             processed = event_count * 10 + (10 * item_count / items_in_table)
             processed = min(processed, total_events)  # limit at 100%

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -177,8 +177,8 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
         for n, item_row in enumerate(fixture_data):
             _update_progress(event_count, n, num_rows)
             data_items_book_by_type[data_type.tag].append(item_row)
-            max_groups = max(max_groups, owner_names.count(item_row, OwnerType.User))
-            max_users = max(max_users, owner_names.count(item_row, OwnerType.Group))
+            max_groups = max(max_groups, owner_names.count(item_row, OwnerType.Group))
+            max_users = max(max_users, owner_names.count(item_row, OwnerType.User))
             max_locations = max(max_locations, owner_names.count(item_row, OwnerType.Location))
             for field_key in item_row.fields:
                 if field_key in max_field_prop_combos:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14051

Users encountered issues when attempting to upload lookup tables that assigned rows to groups, similar to this:
![Screen Shot 2022-10-24 at 10 23 08 AM](https://user-images.githubusercontent.com/15785053/197587659-5074201c-bb65-45c8-a803-e59a179733b9.png)

resulted in

![Screen Shot 2022-10-24 at 10 22 23 AM](https://user-images.githubusercontent.com/15785053/197587543-834cbf11-0f83-4d80-af65-496e0d52f050.png)

This issue was due to a minor bug where `OwnerType.Group` and `OwnerType.User` were switched.
```
max_groups = max(max_groups, owner_names.count(item_row, OwnerType.User))
max_users = max(max_users, owner_names.count(item_row, OwnerType.Group))
```

This `_prepare_fixture` has already been flagged as an area of code that needs work, and is prone to errors due to the difficulty testing this behemoth.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and resolves issue. This is a safe change as it is only correcting existing behavior, but not fundamentally changing anything.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
