### PR TITLE
Add feature flag to combine downloaded lookup tables

### DIFF
--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -567,7 +567,7 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
                         extra_props = max_field_prop_combos[field_name] - len(item_row.fields[field_name])
                         if extra_props > 0:
                             field_prop_vals.extend(
-                                empty_padding_list(extra_props * (max_field_prop_combos[field_name]) + 1))
+                                empty_padding_list(extra_props * len(field_properties[field_name]) + 1))
                     else:
                         field_prop_vals.extend(empty_padding_list((len(field_properties[field_name]) + 1)
                                                * max_field_prop_combos[field_name]))

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -490,7 +490,7 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
         types_sheet["rows"].append(row)
 
     # prevent combined sheets from being imported
-    types_sheet["rows"].append(tuple(["N", "combined_sheet_via_feature_flag", yesno(False)]))
+    types_sheet["rows"].append(("N", "combined_sheet_via_feature_flag", yesno(False)))
 
     types_sheet["rows"] = tuple(types_sheet["rows"])
     types_sheet["headers"] = tuple(types_sheet["headers"])

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -370,7 +370,6 @@ class OwnerNames:
 
 
 def _prepare_fixture_collated(table_ids, domain, task=None):
-
     # Feature flag only function
     # Collects all separate sheets into one master sheet and adds a "table_id" column
     # that indicates which table that row came from.
@@ -390,23 +389,26 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
     # book-keeping data from view_results for repeated use
     data_types_book = []
     data_items_book_by_type = {}
-    combined_item_helper = {
-        "max_users": 0,
-        "max_groups": 0,
-        "max_locations": 0,
-    }
+
+    # data for building the combined sheet
+    max_users = 0
+    max_groups = 0
+    max_locations = 0
     max_field_prop_combos = {}
-    excel_sheets = {}  # will contain only "types" and "combined_sheets" sheets
+    field_properties = {}
     all_fields = []
     all_item_attrs = []
+
+    excel_sheets = {}  # will contain only "types" and "combined_sheets" sheets
+
+    # data for building the "types" sheet
     max_fields = 0
     max_item_attributes = 0
     field_prop_count = []
     type_field_properties = {}
-    owner_names = OwnerNames(data_types_view)
 
+    owner_names = OwnerNames(data_types_view)
     for event_count, data_type in enumerate(data_types_view):
-        # Helpers to generate 'types' sheet
         type_field_properties[data_type.tag] = {}
         data_types_book.append(data_type)
         if len(data_type.fields) > max_fields:
@@ -417,8 +419,6 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
             if attribute not in all_item_attrs:
                 all_item_attrs.append(attribute)
         for index, field in enumerate(data_type.fields):
-            if field.name not in all_fields:
-                all_fields.append(field.name)
             if len(field_prop_count) <= index:
                 field_prop_count.append(len(field.properties))
             elif field_prop_count[index] <= len(field.properties):
@@ -427,41 +427,31 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
                 for prop_index, property in enumerate(field.properties):
                     prop_key = get_field_prop_format(index + 1, prop_index + 1)
                     type_field_properties[data_type.tag][prop_key] = property
+            if field.name not in all_fields:
+                all_fields.append(field.name)
+            if field.name not in field_properties:
+                field_properties[field.name] = []
+            if field.name not in max_field_prop_combos:
+                max_field_prop_combos[field.name] = 0
 
-        # Helpers to generate item-sheets
         data_items_book_by_type[data_type.tag] = []
-        max_users = 0
-        max_groups = 0
-        max_locations = 0
-        if "field_properties" in combined_item_helper:
-            field_properties = combined_item_helper["field_properties"]
-        else:
-            field_properties = {field.name: [] for field in data_type.fields}
         fixture_data = LookupTableRow.objects.iter_rows(domain, table_id=data_type.id)
         num_rows = LookupTableRow.objects.filter(domain=domain, table_id=data_type.id).count()
         for field in data_type.fields:
-            if field.name not in field_properties:
-                field_properties[field.field_name] = []
-            if field.name not in max_field_prop_combos:
-                max_field_prop_combos[field.field_name] = 0
             for property in field.properties:
-                if property not in field_properties[field.field_name]:
-                    field_properties[field.field_name].append(property)
-            max_field_prop_combos[field.field_name] = len(field_properties[field.field_name])
+                if property not in field_properties[field.name]:
+                    field_properties[field.name].append(property)
+            max_field_prop_combos[field.name] = max(max_field_prop_combos[field.name],
+                                                    len(field_properties[field.name]))
         for n, item_row in enumerate(fixture_data):
             _update_progress(task, last_update, event_count, n, num_rows, total_events)
             data_items_book_by_type[data_type.tag].append(item_row)
             max_groups = max(max_groups, owner_names.count(item_row, OwnerType.User))
             max_users = max(max_users, owner_names.count(item_row, OwnerType.Group))
             max_locations = max(max_locations, owner_names.count(item_row, OwnerType.Location))
-            for field_key in item_row.fields:
-                max_field_prop_combos[field.field_name] = max(max_field_prop_combos[field.field_name],
-                                                              len(item_row.fields[field_key]))
-
-        combined_item_helper["max_users"] = max(combined_item_helper["max_users"], max_users)
-        combined_item_helper["max_groups"] = max(combined_item_helper["max_groups"], max_groups)
-        combined_item_helper["max_locations"] = max(combined_item_helper["max_locations"], max_locations)
-        combined_item_helper["field_properties"] = field_properties
+            for field in item_row.fields:
+                max_field_prop_combos[field] = max(max_field_prop_combos[field],
+                                                   len(item_row.fields[field]))
 
     # Prepare 'types' sheet data
     indexed_field_numbers = get_indexed_field_numbers(data_types_view)
@@ -498,6 +488,7 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
             prop_vals.extend([props.get(key, "") for key in field_prop_headers])
         row = tuple(common_vals + field_vals + item_att_vals + prop_vals)
         types_sheet["rows"].append(row)
+
     # prevent combined sheets from being imported
     types_sheet["rows"].append(tuple(["N", "combined_sheet_via_feature_flag", yesno(False)]))
 
@@ -508,15 +499,15 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
     # Making the collated master sheet
     item_sheet = {"headers": [], "rows": []}
     common_headers = ["UID", DELETE_HEADER]
-    user_headers = ["user %d" % x for x in range(1, combined_item_helper["max_users"] + 1)]
-    group_headers = ["group %d" % x for x in range(1, combined_item_helper["max_groups"] + 1)]
-    location_headers = ["location %d" % x for x in range(1, combined_item_helper["max_locations"] + 1)]
+    user_headers = ["user %d" % x for x in range(1, max_users + 1)]
+    group_headers = ["group %d" % x for x in range(1, max_groups + 1)]
+    location_headers = ["location %d" % x for x in range(1, max_locations + 1)]
     item_att_headers = ["property: " + attribute for attribute in all_item_attrs]
     all_field_headers = []
 
     # building the all_field_headers list
     for field_name in all_fields:
-        field_props = combined_item_helper["field_properties"][field_name]
+        field_props = field_properties[field_name]
         if len(field_props) == 0:
             field_value = "field: " + field_name
             if field_value not in all_field_headers:
@@ -543,16 +534,15 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
     # building the rows
     for n, data_type in enumerate(data_types_book):
         _update_progress(task, last_update, total_tables, n, total_tables, total_events)
-        field_props = combined_item_helper["field_properties"]
         for item_row in data_items_book_by_type[data_type.tag]:
-            common_vals = [str(item_row.id.hex), "N"]
             users = owner_names.get_usernames(item_row)
             groups = owner_names.get_group_names(item_row)
             locations = owner_names.get_location_codes(item_row)
-            user_vals = (users + empty_padding_list(combined_item_helper["max_users"] - len(users)))
-            group_vals = (groups + empty_padding_list(combined_item_helper["max_groups"] - len(groups)))
-            location_vals = (locations + empty_padding_list(
-                combined_item_helper["max_locations"] - len(locations)))
+
+            common_vals = [str(item_row.id.hex), "N"]
+            user_vals = (users + empty_padding_list(max_users - len(users)))
+            group_vals = (groups + empty_padding_list(max_groups - len(groups)))
+            location_vals = (locations + empty_padding_list(max_locations - len(locations)))
 
             item_att_vals = []
             for attribute in all_item_attrs:
@@ -564,14 +554,14 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
             field_vals = []
             for field_name in all_fields:
                 field_values = item_row.fields.get(field_name)
-                if len(field_props[field_name]) == 0:
+                if len(field_properties[field_name]) == 0:
                     value = field_values[0].value if field_values else ""
                     field_vals.append(value)
                 else:
                     field_prop_vals = []
                     if field_name in item_row.fields:
                         for field_prop_combo in item_row.fields[field_name]:
-                            for property in field_props[field_name]:
+                            for property in field_properties[field_name]:
                                 field_prop_vals.append(field_prop_combo.properties.get(property, None) or "")
                             field_prop_vals.append(field_prop_combo.value)
                         extra_props = max_field_prop_combos[field_name] - len(item_row.fields[field_name])
@@ -579,7 +569,7 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
                             field_prop_vals.extend(
                                 empty_padding_list(extra_props * (max_field_prop_combos[field_name]) + 1))
                     else:
-                        field_prop_vals.extend(empty_padding_list((len(field_props[field_name]) + 1)
+                        field_prop_vals.extend(empty_padding_list((len(field_properties[field_name]) + 1)
                                                * max_field_prop_combos[field_name]))
                     field_vals.extend(field_prop_vals)
             row = tuple(

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -395,6 +395,7 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
         "max_groups": 0,
         "max_locations": 0,
     }
+    max_field_prop_combos = {}
     excel_sheets = {}  # will contain only "types" and "combined_sheets" sheets
     all_fields = []
     all_item_attrs = []
@@ -432,29 +433,35 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
         max_users = 0
         max_groups = 0
         max_locations = 0
-        if "max_field_prop_combos" in combined_item_helper:
-            max_field_prop_combos = combined_item_helper["max_field_prop_combos"]
+        if "field_properties" in combined_item_helper:
+            field_properties = combined_item_helper["field_properties"]
         else:
-            max_field_prop_combos = {field.name: [] for field in data_type.fields}
+            field_properties = {field.name: [] for field in data_type.fields}
         fixture_data = LookupTableRow.objects.iter_rows(domain, table_id=data_type.id)
         num_rows = LookupTableRow.objects.filter(domain=domain, table_id=data_type.id).count()
+        for field in data_type.fields:
+            if field.name not in field_properties:
+                field_properties[field.field_name] = []
+            if field.name not in max_field_prop_combos:
+                max_field_prop_combos[field.field_name] = 0
+            for property in field.properties:
+                if property not in field_properties[field.field_name]:
+                    field_properties[field.field_name].append(property)
+            max_field_prop_combos[field.field_name] = len(field_properties[field.field_name])
         for n, item_row in enumerate(fixture_data):
             _update_progress(task, last_update, event_count, n, num_rows, total_events)
             data_items_book_by_type[data_type.tag].append(item_row)
             max_groups = max(max_groups, owner_names.count(item_row, OwnerType.User))
             max_users = max(max_users, owner_names.count(item_row, OwnerType.Group))
             max_locations = max(max_locations, owner_names.count(item_row, OwnerType.Location))
-        for field in data_type.fields:
-            if field.name not in max_field_prop_combos:
-                max_field_prop_combos[field.field_name] = []
-            for property in field.properties:
-                if property not in max_field_prop_combos[field.field_name]:
-                    max_field_prop_combos[field.field_name].append(property)
+            for field_key in item_row.fields:
+                max_field_prop_combos[field.field_name] = max(max_field_prop_combos[field.field_name],
+                                                              len(item_row.fields[field_key]))
 
         combined_item_helper["max_users"] = max(combined_item_helper["max_users"], max_users)
         combined_item_helper["max_groups"] = max(combined_item_helper["max_groups"], max_groups)
         combined_item_helper["max_locations"] = max(combined_item_helper["max_locations"], max_locations)
-        combined_item_helper["max_field_prop_combos"] = max_field_prop_combos
+        combined_item_helper["field_properties"] = field_properties
 
     # Prepare 'types' sheet data
     indexed_field_numbers = get_indexed_field_numbers(data_types_view)
@@ -509,15 +516,15 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
 
     # building the all_field_headers list
     for field_name in all_fields:
-        max_prop_combos = combined_item_helper["max_field_prop_combos"][field_name]
-        if len(max_prop_combos) == 0:
+        field_props = combined_item_helper["field_properties"][field_name]
+        if len(field_props) == 0:
             field_value = "field: " + field_name
             if field_value not in all_field_headers:
                 all_field_headers.append(field_value)
         else:
             prop_headers = []
-            for x in range(1, len(max_prop_combos) + 1):
-                for property in max_prop_combos:
+            for x in range(1, max_field_prop_combos[field_name] + 1):
+                for property in field_props:
                     prop_header = "%(name)s: %(prop)s %(count)s" % {
                         "name": field_name,
                         "prop": property,
@@ -536,7 +543,7 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
     # building the rows
     for n, data_type in enumerate(data_types_book):
         _update_progress(task, last_update, total_tables, n, total_tables, total_events)
-        max_prop_combos = combined_item_helper["max_field_prop_combos"]
+        field_props = combined_item_helper["field_properties"]
         for item_row in data_items_book_by_type[data_type.tag]:
             common_vals = [str(item_row.id.hex), "N"]
             users = owner_names.get_usernames(item_row)
@@ -557,15 +564,23 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
             field_vals = []
             for field_name in all_fields:
                 field_values = item_row.fields.get(field_name)
-                if len(max_prop_combos[field_name]) == 0:
+                if len(field_props[field_name]) == 0:
                     value = field_values[0].value if field_values else ""
                     field_vals.append(value)
                 else:
                     field_prop_vals = []
-                    for field_prop_combo in item_row.fields[field_name]:
-                        for property in max_prop_combos[field_name]:
-                            field_prop_vals.append(field_prop_combo.properties.get(property, None) or "")
-                        field_prop_vals.append(field_prop_combo.value)
+                    if field_name in item_row.fields:
+                        for field_prop_combo in item_row.fields[field_name]:
+                            for property in field_props[field_name]:
+                                field_prop_vals.append(field_prop_combo.properties.get(property, None) or "")
+                            field_prop_vals.append(field_prop_combo.value)
+                        extra_props = max_field_prop_combos[field_name] - len(item_row.fields[field_name])
+                        if extra_props > 0:
+                            field_prop_vals.extend(
+                                empty_padding_list(extra_props * (max_field_prop_combos[field_name]) + 1))
+                    else:
+                        field_prop_vals.extend(empty_padding_list((len(field_props[field_name]) + 1)
+                                               * max_field_prop_combos[field_name]))
                     field_vals.extend(field_prop_vals)
             row = tuple(
                 common_vals

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -25,16 +25,24 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.models import CommCareUser
 
 
-def prepare_fixture_download(table_ids, domain, task, download_id, owner_id):
+def prepare_fixture_download(table_ids, domain, task, download_id, owner_id, combine_sheets=False):
     """Prepare fixture data for Excel download
     """
-    data_types_book, excel_sheets = _prepare_fixture(table_ids, domain, task=task)
-
-    header_groups = [("types", excel_sheets["types"]["headers"])]
-    value_groups = [("types", excel_sheets["types"]["rows"])]
-    for data_type in data_types_book:
-        header_groups.append((data_type.tag, excel_sheets[data_type.tag]["headers"]))
-        value_groups.append((data_type.tag, excel_sheets[data_type.tag]["rows"]))
+    header_groups = []
+    value_groups = []
+    if combine_sheets:
+        # the sheets here will always just be "types" and "combined_sheet"
+        sheets, excel_sheets = _prepare_fixture_collated(table_ids, domain, task=task)
+        for sheet in sheets:
+            header_groups.append((sheet, excel_sheets[sheet]["headers"]))
+            value_groups.append((sheet, excel_sheets[sheet]["rows"]))
+    else:
+        data_types_book, excel_sheets = _prepare_fixture(table_ids, domain, task=task)
+        header_groups.append(("types", excel_sheets["types"]["headers"]))
+        value_groups.append(("types", excel_sheets["types"]["rows"]))
+        for data_type in data_types_book:
+            header_groups.append((data_type.tag, excel_sheets[data_type.tag]["headers"]))
+            value_groups.append((data_type.tag, excel_sheets[data_type.tag]["rows"]))
 
     file = io.BytesIO()
     format = Format.XLS_2007
@@ -89,17 +97,7 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
     # when total_tables < 4 the final percentage can be >= 100%, but for
     # a small number of tables it renders more accurate progress
     total_events = (total_tables + (0 if total_tables < 4 else 1)) * 10
-
-    now = datetime.utcnow
-    last_update = [now()]
-    update_period = timedelta(seconds=1)  # do not update progress more than once a second
-
-    def _update_progress(event_count, item_count, items_in_table):
-        if task and now() - last_update[0] > update_period:
-            last_update[0] = now()
-            processed = event_count * 10 + (10 * item_count / items_in_table)
-            processed = min(processed, total_events)  # limit at 100%
-            DownloadBase.set_progress(task, processed, total_events)
+    last_update = [datetime.utcnow()]
 
     # book-keeping data from view_results for repeated use
     data_types_book = []
@@ -120,12 +118,6 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
         }
     """
     excel_sheets = {}
-
-    def get_field_prop_format(field_number, property_number):
-        return f"field {field_number} : property {property_number}"
-
-    def empty_padding_list(length):
-        return [""] * length
 
     max_fields = 0
     max_item_attributes = 0
@@ -175,7 +167,7 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
         fixture_data = LookupTableRow.objects.iter_rows(domain, table_id=data_type.id)
         num_rows = LookupTableRow.objects.filter(domain=domain, table_id=data_type.id).count()
         for n, item_row in enumerate(fixture_data):
-            _update_progress(event_count, n, num_rows)
+            _update_progress(task, last_update, event_count, n, num_rows, total_events)
             data_items_book_by_type[data_type.tag].append(item_row)
             max_groups = max(max_groups, owner_names.count(item_row, OwnerType.Group))
             max_users = max(max_users, owner_names.count(item_row, OwnerType.User))
@@ -239,7 +231,7 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
 
     # Prepare 'items' sheet data for each data-type
     for n, data_type in enumerate(data_types_book):
-        _update_progress(total_tables, n, total_tables)
+        _update_progress(task, last_update, total_tables, n, total_tables, total_events)
         item_sheet = {"headers": [], "rows": []}
         item_helpers = item_helpers_by_type[data_type.tag]
         max_users = item_helpers["max_users"]
@@ -277,7 +269,6 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
             + group_headers
             + location_headers
         )
-        excel_sheets[data_type.tag] = item_sheet
         for item_row in data_items_book_by_type[data_type.tag]:
             common_vals = [str(item_row.id.hex), "N"]
             users = owner_names.get_usernames(item_row)
@@ -376,6 +367,246 @@ class OwnerNames:
         loc_ids = self.owners[row.id][OwnerType.Location]
         names = self.names[OwnerType.Location]
         return sorted(names[loc_id] for loc_id in loc_ids if loc_id in names)
+
+
+def _prepare_fixture_collated(table_ids, domain, task=None):
+
+    # Feature flag only function
+    # Collects all separate sheets into one master sheet and adds a "table_id" column
+    # that indicates which table that row came from.
+
+    if table_ids and table_ids[0]:
+        try:
+            data_types_view = [LookupTable.objects.get(id=id) for id in table_ids]
+        except LookupTable.DoesNotExist:
+            data_types_view = LookupTable.objects.by_domain(domain)
+    else:
+        data_types_view = LookupTable.objects.by_domain(domain)
+
+    total_tables = len(data_types_view)
+    total_events = (total_tables + (0 if total_tables < 4 else 1)) * 10
+    last_update = [datetime.utcnow()]
+
+    # book-keeping data from view_results for repeated use
+    data_types_book = []
+    data_items_book_by_type = {}
+    combined_item_helper = {
+        "max_users": 0,
+        "max_groups": 0,
+        "max_locations": 0,
+    }
+    excel_sheets = {}  # will contain only "types" and "combined_sheets" sheets
+    all_fields = []
+    all_item_attrs = []
+    max_fields = 0
+    max_item_attributes = 0
+    field_prop_count = []
+    type_field_properties = {}
+    owner_names = OwnerNames(data_types_view)
+
+    for event_count, data_type in enumerate(data_types_view):
+        # Helpers to generate 'types' sheet
+        type_field_properties[data_type.tag] = {}
+        data_types_book.append(data_type)
+        if len(data_type.fields) > max_fields:
+            max_fields = len(data_type.fields)
+        if len(data_type.item_attributes) > max_item_attributes:
+            max_item_attributes = len(data_type.item_attributes)
+        for attribute in data_type.item_attributes:
+            if attribute not in all_item_attrs:
+                all_item_attrs.append(attribute)
+        for index, field in enumerate(data_type.fields):
+            # this might pose a problem when fields of the same name have different properties..
+            if field not in all_fields:
+                all_fields.append(field)
+            if len(field_prop_count) <= index:
+                field_prop_count.append(len(field.properties))
+            elif field_prop_count[index] <= len(field.properties):
+                field_prop_count[index] = len(field.properties)
+            if len(field.properties) > 0:
+                for prop_index, property in enumerate(field.properties):
+                    prop_key = get_field_prop_format(index + 1, prop_index + 1)
+                    type_field_properties[data_type.tag][prop_key] = property
+
+        # Helpers to generate item-sheets
+        data_items_book_by_type[data_type.tag] = []
+        max_users = 0
+        max_groups = 0
+        max_locations = 0
+        if "field_prop_combos" in combined_item_helper:
+            field_prop_combos = combined_item_helper["field_prop_combos"]
+        else:
+            field_prop_combos = {field.name: [] for field in data_type.fields}
+        fixture_data = LookupTableRow.objects.iter_rows(domain, table_id=data_type.id)
+        num_rows = LookupTableRow.objects.filter(domain=domain, table_id=data_type.id).count()
+        for n, item_row in enumerate(fixture_data):
+            _update_progress(task, last_update, event_count, n, num_rows, total_events)
+            data_items_book_by_type[data_type.tag].append(item_row)
+            max_groups = max(max_groups, owner_names.count(item_row, OwnerType.User))
+            max_users = max(max_users, owner_names.count(item_row, OwnerType.Group))
+            max_locations = max(max_locations, owner_names.count(item_row, OwnerType.Location))
+        for field in data_type.fields:
+            # need for a check to see if field.field_name is in max_field_prop_combos?
+            for property in field.properties:
+                if property not in field_prop_combos[field.field_name]:
+                    field_prop_combos[field.field_name].append(property)
+
+        combined_item_helper["max_users"] = max(combined_item_helper["max_users"], max_users)
+        combined_item_helper["max_groups"] = max(combined_item_helper["max_groups"], max_groups)
+        combined_item_helper["max_locations"] = max(combined_item_helper["max_locations"], max_locations)
+        combined_item_helper["field_prop_combos"] = field_prop_combos
+
+    # Prepare 'types' sheet data
+    indexed_field_numbers = get_indexed_field_numbers(data_types_view)
+    types_sheet = {"headers": [], "rows": []}
+    types_sheet["headers"] = [DELETE_HEADER, "table_id", 'is_global?']
+    types_sheet["headers"].extend(iter_types_headers(max_fields, indexed_field_numbers))
+    types_sheet["headers"].extend(["property %d" % x for x in range(1, max_item_attributes + 1)])
+    field_prop_headers = []
+    for field_num, prop_num in enumerate(field_prop_count):
+        if prop_num > 0:
+            for c in range(0, prop_num):
+                prop_key = get_field_prop_format(field_num + 1, c + 1)
+                field_prop_headers.append(prop_key)
+                types_sheet["headers"].append(prop_key)
+
+    for data_type in data_types_book:
+        common_vals = ["N", data_type.tag, yesno(data_type.is_global)]
+        field_vals = []
+        # Count "is_indexed?" columns added, because data types with fewer fields will add fewer columns
+        indexed_field_count = 0
+        for i, field in enumerate(data_type.fields):
+            field_vals.append(field.field_name)
+            if i in indexed_field_numbers:
+                field_vals.append('yes' if field.is_indexed else 'no')
+                indexed_field_count += 1
+        field_vals.extend(empty_padding_list(
+            max_fields - len(data_type.fields)
+            + len(indexed_field_numbers) - indexed_field_count
+        ))
+        item_att_vals = (data_type.item_attributes + empty_padding_list(
+            max_item_attributes - len(data_type.item_attributes)
+        ))
+        prop_vals = []
+        if data_type.tag in type_field_properties:
+            props = type_field_properties.get(data_type.tag)
+            prop_vals.extend([props.get(key, "") for key in field_prop_headers])
+        row = tuple(common_vals + field_vals + item_att_vals + prop_vals)
+        types_sheet["rows"].append(row)
+
+    types_sheet["rows"] = tuple(types_sheet["rows"])
+    types_sheet["headers"] = tuple(types_sheet["headers"])
+    excel_sheets["types"] = types_sheet
+
+    # Making the collated master sheet
+    item_sheet = {"headers": [], "rows": []}
+    common_headers = ["UID", DELETE_HEADER]
+    user_headers = ["user %d" % x for x in range(1, combined_item_helper["max_users"] + 1)]
+    group_headers = ["group %d" % x for x in range(1, combined_item_helper["max_groups"] + 1)]
+    location_headers = ["location %d" % x for x in range(1, combined_item_helper["max_locations"] + 1)]
+    item_att_headers = ["property: " + attribute for attribute in all_item_attrs]
+    all_field_headers = []
+    # building the all_field_headers list
+    for field in all_fields:
+        if len(field.properties) == 0:
+            field_value = "field: " + field.field_name
+            if field_value not in all_field_headers:
+                all_field_headers.append(field_value)
+        else:
+            # will need to revisit this
+            prop_headers = []
+            for x in range(1, len(combined_item_helper["max_field_prop_combos"][field.field_name]) + 1):
+                for property in combined_item_helper["max_field_prop_combos"][field.field_name]:
+                    prop_headers.append("%(name)s: %(prop)s %(count)s" % {
+                        "name": field.field_name,
+                        "prop": property,
+                        "count": x
+                    })
+                prop_headers.append("field: %(name)s %(count)s" % {
+                    "name": field.field_name,
+                    "count": x
+                })
+            all_field_headers.extend(prop_headers)
+
+    # building the rows
+    for n, data_type in enumerate(data_types_book):
+        _update_progress(task, last_update, total_tables, n, total_tables, total_events)
+        for item_row in data_items_book_by_type[data_type.tag]:
+            common_vals = [str(item_row.id.hex), "N"]
+            users = owner_names.get_usernames(item_row)
+            groups = owner_names.get_group_names(item_row)
+            locations = owner_names.get_location_codes(item_row)
+            user_vals = (users + empty_padding_list(combined_item_helper["max_users"] - len(users)))
+            group_vals = (groups + empty_padding_list(combined_item_helper["max_groups"] - len(groups)))
+            location_vals = (locations + empty_padding_list(
+                combined_item_helper["max_locations"] - len(locations)))
+            field_vals = []
+            item_att_vals = []
+            for attribute in all_item_attrs:
+                if attribute in item_row.item_attributes:
+                    item_att_vals.append(item_row.item_attributes[attribute])
+                else:
+                    item_att_vals.append("")
+            for field in all_fields:
+                if len(field.properties) == 0:
+                    field_values = item_row.fields.get(field.name)
+                    value = field_values[0].value if field_values else ""
+                    field_vals.append(value)
+                else:
+                    # there needs to be a check here that the field exists for this item row
+                    # similar to what's happening above actually...
+                    # if not, refer to the max_field_prop_combos and add a padding list
+                    # need to revisit this section (and corresponding headers)
+                    field_prop_vals = []
+                    cur_combo_count = len(item_row.fields.get(field.field_name).field_list)
+                    cur_prop_count = len(field.properties)
+                    for count, field_prop_combo in enumerate(item_row.fields.get(field.field_name).field_list):
+                        for property in field.properties:
+                            field_prop_vals.append(field_prop_combo.properties.get(property, None) or "")
+                        field_prop_vals.append(field_prop_combo.field_value)
+                    padding_list_len = ((combined_item_helper["max_field_prop_combos"][field.field_name]
+                                         - cur_combo_count) * (cur_prop_count + 1))
+                    field_prop_vals.extend(empty_padding_list(padding_list_len))
+                    field_vals.extend(field_prop_vals)
+            row = tuple(
+                common_vals
+                + field_vals
+                + item_att_vals
+                + user_vals
+                + group_vals
+                + location_vals
+                + [data_type.tag]
+            )
+            item_sheet["rows"].append(row)
+    item_sheet["headers"] = tuple(
+        common_headers
+        + all_field_headers
+        + item_att_headers
+        + user_headers
+        + group_headers
+        + location_headers
+        + ['table_id']
+    )
+    item_sheet["rows"] = tuple(item_sheet["rows"])
+    excel_sheets['combined_sheet'] = item_sheet
+    return ["types", "combined_sheet"], excel_sheets
+
+
+def _update_progress(task, last_update, event_count, item_count, items_in_table, total_events):
+    update_period = timedelta(seconds=1)  # do not update progress more than once a second
+    if task and datetime.utcnow() - last_update[0] > update_period:
+        last_update[0] = datetime.utcnow()
+        processed = event_count * 10 + (10 * item_count / items_in_table)
+        processed = min(processed, total_events)  # limit at 100%
+        DownloadBase.set_progress(task, processed, total_events)
+
+
+def get_field_prop_format(field_number, property_number):
+    return f"field {field_number} : property {property_number}"
+
+
+def empty_padding_list(length):
+    return [""] * length
 
 
 def get_indexed_field_numbers(tables):

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -491,6 +491,8 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
             prop_vals.extend([props.get(key, "") for key in field_prop_headers])
         row = tuple(common_vals + field_vals + item_att_vals + prop_vals)
         types_sheet["rows"].append(row)
+    # prevent combined sheets from being imported
+    types_sheet["rows"].append(tuple(["N", "combined_sheet_via_feature_flag", yesno(False)]))
 
     types_sheet["rows"] = tuple(types_sheet["rows"])
     types_sheet["headers"] = tuple(types_sheet["headers"])

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -416,9 +416,8 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
             if attribute not in all_item_attrs:
                 all_item_attrs.append(attribute)
         for index, field in enumerate(data_type.fields):
-            # this might pose a problem when fields of the same name have different properties..
-            if field not in all_fields:
-                all_fields.append(field)
+            if field.name not in all_fields:
+                all_fields.append(field.name)
             if len(field_prop_count) <= index:
                 field_prop_count.append(len(field.properties))
             elif field_prop_count[index] <= len(field.properties):
@@ -433,10 +432,10 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
         max_users = 0
         max_groups = 0
         max_locations = 0
-        if "field_prop_combos" in combined_item_helper:
-            field_prop_combos = combined_item_helper["field_prop_combos"]
+        if "max_field_prop_combos" in combined_item_helper:
+            max_field_prop_combos = combined_item_helper["max_field_prop_combos"]
         else:
-            field_prop_combos = {field.name: [] for field in data_type.fields}
+            max_field_prop_combos = {field.name: [] for field in data_type.fields}
         fixture_data = LookupTableRow.objects.iter_rows(domain, table_id=data_type.id)
         num_rows = LookupTableRow.objects.filter(domain=domain, table_id=data_type.id).count()
         for n, item_row in enumerate(fixture_data):
@@ -446,20 +445,20 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
             max_users = max(max_users, owner_names.count(item_row, OwnerType.Group))
             max_locations = max(max_locations, owner_names.count(item_row, OwnerType.Location))
         for field in data_type.fields:
-            # need for a check to see if field.field_name is in max_field_prop_combos?
+            if field.name not in max_field_prop_combos:
+                max_field_prop_combos[field.field_name] = []
             for property in field.properties:
-                if property not in field_prop_combos[field.field_name]:
-                    field_prop_combos[field.field_name].append(property)
+                if property not in max_field_prop_combos[field.field_name]:
+                    max_field_prop_combos[field.field_name].append(property)
 
         combined_item_helper["max_users"] = max(combined_item_helper["max_users"], max_users)
         combined_item_helper["max_groups"] = max(combined_item_helper["max_groups"], max_groups)
         combined_item_helper["max_locations"] = max(combined_item_helper["max_locations"], max_locations)
-        combined_item_helper["field_prop_combos"] = field_prop_combos
+        combined_item_helper["max_field_prop_combos"] = max_field_prop_combos
 
     # Prepare 'types' sheet data
     indexed_field_numbers = get_indexed_field_numbers(data_types_view)
-    types_sheet = {"headers": [], "rows": []}
-    types_sheet["headers"] = [DELETE_HEADER, "table_id", 'is_global?']
+    types_sheet = {"headers": [DELETE_HEADER, "table_id", 'is_global?'], "rows": []}
     types_sheet["headers"].extend(iter_types_headers(max_fields, indexed_field_numbers))
     types_sheet["headers"].extend(["property %d" % x for x in range(1, max_item_attributes + 1)])
     field_prop_headers = []
@@ -473,7 +472,6 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
     for data_type in data_types_book:
         common_vals = ["N", data_type.tag, yesno(data_type.is_global)]
         field_vals = []
-        # Count "is_indexed?" columns added, because data types with fewer fields will add fewer columns
         indexed_field_count = 0
         for i, field in enumerate(data_type.fields):
             field_vals.append(field.field_name)
@@ -506,31 +504,37 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
     location_headers = ["location %d" % x for x in range(1, combined_item_helper["max_locations"] + 1)]
     item_att_headers = ["property: " + attribute for attribute in all_item_attrs]
     all_field_headers = []
+
     # building the all_field_headers list
-    for field in all_fields:
-        if len(field.properties) == 0:
-            field_value = "field: " + field.field_name
+    for field_name in all_fields:
+        max_prop_combos = combined_item_helper["max_field_prop_combos"][field_name]
+        if len(max_prop_combos) == 0:
+            field_value = "field: " + field_name
             if field_value not in all_field_headers:
                 all_field_headers.append(field_value)
         else:
-            # will need to revisit this
             prop_headers = []
-            for x in range(1, len(combined_item_helper["max_field_prop_combos"][field.field_name]) + 1):
-                for property in combined_item_helper["max_field_prop_combos"][field.field_name]:
-                    prop_headers.append("%(name)s: %(prop)s %(count)s" % {
-                        "name": field.field_name,
+            for x in range(1, len(max_prop_combos) + 1):
+                for property in max_prop_combos:
+                    prop_header = "%(name)s: %(prop)s %(count)s" % {
+                        "name": field_name,
                         "prop": property,
                         "count": x
-                    })
-                prop_headers.append("field: %(name)s %(count)s" % {
-                    "name": field.field_name,
+                    }
+                    if prop_header not in all_field_headers:
+                        prop_headers.append(prop_header)
+                prop_header = "field: %(name)s %(count)s" % {
+                    "name": field_name,
                     "count": x
-                })
+                }
+                if prop_header not in all_field_headers:
+                    prop_headers.append(prop_header)
             all_field_headers.extend(prop_headers)
 
     # building the rows
     for n, data_type in enumerate(data_types_book):
         _update_progress(task, last_update, total_tables, n, total_tables, total_events)
+        max_prop_combos = combined_item_helper["max_field_prop_combos"]
         for item_row in data_items_book_by_type[data_type.tag]:
             common_vals = [str(item_row.id.hex), "N"]
             users = owner_names.get_usernames(item_row)
@@ -540,33 +544,26 @@ def _prepare_fixture_collated(table_ids, domain, task=None):
             group_vals = (groups + empty_padding_list(combined_item_helper["max_groups"] - len(groups)))
             location_vals = (locations + empty_padding_list(
                 combined_item_helper["max_locations"] - len(locations)))
-            field_vals = []
+
             item_att_vals = []
             for attribute in all_item_attrs:
                 if attribute in item_row.item_attributes:
                     item_att_vals.append(item_row.item_attributes[attribute])
                 else:
                     item_att_vals.append("")
-            for field in all_fields:
-                if len(field.properties) == 0:
-                    field_values = item_row.fields.get(field.name)
+
+            field_vals = []
+            for field_name in all_fields:
+                field_values = item_row.fields.get(field_name)
+                if len(max_prop_combos[field_name]) == 0:
                     value = field_values[0].value if field_values else ""
                     field_vals.append(value)
                 else:
-                    # there needs to be a check here that the field exists for this item row
-                    # similar to what's happening above actually...
-                    # if not, refer to the max_field_prop_combos and add a padding list
-                    # need to revisit this section (and corresponding headers)
                     field_prop_vals = []
-                    cur_combo_count = len(item_row.fields.get(field.field_name).field_list)
-                    cur_prop_count = len(field.properties)
-                    for count, field_prop_combo in enumerate(item_row.fields.get(field.field_name).field_list):
-                        for property in field.properties:
+                    for field_prop_combo in item_row.fields[field_name]:
+                        for property in max_prop_combos[field_name]:
                             field_prop_vals.append(field_prop_combo.properties.get(property, None) or "")
-                        field_prop_vals.append(field_prop_combo.field_value)
-                    padding_list_len = ((combined_item_helper["max_field_prop_combos"][field.field_name]
-                                         - cur_combo_count) * (cur_prop_count + 1))
-                    field_prop_vals.extend(empty_padding_list(padding_list_len))
+                        field_prop_vals.append(field_prop_combo.value)
                     field_vals.extend(field_prop_vals)
             row = tuple(
                 common_vals

--- a/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
+++ b/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
@@ -7,6 +7,7 @@ hqDefine("fixtures/js/lookup-manage", [
     "knockout",
     "hqwebapp/js/assert_properties",
     "hqwebapp/js/initial_page_data",
+    'hqwebapp/js/toggles',
     "hqwebapp/js/hq.helpers",
     "hqwebapp/js/knockout_bindings.ko",
 ], function (
@@ -14,7 +15,8 @@ hqDefine("fixtures/js/lookup-manage", [
     _,
     ko,
     assertProperties,
-    initialPageData
+    initialPageData,
+    toggles
 ) {
     "use strict";
     var somethingWentWrong = $("#FailText").text();
@@ -244,7 +246,13 @@ hqDefine("fixtures/js/lookup-manage", [
         var self = {};
         self.data_types = ko.observableArray(_.map(options.data_types, function (t) { return makeDataType(t, self); }));
         self.file = ko.observable();
+        self.combineSheets = ko.observable(false);
+        self.flagEnabled = ko.observable(false);
         self.selectedTables = ko.observableArray([]);
+
+        if (toggles.toggleEnabled('COMBINE_LOOKUP_TABLES')) {
+            self.flagEnabled = true;
+        }
 
         self.removeBadDataType = function (dataType) {
             setTimeout(function () {
@@ -296,6 +304,7 @@ hqDefine("fixtures/js/lookup-manage", [
                     type: 'POST',
                     data: {
                         'table_ids': tables,
+                        'extraParam': self.combineSheets(),
                     },
                     dataType: 'json',
                     success: function (response) {

--- a/corehq/apps/fixtures/tasks.py
+++ b/corehq/apps/fixtures/tasks.py
@@ -52,8 +52,8 @@ def send_upload_fixture_complete_email(email, domain, time_start, time_end, mess
 
 
 @task
-def async_fixture_download(table_ids, domain, download_id, owner_id):
+def async_fixture_download(table_ids, domain, download_id, owner_id, combine_sheets=False):
     task = async_fixture_download
     DownloadBase.set_progress(task, 0, 100)
-    prepare_fixture_download(table_ids, domain, task, download_id, owner_id)
+    prepare_fixture_download(table_ids, domain, task, download_id, owner_id, combine_sheets=combine_sheets)
     DownloadBase.set_progress(task, 100, 100)

--- a/corehq/apps/fixtures/templates/fixtures/manage_tables.html
+++ b/corehq/apps/fixtures/templates/fixtures/manage_tables.html
@@ -101,6 +101,10 @@
         </tr>
         </tbody>
       </table>
+      <!-- ko if: flagEnabled -->
+      <input type="checkbox" data-bind="checked: combineSheets" />
+      {% trans "Combine sheets" %}
+      <!-- /ko -->
     </div>
   </div>
   <div class="row">

--- a/corehq/apps/fixtures/templates/fixtures/view_table.html
+++ b/corehq/apps/fixtures/templates/fixtures/view_table.html
@@ -20,7 +20,7 @@
 {% block page_content %}
   {% initial_page_data 'renderReportTables' 1 %}
   {% initial_page_data 'dataTablesOptions' data_tables_options %}
-  {% if not table_not_selected %}
+  {% if not table_not_selected and table_description %}
     <h4>{{ table_description }}</h4>
   {% endif %}
 
@@ -56,12 +56,14 @@
         </div>
       </div>
       {% if not table_not_selected %}
+        <!-- need to look at this styling again -->
+        <div class="panel-heading"
+             style="position: sticky; top: 0; z-index:100; background-color: #ffffff; width:100%;">
+          <h2 class="panel-title">
+            {% blocktrans %}Table {% endblocktrans %}'{{ selected_table }}'
+          </h2>
+        </div>
         <div class="panel panel-default">
-          <div class="panel-heading">
-            <h2 class="panel-title">
-              {% blocktrans %}Table {% endblocktrans %}'{{ selected_table }}'
-            </h2>
-          </div>
           <div class="panel-body-datatable">
             <table id="report_table_{{ report.slug }}" class="table table-striped datatable" {% if pagination.filter %} data-filter="true"{% endif %}>
               <thead>

--- a/corehq/apps/fixtures/templates/fixtures/view_table.html
+++ b/corehq/apps/fixtures/templates/fixtures/view_table.html
@@ -56,7 +56,6 @@
         </div>
       </div>
       {% if not table_not_selected %}
-        <!-- need to look at this styling again -->
         <div class="panel-heading"
              style="position: sticky; top: 0; z-index:100; background-color: #ffffff; width:100%;">
           <h2 class="panel-title">

--- a/corehq/apps/fixtures/tests/test_upload.py
+++ b/corehq/apps/fixtures/tests/test_upload.py
@@ -248,6 +248,16 @@ validation_test_cases = [
             ('Delete(Y/N)', 'table_id', 'is_global?', 'field 1', 'field 1: property 1'),
             ('N', 'things', 'yes', 'name', 'lang')
         ]
+    }),
+    ("sheets_have_been_combined", [
+        "Cannot upload a lookup table created using the Combine Sheets feature."
+    ], {
+        'things': [('UID', 'Delete(Y/N)', 'field: name'), (None, 'N', 'apple')],
+        'types': [
+            ('Delete(Y/N)', 'table_id', 'is_global?', 'field 1'),
+            ('N', 'things', 'yes', 'name'),
+            ('N', 'combined_sheet_via_feature_flag', 'no')
+        ]
     })
 ]
 

--- a/corehq/apps/fixtures/upload/failure_messages.py
+++ b/corehq/apps/fixtures/upload/failure_messages.py
@@ -63,4 +63,7 @@ FAILURE_MESSAGES = {
     "no_types_sheet": gettext_noop(
         "Workbook does not contain a sheet called types"
     ),
+    "sheets_have_been_combined": gettext_noop(
+        "Cannot upload a lookup table created using the Combine Sheets feature."
+    ),
 }

--- a/corehq/apps/fixtures/upload/validation.py
+++ b/corehq/apps/fixtures/upload/validation.py
@@ -34,6 +34,8 @@ def _validate_fixture_upload(workbook):
         tag = table_def.table_id
         fields = table_def.fields
         item_attributes = table_def.item_attributes
+        if tag == "combined_sheet_via_feature_flag":
+            return [_(FAILURE_MESSAGES["sheets_have_been_combined"])]
         try:
             data_items = workbook.get_data_sheet(tag)
         except WorksheetNotFound:

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -283,11 +283,16 @@ def download_item_lists(request, domain):
     """Asynchronously serve excel download for edit_lookup_tables
     """
     download = DownloadBase()
+    combine_sheets = False
+    if request.POST.get('extraParam', 'false') == 'true':
+        combine_sheets = True
+
     download.set_task(async_fixture_download.delay(
         table_ids=request.POST.getlist("table_ids[]", []),
         domain=domain,
         download_id=download.download_id,
         owner_id=request.couch_user.get_id,
+        combine_sheets=combine_sheets,
     ))
     return download.get_start_response()
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2371,3 +2371,10 @@ EMBED_TABLEAU_REPORT_BY_USER = StaticToggle(
                 'Turn on this flag to instead send "HQ/{the user\'s HQ username}", i.e. "HQ/jdoe@dimagi.com", '
                 'to Tableau to get the embedded report.',
 )
+
+COMBINE_LOOKUP_TABLES = StaticToggle(
+    'combine_lookup_tables',
+    "Combines lookup table exports into one master sheet",
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Feature flag only!!

This PR adds two features:

1. Table titles are now stickied to the top of the page when scrolling through long tables  in the View Tables page.

2. Adds a feature flag that allows for multiple lookup tables to be combined under one master table. Exports downloaded with this feature flag on won't be able to be imported back into commcare. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13747)

The "Combine Sheets" feature flag option combines multiple lookup tables into one master sheet called `combined_sheet`. It's designed such that if two or more lookup tables share a similar field/property/attribute name it will be collected under the same column (case sensitive). It also appends an extra column at the end of every row under `table_id`, that notes which lookup table that particular row comes from. 

To avoid complicating the already convoluted download function `_prepare_fixture` the new function (`_prepare_fixture_collated`) is a heavily modified, but still cloned version that has chunks of code in common (namely, the process that prepares the "types" sheet, which the combined download still has). 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

This PR adds a new FF called `combine_lookup_tables`. ([on staging](https://staging.commcarehq.org/hq/flags/edit/combine_lookup_tables))

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging with a wide variety of lookup tables. QA tested. 

Inherently safe since this feature only reads data to produce the sheets.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-4648)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
