### PR TITLE
Allow user to increase inactivity timeout length

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -512,6 +512,8 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
             if toggles.SECURE_SESSION_TIMEOUT.enabled(name):
                 return domain_obj.secure_sessions_timeout or settings.SECURE_TIMEOUT
             return settings.SECURE_TIMEOUT
+        elif not domain_obj.secure_sessions:
+            return settings.INACTIVITY_TIMEOUT
 
         return None
 

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -158,10 +158,10 @@ class TimeoutMiddleware(MiddlewareMixin):
         timeouts = list(map(Domain.secure_timeout, domains))
         timeouts = list(filter(None, timeouts))
 
-        # Include timeout in current session, important for users who are not domain members
+        # Important for users who are not domain members
         # (e.g., superusers) who visited a secure domain and are now looking at a non-secure domain
         if 'secure_session_timeout' in session:
-            timeouts.append(session['secure_session_timeout'])
+            timeouts.append(settings.SECURE_TIMEOUT)
 
         return min(timeouts) if timeouts else settings.SECURE_TIMEOUT
 


### PR DESCRIPTION
## Product Description

A pop-up to extend session will appear after the shortest timeout value has elapsed, and this value is based off current user inputs as opposed to a shorter timeout value that was _once_ inputted.

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-2577

In TimeoutMiddleware, session['secure_session_timeout'] is appended to a timeout values list (the timeout values per domain as specified by the user) every time _get_timeout is called. That is, the current session's timeout value is added. _get_timeout returns the minimum value in the timeouts list. The current session timeout may be less than the updated timeout values provided by the user. If that is the case, _get_timeout will return the timeout value in session, despite this value being changed by the user. The result is the timeout value cannot be increased; it remains at the lowest value that has ever been inputted.

Appending settings.SECURE_TIMEOUT instead of session['secure_session_timeout'] prevents this, whilst still ensuring that if a non-domain page is visited after a secure domain page is visited, that non-domain page is secure.

In secure_timeout (located in corehq/apps/domain/models.py), I added that settings.INACTIVITY_TIMEOUT is returned if the secure_sessions is not true (i.e. shorten inactivity timeout is not checked by user).

PS: Evan Mapson seems to already have this ticket in review, but with my lack of access to Jira I didn't realise! (So this is probably redundant, but I'm an eager intern who wants to prove to herself she can make a pull request) 

## Feature Flag

USH: Allow domain to override default length of inactivity timeout

## Safety Assurance

### Safety story

Existing local tests pass, and a new test was written to check that the timeout value can be increased by the user. Changes were also tested manually by running my local commcare-hq with developer tools open to see the log changes reflecting the current timeout value in session.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
