### PR TITLE
Figure out content type if `None`

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -348,13 +348,13 @@ class CommCareImage(CommCareMultimedia):
 
     def attach_data(self, data, original_filename=None, username=None, attachment_id=None, media_meta=None):
         image = self.get_image_object(data)
-        attachment_id = "%dx%d" % image.size
-        attachment_id = "%s-%s.%s" % (self.file_hash, attachment_id, image.format)
+        width, height = image.size
+        attachment_id = f'{self.file_hash}-{width}x{height}.{image.format}'
         if not media_meta:
             media_meta = {}
         media_meta["size"] = {
-            "width": image.size[0],
-            "height": image.size[1]
+            "width": width,
+            "height": height,
         }
         return super(CommCareImage, self).attach_data(data, original_filename=original_filename, username=username,
                                                       attachment_id=attachment_id, media_meta=media_meta)

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -993,8 +993,11 @@ class ViewMultimediaFile(View):
         data, content_type = self.multimedia.get_display_file()
         if self.thumb:
             data = CommCareImage.get_thumbnail_data(data, self.thumb)
+        filename = 'download' + self.multimedia.get_file_extension()
+        if not content_type:
+            content_type = self.multimedia.get_mime_type(data, filename)
         response = HttpResponse(data, content_type=content_type)
-        response['Content-Disposition'] = 'filename="download{}"'.format(self.multimedia.get_file_extension())
+        response['Content-Disposition'] = f'filename="{filename}"'
         return response
 
 


### PR DESCRIPTION
## Technical Summary

An attempt to resolve broken multimedia. Opening this PR for testing. Do not merge.

This change figures out the content type if it is set to `None`.

fyi @sravfeyn @Charl1996 

## Feature Flag

N/A

## Safety Assurance

### Safety story

Unable to reproduce locally. This branch is intended for testing in environments where the problem is happening.

### Automated test coverage

Does not include tests.

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
