### PR TITLE
Cs/sc 2360 auto update rule overwrites case property

### DIFF
--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -120,7 +120,7 @@ def submit_case_block_from_template(domain, template, context, xmlns=None,
     )
 
 
-def _get_update_or_close_case_block(case_id, case_properties=None, close=False, owner_id=None):
+def _get_update_or_close_case_block(case_id, case_properties=None, close=False, owner_id=None, domain=None):
     kwargs = {
         'create': False,
         'user_id': SYSTEM_USER_ID,
@@ -130,6 +130,8 @@ def _get_update_or_close_case_block(case_id, case_properties=None, close=False, 
         kwargs['update'] = case_properties
     if owner_id:
         kwargs['owner_id'] = owner_id
+    if domain:
+        kwargs['domain'] = domain
 
     return CaseBlock.deprecated_init(case_id, **kwargs)
 
@@ -150,7 +152,7 @@ def update_case(domain, case_id, case_properties=None, close=False,
                the project is over its submission rate limit.
                See the docstring for submit_form_locally for meaning of values
     """
-    caseblock = _get_update_or_close_case_block(case_id, case_properties, close, owner_id)
+    caseblock = _get_update_or_close_case_block(case_id, case_properties, close, owner_id, domain=domain)
     return submit_case_blocks(
         ElementTree.tostring(caseblock.as_xml(), encoding='utf-8').decode('utf-8'),
         domain,

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_case_block.py
@@ -1,5 +1,6 @@
 from django.test import SimpleTestCase
 from casexml.apps.case.mock import CaseBlock
+from corehq.util.test_utils import flag_disabled, flag_enabled
 
 
 class TestCaseBlock(SimpleTestCase):
@@ -8,3 +9,17 @@ class TestCaseBlock(SimpleTestCase):
         xml = CaseBlock("arbitrary_id", update={'float': float(1.2), 'int': 5}).as_xml()
         self.assertEqual(xml.findtext('update/float'), "1.2")
         self.assertEqual(xml.findtext('update/int'), "5")
+
+    @flag_disabled('USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY')
+    def test_custom_external_id_property_not_used(self):
+        domain = "test-domain"
+        xml = CaseBlock("arbitrary_id", update={'external_id': "01234"}, external_id="43210", domain=domain)\
+            .as_xml()
+        self.assertEqual(xml.findtext('update/external_id'), "43210")
+
+    @flag_enabled('USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY')
+    def test_custom_external_id_property_used(self):
+        domain = "test-domain"
+        xml = CaseBlock("arbitrary_id", update={'external_id': "01234"}, external_id="43210", domain=domain)\
+            .as_xml()
+        self.assertEqual(xml.findtext('update/external_id'), "01234")

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -637,6 +637,13 @@ LAZY_LOAD_MULTIMEDIA = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY = StaticToggle(
+    'custom-external_id-case-property',
+    'eCHIS: Use the user defined external_id case property when running auto case update rules.',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+)
+
 APP_BUILDER_ADVANCED = StaticToggle(
     'advanced-app-builder',
     'Advanced Module in App-Builder',


### PR DESCRIPTION
## Product Description
An auto update rule that didn't update a specific case property, `external_id`, will now update that property to the desired value, given that the new feature flag is enabled (see **Technical Summary** for details).

## Technical Summary

#### Problem
Upon investigating [this](https://dimagi-dev.atlassian.net/browse/SC-2360) ticket I found an edge case where a user-defined case property conflicts with a system-defined case property. The property in question is `external_id`. 
This conflict resulted in the system-defined property enjoying preference when an auto case update rule was supposed to update the user-defined property, but did not take effect due to the system-property being undefined.

#### Solving the immediate problem
Our options for solving the `external_id` problem in particular are as follows:
1. Check for an existing user-defined case property called `external_id` and use that instead of overwriting it with the system defined property value.
2. Same as one, but put it behind a feature flag so as to make the user explicitly aware of what’s happening below the surface.
3. Change the user-defined `external_id` property name to something else and make `external_id` a reserved case property name. (much more effort from dev and will require partner to make changes to their data)

Option 2 above seems the most reasonable given the priority, effort and longevity of the solution, so it was decided to go with that solution, although I'm open to any new or additional suggestions.

## Feature Flag
New custom feature flag, `USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY`.

## Safety Assurance

### Safety story
Unit tests show this feature to be safe.

### Automated test coverage
Unit tests cover the feature flag checking.

### QA Plan
Unit tests, maybe some testing on staging.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
