### PR TITLE
Include form name in success message on formplayer

### DIFF
--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -177,7 +177,7 @@ class SubmissionPost(object):
     def _get_form_name(self, instance, user):
         default_language, names_by_xmlns = _get_form_name_info(instance.domain, instance.build_id)
         names = names_by_xmlns.get(instance.xmlns, {})
-        if user.language and names.get(user.language):
+        if user and user.language and names.get(user.language):
             return names[user.language]
         if names.get(default_language):
             return names[default_language]
@@ -665,6 +665,8 @@ def _get_form_name_info(domain, build_id):
     """
     :return: (default_language, {'http://my.xmlns': {'en': 'My Form'}})
     """
+    if not build_id:
+        return 'en', {}
     try:
         app_build = get_current_app(domain, build_id)
     except ResourceNotFound:

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -175,12 +175,13 @@ class SubmissionPost(object):
         return "\n\n".join(messages)
 
     def _get_form_name(self, instance, user):
-        default_language, names_by_xmlns = _get_form_name_info(instance.domain, instance.build_id)
-        names = names_by_xmlns.get(instance.xmlns, {})
-        if user and user.language and names.get(user.language):
-            return names[user.language]
-        if names.get(default_language):
-            return names[default_language]
+        if instance.build_id:
+            default_language, names_by_xmlns = _get_form_name_info(instance.domain, instance.build_id)
+            names = names_by_xmlns.get(instance.xmlns, {})
+            if user and user.language and names.get(user.language):
+                return names[user.language]
+            if names.get(default_language):
+                return names[default_language]
         return instance.name
 
     def _success_message_links(self, user, instance, cases):
@@ -665,8 +666,6 @@ def _get_form_name_info(domain, build_id):
     """
     :return: (default_language, {'http://my.xmlns': {'en': 'My Form'}})
     """
-    if not build_id:
-        return 'en', {}
     try:
         app_build = get_current_app(domain, build_id)
     except ResourceNotFound:


### PR DESCRIPTION
## Product Description
Currently in formplayer, when you submit a form, you get a success message like this:
![image](https://user-images.githubusercontent.com/2367539/207720053-42392d5c-f9da-478a-bff8-f29c1c88f112.png)

This changes that to include the name of the form:
![image](https://user-images.githubusercontent.com/2367539/207719855-332781b4-9f2b-4633-937a-a954a54b2dfd.png)
(the links appear only if you're a web user and not using login-as - nothing's changed there)

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2247
https://docs.google.com/document/d/1lRGeVGJx604OzPRZGir-a7UJAxgI-5yhnMj5kXmzpj0/edit#

Note that this change only affects web apps.  There's some weirdness around localization in web apps - form name is sometimes pulled from the app (and localized), and other times pulled from the form xml, where it isn't localized correctly (it looks like it's some language at random, but I'm not sure).  This PR attempts to use the localized name from the app, and falls back to the XML name if needed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
This change is constrained to formplayer (the code short-circuits if the device ID is not `FORMPLAYER_DEVICE_ID`).  I tested locally with a web user, web user using login-as, mobile worker with lang=en, with lang=ita, and with no lang defined.  I also tried including `>` and other special characters in the string to see if it'd break anything.  The code is written pretty defensively.  I'll still throw it on staging for a bit to try to trigger edge-cases, I may not have thought of, though.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
