### PR TITLE
Ignore plaintext_password check when auth type is set to None

### DIFF
--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -285,7 +285,8 @@ def test_connection_settings(request, domain):
     ):
         raise Http404
 
-    if request.POST.get('plaintext_password') == PASSWORD_PLACEHOLDER:
+    # If auth_type is set to None, we ignore this check
+    if request.POST.get('plaintext_password') == PASSWORD_PLACEHOLDER and request.POST.get('auth_type'):
         # The user is editing an existing instance, and the form is
         # showing the password placeholder. (We don't tell the user what
         # the API password is.)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
For an already saved connection setting with some auth set, when we change auth to None and test the connection, it asks to provide a password. The PR fixes the issue.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/QA-4633
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Very small change limited to a small feature.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
