### PR TITLE
Move setting up in file

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1119,6 +1119,7 @@ IGNORE_ALL_DEMO_USER_SUBMISSIONS = False
 # to help in performance, avoid use of phone entries in an environment that does not need them
 # so HQ does not try to keep them up to date
 USE_PHONE_ENTRIES = True
+COMMCARE_ANALYTICS_HOST = ""
 
 try:
     # try to see if there's an environmental variable set for local_settings
@@ -2061,4 +2062,3 @@ GOOGLE_SHEETS_API_NAME = "sheets"
 GOOGLE_SHEETS_API_VERSION = "v4"
 
 DAYS_KEEP_GSHEET_STATUS = 14
-COMMCARE_ANALYTICS_HOST = ""


### PR DESCRIPTION
## Product Description
The [Navigate to Superset](https://staging.commcarehq.org/a/charlsmit-testy/data/export/custom/commcare_analytics/) link was not working due to the setting in this PR being in the wrong place in the settings.py file (was essentially being overwritten with the settings.py file value and not the value specified in the environment's locasettings block). 

## Feature Flag
[SUPERSET_ANALYTICS](https://staging.commcarehq.org/hq/flags/edit/superset-analytics/)

## Safety Assurance

### Safety story
Tested this on staging myself

### Automated test coverage
No tests necessary

### QA Plan
No formal QA necessary, only testing on staging

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
