### PR TITLE
Accessibility Tree changes for Form elements

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -25,6 +25,16 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         return mdAnchorRender(tokens, idx, options, env, self);
     };
 
+    md.renderer.rules.heading_open = function (tokens, idx, options, env, self) {
+        var aIndex = tokens[idx].attrIndex('tabindex');
+
+        if (aIndex < 0) {
+            tokens[idx].attrPush(['tabindex', '0']);
+        }
+
+        return mdAnchorRender(tokens, idx, options, env, self);
+    };
+
     _.delay(function () {
         ko.bindingHandlers.renderMarkdown = {
             update: function (element, valueAccessor) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -513,6 +513,12 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
                 }
             });
         };
+
+        self.isVisibleGroup = function () {
+            const hasChildren = self.children().length !== 0;
+            const hasLabel = !!ko.utils.unwrapObservable(self.caption_markdown) || !!self.caption();
+            return hasChildren && hasLabel;
+        };
     }
     Group.prototype = Object.create(Container.prototype);
     Group.prototype.constructor = Container;

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -20,10 +20,11 @@
                 'role': 'button',
                 'aria-expanded': showChildren() ? 'true' : 'false',
                 'aria-labelledby': captionId(),
-                'tabindex': ko.utils.unwrapObservable($data.caption_markdown) || caption() ? '0' : '-1'
+                // tab focus only if group is visible
+                'tabindex': isVisibleGroup() ? '0' : '-1'
               } : {
                 'aria-labelledby': captionId(),
-                'tabindex': ko.utils.unwrapObservable($data.caption_markdown) || caption() ? '0' : '-1'
+                'tabindex': isVisibleGroup() ? '0' : '-1'
               },
         click: toggleChildren,
         event: {keypress: keyPressAction}">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -17,13 +17,13 @@
            clickable: collapsible
         },
         attr: collapsible ? {
-                role: 'button',
+                'role': 'button',
                 'aria-expanded': showChildren() ? 'true' : 'false',
                 'aria-labelledby': captionId(),
-                tabindex: ko.utils.unwrapObservable($data.caption_markdown) || caption() ? '0' : '-1'
+                'tabindex': ko.utils.unwrapObservable($data.caption_markdown) || caption() ? '0' : '-1'
               } : {
                 'aria-labelledby': captionId(),
-                tabindex: ko.utils.unwrapObservable($data.caption_markdown) || caption() ? '0' : '-1'
+                'tabindex': ko.utils.unwrapObservable($data.caption_markdown) || caption() ? '0' : '-1'
               },
         click: toggleChildren,
         event: {keypress: keyPressAction}">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -19,13 +19,14 @@
         attr: collapsible ? {
                 role: 'button',
                 'aria-expanded': showChildren() ? 'true' : 'false',
-                'aria-labelledby': captionId()
+                'aria-labelledby': captionId(),
+                tabindex: ko.utils.unwrapObservable($data.caption_markdown) || caption() ? '0' : '-1'
               } : {
-                'aria-labelledby': captionId()
+                'aria-labelledby': captionId(),
+                tabindex: ko.utils.unwrapObservable($data.caption_markdown) || caption() ? '0' : '-1'
               },
         click: toggleChildren,
-        event: {keypress: keyPressAction}"
-              tabindex="0">
+        event: {keypress: keyPressAction}">
       <div data-bind="ifnot: collapsible">
         <legend>
           <span class="caption webapp-markdown-output"

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -437,7 +437,7 @@
 </script>
 <script type="text/html" id="select-entry-ko-template">
   <fieldset>
-  <legend aria-hidden="true" class="sr-only">{% trans "Answer Choices" %}</legend>
+  <legend class="sr-only" data-bind="text: question.caption()"></legend>
     <div class="sel clear">
       <div data-bind="foreach: choices, as: 'choice'">
         <div data-bind="css: { checkbox: $parent.isMulti, radio: !$parent.isMulti }, class: $parent.colStyleIfHideLabel">


### PR DESCRIPTION
## Product Description
Accessibility changes for form elements like radio button groups and checkbox groups, fixed screen-readability of element labels and refactored the accessibility tree to improve screen-reader experience. Added tabindex for heading in markdown, made the Check-box group and Radio groups legend screen-reader visible and added the question as the legend, and Group widget are only focused if they have a visible description.

<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
[Ticket Link](https://dimagi-dev.atlassian.net/browse/USH-1932)
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
### Safety story
Tested locally on Mac with Voiceover
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-4738

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
