### PR TITLE
Remove unused ICDS Elasticsearch settings

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -7,7 +7,6 @@ from functools import cached_property
 
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 from django.conf import settings
-from django.utils.functional import classproperty
 
 from memoized import memoized
 from corehq.apps.es.filters import term
@@ -392,10 +391,6 @@ class ElasticDocumentAdapter(BaseAdapter):
         adapter = copy.copy(self)
         adapter._es = get_client(for_export=True)
         return adapter
-
-    @classproperty
-    def settings(cls):
-        return settings.ELASTIC_ADAPTER_SETTINGS.get(cls.__name__, {})
 
     @classmethod
     def from_python(cls, doc):

--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -1568,9 +1568,6 @@ class TestElasticMultiplexAdapter(SimpleTestCase, ESTestHelpers):
         TestDocumentAdapter("secondary", "doc"),
     )
 
-    def test_settings(self):
-        self.assertEqual(self.adapter.settings, self.adapter.primary.settings)
-
     def test_to_json(self):
         doc = self._make_doc()
         as_json = {"_id": doc.id, "value": doc.value, "entropy": doc.entropy}

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -3,7 +3,6 @@ import math
 from collections import namedtuple
 from urllib.parse import urlencode
 
-from django.conf import settings
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
@@ -1272,10 +1271,6 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
     NO_FORMS_TEXT = gettext_noop('None')
 
     @property
-    def include_active_cases(self):
-        return not settings.CASE_ES_DROP_FORM_FIELDS
-
-    @property
     def fields(self):
         if toggles.EMWF_WORKER_ACTIVITY_REPORT.enabled(self.request.domain):
             return [
@@ -1549,17 +1544,13 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
             owner_ids = _get_owner_ids_from_users(users)
 
             total_cases = sum([int(report_data.total_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids])
-            if self.include_active_cases:
-                active_cases = sum([
-                    int(report_data.active_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids
-                ])
-                active_cases_cell = util.numcell(active_cases)
-                pct_active = util.numcell(
-                    (float(active_cases) / total_cases) * 100 if total_cases else 'nan', convert='float'
-                )
-            else:
-                active_cases_cell = util.numcell('---')
-                pct_active = util.numcell('---')
+            active_cases = sum([
+                int(report_data.active_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids
+            ])
+            active_cases_cell = util.numcell(active_cases)
+            pct_active = util.numcell(
+                (float(active_cases) / total_cases) * 100 if total_cases else 'nan', convert='float'
+            )
 
             active_users = int(active_users_by_group.get(group, 0))
             total_users = len(self.users_by_group.get(group, []))
@@ -1613,24 +1604,20 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
             owner_ids = set([user["user_id"].lower(), user["location_id"]] + user["group_ids"])
             total_cases = sum([int(report_data.total_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids])
 
-            if self.include_active_cases:
-                active_cases = sum([
-                    int(report_data.active_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids
-                ])
-                if today_or_tomorrow(self.datespan.enddate):
-                    active_cases_cell = util.numcell(
-                        self._html_anchor_tag(self._case_list_url_active_cases(user['user_id']), active_cases),
-                        active_cases,
-                    )
-                else:
-                    active_cases_cell = util.numcell(active_cases)
-
-                pct_active = util.numcell(
-                    (float(active_cases) / total_cases) * 100 if total_cases else 'nan', convert='float'
+            active_cases = sum([
+                int(report_data.active_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids
+            ])
+            if today_or_tomorrow(self.datespan.enddate):
+                active_cases_cell = util.numcell(
+                    self._html_anchor_tag(self._case_list_url_active_cases(user['user_id']), active_cases),
+                    active_cases,
                 )
             else:
-                active_cases_cell = util.numcell('---')
-                pct_active = util.numcell('---')
+                active_cases_cell = util.numcell(active_cases)
+
+            pct_active = util.numcell(
+                (float(active_cases) / total_cases) * 100 if total_cases else 'nan', convert='float'
+            )
 
             cases_opened = int(report_data.cases_opened_by_user.get(user["user_id"].lower(), 0))
             cases_closed = int(report_data.cases_closed_by_user.get(user["user_id"].lower(), 0))
@@ -1692,12 +1679,9 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
         case_owners = _get_owner_ids_from_users(users_to_iterate)
         user_ids = user_ids
 
-        if self.include_active_cases:
-            active_cases_by_owner = get_active_case_counts_by_owner(
-                self.domain, self.datespan, self.case_types, owner_ids=case_owners, export=export
-            )
-        else:
-            active_cases_by_owner = {}
+        active_cases_by_owner = get_active_case_counts_by_owner(
+            self.domain, self.datespan, self.case_types, owner_ids=case_owners, export=export
+        )
 
         return WorkerActivityReportData(
             avg_submissions_by_user=get_submission_counts_by_user(
@@ -1734,7 +1718,7 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
 
         total_row[6] = sum(
             [int(report_data.active_cases_by_owner.get(id, 0))
-             for id in case_owners]) if self.include_active_cases else '---'
+             for id in case_owners])
 
         total_row[7] = sum(
             [int(report_data.total_cases_by_owner.get(id, 0))

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -38,12 +38,6 @@ def transform_case_for_elasticsearch(doc_dict):
     if 'backend_id' not in doc_ret:
         doc_ret['backend_id'] = 'couch'
 
-    if settings.CASE_ES_DROP_FORM_FIELDS:
-        # these fields are lazily loaded so replacing or removing them
-        # prevents them from being loaded from the DB
-        doc_ret['actions'] = []
-        doc_ret['xform_ids'] = []
-
     return doc_ret
 
 

--- a/corehq/pillows/mappings/xform_mapping.py
+++ b/corehq/pillows/mappings/xform_mapping.py
@@ -219,9 +219,6 @@ XFORM_MAPPING = {
     }
 }
 
-if form_adapter.settings.get("DISABLE_ALL"):
-    XFORM_MAPPING["_all"] = {"enabled": False}
-
 XFORM_INDEX_INFO = ElasticsearchIndexInfo(
     index=XFORM_INDEX,
     alias=XFORM_ALIAS,

--- a/settings.py
+++ b/settings.py
@@ -1052,22 +1052,8 @@ CUSTOM_LANDING_TEMPLATE = {
     # "default": 'login_and_password/login.html',
 }
 
-ELASTIC_ADAPTER_SETTINGS = {
-    "ElasticCase": {
-        # Set to True to remove the `actions` and `xform_id` fields from the
-        # Elastic "hqcases_..." index. These fields contribute high load to the
-        # shard databases.
-        "DROP_FORM_FIELDS": False,
-    },
-    "ElasticForm": {
-        # TODO: document what this is for
-        "DISABLE_ALL": False,
-    },
-}
-
-# TODO: remove these Elastic settings:
-ES_SETTINGS = None  # [do not use] legacy mechanism for tests
-CASE_ES_DROP_FORM_FIELDS = ELASTIC_ADAPTER_SETTINGS["ElasticCase"]["DROP_FORM_FIELDS"]
+# used to override low-level index settings (number_of_replicas, number_of_shards, etc)
+ES_SETTINGS = None
 
 PHI_API_KEY = None
 PHI_PASSWORD = None


### PR DESCRIPTION
## Technical Summary

Remove unused ICDS Elasticsearch settings.

- `CASE_ES_DROP_FORM_FIELDS` added in #24914
- `ES_XFORM_DISABLE_ALL` added in #26695

Settings were added for ICDS Elasticsearch tuning and are no longer used. This change will be accompanied by a (forthcoming) commcare-cloud PR.

Jira: [SAAS-14003](https://dimagi-dev.atlassian.net/browse/SAAS-14003)

## Safety Assurance

### Safety story

These settings are not used in any SaaS environments.

### Automated test coverage

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
