### PR TITLE
Reserved words

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/case-reserved-words.json
+++ b/corehq/apps/app_manager/static/app_manager/json/case-reserved-words.json
@@ -17,7 +17,7 @@
     "date_opened",
     "doc_type",
     "domain",
-    "external-id",
+    "external_id",
     "index",
     "indices",
     "initial_processing_complete",

--- a/corehq/apps/app_manager/static/app_manager/json/case-reserved-words.json
+++ b/corehq/apps/app_manager/static/app_manager/json/case-reserved-words.json
@@ -18,6 +18,8 @@
     "doc_type",
     "domain",
     "external_id",
+    "owner_id",
+    "location_id",
     "index",
     "indices",
     "initial_processing_complete",

--- a/corehq/apps/custom_data_fields/tests/test_verification.py
+++ b/corehq/apps/custom_data_fields/tests/test_verification.py
@@ -48,10 +48,24 @@ class TestCustomDataFieldsVerification(SimpleTestCase):
     def test_no_reserved_words(self):
         self.assertEqual(set(), CustomDataFieldsForm.verify_no_reserved_words(self.fields))
         self.assertEqual(
+            set(),
+            CustomDataFieldsForm.verify_no_reserved_words([{
+                "slug": "external-id",
+                "choices": ["omega_supreme", "astrotrain", "blitzwing"],
+            }])
+        )
+        self.assertEqual(
             {"Key 'type' is a reserved word in Commcare."},
             CustomDataFieldsForm.verify_no_reserved_words([{
                 "slug": "type",
                 "choices": ["autobot", "decepticon", "dinobot"],
+            }])
+        )
+        self.assertEqual(
+            {"Key 'owner_id' is a reserved word in Commcare."},
+            CustomDataFieldsForm.verify_no_reserved_words([{
+                "slug": "owner_id",
+                "choices": ["optimus_prime", "megatron"],
             }])
         )
 


### PR DESCRIPTION
## Technical Summary

Corrects the spelling of case property "external_id", and adds "owner_id" and "location_id" to case-reserved-words.json.

"owner_id" and "location_id" (which links a supply point to its location) are not new case properties, but they are conspicuously missing from case-reserved-words.json. _Is there a reason for that?_ Or is that just an accidental omission?

cc @Charl1996 @millerdev 

## Feature Flag

N/A

## Safety Assurance

### Safety story

* This change does not affect existing app versions -- if an app is already overwriting the "owner_id" case property, it will continue to do so. But it does prevent new app versions being built.
* This change should make app building safer.

### Automated test coverage

This change is covered by tests

### QA Plan

QA not planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
