### PR TITLE
[USH-2725] [bug] add uniqueId to form links when preparing context for view

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -884,6 +884,23 @@ class FormLink(DocumentSchema):
     module_unique_id = StringProperty()
     datums = SchemaListProperty(FormDatum)
 
+    def get_unique_id(self, app):
+        """"Get a unique ID for this link. For links to modules this is just the ID
+        of the module since that is already unique in the app.
+
+        For links to forms this is a combination of the form and module ID which is
+        necessary to support linking to forms in shadow modules.
+        """
+        if self.module_unique_id:
+            return self.module_unique_id
+
+        if self.form_module_id:
+            return f"{self.form_module_id}.{self.form_id}"
+
+        # legacy data does not have 'form_module_id'
+        form = app.get_form(self.form_id)
+        return f"{form.get_module().unique_id}.{self.form_id}"
+
 
 class FormSchedule(DocumentSchema):
     """

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -41,11 +41,11 @@ hqDefine('app_manager/js/forms/form_workflow', function () {
 
         var uniqueIds = _.pluck(self.forms,  'uniqueId');
         self.formLinks = ko.observableArray(_.map(_.filter(options.formLinks, function (link) {
-            return _.intersection(uniqueIds, [link.form_id, link.module_unique_id]).length;
+            return uniqueIds.indexOf(link.uniqueId) > 0;
         }), function (link) {
             return new FormWorkflow.FormLink(
                 link.xpath,
-                link.form_id || link.module_unique_id,
+                link.uniqueId,
                 self,
                 link.datums
             );

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -41,7 +41,7 @@ hqDefine('app_manager/js/forms/form_workflow', function () {
 
         var uniqueIds = _.pluck(self.forms,  'uniqueId');
         self.formLinks = ko.observableArray(_.map(_.filter(options.formLinks, function (link) {
-            return uniqueIds.indexOf(link.uniqueId) > 0;
+            return uniqueIds.indexOf(link.uniqueId) >= 0;
         }), function (link) {
             return new FormWorkflow.FormLink(
                 link.xpath,

--- a/corehq/apps/app_manager/static/app_manager/spec/form_workflow_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_workflow_spec.js
@@ -80,8 +80,8 @@ describe('Form Workflow', function () {
                 { name: 'My First Form', unique_id: realID, auto_link: true },
             ];
             options.formLinks = [
-                { xpath: "true()", doc_type: "FormLink", form_id: realID, datums: [] },
-                { xpath: "false()", doc_type: "FormLink", form_id: fakeID, datums: [] },
+                { xpath: "true()", doc_type: "FormLink", form_id: realID, datums: [], uniqueId: realID },
+                { xpath: "false()", doc_type: "FormLink", form_id: fakeID, datums: [], uniqueId: fakeID },
             ];
             workflow = new FormWorkflow(options);
             assert.lengthOf(workflow.forms, 1);

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -158,7 +158,7 @@
   {% registerurl "validate_form_for_build" domain app.id form.unique_id %}
 
   {# End of form navigation #}
-  {% initial_page_data 'form_links' form.form_links %}
+  {% initial_page_data 'form_links' form_links %}
   {% initial_page_data 'linkable_forms' linkable_forms %}
   {% initial_page_data 'post_form_workflow' form.post_form_workflow %}
   {% initial_page_data 'post_form_workflow_fallback' form.post_form_workflow_fallback %}

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -15,6 +15,8 @@ from corehq.apps.app_manager.exceptions import XFormValidationError
 from corehq.apps.app_manager.models import (
     AdvancedModule,
     Application,
+    FormDatum,
+    FormLink,
     Module,
     ReportModule,
     ShadowModule,
@@ -24,7 +26,11 @@ from corehq.apps.app_manager.views import (
     AppCaseSummaryView,
     AppFormSummaryView,
 )
-from corehq.apps.app_manager.views.forms import get_apps_modules
+from corehq.apps.app_manager.views.forms import (
+    _get_form_links,
+    _get_linkable_forms_context,
+    get_apps_modules,
+)
 from corehq.apps.builds.models import BuildSpec
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.tests.utils import es_test
@@ -34,6 +40,7 @@ from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.pillows.mappings.app_mapping import APP_INDEX_INFO
 from corehq.util.test_utils import timelimit, flag_enabled
 
+from .app_factory import AppFactory
 from .test_form_versioning import INVALID_TEMPLATE
 
 
@@ -280,6 +287,133 @@ class TestViews(TestCase):
             )
             names = sorted([a['name'] for a in apps_modules])
             self.assertEqual(names, ['LinkedApp', 'OtherApp', 'TestApp'])
+
+    def test_form_linking_context(self, _):
+        factory = AppFactory(build_version='2.9.0')
+        m0, m0f0 = factory.new_basic_module('m0', 'frog')
+        # multiselect module (can't be linked to)
+        m1, m2f0 = factory.new_basic_module('m1', 'frog')
+        m1.case_details.short.multi_select = True
+        # shadow module
+        factory.new_shadow_module('m2', m0, with_form=False)
+        # module with different case type
+        factory.new_basic_module('m3', 'rabbit')
+
+        linkables = _get_linkable_forms_context(m0, factory.app.langs)
+        self.assertEqual(linkables, [
+            {
+                'allow_manual_linking': False,
+                'auto_link': True,
+                'name': 'm0 module',
+                'unique_id': 'm0_module'
+            },
+            {
+                'allow_manual_linking': True,
+                'auto_link': True,
+                'name': 'm0 module > m0 form 0',
+                'unique_id': 'm0_module.m0_form_0'
+            },
+            {
+                'allow_manual_linking': False,
+                'auto_link': True,
+                'name': 'm2 module',
+                'unique_id': 'm2_module'
+            },
+            {
+                'allow_manual_linking': True,
+                'auto_link': True,
+                'name': 'm2 module > m0 form 0',
+                'unique_id': 'm2_module.m0_form_0'
+            },
+            {
+                'allow_manual_linking': False,
+                'auto_link': True,
+                'name': 'm3 module',
+                'unique_id': 'm3_module'
+            },
+            {
+                'allow_manual_linking': True,
+                'auto_link': False,  # can't autolink to a form with a different case type
+                'name': 'm3 module > m3 form 0',
+                'unique_id': 'm3_module.m3_form_0'
+            }
+        ])
+
+    def test_form_linking_context_multi_select(self, _):
+        factory = AppFactory(build_version='2.9.0')
+        factory.new_basic_module('m0', 'frog')
+
+        # multiselect module (can't be linked to)
+        m1, m2f0 = factory.new_basic_module('m1', 'frog')
+        m1.case_details.short.multi_select = True
+
+        linkables = _get_linkable_forms_context(m1, factory.app.langs)
+
+        # no auto linking allowed
+        self.assertEqual(linkables, [
+            {
+                'allow_manual_linking': False,
+                'auto_link': True,
+                'name': 'm0 module',
+                'unique_id': 'm0_module'
+            },
+            {
+                'allow_manual_linking': True,
+                'auto_link': False,
+                'name': 'm0 module > m0 form 0',
+                'unique_id': 'm0_module.m0_form_0'
+            }
+        ])
+
+    def test_form_links_context(self, _):
+        self.maxDiff = None
+        factory = AppFactory(build_version='2.9.0')
+        m0, m0f0 = factory.new_basic_module('m0', 'frog')
+        m1, m1f0 = factory.new_basic_module('m1', 'frog')
+        m0f0.form_links = [
+            FormLink(xpath="true()", form_id=m1f0.unique_id, form_module_id=m1.unique_id, datums=[
+                FormDatum(name="case_id", xpath="instance('commcaresession')/session/data/case_id")
+            ]),
+            FormLink(xpath="true()", form_id=m1f0.unique_id),
+            FormLink(module_unique_id=m1.unique_id),
+        ]
+        links = _get_form_links(factory.app, m0f0)
+        self.assertEqual(links, [
+            {
+                'datums': [
+                    {
+                        'doc_type': 'FormDatum',
+                        'name': 'case_id',
+                        'xpath': "instance('commcaresession')/session/data/case_id"
+                    }
+                ],
+                'doc_type': 'FormLink',
+                'form_id': 'm1_form_0',
+                'form_module_id': 'm1_module',
+                'module_unique_id': None,
+                'uniqueId': 'm1_module.m1_form_0',
+                'xpath': 'true()'
+            },
+            # legacy data still produced the correct uniqueId
+            {
+                'datums': [],
+                'doc_type': 'FormLink',
+                'form_id': 'm1_form_0',
+                'form_module_id': None,
+                'module_unique_id': None,
+                'uniqueId': 'm1_module.m1_form_0',
+                'xpath': 'true()'
+            },
+            {
+                'datums': [],
+                'doc_type': 'FormLink',
+                'form_id': None,
+                'form_module_id': None,
+                'module_unique_id': 'm1_module',
+                'uniqueId': 'm1_module',
+                'xpath': None
+            }
+        ])
 
 
 @contextmanager

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -2,12 +2,11 @@ import base64
 import json
 import re
 from contextlib import contextmanager
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
-
-from unittest.mock import patch
 
 from pillowtop.es_utils import initialize_index_and_mapping
 
@@ -38,11 +37,10 @@ from corehq.apps.linked_domain.applications import create_linked_app
 from corehq.apps.users.models import HQApiKey, WebUser
 from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.pillows.mappings.app_mapping import APP_INDEX_INFO
-from corehq.util.test_utils import timelimit, flag_enabled
+from corehq.util.test_utils import flag_enabled, timelimit
 
 from .app_factory import AppFactory
 from .test_form_versioning import INVALID_TEMPLATE
-
 
 User = get_user_model()
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-2725

Escape defect from https://dimagi-dev.atlassian.net/browse/QA-4693

## Technical Summary
Fixes a bug where the view context for existing links does not match the 'available links' list causing the UI to now show existing links.

## Safety Assurance

### Safety story
I've tested this locally with old and new data and also with and without form-linking enabled.

### Automated test coverage
Tests added in this PR

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
