### PR TITLE
Update `makemigrations` manage command to honor the `--dry-run` option

### DIFF
--- a/hqscripts/management/commands/makemigrations.py
+++ b/hqscripts/management/commands/makemigrations.py
@@ -71,7 +71,7 @@ class Command(makemigrations.Command):
 
     def write_migration_files(self, changes):
         super().write_migration_files(changes)
-        if self.dry_run:
+        if not self.dry_run:
             self.write_migrations_lock()
 
     def get_migrations_list(self, preamble=LOCK_PREAMBLE):

--- a/hqscripts/management/commands/makemigrations.py
+++ b/hqscripts/management/commands/makemigrations.py
@@ -71,7 +71,7 @@ class Command(makemigrations.Command):
 
     def write_migration_files(self, changes):
         super().write_migration_files(changes)
-        self.write_migrations_lock()
+        self.write_migrations_lock(self.dry_run)
 
     def get_migrations_list(self, preamble=LOCK_PREAMBLE):
         """Generate and return the full list of existing migrations.
@@ -94,8 +94,10 @@ class Command(makemigrations.Command):
             lines.append(line)
         return lines
 
-    def write_migrations_lock(self):
+    def write_migrations_lock(self, dry_run=False):
         """Write a new migrations.lock file."""
+        if dry_run:
+            return
         with open(self.lock_path, "w") as file:
             file.write("".join(self.get_migrations_list()))
 

--- a/hqscripts/management/commands/makemigrations.py
+++ b/hqscripts/management/commands/makemigrations.py
@@ -71,7 +71,8 @@ class Command(makemigrations.Command):
 
     def write_migration_files(self, changes):
         super().write_migration_files(changes)
-        self.write_migrations_lock(self.dry_run)
+        if self.dry_run:
+            self.write_migrations_lock()
 
     def get_migrations_list(self, preamble=LOCK_PREAMBLE):
         """Generate and return the full list of existing migrations.
@@ -94,10 +95,8 @@ class Command(makemigrations.Command):
             lines.append(line)
         return lines
 
-    def write_migrations_lock(self, dry_run=False):
+    def write_migrations_lock(self):
         """Write a new migrations.lock file."""
-        if dry_run:
-            return
         with open(self.lock_path, "w") as file:
             file.write("".join(self.get_migrations_list()))
 


### PR DESCRIPTION
## Technical Summary

While working on new Elastic migration operations ([SAAS-14003](https://dimagi-dev.atlassian.net/browse/SAAS-14003)), I realized that the current `makemigrations` manage command hasn't been properly honoring the `--dry-run` commandline option. This means that in some circumstances, running `makemigrations --dry-run` can write a new `migrations.lock` file, which it should not do for a dry run.  This change fixes the behavior so the lock file is not written during a dry run.

## Safety Assurance

### Safety story

Updates to developer tool only, and makes it more robust (`--dry-run` works correctly now).

### Automated test coverage

No tests.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-14003]: https://dimagi-dev.atlassian.net/browse/SAAS-14003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-14003]: https://dimagi-dev.atlassian.net/browse/SAAS-14003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ