### PR TITLE
Do not set multiplexer mappings in init

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -903,7 +903,7 @@ class ElasticMultiplexAdapter(BaseAdapter):
         self.secondary.from_python = self.from_python
 
     @property
-    def mappings(self):
+    def mapping(self):
         return self.primary.mapping
 
     def export_adapter(self):

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -896,12 +896,15 @@ class ElasticMultiplexAdapter(BaseAdapter):
         super().__init__()
         self.index_name = primary_adapter.index_name
         self.type = primary_adapter.type
-        self.mapping = primary_adapter.mapping
 
         self.primary = primary_adapter
         self.secondary = secondary_adapter
         # TODO document this better
         self.secondary.from_python = self.from_python
+
+    @property
+    def mappings(self):
+        return self.primary.mapping
 
     def export_adapter(self):
         adapter = copy.copy(self)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
While writing tests for ES sync utility, I came across this issue where we were trying to set the mapping of a multiplexed index before `_DOC_MAPPINGS_BY_INDEX` which was causing Django to fail on startup.  

Not sure if it is the best way to go about it but it made sense, so opening it up here for review.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
