### PR TITLE
[USH-2607] shadow module form links

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -829,6 +829,7 @@ def validate_property(property, allow_parents=True):
 class FormBaseValidator(object):
     def __init__(self, form):
         self.form = form
+        self.app = form.get_app()
 
     def error_meta(self, module=None):
         if not module:
@@ -932,14 +933,14 @@ class FormBaseValidator(object):
                 linked_module = None
                 if form_link.form_id:
                     try:
-                        linked_form = self.form.get_app().get_form(form_link.form_id)
+                        linked_form = self.app.get_form(form_link.form_id)
                     except FormNotFoundException:
                         errors.append(dict(type='bad form link', **meta))
                         continue
 
                     if form_link.form_module_id:
                         try:
-                            linked_module = self.form.get_app().get_module_by_unique_id(form_link.form_module_id)
+                            linked_module = self.app.get_module_by_unique_id(form_link.form_module_id)
                         except ModuleNotFoundException:
                             errors.append(dict(type='bad form link', **meta))
                             continue
@@ -956,7 +957,7 @@ class FormBaseValidator(object):
 
                 else:
                     try:
-                        linked_module = self.form.get_app().get_module_by_unique_id(form_link.module_unique_id)
+                        linked_module = self.app.get_module_by_unique_id(form_link.module_unique_id)
                     except ModuleNotFoundException:
                         errors.append(dict(type='bad form link', **meta))
                 if linked_module:
@@ -988,7 +989,7 @@ class FormBaseValidator(object):
 class IndexedFormBaseValidator(FormBaseValidator):
     @property
     def timing_context(self):
-        return self.form.get_app().timing_context
+        return self.app.timing_context
 
     def check_case_properties(self, all_names=None, subcase_names=None, case_tag=None):
         all_names = all_names or []
@@ -1020,7 +1021,7 @@ class IndexedFormBaseValidator(FormBaseValidator):
         except XFormException as e:
             errors.append({'type': 'invalid xml', 'message': str(e)})
         else:
-            no_multimedia = not self.form.get_app().enable_multimedia_case_property
+            no_multimedia = not self.app.enable_multimedia_case_property
             for path in set(paths):
                 if path not in valid_paths:
                     errors.append({'type': 'path error', 'path': path})

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -874,11 +874,13 @@ class FormLink(DocumentSchema):
 
     xpath: XPath condition that must be true in order to execute link
     form_id: ID of next form to open, mutually exclusive with module_unique_id
+    form_module_id: ID of the form's module (this is used for shadow modules)
     module_unique_id: ID of next module to open, mutually exclusive with form_id
     datums: Any user-provided datums, necessary when HQ can't figure them out automatically
     """
     xpath = StringProperty()
     form_id = FormIdProperty('modules[*].forms[*].form_links[*].form_id')
+    form_module_id = StringProperty()
     module_unique_id = StringProperty()
     datums = SchemaListProperty(FormDatum)
 

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -397,7 +397,10 @@ class EndOfFormNavigationWorkflow(object):
         source_form_datums = self.helper.get_form_datums(form)
         if link.form_id:
             target_form = self.helper.app.get_form(link.form_id)
-            target_module = target_form.get_module()
+            if link.form_module_id:
+                target_module = self.helper.app.get_module_by_unique_id(link.form_module_id)
+            else:
+                target_module = target_form.get_module()
             if module.module_type == "shadow" and module.source_module_id == target_module.unique_id:
                 # If this is a shadow module and we're navigating to a form from the source module,
                 # presume we should navigate to the version of the form in the current (shadow) module.

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -7,6 +7,7 @@ from django.test import SimpleTestCase
 from corehq.apps.app_manager.const import (
     REGISTRY_WORKFLOW_LOAD_CASE,
     REGISTRY_WORKFLOW_SMART_LINK,
+    WORKFLOW_FORM,
     WORKFLOW_MODULE,
 )
 from corehq.apps.app_manager.models import (
@@ -16,6 +17,7 @@ from corehq.apps.app_manager.models import (
     CaseSearchLabel,
     CaseSearchProperty,
     DetailColumn,
+    FormLink,
     Module,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
@@ -279,4 +281,78 @@ class BuildErrorsTest(SimpleTestCase):
             'form_type': 'module_form',
             'module': {'id': 1, 'name': {'en': 'shadow module'}},
             'form': {'id': 0, 'name': {'en': 'register form 0'}},
+        }, errors)
+
+    @flag_enabled('FORM_LINK_WORKFLOW')
+    def test_form_link_validation_ok(self, *args):
+        factory = AppFactory(build_version='2.24.0', include_xmlns=True)
+        m0, m0f0 = factory.new_basic_module('m0', 'frog')
+        m1, m1f0 = factory.new_basic_module('m1', 'frog')
+
+        m0f0.post_form_workflow = WORKFLOW_FORM
+        m0f0.form_links = [
+            FormLink(xpath="true()", form_id=m1f0.unique_id, form_module_id=m1.unique_id),
+            FormLink(xpath="true()", form_id=m1f0.unique_id)  # legacy data
+        ]
+
+        errors = factory.app.validate_app()
+        self.assertNotIn('bad form link', [error['type'] for error in errors])
+
+    @flag_enabled('FORM_LINK_WORKFLOW')
+    def test_form_link_validation_mismatched_module(self, *args):
+        factory = AppFactory(build_version='2.24.0', include_xmlns=True)
+        m0, m0f0 = factory.new_basic_module('m0', 'frog')
+        m1, m1f0 = factory.new_basic_module('m1', 'frog')
+
+        m0f0.post_form_workflow = WORKFLOW_FORM
+        m0f0.form_links = [
+            FormLink(xpath="true()", form_id=m1f0.unique_id, form_module_id=m0.unique_id)
+        ]
+
+        errors = factory.app.validate_app()
+
+        self._clean_unique_id(errors)
+        self.assertIn({
+            'type': 'bad form link',
+            'form_type': 'module_form',
+            'module': {'id': 0, 'name': {'en': 'm0 module'}},
+            'form': {'id': 0, 'name': {'en': 'm0 form 0'}},
+        }, errors)
+
+    @flag_enabled('FORM_LINK_WORKFLOW')
+    def test_form_link_validation_shadow_module_ok(self, *args):
+        factory = AppFactory(build_version='2.9.0')
+        m0, m0f0 = factory.new_basic_module('parent', 'mother')
+        m1, m1f0 = factory.new_basic_module('other', 'mother')
+        m2 = factory.new_shadow_module('shadow_module', m1, with_form=False)
+
+        m0f0.post_form_workflow = WORKFLOW_FORM
+        m0f0.form_links = [
+            FormLink(xpath='true()', form_id=m1f0.unique_id, form_module_id=m1.unique_id),
+            FormLink(xpath='true()', form_id=m1f0.unique_id, form_module_id=m2.unique_id),
+        ]
+
+        errors = factory.app.validate_app()
+        self.assertNotIn('bad form link', [error['type'] for error in errors])
+
+    @flag_enabled('FORM_LINK_WORKFLOW')
+    def test_form_link_validation_mismatched_shadow_module(self, *args):
+        factory = AppFactory(build_version='2.9.0')
+        m0, m0f0 = factory.new_basic_module('m0', 'mother')
+        m1, m1f0 = factory.new_basic_module('m1', 'mother')
+        factory.new_shadow_module('shadow_module', m1, with_form=False)
+
+        # link from m0-f0 to m1-f0 (in the shadow module)
+        m0f0.post_form_workflow = WORKFLOW_FORM
+        # module_id is incorrect - it should be either m1 or m2 but not m0
+        m0f0.form_links = [FormLink(xpath='true()', form_id=m1f0.unique_id, form_module_id=m0.unique_id)]
+
+        errors = factory.app.validate_app()
+
+        self._clean_unique_id(errors)
+        self.assertIn({
+            'type': 'bad form link',
+            'form_type': 'module_form',
+            'module': {'id': 0, 'name': {'en': 'm0 module'}},
+            'form': {'id': 0, 'name': {'en': 'm0 form 0'}},
         }, errors)

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -524,6 +524,32 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         """
         self.assertXmlPartialEqual(expected, suite_xml, "./entry[2]/stack")
 
+    def test_form_links_to_shadow_module(self):
+        factory = AppFactory(build_version='2.9.0')
+        m0, m0f0 = factory.new_basic_module('parent', 'mother')
+        m1, m1f0 = factory.new_basic_module('other', 'mother')
+        m2 = factory.new_shadow_module('shadow_module', m1, with_form=False)
+
+        #link from m0-f0 to m1-f0 (in the shadow module)
+        m0f0.post_form_workflow = WORKFLOW_FORM
+        m0f0.form_links = [FormLink(xpath='true()', form_id=m1f0.unique_id, form_module_id=m2.unique_id)]
+
+        suite_xml = factory.app.create_suite()
+
+        print(suite_xml.decode())
+        # In m0, the regular module, EOF nav goes back to m0
+        expected = """
+        <partial>
+            <stack>
+                <create if="true()">
+                    <command value="'m2'"/>
+                    <command value="'m2-f0'"/>
+                </create>
+            </stack>
+        </partial>
+        """
+        self.assertXmlPartialEqual(expected, suite_xml, "./entry[1]/stack")
+
     def test_form_links_other_child_module(self):
         # This test demonstrates current behavior that I believe to be flawed
 

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -548,7 +548,6 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         suite_xml = factory.app.create_suite()
 
-        print(suite_xml.decode())
         # In m0, the regular module, EOF nav goes back to m0
         expected = """
         <partial>

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -31,6 +31,18 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         m0f0.post_form_workflow = WORKFLOW_FORM
         m0f0.form_links = [
+            FormLink(xpath="(today() - dob) &lt; 7", form_id=m1f0.unique_id, form_module_id=m1.unique_id)
+        ]
+        self.assertXmlPartialEqual(self.get_xml('form_link_basic_form'), factory.app.create_suite(), "./entry[1]")
+
+    def test_basic_form_legacy_form_link_data(self, *args):
+        """Test that FormLink objects without the `form_module_id` field still work"""
+        factory = AppFactory(build_version='2.9.0')
+        m0, m0f0 = factory.new_basic_module('m0', 'frog')
+        m1, m1f0 = factory.new_basic_module('m1', 'frog')
+
+        m0f0.post_form_workflow = WORKFLOW_FORM
+        m0f0.form_links = [
             FormLink(xpath="(today() - dob) &lt; 7", form_id=m1f0.unique_id)
         ]
         self.assertXmlPartialEqual(self.get_xml('form_link_basic_form'), factory.app.create_suite(), "./entry[1]")
@@ -73,7 +85,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         m0f0.post_form_workflow = WORKFLOW_FORM
         m0f0.form_links = [
-            FormLink(xpath="(today() - dob) > 7", form_id=m1f0.unique_id)
+            FormLink(xpath="(today() - dob) > 7", form_id=m1f0.unique_id, form_module_id=m1.unique_id)
         ]
 
         self.assertXmlPartialEqual(self.get_xml('form_link_update_case'), factory.app.create_suite(), "./entry[1]")
@@ -87,7 +99,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         m0f0.post_form_workflow = WORKFLOW_FORM
         m0f0.form_links = [
-            FormLink(xpath='true()', form_id=m1f0.unique_id)
+            FormLink(xpath='true()', form_id=m1f0.unique_id, form_module_id=m1.unique_id)
         ]
 
         self.assertXmlPartialEqual(self.get_xml('form_link_create_update_case'), factory.app.create_suite(), "./entry[1]")
@@ -104,8 +116,8 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         m0f0.post_form_workflow = WORKFLOW_FORM
         m0f0.form_links = [
-            FormLink(xpath="a = 1", form_id=m1f0.unique_id),
-            FormLink(xpath="a = 2", form_id=m1f1.unique_id)
+            FormLink(xpath="a = 1", form_id=m1f0.unique_id, form_module_id=m1.unique_id),
+            FormLink(xpath="a = 2", form_id=m1f1.unique_id, form_module_id=m1.unique_id)
         ]
 
         self.assertXmlPartialEqual(self.get_xml('form_link_multiple'), factory.app.create_suite(), "./entry[1]")
@@ -125,12 +137,12 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         m0f0.post_form_workflow = WORKFLOW_FORM
         m0f0.form_links = [
-            FormLink(xpath="true()", form_id=m1f0.unique_id),
+            FormLink(xpath="true()", form_id=m1f0.unique_id, form_module_id=m1.unique_id),
         ]
 
         m1f0.post_form_workflow = WORKFLOW_FORM
         m1f0.form_links = [
-            FormLink(xpath="true()", form_id=m2f0.unique_id),
+            FormLink(xpath="true()", form_id=m2f0.unique_id, form_module_id=m2.unique_id),
         ]
 
         self.assertXmlPartialEqual(self.get_xml('form_link_tdh'), factory.app.create_suite(), "./entry")
@@ -264,14 +276,14 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         m0f0.post_form_workflow = WORKFLOW_FORM
         m0f0.form_links = [
-            FormLink(xpath="true()", form_id=m1f0.unique_id, datums=[
+            FormLink(xpath="true()", form_id=m1f0.unique_id, form_module_id=m1.unique_id, datums=[
                 FormDatum(name='case_id', xpath="instance('commcaresession')/session/data/case_id_new_child_0")
             ]),
         ]
 
         m1f0.post_form_workflow = WORKFLOW_FORM
         m1f0.form_links = [
-            FormLink(xpath="true()", form_id=m2f0.unique_id, datums=[
+            FormLink(xpath="true()", form_id=m2f0.unique_id, form_module_id=m2.unique_id, datums=[
                 FormDatum(name='case_id', xpath="instance('commcaresession')/session/data/case_id"),
                 FormDatum(name='case_id_load_visit_0', xpath="instance('commcaresession')/session/data/case_id_new_visit_0"),
             ]),
@@ -294,7 +306,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         m0f0.post_form_workflow = WORKFLOW_FORM
         m0f0.form_links = [
-            FormLink(xpath="true()", form_id=m1f0.unique_id, datums=[
+            FormLink(xpath="true()", form_id=m1f0.unique_id, form_module_id=m1.unique_id, datums=[
                 FormDatum(name='case_id', xpath="instance('commcaresession')/session/data/case_id_new_child_0")
             ]),
         ]
@@ -303,12 +315,12 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         condition_for_xpath = "instance('casedb')/casedb/case[@case_id = " \
                               "instance('commcaresession')/session/data/case_id]/prop = 'value'"
         m1f0.form_links = [
-            FormLink(xpath="true()", form_id=m2f0.unique_id, datums=[
+            FormLink(xpath="true()", form_id=m2f0.unique_id, form_module_id=m2.unique_id, datums=[
                 FormDatum(name='case_id', xpath="instance('commcaresession')/session/data/case_id"),
                 FormDatum(name='case_id_load_visit_0',
                           xpath="instance('commcaresession')/session/data/case_id_new_visit_0"),
             ]),
-            FormLink(xpath=condition_for_xpath, form_id=m2f0.unique_id, datums=[
+            FormLink(xpath=condition_for_xpath, form_id=m2f0.unique_id, form_module_id=m2.unique_id, datums=[
                 FormDatum(name='case_id', xpath="instance('commcaresession')/session/data/case_id"),
                 FormDatum(name='case_id_load_visit_0',
                           xpath="instance('commcaresession')/session/data/case_id_new_visit_0"),
@@ -360,7 +372,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         m1f0.post_form_workflow = WORKFLOW_FORM
         m1f0.form_links = [
-            FormLink(xpath="true()", form_id=m2f0.unique_id, datums=[
+            FormLink(xpath="true()", form_id=m2f0.unique_id, form_module_id=m2.unique_id, datums=[
                 FormDatum(name='case_id_load_episode_0', xpath="instance('commcaresession')/session/data/case_id_new_episode_0")
             ]),
         ]
@@ -460,7 +472,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         # link to child -> edit child
         m2f0.post_form_workflow = WORKFLOW_FORM
         m2f0.form_links = [
-            FormLink(xpath="true()", form_id=m1f0.unique_id),
+            FormLink(xpath="true()", form_id=m1f0.unique_id, form_module_id=m1.unique_id),
         ]
 
         self.assertXmlPartialEqual(self.get_xml('form_link_child_modules'), factory.app.create_suite(), "./entry[3]")
@@ -483,7 +495,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         m1f0.post_form_workflow = WORKFLOW_FORM
         m1f0.form_links = [
-            FormLink(xpath="true()", form_id=m1f1.unique_id),
+            FormLink(xpath="true()", form_id=m1f1.unique_id, form_module_id=m1.unique_id),
         ]
 
         self.assertXmlPartialEqual(self.get_xml('form_link_submodule'), factory.app.create_suite(), "./entry")
@@ -494,7 +506,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         factory.new_shadow_module('shadow_module', m0, with_form=False)
 
         m0f0.post_form_workflow = WORKFLOW_FORM
-        m0f0.form_links = [FormLink(xpath='true()', form_id=m0f0.unique_id)]
+        m0f0.form_links = [FormLink(xpath='true()', form_id=m0f0.unique_id, form_module_id=m0.unique_id)]
 
         suite_xml = factory.app.create_suite()
 
@@ -561,11 +573,11 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
 
         m0f1 = factory.new_form(m0)
         m0f1.post_form_workflow = WORKFLOW_FORM
-        m0f1.form_links = [FormLink(xpath='true()', form_id=m1f0.unique_id)]
+        m0f1.form_links = [FormLink(xpath='true()', form_id=m1f0.unique_id, form_module_id=m1.unique_id)]
 
         m2, m2f0 = factory.new_basic_module('other_module', 'baby')
         m2f0.post_form_workflow = WORKFLOW_FORM
-        m2f0.form_links = [FormLink(xpath='true()', form_id=m1f0.unique_id)]
+        m2f0.form_links = [FormLink(xpath='true()', form_id=m1f0.unique_id, form_module_id=m1.unique_id)]
         suite_xml = factory.app.create_suite()
 
         # m0f1 links to m1f0, a form in its child module. Here's the stack for that:

--- a/corehq/apps/app_manager/tests/test_form_workflow_multiple_case_types.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow_multiple_case_types.py
@@ -21,11 +21,10 @@ def test_form_linking_multiple_case_types():
 
     m0f0.post_form_workflow = WORKFLOW_FORM
     m0f0.form_links = [
-        FormLink(form_id=m1f0.unique_id),
+        FormLink(form_id=m1f0.unique_id, form_module_id=m1.unique_id),
     ]
 
     suite = factory.app.create_suite()
-    print(suite.decode('utf8'))
 
     # ensure that target datum contains both case types
     datum = extract_xml_partial(suite, "./entry[2]/session/datum[@id='case_id']", wrap=False).decode('utf8')
@@ -59,11 +58,10 @@ def test_form_linking_multiple_case_types_child_module():
 
     m1f0.post_form_workflow = WORKFLOW_FORM
     m1f0.form_links = [
-        FormLink(form_id=m2f0.unique_id),
+        FormLink(form_id=m2f0.unique_id, form_module_id=m2.unique_id),
     ]
 
     suite = factory.app.create_suite()
-    print(suite.decode('utf8'))
 
     expected_stack = """
     <partial>

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -72,7 +72,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         self.reg_form.actions.open_case.condition.type = 'always'
         self.reg_form.post_form_workflow = WORKFLOW_FORM
         self.reg_form.form_links = [
-            FormLink(form_id=self.form.get_unique_id())
+            FormLink(form_id=self.form.get_unique_id(), form_module_id=self.module.unique_id)
         ]
 
         self.module.assign_references()
@@ -583,11 +583,12 @@ class InlineSearchChildModuleTest(SimpleTestCase, SuiteMixin):
         self.assertXmlPartialEqual(expected_entry, suite, "./entry[2]")
 
     def test_form_link_in_child_module_with_inline_search(self):
-        form1 = self.app.get_module(1).get_form(0)
-        form2 = self.app.get_module(1).get_form(1)
+        module = self.app.get_module(1)
+        form1 = module.get_form(0)
+        form2 = module.get_form(1)
         # link from f1 to f2 (both in the child module)
         form1.post_form_workflow = WORKFLOW_FORM
-        form1.form_links = [FormLink(form_id=form2.get_unique_id())]
+        form1.form_links = [FormLink(form_id=form2.get_unique_id(), form_module_id=module.unique_id)]
         suite = self.app.create_suite()
         expected = f"""
         <partial>

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -542,12 +542,14 @@ class MultiSelectEndOfFormNavTests(SimpleTestCase, TestXmlMixin):
         form0.form_links = [FormLink(
             xpath="true()",
             form_id=form1.unique_id,    # can't link *to* multi-select form
+            form_module_id=self.single_loner.unique_id
         )]
 
         form1.post_form_workflow = WORKFLOW_FORM    # can't link *from* multi-select form
         form1.form_links = [FormLink(
             xpath="true()",
             form_id=form0.unique_id,
+            form_module_id=self.multi_loner.unique_id
         )]
 
         form2.post_form_workflow = WORKFLOW_FORM    # can't link *to* multi-select module
@@ -591,6 +593,7 @@ class MultiSelectEndOfFormNavTests(SimpleTestCase, TestXmlMixin):
         form.form_links = [FormLink(
             xpath="true()",
             form_id=form.unique_id,
+            form_module_id=self.single_child.unique_id
         )]
         self.assertIn({
             'type': 'parent multi select form links',

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -84,7 +84,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.reg_form.actions.open_case.condition.type = 'always'
         self.reg_form.post_form_workflow = WORKFLOW_FORM
         self.reg_form.form_links = [
-            FormLink(form_id=self.form.get_unique_id())
+            FormLink(form_id=self.form.get_unique_id(), form_module_id=self.module.unique_id)
         ]
 
         # wrap to have assign_references called
@@ -472,7 +472,7 @@ class RemoteRequestSuiteFormLinkChildModuleTest(SimpleTestCase, SuiteMixin):
 
         # link from f1 to f2 (both in the child module)
         f1.post_form_workflow = WORKFLOW_FORM
-        f1.form_links = [FormLink(form_id=f2.get_unique_id())]
+        f1.form_links = [FormLink(form_id=f2.get_unique_id(), form_module_id=m1.unique_id)]
 
         factory.app._id = "123"
         # wrap to have assign_references called

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -909,8 +909,8 @@ def _get_form_link_context(module, langs):
     def _module_name(module):
         return trans(module.name, langs)
 
-    def _form_name(form):
-        module_name = _module_name(form.get_module())
+    def _form_name(module, form):
+        module_name = _module_name(module)
         form_name = trans(form.name, langs)
         return "{} > {}".format(module_name, form_name)
 
@@ -943,8 +943,9 @@ def _get_form_link_context(module, langs):
             case_type_match = candidate_module.case_type == module.case_type
             is_parent = candidate_module.unique_id == module.root_module_id
             linkable_items.append({
-                'unique_id': candidate_form.unique_id,
-                'name': _form_name(candidate_form),
+                # this is necessary to disambiguate forms in shadow modules
+                'unique_id': f'{candidate_module.unique_id}.{candidate_form.unique_id}',
+                'name': _form_name(candidate_module, candidate_form),
                 'auto_link': case_type_match or is_parent,
                 'allow_manual_linking': True,
             })

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -937,7 +937,7 @@ def _get_form_link_context(module, langs):
                     'auto_link': True,
                     'allow_manual_linking': False,
                 })
-        for candidate_form in candidate_module.get_forms():
+        for candidate_form in candidate_module.get_suite_forms():
             # Forms can be linked automatically if their module is the same case type as this module,
             # or if they belong to this module's parent module. All other forms can be linked manually.
             case_type_match = candidate_module.case_type == module.case_type


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-2607

## Product Description
Allow creating End of Form navigation that links to a form in a specific shadow module.

## Technical Summary
Previously EOF nav could not be setup to link to forms in a shadow module. You could link to forms in the shadow modules' source module but not the shadow module itself. This has implications for form navigation and app flow.

With this change all shadow module forms will be made available for form linking (applying the same rules as normal forms). If a form in a shadow module is selected the app navigation will direct the user to that form via the shadow module.

## Safety Assurance

### Safety story
This is backwards compatible with the current data model and data. It adds a new field to the FormLink app model but reverts to the previous functionality if the field is blank.

### Automated test coverage
The suite generation changes are covered by existing tests. I ran all the tests prior to updating them with the new field and verified that they pass with and without it.

I have also added a new test to specifically test the functionality without the field.

### QA Plan
QA on staging just to be sure


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

There should not be any issues with rolling this back but if apps have already used the new feature then rolling it back will revert the form linking to the previous behaviour for builds created after the rollback.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
