### PR TITLE
Add nose plugin for detecting tests that alter existing Elastic indexes

### DIFF
--- a/corehq/tests/noseplugins/elasticsnitch.py
+++ b/corehq/tests/noseplugins/elasticsnitch.py
@@ -1,0 +1,69 @@
+"""A test timing plugin for nose
+
+Usage: ./manage.py test --with-elasticsnitch --snitch-out=/path/to/elasticsnitch.txt
+"""
+import sys
+
+from nose.plugins import Plugin
+from corehq.tests.noseplugins.uniformresult import uniform_description
+from corehq.apps.es.client import manager
+
+
+class ElasticSnitchPlugin(Plugin):
+    """A plugin to snitch on tests that change (add or delete) Elasticsearch
+    indexes without cleaning up after themselves (putting the index "state"
+    back how they found it).
+    """
+
+    name = "elasticsnitch"
+
+    def options(self, parser, env):
+        """Register commandline options."""
+        super().options(parser, env)
+        parser.add_option("--snitch-out", action="store", metavar="FILE",
+                          help="Snitch output file (default: STDOUT)")
+
+    def configure(self, options, conf):
+        """Configure plugin."""
+        super().configure(options, conf)
+        self.conf = conf
+        self.snitch_out = options.snitch_out
+        self.prefix = "" if self.snitch_out else f"{self.name}: "
+
+    def begin(self):
+        self.output = (open(self.snitch_out, "w", encoding="utf-8")
+                       if self.snitch_out else sys.__stdout__)
+
+    def finalize(self, result):
+        if self.output is not None and self.output is not sys.__stdout__:
+            self.output.close()
+
+    def startTest(self, case):
+        """Make a record of existing index names.
+
+        Called prior to test run:
+        - after ``case.setUpClass()``
+        - before ``case.setUp()``
+        """
+        self.start_indexes = get_all_index_names()
+
+    def stopTest(self, case):
+        """Compare existing index names against pre-test ones. If there are
+        differences, write the delta.
+
+        Called on test completion:
+        - after: case.tearDown()
+        - before: case.tearDownClass()
+        """
+        name = uniform_description(case.test)
+        end_indexes = get_all_index_names()
+        if not end_indexes ^ self.start_indexes:  # XOR
+            return
+        added = end_indexes - self.start_indexes
+        removed = self.start_indexes - end_indexes
+        self.output.write(f"{self.prefix}{name}: +{sorted(added)}, -{sorted(removed)}\n")
+
+
+def get_all_index_names():
+    """Returns a set of all existing Elasticsearch index names."""
+    return set(manager.get_indices())

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -31,6 +31,11 @@ function setup {
 
     rm *.log || true
 
+    if [ -n "$GITHUB_ACTIONS" ]; then
+        # create the artifacts dir with container-write ownership
+        install -dm0755 -o cchq -g cchq ./artifacts
+    fi
+
     pip-sync requirements/test-requirements.txt
     pip check  # make sure there are no incompatibilities in test-requirements.txt
     python_preheat  # preheat the python libs

--- a/testsettings.py
+++ b/testsettings.py
@@ -38,6 +38,7 @@ NOSE_PLUGINS = [
     'corehq.tests.noseplugins.logfile.LogFilePlugin',
     'corehq.tests.noseplugins.timing.TimingPlugin',
     'corehq.tests.noseplugins.output.OutputPlugin',
+    'corehq.tests.noseplugins.elasticsnitch.ElasticSnitchPlugin',
 
     # Uncomment to debug tests. Plugins have nice hooks for inspecting state
     # before/after each test or context setup/teardown, etc.


### PR DESCRIPTION
## Technical Summary

Nose plugin for detecting Elasticsearch index anomalies during test runs.  Started as a troubleshooting utility for failing tests on #32485, morphed into a full blown nose plugin after @millerdev mentioned `corehq/tests/noseplugins/timing.py`.

## Safety Assurance

### Safety story

Optional test utility (not enabled anywhere by default).

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
