### PR TITLE
Render value in correct place for textarea element

### DIFF
--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -141,8 +141,7 @@ def input_trans(name, langs=None, input_name='name', input_id=None, data_bind=No
         template = '''
             <textarea name="{input_name}" {input_id_attribute} {data_bind_attribute}
                       class="form-control vertical-resize"
-                      value="{value}"
-            ></textarea>
+                      >{value}</textarea>
         '''
 
     return format_html(template, **options)


### PR DESCRIPTION
## Product Description
Likely no visible impact. Does fix an edge case where Search Screen Subtitle field could appear blank despite having a saved value.

## Technical Summary
Corrects the html used to render `input_trans` as a textarea by placing the value between `<textarea>` tags, instead of using a `value` attribute which textarea does not support. https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element

## Safety Assurance

### Safety story
Minor change to correct html syntax only.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
