### PR TITLE
Do not use transaction for Couch to SQL migrations

### DIFF
--- a/corehq/apps/fixtures/migrations/0008_sqllookuptables.py
+++ b/corehq/apps/fixtures/migrations/0008_sqllookuptables.py
@@ -7,6 +7,7 @@ from ..management.commands.populate_lookuptablerowowners import Command as Looku
 
 
 class Migration(migrations.Migration):
+    atomic = False
 
     dependencies = [
         ('fixtures', '0007_db_cascade'),


### PR DESCRIPTION
Hopefully prevent errors like [this one](https://forum.dimagi.com/t/unable-to-run-commcare-deploy/9379).

## Safety Assurance

### Safety story

Small change to a migration script.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations