### PR TITLE
Migrated hqwebapp js tests to RequireJS

### DIFF
--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -1,7 +1,6 @@
 {% extends "formplayer-common/base.html" %}
 {% load hq_shared_tags %}
 {% load compress %}
-{% load statici18n %}
 
 {% block css %}
   {% compress css %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/common.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/common.js
@@ -4,7 +4,6 @@ hqDefine("hqwebapp/js/common", [
     'ko.mapping',
     'underscore',
     'bootstrap',
-    'hqwebapp/js/django',
 ], function () {
     // nothing to do, this is just to define the major common dependencies for HQ
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/django.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/django.js
@@ -3,5 +3,5 @@
     Allow usage of gettext, RequireJS-style, rather than accessing the global django.
 */
 define([], function () {
-    return { gettext: window.django ? django.gettext : undefined };
+    return { gettext: django.gettext };
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/django.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/django.js
@@ -3,5 +3,5 @@
     Allow usage of gettext, RequireJS-style, rather than accessing the global django.
 */
 define([], function () {
-    return { gettext: django.gettext };
+    return { gettext: window.django ? django.gettext : undefined };
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -61,10 +61,13 @@ function hqDefine(path, dependencies, moduleAccessor) {
                 'underscore': '_',
                 'clipboard/dist/clipboard': 'Clipboard',
                 'ace-builds/src-min-noconflict/ace': 'ace',
+                'chai/chai': 'chai',
                 'DOMPurify/dist/purify.min': 'DOMPurify',
+                'mocha/mocha': 'mocha',
                 'moment/moment': 'moment',
                 'crypto-js/crypto-js': 'CryptoJS',
                 'hqwebapp/js/lib/modernizr': 'Modernizr',
+                'sinon/pkg/sinon': 'sinon',
             };
             var args = [];
             for (var i = 0; i < dependencies.length; i++) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/mocha.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/mocha.js
@@ -11,11 +11,11 @@ hqDefine("hqwebapp/js/mocha", [
     googleAnalytics,
     kissAnalytics
 ) {
-    mocha.setup('bdd')
-    window.assert = chai.assert
+    mocha.setup('bdd');
+    window.assert = chai.assert;
 
     function gettext(str) {
-      return str;
+        return str;
     }
     window.gettext = gettext;
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/mocha.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/mocha.js
@@ -1,0 +1,35 @@
+hqDefine("hqwebapp/js/mocha", [
+    "mocha/mocha",
+    "chai/chai",
+    "sinon/pkg/sinon",
+    "analytix/js/google",
+    "analytix/js/kissmetrix",
+], function (
+    mocha,
+    chai,
+    sinon,
+    googleAnalytics,
+    kissAnalytics
+) {
+    mocha.setup('bdd')
+    window.assert = chai.assert
+
+    function gettext(str) {
+      return str;
+    }
+    window.gettext = gettext;
+
+    googleAnalytics.track.event = sinon.spy();
+    googleAnalytics.track.click = sinon.spy();
+    kissAnalytics.track.event = sinon.spy();
+
+    var run = function () {
+        if (navigator.userAgent.indexOf('PhantomJS') < 0) {
+            mocha.run();
+        }
+    };
+
+    return {
+        run: run,
+    };
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/assert_properties_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/assert_properties_spec.js
@@ -1,33 +1,38 @@
 /* eslint-env mocha */
-/* global $, sinon */
+hqDefine("hqwebapp/spec/assert_properties_spec", [
+    'jquery',
+    'hqwebapp/js/assert_properties',
+], function (
+    $,
+    lib
+) {
+    describe('assert_properties', function () {
+        var object = {
+                alpha: 1,
+                beta: 2,
+                delta: 3,
+            };
 
-describe('assert_properties', function () {
-    var lib = hqImport("hqwebapp/js/assert_properties"),
-        object = {
-            alpha: 1,
-            beta: 2,
-            delta: 3,
-        };
+        it('should fail if required properties are missing', function () {
+            try {
+                lib.assert(object, ['alpha', 'beta', 'delta', 'gamma'], []);
+            } catch (e) {
+                assert.equal(e.message, "Required properties missing: gamma");
+            }
+        });
 
-    it('should fail if required properties are missing', function () {
-        try {
-            lib.assert(object, ['alpha', 'beta', 'delta', 'gamma'], []);
-        } catch (e) {
-            assert.equal(e.message, "Required properties missing: gamma");
-        }
-    });
+        it('should fail if extra properties are provided', function () {
+            try {
+                lib.assert(object, ['alpha', 'beta'], []);
+            } catch (e) {
+                assert.equal(e.message, "Unexpected properties encountered: delta");
+            }
+        });
 
-    it('should fail if extra properties are provided', function () {
-        try {
-            lib.assert(object, ['alpha', 'beta'], []);
-        } catch (e) {
-            assert.equal(e.message, "Unexpected properties encountered: delta");
-        }
-    });
-
-    it('should pass if all required properties and any optional properties are provided', function () {
-        assert(lib.assert(object, ['alpha', 'beta', 'delta'], []));
-        assert(lib.assert(object, ['alpha', 'beta'], ['delta']));
-        assert(lib.assert(object, [], ['alpha', 'beta', 'delta']));
+        it('should pass if all required properties and any optional properties are provided', function () {
+            assert(lib.assert(object, ['alpha', 'beta', 'delta'], []));
+            assert(lib.assert(object, ['alpha', 'beta'], ['delta']));
+            assert(lib.assert(object, [], ['alpha', 'beta', 'delta']));
+        });
     });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/assert_properties_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/assert_properties_spec.js
@@ -8,10 +8,10 @@ hqDefine("hqwebapp/spec/assert_properties_spec", [
 ) {
     describe('assert_properties', function () {
         var object = {
-                alpha: 1,
-                beta: 2,
-                delta: 3,
-            };
+            alpha: 1,
+            beta: 2,
+            delta: 3,
+        };
 
         it('should fail if required properties are missing', function () {
             try {

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/inactivity_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/inactivity_spec.js
@@ -1,55 +1,58 @@
 /* eslint-env mocha */
+hqDefine("hqwebapp/spec/inactivity_spec", [
+    'hqwebapp/js/inactivity',
+], function (
+    module
+) {
+    describe('inactivity', function () {
+        var tolerantAssert = function (expected, actual) {
+            expected = Math.round(expected / 10);
+            actual = Math.round(actual / 10);
+            assert.equal(expected, actual);
+        };
 
-describe('inactivity', function () {
-    var module = hqImport("hqwebapp/js/inactivity");
+        var responseForFutureExpiration = function (minutes) {
+            return module.calculateDelayAndWarning(new Date() * 1 + minutes * 60 * 1000);
+        };
 
-    var tolerantAssert = function (expected, actual) {
-        expected = Math.round(expected / 10);
-        actual = Math.round(actual / 10);
-        assert.equal(expected, actual);
-    };
+        describe('inactivityTimeout', function () {
+            it('should ping in 10 minutes if expiryDate is unknown', function () {
+                // last request unknown => 8 minutes left
+                var response = module.calculateDelayAndWarning();
+                tolerantAssert(response.delay, 8 * 60 * 1000);
+                assert.isFalse(response.show_warning);
+            });
 
-    var responseForFutureExpiration = function (minutes) {
-        return module.calculateDelayAndWarning(new Date() * 1 + minutes * 60 * 1000);
-    };
+            it('should ping when there are 2 minutes left', function () {
+                // expiring in 5 minutes => ping in 3 minutes
+                var response = responseForFutureExpiration(5);
+                tolerantAssert(response.delay, 3 * 60 * 1000);
+                assert.isFalse(response.show_warning);
+            });
 
-    describe('inactivityTimeout', function () {
-        it('should ping in 10 minutes if expiryDate is unknown', function () {
-            // last request unknown => 8 minutes left
-            var response = module.calculateDelayAndWarning();
-            tolerantAssert(response.delay, 8 * 60 * 1000);
-            assert.isFalse(response.show_warning);
-        });
+            it('should warn and ping every 10 seconds in the last 2 minutes', function () {
+                var response = responseForFutureExpiration(1);
+                tolerantAssert(response.delay, 10 * 1000);
+                assert.isTrue(response.show_warning);
+            });
 
-        it('should ping when there are 2 minutes left', function () {
-            // expiring in 5 minutes => ping in 3 minutes
-            var response = responseForFutureExpiration(5);
-            tolerantAssert(response.delay, 3 * 60 * 1000);
-            assert.isFalse(response.show_warning);
-        });
+            it('should warn and ping every 3 seconds in the last 30 seconds', function () {
+                var response = responseForFutureExpiration(0.25);
+                tolerantAssert(response.delay, 3 * 1000);
+                assert.isTrue(response.show_warning);
+            });
 
-        it('should warn and ping every 10 seconds in the last 2 minutes', function () {
-            var response = responseForFutureExpiration(1);
-            tolerantAssert(response.delay, 10 * 1000);
-            assert.isTrue(response.show_warning);
-        });
+            it('should use absolute value in case session appears expired', function () {
+                var response = responseForFutureExpiration(-5);
+                tolerantAssert(response.delay, 3 * 60 * 1000);
+                assert.isFalse(response.show_warning);
+            });
 
-        it('should warn and ping every 3 seconds in the last 30 seconds', function () {
-            var response = responseForFutureExpiration(0.25);
-            tolerantAssert(response.delay, 3 * 1000);
-            assert.isTrue(response.show_warning);
-        });
-
-        it('should use absolute value in case session appears expired', function () {
-            var response = responseForFutureExpiration(-5);
-            tolerantAssert(response.delay, 3 * 60 * 1000);
-            assert.isFalse(response.show_warning);
-        });
-
-        it('should use absolute value in case session is very expired', function () {
-            var response = responseForFutureExpiration(-20);
-            tolerantAssert(response.delay, 18 * 60 * 1000);
-            assert.isFalse(response.show_warning);
+            it('should use absolute value in case session is very expired', function () {
+                var response = responseForFutureExpiration(-20);
+                tolerantAssert(response.delay, 18 * 60 * 1000);
+                assert.isFalse(response.show_warning);
+            });
         });
     });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/main.js
@@ -1,39 +1,15 @@
 hqDefine("hqwebapp/spec/main", [
-    "analytix/js/google",
-    "analytix/js/kissmetrix",
-    "mocha/mocha",
-    "chai/chai",
-    "sinon/pkg/sinon",
+    "hqwebapp/js/mocha",
 ], function (
-    googleAnalytics,
-    kissAnalytics,
-    mocha,
-    chai,
-    sinon
+    hqMocha
 ) {
-    // TODO: DRY up with mocha/base.html
-    mocha.setup('bdd')
-    window.assert = chai.assert
-
-    function gettext(str) {
-        return str;
-    }
-    window.gettext = gettext;
-
-    googleAnalytics.track.event = sinon.spy();
-    googleAnalytics.track.click = sinon.spy();
-    kissAnalytics.track.event = sinon.spy();
-
     hqRequire([
         "hqwebapp/spec/assert_properties_spec",
         "hqwebapp/spec/inactivity_spec",
         "hqwebapp/spec/urllib_spec",
         "hqwebapp/spec/widgets_spec",
     ], function () {
-        // TODO: DRY up with mocha/base.html
-        if (navigator.userAgent.indexOf('PhantomJS') < 0) {
-            mocha.run();
-        }
+        hqMocha.run();
     });
 
     return 1;

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/main.js
@@ -28,6 +28,7 @@ hqDefine("hqwebapp/spec/main", [
         "hqwebapp/spec/assert_properties_spec",
         "hqwebapp/spec/inactivity_spec",
         "hqwebapp/spec/urllib_spec",
+        "hqwebapp/spec/widgets_spec",
     ], function () {
         // TODO: DRY up with mocha/base.html
         if (navigator.userAgent.indexOf('PhantomJS') < 0) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/main.js
@@ -27,6 +27,7 @@ hqDefine("hqwebapp/spec/main", [
     hqRequire([
         "hqwebapp/spec/assert_properties_spec",
         "hqwebapp/spec/inactivity_spec",
+        "hqwebapp/spec/urllib_spec",
     ], function () {
         // TODO: DRY up with mocha/base.html
         if (navigator.userAgent.indexOf('PhantomJS') < 0) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/main.js
@@ -1,0 +1,35 @@
+hqDefine("hqwebapp/spec/main", [
+    "analytix/js/google",
+    "analytix/js/kissmetrix",
+    "mocha/mocha",
+    "chai/chai",
+    "sinon/pkg/sinon",
+], function (
+    googleAnalytics,
+    kissAnalytics,
+    mocha,
+    chai,
+    sinon
+) {
+    // TODO: DRY up with mocha/base.html
+    mocha.setup('bdd')
+    window.assert = chai.assert
+
+    function gettext(str) {
+        return str;
+    }
+    window.gettext = gettext;
+
+    googleAnalytics.track.event = sinon.spy();
+    googleAnalytics.track.click = sinon.spy();
+    kissAnalytics.track.event = sinon.spy();
+
+    hqRequire(["hqwebapp/spec/assert_properties_spec"], function () {
+        // TODO: DRY up with mocha/base.html
+        if (navigator.userAgent.indexOf('PhantomJS') < 0) {
+            mocha.run();
+        }
+    });
+
+    return 1;
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/main.js
@@ -24,7 +24,10 @@ hqDefine("hqwebapp/spec/main", [
     googleAnalytics.track.click = sinon.spy();
     kissAnalytics.track.event = sinon.spy();
 
-    hqRequire(["hqwebapp/spec/assert_properties_spec"], function () {
+    hqRequire([
+        "hqwebapp/spec/assert_properties_spec",
+        "hqwebapp/spec/inactivity_spec",
+    ], function () {
         // TODO: DRY up with mocha/base.html
         if (navigator.userAgent.indexOf('PhantomJS') < 0) {
             mocha.run();

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/urllib_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/urllib_spec.js
@@ -1,46 +1,49 @@
 /* eslint-env mocha */
-/* global $, sinon */
+hqDefine("hqwebapp/spec/urllib_spec", [
+    'hqwebapp/js/initial_page_data',
+], function (
+    urllib
+) {
+    describe('urllib', function () {
+        describe('getUrlParameterFromString', function () {
+            it('should return undefined when URL param missing', function () {
+                assert.strictEqual(urllib.getUrlParameterFromString('asdf', '?limit=29'), undefined);
+            });
 
-describe('urllib', function () {
-    var urllib = hqImport('hqwebapp/js/initial_page_data');
-    describe('getUrlParameterFromString', function () {
-        it('should return undefined when URL param missing', function () {
-            assert.strictEqual(urllib.getUrlParameterFromString('asdf', '?limit=29'), undefined);
+            it('should return correct value when present in URL', function () {
+                assert.equal(urllib.getUrlParameterFromString('limit', '?limit=29'), '29');
+            });
+
+            it('should return correct value when multiple present in URL', function () {
+                assert.equal(urllib.getUrlParameterFromString('limit', '?limit=29&color=red'), '29');
+                assert.equal(urllib.getUrlParameterFromString('color', '?limit=29&color=red'), 'red');
+            });
+
+            it('should return the URL-decoded value', function () {
+                assert.equal(urllib.getUrlParameterFromString('json', '?json=[%22hi%22]'), '["hi"]');
+            });
+
+            it('should allow & in the value', function () {
+                assert.equal(
+                    urllib.getUrlParameterFromString('drink', '?drink=gin%20%26%20tonic&food=eggplant%20parm'),
+                    'gin & tonic'
+                );
+            });
         });
 
-        it('should return correct value when present in URL', function () {
-            assert.equal(urllib.getUrlParameterFromString('limit', '?limit=29'), '29');
-        });
-
-        it('should return correct value when multiple present in URL', function () {
-            assert.equal(urllib.getUrlParameterFromString('limit', '?limit=29&color=red'), '29');
-            assert.equal(urllib.getUrlParameterFromString('color', '?limit=29&color=red'), 'red');
-        });
-
-        it('should return the URL-decoded value', function () {
-            assert.equal(urllib.getUrlParameterFromString('json', '?json=[%22hi%22]'), '["hi"]');
-        });
-
-        it('should allow & in the value', function () {
-            assert.equal(
-                urllib.getUrlParameterFromString('drink', '?drink=gin%20%26%20tonic&food=eggplant%20parm'),
-                'gin & tonic'
-            );
-        });
-    });
-
-    describe('registerUrl', function () {
-        it('should fetch a static url', function () {
-            urllib.registerUrl("case_importer_uploads", "/a/hqsharedtags/importer/history/uploads/");
-            assert.equal(urllib.reverse("case_importer_uploads"), "/a/hqsharedtags/importer/history/uploads/");
-        });
-        it('should interpolate a templated url', function () {
-            urllib.registerUrl("case_importer_upload_file_download", "/a/hqsharedtags/importer/history/uploads/---/");
-            assert.equal(urllib.reverse("case_importer_upload_file_download", 'asdf-ghjk'), "/a/hqsharedtags/importer/history/uploads/asdf-ghjk/");
-        });
-        it('should correctly interpolate a templated url with multiple variables', function () {
-            urllib.registerUrl("multiple_args", "/a/---/importer/history/uploads/---/");
-            assert.equal(urllib.reverse("multiple_args", 'hqsharedtags', 'asdf-ghjk'), "/a/hqsharedtags/importer/history/uploads/asdf-ghjk/");
+        describe('registerUrl', function () {
+            it('should fetch a static url', function () {
+                urllib.registerUrl("case_importer_uploads", "/a/hqsharedtags/importer/history/uploads/");
+                assert.equal(urllib.reverse("case_importer_uploads"), "/a/hqsharedtags/importer/history/uploads/");
+            });
+            it('should interpolate a templated url', function () {
+                urllib.registerUrl("case_importer_upload_file_download", "/a/hqsharedtags/importer/history/uploads/---/");
+                assert.equal(urllib.reverse("case_importer_upload_file_download", 'asdf-ghjk'), "/a/hqsharedtags/importer/history/uploads/asdf-ghjk/");
+            });
+            it('should correctly interpolate a templated url with multiple variables', function () {
+                urllib.registerUrl("multiple_args", "/a/---/importer/history/uploads/---/");
+                assert.equal(urllib.reverse("multiple_args", 'hqsharedtags', 'asdf-ghjk'), "/a/hqsharedtags/importer/history/uploads/asdf-ghjk/");
+            });
         });
     });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/widgets_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/widgets_spec.js
@@ -1,14 +1,17 @@
 /* eslint-env mocha */
-/* global $, sinon */
-
-describe('widgets', function () {
-    var widgets = hqImport('hqwebapp/js/widgets');
-    describe('parseEmail', function () {
-        it('should parse comma-separated input into individual emails', function () {
-            assert.deepEqual(widgets.parseEmails("abcdefghi"), ["abcdefghi"]);
-            assert.deepEqual(widgets.parseEmails("a@b.com, x@y.com"), ["a@b.com", "x@y.com"]);
-            assert.deepEqual(widgets.parseEmails("a@b.com,x@y.com"), ["a@b.com", "x@y.com"]);
-            assert.deepEqual(widgets.parseEmails("a@b.com  x@y.com"), ["a@b.com", "x@y.com"]);
+hqDefine("hqwebapp/spec/widgets_spec", [
+    'hqwebapp/js/widgets',
+], function (
+    widgets
+) {
+    describe('widgets', function () {
+        describe('parseEmail', function () {
+            it('should parse comma-separated input into individual emails', function () {
+                assert.deepEqual(widgets.parseEmails("abcdefghi"), ["abcdefghi"]);
+                assert.deepEqual(widgets.parseEmails("a@b.com, x@y.com"), ["a@b.com", "x@y.com"]);
+                assert.deepEqual(widgets.parseEmails("a@b.com,x@y.com"), ["a@b.com", "x@y.com"]);
+                assert.deepEqual(widgets.parseEmails("a@b.com  x@y.com"), ["a@b.com", "x@y.com"]);
+            });
         });
     });
 });

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -148,13 +148,6 @@
 
     {% block head %}
     {% endblock %}
-
-    {# This is fine as an inline script; it'll be removed once form designer is migrated to RequireJS #}
-    <script>
-      // hqModules.js uses `typeof define` and `define.amd` to determine whether or not to use RequireJS, but
-      // this fails for form designer, which currently uses RequireJS for vellum but not for the surrounding page.
-      window.USE_REQUIREJS = {{ requirejs_main|BOOL }};
-    </script>
   </head>
   <body>
     {% if ANALYTICS_IDS.GTM_ID %}
@@ -278,38 +271,12 @@
 
     {# javascript below this line #}
 
-    {% if requirejs_main %}
-      <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
-      <script src="{% static 'requirejs/require.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
-      {# Do not compress these, which are re-written during depeloy #}
-      <script src="{% static 'hqwebapp/js/requirejs_config.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/resource_versions.js' %}"></script>
-      <script>
-        requirejs.config({
-          deps: ['knockout', 'ko.mapping'],
-          callback: function (ko, mapping) {
-            ko.mapping = mapping;
-          }
-        });
-        requirejs([
-          'hqwebapp/js/common',
-        ], function() {
-          requirejs([
-            'hqwebapp/js/base_main',
-          ], function () {
-            requirejs(['{{ requirejs_main }}'], function () {
-              console.log("Loaded requirejs main module: {{ requirejs_main }}");
-            });
-          });
-        });
-      </script>
-    {% endif %}
+    {% include "hqwebapp/partials/requirejs.html" with BASE_MAIN=True %}
+
+    <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
 
     {# HQ Specific Libraries #}
     {% if not requirejs_main %}
-      <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
-
       {% compress js %}
         <script src="{% static 'hqwebapp/js/hq_extensions.jquery.js' %}"></script>
         <script src="{% static 'hqwebapp/js/hq-bug-report.js' %}"></script>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
@@ -1,0 +1,40 @@
+{% load hq_shared_tags %}
+
+{# This is fine as an inline script; it'll be removed once form designer is migrated to RequireJS #}
+<script>
+  // hqModules.js uses `typeof define` and `define.amd` to determine whether or not to use RequireJS, but
+  // this fails for form designer, which currently uses RequireJS for vellum but not for the surrounding page.
+  window.USE_REQUIREJS = {{ requirejs_main|BOOL }};
+</script>
+
+{% if requirejs_main %}
+  <script src="{% static 'requirejs/require.js' %}"></script>
+  <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
+  {# Do not compress these, which are re-written during depeloy #}
+  <script src="{% static 'hqwebapp/js/requirejs_config.js' %}"></script>
+  <script src="{% static 'hqwebapp/js/resource_versions.js' %}"></script>
+  <script>
+    requirejs.config({
+      deps: ['knockout', 'ko.mapping'],
+      callback: function (ko, mapping) {
+        ko.mapping = mapping;
+      }
+    });
+    requirejs([
+      'hqwebapp/js/common',
+    ], function() {
+      {% if BASE_MAIN %}
+        {# This module is relevant for running HQ, but not for tests #}
+        requirejs([
+          'hqwebapp/js/base_main',
+        ], function () {
+      {% endif %}
+          requirejs(['{{ requirejs_main }}'], function () {
+            console.log("Loaded requirejs main module: {{ requirejs_main }}");
+          });
+      {% if BASE_MAIN %}
+        });
+      {% endif %}
+    });
+  </script>
+{% endif %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
@@ -24,15 +24,17 @@
       'hqwebapp/js/common',
     ], function() {
       {% if BASE_MAIN %}
-        {# This module is relevant for running HQ, but not for tests #}
-        requirejs([
-          'hqwebapp/js/base_main',
-        ], function () {
+        {# This code is relevant for running HQ, but not for tests #}
+        requirejs(['hqwebapp/js/django'], function () {
+          requirejs([
+            'hqwebapp/js/base_main',
+          ], function () {
       {% endif %}
-          requirejs(['{{ requirejs_main }}'], function () {
-            console.log("Loaded requirejs main module: {{ requirejs_main }}");
-          });
+            requirejs(['{{ requirejs_main }}'], function () {
+              console.log("Loaded requirejs main module: {{ requirejs_main }}");
+            });
       {% if BASE_MAIN %}
+          });
         });
       {% endif %}
     });

--- a/corehq/apps/hqwebapp/templates/hqwebapp/spec/mocha.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/spec/mocha.html
@@ -6,7 +6,6 @@
 {% comment %}
 {% block mocha_tests %}
   <!-- TODO: handle these -->
-  <script src="{% static 'hqwebapp/spec/inactivity_spec.js' %}"></script>
   <script src="{% static 'hqwebapp/spec/urllib_spec.js' %}"></script>
   <script src="{% static 'hqwebapp/spec/widgets_spec.js' %}"></script>
 {% endblock %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/spec/mocha.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/spec/mocha.html
@@ -3,12 +3,5 @@
 
 {% requirejs_main "hqwebapp/spec/main" %}
 
-{% comment %}
-{% block mocha_tests %}
-  <!-- TODO: handle these -->
-  <script src="{% static 'hqwebapp/spec/widgets_spec.js' %}"></script>
-{% endblock %}
-{% endcomment %}
-
 {% block fixtures %}
 {% endblock %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/spec/mocha.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/spec/mocha.html
@@ -1,16 +1,16 @@
 {% extends "mocha/base.html" %}
 {% load hq_shared_tags %}
 
-{% block dependencies %}
-  <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
-{% endblock %}
+{% requirejs_main "hqwebapp/spec/main" %}
 
+{% comment %}
 {% block mocha_tests %}
-  <script src="{% static 'hqwebapp/spec/assert_properties_spec.js' %}"></script>
+  <!-- TODO: handle these -->
   <script src="{% static 'hqwebapp/spec/inactivity_spec.js' %}"></script>
   <script src="{% static 'hqwebapp/spec/urllib_spec.js' %}"></script>
   <script src="{% static 'hqwebapp/spec/widgets_spec.js' %}"></script>
 {% endblock %}
+{% endcomment %}
 
 {% block fixtures %}
 {% endblock %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/spec/mocha.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/spec/mocha.html
@@ -6,7 +6,6 @@
 {% comment %}
 {% block mocha_tests %}
   <!-- TODO: handle these -->
-  <script src="{% static 'hqwebapp/spec/urllib_spec.js' %}"></script>
   <script src="{% static 'hqwebapp/spec/widgets_spec.js' %}"></script>
 {% endblock %}
 {% endcomment %}

--- a/corehq/apps/mocha/templates/mocha/base.html
+++ b/corehq/apps/mocha/templates/mocha/base.html
@@ -1,6 +1,7 @@
 {% load compress %}
 {% load hq_shared_tags %}
 {% load statici18n %}
+{% requirejs_main %}
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>
@@ -25,32 +26,39 @@
 
     <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
 
-    <script src="{% static 'mocha/mocha.js' %}"></script>
-    <script src="{% static 'chai/chai.js' %}"></script>
-    <script src="{% static 'sinon/pkg/sinon.js' %}"></script>
-    <script>
-      mocha.setup('bdd')
-      window.assert = chai.assert
+    {% if not requirejs_main %}
+      <script src="{% static 'mocha/mocha.js' %}"></script>
+      <script src="{% static 'chai/chai.js' %}"></script>
+      <script src="{% static 'sinon/pkg/sinon.js' %}"></script>
+      <script>
+        mocha.setup('bdd')
+        window.assert = chai.assert
 
-      function gettext(str) {
-        return str;
-      }
-    </script>
+        function gettext(str) {
+          return str;
+        }
+      </script>
+    {% endif %}
 
     <!-- Core Libraries -->
-    {% block core_libraries %}
-      {% javascript_libraries underscore=True ko=True hq=True analytics=True %}
-    {% endblock %}
-    <script src="{% static 'hqwebapp/js/toggles.js' %}"></script>
+    {% if not requirejs_main %}
+      {% block core_libraries %}
+        {% javascript_libraries underscore=True ko=True hq=True analytics=True %}
+      {% endblock %}
+      <script src="{% static 'hqwebapp/js/toggles.js' %}"></script>
+    {% endif %}
 
     <!-- App specific dependencies -->
     {% block dependencies %}{% endblock %}
 
-    <script>
-      hqImport('analytix/js/google').track.event = sinon.spy();
-      hqImport('analytix/js/google').track.click = sinon.spy();
-      hqImport('analytix/js/kissmetrix').track.event = sinon.spy();
-    </script>
+    {% if not requirejs_main %}
+      <script>
+        hqImport('analytix/js/google').track.event = sinon.spy();
+        hqImport('analytix/js/google').track.click = sinon.spy();
+        hqImport('analytix/js/kissmetrix').track.event = sinon.spy();
+      </script>
+    {% endif %}
+
   </head>
   <body>
     <div class="initial-analytics-data hide"></div>
@@ -62,11 +70,14 @@
     </div>
     <div id="mocha-sandbox"></div>
     {% block mocha_tests %}{% endblock %}
-    <script charset="utf-8">
-      // Only tests run in real browser, injected script run if options.run == true
-      if (navigator.userAgent.indexOf('PhantomJS') < 0) {
-        mocha.run();
-      }
-    </script>
+
+    {% if not requirejs_main %}
+      <script charset="utf-8">
+        // Only tests run in real browser, injected script run if options.run == true
+        if (navigator.userAgent.indexOf('PhantomJS') < 0) {
+          mocha.run();
+        }
+      </script>
+    {% endif %}
   </body>
 </html>

--- a/corehq/apps/mocha/templates/mocha/base.html
+++ b/corehq/apps/mocha/templates/mocha/base.html
@@ -30,14 +30,6 @@
       <script src="{% static 'mocha/mocha.js' %}"></script>
       <script src="{% static 'chai/chai.js' %}"></script>
       <script src="{% static 'sinon/pkg/sinon.js' %}"></script>
-      <script>
-        mocha.setup('bdd')
-        window.assert = chai.assert
-
-        function gettext(str) {
-          return str;
-        }
-      </script>
     {% endif %}
 
     <!-- Core Libraries -->
@@ -45,19 +37,12 @@
       {% block core_libraries %}
         {% javascript_libraries underscore=True ko=True hq=True analytics=True %}
       {% endblock %}
+      <script src="{% static 'hqwebapp/js/mocha.js' %}"></script>
       <script src="{% static 'hqwebapp/js/toggles.js' %}"></script>
     {% endif %}
 
     <!-- App specific dependencies -->
     {% block dependencies %}{% endblock %}
-
-    {% if not requirejs_main %}
-      <script>
-        hqImport('analytix/js/google').track.event = sinon.spy();
-        hqImport('analytix/js/google').track.click = sinon.spy();
-        hqImport('analytix/js/kissmetrix').track.event = sinon.spy();
-      </script>
-    {% endif %}
 
   </head>
   <body>
@@ -73,10 +58,7 @@
 
     {% if not requirejs_main %}
       <script charset="utf-8">
-        // Only tests run in real browser, injected script run if options.run == true
-        if (navigator.userAgent.indexOf('PhantomJS') < 0) {
-          mocha.run();
-        }
+        hqImport("hqwebapp/js/mocha").run();
       </script>
     {% endif %}
   </body>

--- a/corehq/apps/mocha/templates/mocha/base.html
+++ b/corehq/apps/mocha/templates/mocha/base.html
@@ -1,5 +1,6 @@
 {% load compress %}
 {% load hq_shared_tags %}
+{% load statici18n %}
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>
@@ -19,6 +20,10 @@
     </style>
 
     {% block stylesheets %}{% endblock %}
+
+    {% include "hqwebapp/partials/requirejs.html" with BASE_MAIN=False %}
+
+    <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
 
     <script src="{% static 'mocha/mocha.js' %}"></script>
     <script src="{% static 'chai/chai.js' %}"></script>


### PR DESCRIPTION
## Technical Summary
All of our js tests run in non-requirejs, even though most of the code they test is used in a requirejs environment. This isn't tenable for web apps, where I've needed to make significant changes to the dependency graph and it's not viable to maintain a non-requirejs list of ordered script tags just to support tests.

This PR updates our base mocha code to support requirejs, and it migrates the hqwebapp tests to requirejs as a proof of concept.

Review by commit.

## Safety Assurance

### Safety story
This is largely test code. I smoke tested a requirejs page and non-requirejs page to make sure the changes to `hqwebapp/base.html` aren't problematic.

### Automated test coverage

In PR.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
