### PR TITLE
[DHIS2] Check relationship existence before trying to create it

### DIFF
--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -95,11 +95,11 @@ def get_tracked_entity_and_etag(requests, case_trigger_info, case_config):
     its ETag, or (None, None) if a corresponding Tracked Entity was not
     found.
 
-    Raises BadTrackedEntityInstanceID if a Tracked Entity ID believed to
-    have been issued by the DHIS2 server is not found on that server.
-
-    Raises MultipleInstancesFound if unable to select a
-    corresponding Tracked Entity from multiple available candidates.
+    Raises:
+        BadTrackedEntityInstanceID: if a Tracked Entity ID believed to
+            have been issued by the DHIS2 server is not found on that server.
+        MultipleInstancesFound: if unable to select a
+            corresponding Tracked Entity from multiple available candidates.
     """
     tei_id = get_tracked_entity_instance_id(case_trigger_info, case_config)
     if not tei_id:

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -343,8 +343,7 @@ def ensure_relationship_exists(requests, relationship_spec, existing_relationshi
     relationship represented by `relationship_spec`.
     """
     for existing_spec in existing_relationships:
-        relationships_match = relationship_spec.as_dict() == existing_spec.as_dict()
-        if relationships_match:
+        if relationship_spec.as_dict() == existing_spec.as_dict():
             return None
 
     if relationship_spec.relationship_type_id:

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -316,26 +316,30 @@ def create_relationships(
                 'Unable to create DHIS2 relationship: The case {case} is not '
                 'registered in DHIS2.'
             ).format(case=supercase_trigger_info))
-        supercase_to_subcase_relationship_spec = RelationshipSpec(
-            relationship_type_id=relationship_config.supercase_to_subcase_dhis2_id,
-            from_tracked_entity_instance_id=supercase_tracked_entity_instance_id,
-            to_tracked_entity_instance_id=subcase_tracked_entity_instance_id
-        )
-        subcase_to_supercase_relationship_spec = RelationshipSpec(
-            relationship_type_id=relationship_config.subcase_to_supercase_dhis2_id,
-            from_tracked_entity_instance_id=subcase_tracked_entity_instance_id,
-            to_tracked_entity_instance_id=supercase_tracked_entity_instance_id,
-        )
-        ensure_relationship_exists(
-            requests=requests,
-            relationship_spec=supercase_to_subcase_relationship_spec,
-            existing_relationships=tracked_entity_relationships
-        )
-        ensure_relationship_exists(
-            requests=requests,
-            relationship_spec=subcase_to_supercase_relationship_spec,
-            existing_relationships=tracked_entity_relationships
-        )
+
+        if relationship_config.supercase_to_subcase_dhis2_id:
+            relationship_spec = RelationshipSpec(
+                relationship_type_id=relationship_config.supercase_to_subcase_dhis2_id,
+                from_tracked_entity_instance_id=supercase_tracked_entity_instance_id,
+                to_tracked_entity_instance_id=subcase_tracked_entity_instance_id
+            )
+            ensure_relationship_exists(
+                requests=requests,
+                relationship_spec=relationship_spec,
+                existing_relationships=tracked_entity_relationships
+            )
+
+        if relationship_config.subcase_to_supercase_dhis2_id:
+            relationship_spec = RelationshipSpec(
+                relationship_type_id=relationship_config.subcase_to_supercase_dhis2_id,
+                from_tracked_entity_instance_id=subcase_tracked_entity_instance_id,
+                to_tracked_entity_instance_id=supercase_tracked_entity_instance_id,
+            )
+            ensure_relationship_exists(
+                requests=requests,
+                relationship_spec=relationship_spec,
+                existing_relationships=tracked_entity_relationships
+            )
 
 
 def ensure_relationship_exists(requests, relationship_spec, existing_relationships):

--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -348,7 +348,7 @@ def ensure_relationship_exists(requests, relationship_spec, existing_relationshi
     """
     for existing_spec in existing_relationships:
         if relationship_spec.as_dict() == existing_spec.as_dict():
-            return None
+            return
 
     if relationship_spec.relationship_type_id:
         create_relationship(requests, relationship_spec)

--- a/corehq/motech/dhis2/tests/test_entities_helpers.py
+++ b/corehq/motech/dhis2/tests/test_entities_helpers.py
@@ -771,7 +771,7 @@ def test_get_tracked_entity_relationship_specs_should_return_a_valid_instance():
 
 
 def test_get_tracked_entity_relationship_specs_should_return_empty_array():
-    actual_output = _get_tracked_entity_instance_with_relationship_json(None)
+    actual_output = entities_helpers._get_tracked_entity_relationship_specs(None)
     assert actual_output == []
 
 

--- a/corehq/motech/dhis2/tests/test_entities_helpers.py
+++ b/corehq/motech/dhis2/tests/test_entities_helpers.py
@@ -732,7 +732,7 @@ def test_doctests():
     assert results.failed == 0
 
 
-def test_get_tracked_entity_relationship_specs():
+def test_get_tracked_entity_relationship_specs_should_return_a_valid_instance():
     relationship_type_id = "TDEdu7DAEQL"
     from_tracked_entity_instance_id = "2adsD3da"
     to_tracked_entity_instance_id = "DD8jasd"
@@ -768,6 +768,11 @@ def test_get_tracked_entity_relationship_specs():
     assert relationship_spec.relationship_type_id == relationship_type_id
     assert relationship_spec.from_tracked_entity_instance_id == from_tracked_entity_instance_id
     assert relationship_spec.to_tracked_entity_instance_id == to_tracked_entity_instance_id
+
+
+def test_get_tracked_entity_relationship_specs_should_return_empty_array():
+    actual_output = _get_tracked_entity_instance_with_relationship_json(None)
+    assert actual_output == []
 
 
 def _get_tracked_entity_instance_with_relationship_json(existing_relationships):


### PR DESCRIPTION
## Product Description
We never did a check to see if a relationship exists between cases on DHIS2 before trying to create the relationship. When the repeater made the POST request to create the relationship, we get a [409 Conflict](https://www.commcarehq.org/a/hmhb-dev/motech/logs/244986371/). This is not a trainsmash, but has the potential to create messy logs.

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2267).
Basically what this PR does is using the response from the "GET tracked entity instance" call - which includes the whole state of the tracked entity - and look at the relationships that exist for this entity. Before we then make the POST calls to create new relationships, we first check to see if this relationship doesn't already exist. Only if it doesn't exist already, do we make the POST call to create it.

Example: Look at [this GET call's body](https://www.commcarehq.org/a/hmhb-dev/motech/logs/244999030/#:~:text=%22relationships%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22bidirectional%22%3A%20false,programOwners%22%3A%20%5B%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%22trackedEntityInstance%22%3A%20%22G4ZqjuNtU0c%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%5D%2C) and [this POST's body](https://www.commcarehq.org/a/hmhb-dev/motech/logs/244999038/#:~:text=%7B%0A%20%20%22from%22%3A%20%7B%0A%20%20%20%20%22trackedEntityInstance%22%3A%20%7B%0A%20%20%20%20%20%20%22trackedEntityInstance%22%3A%20%22FJUEDQWMlAX%22%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22relationshipType%22%3A%20%22pmEdu7DAEQL%22%2C%0A%20%20%22to%22%3A%20%7B%0A%20%20%20%20%22trackedEntityInstance%22%3A%20%7B%0A%20%20%20%20%20%20%22trackedEntityInstance%22%3A%20%22G4ZqjuNtU0c%22%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D) to see that we try to create an already existing relationship.

## Safety Assurance

### Safety story
Unit testing

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly  <<<<<---- I think so?
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
