### PR TITLE
Add checkbox to case search fields

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -148,7 +148,10 @@ hqDefine("app_manager/js/details/case_claim", function () {
             var itemLists = get('js_options').item_lists;
             return _.map(
                 _.filter(itemLists, function (p) {
-                    return p.fixture_type === self.appearance();
+                    return (
+                        p.fixture_type === self.appearance()
+                        || (p.fixture_type === 'lookup_table_fixture' && self.appearance() === 'checkbox')
+                    );
                 }),
                 function (p) {
                     return {
@@ -300,18 +303,14 @@ hqDefine("app_manager/js/details/case_claim", function () {
             var uri = searchProperty.itemset.instance_uri;
             if (uri !== null && uri.includes("commcare-reports")) {
                 appearance = "report_fixture";
-            }
-            else {
+            } else {
                 appearance = "lookup_table_fixture";
             }
         }
         if (searchProperty.appearance === "address") {
             appearance = "address";
         }
-        if (searchProperty.input_ === "checkbox") {
-            appearance = "checkbox";
-        }
-        if (["date", "daterange"].indexOf(searchProperty.input_) !== -1) {
+        if (["date", "daterange", "checkbox"].indexOf(searchProperty.input_) !== -1) {
             appearance = searchProperty.input_;
         }
         return appearance;

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -308,6 +308,9 @@ hqDefine("app_manager/js/details/case_claim", function () {
         if (searchProperty.appearance === "address") {
             appearance = "address";
         }
+        if (searchProperty.input_ === "checkbox") {
+            appearance = "checkbox";
+        }
         if (["date", "daterange"].indexOf(searchProperty.input_) !== -1) {
             appearance = searchProperty.input_;
         }

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -57,7 +57,7 @@
                     <p class="help-block" data-bind="visible: appearance() == 'daterange'">
                       {% trans 'In "YYYY-MM-DD to YYYY-MM-DD" format' %}
                     </p>
-                    <p class="help-block" data-bind="visible: (appearanceFinal() == 'fixture' || appearanceFinal() == 'checkbox') && isMultiselect()">
+                    <p class="help-block" data-bind="visible: (appearanceFinal() == 'fixture' && isMultiselect()) || appearanceFinal() == 'checkbox'">
                       {% trans 'e.g. Use #,# as separator to select multiple values' %}
                     </p>
                   </div>
@@ -97,7 +97,8 @@
                           {% trans "Allow multiple selections" %}
                       </label>
                       <div class="col-xs-12 col-sm-9">
-                          <input type="checkbox" data-bind="checked: isMultiselect"/>
+                          <input type="checkbox" data-bind="visible: appearanceFinal() != 'checkbox', checked: isMultiselect"/>
+                          <input type="checkbox" checked disabled data-bind="visible: appearanceFinal() == 'checkbox'"/>
                       </div>
                   </div>
                 {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -72,8 +72,9 @@
                       <select class="form-control" data-bind="value: appearance">
                         <option value="">{% trans "Text" %}</option>
                         {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
-                          {# limit to USH since datepicker is only available on web apps #}
+                          {# limit to USH since datepicker and checkbox are only available on web apps #}
                           <option value="date">{% trans "Date" %}</option>
+                          <option value="checkbox">{% trans "Checkbox" %}</option>
                         {% endif %}
                         <option value="daterange">{% trans "Date Range" %}</option>
                         <option value="barcode_scan">{% trans "Barcode" %}</option>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -57,7 +57,7 @@
                     <p class="help-block" data-bind="visible: appearance() == 'daterange'">
                       {% trans 'In "YYYY-MM-DD to YYYY-MM-DD" format' %}
                     </p>
-                    <p class="help-block" data-bind="visible: appearanceFinal() == 'fixture' && isMultiselect()">
+                    <p class="help-block" data-bind="visible: (appearanceFinal() == 'fixture' || appearanceFinal() == 'checkbox') && isMultiselect()">
                       {% trans 'e.g. Use #,# as separator to select multiple values' %}
                     </p>
                   </div>
@@ -73,8 +73,10 @@
                         <option value="">{% trans "Text" %}</option>
                         {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
                           {# limit to USH since datepicker and checkbox are only available on web apps #}
-                          <option value="date">{% trans "Date" %}</option>
+                          {% if js_options.has_lookup_tables %}
                           <option value="checkbox">{% trans "Checkbox" %}</option>
+                          {% endif %}
+                          <option value="date">{% trans "Date" %}</option>
                         {% endif %}
                         <option value="daterange">{% trans "Date Range" %}</option>
                         <option value="barcode_scan">{% trans "Barcode" %}</option>
@@ -90,7 +92,7 @@
                       </select>
                     </div>
                   </div>
-                  <div class="form-group" data-bind="visible: appearanceFinal() == 'fixture'">
+                  <div class="form-group" data-bind="visible: appearanceFinal() == 'fixture' || appearanceFinal() == 'checkbox'">
                       <label class="control-label col-xs-12 col-sm-3">
                           {% trans "Allow multiple selections" %}
                       </label>
@@ -111,7 +113,7 @@
                 {% endif %}
               </fieldset>
               {% if js_options.search_prompt_appearance_enabled %}
-              <fieldset data-bind="visible: appearanceFinal() == 'fixture'">
+              <fieldset data-bind="visible: appearanceFinal() == 'fixture' || appearanceFinal() == 'checkbox'">
                 <legend data-bind="text: dropdownLabels().optionsLabel"></legend>
                 <div class="form-group">
                   <label class="control-label col-xs-12 col-sm-3"
@@ -150,8 +152,8 @@
                     <fieldset>
                       <legend>{% trans "Advanced Options" %}</legend>
                       {% if js_options.has_geocoder_privs %}
-                        <div data-bind="visible: appearanceFinal() == 'fixture' || appearance() == ''">
-                          <div class="form-group" >
+                        <div data-bind="visible: ['', 'fixture', 'checkbox'].indexOf(appearanceFinal()) !== -1 ">
+                          <div class="form-group" data-bind="visible: appearanceFinal() !== 'checkbox'">
                             <label class="control-label col-xs-12 col-sm-3">
                               {% trans "Geocoder Receiver Expression" %}
                             </label>
@@ -215,7 +217,7 @@
                       {% endif %}
                     </fieldset>
                 {% endif %}
-                <fieldset data-bind="visible: appearanceFinal() == 'fixture'">
+                <fieldset data-bind="visible: appearanceFinal() == 'fixture' || appearanceFinal() == 'checkbox'">
                   <legend  data-bind="text: dropdownLabels().advancedLabel"></legend>
                   <div class="form-group">
                     <label class="control-label col-xs-12 col-sm-3">

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -46,6 +46,13 @@
             </text>
           </display>
         </prompt>
+        <prompt key="consent" input="checkbox">
+          <display>
+            <text>
+              <locale id="search_property.{module_id}.consent"/>
+            </text>
+          </display>
+        </prompt>
       </query>
       <datum id="search_case_id"
              nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_is_related_case=true())]"

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -44,6 +44,13 @@
             </text>
           </display>
         </prompt>
+        <prompt key="consent" input="checkbox">
+          <display>
+            <text>
+              <locale id="search_property.m0.consent"/>
+            </text>
+          </display>
+        </prompt>
       </query>
       <datum id="search_case_id"
              nodeset="instance('results')/results/case[@case_type='case'][name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name][not(commcare_is_related_case=true())]"

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -164,7 +164,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             ),
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
-                CaseSearchProperty(name='dob', label={'en': 'Date of birth'}, input_="date")
+                CaseSearchProperty(name='dob', label={'en': 'Date of birth'}, input_="date"),
+                CaseSearchProperty(name='consent', label={'en': 'Consent to search'}, input_="checkbox")
             ],
             additional_relevant="instance('groups')/groups/group",
             search_filter="name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name",

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1075,6 +1075,8 @@ def _update_search_properties(module, search_properties, lang='en'):
             ret['appearance'] = 'barcode_scan'
         elif prop.get('appearance', '') == 'address':
             ret['appearance'] = 'address'
+        elif prop.get('appearance', '') == 'checkbox':
+            ret['input_'] = 'checkbox'
         elif prop.get('appearance', '') in ['date', 'daterange']:
             ret['input_'] = prop['appearance']
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1075,9 +1075,7 @@ def _update_search_properties(module, search_properties, lang='en'):
             ret['appearance'] = 'barcode_scan'
         elif prop.get('appearance', '') == 'address':
             ret['appearance'] = 'address'
-        elif prop.get('appearance', '') == 'checkbox':
-            ret['input_'] = 'checkbox'
-        elif prop.get('appearance', '') in ['date', 'daterange']:
+        elif prop.get('appearance', '') in ('date', 'daterange', 'checkbox'):
             ret['input_'] = prop['appearance']
 
         if prop.get('appearance', '') == 'fixture' or not prop.get('appearance', ''):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1075,7 +1075,9 @@ def _update_search_properties(module, search_properties, lang='en'):
             ret['appearance'] = 'barcode_scan'
         elif prop.get('appearance', '') == 'address':
             ret['appearance'] = 'address'
-        elif prop.get('appearance', '') in ('date', 'daterange', 'checkbox'):
+        elif prop.get('appearance', '') == 'checkbox':
+            ret['input_'] = 'checkbox'
+        elif prop.get('appearance', '') in ['date', 'daterange']:
             ret['input_'] = prop['appearance']
 
         if prop.get('appearance', '') == 'fixture' or not prop.get('appearance', ''):

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -18,7 +18,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             var value = model.get('value');
             if (value && model.get("input") === "daterange") {
                 value = "__range__" + value.replace(separator, "__");
-            } else if (value && model.get('input') === 'select') {
+            } else if (value && (model.get('input') === 'select' || model.get('input') === 'checkbox')) {
                 value = value.join(selectDelimiter);
             }
 
@@ -39,7 +39,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 searchForBlank = _.contains(values, ""),
                 values = _.without(values, "");
 
-            if (model.get('input') === 'select') {
+            if (model.get('input') === 'select' || model.get('input') === 'checkbox') {
                 value = values;
             } else if (values.length === 1) {
                 value = values[0];
@@ -182,7 +182,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             if (stickyValue && !value) {  // Sticky values don't override default values
                 value = stickyValue;
             }
-            if (this.model.get('input') === 'select' && _.isString(value)) {
+            if ((this.model.get('input') === 'select' || this.model.get('input') === 'checkbox') && _.isString(value)) {
                 value = value.split(selectDelimiter);
             }
             this.model.set('value', value);
@@ -287,8 +287,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             } else if (this.model.get('input') === 'address') {
                 // geocoderItemCallback sets the value on the model
             } else if (this.model.get('input') === 'checkbox') {
-                let value = this.model.get('value');
-                this.model.set('value', value !== 'checked' ? 'checked' : '');
+                var newValue = _.chain($(e.currentTarget).find('input[type=checkbox]'))
+                    .filter(function (checkbox) { return checkbox.checked })
+                    .map(function (checkbox) { return checkbox.value })
+                    .value();
+                this.model.set('value', newValue)
             } else {
                 this.model.set('value', $(e.currentTarget).val());
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -200,7 +200,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         events: {
             'change @ui.queryField': 'changeQueryField',
             'change @ui.searchForBlank': 'notifyParentOfFieldChange',
-            'dp.change @ui.queryField': 'changeDateQueryField',
             'click @ui.searchForBlank': 'toggleBlankSearch',
         },
 
@@ -279,12 +278,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         },
 
         changeQueryField: function (e) {
-            if (this.model.get('input') === 'date') {
-                // Skip because dates get handled by changeDateQueryField
-                return;
-            } else if (this.model.get('input') === 'select1' || this.model.get('input') === 'select') {
-                this.model.set('value', $(e.currentTarget).val());
-            } else if (this.model.get('input') === 'address') {
+            if (this.model.get('input') === 'address') {
                 // geocoderItemCallback sets the value on the model
             } else if (this.model.get('input') === 'checkbox') {
                 let value = this.model.get('value');
@@ -292,12 +286,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             } else {
                 this.model.set('value', $(e.currentTarget).val());
             }
-            this.notifyParentOfFieldChange(e);
-            this.parentView.setStickyQueryInputs();
-        },
-
-        changeDateQueryField: function (e) {
-            this.model.set('value', $(e.currentTarget).val());
             this.notifyParentOfFieldChange(e);
             this.parentView.setStickyQueryInputs();
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -272,6 +272,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 this.model.set('value', $(e.currentTarget).val());
             } else if (this.model.get('input') === 'address') {
                 // geocoderItemCallback sets the value on the model
+            } else if (this.model.get('input') === 'checkbox') {
+                let value = this.model.get('value');
+                this.model.set('value', value !== 'checked' ? 'checked' : '');
             } else {
                 this.model.set('value', $(e.currentTarget).val());
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -200,6 +200,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         events: {
             'change @ui.queryField': 'changeQueryField',
             'change @ui.searchForBlank': 'notifyParentOfFieldChange',
+            'dp.change @ui.queryField': 'changeDateQueryField',
             'click @ui.searchForBlank': 'toggleBlankSearch',
         },
 
@@ -278,7 +279,12 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         },
 
         changeQueryField: function (e) {
-            if (this.model.get('input') === 'address') {
+            if (this.model.get('input') === 'date') {
+                // Skip because dates get handled by changeDateQueryField
+                return;
+            } else if (this.model.get('input') === 'select1' || this.model.get('input') === 'select') {
+                this.model.set('value', $(e.currentTarget).val());
+            } else if (this.model.get('input') === 'address') {
                 // geocoderItemCallback sets the value on the model
             } else if (this.model.get('input') === 'checkbox') {
                 let value = this.model.get('value');
@@ -286,6 +292,12 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             } else {
                 this.model.set('value', $(e.currentTarget).val());
             }
+            this.notifyParentOfFieldChange(e);
+            this.parentView.setStickyQueryInputs();
+        },
+
+        changeDateQueryField: function (e) {
+            this.model.set('value', $(e.currentTarget).val());
             this.notifyParentOfFieldChange(e);
             this.parentView.setStickyQueryInputs();
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -288,10 +288,10 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 // geocoderItemCallback sets the value on the model
             } else if (this.model.get('input') === 'checkbox') {
                 var newValue = _.chain($(e.currentTarget).find('input[type=checkbox]'))
-                    .filter(function (checkbox) { return checkbox.checked })
-                    .map(function (checkbox) { return checkbox.value })
+                    .filter(checkbox => checkbox.checked)
+                    .map(checkbox => checkbox.value)
                     .value();
-                this.model.set('value', newValue)
+                this.model.set('value', newValue);
             } else {
                 this.model.set('value', $(e.currentTarget).val());
             }

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -71,6 +71,14 @@
            value="<%- value %>"
            <% if (required) { %> aria-required="true"<% } %>>
 
+    <% } else if (input === "checkbox") { %>
+    <input id="<%- text ? text : "" %>"
+           type="checkbox"
+           class="checkbox query-field"
+           value="<%- value %>"
+           <% if (value === 'checked') { %> checked <% } %>
+           <% if (required) { %> aria-required="true"<% } %>>
+
     <% } else if (input == "address") { %>
     <div class="query-field" value="<%- value %>" id="<%- id %>_mapbox" data-address="<%- id %>">
     </div>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -43,7 +43,7 @@
             <%- itemsetChoices[i] %>
         </option>
         <% } %>
-    <select>
+    </select>
 
     <% } else if (input == "select") { %>
     <select multiple class="query-field form-control hqwebapp-select2" data-receive="<%- receive %>"<% if (required) { %> aria-required="true"<% } %>>
@@ -52,7 +52,7 @@
             <%- itemsetChoices[i] %>
         </option>
         <% } %>
-    <select>
+    </select>
 
     <% } else if (input === "date") { %>
     <div class="input-group">

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -72,12 +72,17 @@
            <% if (required) { %> aria-required="true"<% } %>>
 
     <% } else if (input === "checkbox") { %>
-    <input id="<%- text ? text : "" %>"
-           type="checkbox"
-           class="checkbox query-field"
-           value="<%- value %>"
-           <% if (value === 'checked') { %> checked <% } %>
-           <% if (required) { %> aria-required="true"<% } %>>
+    <fieldset multiple class="query-field" id="<%- text ? text : "" %>" <% if (required) { %> aria-required="true"<% } %>>
+      <legend class="sr-only"><%- text ? text : "" %></legend>
+      <% for (var i = 0; i < itemsetChoices.length; i++) { %>
+      <div id="<%- text ? text : "checkbox" %>-<%- i %>" class="checkbox">
+        <label>
+          <input type="checkbox" value="<%- i %>" <% if (value && value.indexOf(String(i)) !== -1) { %>checked<% } %>>
+          <%- itemsetChoices[i] %>
+        </label>
+      </div>
+      <% } %>
+    </fieldset>
 
     <% } else if (input == "address") { %>
     <div class="query-field" value="<%- value %>" id="<%- id %>_mapbox" data-address="<%- id %>">


### PR DESCRIPTION
## Product Description
Adds checkbox to case search fields options and query screen ui.
![Screen Shot 2022-11-02 at 3 56 29 PM](https://user-images.githubusercontent.com/100609770/199618259-3a8544d1-ef88-4cbd-9c76-b5cc71621c75.png)

On case search query screen:
![Screen Shot 2022-11-02 at 3 59 36 PM](https://user-images.githubusercontent.com/100609770/199618325-e84fd387-8118-4dec-a03a-42ec41d05957.png)


## Technical Summary
[USH-2042](https://dimagi-dev.atlassian.net/browse/USH-2042?atlOrigin=eyJpIjoiMGVjMTdjM2FiZjZiNGVhZjgzMzIwZWEzYTA4ZjI1NjYiLCJwIjoiaiJ9)

Adds checkbox to:
-  `query_view.html` HTML template for UI
-  `query.js` for JavaScript model
-  `case_search_property.html` and `modules.py` for case search fields options
- Commcare-core, in https://github.com/dimagi/commcare-core/pull/1158
- Test XML

Checkbox works as a multi-select field connected to a lookup table, similar to the "Lookup Table Field" option. It is expected to be used with the "Allow multiple selections" option selected if the lookup table has more than one choice. The checkbox field _may_ work as a single-select group, but has not been tested for this and a single-select dropdown would be more appropriate.

A previous version of this PR also refactored `changeQueryField` and `changeDateQueryField`. That change has been reverted after finding it broke functionality of the date field.


## Feature Flag
USH_CASE_CLAIM_UPDATES

## Safety Assurance

### Safety story
Tested functionality locally, ensuring no effects on other case search fields. Sending to QA.

### Automated test coverage
Added checkbox prompts in `corehq.apps.app_manager.tests.test_suite_remote_request`

### QA Plan

[QA-4644](https://dimagi-dev.atlassian.net/browse/QA-4644?atlOrigin=eyJpIjoiOTk4MWQyNjUxMzZhNDY4OTlhZTU5NDQ2MDY5ZDE0M2IiLCJwIjoiaiJ9)


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
