### PR TITLE
Case search filter feature flag

### DIFF
--- a/corehq/apps/app_manager/management/commands/flag_domains_using_search_filter.py
+++ b/corehq/apps/app_manager/management/commands/flag_domains_using_search_filter.py
@@ -23,9 +23,13 @@ def flag_domains_using_search_filter():
 
 def _any_app_uses_search_filter(domain):
     for app_id in get_app_ids_in_domain(domain):
-        app = get_current_app(domain, app_id)
-        if app.modules and _any_module_uses_search_filter(app):
-            return True
+        try:
+            app = get_current_app(domain, app_id)
+        except Exception:
+            pass
+        else:
+            if app.modules and _any_module_uses_search_filter(app):
+                return True
     return False
 
 

--- a/corehq/apps/app_manager/management/commands/flag_domains_using_search_filter.py
+++ b/corehq/apps/app_manager/management/commands/flag_domains_using_search_filter.py
@@ -10,6 +10,7 @@ from corehq.util.log import with_progress_bar
 
 APP_WRAPPING_ERRORS_LOG = "migrate_to_search_filter_flag_wrapping_errors.txt"
 
+
 class Command(BaseCommand):
     help = "One-time command to enable search filter flag where 'search filter' is already in use"
 

--- a/corehq/apps/app_manager/management/commands/flag_domains_using_search_filter.py
+++ b/corehq/apps/app_manager/management/commands/flag_domains_using_search_filter.py
@@ -1,0 +1,37 @@
+from django.core.management import BaseCommand
+
+from corehq import toggles
+from corehq.apps.app_manager.dbaccessors import domain_has_apps, get_app_ids_in_domain, get_current_app
+from corehq.util.log import with_progress_bar
+
+
+class Command(BaseCommand):
+    help = "One-time command to enable search filter flag where 'search filter' is already in use"
+
+    def handle(self, **options):
+        flag_domains_using_search_filter()
+
+
+def flag_domains_using_search_filter():
+    domains = (
+        set(toggles.USH_CASE_CLAIM_UPDATES.get_enabled_domains())
+        - set(toggles.USH_SEARCH_FILTER.get_enabled_domains())
+    )
+    for domain in with_progress_bar(domains):
+        enabled = domain_has_apps(domain) and _any_app_uses_search_filter(domain)
+        toggles.USH_SEARCH_FILTER.set(domain, enabled, namespace=toggles.NAMESPACE_DOMAIN)
+
+
+def _any_app_uses_search_filter(domain):
+    for app_id in get_app_ids_in_domain(domain):
+        app = get_current_app(domain, app_id)
+        if app.has_modules() and _any_module_uses_search_filter(app):
+            return True
+    return False
+
+
+def _any_module_uses_search_filter(app):
+    for module in app.modules:
+        if module.search_config.search_filter:
+            return True
+    return False

--- a/corehq/apps/app_manager/migrations/0025_migrate_to_search_filter_flag.py
+++ b/corehq/apps/app_manager/migrations/0025_migrate_to_search_filter_flag.py
@@ -1,4 +1,3 @@
-import traceback
 from django.db import migrations
 
 from django.core.management import call_command

--- a/corehq/apps/app_manager/migrations/0025_migrate_to_search_filter_flag.py
+++ b/corehq/apps/app_manager/migrations/0025_migrate_to_search_filter_flag.py
@@ -1,0 +1,26 @@
+import traceback
+from django.db import migrations
+
+from django.core.management import call_command
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def migrate_to_search_filter_flag(apps, schema_editor):
+    try:
+        call_command(
+            "flag_domains_using_search_filter",
+        )
+    except Exception:
+        traceback.print_exc()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('app_manager', '0024_applicationreleaselog_info'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_to_search_filter_flag, migrations.RunPython.noop)
+    ]

--- a/corehq/apps/app_manager/migrations/0025_migrate_to_search_filter_flag.py
+++ b/corehq/apps/app_manager/migrations/0025_migrate_to_search_filter_flag.py
@@ -7,12 +7,9 @@ from corehq.util.django_migrations import skip_on_fresh_install
 
 @skip_on_fresh_install
 def migrate_to_search_filter_flag(apps, schema_editor):
-    try:
-        call_command(
-            "flag_domains_using_search_filter",
-        )
-    except Exception:
-        traceback.print_exc()
+    call_command(
+        "flag_domains_using_search_filter",
+    )
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -223,7 +223,7 @@ class RemoteRequestFactory(object):
             if additional_types:
                 nodeset = CaseTypeXpath(self.module.case_type).cases(
                     additional_types, instance_name=self.storage_instance)
-            if self.module.search_config.search_filter:
+            if self.module.search_config.search_filter and toggles.USH_SEARCH_FILTER.enabled(self.app.domain):
                 nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
         nodeset += EXCLUDE_RELATED_CASES_FILTER
 

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -57,6 +57,7 @@ from corehq.apps.app_manager.xpath import (
 )
 from corehq.apps.case_search.const import EXCLUDE_RELATED_CASES_FILTER
 from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY
+from corehq.toggles import USH_SEARCH_FILTER
 from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
 
@@ -560,7 +561,7 @@ class EntriesHelper(object):
                     instance_name, root_element = "results:inline", "results"
                 elif loads_registry_case:
                     instance_name, root_element = "results", "results"
-                if detail_module.search_config.search_filter:
+                if detail_module.search_config.search_filter and USH_SEARCH_FILTER.enabled(self.app.domain):
                     filter_xpath += f"[{interpolate_xpath(detail_module.search_config.search_filter)}]"
                 filter_xpath += EXCLUDE_RELATED_CASES_FILTER
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -211,7 +211,7 @@
               ></textarea>
             </div>
           </div>
-          {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
+          {% if request|toggle_enabled:'USH_SEARCH_FILTER' %}
           <div class="form-group">
             <label for="search-filter" class="control-label {% css_label_class %}">
               {% trans "Search Filter" %}

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -81,7 +81,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         self.module = self.app.modules[0]
         self.form = self.module.forms[0]
 
-    @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    @flag_enabled('USH_SEARCH_FILTER')
     def test_inline_search(self):
         suite = self.app.create_suite()
 
@@ -129,7 +129,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_search_short']")
         self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_search_long']")
 
-    @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    @flag_enabled('USH_SEARCH_FILTER')
     def test_inline_search_case_list_item(self):
         self.module.case_list.show = True
         suite = self.app.create_suite()
@@ -166,6 +166,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         </partial>"""  # noqa: E501
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[2]")
 
+    @flag_enabled('USH_SEARCH_FILTER')
     def test_inline_search_multi_select(self):
         self.module.case_details.short.multi_select = True
         self.module.case_details.short.columns.append(
@@ -352,6 +353,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             f"./entry[1]/instance[@id='{instance_id}']",
         )
 
+    @flag_enabled('USH_SEARCH_FILTER')
     def test_inline_search_with_parent_select(self):
         """Inline search module can have 'parent select' as long as the
         relationship is 'other' (None).

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -211,6 +211,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                          "($case_id != '') and (double(now()) mod 2 = 0)")
 
     @flag_enabled("USH_CASE_CLAIM_UPDATES")
+    @flag_enabled('USH_SEARCH_FILTER')
     def test_remote_request(self, *args):
         """
         Suite should include remote-request if searching is configured
@@ -223,6 +224,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         )
 
     @flag_enabled("USH_CASE_CLAIM_UPDATES")
+    @flag_enabled('USH_SEARCH_FILTER')
     def test_remote_request_custom_detail(self, *args):
         """Remote requests for modules with custom details point to the custom detail
         """
@@ -231,6 +233,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.assertXmlPartialEqual(self.get_xml('remote_request_custom_detail'), suite, "./remote-request[1]")
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    @flag_enabled('USH_SEARCH_FILTER')
     @patch('corehq.apps.app_manager.suite_xml.post_process.resources.ResourceOverrideHelper.update_suite')
     def test_duplicate_remote_request(self, *args):
         """
@@ -286,6 +289,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.assertXmlPartialEqual(self.get_xml('search_command_detail'), suite, "./detail")
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    @flag_enabled('USH_SEARCH_FILTER')
     def test_case_search_filter(self, *args):
         search_filter = "rating > 3"
         self.module.search_config.search_filter = search_filter
@@ -304,6 +308,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         )
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    @flag_enabled('USH_SEARCH_FILTER')
     def test_additional_types(self, *args):
         another_case_type = "another_case_type"
         self.module.search_config.additional_case_types = [another_case_type]

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -949,6 +949,14 @@ USH_CASE_CLAIM_UPDATES = StaticToggle(
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
 )
 
+USH_SEARCH_FILTER = StaticToggle(
+    'case_search_filter',
+    "USH Specific toggle to use Search Filter in case search options.",
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+    parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
+)
+
 USH_INLINE_SEARCH = StaticToggle(
     'inline_case_search',
     "USH Specific toggle to making case search user input available to other parts of the app.",

--- a/migrations.lock
+++ b/migrations.lock
@@ -127,6 +127,7 @@ app_manager
  0022_migrate_to_conditional_case_update
  0023_applicationreleaselog
  0024_applicationreleaselog_info
+ 0025_migrate_to_search_filter_flag
 auditcare
  0001_sqlmodels
  0002_uniques


### PR DESCRIPTION
## Product Description
Puts case search "Search Filter" option behind a feature flag.
![image](https://user-images.githubusercontent.com/100609770/211930904-e95f74fe-ef4e-4a5e-8861-e9f11e545bd3.png)


## Technical Summary
[USH-2679](https://dimagi-dev.atlassian.net/browse/USH-2679?atlOrigin=eyJpIjoiNzUyYmFiNmNhNjNhNGY4ZWI1Y2ViNDRjMTNmZjI0MjIiLCJwIjoiaiJ9)
Adds a new feature flag which hides/shows the UI for Search Filter and enables/disables the generation of XML to apply the filter. Uses a migration to apply a management command which enables the feature flag for domains already using the Search Filter option.

## Feature Flag
USH Search Filter

## Safety Assurance

### Safety story
This change will only hide the Search Filter functionality for projects not already using it. The migration to conditionally enable the new flag uses an existing `.set` function on the feature flag (`StaticToggle`) model and doesn't modify existing data.

### Automated test coverage
Modifies existing automated tests to use `USH_SEARCH_FILTER` flag where needed.

### QA Plan
Sending to QA to confirm functionality is properly enabled/disabled with the feature flag.

### Migrations
- [X] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-2679]: https://dimagi-dev.atlassian.net/browse/USH-2679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ