### PR TITLE
Remove FORM_LINK_WORKFLOW toggle, enable it by default

### DIFF
--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -260,7 +260,6 @@ class BuildErrorsTest(SimpleTestCase):
             [error['type'] for error in factory.app.validate_app()]
         )
 
-    @flag_enabled('FORM_LINK_WORKFLOW')
     def test_form_module_validation(self, *args):
         factory = AppFactory(build_version='2.24.0')
         app = factory.app

--- a/corehq/apps/hqwebapp/session_details_endpoint/tests.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/tests.py
@@ -209,7 +209,7 @@ class SessionDetailsViewTest(TestCase):
         self.assertEqual(401, response.status_code)
 
     @softer_assert()
-    @flag_enabled('FORM_LINK_WORKFLOW')
+    @flag_enabled('SECURE_SESSION_TIMEOUT')
     @flag_enabled('CALC_XPATHS', is_preview=True)
     def test_session_details_view_toggles(self):
         toggles.all_toggles()
@@ -217,7 +217,7 @@ class SessionDetailsViewTest(TestCase):
         response = _post_with_hmac(self.url, data, content_type="application/json")
         self.assertEqual(200, response.status_code)
         expected_response = self.expected_response.copy()
-        expected_response['enabled_toggles'] = ['FORM_LINK_WORKFLOW']
+        expected_response['enabled_toggles'] = ['SECURE_SESSION_TIMEOUT']
         expected_response['enabled_previews'] = ['CALC_XPATHS']
         self.assertJSONEqual(response.content, expected_response)
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1094,14 +1094,6 @@ TRANSFER_DOMAIN = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-FORM_LINK_WORKFLOW = StaticToggle(
-    'form_link_workflow',
-    'Form linking workflow available on forms',
-    TAG_SOLUTIONS_CONDITIONAL,
-    [NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/saas/Form+Link+Workflow+Feature+Flag',
-)
-
 SECURE_SESSION_TIMEOUT = StaticToggle(
     'secure_session_timeout',
     "USH: Allow domain to override default length of inactivity timeout",

--- a/docs/apps/advanced_app_features.rst
+++ b/docs/apps/advanced_app_features.rst
@@ -71,7 +71,7 @@ End of form navigation ("EOF nav") allows for a couple of specific locations, su
 parent module. EOF nav also has a "previous screen" option this is particularly fragile, since it requires HQ to
 replicate CommCare's UI logic.
 
-Form linking, which is behind the ``FORM_LINK_WORKFLOW`` flag, allows the user to select a form as the destination.
+Form linking under EOF nav, allows the user to select a form as the destination.
 Form linking allows the user to link to multiple forms, depending on the value of an XPath expression.
 
 Most forms can be linked "automatically", meaning that it's easy for HQ to determine what datums are needed.


### PR DESCRIPTION
## Product Description
This removes the FORM_LINK_WORKFLOW toggle and enables it by default to all domains within the existing End of Form Navigation feature.
https://dimagi-dev.atlassian.net/browse/SC-2410

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Removed FORM_LINK_WORKFLOW toggle

## Safety Assurance
Should be safe without any migrations and such

### Safety story
I have tested this locally for apps built with toggle enabled previously before removing the toggle and I have tested that the feature works without the toggle for fresh apps.

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Tests exists

### QA Plan
NA, I have done UI tests myself as they are minimal
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

If the toggle deletion needs to be reverted we need to identify domains that start using the feature without the toggle and then enable the toggle for those domains after reverting

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
