### PR TITLE
properly tag rabbitmq error

### DIFF
--- a/corehq/util/sentry.py
+++ b/corehq/util/sentry.py
@@ -25,6 +25,7 @@ RATE_LIMITED_EXCEPTIONS = {
 
     'OperationalError': 'postgres',  # could be psycopg2._psycopg or django.db.utils
 
+    'kombu.connection.OperationalError': 'rabbitmq',
     'socket.error': 'rabbitmq',
 
     'redis.exceptions.ConnectionError': 'redis',
@@ -54,10 +55,10 @@ RATE_LIMIT_BY_PACKAGE = {
 def _get_rate_limit_key(exc_info):
     exc_type, value, tb = exc_info
     exc_name = '%s.%s' % (exc_type.__module__, exc_type.__name__)
-    if exc_type.__name__ in RATE_LIMITED_EXCEPTIONS:
-        return RATE_LIMITED_EXCEPTIONS[exc_type.__name__]
-    elif exc_name in RATE_LIMITED_EXCEPTIONS:
+    if exc_name in RATE_LIMITED_EXCEPTIONS:
         return RATE_LIMITED_EXCEPTIONS[exc_name]
+    elif exc_type.__name__ in RATE_LIMITED_EXCEPTIONS:
+        return RATE_LIMITED_EXCEPTIONS[exc_type.__name__]
 
     if exc_name in RATE_LIMIT_BY_PACKAGE:
         # not super happy with this approach but want to be able to


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
`OperationalError` can be raised in a few places and one raised from rabbitmq was being mistagged. This also changes the order of error lookup to start with the more specific one first, which feels more correct in addition to being necessary in this case.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Metrics only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
