### PR TITLE
[USH-2606] backfill remaining data in subevent table

### DIFF
--- a/corehq/apps/sms/tests/test_backfill_subevent.py
+++ b/corehq/apps/sms/tests/test_backfill_subevent.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.test import TestCase
 
 from corehq.apps.accounting.models import Subscription
@@ -5,12 +7,14 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.sms.management.commands.backfill_sms_subevent_date import (
     update_subevent_date_from_emails,
     update_subevent_date_from_sms,
+    update_subevent_date_from_subevent,
     update_subevent_date_from_xform_session,
 )
 from corehq.apps.sms.models import MessagingSubEvent
 from corehq.apps.sms.tests.data_generator import (
     create_fake_sms,
     make_email_event_for_test,
+    make_events_for_test,
     make_survey_sms_for_test,
 )
 from corehq.apps.users.models import CommCareUser
@@ -34,6 +38,10 @@ class TestBackfillSubeventDate(TestCase):
     def test_update_from_xform_session(self):
         self._setup_survey_data()
         self._do_backfill_validate_result(update_subevent_date_from_xform_session)
+
+    def test_update_from_subevent(self):
+        self._setup_subevent_data()
+        self._do_backfill_validate_result(update_subevent_date_from_subevent)
 
     def _do_backfill_validate_result(self, update_fn):
         rows_updated, iterations = update_fn(chunk_size=2, explain=False)
@@ -61,6 +69,12 @@ class TestBackfillSubeventDate(TestCase):
     def _setup_survey_data(self):
         for i in range(4):
             make_survey_sms_for_test(self.domain.name, "test survey")
+
+        self._reset_dates_and_check()
+
+    def _setup_subevent_data(self):
+        for i in range(4):
+            make_events_for_test(self.domain.name, datetime.datetime.utcnow())
 
         self._reset_dates_and_check()
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-2606

## Technical Summary
Followup from https://github.com/dimagi/commcare-hq/pull/32311

I discovered that the backfill is incomplete because not all subevent records have associated SMS, Email or XFormSessions. The majority of these are 'error' records, but I've found that there are a number of places in code where a message is updated in code without
being saved immediately which leaves scope for the message never being updated
the subevent ID (e.g. https://github.com/dimagi/commcare-hq/blob/826b1758f5ee3320d69001aaba9b2761f0ce8ff7/corehq/apps/sms/handlers/keyword.py#L580). Finding and fixing all of those is out of the scope of the current work.

## Safety Assurance

### Safety story
Updates to a management command. The command itself has tests and has been tested on staging.

### Automated test coverage
Updated in the PR

### QA Plan
Tested on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
