### PR TITLE
Add management command to get es version when index was created

### DIFF
--- a/corehq/apps/es/management/commands/es_version_for_index.py
+++ b/corehq/apps/es/management/commands/es_version_for_index.py
@@ -1,0 +1,45 @@
+from django.core.management.base import BaseCommand
+from corehq.apps.es.client import ElasticManageAdapter
+from corehq.util.markup import SimpleTableWriter, TableRowFormatter
+
+
+class Command(BaseCommand):
+    help = ("Prints the ES version with which each index was created")
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--only-older-version-indexes',
+            default=False,
+            action='store_true',
+            help="""Would only print indexes that were
+            created with versions older than currently running ES""",
+        )
+
+    def _normalize_version(self, version):
+        """
+        Transforms es version string to human readable form
+        """
+        return f"{version[0]}.{version[2]}.{version[4]}"
+
+    def handle(self, only_older_version_indexes, **options):
+        es_manager = ElasticManageAdapter()
+        indices = es_manager.get_indices()
+        current_es_version = es_manager.info()['version']['number']
+
+        rows = []
+        for index_name, index_info in indices.items():
+            version = self._normalize_version(index_info["settings"]["index"]["version"]["created"])
+            aliases = list(index_info["aliases"].keys())
+            alias = aliases[0] if aliases else "--"
+            if only_older_version_indexes and current_es_version <= version:
+                continue
+            rows.append([index_name, alias, version])
+        self.print_table(rows)
+
+    def print_table(self, rows):
+        row_formatter = TableRowFormatter(
+            [60, 20, 20]
+        )
+        SimpleTableWriter(self.stdout, row_formatter).write_table(
+            ['Index Name', 'Alias', 'ES Version'], rows=rows
+        )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A small utility to get list of indexes with the ES versions in which they were created.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
A very secluded change would not interfere with any HQ component.
### Automated test coverage
NA
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
