### PR TITLE
add links to generic inbound expressions in list and edit view

### DIFF
--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -276,11 +276,25 @@ class FieldWithExtras(Field):
 
 
 class FieldWithHelpBubble(FieldWithExtras):
+    """Add a help bubble after the field label.
+
+    Provide the help text using the `help_bubble_text` kwarg.
+    """
     template = "hqwebapp/crispy/field_with_help_bubble.html"
     extra_context = ['help_bubble_text']
 
 
 class FieldWithAddons(FieldWithExtras):
+    """Add 'input-group-addon' divs before / after the input
+    element. This is mostly only useful with inputs of type
+    'text' and 'select'.
+
+    The addon element must be provided using the `pre_addon`
+    and `post_addon` kwargs. The value should be a string or
+    'SafeString' (to prevent HTML escaping).
+
+    See the Bootstrap docs for addon examples.
+    """
     template = "hqwebapp/crispy/field_with_addons.html"
     extra_context = ['pre_addon', 'post_addon']
 

--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -260,19 +260,29 @@ class CrispyTemplate(object):
         return render_to_string(self.template, context.flatten())
 
 
-class FieldWithHelpBubble(Field):
-    template = "hqwebapp/crispy/field_with_help_bubble.html"
+class FieldWithExtras(Field):
+    extra_context = None
 
     def __init__(self, *args, **kwargs):
-        super(FieldWithHelpBubble, self).__init__(*args, **kwargs)
-        self.help_bubble_text = kwargs.pop('help_bubble_text')
+        self.extras = {
+            extra: kwargs.pop(extra, None) for extra in self.extra_context
+        }
+        super(FieldWithExtras, self).__init__(*args, **kwargs)
 
     def render(self, form, form_style, context, template_pack=None):
         template_pack = template_pack or get_template_pack()
-        context.update({
-            'help_bubble_text': self.help_bubble_text,
-        })
-        return super(FieldWithHelpBubble, self).render(form, form_style, context, template_pack=template_pack)
+        context.update(self.extras)
+        return super(FieldWithExtras, self).render(form, form_style, context, template_pack=template_pack)
+
+
+class FieldWithHelpBubble(FieldWithExtras):
+    template = "hqwebapp/crispy/field_with_help_bubble.html"
+    extra_context = ['help_bubble_text']
+
+
+class FieldWithAddons(FieldWithExtras):
+    template = "hqwebapp/crispy/field_with_addons.html"
+    extra_context = ['pre_addon', 'post_addon']
 
 
 class LinkButton(LayoutObject):

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -94,7 +94,7 @@ hqDefine('hqwebapp/js/initial_page_data', ['jquery', 'underscore'], function ($,
                 throw new Error("URL '" + name + "' not found in registry");
             }
         }
-        return urls[name].replace(/---/g, function () {
+        return urls[name].replace(/(---)|(000)/g, function () {
             return args[index++];
         });
     };

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/field_with_addons.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/field_with_addons.html
@@ -17,9 +17,9 @@
 
         <div class="controls {{ field_class }}">
           {% if pre_addon or post_addon %}<div class="input-group">{% endif %}
-            {% if pre_addon %}<div class="input-group-addon">{{ pre_addon|safe }}</div>{% endif %}
+            {% if pre_addon %}<div class="input-group-addon">{{ pre_addon }}</div>{% endif %}
             {% crispy_field field %}
-            {% if post_addon %}<div class="input-group-addon">{{ post_addon|safe }}</div>{% endif %}
+            {% if post_addon %}<div class="input-group-addon">{{ post_addon }}</div>{% endif %}
           {% if pre_addon or post_addon %}</div>{% endif %}
           {% include 'bootstrap3/layout/help_text_and_errors.html' %}
         </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/field_with_addons.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/field_with_addons.html
@@ -1,0 +1,27 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    <div
+        id="div_{{ field.auto_id }}"
+        class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} error has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}"
+    >
+        {% if field.label and form_show_labels %}
+            <div class="control-label {{ label_class }} {% if field.field.required %}requiredField{% endif %}">
+                <label for="{{ field.id_for_label }}" class="inner-control-label">
+                    {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                </label>
+            </div>
+        {% endif %}
+
+        <div class="controls {{ field_class }}">
+          {% if pre_addon or post_addon %}<div class="input-group">{% endif %}
+            {% if pre_addon %}<div class="input-group-addon">{{ pre_addon|safe }}</div>{% endif %}
+            {% crispy_field field %}
+            {% if post_addon %}<div class="input-group-addon">{{ post_addon|safe }}</div>{% endif %}
+          {% if pre_addon or post_addon %}</div>{% endif %}
+          {% include 'bootstrap3/layout/help_text_and_errors.html' %}
+        </div>
+    </div>
+{% endif %}

--- a/corehq/motech/generic_inbound/forms.py
+++ b/corehq/motech/generic_inbound/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.forms import inlineformset_factory
 from django.urls import reverse
+from django.utils.safestring import SafeString
 from django.utils.translation import gettext_lazy as _
 
 from crispy_forms import layout as crispy
@@ -71,7 +72,9 @@ ApiValidationFormSet = inlineformset_factory(
 
 
 def _expression_link(domain):
-    return '<a href="{url}" target="_blank" title="{title}"><i class="fa fa-external-link"></i></a>'.format(
-        url=reverse('ucr_expressions', args=(domain,)),
-        title=_("Filters and Expressions")
+    return SafeString(
+        '<a href="{url}" target="_blank" title="{title}"><i class="fa fa-external-link"></i></a>'.format(
+            url=reverse('ucr_expressions', args=(domain,)),
+            title=_("Filters and Expressions")
+        )
     )

--- a/corehq/motech/generic_inbound/forms.py
+++ b/corehq/motech/generic_inbound/forms.py
@@ -1,10 +1,11 @@
 from django import forms
 from django.forms import inlineformset_factory
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from crispy_forms import layout as crispy
 
-from corehq.apps.hqwebapp.crispy import HQFormHelper
+from corehq.apps.hqwebapp.crispy import HQFormHelper, FieldWithAddons
 from corehq.apps.userreports.models import UCRExpression
 from corehq.motech.generic_inbound.models import (
     ConfigurableAPI,
@@ -39,8 +40,8 @@ class ConfigurableAPICreateForm(forms.ModelForm):
                 self.fieldset_title,
                 crispy.Field('name'),
                 crispy.Field('description'),
-                crispy.Field('filter_expression'),
-                crispy.Field('transform_expression'),
+                FieldWithAddons('filter_expression', post_addon=_expression_link(self.domain)),
+                FieldWithAddons('transform_expression', post_addon=_expression_link(self.domain)),
             )
         )
         self.helper.render_required_fields = True
@@ -67,3 +68,10 @@ ApiValidationFormSet = inlineformset_factory(
     ConfigurableAPI, ConfigurableApiValidation, fields=("name", "expression", "message"),
     extra=0, can_delete=True
 )
+
+
+def _expression_link(domain):
+    return '<a href="{url}" target="_blank" title="{title}"><i class="fa fa-external-link"></i></a>'.format(
+        url=reverse('ucr_expressions', args=(domain,)),
+        title=_("Filters and Expressions")
+    )

--- a/corehq/motech/generic_inbound/static/generic_inbound/js/api_edit.js
+++ b/corehq/motech/generic_inbound/static/generic_inbound/js/api_edit.js
@@ -9,6 +9,14 @@ hqDefine('generic_inbound/js/api_edit', [
         "name": "", "expression_id": null, "message": "", "id": null, "toDelete": false,
     };
 
+    const getExpressionUrl = function (expressionId) {
+        if (expressionId) {
+            return initialPageData.reverse('edit_ucr_expression', expressionId);
+        } else {
+            return initialPageData.reverse('ucr_expressions');
+        }
+    };
+
     let ValidationModel = function (data) {
         data = _.defaults(data, VALIDATION_DEFAULTS);
         let self = ko.mapping.fromJS(data);
@@ -18,6 +26,10 @@ hqDefine('generic_inbound/js/api_edit', [
 
         self.expressionError = ko.computed(() => {
             return self.expression_id() === null;
+        });
+
+        self.editUrl = ko.computed(() => {
+            return getExpressionUrl(self.expression_id());
         });
 
         self.messageError = ko.computed(() => {
@@ -54,6 +66,29 @@ hqDefine('generic_inbound/js/api_edit', [
 
         self.filters = initialPageData.get("filters");
         self.validations = SubModelWrapper(ValidationModel, validations, VALIDATION_DEFAULTS);
+
+        // update the links based on selection
+        const filterLinkEl = $('#div_id_filter_expression .input-group-addon a');
+        const transformLinkEl = $('#div_id_transform_expression .input-group-addon a');
+        const filterSelect = $('#id_filter_expression');
+        const transformSelect = $('#id_transform_expression');
+
+        const updateLink = function (selectEl, element) {
+            let optionSelected = selectEl.find("option:selected");
+            element.attr('href', getExpressionUrl(optionSelected.val()));
+        };
+
+        filterSelect.change(function () {
+            updateLink($(this), filterLinkEl);
+        });
+
+        transformSelect.change(function () {
+            updateLink($(this), transformLinkEl);
+        });
+
+        // update based on initial values
+        updateLink(filterSelect, filterLinkEl);
+        updateLink(transformSelect, transformLinkEl);
 
         self.validateForm = function () {
             return self.validations.allValid();

--- a/corehq/motech/generic_inbound/static/generic_inbound/js/api_edit.js
+++ b/corehq/motech/generic_inbound/static/generic_inbound/js/api_edit.js
@@ -2,19 +2,12 @@ hqDefine('generic_inbound/js/api_edit', [
     'underscore',
     'knockout',
     'hqwebapp/js/initial_page_data',
+    'generic_inbound/js/manage_links',
     'generic_inbound/js/copy_data',
-], function (_, ko, initialPageData) {
+], function (_, ko, initialPageData, manageLinks) {
 
     const VALIDATION_DEFAULTS = {
         "name": "", "expression_id": null, "message": "", "id": null, "toDelete": false,
-    };
-
-    const getExpressionUrl = function (expressionId) {
-        if (expressionId) {
-            return initialPageData.reverse('edit_ucr_expression', expressionId);
-        } else {
-            return initialPageData.reverse('ucr_expressions');
-        }
     };
 
     let ValidationModel = function (data) {
@@ -29,7 +22,7 @@ hqDefine('generic_inbound/js/api_edit', [
         });
 
         self.editUrl = ko.computed(() => {
-            return getExpressionUrl(self.expression_id());
+            return manageLinks.getExpressionUrl(self.expression_id());
         });
 
         self.messageError = ko.computed(() => {
@@ -66,29 +59,6 @@ hqDefine('generic_inbound/js/api_edit', [
 
         self.filters = initialPageData.get("filters");
         self.validations = SubModelWrapper(ValidationModel, validations, VALIDATION_DEFAULTS);
-
-        // update the links based on selection
-        const filterLinkEl = $('#div_id_filter_expression .input-group-addon a');
-        const transformLinkEl = $('#div_id_transform_expression .input-group-addon a');
-        const filterSelect = $('#id_filter_expression');
-        const transformSelect = $('#id_transform_expression');
-
-        const updateLink = function (selectEl, element) {
-            let optionSelected = selectEl.find("option:selected");
-            element.attr('href', getExpressionUrl(optionSelected.val()));
-        };
-
-        filterSelect.change(function () {
-            updateLink($(this), filterLinkEl);
-        });
-
-        transformSelect.change(function () {
-            updateLink($(this), transformLinkEl);
-        });
-
-        // update based on initial values
-        updateLink(filterSelect, filterLinkEl);
-        updateLink(transformSelect, transformLinkEl);
 
         self.validateForm = function () {
             return self.validations.allValid();

--- a/corehq/motech/generic_inbound/static/generic_inbound/js/api_list.js
+++ b/corehq/motech/generic_inbound/static/generic_inbound/js/api_list.js
@@ -1,6 +1,8 @@
 hqDefine('generic_inbound/js/api_list', [
     "hqwebapp/js/crud_paginated_list_init",
     "generic_inbound/js/copy_data",
+    "generic_inbound/js/manage_links",
 ], function () {
-    // used to include the copy_data JS module
+    // used to include the copy_data and manage_links JS module
+
 });

--- a/corehq/motech/generic_inbound/static/generic_inbound/js/manage_links.js
+++ b/corehq/motech/generic_inbound/static/generic_inbound/js/manage_links.js
@@ -1,0 +1,42 @@
+hqDefine('generic_inbound/js/manage_links', [
+    "hqwebapp/js/initial_page_data",
+], function (initialPageData) {
+    // manages the expression links in the API form
+
+    const getExpressionUrl = function (expressionId) {
+        if (expressionId) {
+            return initialPageData.reverse('edit_ucr_expression', expressionId);
+        } else {
+            return initialPageData.reverse('ucr_expressions');
+        }
+    };
+
+    $(function () {
+        // update the links based on selection
+        const filterLinkEl = $('#div_id_filter_expression .input-group-addon a');
+        const transformLinkEl = $('#div_id_transform_expression .input-group-addon a');
+        const filterSelect = $('#id_filter_expression');
+        const transformSelect = $('#id_transform_expression');
+
+        const updateLink = function (selectEl, element) {
+            let optionSelected = selectEl.find("option:selected");
+            element.attr('href', getExpressionUrl(optionSelected.val()));
+        };
+
+        filterSelect.change(function () {
+            updateLink($(this), filterLinkEl);
+        });
+
+        transformSelect.change(function () {
+            updateLink($(this), transformLinkEl);
+        });
+
+        // update based on initial values
+        updateLink(filterSelect, filterLinkEl);
+        updateLink(transformSelect, transformLinkEl);
+    });
+
+    return {
+        getExpressionUrl: getExpressionUrl,
+    };
+});

--- a/corehq/motech/generic_inbound/templates/generic_inbound/api_edit.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/api_edit.html
@@ -9,6 +9,8 @@
 {% block page_content %}
 {% initial_page_data "filters" filter_expressions %}
 {% initial_page_data "validations" validations %}
+{% registerurl 'edit_ucr_expression' domain '---' %}
+{% registerurl 'ucr_expressions' domain %}
 <div id="edit-api">
   <div class="row">
     <div class="col-xs-12 col-sm-10 col-md-8 col-lg-8">
@@ -53,15 +55,20 @@
                 </span>
               </td>
               <td data-bind="css: {'has-error': expressionError}">
-                <select class="select form-control" required data-bind="
-                  value: expression_id,
-                  valueAllowUnset: true,
-                  options: $root.filters,
-                  optionsText: 'label',
-                  optionsValue: 'id',
-                  attr: {name: `validations-${$index()}-expression`},
-                  ">
-                  </select>
+                <div class="input-group">
+                  <select class="select form-control" required data-bind="
+                    value: expression_id,
+                    valueAllowUnset: true,
+                    options: $root.filters,
+                    optionsText: 'label',
+                    optionsValue: 'id',
+                    attr: {name: `validations-${$index()}-expression`},
+                    ">
+                    </select>
+                    <div class="input-group-addon">
+                      <a data-bind="attr: {href: editUrl}" target="_blank"><i class="fa fa-external-link"></i></a>
+                    </div>
+                </div>
                   <span class='help-block' data-bind="visible: expressionError">
                     {% translate "Expression is required" %}
                   </span>

--- a/corehq/motech/generic_inbound/templates/generic_inbound/api_edit.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/api_edit.html
@@ -9,7 +9,7 @@
 {% block page_content %}
 {% initial_page_data "filters" filter_expressions %}
 {% initial_page_data "validations" validations %}
-{% registerurl 'edit_ucr_expression' domain '---' %}
+{% registerurl 'edit_ucr_expression' domain '000' %}
 {% registerurl 'ucr_expressions' domain %}
 <div id="edit-api">
   <div class="row">

--- a/corehq/motech/generic_inbound/templates/generic_inbound/api_edit.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/api_edit.html
@@ -89,7 +89,7 @@
                 <button type="btn" data-bind="
                   click: $parent.remove,
                   hidden: id
-                "><i class="fa fa-undo"></i></button>
+                "><i class="fa fa-trash"></i></button>
               </td>
             </tr>
           </tbody>

--- a/corehq/motech/generic_inbound/templates/generic_inbound/api_list.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/api_list.html
@@ -7,6 +7,8 @@
 {% block page_title %}{{ current_page.title }}{% endblock %}
 
 {% block pagination_templates %}
+{% registerurl 'edit_ucr_expression' domain '000' %}
+{% registerurl 'ucr_expressions' domain %}
 <script type="text/html" id="base-api-config-template">
     <td>
       <a data-bind="text: name, attr: {href: edit_url}"></a>


### PR DESCRIPTION
## Product Description
It's bugged me since I built this that if you want to view the expression you have a 3 step navigation which is very painful (`data tab -> expression list -> select expression`). That also assumes you know where to look. 

This PR adds a link button to the expression fields in the form in both the list and edit view. 

![Peek 2022-11-23 16-07](https://user-images.githubusercontent.com/249606/203567414-82472801-4ab3-4272-91a3-3cf8428e48e3.gif)


The views update the links dynamically so that they go to the edit page for the selected expression. If no expression is selected, the link will go to the expression list page.

## Technical Summary
This still uses crispy forms but with a custom field template which uses bootstrap field addons. I debated doing this without crispy but that would require adding custom HTML for the form which would be a lot more code. The link updates are doing using JQuery (though it could also be vanilla JS).

## Feature Flag
Generic Inbound API

## Safety Assurance

### Safety story
This only impacts the create / edit views and not the API functionality. I have tested these changes locally.

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
