### PR TITLE
Missed a variable rename

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -932,7 +932,7 @@ class ApplicationMediaMixin(Document, MediaMixin):
             except ResourceConflict:
                 # Attempt to fetch the document again.
                 updated_doc = self.get(self._id)
-                updated_doc.create_mapping(multimedia, form_path)
+                updated_doc.create_mapping(multimedia, path)
 
     def get_media_objects(self, build_profile_id=None, remove_unused=False, multimedia_map=None):
         """


### PR DESCRIPTION
## Technical Summary

In 86bb150a8ec4c9d8c8be27b6990b63b1be9e3dc2 the variable `form_path` was renamed to `path`, but this last one was missed.

## Feature Flag

N/A

## Safety Assurance

### Safety story

A tiny change that fixes an undefined variable.

### Automated test coverage

Not covered by tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
