### PR TITLE
Generic Inbound API - Log Action: Archive

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -115,6 +115,7 @@ from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.utils.general import use_sqlite_backend
 from corehq.form_processor.utils.xform import resave_form
+from corehq.motech.generic_inbound.utils import revert_api_request_from_form
 from corehq.tabs.tabclasses import ProjectReportsTab
 from corehq.toggles import VIEW_FORM_ATTACHMENT
 from corehq.util import cmp
@@ -1531,6 +1532,7 @@ def archive_form(request, domain, instance_id):
             notify_level = messages.ERROR
         else:
             instance.archive(user_id=request.couch_user._id)
+            revert_api_request_from_form(instance_id)
             notify_msg = _("Form was successfully archived.")
     elif instance.is_archived:
         notify_msg = _("Form was already archived.")

--- a/corehq/motech/generic_inbound/templates/generic_inbound/request_log_detail.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/request_log_detail.html
@@ -167,11 +167,15 @@
       </button>
     </form>
   {% elif log.status == 'success' %}
-    <form action="{% url 'archive_api_request' domain log.id %}" method="post" class="pull-left">{% csrf_token %}
+    <form action="{% url 'revert_api_request' domain log.id %}" method="post" class="pull-left">{% csrf_token %}
       <button type="submit" class="btn btn-danger disable-on-submit" >
-        <i class="fa fa-archive"></i>
-        {% trans 'Archive' %}
+        <i class="fa fa-undo"></i>
+        {% trans 'Revert' %}
       </button>
+      <span class="hq-help-template"
+            data-title="{% trans 'Reverting API Requests' %}"
+            data-content="{% blocktrans %}Reverts actions performed in this request and archives any associated forms.{% endblocktrans %}">
+      </span>
     </form>
   {% endif %}
 </div>

--- a/corehq/motech/generic_inbound/templates/generic_inbound/request_log_detail.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/request_log_detail.html
@@ -166,6 +166,13 @@
         {% trans 'Retry' %}
       </button>
     </form>
+  {% elif log.status == 'success' %}
+    <form action="{% url 'archive_api_request' domain log.id %}" method="post" class="pull-left">{% csrf_token %}
+      <button type="submit" class="btn btn-danger disable-on-submit" >
+        <i class="fa fa-archive"></i>
+        {% trans 'Archive' %}
+      </button>
+    </form>
   {% endif %}
 </div>
 

--- a/corehq/motech/generic_inbound/tests/test_api.py
+++ b/corehq/motech/generic_inbound/tests/test_api.py
@@ -14,6 +14,7 @@ from corehq.apps.userreports.const import (
 )
 from corehq.apps.userreports.models import UCRExpression
 from corehq.apps.users.models import HQApiKey, WebUser
+from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.motech.generic_inbound.models import (
     ConfigurableAPI,
@@ -23,7 +24,9 @@ from corehq.motech.generic_inbound.models import (
 )
 from corehq.motech.generic_inbound.utils import (
     ApiRequest,
+    archive_api_request,
     reprocess_api_request,
+    revert_api_request_from_form,
 )
 from corehq.util.test_utils import flag_enabled, privilege_enabled
 
@@ -345,3 +348,32 @@ class TestGenericInboundAPIView(TestCase):
         attempt = log.processingattempt_set.last()
         self.assertEqual(attempt.is_retry, True)
         self.assertEqual(attempt.raw_response, {"error": "Payload must be valid JSON"})
+
+    def test_archive_forms(self):
+        properties_expression = {'prop': 'const'}
+        self._call_api(properties_expression)
+
+        log = RequestLog.objects.last()
+        xform = XFormInstance.get_obj_by_id(log.processingattempt_set.last().xform_id)
+        self.assertEqual(xform.is_archived, False)
+        self.assertEqual(log.status, RequestLog.Status.SUCCESS)
+
+        # Archive form(s) based on request log
+        archive_api_request(log, self.user._id)
+        log.refresh_from_db()
+        xform.refresh_from_db()
+        self.assertEqual(xform.is_archived, True)
+        self.assertEqual(log.status, RequestLog.Status.REVERTED)
+
+    def test_revert_log(self):
+        properties_expression = {'prop': 'const'}
+        self._call_api(properties_expression)
+
+        log = RequestLog.objects.last()
+        xform = XFormInstance.get_obj_by_id(log.processingattempt_set.last().xform_id)
+        self.assertEqual(log.status, RequestLog.Status.SUCCESS)
+
+        # Revert request log based on form
+        revert_api_request_from_form(xform.form_id)
+        log.refresh_from_db()
+        self.assertEqual(log.status, RequestLog.Status.REVERTED)

--- a/corehq/motech/generic_inbound/utils.py
+++ b/corehq/motech/generic_inbound/utils.py
@@ -141,3 +141,12 @@ def _revert_api_request_log(request_log):
     if request_log.status == RequestLog.Status.SUCCESS:
         request_log.status = RequestLog.Status.REVERTED
         request_log.save()
+
+
+def revert_api_request_from_form(form_id):
+    from corehq.motech.generic_inbound.models import ProcessingAttempt
+    try:
+        attempt = ProcessingAttempt.objects.get(xform_id=form_id)
+        _revert_api_request_log(attempt.log)
+    except ProcessingAttempt.DoesNotExist:
+        return

--- a/corehq/motech/generic_inbound/views.py
+++ b/corehq/motech/generic_inbound/views.py
@@ -39,6 +39,7 @@ from corehq.motech.generic_inbound.utils import (
     ApiResponse,
     make_processing_attempt,
     reprocess_api_request,
+    revert_api_request,
 )
 from corehq.util import reverse
 from corehq.util.view_utils import json_error
@@ -220,4 +221,11 @@ def _log_api_request(api, request, response):
 def retry_api_request(request, domain, log_id):
     request_log = get_object_or_404(RequestLog, domain=domain, id=log_id)
     reprocess_api_request(request_log)
+    return redirect(ApiLogDetailView.urlname, domain, log_id)
+
+
+@can_administer_generic_inbound
+def archive_api_request(request, domain, log_id):
+    request_log = get_object_or_404(RequestLog, domain=domain, id=log_id)
+    revert_api_request(request_log, request.couch_user._id)
     return redirect(ApiLogDetailView.urlname, domain, log_id)

--- a/corehq/motech/generic_inbound/views.py
+++ b/corehq/motech/generic_inbound/views.py
@@ -37,9 +37,9 @@ from corehq.motech.generic_inbound.reports import ApiLogDetailView
 from corehq.motech.generic_inbound.utils import (
     ApiRequest,
     ApiResponse,
+    archive_api_request,
     make_processing_attempt,
     reprocess_api_request,
-    revert_api_request,
 )
 from corehq.util import reverse
 from corehq.util.view_utils import json_error
@@ -225,7 +225,7 @@ def retry_api_request(request, domain, log_id):
 
 
 @can_administer_generic_inbound
-def archive_api_request(request, domain, log_id):
+def revert_api_request(request, domain, log_id):
     request_log = get_object_or_404(RequestLog, domain=domain, id=log_id)
-    revert_api_request(request_log, request.couch_user._id)
+    archive_api_request(request_log, request.couch_user._id)
     return redirect(ApiLogDetailView.urlname, domain, log_id)

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -13,6 +13,7 @@ from corehq.motech.generic_inbound.reports import ApiLogDetailView
 from corehq.motech.generic_inbound.views import (
     ConfigurableAPIEditView,
     ConfigurableAPIListView,
+    archive_api_request,
     retry_api_request,
 )
 from corehq.motech.openmrs.views import (
@@ -125,5 +126,6 @@ urlpatterns = [
     url(r'^inbound/$', ConfigurableAPIListView.as_view(), name=ConfigurableAPIListView.urlname),
     url(r'^inbound/(?P<api_id>\d+)/$', ConfigurableAPIEditView.as_view(), name=ConfigurableAPIEditView.urlname),
     url(r'^inbound/log/(?P<log_id>[\w-]+)/$', ApiLogDetailView.as_view(), name=ApiLogDetailView.urlname),
+    url(r'^inbound/archive/(?P<log_id>[\w-]+)/$', archive_api_request, name='archive_api_request'),
     url(r'^inbound/retry/(?P<log_id>[\w-]+)/$', retry_api_request, name='retry_api_request'),
 ]

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -13,8 +13,8 @@ from corehq.motech.generic_inbound.reports import ApiLogDetailView
 from corehq.motech.generic_inbound.views import (
     ConfigurableAPIEditView,
     ConfigurableAPIListView,
-    archive_api_request,
     retry_api_request,
+    revert_api_request,
 )
 from corehq.motech.openmrs.views import (
     AddOpenmrsRepeaterView,
@@ -126,6 +126,6 @@ urlpatterns = [
     url(r'^inbound/$', ConfigurableAPIListView.as_view(), name=ConfigurableAPIListView.urlname),
     url(r'^inbound/(?P<api_id>\d+)/$', ConfigurableAPIEditView.as_view(), name=ConfigurableAPIEditView.urlname),
     url(r'^inbound/log/(?P<log_id>[\w-]+)/$', ApiLogDetailView.as_view(), name=ApiLogDetailView.urlname),
-    url(r'^inbound/archive/(?P<log_id>[\w-]+)/$', archive_api_request, name='archive_api_request'),
+    url(r'^inbound/revert/(?P<log_id>[\w-]+)/$', revert_api_request, name='revert_api_request'),
     url(r'^inbound/retry/(?P<log_id>[\w-]+)/$', retry_api_request, name='retry_api_request'),
 ]


### PR DESCRIPTION
## Product Description
Adds "Revert" button and info text to successful inbound API request logs.
<img width="399" alt="image" src="https://user-images.githubusercontent.com/100609770/210624367-2eb552e7-92bd-462c-8a37-a51fc1dc033f.png">


## Technical Summary
[USH-2559
](https://dimagi-dev.atlassian.net/browse/USH-2559?atlOrigin=eyJpIjoiNWQyMzBiMzI3NGZiNGMxZjljMWJkYmE1ODk5NjRkZWQiLCJwIjoiaiJ9)
Allows reverting a successful inbound API request by archiving its associated form(s) with `archive_api_request` and updating its `RequestLog` status to reverted through `_revert_api_request_log`. A reverted api request log may also have its request retried - no change was made explicitly to allow this, but it is an easy way a request could have multiple associated forms.

Adds a call to the `archive_form` view action which reverts the request log that created the form, if applicable. The call is on the view, rather than the model, to avoid circular calls when a form is archived based on its request log. This call does not affect any other forms that may be attached to the request log since it could be a confusing side effect.

The `revert_api_request_from_form` action is done _any time_ a form that has an associated api request log is archived through the `archive_form` action, for simplicity. A user could manually unarchive individual forms in ways that would get very convoluted very quickly. The possibility of only running the action when the _most recent_ form is archived was discussed, but the ordering of forms might also be inconsistent and lead to confusing results.

## Feature Flag
Generic inbound APIs

## Safety Assurance

### Safety story
Uses existing `archive` action on the xform instance model without changing how its data is handled. Only archives/reverts and does not delete any data.


### Automated test coverage
Added test coverage in in `corehq.motech.generic_inbound.tests.test_api`

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-2559]: https://dimagi-dev.atlassian.net/browse/USH-2559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-2559]: https://dimagi-dev.atlassian.net/browse/USH-2559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ