### PR TITLE
Escape closing script tags without a space

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -45,7 +45,7 @@ def JSON(obj):
 
 def escape_script_tags(unsafe_str):
     # seriously: http://stackoverflow.com/a/1068548/8207
-    return unsafe_str.replace('</script>', '<" + "/script>')
+    return unsafe_str.replace('</script>', '<\\/script>')
 
 
 @register.filter


### PR DESCRIPTION
## Technical Summary
[USH-2698](https://dimagi-dev.atlassian.net/browse/USH-2698?atlOrigin=eyJpIjoiNzRlODUzNjA0OTc0NDhhYmIzMGJmNzEyOTQwNzhmNjgiLCJwIjoiaiJ9)
Changes the way the string `'</script>'` is escaped to be read correctly as JSON by jQuery's `.data()`.

The previous method would produce the JSON-invalid `'<' + '/script'>` which caused the object containing it to be read by `.data()` as a string and not an object; the page expecting an object of properties and receiving a string would then display incorrectly.

## Safety Assurance

### Safety story
Data loaded into `initial_page_data` from context are run through `escape_script_tags` before being HTML escaped. Contents of the hidden `initial-page-data` div are then read by jQuery and UTF escaped before being rendered to the user. The `escape_script_tags` method may not even be strictly necessary, but this change allows it to remain in place while improving compatibility with JSON.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
