### PR TITLE
Migration to create initial audit events for AutomaticUpdateRule

### DIFF
--- a/corehq/apps/data_interfaces/migrations/0032_bootstrap_audit_events_for_update_rules.py
+++ b/corehq/apps/data_interfaces/migrations/0032_bootstrap_audit_events_for_update_rules.py
@@ -1,0 +1,24 @@
+from django.core.management import call_command
+from django.db import migrations
+
+
+def bootstrap_audit_events_for_automatic_update_rule(apps, schema_editor):
+    call_command('bootstrap_field_audit_events',
+                 'top-up',
+                 ['AutomaticUpdateRule'])
+
+
+def noop(*args, **kwargs):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_interfaces', '0031_add_domaincaserulerun_status_choices'),
+    ]
+
+    operations = [
+        migrations.RunPython(bootstrap_audit_events_for_automatic_update_rule,
+                             reverse_code=noop)
+    ]

--- a/corehq/apps/data_interfaces/migrations/0032_bootstrap_audit_events_for_update_rules.py
+++ b/corehq/apps/data_interfaces/migrations/0032_bootstrap_audit_events_for_update_rules.py
@@ -11,10 +11,6 @@ def bootstrap_audit_events_for_automatic_update_rule(apps, schema_editor):
                  ['AutomaticUpdateRule'])
 
 
-def noop(*args, **kwargs):
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -24,5 +20,5 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(bootstrap_audit_events_for_automatic_update_rule,
-                             reverse_code=noop)
+                             reverse_code=migrations.RunPython.noop)
     ]

--- a/corehq/apps/data_interfaces/migrations/0032_bootstrap_audit_events_for_update_rules.py
+++ b/corehq/apps/data_interfaces/migrations/0032_bootstrap_audit_events_for_update_rules.py
@@ -16,6 +16,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('data_interfaces', '0031_add_domaincaserulerun_status_choices'),
+        ('field_audit', '0002_add_is_bootstrap_column'),
     ]
 
     operations = [

--- a/corehq/apps/data_interfaces/migrations/0032_bootstrap_audit_events_for_update_rules.py
+++ b/corehq/apps/data_interfaces/migrations/0032_bootstrap_audit_events_for_update_rules.py
@@ -1,7 +1,10 @@
 from django.core.management import call_command
 from django.db import migrations
 
+from corehq.util.django_migrations import skip_on_fresh_install
 
+
+@skip_on_fresh_install
 def bootstrap_audit_events_for_automatic_update_rule(apps, schema_editor):
     call_command('bootstrap_field_audit_events',
                  'top-up',

--- a/migrations.lock
+++ b/migrations.lock
@@ -290,6 +290,7 @@ data_interfaces
  0029_locationfilterdefinition_include_child_locations
  0030_add_workflow_choices
  0031_add_domaincaserulerun_status_choices
+ 0032_bootstrap_audit_events_for_update_rules
 dhis2
  0001_initial
  0002_auto_20170322_1323


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SAAS-13015

Followup to https://github.com/dimagi/commcare-hq/pull/32336

This ensures initial audit events are created for existing AutomaticUpdateRules in an automated fashion. The initial PR was deployed on December 8th, which means that any updates to AutomaticUpdateRules has been audited since then.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This management command is implemented and tested in the django-field-audit library. This is safe because audit events are strictly not user facing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->
https://github.com/dimagi/commcare-hq/pull/32336

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
This migration runs a management command that does not have a built in way to reverse. If needed, all bootstrapped audit events for the AutomaticUpdateRule could be deleted, and that would be fairly straightforward to implement.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
