### PR TITLE
Bump last known good DHIS2 version

### DIFF
--- a/corehq/motech/dhis2/const.py
+++ b/corehq/motech/dhis2/const.py
@@ -64,7 +64,7 @@ DHIS2_UID_MESSAGE = _('A DHIS2 "UID" is exactly 11 alpha-numeric characters '
 # (Used for updating cases with their tracked entity instance ID.)
 XMLNS_DHIS2 = 'http://commcarehq.org/dhis2-integration'
 
-DHIS2_MAX_VERSION = "2.35.1"
+DHIS2_MAX_KNOWN_GOOD_VERSION = "2.39.0"
 
 COMPLETE_DATE_EMPTY = "complete_date_empty"
 COMPLETE_DATE_COLUMN = "complete_date_column"

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -21,7 +21,7 @@ from dimagi.ext.couchdbkit import (
 )
 
 from corehq.form_processor.models import XFormInstance
-from corehq.motech.dhis2.const import DHIS2_MAX_VERSION, XMLNS_DHIS2
+from corehq.motech.dhis2.const import DHIS2_MAX_KNOWN_GOOD_VERSION, XMLNS_DHIS2
 from corehq.motech.dhis2.dhis2_config import Dhis2Config, Dhis2EntityConfig
 from corehq.motech.dhis2.entities_helpers import send_dhis2_entities
 from corehq.motech.dhis2.events_helpers import send_dhis2_event
@@ -78,7 +78,7 @@ class Dhis2Instance(Document):
         except Dhis2Exception as err:
             requests.notify_exception(str(err))
             raise
-        if LooseVersion(dhis2_version) > DHIS2_MAX_VERSION:
+        if LooseVersion(dhis2_version) > DHIS2_MAX_KNOWN_GOOD_VERSION:
             requests.notify_error(
                 "Integration has not yet been tested for DHIS2 version "
                 f"{dhis2_version}. Its API may not be supported."
@@ -268,7 +268,7 @@ class SQLDhis2Instance(object):
         except Dhis2Exception as err:
             requests.notify_exception(str(err))
             raise
-        if LooseVersion(dhis2_version) > DHIS2_MAX_VERSION:
+        if LooseVersion(dhis2_version) > DHIS2_MAX_KNOWN_GOOD_VERSION:
             requests.notify_error(
                 "Integration has not yet been tested for DHIS2 version "
                 f"{dhis2_version}. Its API may not be supported."

--- a/corehq/motech/dhis2/tests/test_repeaters.py
+++ b/corehq/motech/dhis2/tests/test_repeaters.py
@@ -11,7 +11,7 @@ from django.test import SimpleTestCase, TestCase
 from unittest.mock import Mock, patch
 from nose.tools import assert_equal, assert_true
 
-from corehq.motech.dhis2.const import DHIS2_MAX_VERSION
+from corehq.motech.dhis2.const import DHIS2_MAX_KNOWN_GOOD_VERSION as KNOWN_GOOD
 from corehq.motech.dhis2.exceptions import Dhis2Exception
 from corehq.motech.dhis2.repeaters import Dhis2Repeater
 from corehq.motech.repeaters.dbaccessors import delete_all_repeaters
@@ -226,7 +226,7 @@ class SlowApiVersionTest(TestCase):
             mock_fetch.assert_called()
 
     def test_max_version_exceeded_notifies_admins(self):
-        major_ver, max_api_ver, patch_ver = LooseVersion(DHIS2_MAX_VERSION).version
+        major_ver, max_api_ver, patch_ver = LooseVersion(KNOWN_GOOD).version
         bigly_api_version = max_api_ver + 1
         bigly_dhis2_version = f"{major_ver}.{bigly_api_version}.{patch_ver}"
         with patch('corehq.motech.dhis2.repeaters.fetch_metadata') as mock_fetch, \


### PR DESCRIPTION
## Technical Summary

CommCare has been tested with DHIS2 ver 2.39. This change bumps the last known good version of the DHIS2 API to reflect that.

## Feature Flag
DHIS2 Integration

## Safety Assurance

### Safety story

No change to functionality. Only affects when admins are notified that their version of DHIS2 has not been tested with CommCare.

### Automated test coverage

Covered by tests

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
