### PR TITLE
Update components.ko.js to return a value

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components.ko.js
@@ -39,4 +39,6 @@ hqDefine("hqwebapp/js/components.ko", [
             });
         });
     });
+    
+    return 1;
 });


### PR DESCRIPTION
Teeny issue causing problems with js tests locally. JS modules should return a value, otherwise [this line](https://github.com/dimagi/commcare-hq/blob/5211424c0334a152e2143dad8c100a2ad0170cce/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js#L96-L99) will think they don't exist and break when another module tries to include them in a non-requirejs context.