### PR TITLE
Increase Visibility into UCR Rebuilds

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -184,6 +184,27 @@ class DataSourceBuildInformation(DocumentSchema):
     initiated_in_place = DateTimeProperty()
     rebuilt_asynchronously = BooleanProperty(default=False)
 
+    @property
+    def is_rebuilding(self):
+        return (
+            self.initiated
+            and (
+                not self.finished
+                and not self.rebuilt_asynchronously
+            )
+        )
+
+    @property
+    def is_rebuilding_in_place(self):
+        return (
+            self.initiated_in_place
+            and not self.finished_in_place
+        )
+
+    @property
+    def is_rebuild_in_progress(self):
+        return self.is_rebuilding or self.is_rebuilding_in_place
+
 
 class DataSourceMeta(DocumentSchema):
     build = SchemaProperty(DataSourceBuildInformation)
@@ -540,21 +561,6 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
     @property
     def data_domains(self):
         return [self.domain]
-
-    @property
-    def is_rebuild_in_progress(self):
-        return (
-            not self.is_static
-            and (
-                self.meta.build.initiated
-                or self.meta.build.initiated_in_place
-            )
-            and (
-                not self.meta.build.finished
-                and not self.meta.build.finished_in_place
-                and not self.meta.build.rebuilt_asynchronously
-            )
-        )
 
     def _verify_contains_allowed_expressions(self):
         """

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -541,6 +541,21 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
     def data_domains(self):
         return [self.domain]
 
+    @property
+    def is_rebuild_in_progress(self):
+        return (
+            not self.is_static
+            and (
+                self.meta.build.initiated
+                or self.meta.build.initiated_in_place
+            )
+            and (
+                not self.meta.build.finished
+                and not self.meta.build.finished_in_place
+                and not self.meta.build.rebuilt_asynchronously
+            )
+        )
+
     def _verify_contains_allowed_expressions(self):
         """
         Raise BadSpecError if any disallowed expression is present in datasource

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -95,9 +95,7 @@ def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1, source=
 
     success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
     failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
-    send = False
-    if limit == -1:
-        send = toggles.SEND_UCR_REBUILD_INFO.enabled(initiated_by)
+    send = limit == -1
     with notify_someone(initiated_by, success_message=success, error_message=failure, send=send):
         adapter = get_indicator_adapter(config)
 
@@ -131,8 +129,7 @@ def rebuild_indicators_in_place(indicator_config_id, initiated_by=None, source=N
     config = get_ucr_datasource_config_by_id(indicator_config_id)
     success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
     failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
-    send = toggles.SEND_UCR_REBUILD_INFO.enabled(initiated_by)
-    with notify_someone(initiated_by, success_message=success, error_message=failure, send=send):
+    with notify_someone(initiated_by, success_message=success, error_message=failure, send=True):
         adapter = get_indicator_adapter(config)
         if not id_is_static(indicator_config_id):
             config.meta.build.initiated_in_place = datetime.utcnow()
@@ -149,8 +146,7 @@ def resume_building_indicators(indicator_config_id, initiated_by=None):
     config = get_ucr_datasource_config_by_id(indicator_config_id)
     success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
     failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
-    send = toggles.SEND_UCR_REBUILD_INFO.enabled(initiated_by)
-    with notify_someone(initiated_by, success_message=success, error_message=failure, send=send):
+    with notify_someone(initiated_by, success_message=success, error_message=failure, send=True):
         resume_helper = DataSourceResumeHelper(config)
         adapter = get_indicator_adapter(config)
         adapter.log_table_build(

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -4,9 +4,17 @@
 {% load i18n %}
 
 {% block page_content %}
-  {% if data_source.is_rebuild_in_progress %}
+  {% if data_source.meta.build.is_rebuild_in_progress %}
         <div id="built-warning" class="alert alert-warning">
-          <h4><i class="fa fa-exclamation-triangle"></i> {% trans "Please note that this datasource is being rebuilt." %}</h4>
+          <h4><i class="fa fa-exclamation-triangle"></i>
+          {% if data_source.meta.build.is_rebuilding %}
+            {% trans "Please note that this datasource is being rebuilt." %}
+          {% endif %}
+          {% if data_source.meta.build.is_rebuilding_in_place %}
+            {% trans "Please note that this datasource is being rebuilt in place." %}
+          {% endif %}
+          </h4>
+          {% trans "If rebuilt again next rebuild will only start when the previous rebuild(s) finishes." %}
         </div>
   {% endif %}
   {% if data_source.get_id %}
@@ -23,7 +31,7 @@
         <div class="btn-group">
           <form method='post' action="{% url 'rebuild_configurable_data_source' domain data_source.get_id %}" >
             {% csrf_token %}
-            <div {% if is_rebuilding or data_source.disable_destructive_rebuild %}style="margin-right: 15px;"{% endif %}>
+            <div {% if data_source.disable_destructive_rebuild %}style="margin-right: 15px;"{% endif %}>
               {% if use_updated_ucr_naming %}
               <button type="submit"
                 class="btn btn-default disable-on-submit"
@@ -47,17 +55,11 @@
                 {% trans 'Rebuild Data Source'%}
               </button>
               {% endif %}
-              {# janky: can't use a tooltip on a disabled button, so instead add a help icon and force extra space (above) so it's clear which button this is for #}
+              {# janky: can't use a tooltip on a disabled button, so instead add a help icon and force extra space (above) so it's clear which button this is for. Todo: After bootstrap 4 upgrade there is a fix https://getbootstrap.com/docs/4.4/components/tooltips/#disabled-elements #}
               {% if data_source.disable_destructive_rebuild %}
                 <span class="hq-help-template"
                   data-title="{% trans_html_attr "Rebuild Unavailable" %}"
                   data-content="{% trans_html_attr "Fully rebuilding has been disabled for this data source. Please use the in place rebuild if necessary." %}"
-                  data-placement="left"></span>
-              {% endif %}
-              {% if is_rebuilding %}
-                <span class="hq-help-template"
-                  data-title="{% trans_html_attr "Rebuilding Data Source" %}"
-                  data-content="{% trans_html_attr "Currently a rebuild is already in progress for this data source. The next rebuild will start when the previous rebuild(s) finishes." %}"
                   data-placement="left"></span>
               {% endif %}
             </div>
@@ -93,13 +95,6 @@
             <li>
               <a class="submit-dropdown-form"
                  href=""
-                {% if is_rebuilding_inplace %}
-                  data-toggle="popover"
-                  title="Warning"
-                  data-container="body"
-                  data-content="{% trans_html_attr "Currently an in-place rebuild is already in progress for this data source. The next rebuild will start when the previous rebuild(s) finishes." %}"
-                  data-trigger="hover"
-                {% endif %}
                  data-action="{% url 'build_in_place' domain data_source.get_id %}">
                 {% trans 'Rebuild Table in Place' %}
               </a>

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -4,6 +4,11 @@
 {% load i18n %}
 
 {% block page_content %}
+  {% if data_source.is_rebuild_in_progress %}
+        <div id="built-warning" class="alert alert-warning">
+          <h4><i class="fa fa-exclamation-triangle"></i> {% trans "Please note that this datasource is being rebuilt." %}</h4>
+        </div>
+  {% endif %}
   {% if data_source.get_id %}
     <div class="btn-toolbar pull-right">
         <div class="btn-group">

--- a/corehq/apps/userreports/templates/userreports/partials/build_in_progress_warning.html
+++ b/corehq/apps/userreports/templates/userreports/partials/build_in_progress_warning.html
@@ -1,13 +1,9 @@
 {% load i18n %}
-{% if not data_source_config.is_static %}
-  {% if data_source_config.meta.build.initiated or data_source_config.meta.build.initiated_in_place %}
-    {% if not data_source_config.meta.build.finished and not data_source_config.meta.build.finished_in_place and not data_source_config.meta.build.rebuilt_asynchronously %}
+{% if data_source_config.is_rebuild_in_progress %}
       <div id="built-warning" class="alert alert-warning">
         <h4><i class="fa fa-exclamation-triangle"></i> {% trans "Your report is still being populated." %}</h4>
         {% blocktrans %}
           What you are seeing now is just a preview, and contains some or none of your data.
         {% endblocktrans %}
       </div>
-    {% endif %}
-  {% endif %}
 {% endif %}

--- a/corehq/apps/userreports/templates/userreports/partials/build_in_progress_warning.html
+++ b/corehq/apps/userreports/templates/userreports/partials/build_in_progress_warning.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% if data_source_config.is_rebuild_in_progress %}
+{% if not data_source_config.is_static and data_source_config.meta.build.is_rebuild_in_progress  %}
       <div id="built-warning" class="alert alert-warning">
         <h4><i class="fa fa-exclamation-triangle"></i> {% trans "Your report is still being populated." %}</h4>
         {% blocktrans %}

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1135,25 +1135,12 @@ class BaseEditDataSourceView(BaseUserConfigReportsView):
 
     @property
     def page_context(self):
-        is_rebuilding = (
-            self.config.meta.build.initiated
-            and (
-                not self.config.meta.build.finished
-                and not self.config.meta.build.rebuilt_asynchronously
-            )
-        )
-        is_rebuilding_inplace = (
-            self.config.meta.build.initiated_in_place
-            and not self.config.meta.build.finished_in_place
-        )
         allowed_ucr_expression = AllowedUCRExpressionSettings.get_allowed_ucr_expressions(self.request.domain)
         return {
             'form': self.edit_form,
             'data_source': self.config,
             'read_only': self.read_only,
             'used_by_reports': self.get_reports(),
-            'is_rebuilding': is_rebuilding,
-            'is_rebuilding_inplace': is_rebuilding_inplace,
             'allowed_ucr_expressions': allowed_ucr_expression,
         }
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1429,14 +1429,6 @@ MOBILE_USER_DEMO_MODE = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN]
 )
 
-SEND_UCR_REBUILD_INFO = StaticToggle(
-    'send_ucr_rebuild_info',
-    'Notify when UCR rebuilds finish or error.',
-    TAG_SOLUTIONS_CONDITIONAL,
-    namespaces=[NAMESPACE_USER],
-    parent_toggles=[USER_CONFIGURABLE_REPORTS]
-)
-
 ALLOW_USER_DEFINED_EXPORT_COLUMNS = StaticToggle(
     'allow_user_defined_export_columns',
     'Add user defined columns to exports',


### PR DESCRIPTION
## Product Description
This adds 'UCR being rebuilt' warning to the 'Edit Data Source' page (in addition to Preview Data) and notifies the user of the rebuilt status irrespective of the toggle.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Killing SEND_UCR_REBUILD_INFO 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
It's a minor UI change and I have tested locally

### Automated test coverage

It's a minor UI change and I have tested locally
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
