### PR TITLE
add bootstrap 5.2.3 as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "bootstrap-switch": "3.3.2",
         "bootstrap-timepicker": "0.5.1",
         "bootstrap3-typeahead": "bassjobsen/Bootstrap-3-Typeahead#~3.1.1",
+        "bootstrap5": "npm:bootstrap@5.2.3",
         "calendars": "kbwood/calendars#2.1.2",
         "clipboard": "1.5.15",
         "crypto-js": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -748,6 +748,11 @@ bootstrap3-typeahead@bassjobsen/Bootstrap-3-Typeahead#~3.1.1:
   version "3.1.1"
   resolved "https://codeload.github.com/bassjobsen/Bootstrap-3-Typeahead/tar.gz/c65c829fe8411f6eadb88415d09c1e85bb4603d0"
 
+"bootstrap5@npm:bootstrap@5.2.3":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.3.tgz#54739f4414de121b9785c5da3c87b37ff008322b"
+  integrity sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==
+
 bootstrap@3.4.1, bootstrap@^3.3:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"


### PR DESCRIPTION
## Technical Summary

And so it really (finally) begins...
https://dimagi-dev.atlassian.net/browse/SAAS-14128

This just adds bootstrap 5 as a dependency in `package.json`. I need it as a reference to see how to migrate our styles fit bootstrap 5's new style names, reference any helpful utilities, and see what things need to be changed/overidden globally to ensure the UI does not change in a way that is extremely visible to the user.

## Safety Assurance

### Safety story
100% safe. Just adding a dependency

### Automated test coverage
N/A

### QA Plan
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
