### PR TITLE
Log pillow ES processor delete doc changes

### DIFF
--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import time
 
@@ -24,6 +25,8 @@ from pillowtop.utils import (
 )
 
 from .interface import BulkPillowProcessor, PillowProcessor
+
+logger = logging.getLogger(__name__)
 
 
 def identity(x):
@@ -76,6 +79,7 @@ class ElasticProcessor(PillowProcessor):
                     self._delete_doc_if_exists(change.id)
             else:
                 self._delete_doc_if_exists(change.id)
+            logger.info(f'Processed doc deletion for change {change.id}')
             return
 
         with self._datadog_timing('extract'):

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -72,6 +72,7 @@ class ElasticProcessor(PillowProcessor):
             return
 
         if change.deleted and change.id:
+            logger.info(f'Attempting to delete document for change {change.id}')
             doc = change.get_document()
             if doc and doc.get('doc_type'):
                 current_meta = get_doc_meta_object_from_document(doc)
@@ -79,7 +80,7 @@ class ElasticProcessor(PillowProcessor):
                     self._delete_doc_if_exists(change.id)
             else:
                 self._delete_doc_if_exists(change.id)
-            logger.info(f'Processed doc deletion for change {change.id}')
+            logger.info(f'Deleted document for change {change.id}')
             return
 
         with self._datadog_timing('extract'):
@@ -144,6 +145,7 @@ class BulkElasticProcessor(ElasticProcessor, BulkPillowProcessor):
     """
 
     def process_changes_chunk(self, changes_chunk):
+        logger.info('Processing chunk of changes in BulkElasticProcessor')
         if self.change_filter_fn:
             changes_chunk = [
                 change for change in changes_chunk


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14014

The goal is to leave a trace of deleted docs that have been processed by pillows. I've confirmed that docs have made it into Kafka, but have no way of proving that a pillow processed a change once in kafka. By having confirmation that the pillow processed the change, we will then be able to single out ES as the source of issues for docs that should be deleted but are not.

I _think_ this will get picked up by cloudwatch, but if not please let me know what I need to do differently.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Just logging 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
