### PR TITLE
Refactor legacy Elastic utils in tests

### DIFF
--- a/corehq/apps/domain/tests/test_domain_calculated_properties.py
+++ b/corehq/apps/domain/tests/test_domain_calculated_properties.py
@@ -24,11 +24,7 @@ class BaseCalculatedPropertiesTest(TestCase):
         super(BaseCalculatedPropertiesTest, cls).setUpClass()
         cls.domain = Domain(name='test-b9289e19d819')
         cls.domain.save()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.domain.delete()
-        super(BaseCalculatedPropertiesTest, cls).tearDownClass()
+        cls.addClassCleanup(cls.domain.delete)
 
     def setUp(self):
         super().setUp()

--- a/corehq/apps/domain/tests/test_domain_calculated_properties.py
+++ b/corehq/apps/domain/tests/test_domain_calculated_properties.py
@@ -7,75 +7,48 @@ from corehq.apps.es.sms import SMSES
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.sms.models import INCOMING, OUTGOING
 from dimagi.utils.parsing import json_format_datetime
-from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.domain.calculations import all_domain_stats, calced_props, sms, get_sms_count
 from corehq.apps.domain.models import Domain
-from corehq.elastic import get_es_new, refresh_elasticsearch_index
-from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
-from corehq.pillows.mappings.sms_mapping import SMS_INDEX_INFO
-from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
-from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
-from corehq.util.elastic import ensure_index_deleted
-from corehq.elastic import send_to_elasticsearch
+from corehq.apps.es.cases import case_adapter
+from corehq.apps.es.forms import form_adapter
+from corehq.apps.es.sms import sms_adapter
+from corehq.apps.es.users import user_adapter
 
 
-@es_test
+@es_test(requires=[case_adapter, form_adapter, sms_adapter, user_adapter])
 class BaseCalculatedPropertiesTest(TestCase):
+
     @classmethod
     def setUpClass(cls):
         super(BaseCalculatedPropertiesTest, cls).setUpClass()
-        cls.es = [{
-            'info': index_info,
-            'instance': get_es_new(),
-        } for index_info in [CASE_INDEX_INFO, SMS_INDEX_INFO, XFORM_INDEX_INFO, USER_INDEX_INFO]]
-
         cls.domain = Domain(name='test-b9289e19d819')
         cls.domain.save()
 
     @classmethod
     def tearDownClass(cls):
         cls.domain.delete()
-        for es in cls.es:
-            ensure_index_deleted(es['info'].index)
         super(BaseCalculatedPropertiesTest, cls).tearDownClass()
 
     def setUp(self):
-        for es in self.es:
-            ensure_index_deleted(es['info'].index)
-            initialize_index_and_mapping(es['instance'], es['info'])
-
-    @staticmethod
-    def create_sms_in_es(domain_name, direction):
+        super().setUp()
         sms_doc = {
             '_id': 'some_sms_id',
-            'domain': domain_name,
-            'direction': direction,
+            'domain': self.domain.name,
+            'direction': INCOMING,
             'date': json_format_datetime(datetime.datetime.utcnow()),
-            'doc_type': SMS_INDEX_INFO.type,
         }
-        send_to_elasticsearch("sms", sms_doc)
-        refresh_elasticsearch_index('sms')
-        return sms_doc
-
-    @staticmethod
-    def delete_sms_in_es(sms_doc):
-        send_to_elasticsearch("sms", sms_doc, delete=True)
-        refresh_elasticsearch_index('sms')
+        sms_adapter.index(sms_doc, refresh=True)
 
 
 class DomainCalculatedPropertiesTest(BaseCalculatedPropertiesTest):
 
     def test_calculated_properties_are_serializable(self):
-        sms_doc = self.create_sms_in_es(self.domain.name, INCOMING)
-        self.addCleanup(self.delete_sms_in_es, sms_doc)
         all_stats = all_domain_stats()
         props = calced_props(self.domain, self.domain._id, all_stats)
         json.dumps(props)
 
     def test_domain_does_not_have_apps(self):
-        sms_doc = self.create_sms_in_es(self.domain.name, INCOMING)
-        self.addCleanup(self.delete_sms_in_es, sms_doc)
         all_stats = all_domain_stats()
         props = calced_props(self.domain, self.domain._id, all_stats)
         self.assertFalse(props['cp_has_app'])
@@ -84,14 +57,10 @@ class DomainCalculatedPropertiesTest(BaseCalculatedPropertiesTest):
 class GetSMSCountTest(BaseCalculatedPropertiesTest):
 
     def test_sms_count(self):
-        sms_doc = self.create_sms_in_es(self.domain.name, INCOMING)
-        self.addCleanup(self.delete_sms_in_es, sms_doc)
         self.assertEqual(SMSES().count(), 1)
         self.assertEqual(sms(self.domain.name, INCOMING), 1)
         self.assertEqual(sms(self.domain.name, OUTGOING), 0)
 
     def test_days_as_str_is_valid(self):
-        sms_doc = self.create_sms_in_es(self.domain.name, INCOMING)
-        self.addCleanup(self.delete_sms_in_es, sms_doc)
         count = get_sms_count(self.domain.name, days='30')
         self.assertEqual(count, 1)

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -1,10 +1,9 @@
 from pillowtop.processors.elastic import send_to_elasticsearch as send_to_es
 
-from corehq.apps.es.client import get_client, manager
+from corehq.apps.es.client import get_client
 from corehq.apps.es.exceptions import ESError  # noqa: F401
 from corehq.apps.es.transient_util import (  # noqa: F401
     index_info_from_cname,
-    doc_adapter_from_cname,
     doc_adapter_from_info,
     report_and_fail_on_shard_failures,
 )
@@ -47,7 +46,3 @@ def send_to_elasticsearch(index_cname, doc, delete=False, es_merge_update=False)
         delete=delete,
         es_merge_update=es_merge_update,
     )
-
-
-def refresh_elasticsearch_index(index_cname):
-    manager.index_refresh(doc_adapter_from_cname(index_cname).index_name)

--- a/testapps/test_elasticsearch/tests/test_xform_es.py
+++ b/testapps/test_elasticsearch/tests/test_xform_es.py
@@ -2,31 +2,23 @@ from collections import namedtuple
 import uuid
 import datetime
 from django.test import SimpleTestCase
-from corehq.util.es.elasticsearch import ConnectionError
 
-from corehq.apps.es import FormES
+from corehq.apps.es.client import manager
+from corehq.apps.es.forms import FormES, form_adapter
 from corehq.apps.es.tests.utils import es_test
-from corehq.elastic import get_es_new, send_to_elasticsearch, doc_exists_in_es
 from corehq.form_processor.utils import TestFormMetadata
-from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
-from corehq.util.es.interface import ElasticsearchInterface
-from corehq.util.test_utils import make_es_ready_form, trap_extra_setup
-from pillowtop.es_utils import initialize_index_and_mapping
+from corehq.util.test_utils import make_es_ready_form
 
 WrappedJsonFormPair = namedtuple('WrappedJsonFormPair', ['wrapped_form', 'json_form'])
 
 
-@es_test
+@es_test(requires=[form_adapter])
 class XFormESTestCase(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
         super(XFormESTestCase, cls).setUpClass()
-        cls.now = datetime.datetime.utcnow()
         cls.forms = []
-        with trap_extra_setup(ConnectionError):
-            cls.es = get_es_new()
-            initialize_index_and_mapping(cls.es, XFORM_INDEX_INFO)
 
     def setUp(self):
         super(XFormESTestCase, self).setUp()
@@ -38,26 +30,22 @@ class XFormESTestCase(SimpleTestCase):
             form_metadata = form_metadata or TestFormMetadata()
             form_pair = make_es_ready_form(form_metadata)
             cls.forms.append(form_pair)
-            send_to_elasticsearch('forms', form_pair.json_form)
+            form_adapter.index(form_pair.json_form)
         # have to refresh the index to make sure changes show up
-        cls.es.indices.refresh(XFORM_INDEX_INFO.index)
+        manager.index_refresh(form_adapter.index_name)
 
     @classmethod
     def tearDownClass(cls):
-        interface = ElasticsearchInterface(cls.es)
-        for form in cls.forms:
-            interface.delete_doc(XFORM_INDEX_INFO.alias, XFORM_INDEX_INFO.type, form.wrapped_form.form_id)
-        cls.es.indices.refresh(XFORM_INDEX_INFO.index)
         cls.forms = []
         super(XFormESTestCase, cls).tearDownClass()
 
     def test_forms_are_in_index(self):
         for form in self.forms:
-            self.assertFalse(doc_exists_in_es(XFORM_INDEX_INFO, form.wrapped_form.form_id))
+            self.assertFalse(form_adapter.exists(form.wrapped_form.form_id))
         self._ship_forms_to_es([None, None])
         self.assertEqual(2, len(self.forms))
         for form in self.forms:
-            self.assertTrue(doc_exists_in_es(XFORM_INDEX_INFO, form.wrapped_form.form_id))
+            self.assertTrue(form_adapter.exists(form.wrapped_form.form_id))
 
     def test_query_by_domain(self):
         domain1 = 'test1-{}'.format(self.test_id)


### PR DESCRIPTION
## Technical Summary

Some low-hanging fruit in the ongoing effort to clean up `corehq.elastic`.  These tests are either isolated from their "product" code or said product code doesn't use legacy Elastic utils. These made sense to just clean up together as a standalone PR.

Review: commit by commit

Jira: [SAAS-14278](https://dimagi-dev.atlassian.net/browse/SAAS-14278)

## Safety Assurance

### Safety story

Tests only.

### Automated test coverage

Test improvements.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-14278]: https://dimagi-dev.atlassian.net/browse/SAAS-14278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ