### PR TITLE
Send emails when reaching 90% and 100% of mobile user limit

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1971,6 +1971,14 @@ class Subscription(models.Model):
         else:
             return True
 
+    @classmethod
+    def get_plan_and_user_count_by_domain(cls, domain):
+        from corehq.apps.accounting.usage import FeatureUsageCalculator
+        subscription = cls.get_active_subscription_by_domain(domain)
+        plan_version = subscription.plan_version if subscription else DefaultProductPlan.get_default_plan_version()
+        user_rate = next(rate for rate in plan_version.feature_rates.all() if rate.feature.feature_type == 'User')
+        return user_rate.monthly_limit, FeatureUsageCalculator(user_rate, domain).get_usage()
+
 
 class InvoiceBaseManager(models.Manager):
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2403,6 +2403,14 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
                 yield web_user
 
     @classmethod
+    def get_billing_admins_by_domain(cls, domain):
+        from corehq.apps.users.role_utils import UserRolePresets
+        users = cls.by_domain(domain)
+        for user in users:
+            if user.role_label(domain) == UserRolePresets.BILLING_ADMIN:
+                yield user
+
+    @classmethod
     def get_dimagi_emails_by_domain(cls, domain):
         user_ids = cls.ids_by_domain(domain)
         for user_doc in iter_docs(cls.get_db(), user_ids):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3088,7 +3088,7 @@ def check_and_send_limit_email(domain, plan_limit, user_count, prev_count):
         subject = _("User count has reached 90% of the Plan limit for {}").format(domain)
     send_html_email_async(
         subject,
-        admins + billing_admins,
+        set(admins + billing_admins),
         render_to_string('users/email/user_limit_notice.html', context={
             'at_capacity': at_capacity,
             'url': ADDITIONAL_USERS_PRICING,

--- a/corehq/apps/users/templates/users/email/user_limit_notice.html
+++ b/corehq/apps/users/templates/users/email/user_limit_notice.html
@@ -2,14 +2,14 @@
   <p>
     Please note that you have reached the user limit included in your plan.
     Your user limit represents all mobile users that are not currently deactivated
-    <a href="{{ url }}">(see here for more)</a>. If you exceed the number of mobile users
-    included for free in your plan, you will be charged as per the terms of plan.
+    (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
+    included in your plan, you will be charged as per the terms of plan.
   </p>
 {% else %}
   <p>
-    Please note that you have utilised about 90% of the user limit included in your plan.
+    Please note that you have utilised 90% of the user limit included in your plan.
     Your user limit represents all mobile users that are not currently deactivated
-    <a href="{{ url }}">(see here for more)</a>. If you exceed the number of mobile users
-    included for free in your plan, you will be charged as per the terms of plan.
+    (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
+    included in your plan, you will be charged as per the terms of plan.
   </p>
 {% endif %}

--- a/corehq/apps/users/templates/users/email/user_limit_notice.html
+++ b/corehq/apps/users/templates/users/email/user_limit_notice.html
@@ -2,7 +2,7 @@
 {% if at_capacity %}
   <p>
     {% blocktrans %}
-      Please note that you have reached the user limit included in your plan.
+      Please note that you have reached {{ user_count }} mobile users, the maximum user limit included in your plan.
       Your user limit represents all mobile users that are not currently deactivated
       (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
       included in your plan, you will be charged as per the terms of plan.
@@ -12,6 +12,7 @@
   <p>
     {% blocktrans %}
       Please note that you have utilised 90% of the user limit included in your plan.
+      Your project currently has {{ user_count }} mobile users out of {{ plan_limit }} included in your plan.
       Your user limit represents all mobile users that are not currently deactivated
       (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
       included in your plan, you will be charged as per the terms of plan.

--- a/corehq/apps/users/templates/users/email/user_limit_notice.html
+++ b/corehq/apps/users/templates/users/email/user_limit_notice.html
@@ -1,0 +1,15 @@
+{% if at_capacity %}
+  <p>
+    Please note that you have reached the user limit included in your plan.
+    Your user limit represents all mobile users that are not currently deactivated
+    <a href="{{ url }}">(see here for more)</a>. If you exceed the number of mobile users
+    included for free in your plan, you will be charged as per the terms of plan.
+  </p>
+{% else %}
+  <p>
+    Please note that you have utilised about 90% of the user limit included in your plan.
+    Your user limit represents all mobile users that are not currently deactivated
+    <a href="{{ url }}">(see here for more)</a>. If you exceed the number of mobile users
+    included for free in your plan, you will be charged as per the terms of plan.
+  </p>
+{% endif %}

--- a/corehq/apps/users/templates/users/email/user_limit_notice.html
+++ b/corehq/apps/users/templates/users/email/user_limit_notice.html
@@ -1,15 +1,20 @@
+{% load i18n %}
 {% if at_capacity %}
   <p>
-    Please note that you have reached the user limit included in your plan.
-    Your user limit represents all mobile users that are not currently deactivated
-    (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
-    included in your plan, you will be charged as per the terms of plan.
+    {% blocktrans %}
+      Please note that you have reached the user limit included in your plan.
+      Your user limit represents all mobile users that are not currently deactivated
+      (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
+      included in your plan, you will be charged as per the terms of plan.
+    {% endblocktrans %}
   </p>
 {% else %}
   <p>
-    Please note that you have utilised 90% of the user limit included in your plan.
-    Your user limit represents all mobile users that are not currently deactivated
-    (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
-    included in your plan, you will be charged as per the terms of plan.
+    {% blocktrans %}
+      Please note that you have utilised 90% of the user limit included in your plan.
+      Your user limit represents all mobile users that are not currently deactivated
+      (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
+      included in your plan, you will be charged as per the terms of plan.
+    {% endblocktrans %}
   </p>
 {% endif %}

--- a/corehq/apps/users/tests/test_email_events.py
+++ b/corehq/apps/users/tests/test_email_events.py
@@ -1,16 +1,14 @@
 import os
 from datetime import datetime
 
+from unittest.mock import patch
+
 from dimagi.utils.django.email import COMMCARE_MESSAGE_ID_HEADER
 
 from django.core import mail
 
-from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.event_handlers import handle_email_invite_message
-from corehq.apps.users.models import Invitation, InvitationStatus, WebUser
-from corehq.apps.users.models_role import UserRole
-from corehq.apps.users.role_utils import UserRolePresets, initialize_domain_with_default_roles
-from corehq.apps.users.views.mobile.users import MobileWorkerListView
+from corehq.apps.users.models import Invitation, InvitationStatus, WebUser, check_and_send_limit_email
 from corehq.util.tests.test_email_event_utils import TestSnsEmailBase
 
 
@@ -46,47 +44,68 @@ class TestInviteMessages(TestSnsEmailBase):
 
 class TestUserLimitWarnings(TestSnsEmailBase):
     def setUp(self):
-        self.domain = create_domain("testapp")
-        initialize_domain_with_default_roles(self.domain.name)
-        self.recipients = ["orange@gmail.com", "purple@gmail.com"]
-        self.domain_admin = WebUser.create(self.domain.name, self.recipients[0], "123", None, None, is_admin=True)
-        self.domain_admin.save()
-        self.billing_admin_user = WebUser.create(self.domain.name, self.recipients[1], "123", None, None)
-        role = UserRole.objects.get(domain=self.domain, name=UserRolePresets.BILLING_ADMIN)
-        self.billing_admin_user.set_role(self.domain.name, role.get_qualified_id())
-        self.billing_admin_user.save()
+        self.domain = 'test_domain'
+        self.recipients = ['orange@gmail.com', 'purple@gmail.com']
+        self.plan_limit = 100
+
+        get_admins_patcher = patch.object(WebUser, 'get_admins_by_domain')
+        self.mock_get_admins = get_admins_patcher.start()
+        self.mock_get_admins.return_value = [WebUser(username=self.recipients[0])]
+        self.addCleanup(get_admins_patcher.stop)
+
+        billing_admin_patcher = patch.object(WebUser, 'get_billing_admins_by_domain')
+        self.mock_get_billing_admins = billing_admin_patcher.start()
+        self.mock_get_billing_admins.return_value = [WebUser(username=self.recipients[1])]
+        self.addCleanup(billing_admin_patcher.stop)
 
     def tearDown(self):
-        self.domain_admin.delete(self.domain.name, None)
-        self.billing_admin_user.delete(self.domain.name, None)
-        self.domain.delete()
+        super().tearDown()
 
-    def test_limit_emails(self):
-        plan_limit = 100
-
+    def dont_send_email_below_threshold(self):
         # email should not send if user count is still below the 90% threshold
-        prev_user_count = 75
-        post_user_count = 85
-        MobileWorkerListView.check_and_send_limit_email(self.domain.name, plan_limit,
-                                                        post_user_count, prev_user_count)
+        prev_user_count = 79
+        post_user_count = 89
+        check_and_send_limit_email(self.domain, self.plan_limit, post_user_count, prev_user_count)
         self.assertEqual(len(mail.outbox), 0)
 
+    def send_warning_email_at_threshold(self):
         # email should send upon reaching/crossing 90% of the plan limit
-        prev_user_count = 85
-        post_user_count = 95
-        MobileWorkerListView.check_and_send_limit_email(self.domain.name, plan_limit,
-                                                        post_user_count, prev_user_count)
+        prev_user_count = 80
+        post_user_count = 90
+        check_and_send_limit_email(self.domain, self.plan_limit, post_user_count, prev_user_count)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, self.recipients)
         self.assertEqual(mail.outbox[0].subject,
-                         "User count has reached 90% of the Plan limit for {}".format(self.domain.name))
+                         "User count has reached 90% of the Plan limit for {}".format(self.domain))
 
+    def send_final_email_at_threshold(self):
         # email should send upon reaching/crossing the plan limit
-        prev_user_count = 95
+        prev_user_count = 90
         post_user_count = 100
-        MobileWorkerListView.check_and_send_limit_email(self.domain.name, plan_limit,
-                                                        post_user_count, prev_user_count)
-        self.assertEqual(len(mail.outbox), 2)
+        check_and_send_limit_email(self.domain, self.plan_limit, post_user_count, prev_user_count)
+        self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, self.recipients)
-        self.assertEqual(mail.outbox[1].subject,
-                         "User count has reached the Plan limit for {}".format(self.domain.name))
+        self.assertEqual(mail.outbox[0].subject,
+                         "User count has reached the Plan limit for {}".format(self.domain))
+
+    def dont_send_email_for_enterprise(self):
+        # email shouldn't send when subscribed to the enterprise plan
+        enterprise_plan_limit = -1
+        prev_user_count = 90
+        post_user_count = 100
+        check_and_send_limit_email(self.domain, enterprise_plan_limit, post_user_count, prev_user_count)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def only_send_warning_email_once(self):
+        # the warning email should only send once: when reaching/crossing the 90% threshold
+        prev_user_count = 90
+        post_user_count = 91
+        check_and_send_limit_email(self.domain, self.plan_limit, post_user_count, prev_user_count)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def only_send_final_email_once(self):
+        # the final email should only send once: when reaching/crossing the 100% threshold
+        prev_user_count = 100
+        post_user_count = 101
+        check_and_send_limit_email(self.domain, self.plan_limit, post_user_count, prev_user_count)
+        self.assertEqual(len(mail.outbox), 0)

--- a/corehq/apps/users/tests/test_email_events.py
+++ b/corehq/apps/users/tests/test_email_events.py
@@ -58,9 +58,6 @@ class TestUserLimitWarnings(TestSnsEmailBase):
         self.mock_get_billing_admins.return_value = [WebUser(username=self.recipients[1])]
         self.addCleanup(billing_admin_patcher.stop)
 
-    def tearDown(self):
-        super().tearDown()
-
     def dont_send_email_below_threshold(self):
         # email should not send if user count is still below the 90% threshold
         prev_user_count = 79

--- a/corehq/apps/users/tests/test_email_events.py
+++ b/corehq/apps/users/tests/test_email_events.py
@@ -3,8 +3,14 @@ from datetime import datetime
 
 from dimagi.utils.django.email import COMMCARE_MESSAGE_ID_HEADER
 
+from django.core import mail
+
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.event_handlers import handle_email_invite_message
-from corehq.apps.users.models import Invitation, InvitationStatus
+from corehq.apps.users.models import Invitation, InvitationStatus, WebUser
+from corehq.apps.users.models_role import UserRole
+from corehq.apps.users.role_utils import UserRolePresets, initialize_domain_with_default_roles
+from corehq.apps.users.views.mobile.users import MobileWorkerListView
 from corehq.util.tests.test_email_event_utils import TestSnsEmailBase
 
 
@@ -36,3 +42,51 @@ class TestInviteMessages(TestSnsEmailBase):
         invite = Invitation.objects.get(uuid=self.invite.uuid)
 
         self.assertEqual(invite.email_status, InvitationStatus.BOUNCED)
+
+
+class TestUserLimitWarnings(TestSnsEmailBase):
+    def setUp(self):
+        self.domain = create_domain("testapp")
+        initialize_domain_with_default_roles(self.domain.name)
+        self.recipients = ["orange@gmail.com", "purple@gmail.com"]
+        self.domain_admin = WebUser.create(self.domain.name, self.recipients[0], "123", None, None, is_admin=True)
+        self.domain_admin.save()
+        self.billing_admin_user = WebUser.create(self.domain.name, self.recipients[1], "123", None, None)
+        role = UserRole.objects.get(domain=self.domain, name=UserRolePresets.BILLING_ADMIN)
+        self.billing_admin_user.set_role(self.domain.name, role.get_qualified_id())
+        self.billing_admin_user.save()
+
+    def tearDown(self):
+        self.domain_admin.delete(self.domain.name, None)
+        self.billing_admin_user.delete(self.domain.name, None)
+        self.domain.delete()
+
+    def test_limit_emails(self):
+        plan_limit = 100
+
+        # email should not send if user count is still below the 90% threshold
+        prev_user_count = 75
+        post_user_count = 85
+        MobileWorkerListView.check_and_send_limit_email(self.domain.name, plan_limit,
+                                                        post_user_count, prev_user_count)
+        self.assertEqual(len(mail.outbox), 0)
+
+        # email should send upon reaching/crossing 90% of the plan limit
+        prev_user_count = 85
+        post_user_count = 95
+        MobileWorkerListView.check_and_send_limit_email(self.domain.name, plan_limit,
+                                                        post_user_count, prev_user_count)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, self.recipients)
+        self.assertEqual(mail.outbox[0].subject,
+                         "User count has reached 90% of the Plan limit for {}".format(self.domain.name))
+
+        # email should send upon reaching/crossing the plan limit
+        prev_user_count = 95
+        post_user_count = 100
+        MobileWorkerListView.check_and_send_limit_email(self.domain.name, plan_limit,
+                                                        post_user_count, prev_user_count)
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(mail.outbox[0].to, self.recipients)
+        self.assertEqual(mail.outbox[1].subject,
+                         "User count has reached the Plan limit for {}".format(self.domain.name))

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -55,7 +55,6 @@ from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.crispy import make_form_readonly
 from corehq.apps.hqwebapp.decorators import use_multiselect
-from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.locations.models import SQLLocation

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -789,7 +789,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
         if at_capacity:
             subject = _("User count has reached the Plan limit for {}").format(domain)
         else:
-            subject = _("User count has reached 90% of the Plan limit for ({})").format(domain)
+            subject = _("User count has reached 90% of the Plan limit for {}").format(domain)
         send_html_email_async(
             subject,
             admins + billing_admins,

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -776,7 +776,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
         subscription = Subscription.get_active_subscription_by_domain(domain)
         plan_version = subscription.plan_version if subscription else DefaultProductPlan.get_default_plan_version()
         for rate in plan_version.feature_rates.all():
-            if 'User' in rate.feature.name:
+            if rate.feature.feature_type == 'User':
                 user_rate = rate
                 break
         return {

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -5,6 +5,7 @@ import time
 
 from braces.views import JsonRequestResponseMixin
 from couchdbkit import ResourceNotFound
+from dimagi.utils.django.email import send_HTML_email
 from django.contrib import messages
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.exceptions import ValidationError
@@ -34,8 +35,11 @@ from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.accounting.models import (
     BillingAccount,
     BillingAccountType,
+    DefaultProductPlan,
     EntryPoint,
+    Subscription,
 )
+from corehq.apps.accounting.usage import FeatureUsageCalculator
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.custom_data_fields.edit_entity import CustomDataEditor
@@ -94,6 +98,7 @@ from corehq.apps.users.models import (
     CommCareUser,
     CouchUser,
     DeactivateMobileWorkerTrigger,
+    WebUser,
 )
 from corehq.apps.users.models_role import UserRole
 from corehq.apps.users.tasks import (
@@ -146,6 +151,8 @@ BULK_MOBILE_HELP_SITE = ("https://confluence.dimagi.com/display/commcarepublic"
                          "/Create+and+Manage+CommCare+Mobile+Workers#Createand"
                          "ManageCommCareMobileWorkers-B.UseBulkUploadtocreatem"
                          "ultipleusersatonce")
+ADDITIONAL_USERS_PRICING = ("https://confluence.dimagi.com/display/commcarepublic"
+                            "/CommCare+Pricing+FAQs#CommCarePricingFAQs-Feesforadditionalusers")
 DEFAULT_USER_LIST_LIMIT = 10
 BAD_MOBILE_USERNAME_REGEX = re.compile("[^A-Za-z0-9.+-_]")
 
@@ -756,6 +763,42 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
             phone_number = self.new_mobile_worker_form.cleaned_data['phone_number']
             couch_user.set_default_phone_number(phone_number)
             send_account_confirmation_sms_if_necessary(couch_user)
+
+        subscription = Subscription.get_active_subscription_by_domain(self.domain)
+        plan_version = subscription.plan_version if subscription else DefaultProductPlan.get_default_plan_version()
+        for rate in plan_version.feature_rates.all():
+            if 'User' in rate.feature.name:
+                user_rate = rate
+                break
+        plan_limit = user_rate.monthly_limit
+
+        def send_email_to_admins_and_billing(at_capacity):
+            users = WebUser.by_domain(self.domain)
+            recipients = []
+            for user in users:
+                if user.role_label(self.domain) == 'Billing Admin' or user.role_label(self.domain) == 'Admin':
+                    recipients.append(user.username)
+            if at_capacity:
+                subject = _("User count has reached the Plan limit for {}").format(self.domain)
+            else:
+                subject = _("User count has reached 90% of the Plan limit for ({})").format(self.domain)
+            send_HTML_email(
+                subject,
+                recipients,
+                render_to_string('users/email/user_limit_notice.html', context={
+                    'at_capacity': at_capacity,
+                    'url': ADDITIONAL_USERS_PRICING
+                }),
+            )
+            return None
+
+        if plan_limit != -1:
+            user_count = FeatureUsageCalculator(user_rate, self.domain).get_usage()
+            if user_count == plan_limit:
+                send_email_to_admins_and_billing(at_capacity=True)
+            elif plan_limit > user_count >= (0.9 * plan_limit) > (user_count - 1):
+                send_email_to_admins_and_billing(at_capacity=False)
+
         return {
             'success': True,
             'user_id': couch_user.userID,

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -795,7 +795,9 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
             admins + billing_admins,
             render_to_string('users/email/user_limit_notice.html', context={
                 'at_capacity': at_capacity,
-                'url': ADDITIONAL_USERS_PRICING
+                'url': ADDITIONAL_USERS_PRICING,
+                'user_count': user_count,
+                'plan_limit': plan_limit,
             }),
         )
         return None


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

A one-time email notice will now be sent out when the mobile worker count crosses the 90% and 100% threshold based on that domain's plan's mobile worker limit. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SALES-26419)
[Specs](https://docs.google.com/document/d/1n3__riOHJTjYFxI6Vvq1JpBpJzXJv-ZH8jR7NCfovmM/edit) (also in ticket)

Emails will be sent regardless of if the mobile worker was added manually/individually or through the bulk upload action since they both use the new `check_and_send_limit_email` static function that checks whether the email should be sent at all and if so, which one, based on the given plan limit and user count from before and after the user creation action. `get_plan_and_user_count_by_domain` was separated out as its own function since I need to use it twice (before and after bulk upload action) to check whether the email should send or not. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging + QA tested. This doesn't change any data only gets it. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-4683)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
