### PR TITLE
[security] bump setuptools to 65.5.1

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -626,7 +626,7 @@ class AppStringsBase(object):
 class DumpKnownAppStrings(AppStringsBase):
 
     def app_strings_parts(self, app, lang, for_default=False, build_profile_id=None):
-        commcare_version = app.build_version.vstring if app.build_version else None
+        commcare_version = str(app.build_version) if app.build_version else None
 
         yield self.create_custom_app_strings(app, lang, for_default=for_default, build_profile_id=build_profile_id)
         yield self.get_default_translations(lang, commcare_version)
@@ -654,7 +654,7 @@ class SelectKnownAppStrings(AppStringsBase):
 
     def app_strings_parts(self, app, lang, for_default=False, build_profile_id=None):
         yield self.create_custom_app_strings(app, lang, for_default=for_default, build_profile_id=build_profile_id)
-        commcare_version = app.build_version.vstring if app.build_version else None
+        commcare_version = str(app.build_version) if app.build_version else None
         cc_trans = self.get_default_translations(lang, commcare_version)
         yield {key: cc_trans[key] for key in self.get_app_translation_keys(app) if key in cc_trans}
         yield non_empty_only(app.translations.get(lang, {}))

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -1,5 +1,5 @@
 import functools
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 
 from django.utils.translation import gettext
 
@@ -513,7 +513,7 @@ def _create_dependencies_app_strings(app):
 
 
 def _maybe_add_index(text, app):
-    if app.build_version and app.build_version >= parse_version('2.8'):
+    if app.build_version and app.build_version >= LooseVersion('2.8'):
         sense_on = app.profile.get('features', {}).get('sense') == 'true'
         entry_mode = app.profile.get('properties', {}).get('cc-entry-mode')
         numeric_nav_on = entry_mode == 'cc-entry-review'
@@ -626,7 +626,7 @@ class AppStringsBase(object):
 class DumpKnownAppStrings(AppStringsBase):
 
     def app_strings_parts(self, app, lang, for_default=False, build_profile_id=None):
-        commcare_version = str(app.build_version) if app.build_version else None
+        commcare_version = app.build_version.vstring if app.build_version else None
 
         yield self.create_custom_app_strings(app, lang, for_default=for_default, build_profile_id=build_profile_id)
         yield self.get_default_translations(lang, commcare_version)
@@ -654,7 +654,7 @@ class SelectKnownAppStrings(AppStringsBase):
 
     def app_strings_parts(self, app, lang, for_default=False, build_profile_id=None):
         yield self.create_custom_app_strings(app, lang, for_default=for_default, build_profile_id=build_profile_id)
-        commcare_version = str(app.build_version) if app.build_version else None
+        commcare_version = app.build_version.vstring if app.build_version else None
         cc_trans = self.get_default_translations(lang, commcare_version)
         yield {key: cc_trans[key] for key in self.get_app_translation_keys(app) if key in cc_trans}
         yield non_empty_only(app.translations.get(lang, {}))

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -1,5 +1,5 @@
 import functools
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 from django.utils.translation import gettext
 
@@ -513,7 +513,7 @@ def _create_dependencies_app_strings(app):
 
 
 def _maybe_add_index(text, app):
-    if app.build_version and app.build_version >= LooseVersion('2.8'):
+    if app.build_version and app.build_version >= parse_version('2.8'):
         sense_on = app.profile.get('features', {}).get('sense') == 'true'
         entry_mode = app.profile.get('properties', {}).get('cc-entry-mode')
         numeric_nav_on = entry_mode == 'cc-entry-review'

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -1,5 +1,4 @@
 from looseversion import LooseVersion
-from packaging.version import Version
 
 from django.conf import settings
 
@@ -13,8 +12,8 @@ class CommCareFeatureSupportMixin(object):
     def _require_minimum_version(self, minimum_version):
         if settings.UNIT_TESTING and self.build_version is None:
             return False
-        assert isinstance(self.build_version, Version)
-        assert isinstance(minimum_version, (str, Version))
+        assert isinstance(self.build_version, LooseVersion)
+        assert isinstance(minimum_version, (str, LooseVersion))
         if isinstance(minimum_version, str):
             minimum_version = LooseVersion(minimum_version)
         return self.build_version and self.build_version >= minimum_version

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -1,4 +1,5 @@
-from packaging.version import Version, parse as parse_version
+from looseversion import LooseVersion
+from packaging.version import Version
 
 from django.conf import settings
 
@@ -7,7 +8,7 @@ from corehq import toggles
 
 class CommCareFeatureSupportMixin(object):
     # overridden by subclass
-    build_version = parse_version('')
+    build_version = LooseVersion('')
 
     def _require_minimum_version(self, minimum_version):
         if settings.UNIT_TESTING and self.build_version is None:
@@ -15,7 +16,7 @@ class CommCareFeatureSupportMixin(object):
         assert isinstance(self.build_version, Version)
         assert isinstance(minimum_version, (str, Version))
         if isinstance(minimum_version, str):
-            minimum_version = parse_version(minimum_version)
+            minimum_version = LooseVersion(minimum_version)
         return self.build_version and self.build_version >= minimum_version
 
     @property

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion, Version
+from packaging.version import Version, parse as parse_version
 
 from django.conf import settings
 
@@ -7,7 +7,7 @@ from corehq import toggles
 
 class CommCareFeatureSupportMixin(object):
     # overridden by subclass
-    build_version = LooseVersion('')
+    build_version = parse_version('')
 
     def _require_minimum_version(self, minimum_version):
         if settings.UNIT_TESTING and self.build_version is None:
@@ -15,7 +15,7 @@ class CommCareFeatureSupportMixin(object):
         assert isinstance(self.build_version, Version)
         assert isinstance(minimum_version, (str, Version))
         if isinstance(minimum_version, str):
-            minimum_version = LooseVersion(minimum_version)
+            minimum_version = parse_version(minimum_version)
         return self.build_version and self.build_version >= minimum_version
 
     @property

--- a/corehq/apps/app_manager/management/commands/find_broken_builds.py
+++ b/corehq/apps/app_manager/management/commands/find_broken_builds.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 from django.core.management import BaseCommand
 
@@ -15,7 +15,7 @@ from corehq.blobs.mixin import BlobHelper
 
 def premature_auto_gps(build):
     app = Application.wrap(build)
-    if app.build_version and app.build_version >= LooseVersion('2.14'):
+    if app.build_version and app.build_version >= parse_version('2.14'):
         return
 
     for module in app.get_modules():

--- a/corehq/apps/app_manager/management/commands/find_broken_builds.py
+++ b/corehq/apps/app_manager/management/commands/find_broken_builds.py
@@ -1,4 +1,4 @@
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 
 from django.core.management import BaseCommand
 
@@ -15,7 +15,7 @@ from corehq.blobs.mixin import BlobHelper
 
 def premature_auto_gps(build):
     app = Application.wrap(build)
-    if app.build_version and app.build_version >= parse_version('2.14'):
+    if app.build_version and app.build_version >= LooseVersion('2.14'):
         return
 
     for module in app.get_modules():

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -11,7 +11,7 @@ import types
 import uuid
 from collections import Counter, OrderedDict, defaultdict, namedtuple
 from copy import deepcopy
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 from functools import wraps
 from io import BytesIO, open
 from itertools import chain
@@ -4448,11 +4448,8 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
 
     @property
     def build_version(self):
-        # `LooseVersion`s are smart!
-        # LooseVersion('2.12.0') > '2.2'
-        # (even though '2.12.0' < '2.2')
         if self.build_spec.version:
-            return LooseVersion(self.build_spec.version)
+            return parse_version(self.build_spec.version)
 
     @property
     def commcare_minor_release(self):
@@ -5615,7 +5612,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
                 setting = contingent["value"]
         if setting is not None:
             return setting
-        if not self.build_version or self.build_version < LooseVersion(yaml_setting.get("since", "0")):
+        if not self.build_version or self.build_version < parse_version(yaml_setting.get("since", "0")):
             setting = yaml_setting.get("disabled_default", None)
             if setting is not None:
                 return setting

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -11,7 +11,7 @@ import types
 import uuid
 from collections import Counter, OrderedDict, defaultdict, namedtuple
 from copy import deepcopy
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 from functools import wraps
 from io import BytesIO, open
 from itertools import chain
@@ -4448,8 +4448,11 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
 
     @property
     def build_version(self):
+        # `LooseVersion`s are smart!
+        # LooseVersion('2.12.0') > '2.2'
+        # (even though '2.12.0' < '2.2')
         if self.build_spec.version:
-            return parse_version(self.build_spec.version)
+            return LooseVersion(self.build_spec.version)
 
     @property
     def commcare_minor_release(self):
@@ -5612,7 +5615,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
                 setting = contingent["value"]
         if setting is not None:
             return setting
-        if not self.build_version or self.build_version < parse_version(yaml_setting.get("since", "0")):
+        if not self.build_version or self.build_version < LooseVersion(yaml_setting.get("since", "0")):
             setting = yaml_setting.get("disabled_default", None)
             if setting is not None:
                 return setting

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 from django.urls import reverse
 
@@ -153,7 +153,7 @@ class MediaSuiteGenerator(object):
                 m.unique_id = HQMediaMapItem.gen_unique_id(m.multimedia_id, unchanged_path)
 
             descriptor = None
-            if self.app.build_version and self.app.build_version >= LooseVersion('2.9'):
+            if self.app.build_version and self.app.build_version >= parse_version('2.9'):
                 type_mapping = {"CommCareImage": "Image",
                                 "CommCareAudio": "Audio",
                                 "CommCareVideo": "Video",

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -1,4 +1,4 @@
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 
 from django.urls import reverse
 
@@ -153,7 +153,7 @@ class MediaSuiteGenerator(object):
                 m.unique_id = HQMediaMapItem.gen_unique_id(m.multimedia_id, unchanged_path)
 
             descriptor = None
-            if self.app.build_version and self.app.build_version >= parse_version('2.9'):
+            if self.app.build_version and self.app.build_version >= LooseVersion('2.9'):
                 type_mapping = {"CommCareImage": "Image",
                                 "CommCareAudio": "Audio",
                                 "CommCareVideo": "Video",

--- a/corehq/apps/app_manager/suite_xml/sections/resources.py
+++ b/corehq/apps/app_manager/suite_xml/sections/resources.py
@@ -9,7 +9,7 @@ These external resources are text files that are also part of the application's 
 * ``LocaleResourceContributor`` handles the text files containing translations
 * ``PracticeUserRestoreContributor`` handles a dummy restore used for Practice Mode
 """
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml.contributors import SectionContributor
@@ -53,7 +53,7 @@ class FormResourceContributor(SectionContributor):
                 local=path,
                 remote=remote_path,
             )
-            if self.app.build_version and self.app.build_version >= parse_version('2.9'):
+            if self.app.build_version and self.app.build_version >= LooseVersion('2.9'):
                 default_lang = self.app.default_language if not self.build_profile_id \
                     else self.app.build_profiles[self.build_profile_id].langs[0]
                 resource.descriptor = "Form: (Module {module_name}) - {form_name}".format(
@@ -82,7 +82,7 @@ class LocaleResourceContributor(SectionContributor):
                 local=path,
                 remote=remote_path,
             )
-            if self.app.build_version and self.app.build_version >= parse_version('2.9'):
+            if self.app.build_version and self.app.build_version >= LooseVersion('2.9'):
                 unknown_lang_txt = "Unknown Language (%s)" % lang
                 resource.descriptor = "Translations: %s" % languages_mapping().get(lang, [unknown_lang_txt])[0]
             yield resource

--- a/corehq/apps/app_manager/suite_xml/sections/resources.py
+++ b/corehq/apps/app_manager/suite_xml/sections/resources.py
@@ -9,7 +9,7 @@ These external resources are text files that are also part of the application's 
 * ``LocaleResourceContributor`` handles the text files containing translations
 * ``PracticeUserRestoreContributor`` handles a dummy restore used for Practice Mode
 """
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml.contributors import SectionContributor
@@ -53,7 +53,7 @@ class FormResourceContributor(SectionContributor):
                 local=path,
                 remote=remote_path,
             )
-            if self.app.build_version and self.app.build_version >= LooseVersion('2.9'):
+            if self.app.build_version and self.app.build_version >= parse_version('2.9'):
                 default_lang = self.app.default_language if not self.build_profile_id \
                     else self.app.build_profiles[self.build_profile_id].langs[0]
                 resource.descriptor = "Form: (Module {module_name}) - {form_name}".format(
@@ -82,7 +82,7 @@ class LocaleResourceContributor(SectionContributor):
                 local=path,
                 remote=remote_path,
             )
-            if self.app.build_version and self.app.build_version >= LooseVersion('2.9'):
+            if self.app.build_version and self.app.build_version >= parse_version('2.9'):
                 unknown_lang_txt = "Unknown Language (%s)" % lang
                 resource.descriptor = "Translations: %s" % languages_mapping().get(lang, [unknown_lang_txt])[0]
             yield resource

--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -1,4 +1,3 @@
-from distutils.version import StrictVersion
 from io import BytesIO
 
 from django.test import SimpleTestCase

--- a/corehq/apps/app_manager/tests/test_commcare_versioning.py
+++ b/corehq/apps/app_manager/tests/test_commcare_versioning.py
@@ -1,0 +1,45 @@
+from looseversion import LooseVersion
+from django.test import SimpleTestCase
+
+from corehq.apps.app_manager.ui_translations.commcare_versioning import (
+    get_strict_commcare_version_string,
+)
+
+
+class TestGetStrictCommcareVersionNumber(SimpleTestCase):
+
+    def test_invalid_version_string(self):
+        self.assertEqual(get_strict_commcare_version_string('2.0.1+'), None)
+
+    def test_major_version_with_bugfix_string(self):
+        self.assertEqual(get_strict_commcare_version_string('2.0.1'), '2.0.1')
+
+    def test_major_version_string(self):
+        self.assertEqual(get_strict_commcare_version_string('2.0.0'), '2.0')
+
+    def test_major_version_with_minor_version_string(self):
+        self.assertEqual(get_strict_commcare_version_string('2.23.0'), '2.23')
+
+    def test_invalid_version_looseversion(self):
+        self.assertEqual(
+            get_strict_commcare_version_string(LooseVersion('2.0.1+')),
+            None,
+        )
+
+    def test_major_version_with_bugfix_looseversion(self):
+        self.assertEqual(
+            get_strict_commcare_version_string(LooseVersion('2.0.1')),
+            '2.0.1',
+        )
+
+    def test_major_version_looseversion(self):
+        self.assertEqual(
+            get_strict_commcare_version_string(LooseVersion('2.0.0')),
+            '2.0',
+        )
+
+    def test_major_version_with_minor_version_looseversion(self):
+        self.assertEqual(
+            get_strict_commcare_version_string(LooseVersion('2.23.0')),
+            '2.23',
+        )

--- a/corehq/apps/app_manager/tests/test_translation_file_paths.py
+++ b/corehq/apps/app_manager/tests/test_translation_file_paths.py
@@ -1,0 +1,224 @@
+from testil import eq
+
+import commcare_translations
+
+
+def test_version_paths_language_only():
+    eq(
+        commcare_translations.get_translation_file_paths('en'),
+        ['../messages_en-1.txt']
+    )
+
+
+def test_version_paths_with_two_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=2),
+        ['../messages_en-2.txt', '../messages_en-1.txt']
+    )
+
+
+def test_version_paths_with_latest_commcare_version():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=1, commcare_version='latest'),
+        ['../historical-translations-by-version/2.53-messages_en-2.txt', '../messages_en-1.txt']
+    )
+
+
+def test_version_paths_with_latest_commcare_version_and_two_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=2, commcare_version='latest'),
+        [
+            '../historical-translations-by-version/2.53-messages_en-2.txt',
+            '../messages_en-2.txt',
+            '../messages_en-1.txt',
+        ]
+    )
+
+
+def test_version_paths_with_commcare_version_less_than_2_23():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=1, commcare_version='2.2'),
+        ['../messages_en-1.txt']
+    )
+
+
+def test_version_paths_with_commcare_version_less_than_2_23_and_two_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=2, commcare_version='2.2'),
+        [
+            '../historical-translations-by-version/2.23-messages_en-2.txt',
+            '../messages_en-2.txt',
+            '../messages_en-1.txt',
+        ]
+    )
+
+
+def test_version_paths_with_commcare_version_less_than_2_23_and_three_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=3, commcare_version='2.2'),
+        ['../messages_en-3.txt', '../messages_en-2.txt', '../messages_en-1.txt']
+    )
+
+
+def test_fr_version_paths_with_commcare_version_less_than_2_23():
+    eq(
+        commcare_translations.get_translation_file_paths('fr', version=1, commcare_version='2.2'),
+        ['../messages_fr-1.txt']
+    )
+
+
+def test_fr_version_paths_with_commcare_version_less_than_2_23_and_two_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('fr', version=2, commcare_version='2.2'),
+        ['../messages_fr-2.txt', '../messages_fr-1.txt']
+    )
+
+
+def test_fr_version_paths_with_commcare_version_less_than_2_23_and_three_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('fr', version=3, commcare_version='2.2'),
+        ['../messages_fr-3.txt', '../messages_fr-2.txt', '../messages_fr-1.txt']
+    )
+
+
+def test_version_paths_with_commcare_version_later_than_2_23():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=1, commcare_version='2.42'),
+        ['../messages_en-1.txt']
+    )
+
+
+def test_version_paths_with_commcare_version_later_than_2_23_and_two_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=2, commcare_version='2.42'),
+        [
+            '../historical-translations-by-version/2.42-messages_en-2.txt',
+            '../messages_en-2.txt',
+            '../messages_en-1.txt',
+        ]
+    )
+
+
+def test_version_paths_with_commcare_version_later_than_2_23_and_three_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=3, commcare_version='2.42'),
+        ['../messages_en-3.txt', '../messages_en-2.txt', '../messages_en-1.txt']
+    )
+
+
+def test_fr_version_paths_with_commcare_version_later_than_2_23():
+    eq(
+        commcare_translations.get_translation_file_paths('fr', version=1, commcare_version='2.42'),
+        ['../messages_fr-1.txt']
+    )
+
+
+def test_fr_version_paths_with_commcare_version_later_than_2_23_and_two_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('fr', version=2, commcare_version='2.42'),
+        ['../messages_fr-2.txt', '../messages_fr-1.txt']
+    )
+
+
+def test_fr_version_paths_with_commcare_version_later_than_2_23_and_three_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('fr', version=3, commcare_version='2.42'),
+        ['../messages_fr-3.txt', '../messages_fr-2.txt', '../messages_fr-1.txt']
+    )
+
+
+def test_version_paths_with_commcare_version_less_than_2_23_with_bugfix():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=1, commcare_version='2.2.3'),
+        ['../messages_en-1.txt']
+    )
+
+
+def test_version_paths_with_commcare_version_less_than_2_23_and_two_versions_with_bugfix():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=2, commcare_version='2.2.3'),
+        [
+            '../historical-translations-by-version/2.23-messages_en-2.txt',
+            '../messages_en-2.txt',
+            '../messages_en-1.txt',
+        ]
+    )
+
+
+def test_version_paths_with_commcare_version_less_than_2_23_and_three_versions_with_bugfix():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=3, commcare_version='2.2.3'),
+        ['../messages_en-3.txt', '../messages_en-2.txt', '../messages_en-1.txt']
+    )
+
+
+def test_version_paths_with_commcare_version_2_23_with_bugfix():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=1, commcare_version='2.23.3'),
+        ['../messages_en-1.txt']
+    )
+
+
+def test_version_paths_with_commcare_version_2_23_and_two_versions_with_bugfix():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=2, commcare_version='2.23.3'),
+        [
+            '../historical-translations-by-version/2.23.3-messages_en-2.txt',
+            '../historical-translations-by-version/2.23.2-messages_en-2.txt',
+            '../historical-translations-by-version/2.23.1-messages_en-2.txt',
+            '../historical-translations-by-version/2.23-messages_en-2.txt',
+            '../messages_en-2.txt',
+            '../messages_en-1.txt',
+        ]
+    )
+
+
+def test_version_paths_with_commcare_version_2_23_and_three_versions_with_bugfix():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=3, commcare_version='2.23.3'),
+        ['../messages_en-3.txt', '../messages_en-2.txt', '../messages_en-1.txt']
+    )
+
+
+def test_version_paths_with_commcare_version_2_23_beta_and_two_versions_with_bugfix():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=2, commcare_version='2.23.3beta2'),
+        [
+            '../historical-translations-by-version/2.23.3-messages_en-2.txt',
+            '../historical-translations-by-version/2.23.2-messages_en-2.txt',
+            '../historical-translations-by-version/2.23.1-messages_en-2.txt',
+            '../historical-translations-by-version/2.23-messages_en-2.txt',
+            '../messages_en-2.txt',
+            '../messages_en-1.txt',
+        ]
+    )
+
+
+def test_version_paths_with_commcare_version_2_23_beta_and_two_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=2, commcare_version='2.23beta2'),
+        [
+            '../historical-translations-by-version/2.23-messages_en-2.txt',
+            '../messages_en-2.txt',
+            '../messages_en-1.txt',
+        ]
+    )
+
+
+def test_version_paths_with_commcare_version_2_23_invalid_and_two_versions():
+    # 2.23++ should return commcare_version = None
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=2, commcare_version='2.23++'),
+        ['../messages_en-2.txt', '../messages_en-1.txt']
+    )
+
+
+def test_version_paths_with_commcare_version_3_two_versions():
+    eq(
+        commcare_translations.get_translation_file_paths('en', version=2, commcare_version='3.0.0'),
+        [
+            '../historical-translations-by-version/3.0-messages_en-2.txt',
+            '../messages_en-2.txt',
+            '../messages_en-1.txt',
+        ]
+    )

--- a/corehq/apps/app_manager/ui_translations/commcare_versioning.py
+++ b/corehq/apps/app_manager/ui_translations/commcare_versioning.py
@@ -1,4 +1,4 @@
-from packaging.version import Version as StrictVersion
+from looseversion import LooseVersion
 
 import openpyxl
 
@@ -14,14 +14,14 @@ def get_commcare_version_from_workbook(workbook):
             if keyword.startswith(KEYWORD_PREFIX):
                 version = keyword[len(KEYWORD_PREFIX):]
                 try:
-                    return str(StrictVersion(version))
+                    return str(LooseVersion(version))
                 except ValueError:
                     pass
 
 
 def set_commcare_version_in_workbook(workbook, commcare_version):
     try:
-        commcare_version = str(StrictVersion(commcare_version))
+        commcare_version = str(LooseVersion(commcare_version))
     except ValueError:
         return
     assert isinstance(workbook, openpyxl.Workbook)

--- a/corehq/apps/app_manager/ui_translations/commcare_versioning.py
+++ b/corehq/apps/app_manager/ui_translations/commcare_versioning.py
@@ -1,4 +1,4 @@
-from packaging.version import Version
+from packaging.version import Version as StrictVersion
 
 import openpyxl
 
@@ -14,14 +14,14 @@ def get_commcare_version_from_workbook(workbook):
             if keyword.startswith(KEYWORD_PREFIX):
                 version = keyword[len(KEYWORD_PREFIX):]
                 try:
-                    return str(Version(version))
+                    return str(StrictVersion(version))
                 except ValueError:
                     pass
 
 
 def set_commcare_version_in_workbook(workbook, commcare_version):
     try:
-        commcare_version = str(Version(commcare_version))
+        commcare_version = str(StrictVersion(commcare_version))
     except ValueError:
         return
     assert isinstance(workbook, openpyxl.Workbook)

--- a/corehq/apps/app_manager/ui_translations/commcare_versioning.py
+++ b/corehq/apps/app_manager/ui_translations/commcare_versioning.py
@@ -1,8 +1,26 @@
 from looseversion import LooseVersion
+from packaging.version import Version, InvalidVersion
 
 import openpyxl
 
 KEYWORD_PREFIX = 'CommCareVersion='
+
+
+def get_strict_commcare_version_string(version):
+    """This replaces our usage of distutils.version.StrictVersion when ensuring
+    that a version numbering format correctly follows an expected major.minor.patch versioning scheme.
+    """
+    if isinstance(version, LooseVersion):
+        version = version.vstring
+    try:
+        strict_version = Version(version)
+        if strict_version.micro > 0:
+            return '{}.{}.{}'.format(
+                strict_version.major, strict_version.minor, strict_version.micro
+            )
+        return '{}.{}'.format(strict_version.major, strict_version.minor)
+    except InvalidVersion:
+        return
 
 
 def get_commcare_version_from_workbook(workbook):
@@ -13,17 +31,17 @@ def get_commcare_version_from_workbook(workbook):
         for keyword in keywords:
             if keyword.startswith(KEYWORD_PREFIX):
                 version = keyword[len(KEYWORD_PREFIX):]
-                try:
-                    return str(LooseVersion(version))
-                except ValueError:
+                version = get_strict_commcare_version_string(version)
+                if version is None:
                     pass
+                return version
 
 
 def set_commcare_version_in_workbook(workbook, commcare_version):
-    try:
-        commcare_version = str(LooseVersion(commcare_version))
-    except ValueError:
+    commcare_version = get_strict_commcare_version_string(commcare_version)
+    if commcare_version is None:
         return
+
     assert isinstance(workbook, openpyxl.Workbook)
     keywords = workbook.properties.keywords
     if keywords:

--- a/corehq/apps/app_manager/ui_translations/commcare_versioning.py
+++ b/corehq/apps/app_manager/ui_translations/commcare_versioning.py
@@ -1,4 +1,4 @@
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 import openpyxl
 
@@ -14,14 +14,14 @@ def get_commcare_version_from_workbook(workbook):
             if keyword.startswith(KEYWORD_PREFIX):
                 version = keyword[len(KEYWORD_PREFIX):]
                 try:
-                    return str(StrictVersion(version))
+                    return str(Version(version))
                 except ValueError:
                     pass
 
 
 def set_commcare_version_in_workbook(workbook, commcare_version):
     try:
-        commcare_version = str(StrictVersion(commcare_version))
+        commcare_version = str(Version(commcare_version))
     except ValueError:
         return
     assert isinstance(workbook, openpyxl.Workbook)

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -1,7 +1,6 @@
 import io
 import re
 from collections import defaultdict
-from looseversion import LooseVersion
 
 from django.utils.translation import gettext as _
 

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -1,7 +1,6 @@
 import io
 import re
 from collections import defaultdict
-from packaging.version import Version as StrictVersion
 
 from django.utils.translation import gettext as _
 
@@ -128,7 +127,7 @@ def build_ui_translation_download_file(app):
 
     rows = list(row_dict.values())
     try:
-        commcare_version = str(StrictVersion(app.build_version.vstring))
+        commcare_version = str(app.build_version)
     except ValueError:
         commcare_version = None
 

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -12,6 +12,7 @@ from corehq.apps.app_manager import app_strings
 from corehq.apps.app_manager.ui_translations.commcare_versioning import (
     get_commcare_version_from_workbook,
     set_commcare_version_in_workbook,
+    get_strict_commcare_version_string,
 )
 from corehq.apps.translations.models import TransifexBlacklist
 from corehq.util.workbook_json.excel import (
@@ -127,10 +128,7 @@ def build_ui_translation_download_file(app):
             row_dict[prop].append(trans)
 
     rows = list(row_dict.values())
-    try:
-        commcare_version = str(LooseVersion(app.build_version.vstring))
-    except ValueError:
-        commcare_version = None
+    commcare_version = get_strict_commcare_version_string(app.build_version)
 
     all_prop_trans = get_default_translations_for_download(app, commcare_version)
     rows.extend([[t] for t in sorted(all_prop_trans.keys()) if t not in row_dict and t not in blacklist])

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -1,7 +1,7 @@
 import io
 import re
 from collections import defaultdict
-from packaging.version import Version
+from packaging.version import Version as StrictVersion
 
 from django.utils.translation import gettext as _
 
@@ -128,7 +128,7 @@ def build_ui_translation_download_file(app):
 
     rows = list(row_dict.values())
     try:
-        commcare_version = str(Version(app.build_version.vstring))
+        commcare_version = str(StrictVersion(app.build_version.vstring))
     except ValueError:
         commcare_version = None
 

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -1,7 +1,7 @@
 import io
 import re
 from collections import defaultdict
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 from django.utils.translation import gettext as _
 
@@ -128,7 +128,7 @@ def build_ui_translation_download_file(app):
 
     rows = list(row_dict.values())
     try:
-        commcare_version = str(StrictVersion(app.build_version.vstring))
+        commcare_version = str(Version(app.build_version.vstring))
     except ValueError:
         commcare_version = None
 

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -1,6 +1,7 @@
 import io
 import re
 from collections import defaultdict
+from packaging.version import Version as StrictVersion
 
 from django.utils.translation import gettext as _
 
@@ -127,7 +128,7 @@ def build_ui_translation_download_file(app):
 
     rows = list(row_dict.values())
     try:
-        commcare_version = str(app.build_version)
+        commcare_version = str(StrictVersion(app.build_version.vstring))
     except ValueError:
         commcare_version = None
 

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -1,7 +1,7 @@
 import io
 import re
 from collections import defaultdict
-from packaging.version import Version as StrictVersion
+from looseversion import LooseVersion
 
 from django.utils.translation import gettext as _
 
@@ -128,7 +128,7 @@ def build_ui_translation_download_file(app):
 
     rows = list(row_dict.values())
     try:
-        commcare_version = str(StrictVersion(app.build_version.vstring))
+        commcare_version = str(LooseVersion(app.build_version.vstring))
     except ValueError:
         commcare_version = None
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections import OrderedDict
 from functools import partial
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 from django.contrib import messages
 from django.http import (
@@ -565,7 +565,7 @@ def _case_list_form_not_allowed_reasons(module):
                          "which means that registration forms must go in a different case list"))
     if hasattr(module, 'parent_select'):
         app = module.get_app()
-        if (not app.build_version or app.build_version < LooseVersion('2.23')) and module.parent_select.active:
+        if (not app.build_version or app.build_version < parse_version('2.23')) and module.parent_select.active:
             reasons.append(_("'Parent Selection' is configured"))
     return reasons
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections import OrderedDict
 from functools import partial
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 
 from django.contrib import messages
 from django.http import (
@@ -565,7 +565,7 @@ def _case_list_form_not_allowed_reasons(module):
                          "which means that registration forms must go in a different case list"))
     if hasattr(module, 'parent_select'):
         app = module.get_app()
-        if (not app.build_version or app.build_version < parse_version('2.23')) and module.parent_select.active:
+        if (not app.build_version or app.build_version < LooseVersion('2.23')) and module.parent_select.active:
             reasons.append(_("'Parent Selection' is configured"))
     return reasons
 

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from distutils.version import StrictVersion
+from packaging.version import Version
 from itertools import groupby
 from zipfile import ZipFile
 
@@ -239,7 +239,7 @@ class BuildSpec(DocumentSchema):
     def release_greater_than_or_equal_to(self, version):
         if not self.version:
             return False
-        return StrictVersion(self.version) >= StrictVersion(version)
+        return Version(self.version) >= Version(version)
 
 
 class BuildMenuItem(DocumentSchema):

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from packaging.version import Version
+from packaging.version import Version as StrictVersion
 from itertools import groupby
 from zipfile import ZipFile
 
@@ -239,7 +239,7 @@ class BuildSpec(DocumentSchema):
     def release_greater_than_or_equal_to(self, version):
         if not self.version:
             return False
-        return Version(self.version) >= Version(version)
+        return StrictVersion(self.version) >= StrictVersion(version)
 
 
 class BuildMenuItem(DocumentSchema):

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from packaging.version import Version as StrictVersion
+from looseversion import LooseVersion
 from itertools import groupby
 from zipfile import ZipFile
 
@@ -239,7 +239,7 @@ class BuildSpec(DocumentSchema):
     def release_greater_than_or_equal_to(self, version):
         if not self.version:
             return False
-        return StrictVersion(self.version) >= StrictVersion(version)
+        return LooseVersion(self.version) >= LooseVersion(version)
 
 
 class BuildMenuItem(DocumentSchema):

--- a/corehq/apps/hqadmin/management/commands/clean_2fa_sessions.py
+++ b/corehq/apps/hqadmin/management/commands/clean_2fa_sessions.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 from getpass import getpass
 from importlib import import_module
 from pkg_resources import DistributionNotFound, get_distribution
@@ -34,7 +34,7 @@ class Command(BaseCommand):
             print("DRY RUN sessions will not be modified")
 
         tf_ver = get_two_factor_version()
-        if tf_ver and LooseVersion(tf_ver) < LooseVersion("1.12"):
+        if tf_ver and parse_version(tf_ver) < parse_version("1.12"):
             print(f"WARNING old/insecure django-two-factor-auth version detected: {tf_ver}")
             print("Please run this tool again after upgrading.")
         else:

--- a/corehq/apps/hqadmin/management/commands/clean_2fa_sessions.py
+++ b/corehq/apps/hqadmin/management/commands/clean_2fa_sessions.py
@@ -1,4 +1,4 @@
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 from getpass import getpass
 from importlib import import_module
 from pkg_resources import DistributionNotFound, get_distribution
@@ -34,7 +34,7 @@ class Command(BaseCommand):
             print("DRY RUN sessions will not be modified")
 
         tf_ver = get_two_factor_version()
-        if tf_ver and parse_version(tf_ver) < parse_version("1.12"):
+        if tf_ver and LooseVersion(tf_ver) < LooseVersion("1.12"):
             print(f"WARNING old/insecure django-two-factor-auth version detected: {tf_ver}")
             print("Please run this tool again after upgrading.")
         else:

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 from urllib.parse import unquote
 
 from django.conf import settings
@@ -274,7 +274,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     async_restore_enabled = (
         toggles.ASYNC_RESTORE.enabled(domain)
         and openrosa_version
-        and parse_version(openrosa_version) >= parse_version(OPENROSA_VERSION_MAP['ASYNC_RESTORE'])
+        and LooseVersion(openrosa_version) >= LooseVersion(OPENROSA_VERSION_MAP['ASYNC_RESTORE'])
     )
 
     # Ensure fixtures are included if sync is full rather than incremental

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 from urllib.parse import unquote
 
 from django.conf import settings
@@ -274,7 +274,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     async_restore_enabled = (
         toggles.ASYNC_RESTORE.enabled(domain)
         and openrosa_version
-        and LooseVersion(openrosa_version) >= LooseVersion(OPENROSA_VERSION_MAP['ASYNC_RESTORE'])
+        and parse_version(openrosa_version) >= parse_version(OPENROSA_VERSION_MAP['ASYNC_RESTORE'])
     )
 
     # Ensure fixtures are included if sync is full rather than incremental

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 from casexml.apps.phone.fixtures import FixtureProvider
 
@@ -58,7 +58,7 @@ class ProductFixturesProvider(FixtureProvider):
     def __call__(self, restore_state):
         indexed = (
             not restore_state.params.openrosa_version
-            or restore_state.params.openrosa_version >= LooseVersion(OPENROSA_VERSION_MAP['INDEXED_PRODUCTS_FIXTURE'])
+            or restore_state.params.openrosa_version >= parse_version(OPENROSA_VERSION_MAP['INDEXED_PRODUCTS_FIXTURE'])
         )
 
         fixture_nodes = self._get_fixture_items(restore_state, indexed)

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -1,4 +1,4 @@
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 
 from casexml.apps.phone.fixtures import FixtureProvider
 
@@ -58,7 +58,7 @@ class ProductFixturesProvider(FixtureProvider):
     def __call__(self, restore_state):
         indexed = (
             not restore_state.params.openrosa_version
-            or restore_state.params.openrosa_version >= parse_version(OPENROSA_VERSION_MAP['INDEXED_PRODUCTS_FIXTURE'])
+            or restore_state.params.openrosa_version >= LooseVersion(OPENROSA_VERSION_MAP['INDEXED_PRODUCTS_FIXTURE'])
         )
 
         fixture_nodes = self._get_fixture_items(restore_state, indexed)

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -103,13 +103,13 @@ def _validate_indices(case_db, case_updates):
                     invalid = False
                 if invalid:
                     # fail hard on invalid indices
-                    from distutils.version import LooseVersion
+                    from packaging.version import parse as parse_version
                     if case_db.cached_xforms and case_db.domain != 'commcare-tests':
                         xform = case_db.cached_xforms[0]
                         if xform.metadata and xform.metadata.commcare_version:
                             commcare_version = xform.metadata.commcare_version
                             _soft_assert(
-                                commcare_version < LooseVersion("2.39"),
+                                commcare_version < parse_version("2.39"),
                                 "Invalid Case Index in CC version >= 2.39", {
                                     'domain': case_db.domain,
                                     'xform_id': xform.form_id,

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -103,13 +103,13 @@ def _validate_indices(case_db, case_updates):
                     invalid = False
                 if invalid:
                     # fail hard on invalid indices
-                    from packaging.version import parse as parse_version
+                    from looseversion import LooseVersion
                     if case_db.cached_xforms and case_db.domain != 'commcare-tests':
                         xform = case_db.cached_xforms[0]
                         if xform.metadata and xform.metadata.commcare_version:
                             commcare_version = xform.metadata.commcare_version
                             _soft_assert(
-                                commcare_version < parse_version("2.39"),
+                                commcare_version < LooseVersion("2.39"),
                                 "Invalid Case Index in CC version >= 2.39", {
                                     'domain': case_db.domain,
                                     'xform_id': xform.form_id,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 import uuid
 from datetime import datetime, timedelta
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 from io import BytesIO
 from typing import Optional
 from uuid import uuid4
@@ -299,7 +299,7 @@ class RestoreParams(object):
         self.include_item_count = include_item_count
         self.app = app
         self.device_id = device_id
-        self.openrosa_version = (parse_version(openrosa_version)
+        self.openrosa_version = (LooseVersion(openrosa_version)
             if isinstance(openrosa_version, str) else openrosa_version)
 
     @property

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 import uuid
 from datetime import datetime, timedelta
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 from io import BytesIO
 from typing import Optional
 from uuid import uuid4
@@ -299,7 +299,7 @@ class RestoreParams(object):
         self.include_item_count = include_item_count
         self.app = app
         self.device_id = device_id
-        self.openrosa_version = (LooseVersion(openrosa_version)
+        self.openrosa_version = (parse_version(openrosa_version)
             if isinstance(openrosa_version, str) else openrosa_version)
 
     @property

--- a/corehq/form_processor/casedb_base.py
+++ b/corehq/form_processor/casedb_base.py
@@ -154,11 +154,11 @@ class AbstractCaseDbCache(metaclass=ABCMeta):
         actions = {action.action_type_slug for action in case_update.actions}
         if case is None:
             if xform.metadata and xform.metadata.commcare_version:
-                from packaging.version import parse as parse_version
+                from looseversion import LooseVersion
                 commcare_version = xform.metadata.commcare_version
                 message = "Case created without create block"
                 send_to = None
-                if commcare_version >= parse_version("2.44"):
+                if commcare_version >= LooseVersion("2.44"):
                     send_to = "{}@{}.com".format('skelly', 'dimagi')
                     message += " in CC version >= 2.44"
                 soft_assert(to=send_to)(

--- a/corehq/form_processor/casedb_base.py
+++ b/corehq/form_processor/casedb_base.py
@@ -154,11 +154,11 @@ class AbstractCaseDbCache(metaclass=ABCMeta):
         actions = {action.action_type_slug for action in case_update.actions}
         if case is None:
             if xform.metadata and xform.metadata.commcare_version:
-                from distutils.version import LooseVersion
+                from packaging.version import parse as parse_version
                 commcare_version = xform.metadata.commcare_version
                 message = "Case created without create block"
                 send_to = None
-                if commcare_version >= LooseVersion("2.44"):
+                if commcare_version >= parse_version("2.44"):
                     send_to = "{}@{}.com".format('skelly', 'dimagi')
                     message += " in CC version >= 2.44"
                 soft_assert(to=send_to)(

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -798,7 +798,7 @@ class XFormPhoneMetadata(jsonobject.JsonObject):
     @property
     def commcare_version(self):
         from corehq.apps.receiverwrapper.util import get_commcare_version_from_appversion_text
-        from packaging.version import parse as parse_version
+        from looseversion import LooseVersion
         version_text = get_commcare_version_from_appversion_text(self.appVersion)
         if version_text:
-            return parse_version(version_text)
+            return LooseVersion(version_text)

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -798,7 +798,7 @@ class XFormPhoneMetadata(jsonobject.JsonObject):
     @property
     def commcare_version(self):
         from corehq.apps.receiverwrapper.util import get_commcare_version_from_appversion_text
-        from distutils.version import LooseVersion
+        from packaging.version import parse as parse_version
         version_text = get_commcare_version_from_appversion_text(self.appVersion)
         if version_text:
-            return LooseVersion(version_text)
+            return parse_version(version_text)

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -3,7 +3,7 @@ import re
 import sys
 import traceback
 from datetime import datetime, timedelta
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 from django.utils.translation import gettext_lazy as _
 
@@ -78,7 +78,7 @@ class Dhis2Instance(Document):
         except Dhis2Exception as err:
             requests.notify_exception(str(err))
             raise
-        if LooseVersion(dhis2_version) > DHIS2_MAX_KNOWN_GOOD_VERSION:
+        if parse_version(dhis2_version) > DHIS2_MAX_KNOWN_GOOD_VERSION:
             requests.notify_error(
                 "Integration has not yet been tested for DHIS2 version "
                 f"{dhis2_version}. Its API may not be supported."
@@ -268,7 +268,7 @@ class SQLDhis2Instance(object):
         except Dhis2Exception as err:
             requests.notify_exception(str(err))
             raise
-        if LooseVersion(dhis2_version) > DHIS2_MAX_KNOWN_GOOD_VERSION:
+        if parse_version(dhis2_version) > DHIS2_MAX_KNOWN_GOOD_VERSION:
             requests.notify_error(
                 "Integration has not yet been tested for DHIS2 version "
                 f"{dhis2_version}. Its API may not be supported."
@@ -448,7 +448,7 @@ def get_api_version(dhis2_version):
     .. _DHIS 2 Developer guide: https://docs.dhis2.org/master/en/developer/html/webapi_browsing_the_web_api.html#webapi_api_versions
     """
     try:
-        api_version = LooseVersion(dhis2_version).version[1]
+        api_version = parse_version(dhis2_version).version[1]
     except (AttributeError, IndexError):
         raise Dhis2Exception(f"Unable to parse DHIS2 version {dhis2_version}.")
     return api_version

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -3,7 +3,7 @@ import re
 import sys
 import traceback
 from datetime import datetime, timedelta
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 
 from django.utils.translation import gettext_lazy as _
 
@@ -78,7 +78,7 @@ class Dhis2Instance(Document):
         except Dhis2Exception as err:
             requests.notify_exception(str(err))
             raise
-        if parse_version(dhis2_version) > DHIS2_MAX_KNOWN_GOOD_VERSION:
+        if LooseVersion(dhis2_version) > DHIS2_MAX_KNOWN_GOOD_VERSION:
             requests.notify_error(
                 "Integration has not yet been tested for DHIS2 version "
                 f"{dhis2_version}. Its API may not be supported."
@@ -268,7 +268,7 @@ class SQLDhis2Instance(object):
         except Dhis2Exception as err:
             requests.notify_exception(str(err))
             raise
-        if parse_version(dhis2_version) > DHIS2_MAX_KNOWN_GOOD_VERSION:
+        if LooseVersion(dhis2_version) > DHIS2_MAX_KNOWN_GOOD_VERSION:
             requests.notify_error(
                 "Integration has not yet been tested for DHIS2 version "
                 f"{dhis2_version}. Its API may not be supported."
@@ -448,7 +448,7 @@ def get_api_version(dhis2_version):
     .. _DHIS 2 Developer guide: https://docs.dhis2.org/master/en/developer/html/webapi_browsing_the_web_api.html#webapi_api_versions
     """
     try:
-        api_version = parse_version(dhis2_version).version[1]
+        api_version = LooseVersion(dhis2_version).version[1]
     except (AttributeError, IndexError):
         raise Dhis2Exception(f"Unable to parse DHIS2 version {dhis2_version}.")
     return api_version

--- a/corehq/motech/dhis2/tests/test_repeaters.py
+++ b/corehq/motech/dhis2/tests/test_repeaters.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime
 
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 from unittest import skip
 
 from django.test import SimpleTestCase, TestCase
@@ -226,7 +226,7 @@ class SlowApiVersionTest(TestCase):
             mock_fetch.assert_called()
 
     def test_max_version_exceeded_notifies_admins(self):
-        major_ver, max_api_ver, patch_ver = parse_version(KNOWN_GOOD).version
+        major_ver, max_api_ver, patch_ver = LooseVersion(KNOWN_GOOD).version
         bigly_api_version = max_api_ver + 1
         bigly_dhis2_version = f"{major_ver}.{bigly_api_version}.{patch_ver}"
         with patch('corehq.motech.dhis2.repeaters.fetch_metadata') as mock_fetch, \

--- a/corehq/motech/dhis2/tests/test_repeaters.py
+++ b/corehq/motech/dhis2/tests/test_repeaters.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime
 
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 from unittest import skip
 
 from django.test import SimpleTestCase, TestCase
@@ -226,7 +226,7 @@ class SlowApiVersionTest(TestCase):
             mock_fetch.assert_called()
 
     def test_max_version_exceeded_notifies_admins(self):
-        major_ver, max_api_ver, patch_ver = LooseVersion(KNOWN_GOOD).version
+        major_ver, max_api_ver, patch_ver = parse_version(KNOWN_GOOD).version
         bigly_api_version = max_api_ver + 1
         bigly_dhis2_version = f"{major_ver}.{bigly_api_version}.{patch_ver}"
         with patch('corehq.motech.dhis2.repeaters.fetch_metadata') as mock_fetch, \

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -2,7 +2,7 @@ import random
 import re
 import uuid
 from collections import defaultdict
-from packaging.version import Version
+from packaging.version import parse as parse_version
 from functools import wraps
 
 from django.conf import settings
@@ -19,7 +19,7 @@ from psycopg2._psycopg import InterfaceError as Psycopg2InterfaceError
 ACCEPTABLE_STANDBY_DELAY_SECONDS = 3
 STALE_CHECK_FREQUENCY = 30
 
-PG_V10 = Version('10.0.0')
+PG_V10 = parse_version('10.0.0')
 
 REPLICATION_SQL_10 = """
     SELECT
@@ -282,7 +282,7 @@ def get_db_version(db_alias):
         cursor.execute('SHOW SERVER_VERSION;')
         raw_version = cursor.fetchone()[0]
 
-    return Version(raw_version.split(' ')[0])
+    return parse_version(raw_version.split(' ')[0])
 
 
 def get_replication_delay_for_standby(db_alias):

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -2,7 +2,7 @@ import random
 import re
 import uuid
 from collections import defaultdict
-from distutils.version import LooseVersion
+from packaging.version import Version
 from functools import wraps
 
 from django.conf import settings
@@ -19,7 +19,7 @@ from psycopg2._psycopg import InterfaceError as Psycopg2InterfaceError
 ACCEPTABLE_STANDBY_DELAY_SECONDS = 3
 STALE_CHECK_FREQUENCY = 30
 
-PG_V10 = LooseVersion('10.0.0')
+PG_V10 = Version('10.0.0')
 
 REPLICATION_SQL_10 = """
     SELECT
@@ -282,7 +282,7 @@ def get_db_version(db_alias):
         cursor.execute('SHOW SERVER_VERSION;')
         raw_version = cursor.fetchone()[0]
 
-    return LooseVersion(raw_version.split(' ')[0])
+    return Version(raw_version.split(' ')[0])
 
 
 def get_replication_delay_for_standby(db_alias):

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -2,7 +2,7 @@ import random
 import re
 import uuid
 from collections import defaultdict
-from packaging.version import parse as parse_version
+from looseversion import LooseVersion
 from functools import wraps
 
 from django.conf import settings
@@ -19,7 +19,7 @@ from psycopg2._psycopg import InterfaceError as Psycopg2InterfaceError
 ACCEPTABLE_STANDBY_DELAY_SECONDS = 3
 STALE_CHECK_FREQUENCY = 30
 
-PG_V10 = parse_version('10.0.0')
+PG_V10 = LooseVersion('10.0.0')
 
 REPLICATION_SQL_10 = """
     SELECT
@@ -282,7 +282,7 @@ def get_db_version(db_alias):
         cursor.execute('SHOW SERVER_VERSION;')
         raw_version = cursor.fetchone()[0]
 
-    return parse_version(raw_version.split(' ')[0])
+    return LooseVersion(raw_version.split(' ')[0])
 
 
 def get_replication_delay_for_standby(db_alias):

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -22,6 +22,7 @@ WHITELIST = [
     ("compressor.filters.base", "smart_text() is deprecated"),
     ("compressor.signals", "The providing_args argument is deprecated."),
     ("couchdbkit.schema.properties", "'collections.abc'"),
+    ("distutils", "distutils Version classes are deprecated. Use packaging.version instead."),
     ("django.apps", re.compile(r"'(" + "|".join(re.escape(app) for app in [
         "captcha",
         "django_celery_results",

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -37,6 +37,8 @@ WHITELIST = [
     ("tastypie", "request.is_ajax() is deprecated"),
     ("nose.suite", "'collections.abc'"),
     ("nose.plugins.collect", "'collections.abc'"),
+    ("packaging.version",
+     "Creating a LegacyVersion has been deprecated and will be removed in the next major release"),
 
     # warnings that can be resolved with HQ code changes
     ("", "json_response is deprecated.  Use django.http.JsonResponse instead."),

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -37,8 +37,6 @@ WHITELIST = [
     ("tastypie", "request.is_ajax() is deprecated"),
     ("nose.suite", "'collections.abc'"),
     ("nose.plugins.collect", "'collections.abc'"),
-    ("packaging.version",
-     "Creating a LegacyVersion has been deprecated and will be removed in the next major release"),
 
     # warnings that can be resolved with HQ code changes
     ("", "json_response is deprecated.  Use django.http.JsonResponse instead."),

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -22,7 +22,6 @@ WHITELIST = [
     ("compressor.filters.base", "smart_text() is deprecated"),
     ("compressor.signals", "The providing_args argument is deprecated."),
     ("couchdbkit.schema.properties", "'collections.abc'"),
-    ("distutils", "distutils Version classes are deprecated. Use packaging.version instead."),
     ("django.apps", re.compile(r"'(" + "|".join(re.escape(app) for app in [
         "captcha",
         "django_celery_results",
@@ -47,6 +46,7 @@ WHITELIST = [
 
     # other, resolution not obvious
     ("IPython.core.interactiveshell", "install IPython inside the virtualenv.", UserWarning),
+    ("redis.connection", "distutils Version classes are deprecated. Use packaging.version instead."),
     ("sqlalchemy.", re.compile(r"^Predicate of partial index .* ignored during reflection"), SAWarning),
     ("sqlalchemy.",
         "Skipped unsupported reflection of expression-based index form_processor_xformattachmentsql_blobmeta_key",

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -63,6 +63,7 @@ jsonpath-ng @ https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_
 jsonschema
 kafka-python
 laboratory
+looseversion
 lxml
 markdown
 oic

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -731,7 +731,7 @@ zope-interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.3.1
     # via pip-tools
-setuptools==50.3.0
+setuptools==65.5.1
     # via
     #   django-websocket-redis
     #   gevent

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -331,6 +331,8 @@ kombu==5.2.4
     # via celery
 laboratory==0.2.0
     # via -r base-requirements.in
+looseversion==1.0.3
+    # via -r base-requirements.in
 lxml==4.9.1
     # via
     #   -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -279,6 +279,8 @@ kombu==5.2.4
     # via celery
 laboratory==0.2.0
     # via -r base-requirements.in
+looseversion==1.0.3
+    # via -r base-requirements.in
 lxml==4.9.1
     # via
     #   -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -283,6 +283,8 @@ kombu==5.2.4
     # via celery
 laboratory==0.2.0
     # via -r base-requirements.in
+looseversion==1.0.3
+    # via -r base-requirements.in
 lxml==4.9.1
     # via
     #   -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -595,7 +595,7 @@ zope-interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.0.4
     # via -r prod-requirements.in
-setuptools==50.3.0
+setuptools==65.5.1
     # via
     #   django-websocket-redis
     #   gevent

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -263,6 +263,8 @@ kombu==5.2.4
     # via celery
 laboratory==0.2.0
     # via -r base-requirements.in
+looseversion==1.0.3
+    # via -r base-requirements.in
 lxml==4.9.1
     # via
     #   -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -534,7 +534,7 @@ zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==50.3.0
+setuptools==65.5.1
     # via
     #   django-websocket-redis
     #   gevent

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -284,6 +284,8 @@ kombu==5.2.4
     # via celery
 laboratory==0.2.0
     # via -r base-requirements.in
+looseversion==1.0.3
+    # via -r base-requirements.in
 lxml==4.9.1
     # via
     #   -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -601,7 +601,7 @@ zope-interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.3.1
     # via pip-tools
-setuptools==50.3.0
+setuptools==65.5.1
     # via
     #   django-websocket-redis
     #   gevent


### PR DESCRIPTION
## Technical Summary
following the security update referenced here https://dimagi-dev.atlassian.net/browse/SAAS-14248
superseding [this dependabot PR](https://github.com/dimagi/commcare-hq/pull/32443) because tests keep failing due to docker credentials

## Safety Assurance

### Safety story
when tests pass ✅ 

### Automated test coverage
Yes

### QA Plan
N/A because if tests pass, we are clear


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
