### PR TITLE
Add subscription plan name to Feature Flag info page

### DIFF
--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -71,6 +71,25 @@
         <p><a href="{{ static_toggle.help_link }}" target="_blank">{% trans "More information" %}</a></p>
       {% endif %}
 
+      {% if by_service %}
+        {% for service, domains in by_service.items %}
+          <table class="table table-striped table-hover">
+            <thead>
+            <tr>
+              <th class="col-sm-4">Subscription Type</th>
+              <th class="col-sm-8">List of Domains</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+              <td>{{ service }}</td>
+              <td>{{ domains | join:", " }}</td>
+            </tr>
+            </tbody>
+        {% endfor %}
+        </table>
+      {% endif %}
+
       {% if static_toggle.relevant_environments %}
         {% if debug or server_environment in static_toggle.relevant_environments %}
           <div class="alert alert-warning" role="alert">

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -332,8 +332,9 @@ def _get_service_type(toggle):
     for enabled in toggle.enabled_users:
         name = _enabled_item_name(enabled)
         if _namespace_domain(enabled):
-            service_type, plan = get_subscription_info(name)
-    return f"{service_type} : {plan}"
+            plan_type, plan = get_subscription_info(name)
+            service_type[name] = f"{plan_type} : {plan}"
+    return service_type
 
 
 def _namespace_domain(enabled_item):

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -17,7 +17,7 @@ from corehq.apps.hqwebapp.decorators import use_datatables
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.toggle_ui.models import ToggleAudit
 from corehq.apps.toggle_ui.tasks import generate_toggle_csv_download
-from corehq.apps.toggle_ui.utils import find_static_toggle
+from corehq.apps.toggle_ui.utils import find_static_toggle, get_subscription_info
 from corehq.apps.users.models import CouchUser
 from corehq.toggles import (
     ALL_NAMESPACES,
@@ -332,10 +332,8 @@ def _get_service_type(toggle):
     for enabled in toggle.enabled_users:
         name = _enabled_item_name(enabled)
         if _namespace_domain(enabled):
-            subscription = Subscription.get_active_subscription_by_domain(name)
-            if subscription:
-                service_type[name] = subscription.service_type
-    return service_type
+            service_type, plan = get_subscription_info(name)
+    return f"{service_type} : {plan}"
 
 
 def _namespace_domain(enabled_item):


### PR DESCRIPTION
## Product Description
Affects feature flag view (internal only page).

Useful to understand the subscription plan of the domains that have an FF enabled

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
