### PR TITLE
Refactor Elastic service status utils to use adapter implementation

### DIFF
--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -778,6 +778,10 @@ class TestElasticDocumentAdapter(AdapterWithIndexTestCase, ESTestHelpers):
         doc = self._index_new_doc()
         self.assertTrue(self.adapter.exists(doc["_id"]))
 
+    def test_not_exists_returns_bool(self):
+        self.assertEqual([], docs_from_result(self.adapter.search({})))
+        self.assertFalse(self.adapter.exists("does_not_exist"))
+
     def test_get(self):
         doc = self._index_new_doc()
         self.assertEqual(doc, self.adapter.get(doc["_id"]))

--- a/corehq/apps/hqadmin/escheck.py
+++ b/corehq/apps/hqadmin/escheck.py
@@ -1,4 +1,4 @@
-from corehq.elastic import get_es_new
+from corehq.apps.es.client import manager
 
 
 def check_es_cluster_health():
@@ -11,6 +11,4 @@ def check_es_cluster_health():
     There are better realtime tools for monitoring ES clusters which
     should probably be looked at. specifically paramedic or bigdesk
     """
-    es = get_es_new()  # assign to variable to avoid weak reference error
-    cluster_health = es.cluster.health()
-    return cluster_health['status']
+    return manager.cluster_health()["status"]

--- a/corehq/apps/hqadmin/tests/test_service_checks.py
+++ b/corehq/apps/hqadmin/tests/test_service_checks.py
@@ -4,39 +4,47 @@ from unittest.mock import patch
 from corehq.apps.es.groups import group_adapter
 from corehq.apps.es.tests.utils import es_test
 
-from ..service_checks import check_elasticsearch
+from .. import service_checks
+
+
+def always_green():
+    """Patch ``check_es_cluster_health()`` with this function to ensure tests
+    get a deterministic (successful) value, regardless of the Elastic
+    container's actual status.
+    """
+    return "green"
 
 
 @es_test(requires=[group_adapter])
+@patch.object(service_checks, "check_es_cluster_health", always_green)
 class TestCheckElasticsearch(SimpleTestCase):
 
     class Fail(Exception):
         pass
 
     def test_check_elasticsearch(self):
-        status = check_elasticsearch()
-        self.assertTrue(status.success)
+        status = service_checks.check_elasticsearch()
         self.assertEqual(status.msg, "Successfully sent a doc to ES and read it back")
+        self.assertTrue(status.success)
         self.assertIsNone(status.exception)
 
     def test_check_elasticsearch_passes_for_cluster_yellow(self):
-        with patch("corehq.apps.hqadmin.service_checks.check_es_cluster_health", return_value="yellow") as mock:
-            from corehq.apps.hqadmin.service_checks import check_es_cluster_health
-            self.assertEqual("yellow", check_es_cluster_health())
+        with patch.object(service_checks, "check_es_cluster_health", return_value="yellow") as mock:
+            self.assertEqual("yellow", service_checks.check_es_cluster_health())
             mock.reset_mock()
-            self.assertTrue(check_elasticsearch().success)
+            self.assertTrue(service_checks.check_elasticsearch().success)
         mock.assert_called_once()
 
     def test_check_elasticsearch_fails_for_cluster_red(self):
-        with patch("corehq.apps.hqadmin.service_checks.check_es_cluster_health", return_value="red"):
-            status = check_elasticsearch()
+        with patch.object(service_checks, "check_es_cluster_health", return_value="red"):
+            status = service_checks.check_elasticsearch()
         self.assertFalse(status.success)
         self.assertEqual(status.msg, "Cluster health at red")
         self.assertIsNone(status.exception)
 
     def test_check_elasticsearch_fails_with_exc_if_group_doc_index_raises(self):
         with patch.object(group_adapter, "index", side_effect=self.Fail) as mock:
-            status = check_elasticsearch()
+            status = service_checks.check_elasticsearch()
         mock.assert_called_once()
         self.assertFalse(status.success)
         self.assertEqual(status.msg, "Something went wrong sending a doc to ES")
@@ -44,7 +52,7 @@ class TestCheckElasticsearch(SimpleTestCase):
 
     def test_check_elasticsearch_fails_with_exc_if_group_doc_delete_raises(self):
         with patch.object(group_adapter, "delete", side_effect=self.Fail) as mock:
-            status = check_elasticsearch()
+            status = service_checks.check_elasticsearch()
         mock.assert_called_once()
         self.assertFalse(status.success)
         self.assertEqual(status.msg, "Something went wrong sending a doc to ES")
@@ -52,7 +60,7 @@ class TestCheckElasticsearch(SimpleTestCase):
 
     def test_check_elasticsearch_fails_if_indexed_doc_is_missing(self):
         with patch.object(group_adapter, "index", return_value=None) as mock:
-            status = check_elasticsearch()
+            status = service_checks.check_elasticsearch()
         mock.assert_called_once()
         self.assertFalse(status.success)
         self.assertEqual(status.msg, "Something went wrong sending a doc to ES")

--- a/corehq/apps/hqadmin/tests/test_service_checks.py
+++ b/corehq/apps/hqadmin/tests/test_service_checks.py
@@ -1,0 +1,62 @@
+from django.test import SimpleTestCase
+from unittest.mock import patch
+
+from corehq.apps.es.groups import group_adapter
+from corehq.apps.es.tests.utils import es_test
+
+from ..service_checks import check_elasticsearch
+
+
+@es_test(requires=[group_adapter])
+class TestCheckElasticsearch(SimpleTestCase):
+
+    class Fail(Exception):
+        pass
+
+    def test_check_elasticsearch(self):
+        status = check_elasticsearch()
+        self.assertTrue(status.success)
+        self.assertEqual(status.msg, "Successfully sent a doc to ES and read it back")
+        self.assertIsNone(status.exception)
+
+    def test_check_elasticsearch_passes_for_cluster_yellow(self):
+        with patch("corehq.apps.hqadmin.service_checks.check_es_cluster_health", return_value="yellow") as mock:
+            from corehq.apps.hqadmin.service_checks import check_es_cluster_health
+            self.assertEqual("yellow", check_es_cluster_health())
+            mock.reset_mock()
+            self.assertTrue(check_elasticsearch().success)
+        mock.assert_called_once()
+
+    def test_check_elasticsearch_fails_for_cluster_red(self):
+        with patch("corehq.apps.hqadmin.service_checks.check_es_cluster_health", return_value="red"):
+            status = check_elasticsearch()
+        self.assertFalse(status.success)
+        self.assertEqual(status.msg, "Cluster health at red")
+        self.assertIsNone(status.exception)
+
+    def test_check_elasticsearch_fails_with_exc_if_group_doc_index_raises(self):
+        with patch.object(group_adapter, "index", side_effect=self.Fail) as mock:
+            status = check_elasticsearch()
+        mock.assert_called_once()
+        self.assertFalse(status.success)
+        self.assertEqual(status.msg, "Something went wrong sending a doc to ES")
+        self.assertIsInstance(status.exception, self.Fail)
+
+    def test_check_elasticsearch_fails_with_exc_if_group_doc_delete_raises(self):
+        with patch.object(group_adapter, "delete", side_effect=self.Fail) as mock:
+            status = check_elasticsearch()
+        mock.assert_called_once()
+        self.assertFalse(status.success)
+        self.assertEqual(status.msg, "Something went wrong sending a doc to ES")
+        self.assertIsInstance(status.exception, self.Fail)
+
+    def test_check_elasticsearch_fails_if_indexed_doc_is_missing(self):
+        with patch.object(group_adapter, "index", return_value=None) as mock:
+            status = check_elasticsearch()
+        mock.assert_called_once()
+        self.assertFalse(status.success)
+        self.assertEqual(status.msg, "Something went wrong sending a doc to ES")
+        self.assertRegex(
+            str(status.exception),
+            r"^Indexed doc not found: elasticsearch-service-check-",
+        )


### PR DESCRIPTION
## Technical Summary

Refactor Elastic service status utils to use adapter implementation

- use document adapter in `corehq.apps.hqadmin.service_checks`
- make service checks more robust and add tests
- use management adapter in `corehq.apps.hqadmin.escheck`
- add new test for `ElasticDocumentAdapter.exists()` method
- remove dependency on `corehq.elastic`

Review: All at once. ~Squashed view, "in full", :house: (why can't I remember what :house: stood for?)~

Jira: [SAAS-14264](https://dimagi-dev.atlassian.net/browse/SAAS-14264)

## Safety Assurance

### Safety story

Effectively a no-op, change only routes the logic through fewer abstraction layers. Change only affects server status checks, no data.

### Automated test coverage

Adds new tests.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-14264]: https://dimagi-dev.atlassian.net/browse/SAAS-14264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ