### PR TITLE
[DHIS2] Check relationship existence before trying to create it

### DIFF
--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -370,11 +370,7 @@ def ensure_relationship_exists(requests, relationship_spec, existing_relationshi
     """Checks to see if `relationship_spec` is in `existing_relationships`. If not, we try to create the
     relationship represented by `relationship_spec`.
     """
-    for existing_spec in existing_relationships:
-        if relationship_spec.as_dict() == existing_spec.as_dict():
-            return
-
-    if relationship_spec.relationship_type_id:
+    if (relationship_spec not in existing_relationships) and relationship_spec.relationship_type_id:
         create_relationship(requests, relationship_spec)
 
 

--- a/corehq/motech/dhis2/tests/test_entities_helpers.py
+++ b/corehq/motech/dhis2/tests/test_entities_helpers.py
@@ -13,6 +13,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import LocationType, SQLLocation
 from corehq.apps.users.models import WebUser
 from corehq.motech.auth import AuthManager
+from corehq.motech.dhis2 import entities_helpers
 from corehq.motech.dhis2.const import DHIS2_DATA_TYPE_DATE, LOCATION_DHIS_ID
 from corehq.motech.dhis2.dhis2_config import (
     Dhis2CaseConfig,
@@ -246,6 +247,7 @@ class TestCreateRelationships(TestCase):
             case_trigger_info,
             subcase_config,
             dhis2_entity_config,
+            []
         )
         self.create_relationship_func.assert_not_called()
 
@@ -279,12 +281,15 @@ class TestCreateRelationships(TestCase):
             case_trigger_info,
             subcase_config,
             dhis2_entity_config,
+            []
         )
         self.create_relationship_func.assert_called_with(
             requests,
-            'b2a12345678',
-            'johnny12345',
-            'alice123456',
+            entities_helpers.RelationshipSpec(
+                relationship_type_id='b2a12345678',
+                from_tracked_entity_instance_id='johnny12345',
+                to_tracked_entity_instance_id='alice123456'
+            )
         )
 
     def test_index_given_twice(self):
@@ -321,18 +326,23 @@ class TestCreateRelationships(TestCase):
             case_trigger_info,
             subcase_config,
             dhis2_entity_config,
+            []
         )
         self.create_relationship_func.assert_any_call(
             requests,
-            'b2a12345678',
-            'johnny12345',
-            'alice123456',
+            entities_helpers.RelationshipSpec(
+                relationship_type_id='b2a12345678',
+                from_tracked_entity_instance_id='johnny12345',
+                to_tracked_entity_instance_id='alice123456'
+            )
         )
         self.create_relationship_func.assert_called_with(
             requests,
-            'a2b12345678',
-            'alice123456',
-            'johnny12345',
+            entities_helpers.RelationshipSpec(
+                relationship_type_id='a2b12345678',
+                from_tracked_entity_instance_id='alice123456',
+                to_tracked_entity_instance_id='johnny12345'
+            )
         )
 
     def test_both_relationships_given(self):
@@ -366,19 +376,76 @@ class TestCreateRelationships(TestCase):
             case_trigger_info,
             subcase_config,
             dhis2_entity_config,
+            []
         )
         self.create_relationship_func.assert_any_call(
             requests,
-            'a2b12345678',
-            'alice123456',
-            'johnny12345',
+            entities_helpers.RelationshipSpec(
+                relationship_type_id='a2b12345678',
+                from_tracked_entity_instance_id='alice123456',
+                to_tracked_entity_instance_id='johnny12345'
+            )
         )
         self.create_relationship_func.assert_called_with(
             requests,
-            'b2a12345678',
-            'johnny12345',
-            'alice123456',
+            entities_helpers.RelationshipSpec(
+                relationship_type_id='b2a12345678',
+                from_tracked_entity_instance_id='johnny12345',
+                to_tracked_entity_instance_id='alice123456'
+            )
         )
+
+    def test_existing_relationship_not_created_again(self):
+        """Test that we don't try to create a relationship that already exists"""
+        requests = object()
+        case_trigger_info = get_case_trigger_info_for_case(
+            self.child_case, [{
+                'case_property': 'external_id'
+            }, {
+                'case_property': 'dhis2_org_unit_id'
+            }]
+        )
+        subcase_config = Dhis2CaseConfig.wrap({
+            'case_type':
+                'child',
+            'te_type_id':
+                'person12345',
+            'tei_id': {
+                'case_property': 'external_id'
+            },
+            'org_unit_id': {
+                'case_property': 'dhis2_org_unit_id'
+            },
+            'attributes': {},
+            'form_configs': [],
+            'finder_config': {},
+            'relationships_to_export': [{
+                'identifier': 'parent',
+                'referenced_type': 'mother',
+                'subcase_to_supercase_dhis2_id': 'b2a12345678',
+                'supercase_to_subcase_dhis2_id': 'a2b12345678',
+            }]
+        })
+        dhis2_entity_config = Dhis2EntityConfig(case_configs=[subcase_config, self.supercase_config])
+        # Set up a pre-existing relationship which we received from DHIS2
+        tracked_entity_relationship_specs = [
+            entities_helpers.RelationshipSpec(
+                relationship_type_id="b2a12345678",
+                from_tracked_entity_instance_id="johnny12345",
+                to_tracked_entity_instance_id="alice123456"
+            )
+        ]
+
+        create_relationships(
+            requests, case_trigger_info, subcase_config, dhis2_entity_config, tracked_entity_relationship_specs
+        )
+
+        # Only once of the two relationships should trigger a call to create, since the other already exists
+        self.create_relationship_func.assert_called_once()
+        # Ensure that the correct relationship triggered a create call
+        _requests, relationship_created = self.create_relationship_func.call_args[0]
+        existing_relationship = tracked_entity_relationship_specs[0]
+        assert relationship_created.relationship_type_id != existing_relationship.relationship_type_id
 
 
 class TestRequests(TestCase):
@@ -594,8 +661,6 @@ class TestGetSupercase(TestCase):
 
 
 def test_doctests():
-    from corehq.motech.dhis2 import entities_helpers
-
     results = doctest.testmod(entities_helpers)
     assert results.failed == 0
 


### PR DESCRIPTION
## Product Description
We never did a check to see if a relationship exists between cases on DHIS2 before trying to create the relationship. When the repeater made the POST request to create the relationship, we get a [409 Conflict](https://www.commcarehq.org/a/hmhb-dev/motech/logs/244986371/). This is not a trainsmash, but has the potential to create messy logs.

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2267).
Basically what this PR does is using the response from the "GET tracked entity instance" call - which includes the whole state of the tracked entity - and look at the relationships that exist for this entity. Before we then make the POST calls to create new relationships, we first check to see if this relationship doesn't already exist. Only if it doesn't exist already, do we make the POST call to create it.

Example: Look at [this GET call's body](https://www.commcarehq.org/a/hmhb-dev/motech/logs/244999030/#:~:text=%22relationships%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22bidirectional%22%3A%20false,programOwners%22%3A%20%5B%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%22trackedEntityInstance%22%3A%20%22G4ZqjuNtU0c%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%5D%2C) and [this POST's body](https://www.commcarehq.org/a/hmhb-dev/motech/logs/244999038/#:~:text=%7B%0A%20%20%22from%22%3A%20%7B%0A%20%20%20%20%22trackedEntityInstance%22%3A%20%7B%0A%20%20%20%20%20%20%22trackedEntityInstance%22%3A%20%22FJUEDQWMlAX%22%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22relationshipType%22%3A%20%22pmEdu7DAEQL%22%2C%0A%20%20%22to%22%3A%20%7B%0A%20%20%20%20%22trackedEntityInstance%22%3A%20%7B%0A%20%20%20%20%20%20%22trackedEntityInstance%22%3A%20%22G4ZqjuNtU0c%22%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D) to see that we try to create an already existing relationship.

## Safety Assurance

### Safety story
Unit testing

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly  <<<<<---- I think so?
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
