### PR TITLE
Increase time limit for intermittently failing test

### DIFF
--- a/corehq/motech/repeaters/tests/test_models_slow.py
+++ b/corehq/motech/repeaters/tests/test_models_slow.py
@@ -24,6 +24,7 @@ from corehq.motech.repeaters.models import (
     SQLFormRepeater,
     send_request,
 )
+from corehq.util.test_utils import timelimit
 
 DOMAIN = ''.join([random.choice(string.ascii_lowercase) for __ in range(20)])
 
@@ -121,7 +122,30 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
             sql_repeater = self.reget_sql_repeater()
             self.assertIsNone(sql_repeater.next_attempt_at)
 
+    @timelimit(65)
     def test_backoff_on_503(self):
+        """Configured with a custom timelimit to prevent intermittent test
+        failures in GitHub actions. Example:
+
+        ```
+        setup,corehq.motech.repeaters.tests.test_models_slow:ServerErrorTests.test_backoff_on_503,60.48151421546936,1673364559.7436702
+        ERROR
+
+        ======================================================================
+        ERROR: corehq.motech.repeaters.tests.test_models_slow:ServerErrorTests.test_backoff_on_503
+        ----------------------------------------------------------------------
+        Traceback (most recent call last):
+        File "/vendor/lib/python3.9/site-packages/nose/case.py", line 134, in run
+            self.runTest(result)
+        File "/vendor/lib/python3.9/site-packages/nose/case.py", line 152, in runTest
+            test(result)
+        File "/vendor/lib/python3.9/site-packages/django/test/testcases.py", line 245, in __call__
+            self._setup_and_call(result)
+        File "/vendor/lib/python3.9/site-packages/django/test/testcases.py", line 281, in _setup_and_call
+            super().__call__(result)
+        AssertionError: setup time limit (29.0) exceeded: 60.48151421546936
+        ```
+        """
         resp = ResponseMock(status_code=503, reason='Service Unavailable')
         with patch('corehq.motech.repeaters.models.simple_request') as simple_request:
             simple_request.return_value = resp


### PR DESCRIPTION
## Technical Summary

Increase time limit for intermittently failing test.  This test has been failing intermittently recently on several different PRs, requiring manual intervention when it happens.

## Safety Assurance

### Safety story

Test timing only.

### Automated test coverage

Test timing only.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
