### PR TITLE
Specify custom auto-drill option on UCR location filter

### DIFF
--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -454,6 +454,7 @@ class LocationDrilldownFilter(BaseFilter):
             'locations': load_locs_json(self.domain, selected_loc_id=loc_id, user=request_user),
             'loc_url': self.api_root,
             'max_drilldown_levels': self.max_drilldown_levels,
+            'auto_drill': 'false',
         }
 
     def valid_location_ids(self, location_id):

--- a/corehq/apps/reports_core/templates/reports_core/filters/location_async.html
+++ b/corehq/apps/reports_core/templates/reports_core/filters/location_async.html
@@ -10,7 +10,8 @@
         data-locs='{{ context_.locations|JSON }}'
         data-selected='{{ context_.loc_id|default_if_none:"" }}'
         data-hierarchy='{{ context_.hierarchy|JSON }}'
-        data-max-drilldown-levels='{{ context_.max_drilldown_levels }}'>
+        data-max-drilldown-levels='{{ context_.max_drilldown_levels }}'
+        data-auto-drill='{{ context_.auto_drill }}'>
         <div data-bind="foreach: selected_path" style="display: inline-block;">
             {% block location_select %}
               <select class="form-control"

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -826,7 +826,8 @@ class LocationDrilldownFilterTest(LocationHierarchyTestCase):
             'hierarchy': location_hierarchy_config(self.domain),
             'locations': load_locs_json(self.domain),
             'loc_url': '/a/{}/api/v0.5/location_internal/'.format(self.domain),
-            'max_drilldown_levels': 99
+            'max_drilldown_levels': 99,
+            'auto_drill': 'false',
         }
         self.assertDictEqual(ui_filter.filter_context(self.user), filter_context_expected)
 


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2350)

## Product Description
(Please see [this ticket comment](https://dimagi-dev.atlassian.net/browse/SC-2350?focusedCommentId=231055) for best context)

The "I didn't click the link" summary:
A use-case emerged where the auto-drilldown behavior (i.e. "auto-select the location as a filter if it's the only child location to the selected parent location") of the UCR location filter is undesireable. 

## Technical Summary
Set auto-drill option to false in the location drilldown context. If the auto-drill option is not specified in the filter context it takes on the default value of "true" (see [here](https://github.com/dimagi/commcare-hq/blob/6bea0b820ea67b2935958c485166e9289f91a0c8/corehq/apps/locations/static/locations/js/location_drilldown.js#L24); I also tested it manually to confirm this).

## Feature Flag
[User Reports](https://staging.commcarehq.org/hq/flags/edit/user_reports/)

## Safety Assurance

### Safety story
Tested locally. 

### Automated test coverage
No tests added; don't think it's necessary

### QA Plan
Will have QA test on staging for edge cases.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
