### PR TITLE
Hide "Incomplete Forms" Icon

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -9,9 +9,9 @@ hqDefine("cloudcare/js/formplayer/apps/controller", function () {
     return {
         listApps: function () {
             $.when(FormplayerFrontend.getChannel().request("appselect:apps")).done(function (appCollection) {
-                var apps = appCollection.toJSON();
+                let apps = appCollection.toJSON();
                 let isIncompleteFormsDisabled = (app) => app.profile.properties['cc-show-incomplete'] === 'no';
-                let isAllIncompleteFormsDisabled = apps.every(isIncompleteFormsDisabled)
+                let isAllIncompleteFormsDisabled = apps.every(isIncompleteFormsDisabled);
 
                 var appGridView = views.GridView({
                     collection: appCollection,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -5,11 +5,17 @@ hqDefine("cloudcare/js/formplayer/apps/controller", function () {
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
         settingsViews = hqImport("cloudcare/js/formplayer/layout/views/settings"),
         views = hqImport("cloudcare/js/formplayer/apps/views");
+
     return {
         listApps: function () {
-            $.when(FormplayerFrontend.getChannel().request("appselect:apps")).done(function (apps) {
+            $.when(FormplayerFrontend.getChannel().request("appselect:apps")).done(function (appCollection) {
+                var apps = appCollection.toJSON();
+                let isIncompleteFormsDisabled = (app) => app.profile.properties['cc-show-incomplete'] === 'no';
+                let isAllIncompleteFormsDisabled = apps.every(isIncompleteFormsDisabled)
+
                 var appGridView = views.GridView({
-                    collection: apps,
+                    collection: appCollection,
+                    shouldShowIncompleteForms: !isAllIncompleteFormsDisabled,
                 });
                 FormplayerFrontend.regions.getRegion('main').show(appGridView);
             });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
@@ -100,6 +100,16 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
         syncKeyAction: _.extend(BaseAppView.syncKeyAction),
         restoreAsKeyAction: _.extend(BaseAppView.restoreAsKeyAction),
         settingsKeyAction: _.extend(BaseAppView.settingsKeyAction),
+
+        initialize: function (options) {
+            this.shouldShowIncompleteForms = options.shouldShowIncompleteForms;
+        },
+
+        templateContext: function () {
+            return {
+                shouldShowIncompleteForms: this.shouldShowIncompleteForms,
+            };
+        },
     });
 
     /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
@@ -144,7 +144,7 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
                 appName;
             appName = currentApp.get('name');
             return {
-                showIncompleteForms: function () {
+                shouldShowIncompleteForms: function () {
                     return FormplayerFrontend.getChannel()
                         .request('getAppDisplayProperties')['cc-show-incomplete'] === 'yes';
                 },

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -10,6 +10,7 @@
     <div class="js-application-container">
 
     </div>
+    <% if (shouldShowIncompleteForms) { %>
     <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
       <div class="js-incomplete-sessions-item appicon appicon-incomplete" role="link" tabindex="0" aria-labelledby="grid-template-incomplete-forms-heading">
         <i class="ff ff-incomplete-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
@@ -19,6 +20,7 @@
         </div>
       </div>
     </div>
+    <% } %>
 
     <div class=" grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
       <div class="js-sync-item appicon appicon-sync" role="link" tabindex="0" aria-labelledby="grid-template-sync-heading">

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -67,7 +67,7 @@
           </div>
         </div>
       </div>
-      <% if (showIncompleteForms()) { %>
+      <% if (shouldShowIncompleteForms()) { %>
       <div class=" grid-item col-xs-6 col-sm-4 formplayer-request">
         <div class="js-incomplete-sessions-item appicon appicon-incomplete" role="link" tabindex="0" aria-labelledby="single-app-incomplete-forms-heading">
           <i class="ff ff-incomplete-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>


### PR DESCRIPTION
## Product Description
If all apps for a user have "Incomplete Forms" disabled, the "Incomplete Forms" icon is hidden in the "home" screen of web apps. 

<img width="571" alt="Screen Shot 2022-12-14 at 10 15 44 PM" src="https://user-images.githubusercontent.com/88759246/207786885-212524f7-0a3d-46ef-85cc-160ebbe756c7.png">

<img width="1083" alt="Screen Shot 2022-12-14 at 10 17 42 PM" src="https://user-images.githubusercontent.com/88759246/207786894-c9a5e685-ed81-441c-9673-8482cc36c90e.png">

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2685
It was considered to have this as a domain level setting but decided against since:
- The setting to hide "Incomplete Forms" already exists under app-level settings for mobile apps and this avoids having the same configuration in two locations.
- All USH projects have been single-app so far

## Feature Flag
N/A

## Safety Assurance

### Safety story
Tested locally with a domain consisting of two apps. 
Incomplete Forms disabled on: 
one app -> icon visible
both apps -> icon hidden

### Automated test coverage
No automated test.

### QA Plan
No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
