### PR TITLE
Use datasource fetched from remote server if available to check if Data Registry Report

### DIFF
--- a/corehq/apps/linked_domain/ucr.py
+++ b/corehq/apps/linked_domain/ucr.py
@@ -63,7 +63,7 @@ def create_linked_ucr(domain_link, report_config_id):
             raise DataSourceConfigurationNotFoundError(_(
                 'The data source referenced by this report could not be found.'
             ))
-    if is_data_registry_report(report_config):
+    if not domain_link.is_remote and is_data_registry_report(report_config):
         try:
             DataRegistry.objects.accessible_to_domain(domain_link.linked_domain, slug=report_config.registry_slug)
         except DataRegistry.DoesNotExist:

--- a/corehq/apps/linked_domain/ucr.py
+++ b/corehq/apps/linked_domain/ucr.py
@@ -63,7 +63,7 @@ def create_linked_ucr(domain_link, report_config_id):
             raise DataSourceConfigurationNotFoundError(_(
                 'The data source referenced by this report could not be found.'
             ))
-    if not domain_link.is_remote and is_data_registry_report(report_config):
+    if is_data_registry_report(report_config, datasource):
         try:
             DataRegistry.objects.accessible_to_domain(domain_link.linked_domain, slug=report_config.registry_slug)
         except DataRegistry.DoesNotExist:

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -1496,11 +1496,8 @@ def report_config_id_is_static(config_id):
     )
 
 
-def is_data_registry_report(report_config):
-    return (
-        isinstance(report_config, RegistryReportConfiguration)
-        or report_config.config.meta.build.registry_slug
-    )
+def is_data_registry_report(report_config, datasource):
+    return isinstance(report_config, RegistryReportConfiguration) or datasource.meta.build.registry_slug
 
 
 def get_report_configs(config_ids, domain):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -1496,7 +1496,11 @@ def report_config_id_is_static(config_id):
     )
 
 
-def is_data_registry_report(report_config, datasource):
+def is_data_registry_report(report_config, datasource=None):
+    """
+    The optional datasource parameter is useful when checking a report config fetched from a remote server
+    """
+    datasource = datasource or report_config.config
     return isinstance(report_config, RegistryReportConfiguration) or datasource.meta.build.registry_slug
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SUPPORT-15186

Introduced in https://github.com/dimagi/commcare-hq/pull/31682

The check for a report config being associated with a `DataRegistry` assumes the report is hosted on the same server, not a remote server. This is a quick fix to prevent remote links from failing to be pulled due to this check. If there is a use case that calls for it, the better solution is to support data registry reports in remote links as well, but it seems that moving the needle from no remote report links working to non data registry remote report links working is worthwhile.

**Update**: after Ethan's feedback, we had the datasource available from the remote server, and could use that to perform the data registry check.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
