### PR TITLE
Fix app builds with null case search title labels

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2287,7 +2287,8 @@ class CaseSearch(DocumentSchema):
     def get_search_title_label(self, app, lang, for_default=False):
         if for_default:
             lang = app.default_language
-        return self.title_label.get(lang, '')
+        # Some apps have undefined labels incorrectly set to None, normalize here
+        return self.title_label.get(lang) or ''
 
     def overwrite_attrs(self, src_config, slugs):
         if 'search_properties' in slugs:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2719
The [initial lazy migration](https://github.com/dimagi/commcare-hq/pull/31439/files#diff-337e12078a5b6e6d646dea3038748024b5e3e975e24f01dae1813d840b72270cR4866) of this feature inadvertently set these `title_label` translation dicts to something like `{"en": None}`, when they should've been left as empty dicts (the empty string is also an acceptable val in the dict).   This causes [issues in the translation code](https://sentry.io/organizations/dimagi/issues/3420270722/?_allp=1&environment=production&query=is%3Aunresolved&referrer=issue-stream).

We apparently did a [migration on staging](https://github.com/dimagi/commcare-hq/pull/31914) to fix this issue, but must not've realized at the time that it was also present on prod.  I looked in to doing a migration to fix the issue, but decided against it, given the high LoE and associated risks.  It'd need to run on all domains, as any app that had translations defined (`app.translations`) would face this issue if case search were turned on.  It'd also need to be a managed migration so it runs on all environments.  I'm punting that can down the road, not that I'm proud of it.

## Feature Flag
Currently only affects USH case search users, I believe

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing, and it's pretty straightforward code - I opted to address it here rather than in the core translations stuff, which could've had broader impacts.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
