### PR TITLE
update docker dev ES images with phonetic analysis plugin

### DIFF
--- a/docker/files/Dockerfile.es.2
+++ b/docker/files/Dockerfile.es.2
@@ -1,0 +1,3 @@
+FROM  elasticsearch:2.4.6
+
+RUN bin/plugin install analysis-phonetic

--- a/docker/files/Dockerfile.es.5
+++ b/docker/files/Dockerfile.es.5
@@ -1,0 +1,3 @@
+FROM elasticsearch:5.6.16
+
+RUN bin/elasticsearch-plugin install analysis-phonetic

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -90,7 +90,9 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-redis:}/data
 
   elasticsearch2:
-    image: elasticsearch:2.4.6
+    build:
+      context: .
+      dockerfile: ./files/Dockerfile.es.2
     environment:
       ES_JAVA_OPTS: "-Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
     expose:
@@ -100,7 +102,9 @@ services:
       - ./files/elasticsearch_2.yml:/usr/share/elasticsearch/config/elasticsearch.yml:rw
 
   elasticsearch5:
-    image: elasticsearch:5.6.16
+    build:
+      context: .
+      dockerfile: ./files/Dockerfile.es.5
     environment:
       ES_JAVA_OPTS: "-Xms750m -Xmx750m -Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
     expose:


### PR DESCRIPTION
## Technical Summary
Updates to dev environment setup to include the phonetic-analysis plugin in our ES docker images.

This will be used in the case search index: https://github.com/dimagi/commcare-hq/pull/32173

<a name="local-dev"></a>
## Instructions for devs
This is required to have your local ES containers updated with the new plugin. The plugin must be installed to allow the updated ES mappings to work (you'll see errors in ES tests otherwise).

### Docker instructions

1. Update docker containers

  ```shell
  ./scripts/docker stop elasticsearch2
  ./scripts/docker rm elasticsearch2
  ./scripts/docker up -d elasticsearch2
  ```

2. Check that the new plugin is installed

  ```shell
  curl "localhost:9200/_cat/plugins?s=component&h=component,version"
  > analysis-phonetic 2.4.6
  ```

3. Recreate the index

  ```shell
  ./manage.py ptop_reindexer_v2 case-search --cleanup
  ```

### Non-docker instructions
If you are running ES outside of docker you need to manually install the plugin and restart your ES service:

**Elasticsearch v2**
```
$ <es home>/bin/plugin install analysis-phonetic
```

**Elasticsearch v5**
```
$ <es home>/bin/elasticsearch-plugin install analysis-phonetic
```

Now restart your ES service.

## Safety Assurance

### Safety story
Dev env changes only

### Automated test coverage
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
