### PR TITLE
Updated EOF nav config to use select2

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -12,7 +12,8 @@
     <div class="form-group" data-bind="css: {'has-error': hasError, 'has-warning': hasWarning}">
       <select name="post_form_workflow" class="form-control" data-bind="
                 optstr: workflowOptions(),
-                value: workflow
+                value: workflow,
+                staticSelect2: {},
                 "></select>
       <div data-bind="visible: hasError" class="help-block">
         {% trans "This is an unknown value, possibly a deleted form. Please change this value." %}
@@ -48,7 +49,8 @@
           <select name="post_form_workflow_fallback" class="form-control" data-bind="
                         optstr: workflowFallbackOptions(),
                         value: workflowfallback,
-                        optionsCaption: 'Choose a fallback option...'
+                        optionsCaption: gettext('Choose a fallback option...'),
+                        staticSelect2: {},
                     "></select>
         </div>
       </div>
@@ -81,7 +83,8 @@
                   optionsText: 'name',
                   optionsValue: 'uniqueId',
                   optionsCaption: $parent.displayUnknownForm.call($parent, formLink),
-                  value: formLink.formId
+                  value: formLink.formId,
+                  staticSelect2: {},
                   "></select>
         <div data-bind="visible: formLink.allowManualLinking()">
           <input type="hidden" name="datums_json" data-bind="value: formLink.serializedDatums"/>


### PR DESCRIPTION
## Product Description
Switch to select2s for the dropdowns in EOF nav / form linking configuration. The one that lists all menus/forms gets especially long:

![Screen Shot 2022-11-08 at 11 08 12 AM](https://user-images.githubusercontent.com/1486591/200617348-8db749d6-e1ea-4711-8766-4a572ed816af.png)

## Safety Assurance

### Safety story
Tested locally. Pretty minor, uses an existing binding.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
