### PR TITLE
do not throttle admin apis

### DIFF
--- a/corehq/apps/api/accounting.py
+++ b/corehq/apps/api/accounting.py
@@ -2,7 +2,6 @@ from django_prbac.models import Role
 from tastypie import fields
 from tastypie.fields import ToManyField
 from tastypie.resources import ModelResource
-from tastypie.throttle import BaseThrottle
 
 from corehq.apps.accounting.models import (
     BillingAccount,
@@ -26,8 +25,7 @@ from corehq.apps.accounting.models import (
     Subscription,
     SubscriptionAdjustment,
 )
-from corehq.apps.api.resources.auth import AdminAuthentication
-from corehq.apps.api.resources.meta import CustomResourceMeta
+from corehq.apps.api.resources.meta import AdminResourceMeta
 
 
 class AccToManyField(ToManyField):
@@ -41,8 +39,7 @@ class AccToManyField(ToManyField):
         return only_ids
 
 
-class AccountingResourceMeta(CustomResourceMeta):
-    authentication = AdminAuthentication()
+class AccountingResourceMeta(AdminResourceMeta):
     list_allowed_methods = ['get']
     detail_allowed_methods = ['get']
     include_resource_uri = False
@@ -50,7 +47,6 @@ class AccountingResourceMeta(CustomResourceMeta):
         'last_modified': ['gt', 'gte', 'lt', 'lte'],
         'date_updated': ['gt', 'gte', 'lt', 'lte']
     }
-    throttle = BaseThrottle()
 
 
 class FeatureResource(ModelResource):

--- a/corehq/apps/api/accounting.py
+++ b/corehq/apps/api/accounting.py
@@ -2,6 +2,7 @@ from django_prbac.models import Role
 from tastypie import fields
 from tastypie.fields import ToManyField
 from tastypie.resources import ModelResource
+from tastypie.throttle import BaseThrottle
 
 from corehq.apps.accounting.models import (
     BillingAccount,
@@ -49,6 +50,7 @@ class AccountingResourceMeta(CustomResourceMeta):
         'last_modified': ['gt', 'gte', 'lt', 'lte'],
         'date_updated': ['gt', 'gte', 'lt', 'lte']
     }
+    throttle = BaseThrottle()
 
 
 class FeatureResource(ModelResource):

--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -3,14 +3,12 @@ import logging
 from tastypie import fields
 from tastypie.exceptions import NotFound
 from tastypie.resources import ModelResource, Resource
-from tastypie.throttle import BaseThrottle
 
 from dimagi.utils.dates import force_to_datetime
 
 from corehq.apps.accounting.models import Subscription
 from corehq.apps.api.resources import CouchResourceMixin, HqBaseResource
-from corehq.apps.api.resources.auth import AdminAuthentication
-from corehq.apps.api.resources.meta import CustomResourceMeta
+from corehq.apps.api.resources.meta import AdminResourceMeta
 from corehq.apps.api.serializers import XFormInstanceSerializer
 from corehq.apps.data_analytics.models import GIRRow, MALTRow
 from corehq.apps.domain.models import Domain, DomainAuditRecordEntry
@@ -111,19 +109,17 @@ class DomainMetadataResource(CouchResourceMixin, HqBaseResource):
 
             return DomainQuerySetAdapter(DomainES().last_modified(**params).sort('last_modified'))
 
-    class Meta(CustomResourceMeta):
-        authentication = AdminAuthentication()
+    class Meta(AdminResourceMeta):
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get']
         object_class = Domain
         resource_name = 'project_space_metadata'
         serializer = XFormInstanceSerializer(formats=['json'])
-        throttle = BaseThrottle()
 
 
 class MaltResource(ModelResource):
 
-    class Meta(CustomResourceMeta):
+    class Meta(AdminResourceMeta):
         authentication = AdminAuthentication()
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get']
@@ -141,8 +137,7 @@ class MaltResource(ModelResource):
 
 class GIRResource(ModelResource):
 
-    class Meta(CustomResourceMeta):
-        authentication = AdminAuthentication()
+    class Meta(AdminResourceMeta):
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get']
         queryset = GIRRow.objects.all().order_by('pk')
@@ -162,4 +157,3 @@ class GIRResource(ModelResource):
             'month': ['gt', 'gte', 'lt', 'lte'],
             'domain_name': ['exact']
         }
-        throttle = BaseThrottle()

--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -3,6 +3,7 @@ import logging
 from tastypie import fields
 from tastypie.exceptions import NotFound
 from tastypie.resources import ModelResource, Resource
+from tastypie.throttle import BaseThrottle
 
 from dimagi.utils.dates import force_to_datetime
 
@@ -117,6 +118,7 @@ class DomainMetadataResource(CouchResourceMixin, HqBaseResource):
         object_class = Domain
         resource_name = 'project_space_metadata'
         serializer = XFormInstanceSerializer(formats=['json'])
+        throttle = BaseThrottle()
 
 
 class MaltResource(ModelResource):
@@ -160,3 +162,4 @@ class GIRResource(ModelResource):
             'month': ['gt', 'gte', 'lt', 'lte'],
             'domain_name': ['exact']
         }
+        throttle = BaseThrottle()

--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -120,7 +120,6 @@ class DomainMetadataResource(CouchResourceMixin, HqBaseResource):
 class MaltResource(ModelResource):
 
     class Meta(AdminResourceMeta):
-        authentication = AdminAuthentication()
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get']
         queryset = MALTRow.objects.all().order_by('pk')

--- a/corehq/apps/api/resources/meta.py
+++ b/corehq/apps/api/resources/meta.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from tastypie.authorization import ReadOnlyAuthorization
 from tastypie.throttle import BaseThrottle
 
-from corehq.apps.api.resources.auth import LoginAndDomainAuthentication
+from corehq.apps.api.resources.auth import AdminAuthentication, LoginAndDomainAuthentication
 from corehq.apps.api.serializers import CustomXMLSerializer
 from corehq.project_limits.rate_limiter import (
     PerUserRateDefinition,
@@ -74,3 +74,8 @@ class CustomResourceMeta(object):
     serializer = CustomXMLSerializer()
     default_format = 'application/json'
     throttle = get_hq_throttle()
+
+
+class AdminResourceMeta(CustomResourceMeta):
+    authentication = AdminAuthentication()
+    throttle = BaseThrottle()

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -16,7 +16,6 @@ from tastypie.bundle import Bundle
 from tastypie.exceptions import BadRequest, ImmediateHttpResponse, NotFound
 from tastypie.http import HttpForbidden, HttpUnauthorized
 from tastypie.resources import ModelResource, Resource, convert_post_to_patch
-from tastypie.throttle import BaseThrottle
 from tastypie.utils import dict_strip_unicode_keys
 
 from phonelog.models import DeviceReportEntry

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -39,7 +39,7 @@ from corehq.apps.api.resources.auth import (
     ODataAuthentication,
     RequirePermissionAuthentication,
 )
-from corehq.apps.api.resources.meta import CustomResourceMeta
+from corehq.apps.api.resources.meta import AdminResourceMeta, CustomResourceMeta
 from corehq.apps.api.resources.serializers import ListToSingleObjectSerializer
 from corehq.apps.api.util import get_obj
 from corehq.apps.app_manager.models import Application
@@ -299,11 +299,12 @@ class AdminWebUserResource(v0_1.UserResource):
             return [WebUser.get_by_username(bundle.request.GET['username'])]
         return [WebUser.wrap(u) for u in UserES().web_users().run().hits]
 
-    class Meta(WebUserResource.Meta):
-        authentication = AdminAuthentication()
+    class Meta(AdminResourceMeta):
         detail_allowed_methods = ['get']
         list_allowed_methods = ['get']
-        throttle = BaseThrottle()
+        object_class = WebUser
+        resource_name = 'web-user'
+
 
 
 class GroupResource(v0_4.GroupResource):

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -16,6 +16,7 @@ from tastypie.bundle import Bundle
 from tastypie.exceptions import BadRequest, ImmediateHttpResponse, NotFound
 from tastypie.http import HttpForbidden, HttpUnauthorized
 from tastypie.resources import ModelResource, Resource, convert_post_to_patch
+from tastypie.throttle import BaseThrottle
 from tastypie.utils import dict_strip_unicode_keys
 
 from phonelog.models import DeviceReportEntry
@@ -302,6 +303,7 @@ class AdminWebUserResource(v0_1.UserResource):
         authentication = AdminAuthentication()
         detail_allowed_methods = ['get']
         list_allowed_methods = ['get']
+        throttle = BaseThrottle()
 
 
 class GroupResource(v0_4.GroupResource):


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14178

This should fix a problem where our internal use of APIs for salesforce was being rate limited by removing throttling for admin apis. They do not fit naturally into our existing throtlling since they do not map to any domain and they are only accessible to superusers so there is not a real risk of abuse.

I considered making a separate `NoThrottleMixin` that these `Meta` classes could inherit from, to make the change a bit more explicit (and easier to replicate in the future), but it did not seem worth it. Happy to take that approach if it makes sense to others, I don't love the need to manually set the throttle on each class, although each had custom `Meta` already so much of this was already manual, and those with shared `Meta` like the accounting ones were able to be fixed in one place.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Limited to superusers, so low risk of unexpected use, and easy to resolve if it happens.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
