### PR TITLE
Improvement: Join connection_settings when fetching repeaters in management command

### DIFF
--- a/corehq/motech/repeaters/management/commands/populate_repeater_names.py
+++ b/corehq/motech/repeaters/management/commands/populate_repeater_names.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             repeaters = self._get_repeaters_with_empty_names()
 
     def _get_repeaters_with_empty_names(self):
-        return SQLRepeater.objects.filter(name=None)[:CHUNKSIZE]
+        return SQLRepeater.objects.filter(name=None).select_related('connection_settings')[:CHUNKSIZE]
 
     def _show_progress(self, repeater_count):
         self.repeaters_updated_count += repeater_count


### PR DESCRIPTION
## Technical Summary
This is to improve the query in the `populate_repeater_names` django manage command introduced in [this PR](https://github.com/dimagi/commcare-hq/pull/32359).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Local testing

Out of curiosity I checked the raw sql before and after adding the `select_related`
Before:
```SQL
SELECT "repeaters_repeater"."id", "repeaters_repeater"."repeater_type", "repeaters_repeater"."domain", "repeaters_repeater"."repeater_id", "repeaters_repeater"."name", "repeaters_repeater"."format", "repeaters_repeater"."request_method", "repeaters_repeater"."is_paused", "repeaters_repeater"."next_attempt_at", "repeaters_repeater"."last_attempt_at", "repeaters_repeater"."options", "repeaters_repeater"."connection_settings_id", "repeaters_repeater"."is_deleted", "repeaters_repeater"."last_modified", "repeaters_repeater"."date_created" FROM "repeaters_repeater" WHERE (NOT "repeaters_repeater"."is_deleted" AND "repeaters_repeater"."name" IS NULL)
```

After:
```SQL
SELECT "repeaters_repeater"."id", "repeaters_repeater"."repeater_type", "repeaters_repeater"."domain", "repeaters_repeater"."repeater_id", "repeaters_repeater"."name", "repeaters_repeater"."format", "repeaters_repeater"."request_method", "repeaters_repeater"."is_paused", "repeaters_repeater"."next_attempt_at", "repeaters_repeater"."last_attempt_at", "repeaters_repeater"."options", "repeaters_repeater"."connection_settings_id", "repeaters_repeater"."is_deleted", "repeaters_repeater"."last_modified", "repeaters_repeater"."date_created", "motech_connectionsettings"."id", "motech_connectionsettings"."domain", "motech_connectionsettings"."name", "motech_connectionsettings"."url", "motech_connectionsettings"."auth_type", "motech_connectionsettings"."api_auth_settings", "motech_connectionsettings"."username", "motech_connectionsettings"."password", "motech_connectionsettings"."client_id", "motech_connectionsettings"."client_secret", "motech_connectionsettings"."skip_cert_verify", "motech_connectionsettings"."token_url", "motech_connectionsettings"."refresh_url", "motech_connectionsettings"."pass_credentials_in_header", "motech_connectionsettings"."notify_addresses_str", "motech_connectionsettings"."last_token_aes", "motech_connectionsettings"."is_deleted" FROM "repeaters_repeater" INNER JOIN "motech_connectionsettings" ON ("repeaters_repeater"."connection_settings_id" = "motech_connectionsettings"."id") WHERE (NOT "repeaters_repeater"."is_deleted" AND "repeaters_repeater"."name" IS NULL)
```

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
