### PR TITLE
Make v0.6 Case API work with get param auth credentials

### DIFF
--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -1,5 +1,4 @@
 import uuid
-from unittest.mock import patch
 
 from django.test import TestCase
 from django.urls import reverse
@@ -89,12 +88,6 @@ class TestCaseAPI(TestCase):
     def _bulk_update_cases(self, body):
         # for the time being, the implementation is the same
         return self._create_case(body)
-
-    def test_basic_get_list(self):
-        with patch('corehq.apps.hqcase.views.get_list', lambda *args: {'example': 'result'}):
-            res = self.client.get(reverse('case_api', args=(self.domain,)))
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json(), {'example': 'result'})
 
     def test_create_case(self):
         res = self._create_case({

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -154,7 +154,12 @@ def _handle_bulk_fetch(request):
 
 def _handle_list_view(request):
     try:
-        res = get_list(request.domain, request.GET.dict())
+        params = request.GET.dict()
+        if 'username' in params and 'api_key' in params:
+            # 'username' and 'api_key' are being used for auth, strip 'em
+            params.pop('username')
+            params.pop('api_key')
+        res = get_list(request.domain, params)
     except UserError as e:
         return JsonResponse({'error': str(e)}, status=400)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2704
Tastypie supports providing API key credentials in the querystring.  This PR strips those parameters before attempting to interpret them as query parameters.  We do the same in some of the other APIs:
https://github.com/dimagi/commcare-hq/blob/e9f626810de7b6217dcfd7ff07d5be877c294190/corehq/apps/api/es.py#L371-L371
Ideally those would be stripped immediately when used as auth, but Django's `QueryDict` is immutable, so doing it that way sounds questionable.

## Feature Flag
Enable the v0.6 Case API

## Safety Assurance

### Safety story
This API is not yet widely used, and this particular auth pathway was effectively broken.

### Automated test coverage

Included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
