### PR TITLE
Execute git push in the foreground to support interactive pre-push hooks 

### DIFF
--- a/scripts/vellum-to-hq
+++ b/scripts/vellum-to-hq
@@ -25,8 +25,10 @@ import sh
 VELLUM_TAR = "vellum.tar.gz"
 
 
-def get_git(path=None):
-    return sh.git.bake(_tty_out=False, _cwd=path)
+def get_git(path=None, foreground=False):
+    # see: https://amoffat.github.io/sh/sections/special_arguments.html#fg
+    kwargs = {"_fg" if foreground else "_tty_out": foreground}
+    return sh.git.bake(_cwd=path, **kwargs)
 
 
 def main():
@@ -178,7 +180,7 @@ def update_hq(path, branch, base_branch, vellum_dir, vellum_rev, push, target):
     if push:
         print("Pushing HQ origin/{}".format(branch))
         opts = () if branch == "master" else ["-f"]
-        git.push("origin", branch, *opts)
+        get_git(path, foreground=True).push("origin", branch, *opts)
 
     print_vellum_changes(old_vellum_rev, vellum_dir)
 


### PR DESCRIPTION
## Technical Summary

Pushing directly to the default branch isn't a GitHub best practice for large team repositories, as such I use a pre-push git hook that checks if I'm pushing to `master` and interactively prompts me to verify that that is what I want to do.  This change adds support for that workflow to the `vellum-to-hq` script.

## Safety Assurance

### Safety story

Does not affect behavior of script if push command is not interactive (effective noop).

### Automated test coverage

No tests.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
