### PR TITLE
case_configs is not set on a new repeater

### DIFF
--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -426,7 +426,7 @@ def config_dhis2_entity_repeater(request, domain, repeater_id):
             return JsonResponse({'success': _('DHIS2 Tracked Entity configuration saved')})
 
     else:
-        case_configs = repeater.dhis2_entity_config['case_configs']
+        case_configs = repeater.dhis2_entity_config.get('case_configs', [])
     return render(request, 'dhis2/dhis2_entity_config.html', {
         'domain': domain,
         'repeater_id': repeater_id,


### PR DESCRIPTION
## Technical Summary

Tiny.

`SQLDhis2EntityRepeater.dhis2_entity_config['case_configs']` is not defined for a new `SQLDhis2EntityRepeater`. This change sets a default value.

## Feature Flag

DHIS2 Integration

## Safety Assurance

### Safety story

Local testing resolves a KeyError.

### Automated test coverage

Not covered

### QA Plan

Not planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
