### PR TITLE
Display date format to the user

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -537,7 +537,10 @@
 </script>
 <script type="text/html" id="date-entry-ko-template">
   <div class="input-group">
-    <input type="text" class="form-control" data-bind="attr: { id: entryId, 'aria-required': $parent.required() ? 'true' : 'false' }"/>
+    <input type="text" class="form-control" data-bind="attr: {
+      id: entryId,
+      'aria-required': $parent.required() ? 'true' : 'false',
+      placeholder: clientFormat }"/>
     <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
   </div>
 </script>

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -537,7 +537,7 @@
 </script>
 <script type="text/html" id="date-entry-ko-template">
   <div class="input-group">
-    <input type="text" class="form-control" data-bind="attr: {
+    <input type="text" class="form-control" pattern="[0-9-/]+" data-bind="attr: {
       id: entryId,
       'aria-required': $parent.required() ? 'true' : 'false',
       placeholder: clientFormat }"/>


### PR DESCRIPTION
## Product Description
Adds placeholder showing the expected date format for users who'll be entering dates as text.  Other formats sometimes get converted incorrectly, or more commonly not at all, so it makes sense to display this to the user, in my opinion.
![image](https://user-images.githubusercontent.com/2367539/208754748-4435bdf5-bc04-4daf-a384-d01ad10355a6.png)

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2645
Adds a placeholder showing the date format and some rudimentary html5 input validation.

The only officially valid formats are MM/DD/YYYY and MM/DD/YY, but un-padded days and months will get converted properly, as will dashes instead of slashes, so I figure we don't need to be overly prescriptive.  I'm hoping the placeholder text will do most of the heavy lifting anyways.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
I'm pretty confident in the safety of this change, as it's very simple HTML stuff.  I tested it locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
