### PR TITLE
Allow sending non-dict objects via JsonResponse

### DIFF
--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -969,7 +969,7 @@ def get_form_datums(request, domain, app_id):
         make_datum(datum) for datum in helper.get_datums_meta_for_form_generic(form)
         if datum.requires_selection
     ]
-    return JsonResponse(datums)
+    return JsonResponse(datums, safe=False)
 
 
 @require_GET


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Fixes a bug ([jira](https://dimagi-dev.atlassian.net/browse/SC-2395), [sentry](https://sentry.io/organizations/dimagi/issues/3391028999/?_allp=1&end=2022-11-30T15%3A06%3A01&environment=production&query=In+order+to+allow+non-dict+objects+to+be+serialized+set+the+safe+parameter+to+False&referrer=issue-stream&sort=new&start=2022-09-01T15%3A06%3A01&utc=true)) introduced [here](https://github.com/dimagi/commcare-hq/pull/31791/files#diff-4f55c0204e502b998921ff90c540201d8a783f8636138556cd99edfc0a051e6aR951)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
FORM_LINK_WORKFLOW

## Safety Assurance

One line bug fix tested locally

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
