### PR TITLE
[USH-2606] update API to use new date field for sorting

### DIFF
--- a/corehq/apps/api/resources/messaging_event/filters.py
+++ b/corehq/apps/api/resources/messaging_event/filters.py
@@ -165,7 +165,7 @@ def _make_simple_consumer(filter_name, model_filter_arg, validator=None):
 
 COMPOUND_FILTERS = [
     _get_date_filter_consumer("date"),
-    _get_date_filter_consumer("date_last_activity", "date_last_activity_computed"),
+    _get_date_filter_consumer("date_last_activity"),
 ]
 
 SIMPLE_FILTERS = {

--- a/corehq/apps/api/resources/messaging_event/serializers.py
+++ b/corehq/apps/api/resources/messaging_event/serializers.py
@@ -10,7 +10,7 @@ def serialize_event(event):
         "id": event.id,
         "content_type": MessagingEvent.CONTENT_TYPE_SLUGS.get(event.content_type, "unknown"),
         "date": event.date.isoformat(),
-        "date_last_activity": event.date_last_activity_computed.isoformat(),
+        "date_last_activity": event.date_last_activity.isoformat(),
         "case_id": event.case_id,
         "domain": event.parent.domain,
         "error": _serialize_event_error(event),

--- a/corehq/apps/api/resources/messaging_event/utils.py
+++ b/corehq/apps/api/resources/messaging_event/utils.py
@@ -44,11 +44,7 @@ def get_order_by_field(request_params):
     if order_by not in ("date", "-date", "date_last_activity", "-date_last_activity"):
         raise BadRequest(_("No matching '{field_name}' field for ordering").format(field_name=order_by))
 
-    # rename to query field
-    return {
-        "date_last_activity": "date_last_activity_computed",
-        "-date_last_activity": "-date_last_activity_computed"
-    }.get(order_by, order_by)
+    return order_by
 
 
 @attrs

--- a/corehq/apps/api/resources/messaging_event/view.py
+++ b/corehq/apps/api/resources/messaging_event/view.py
@@ -56,27 +56,4 @@ def _get_list(request):
 
 
 def _get_base_query(domain):
-    """The base query includes a 'date_last_activity_computed' field. This field
-    is calculated as:
-      Max(
-        event.date,
-        xform_session.modified_time,  # if it exists
-        Max(sms.date_modified),  # max for the current event
-        Max(email.date_modified)  # max for the current event
-      )
-  """
-    query = MessagingSubEvent.objects.select_related("parent").filter(parent__domain=domain)
-    newest_sms = (
-        SMS.objects.filter(messaging_subevent=OuterRef('pk'))
-        .order_by('-date_modified')
-        .values('date_modified')[:1]
-    )
-    newest_email = (
-       Email.objects.filter(messaging_subevent=OuterRef('pk'))
-       .order_by('-date_modified')
-       .values('date_modified')[:1]
-    )
-    query = query.annotate(date_last_activity_computed=Greatest(
-        'date', 'xforms_session__modified_time', Subquery(newest_sms), Subquery(newest_email)
-    ))
-    return query
+    return MessagingSubEvent.objects.select_related("parent").filter(parent__domain=domain)

--- a/corehq/apps/sms/tests/data_generator.py
+++ b/corehq/apps/sms/tests/data_generator.py
@@ -236,5 +236,6 @@ def make_email_event_for_test(domain, schedule_name, user_ids, utcnow=None):
                 "eventType": "Delivery",
                 "delivery": {"timestamp": "2021-05-27T07:09:42.318Z"}
             }, subevent.id)
+            subevent.refresh_from_db()
             subevents[subevent.recipient_id] = subevent
     return subevents


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-2606

## Technical Summary
Update the `messaging_event` API to use the new date field (`MessagingSubEvent.date_last_activity`).

This depends on the changes in https://github.com/dimagi/commcare-hq/pull/32315 which are already merged.

## Safety Assurance

### Safety story
This is covered by unit tests in code.

### Automated test coverage
Updated in code

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
