### PR TITLE
Fixed a bug with falsey values within device meta updates

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -751,19 +751,15 @@ class DeviceAppMeta(DocumentSchema):
         if other.last_request <= self.last_request:
             return
 
-        for key, prop in self.properties().items():
+        for key, prop in other.properties().items():
             new_val = getattr(other, key)
-            if new_val:
+            if new_val is not None:
                 old_val = getattr(self, key)
-                if not old_val:
-                    setattr(self, key, new_val)
-                    continue
 
                 prop_is_date = isinstance(prop, DateTimeProperty)
-                if prop_is_date and new_val > old_val:
-                    setattr(self, key, new_val)
-                elif not prop_is_date and old_val != new_val:
-                    setattr(self, key, new_val)
+                if prop_is_date and (old_val and new_val <= old_val):
+                    continue  # do not overwrite dates with older ones
+                setattr(self, key, new_val)
 
         self._update_latest_request()
 

--- a/corehq/apps/users/tests/test_models.py
+++ b/corehq/apps/users/tests/test_models.py
@@ -132,7 +132,7 @@ class DeviceAppMetaMergeTests(SimpleTestCase):
         self.assertEqual(self.original_meta.last_heartbeat, self.current_time)
 
     def test_does_not_overwrite_unspecified_properties(self):
-        self.updates_meta.num_unsent_forms = 5
+        self.original_meta.num_unsent_forms = 5
 
         self.original_meta.merge(self.updates_meta)
         self.assertEqual(self.original_meta.num_unsent_forms, 5)

--- a/corehq/apps/users/tests/test_models.py
+++ b/corehq/apps/users/tests/test_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from django.test import SimpleTestCase, TestCase
@@ -8,6 +8,7 @@ from corehq.apps.users.models import (
     CouchUser,
     Invitation,
     WebUser,
+    DeviceAppMeta,
 )
 
 from corehq.apps.domain.models import Domain
@@ -94,3 +95,117 @@ class User_MessagingDomain_Tests(SimpleTestCase):
 
     def _get_domain_by_name(self, name):
         return self.domains[name]
+
+
+class DeviceAppMetaMergeTests(SimpleTestCase):
+    def test_overwrites_key(self):
+        self.original_meta.num_unsent_forms = 5
+        self.updates_meta.num_unsent_forms = 2
+
+        self.original_meta.merge(self.updates_meta)
+        self.assertEqual(self.original_meta.num_unsent_forms, 2)
+
+    def test_ignores_older_submissions(self):
+        recent_meta = DeviceAppMeta(num_unsent_forms=5, last_request=self.current_time)
+        older_meta = DeviceAppMeta(num_unsent_forms=2, last_request=self.previous_time)
+
+        recent_meta.merge(older_meta)
+        self.assertEqual(recent_meta.num_unsent_forms, 5)
+
+    def test_ignores_simultaneous_submissions(self):
+        meta1 = DeviceAppMeta(num_unsent_forms=5, last_request=self.current_time)
+        meta2 = DeviceAppMeta(num_unsent_forms=2, last_request=self.current_time)
+
+        meta1.merge(meta2)
+        self.assertEqual(meta1.num_unsent_forms, 5)
+
+    def test_merges_new_properties(self):
+        self.updates_meta.num_unsent_forms = 5
+
+        self.original_meta.merge(self.updates_meta)
+        self.assertEqual(self.original_meta.num_unsent_forms, 5)
+
+    def test_merges_new_dates(self):
+        self.updates_meta.last_heartbeat = self.current_time
+
+        self.original_meta.merge(self.updates_meta)
+        self.assertEqual(self.original_meta.last_heartbeat, self.current_time)
+
+    def test_does_not_overwrite_unspecified_properties(self):
+        self.updates_meta.num_unsent_forms = 5
+
+        self.original_meta.merge(self.updates_meta)
+        self.assertEqual(self.original_meta.num_unsent_forms, 5)
+
+    def test_uses_nontruthy_values(self):
+        self.original_meta.num_unsent_forms = 5
+        self.updates_meta.num_unsent_forms = 0
+
+        self.original_meta.merge(self.updates_meta)
+        self.assertEqual(self.original_meta.num_unsent_forms, 0)
+
+    def test_updates_dates(self):
+        self.original_meta.last_heartbeat = self.previous_time
+        self.updates_meta.last_heartbeat = self.current_time
+
+        self.original_meta.merge(self.updates_meta)
+        self.assertEqual(self.original_meta.last_heartbeat, self.current_time)
+
+    def test_ignores_older_dates(self):
+        self.original_meta.num_unsent_forms = 5
+        self.original_meta.last_heartbeat = self.current_time
+
+        self.updates_meta.num_unsent_forms = 2
+        self.updates_meta.last_heartbeat = self.previous_time
+
+        self.original_meta.merge(self.updates_meta)
+        self.assertEqual(self.original_meta.num_unsent_forms, 2)  # Normal values should still merge
+        # But the older time should be ignored
+        self.assertEqual(self.original_meta.last_heartbeat, self.current_time)
+
+    def test_updates_last_request(self):
+        original_meta = DeviceAppMeta(last_request=self.previous_time)
+        updates_meta = DeviceAppMeta(last_heartbeat=self.current_time)
+
+        original_meta.merge(updates_meta)
+        self.assertEqual(original_meta.last_request, self.current_time)
+
+    def setUp(self):
+        self.previous_time = datetime(2022, 10, 2)
+        self.current_time = self.previous_time + timedelta(hours=1)
+
+        self.original_meta = DeviceAppMeta(last_request=self.previous_time)
+        self.updates_meta = DeviceAppMeta(last_request=self.current_time)
+
+
+class DeviceAppMetaLatestRequestTests(SimpleTestCase):
+    def test_uses_max_from_submission(self):
+        meta = DeviceAppMeta(
+            last_submission=self.current_time,
+            last_sync=self.previous_time,
+            last_heartbeat=self.previous_time
+        )
+        meta._update_latest_request()
+        self.assertEqual(meta.last_request, self.current_time)
+
+    def test_uses_max_from_sync(self):
+        meta = DeviceAppMeta(
+            last_sync=self.current_time,
+            last_submission=self.previous_time,
+            last_heartbeat=self.previous_time
+        )
+        meta._update_latest_request()
+        self.assertEqual(meta.last_request, self.current_time)
+
+    def test_uses_max_from_heartbeat(self):
+        meta = DeviceAppMeta(
+            last_heartbeat=self.current_time,
+            last_submission=self.previous_time,
+            last_sync=self.previous_time
+        )
+        meta._update_latest_request()
+        self.assertEqual(meta.last_request, self.current_time)
+
+    def setUp(self):
+        self.previous_time = datetime(2022, 10, 2)
+        self.current_time = self.previous_time + timedelta(hours=1)

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -274,42 +274,6 @@ class UserDeviceTest(SimpleTestCase):
         app_meta = device.get_meta_for_app('123')
         self.assertIsNotNone(app_meta)
 
-    def test_merge_device_app_meta(self):
-        m1 = DeviceAppMeta(
-            build_id='build1',
-            build_version=1,
-            last_submission=datetime.utcnow(),
-            num_unsent_forms=1
-        )
-        m2 = DeviceAppMeta(
-            build_id='build2',
-            build_version=2,
-            last_submission=datetime.utcnow(),
-        )
-
-        m2.merge(m1)
-        self.assertNotEqual(m2.build_id, m1.build_id)
-        self.assertNotEqual(m2.build_version, m1.build_version)
-        self.assertNotEqual(m2.last_submission, m1.last_submission)
-        self.assertIsNone(m2.num_unsent_forms)
-
-        m1.merge(m2)
-        self.assertEqual(m1.build_id, m2.build_id)
-        self.assertEqual(m1.build_version, m2.build_version)
-        self.assertEqual(m1.last_submission, m2.last_submission)
-        self.assertEqual(m1.num_unsent_forms, 1)
-
-    def test_merge_device_app_meta_last_is_none(self):
-        m1 = DeviceAppMeta(
-            last_submission=datetime.utcnow(),
-        )
-        m2 = DeviceAppMeta(
-            last_sync=datetime.utcnow(),
-        )
-
-        m1.merge(m2)
-        self.assertEqual(m1.last_sync, m2.last_sync)
-
 
 class TestCommCareUserRoles(TestCase):
     user_class = CommCareUser


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
[Associated ticket](https://dimagi-dev.atlassian.net/browse/SAAS-14190)
This addresses a bug where the user's phone information did not line up with what we were displaying within our reports.
This fixes an issue with our update process for this data, as 'falsey' data would have previously been skipped -- i.e. a user who had previous had unsaved_forms would be unable to reset the number of unsaved_forms to 0, since 0 is falsey.

Apologies for bundling a refactor with the bug fix, rather than creating separate commits.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

New test suite in users/tests/test_models. Removed redundant tests from users/tests/test_user_model

### QA Plan

No QA required.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
