### PR TITLE
Point flower to github repo

### DIFF
--- a/requirements/prod-requirements.in
+++ b/requirements/prod-requirements.in
@@ -2,7 +2,8 @@
 
 pip
 
-flower
+# Switch back to normal package as soon as flower realease a version > 1.2.0
+flower @ git+https://github.com/mher/flower
 setproctitle
 uWSGI
 ipython  # for nicer django shell experience

--- a/requirements/prod-requirements.in
+++ b/requirements/prod-requirements.in
@@ -2,8 +2,8 @@
 
 pip
 
-# Switch back to normal package as soon as flower realease a version > 1.2.0
-flower @ git+https://github.com/mher/flower
+# Switch back to normal package as soon as flower release a version > 1.2.0
+flower @ git+https://github.com/mher/flower@a4fc7c97d897a3172d1058d5269115eb88d811de
 setproctitle
 uWSGI
 ipython  # for nicer django shell experience

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -192,7 +192,7 @@ eulxml==1.1.3
     # via -r base-requirements.in
 executing==0.8.3
     # via stack-data
-flower==1.2.0
+flower @ git+https://github.com/mher/flower
     # via -r prod-requirements.in
 future==0.18.2
     # via pyjwkest

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -192,7 +192,7 @@ eulxml==1.1.3
     # via -r base-requirements.in
 executing==0.8.3
     # via stack-data
-flower @ git+https://github.com/mher/flower
+flower @ git+https://github.com/mher/flower@a4fc7c97d897a3172d1058d5269115eb88d811de
     # via -r prod-requirements.in
 future==0.18.2
     # via pyjwkest


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
We fixed one of the serialization issues in the flower repo and the fix was accepted but a new version(>1.2.0) has not been released yet. So we are temporarily pointing flower to its GitHub repo.
This would be reverted when a new version of flower is released.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13911

## Safety Assurance
A dependency upgrade to fix an existing issue with flower. 


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
