### PR TITLE
Fix repeater URLs

### DIFF
--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -292,6 +292,14 @@ class EditCaseRepeaterView(EditRepeaterView, AddCaseRepeaterView):
         return reverse(AddCaseRepeaterView.urlname, args=[self.domain])
 
 
+class EditReferCaseRepeaterView(EditCaseRepeaterView):
+    urlname = "edit_refer_case_repeater"
+
+
+class EditDataRegistryCaseUpdateRepeater(EditCaseRepeaterView):
+    urlname = "edit_data_registry_case_update_repeater"
+
+
 @require_POST
 @require_can_edit_web_users
 @requires_privilege_with_fallback(privileges.DATA_FORWARDING)

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 from django.contrib import messages
 from django.http import Http404, HttpResponseRedirect
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -229,15 +229,11 @@ class EditRepeaterView(BaseRepeaterView):
 
     def post_save(self, request, repeater):
         messages.success(request, _("Repeater Successfully Updated"))
-        if self.request.GET.get('repeater_type'):
-            return HttpResponseRedirect(
-                reverse(self.urlname, args=[self.domain, repeater.repeater_id])
-                + '?repeater_type=' + self.kwargs['repeater_type']
-            )
-        else:
-            return HttpResponseRedirect(
-                reverse(self.urlname, args=[self.domain, repeater.repeater_id])
-            )
+        try:
+            url = reverse(self.urlname, args=[self.domain, repeater.repeater_id])
+        except NoReverseMatch:
+            url = reverse(self.urlname, args=[self.domain, repeater.repeater_type, repeater.repeater_id])
+        return HttpResponseRedirect(url)
 
 
 class AddFormRepeaterView(AddRepeaterView):

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -37,6 +37,7 @@ from corehq.motech.repeaters.views import (
     pause_repeater,
     resume_repeater,
 )
+from corehq.motech.repeaters.views.repeaters import EditDataRegistryCaseUpdateRepeater, EditReferCaseRepeaterView
 from corehq.motech.views import (
     ConnectionSettingsDetailView,
     ConnectionSettingsListView,
@@ -83,10 +84,13 @@ urlpatterns = [
         {'repeater_type': 'CaseRepeater'}, name=EditCaseRepeaterView.urlname),
     url(r'^forwarding/edit/FormRepeater/(?P<repeater_id>\w+)/$', EditFormRepeaterView.as_view(),
         {'repeater_type': 'FormRepeater'}, name=EditFormRepeaterView.urlname),
-    url(r'^forwarding/edit/ReferCaseRepeater/(?P<repeater_id>\w+)/$', EditCaseRepeaterView.as_view(),
-        {'repeater_type': 'ReferCaseRepeater'}, name=EditCaseRepeaterView.urlname),
-    url(r'^forwarding/edit/DataRegistryCaseUpdateRepeater/(?P<repeater_id>\w+)/$', EditCaseRepeaterView.as_view(),
-        {'repeater_type': 'DataRegistryCaseUpdateRepeater'}, name=EditCaseRepeaterView.urlname),
+    url(r'^forwarding/edit/ReferCaseRepeater/(?P<repeater_id>\w+)/$', EditReferCaseRepeaterView.as_view(),
+        {'repeater_type': 'ReferCaseRepeater'}, name=EditReferCaseRepeaterView.urlname),
+    url(
+        r'^forwarding/edit/DataRegistryCaseUpdateRepeater/(?P<repeater_id>\w+)/$',
+        EditDataRegistryCaseUpdateRepeater.as_view(),
+        {'repeater_type': 'DataRegistryCaseUpdateRepeater'}, name=EditDataRegistryCaseUpdateRepeater.urlname
+    ),
     url(r'^forwarding/edit/OpenmrsRepeater/(?P<repeater_id>\w+)/$', EditOpenmrsRepeaterView.as_view(),
         {'repeater_type': 'OpenmrsRepeater'}, name=EditOpenmrsRepeaterView.urlname),
     url(r'^forwarding/edit/Dhis2Repeater/(?P<repeater_id>\w+)/$', EditDhis2RepeaterView.as_view(),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The PR fixes a current issue when after updating some repeaters they were redirected back to the wrong repeater pages. 

For Example - 
```
In [1]: from django.urls import reverse

In [2]: reverse('edit_case_repeater', args=['some-project', 'someid1234'])
Out[2]: '/a/some-project/motech/forwarding/edit/DataRegistryCaseUpdateRepeater/someid1234/'
```

This is happening because many URLs have the same URL name so calling reverse points to the last url in urls.py file.


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/QA-4721

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
