### PR TITLE
Check if secure_session should be unset

### DIFF
--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -194,28 +194,34 @@ class TimeoutMiddleware(MiddlewareMixin):
         time_since_activity = time - string_to_utc_datetime(activity)
         return time_since_activity > datetime.timedelta(minutes=timeout)
 
+    def _should_use_secure_session(self, session, user, domain):
+        # is the current domain using secure_sessions
+        domain_obj = Domain.get_by_name(domain) if domain else None
+        current_domain_secure = domain_obj and domain_obj.secure_sessions
+
+        # is the user a member of any domain using secure_sessions
+        member_domains = self._get_relevant_domains(user)
+        member_domain_secure = any(filter(Domain.is_secure_session_required, member_domains))
+
+        # has the user visited any domain using secure_sessions that they are not a member of
+        visited_nonmember_secure = (
+            session.get('nonmember_secure_session')
+            or current_domain_secure and domain not in member_domains
+        )
+        session['nonmember_secure_session'] = visited_nonmember_secure
+        return any([current_domain_secure, member_domain_secure, visited_nonmember_secure])
+
     def process_view(self, request, view_func, view_args, view_kwargs):
         if not request.user.is_authenticated:
             return
 
         secure_session = request.session.get('secure_session')
         domain = getattr(request, "domain", None)
-        domain_obj = Domain.get_by_name(domain) if domain else None
 
-        # figure out if we want to switch to or from secure_sessions
-        any_secure_sessions = (
-            (domain_obj and domain_obj.secure_sessions)
-            or any(filter(Domain.is_secure_session_required,
-                          self._get_relevant_domains(request.couch_user, domain)))
-        )
-        change_to_secure_session = not secure_session and any_secure_sessions
-        change_from_secure_session = secure_session and not any_secure_sessions
-
-        if change_to_secure_session or change_from_secure_session:
-            secure_session = not secure_session
-
+        use_secure_session = self._should_use_secure_session(request.session, request.couch_user, domain)
         timeout = self._get_timeout(request.session, secure_session, request.couch_user, domain)
-        if change_to_secure_session:
+
+        if not secure_session and use_secure_session:
             # force re-authentication if the user has been logged in longer than the secure timeout
             if self._session_expired(timeout, request.user.last_login):
                 LogoutView.as_view(template_name=settings.BASE_TEMPLATE)(request)
@@ -226,7 +232,7 @@ class TimeoutMiddleware(MiddlewareMixin):
             self.update_secure_session(request.session, True, request.couch_user, domain)
 
         if not getattr(request, '_bypass_sessions', False):
-            self.update_secure_session(request.session, secure_session, request.couch_user, domain)
+            self.update_secure_session(request.session, use_secure_session, request.couch_user, domain)
 
 
 def always_allow_browser_caching(fn):


### PR DESCRIPTION
## Technical Summary
[USH-2577](https://dimagi-dev.atlassian.net/browse/USH-2577?atlOrigin=eyJpIjoiYWY1MzEwYjBiYjIxNGVkYmI4YzFlOWYyZDNjOGIwY2EiLCJwIjoiaiJ9)
Currently, `TimeoutMiddleware` only checks if `secure_session` is newly enabled with `change_to_secure_session`, not if newly disabled, so the inactivity timeout remains active until the user starts a new session, even after deselected and saved. 

This PR extracts the logic used to set `secure_session` into a function that checks:
1. Whether the current domain uses `secure_session`
2. If the user belongs to any domains that use `secure_session`
3. If the user has visited any domains during this session that they are not a member of, but which use `secure_session`

If any of these criteria are met, `secure_session` is True. This leaves `use_secure_session` slightly overzealous, as a domain meeting criteria 3 might later turn `secure_session` off, but this is a compromise to avoid storing the name of each domain a user has visited and checking the `secure` status of each.

A previous version of this PR added a more basic check `change_from_secure_session` for whether `secure_session` should be disabled, based on the same criteria as `change_to_secure_session` but with inverted logic, however this led to situations where `secure_session` effectively ignored criteria 3, above, and was disabled too soon.

## Feature Flag

## Safety Assurance

### Safety story
`secure_session` will remain True if _any_ of the 3 criteria above are met.

This change also leaves in place security-oriented actions from `change_to_secure_session`, now under the criteria `not secure_session and use_secure_session` to check if a user should be immediately logged out based on the length of their current session. 

### Automated test coverage
Covered by existing automated tests.

### QA Plan

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-2577]: https://dimagi-dev.atlassian.net/browse/USH-2577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-2577]: https://dimagi-dev.atlassian.net/browse/USH-2577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ