### PR TITLE
Check if xform is deleted before accessing

### DIFF
--- a/corehq/apps/data_interfaces/pillow.py
+++ b/corehq/apps/data_interfaces/pillow.py
@@ -26,6 +26,9 @@ class CaseDeduplicationProcessor(PillowProcessor):
         if not CASE_DEDUPE.enabled(domain):
             return
 
+        if change.deleted:
+            return
+
         if is_dedupe_xmlns(change.get_document().get('xmlns')):
             return
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Stack Trace:
```
'NoneType' object has no attribute 'get'

  File "/home/cchq/www/production/current/corehq/ex-submodules/pillowtop/pillow/interface.py", line 257, in process_with_error_handling
    self.process_change(change, serial_only=True)
  File "/home/cchq/www/production/current/corehq/ex-submodules/pillowtop/pillow/interface.py", line 469, in process_change
    processor.process_change(change)
  File "/home/cchq/www/production/releases/2022-12-08_19.36/corehq/apps/data_interfaces/pillow.py", line 29, in process_change
    if is_dedupe_xmlns(change.get_document().get('xmlns')):
```

The dedupe processor was attempting to access the `xmlns` attribute on a document that no longer exists. Since this processor receives any change on a form topic, it needs to check if the change is a deletion before proceeding.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added test to cover this new code.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
