### PR TITLE
remove autonow from new date field to avoid blocking migration

### DIFF
--- a/corehq/apps/sms/migrations/0052_messagingsubevent_date_last_activity.py
+++ b/corehq/apps/sms/migrations/0052_messagingsubevent_date_last_activity.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='messagingsubevent',
             name='date_last_activity',
-            field=models.DateTimeField(auto_now=True, db_index=True, null=True),
+            field=models.DateTimeField(db_index=True, null=True),
         ),
     ]

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1548,7 +1548,7 @@ class MessagingSubEvent(models.Model, MessagingStatusMixin):
 
     parent = models.ForeignKey('MessagingEvent', on_delete=models.CASCADE)
     date = models.DateTimeField(null=False, db_index=True)
-    date_last_activity = models.DateTimeField(null=True, db_index=True, auto_now=True)
+    date_last_activity = models.DateTimeField(null=True, db_index=True)
     recipient_type = models.CharField(max_length=3, choices=RECIPIENT_CHOICES, null=False)
     recipient_id = models.CharField(max_length=126, null=True)
     content_type = models.CharField(max_length=3, choices=MessagingEvent.CONTENT_CHOICES, null=False)


### PR DESCRIPTION
Followup from https://github.com/dimagi/commcare-hq/pull/32307

## Technical Summary
While testing on staging I noticed that the new column was already populated. This turned out to be from the Django migration.

Despite the presence of `null=True` and no default value, the `auto_now` param sets a default for the field which gets used when creating the column. This would result in the table being locked while the new column is populated with the default value.

```sql
-- with 'auto_now'
ALTER TABLE "sms_messagingsubevent" ADD COLUMN "date_last_activity" timestamp with time zone DEFAULT '2022-11-07T12:43:26.906878'::timestamp NULL;
ALTER TABLE "sms_messagingsubevent" ALTER COLUMN "date_last_activity" DROP DEFAULT;
CREATE INDEX "sms_messagingsubevent_date_last_activity_f6da2e38" ON "sms_messagingsubevent" ("date_last_activity");

-- without 'auto_now'
ALTER TABLE "sms_messagingsubevent" ADD COLUMN "date_last_activity" timestamp with time zone NULL;
CREATE INDEX "sms_messagingsubevent_date_last_activity_f6da2e38" ON "sms_messagingsubevent" ("date_last_activity");
```
Once this has been deployed I will re-add the `auto_now` param which is a noop migration.

## Safety Assurance

### Safety story
Tested on staging.

### Automated test coverage
Existing

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
