### PR TITLE
Stop api filter from clearing on apply

### DIFF
--- a/corehq/motech/generic_inbound/reports.py
+++ b/corehq/motech/generic_inbound/reports.py
@@ -36,7 +36,7 @@ class ApiFilter(BaseMultipleOptionFilter):
 
     @property
     def options(self):
-        api_list = [(api.id, api.name) for api in ConfigurableAPI.objects.filter(domain=self.domain)]
+        api_list = [(str(api.id), api.name) for api in ConfigurableAPI.objects.filter(domain=self.domain)]
         return api_list
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
followup to https://github.com/dimagi/commcare-hq/pull/32297

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The API filter selections were clearing after being applied. This came down to the `render_to_string` call inside the `render` method of `BaseReportFilter`

Previously the api filter options were a list of tuples something like `[(2, 'update case'), (1, 'create case')]` with an int and a str value.
This meant that the `render_to_string` call returned an ill-formed `select` tag (note the missing quotes around the digit 2)
```
<select class="span4 form-control report-filter-multi-option"
            multiple="true"
            data-bind="options: select_params, optionsText: 'text', optionsValue: 'val', selectedOptions: current_selection"
            data-options="[{&quot;val&quot;: 2, &quot;text&quot;: &quot;update case&quot;}, {&quot;val&quot;: 1, &quot;text&quot;: &quot;create test case&quot;}]"
            data-selected="[&quot;2&quot;, &quot;1&quot;]"
            placeholder=""
            name="api_id"></select>
```
The api filter options now look something like this `[('2', 'update case'), ('1', 'create case')]` and produce a properly formed `select`
```
<select class="span4 form-control report-filter-multi-option"
            multiple="true"
            data-bind="options: select_params, optionsText: 'text', optionsValue: 'val', selectedOptions: current_selection"
            data-options="[{&quot;val&quot;: &quot;2&quot;, &quot;text&quot;: &quot;update case&quot;}, {&quot;val&quot;: &quot;1&quot;, &quot;text&quot;: &quot;create test case&quot;}]"
            data-selected="[&quot;2&quot;, &quot;1&quot;]"
            placeholder=""
            name="api_id"></select>
```
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
GENERIC_INBOUND_API (configurable_api)
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
small fix localized to generic inbound api report
tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no qa

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
