### PR TITLE
Method def missing `self`

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -539,7 +539,7 @@ class MediaMixin(object):
         An object that has multimedia associated with it.
         Used by apps, modules, forms.
     """
-    def get_media_ref_kwargs():
+    def get_media_ref_kwargs(self):
         raise NotImplementedError
 
     def all_media(self, lang=None):


### PR DESCRIPTION
## Technical Summary

This is really just to stop my IDE from complaining about an error. This method is only ever called on subclasses.

## Feature Flag

N/A

## Safety Assurance

### Safety story

"Fixes" code that is never called.

### Automated test coverage

This unimplemented method is not covered by tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
