### PR TITLE
Fix bug in LookupTableRowManager.iter_by_user

### DIFF
--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -196,10 +196,14 @@ class LookupTableRowManager(models.Manager):
                 break
             row = results._result_cache[-1]
             next_page = models.Q(
+                table_id=row.table_id,
                 sort_key=row.sort_key,
                 id__gt=row.id,
             ) | models.Q(
+                table_id=row.table_id,
                 sort_key__gt=row.sort_key
+            ) | models.Q(
+                table_id__gt=row.table_id,
             )
 
     def with_value(self, domain, table_id, field_name, value):


### PR DESCRIPTION
Querying all rows for a user may match multiple tables, but the `next_page` _WHERE_ clause elements were not constrained by `table_id`, so the result set could be larger or smaller than expected, depending on the sort keys and row ids in the tables.

https://dimagi-dev.atlassian.net/browse/SAAS-14060

### Safety story

Test added to reproduce the bug and ensure that it is fixed.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations