### PR TITLE
Fix: Shadow module to get its persist context and inline details from its own module during build

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -966,9 +966,8 @@ class EntriesHelper(object):
 
         return ret + datums_remaining
 
-    @staticmethod
-    def _get_module_for_persistent_context(app, module_unique_id):
-        module_for_persistent_context = app.get_module_by_unique_id(module_unique_id)
+    def _get_module_for_persistent_context(self, module_unique_id):
+        module_for_persistent_context = self.app.get_module_by_unique_id(module_unique_id)
         if (module_for_persistent_context and
                 (module_for_persistent_context.case_details.short.use_case_tiles or
                  module_for_persistent_context.case_details.short.custom_xml
@@ -982,7 +981,7 @@ class EntriesHelper(object):
             # configured then get id_string for that module
             if detail.persistent_case_tile_from_module:
                 module_for_persistent_context = self._get_module_for_persistent_context(
-                    app=module.get_app(), module_unique_id=detail.persistent_case_tile_from_module
+                    module_unique_id=detail.persistent_case_tile_from_module
                 )
                 if module_for_persistent_context:
                     return id_strings.detail(module_for_persistent_context, detail_type)
@@ -995,7 +994,6 @@ class EntriesHelper(object):
 
     def _get_detail_inline_attr_from_module(self, module, module_unique_id):
         module_for_persistent_context = self._get_module_for_persistent_context(
-            app=module.get_app(),
             module_unique_id=module_unique_id
         )
         if module_for_persistent_context:

--- a/corehq/apps/app_manager/tests/test_suite_shadow_module.py
+++ b/corehq/apps/app_manager/tests/test_suite_shadow_module.py
@@ -94,3 +94,22 @@ class ShadowModuleWithChildSuiteTest(SimpleTestCase, SuiteMixin):
 
         self.assertXmlPartialEqual(self.get_xml('shadow_module_source_parent_v1_v2'),
                                    self.app.create_suite(), "./menu")
+
+
+@patch_get_xform_resource_overrides()
+class ShadowModuleWithPersistentCaseContextOnSource(SimpleTestCase, SuiteMixin):
+    def setUp(self):
+        self.app = Application.new_app('domain', "Untitled Application")
+        self.parent = self.app.add_module(Module.new_module('Parent Module', None))
+        self.parent.case_details.short.persist_case_context = True
+        form = self.app.new_form(self.parent.id, "Parent Form", None)
+        form.requires = 'case'
+        self.shadow = self.app.add_module(ShadowModule.new_module('Shadow Module', None))
+
+    def test_source_module_have_persistent_context_enabled(self, *args):
+        """When a shadow module doesn't have persistent case context enabled, but its source module does, then the
+        shadow module should not be regarded as also having this setting enabled. A KeyError will be raised if
+        this happens, and this test will fail.
+        """
+        self.shadow.source_module_id = self.parent.unique_id
+        self.app.create_suite()


### PR DESCRIPTION
## Technical Summary
[Link](https://dimagi-dev.atlassian.net/browse/SC-2369) to the issue ticket. When I enabled persistent case context for a module and then created a shadow module with said module as its source, then I'm unable to create a new version of the application. See the [Sentry error](https://sentry.io/organizations/dimagi/issues/3677279986/?query=is%3Aunresolved+domain%3Aexperimentations-ma&statsPeriod=14d). It looks like we're "reading" some details from the shadow module's source module and looking for those details on the shadow module, causing the KeyError exception.

### A bit more detail
What happens is that during the application's `suite.xml` build stage when we're in [this](https://github.com/dimagi/commcare-hq/blob/90d07368825132d61dc4a5d61d5b6fdca4d88c34/corehq/apps/app_manager/suite_xml/sections/entries.py#L493) part of the code and looking at a shadow module - so the parameter `module` is the shadow module -, then when the `datum['module']` is the source module, the `detail_module` variable will be the shadow module (see [this condition](https://github.com/dimagi/commcare-hq/blob/90d07368825132d61dc4a5d61d5b6fdca4d88c34/corehq/apps/app_manager/suite_xml/sections/entries.py#L514-L517)).

In the case where the source module's `persist_case_context` flag is enabled and we're hitting [this method](https://github.com/dimagi/commcare-hq/blob/90d07368825132d61dc4a5d61d5b6fdca4d88c34/corehq/apps/app_manager/suite_xml/sections/entries.py#L529), we're going to return the key that could not be found (as seen in the Sentry error), because of [this logic](https://github.com/dimagi/commcare-hq/blob/90d07368825132d61dc4a5d61d5b6fdca4d88c34/corehq/apps/app_manager/suite_xml/sections/entries.py#L994-L996).

This PR also does some small refactoring.

## Feature Flag
- Shadow modules
- Persist case context tiles

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Added a unit test to replicate the issue. The unit test is passing now, meaning the issue is resolved. Also, no other unittests failed due to this change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[QA-4645](https://dimagi-dev.atlassian.net/browse/QA-4645)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
