### PR TITLE
Bump django-field-audit to v1.2.4

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -159,7 +159,7 @@ django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3
     # via -r dev-requirements.in
-django-field-audit==1.2.3
+django-field-audit==1.2.4
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -137,7 +137,7 @@ django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3
     # via -r docs-requirements.in
-django-field-audit==1.2.3
+django-field-audit==1.2.4
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -138,7 +138,7 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
-django-field-audit==1.2.3
+django-field-audit==1.2.4
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -130,7 +130,7 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
-django-field-audit==1.2.3
+django-field-audit==1.2.4
     # via -r base-requirements.in
 django-formtools==2.3
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -139,7 +139,7 @@ django-crispy-forms==1.10.0
     # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
-django-field-audit==1.2.3
+django-field-audit==1.2.4
     # via -r base-requirements.in
 django-formtools==2.3
     # via


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13015

v1.2.4 of django-field-audit includes https://github.com/dimagi/django-field-audit/pull/11, which enables us to audit QuerySet.update usages in HQ, which is blocking https://github.com/dimagi/commcare-hq/pull/32336.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Going to test on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated test coverage exists in the django-field-audit library itself.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

If https://github.com/dimagi/commcare-hq/pull/32336 has been merged, we should avoid reverting this since that code will depend on changes introduced in this version of django-field-audit.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
