### PR TITLE
Changed process_reporting_metadata_staging task to lock 1 row instead of 5

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -330,7 +330,7 @@ def process_reporting_metadata_staging():
     lock_key = "PROCESS_REPORTING_METADATA_STAGING_TASK"
     process_reporting_metadata_lock = get_redis_lock(
         lock_key,
-        timeout=60 * 60, # one hour
+        timeout=60 * 60,  # one hour
         name=lock_key,
     )
     if not process_reporting_metadata_lock.acquire(blocking=False):
@@ -340,11 +340,11 @@ def process_reporting_metadata_staging():
     try:
         start = datetime.utcnow()
 
-        for i in range(20):
+        for i in range(100):
             with transaction.atomic():
                 records = (
                     UserReportingMetadataStaging.objects.select_for_update(skip_locked=True).order_by('pk')
-                )[:5]
+                )[:1]
                 for record in records:
                     user = CouchUser.get_by_user_id(record.user_id, record.domain)
                     try:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Should fix issues with restarting pillows

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[This ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13930) contains all of the relevent discussion for this decision.
[This](https://dimagi-dev.atlassian.net/browse/SAAS-13525) is my ticket.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
local testing. There was a deadlock when locking multiple rows so we think reducing the amount of rows locked to one should remove the deadlock.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Deadlocks are difficult to test.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
