### PR TITLE
Silenced an error with unexpected TurnIO formats

### DIFF
--- a/corehq/messaging/smsbackends/turn/tests/test_views.py
+++ b/corehq/messaging/smsbackends/turn/tests/test_views.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+from django.test import RequestFactory, SimpleTestCase
+from corehq.messaging.smsbackends.turn import views
+
+
+class TurnIncomingSMSViewTests(SimpleTestCase):
+    @patch.object(views, 'incoming_sms')
+    def test_handles_unexpected_message_types(self, mock_incoming_sms):
+        view = views.TurnIncomingSMSView()
+        body = {
+            'messages': [self._create_message(type='interactive')]
+        }
+        request = RequestFactory().post('/some/url', data=body, content_type='application/json')
+        view.post(request, 'api_key')
+
+        mock_incoming_sms.assert_called()
+
+    def _create_message(self, id='5', from_='+111111111111', type='text'):
+        return {
+            'id': id,
+            'from': from_,
+            'type': type
+        }

--- a/corehq/messaging/smsbackends/turn/views.py
+++ b/corehq/messaging/smsbackends/turn/views.py
@@ -17,6 +17,8 @@ class TurnIncomingSMSView(IncomingBackendView):
         for message in request_body.get('messages', []):
             message_id = message.get('id')
             from_ = message.get('from')
+
+            body = None
             if message.get('type') == 'text':
                 body = message.get('text', {}).get('body')
             elif message.get('type') == 'image':


### PR DESCRIPTION
## Product Description
Our TurnIO backend currently only handles 'text' and 'image' types. Any other type is causing an exception that is flooding our servers with errors. The goal here is to simply silence this error while the solutions team determines a proper fix.

## Technical Summary
[Associated Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-14195)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

### Automated test coverage
New `TurnIncomingSMSView` test suite added to address this. The test mocks out `incoming_sms`, but `incoming_sms` should have no issues with an empty body, as it already converts `None` to an empty string. If something down the pipeline can't handle an empty string, that should still only result in the same blocked messages being blocked.

### QA Plan
No QA required.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
