### PR TITLE
Change repeater name property to something else

### DIFF
--- a/corehq/apps/reports/filters/select.py
+++ b/corehq/apps/reports/filters/select.py
@@ -130,7 +130,7 @@ class RepeaterFilter(BaseSingleOptionFilter):
 
     @property
     def options(self):
-        return [(r.repeater_id, f"{r.repeater_type}: {r.name}") for r in self._get_repeaters()]
+        return [(r.repeater_id, f"{r.repeater_type}: {r.repeater_name}") for r in self._get_repeaters()]
 
     def _get_repeaters(self):
         return SQLRepeater.objects.by_domain(self.domain)

--- a/corehq/motech/management/commands/create_repeat_records.py
+++ b/corehq/motech/management/commands/create_repeat_records.py
@@ -43,8 +43,8 @@ class Command(BaseCommand):
             repeater = SQLRepeater.objects.get(repeater_id=repeater_id)
             if repeater_type and repeater_type != repeater.repeater_type:
                 raise CommandError(f"Repeater type does not match: {repeater_type} != {repeater.repeater_type}")
-            if repeater_name_re and not repeater_name_re.match(repeater.name):
-                raise CommandError(f"Repeater name does not match: {repeater.name}")
+            if repeater_name_re and not repeater_name_re.match(repeater.repeater_name):
+                raise CommandError(f"Repeater name does not match: {repeater.repeater_name}")
 
             def _get_repeaters(doc):
                 assert doc.domain == repeater.domain

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -300,6 +300,12 @@ class SQLRepeater(SyncSQLToCouchMixin, RepeaterSuperProxy):
     _has_config = False
 
     @property
+    def repeater_name(self):
+        # This is a temporary name change. We can't have the 'name' property and the name attribute at the same
+        # time. This method/property will be removed in a subsequent PR.
+        return self.connection_settings.name
+
+    @property
     @memoized
     def repeater(self):
         return Repeater.get(self.repeater_id)

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -368,10 +368,6 @@ class SQLRepeater(SyncSQLToCouchMixin, RepeaterSuperProxy):
                                                      RECORD_FAILURE_STATE))
 
     @property
-    def name(self):
-        return self.connection_settings.name
-
-    @property
     def is_ready(self):
         if self.is_paused:
             return False
@@ -955,10 +951,10 @@ class Repeater(SyncCouchToSQLMixin, QuickCachedDocumentMixin, Document):
     _has_config = False
 
     def __str__(self):
-        return f'{self.__class__.__name__}: {self.name}'
+        return f'{self.__class__.__name__}: {self.repeater_name}'
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} {self._id} {self.name!r}>"
+        return f"<{self.__class__.__name__} {self._id} {self.repeater_name!r}>"
 
     @property
     def connection_settings(self):
@@ -977,7 +973,9 @@ class Repeater(SyncCouchToSQLMixin, QuickCachedDocumentMixin, Document):
         return SQLRepeater.objects.get(repeater_id=self._id)
 
     @property
-    def name(self):
+    def repeater_name(self):
+        # This is a temporary name change. We can't have the 'name' property and the name attribute at the same
+        # time. This method/property will be removed in a subsequent PR.
         return self.connection_settings.name
 
     @property

--- a/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 <tr>
-    <td>{{ repeater.name }}
+    <td>{{ repeater.repeater_name }}
         {% if repeater.white_listed_case_types %}
             <br/>Case Type: {{ repeater.white_listed_case_types|join:", " }}
         {% endif %}
@@ -53,7 +53,7 @@
                         {% csrf_token %}
                         <div class="modal-body">
                             <p>
-                                {% blocktrans with repeater.name as name %}
+                                {% blocktrans with repeater.repeater_name as name %}
                                     Are you sure you want to resume forwarding to: "{{ name }}" ?
                                     <br/>
                                     All records enqueued for this forwarder with be triggered
@@ -87,7 +87,7 @@
                         {% csrf_token %}
                         <div class="modal-body">
                             <p>
-                                {% blocktrans with repeater.name as name %}
+                                {% blocktrans with repeater.repeater_name as name %}
                                     Are you sure you want to pause forwarding to: "{{ name }}" ?
                                     <br/>
                                     Please note that new records would get enqueued but would get triggered
@@ -126,7 +126,7 @@
                         {% csrf_token %}
                         <div class="modal-body">
                             <p>
-                                {% blocktrans with repeater.name as name %}
+                                {% blocktrans with repeater.repeater_name as name %}
                                     Are you sure you want to stop forwarding to: {{ name }} ?
                                     <br/>
                                     Forwarder and its data would not be deleted but no new records would get added for

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -193,7 +193,7 @@ class TestRepeaterName(RepeaterTestCase):
         """
         connection_settings = self.repeater.connection_settings
         self.assertEqual(connection_settings.name, self.repeater.url)
-        self.assertEqual(self.repeater.name, connection_settings.name)
+        self.assertEqual(self.repeater.repeater_name, connection_settings.name)
 
     def test_repeater_name(self):
         connection_settings = ConnectionSettings.objects.create(
@@ -204,7 +204,7 @@ class TestRepeaterName(RepeaterTestCase):
         self.repeater.connection_settings_id = connection_settings.id
         self.repeater.save()
 
-        self.assertEqual(self.repeater.name, connection_settings.name)
+        self.assertEqual(self.repeater.repeater_name, connection_settings.name)
 
 
 class TestSQLRepeatRecordOrdering(RepeaterTestCase):

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -174,7 +174,7 @@ class AddRepeaterView(BaseRepeaterView):
         return self.repeater_class()
 
     def post_save(self, request, repeater):
-        messages.success(request, _("Forwarding set up to {}").format(repeater.name))
+        messages.success(request, _("Forwarding set up to {}").format(repeater.repeater_name))
         return HttpResponseRedirect(
             reverse(DomainForwardingOptionsView.urlname, args=[self.domain])
         )


### PR DESCRIPTION
## Technical Summary
See the [ticket](https://dimagi-dev.atlassian.net/jira/software/c/projects/SC/boards/196?modal=detail&selectedIssue=SC-2361) for the reason for this PR.

This is the first PR in a series of 3 that aims to add a name field to the Repeaters. This PR must first be deployed before we can merge the subsequent one.

The reason this change is not shipped along with the subsequent PR is to make rollback possible. Consider the case where this PR and the next one was shipped in one go:
- The `Repeater` model has a `name` property without a setter method
- We add the `name` attribute to the Repeater model
- The above mentioned property's name is changed by this PR so that it will not conflict with the `name` attribute
- When all these changes are deployed and a user creates a new Repeater, the Couch doc for that repeater will include a `name`  field.
- If for some reason we have to roll back, we wouldn't be able to instantiate the Repeater for that created repeater anymore, since the code will try to apply the name it gets from Couch to the `name` property which doesn't have a setter method -> throwing an exception

## Safety Assurance

### Safety story
Local testing. I just renamed the `name` property on the Repeater and updated the references.

### Automated test coverage

Tested

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
