### PR TITLE
Supports all FHIR resource types

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -166,6 +166,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                     },
                     success: function () {
                         var activeCaseType = self.getActiveCaseType();
+                        activeCaseType.fhirResourceType(self.fhirResourceType());
                         activeCaseType.properties(self.casePropertyList());
                     },
                     // Error handling is managed by SaveButton logic in main.js

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -10,6 +10,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
     "hqwebapp/js/toggles",
     "hqwebapp/js/knockout_bindings.ko",
     "data_interfaces/js/make_read_only",
+    'hqwebapp/js/select2_knockout_bindings.ko',
 ], function (
     $,
     ko,
@@ -342,5 +343,6 @@ hqDefine("data_dictionary/js/data_dictionary", [
         $('#download-dict').click(function () {
             googleAnalytics.track.event('Data Dictionary', 'downloaded data dictionary');
         });
+
     });
 });

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -119,10 +119,11 @@
     <div class="col-md-12">
       <h3 data-bind="text: $root.activeCaseType()"></h3>
       {% if fhir_integration_enabled %}
-        <div class="form-inline" data-bind="visible: fhirResourceTypes().length">
+        <div id="fhir-resource-type-form" class="form-inline" data-bind="visible: fhirResourceTypes().length">
           {% trans "FHIR Resource Type" %}
-          <select class="form-control"
-                  data-bind="options: fhirResourceTypes,
+          <select id="fhir-resource-types"
+                  class="form-control"
+                  data-bind="select2: fhirResourceTypes,
                              optionsCaption: '{% trans_html_attr 'Select a resource type' %}',
                              value: fhirResourceType,
                              disable: removefhirResourceType,

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -33,11 +33,11 @@ from corehq.apps.settings.views import BaseProjectDataView
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
 
-from corehq.motech.fhir.const import SUPPORTED_FHIR_RESOURCE_TYPES
 from corehq.motech.fhir.utils import (
     load_fhir_resource_mappings,
     remove_fhir_resource_type,
     update_fhir_resource_type,
+    load_fhir_resource_types,
 )
 from corehq.project_limits.rate_limiter import (
     RateDefinition,
@@ -349,7 +349,7 @@ class DataDictionaryView(BaseProjectDataView):
         fhir_integration_enabled = toggles.FHIR_INTEGRATION.enabled(self.domain)
         if fhir_integration_enabled:
             main_context.update({
-                'fhir_resource_types': SUPPORTED_FHIR_RESOURCE_TYPES,
+                'fhir_resource_types': load_fhir_resource_types(),
             })
         main_context.update({
             'question_types': [{'value': t.value, 'display': t.label}

--- a/corehq/apps/hqwebapp/static/data_dictionary/less/data_dictionary.less
+++ b/corehq/apps/hqwebapp/static/data_dictionary/less/data_dictionary.less
@@ -19,3 +19,7 @@
     margin-bottom: 8px;
   }
 }
+
+#fhir-resource-type-form .select2-container {
+  width: 15% !important;
+}

--- a/corehq/motech/fhir/const.py
+++ b/corehq/motech/fhir/const.py
@@ -42,12 +42,3 @@ FHIR_DATA_TYPE_LIST_OF_STRING = 'fhir_list_of_string'
 FHIR_DATA_TYPES = (
     FHIR_DATA_TYPE_LIST_OF_STRING,
 )
-
-SUPPORTED_FHIR_RESOURCE_TYPES = (
-    'DiagnosticReport',
-    'Encounter',
-    'Immunization',
-    'Observation',
-    'Patient',
-    'ServiceRequest',
-)

--- a/corehq/motech/fhir/tests/test_utils.py
+++ b/corehq/motech/fhir/tests/test_utils.py
@@ -1,10 +1,11 @@
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from nose.tools import assert_equal
 
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.motech.fhir.models import FHIRResourceProperty, FHIRResourceType
 from corehq.motech.fhir.utils import (
+    load_fhir_resource_types,
     resource_url,
     update_fhir_resource_property,
 )
@@ -138,6 +139,14 @@ class TestUpdateFHIRResourceProperty(TestCase):
                 jsonpath=new_fhir_resource_prop_path
             ).count(),
             1)
+
+
+class TestLoadFHIRResourceType(SimpleTestCase):
+
+    def test_load_fhir_resource_types_default(self):
+        resource_types = load_fhir_resource_types()
+        self.assertIsInstance(resource_types, list)
+        self.assertTrue('fhir' not in resource_types)
 
 
 def test_resource_url():

--- a/corehq/motech/fhir/tests/test_validators.py
+++ b/corehq/motech/fhir/tests/test_validators.py
@@ -1,9 +1,8 @@
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 
-from corehq.motech.fhir.const import SUPPORTED_FHIR_RESOURCE_TYPES
 from corehq.motech.fhir.models import FHIRResourceType
-
+from corehq.motech.fhir.utils import load_fhir_resource_types
 
 class TestValidateSupportedFHIRTypes(SimpleTestCase):
     def test_valid_fhir_type(self):
@@ -17,11 +16,12 @@ class TestValidateSupportedFHIRTypes(SimpleTestCase):
     def test_invalid_fhir_type(self):
         fhir_type = FHIRResourceType()
         fhir_type.name = "Random"
+        supported_resources_types = load_fhir_resource_types()
         try:
             fhir_type.full_clean()
         except ValidationError as e:
             self.assertEqual(
                 e.message_dict['name'],
                 ['Unsupported FHIR Resource type Random. Please choose from '
-                 + ', '.join(SUPPORTED_FHIR_RESOURCE_TYPES)]
+                 + ', '.join(supported_resources_types)]
             )

--- a/corehq/motech/fhir/utils.py
+++ b/corehq/motech/fhir/utils.py
@@ -68,7 +68,8 @@ def update_fhir_resource_property(case_property, fhir_resource_type, fhir_resour
 def load_fhir_resource_types(fhir_version=FHIR_VERSION_4_0_1, exclude_resource_types=('fhir',)):
     schemas_base_path = get_schema_dir(fhir_version)
     all_file_names = os.listdir(schemas_base_path)
-    resource_types = [f.removesuffix('.schema.json') for f in all_file_names if f.endswith('.schema.json')]
+    resource_types = [file_name.removesuffix('.schema.json') for file_name in all_file_names
+                      if file_name.endswith('.schema.json')]
     for schema in exclude_resource_types:
         if schema in resource_types:
             resource_types.remove(schema)

--- a/corehq/motech/fhir/utils.py
+++ b/corehq/motech/fhir/utils.py
@@ -1,4 +1,3 @@
-import glob
 import os
 
 from memoized import memoized
@@ -68,8 +67,8 @@ def update_fhir_resource_property(case_property, fhir_resource_type, fhir_resour
 @memoized
 def load_fhir_resource_types(fhir_version=FHIR_VERSION_4_0_1, exclude_resource_types=('fhir',)):
     schemas_base_path = get_schema_dir(fhir_version)
-    all_file_names = glob.glob(os.path.join(schemas_base_path, '*.schema.json'))
-    resource_types = [os.path.basename(f).removesuffix('.schema.json') for f in all_file_names]
+    all_file_names = os.listdir(schemas_base_path)
+    resource_types = [f.removesuffix('.schema.json') for f in all_file_names if f.endswith('.schema.json')]
     for schema in exclude_resource_types:
         if schema in resource_types:
             resource_types.remove(schema)

--- a/corehq/motech/fhir/utils.py
+++ b/corehq/motech/fhir/utils.py
@@ -1,4 +1,14 @@
-from corehq.motech.fhir.models import FHIRResourceProperty, FHIRResourceType
+import glob
+import os
+
+from memoized import memoized
+
+from corehq.motech.fhir.const import FHIR_VERSION_4_0_1
+from corehq.motech.fhir.models import (
+    FHIRResourceProperty,
+    FHIRResourceType,
+    get_schema_dir,
+)
 from corehq.util.view_utils import absolute_reverse
 
 
@@ -53,3 +63,15 @@ def update_fhir_resource_property(case_property, fhir_resource_type, fhir_resour
                                                       resource_type=fhir_resource_type)
         fhir_resource_prop.jsonpath = fhir_resource_prop_path
         fhir_resource_prop.save()
+
+
+@memoized
+def load_fhir_resource_types(fhir_version=FHIR_VERSION_4_0_1, exclude_resource_types=('fhir',)):
+    schemas_base_path = get_schema_dir(fhir_version)
+    all_file_names = glob.glob(os.path.join(schemas_base_path, '*.schema.json'))
+    resource_types = [os.path.basename(f).removesuffix('.schema.json') for f in all_file_names]
+    for schema in exclude_resource_types:
+        if schema in resource_types:
+            resource_types.remove(schema)
+    resource_types.sort()
+    return resource_types

--- a/corehq/motech/fhir/validators.py
+++ b/corehq/motech/fhir/validators.py
@@ -1,12 +1,12 @@
 from django.core.validators import ValidationError
 from django.utils.translation import gettext_lazy as _
 
-from corehq.motech.fhir.const import SUPPORTED_FHIR_RESOURCE_TYPES
-
 
 def validate_supported_type(value):
-    if value and value not in SUPPORTED_FHIR_RESOURCE_TYPES:
+    from corehq.motech.fhir.utils import load_fhir_resource_types
+    supported_resources_types = load_fhir_resource_types()
+    if value and value not in supported_resources_types:
         raise ValidationError(
             _('Unsupported FHIR Resource type {}. Please choose from {}').format(
-                value, ', '.join(SUPPORTED_FHIR_RESOURCE_TYPES))
+                value, ', '.join(supported_resources_types))
         )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This allows users to set resource type from all available FHIR resource types. 
Till now we were allowing only a few of them, reason for which isn't clear. 
We should be able to support all, since the implementations are generic and we have schemas for all resource types available in code.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Same as above

## Feature Flag
FHIR_INTEGRATION
DATA_DICTIONARY

## Safety Assurance
Tested locally that the data dictionary UI 

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
No changes to implementations and no resource types were removed.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Might take this through QA. Will discuss with Norman if it seems necessary.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

This PR can be reverted if needed. Any new integrations added, with newly introduced resource types, would continue to work though will become invalid and will be flagged when they would be edited next time.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
