### PR TITLE
Set pg_isready user and password

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -71,7 +71,7 @@ services:
     expose:
       - "5432"
     healthcheck:
-      test: pg_isready
+      test: pg_isready -d postgresql://commcarehq:commcarehq@postgres
       interval: 10s
       retries: 10
     volumes:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -71,7 +71,7 @@ services:
     expose:
       - "5432"
     healthcheck:
-      test: pg_isready -d postgresql://commcarehq:commcarehq@postgres
+      test: pg_isready -h postgres -U commcarehq
       interval: 10s
       retries: 10
     volumes:


### PR DESCRIPTION
## Technical Summary

Sets `pg_isready` user and password on the postgres container healthcheck to resolve the annoying warning that user "root" does not exist. We know the user and password will always be correct because the environment variables five lines up say so.

## Feature Flag

N/A

## Safety Assurance

### Safety story

* Applies only to Docker environments
* Tested locally

### Automated test coverage

N/A

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
