### PR TITLE
Added properties check to incomplete forms setting logic

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -10,7 +10,7 @@ hqDefine("cloudcare/js/formplayer/apps/controller", function () {
         listApps: function () {
             $.when(FormplayerFrontend.getChannel().request("appselect:apps")).done(function (appCollection) {
                 let apps = appCollection.toJSON();
-                let isIncompleteFormsDisabled = (app) => app.profile.properties['cc-show-incomplete'] === 'no';
+                let isIncompleteFormsDisabled = (app) => (app.profile.properties || {})['cc-show-incomplete'] === 'no';
                 let isAllIncompleteFormsDisabled = apps.every(isIncompleteFormsDisabled);
 
                 var appGridView = views.GridView({


### PR DESCRIPTION
## Product Description
Minor followup to https://github.com/dimagi/commcare-hq/pull/32424/ which was giving me a js error locally for an app whose `profile` was an empty object.

This is something of an edge case. Apps are created with empty profiles, but any settings change will populate the profile.

## Safety Assurance

### Safety story
Tiny. Tested locally.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
