### PR TITLE
[B5] compile sass with django compressor using dart sass (requires commcare-cloud update and maintenance)

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,90 @@
+scss_files: 'assets/style/**/*.css.scss'
+
+linters:
+  BorderZero:
+    enabled: false
+  Indentation:
+    severity: warning
+    width: 2
+  StringQuotes:
+    enabled: true
+  UrlQuotes:
+    enabled: true
+  BangFormat:
+    enabled: true
+  ColorKeyword:
+    enabled: false
+  ColorVariable:
+    enabled: true
+  Comment:
+    enabled: true
+  DebugStatement:
+    enabled: true
+  DeclarationOrder:
+    enabled: true
+  DuplicateProperty:
+    enabled: true
+  ElsePlacement:
+    enabled: true
+  EmptyLineBetweenBlocks:
+    enabled: true
+  EmptyRule:
+    enabled: true
+  FinalNewline:
+    enabled: true
+  HexLength:
+    style: long
+  HexValidation:
+    enabled: true
+  ImportPath:
+    enabled: true
+  LengthVariable:
+    enabled: false
+  MergeableSelector:
+    enabled: true
+  NameFormat:
+    enabled: true
+  NestingDepth:
+    enabled: true
+    max_depth: 3
+  PlaceholderInExtend:
+    enabled: true
+  PrivateNamingConvention:
+    enabled: true
+  PropertySpelling:
+    enabled: true
+  PropertySortOrder:
+    enabled: true
+  PropertyCount:
+    enabled: true
+  PropertyUnits:
+    enabled: true
+    properties:
+      border: ['px']
+      margin: ['px', '%']
+      font-size: ['px', '%', 'em']
+      line-height: ['px']
+  PseudoElement:
+    enabled: true
+  QualifyingElement:
+    enabled: false
+  SelectorDepth:
+    enabled: true
+  SelectorFormat:
+    enabled: true
+    convention: hyphenated_lowercase
+  SingleLinePerProperty:
+    enabled: true
+  Shorthand:
+    enabled: true
+    allowed_shorthands: [1, 2, 3, 4]
+  SingleLinePerSelector:
+    enabled: true
+  SpaceAfterComma:
+    enabled: true
+  SpaceAfterComment:
+    enabled: true
+  SpaceAfterPropertyColon:
+    enabled: true
+  SpaceAfterPropertyName:
+    enabled: true

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -507,7 +507,20 @@ command that sets the stored index names to the aliases.
 ./manage.py ptop_es_manage --flip_all_aliases
 ```
 
-### Step 7: Installing JavaScript Requirements
+### Step 7: Installing JavaScript and Front-End Requirements
+
+#### Install Dart Sass
+
+We are transitioning to using `sass`/`scss` for our stylesheets. In order to compile `*.scss`,
+Dart Sass is required.
+
+We recommend using `npm` to install this globally with:
+```
+npm install -g sass
+```
+
+You can also [follow the instructions here](https://sass-lang.com/install) if you encounter issues with this method.
+
 
 #### Installing Yarn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN npm -g install \
     uglify-js \
     puppeteer \
     mocha-headless-chrome \
+    sass \
  && cd /vendor \
  && npm shrinkwrap \
  && yarn global add phantomjs-prebuilt

--- a/corehq/apps/hqwebapp/precompilers.py
+++ b/corehq/apps/hqwebapp/precompilers.py
@@ -25,3 +25,16 @@ class LessFilter(CompilerFilter):
         content = super(LessFilter, self).input(**kwargs)
         # process absolute file paths
         return CssAbsoluteFilter(content).input(**kwargs)
+
+
+class SassFilter(CompilerFilter):
+
+    def __init__(self, content, attrs, **kwargs):
+        super(SassFilter, self).__init__(content,
+                                         command='sass {infile} {outfile}',
+                                         **kwargs)
+
+    def input(self, **kwargs):
+        content = super(SassFilter, self).input(**kwargs)
+        # process absolute file paths
+        return CssAbsoluteFilter(content).input(**kwargs)

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq.scss
@@ -1,0 +1,3 @@
+// This file is in test mode for the migration to Bootstrap 5
+
+@import 'commcarehq/typography/links';

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/typography/_links.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/typography/_links.scss
@@ -1,0 +1,6 @@
+@import '../variables/colors';
+
+// this is only a test for the beginning of the migration to Bootstrap 5
+a.commcare-blue {
+  color: $color-commcare-blue;
+}

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/variables/_colors.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/variables/_colors.scss
@@ -1,0 +1,3 @@
+$color-commcare-blue: #5D70D2;
+
+$color-link: $color-commcare-blue;

--- a/corehq/apps/styleguide/templates/styleguide/base.html
+++ b/corehq/apps/styleguide/templates/styleguide/base.html
@@ -8,6 +8,10 @@
 
     {% include 'hqwebapp/includes/less.html' %}
     {% compress css %}
+      <link type="text/scss"
+            rel="stylesheet"
+            media="all"
+            href="{% static 'hqwebapp/scss/commcarehq.scss' %}" />
       <link type="text/less"
             rel="stylesheet"
             media="all"
@@ -73,6 +77,7 @@
     <footer class="docs-footer">
       <div class="container">
         <p class="lead">Thanks for reading the style guide! <3</p>
+        <p><a class="commcare-blue" href="/">commcarehq.org</a></p> <!-- a sneaky test of scss -->
       </div>
     </footer>
   </body>

--- a/settings.py
+++ b/settings.py
@@ -900,6 +900,7 @@ DIGEST_LOGIN_FACTORY = 'django_digest.NoEmailLoginFactory'
 # Django Compressor
 COMPRESS_PRECOMPILERS = AVAILABLE_COMPRESS_PRECOMPILERS = (
     ('text/less', 'corehq.apps.hqwebapp.precompilers.LessFilter'),
+    ('text/scss', 'corehq.apps.hqwebapp.precompilers.SassFilter'),
 )
 # if not overwritten in localsettings, these will be replaced by the value they return
 # using the local DEBUG value (which we don't have access to here yet)


### PR DESCRIPTION
## Technical Summary
This PR mainly exists for the build, but is a valid first step to test out compilation of scss files with django compressor.

This will require installing dart-sass globally (`npm -g install sass`), so a followup PR will be needed for commcare-cloud as well as a changelog before this can actually be merged.

Update: commcare-cloud changes in this PR https://github.com/dimagi/commcare-cloud/pull/5710

## Safety Assurance

### Safety story
Tiny change and only to our styleguide so no real effect on anyone. However, we should ensure that all environments are readied with dart-sass installed prior to merging this in. 

Tested installing dart sass on staging. No issues with deploy, and stylguide compiles the `.scss` flawlessly 👍 

### Automated test coverage
Yes, because the django compressor test will fail if the docker configuration doesn't like this change.

### QA Plan
N/A


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
