### PR TITLE
[USH-1563] validate email address in email messaging content

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1056,6 +1056,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
     ERROR_NO_SUITABLE_GATEWAY = 'NO_SUITABLE_GATEWAY'
     ERROR_GATEWAY_NOT_FOUND = 'GATEWAY_NOT_FOUND'
     ERROR_NO_EMAIL_ADDRESS = 'NO_EMAIL_ADDRESS'
+    ERROR_INVALID_EMAIL_ADDRESS = 'ERROR_INVALID_EMAIL_ADDRESS'
     ERROR_TRIAL_EMAIL_LIMIT_REACHED = 'TRIAL_EMAIL_LIMIT_REACHED'
     ERROR_EMAIL_BOUNCED = 'EMAIL_BOUNCED'
     ERROR_EMAIL_GATEWAY = 'EMAIL_GATEWAY_ERROR'
@@ -1107,6 +1108,8 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
             gettext_noop('Gateway could not be found.'),
         ERROR_NO_EMAIL_ADDRESS:
             gettext_noop('Recipient has no email address.'),
+        ERROR_INVALID_EMAIL_ADDRESS:
+            gettext_noop("Recipient's email address is not valid."),
         ERROR_TRIAL_EMAIL_LIMIT_REACHED:
             gettext_noop("Cannot send any more reminder emails. The limit for "
                 "sending reminder emails on a Trial plan has been reached."),

--- a/corehq/messaging/scheduling/exceptions.py
+++ b/corehq/messaging/scheduling/exceptions.py
@@ -1,3 +1,7 @@
+class ContentException(Exception):
+    def __init__(self, error_type, additional_text=None):
+        self.error_type = error_type
+        self.additional_text = additional_text
 
 
 class NoAvailableContent(Exception):

--- a/corehq/messaging/scheduling/exceptions.py
+++ b/corehq/messaging/scheduling/exceptions.py
@@ -1,4 +1,4 @@
-class ContentException(Exception):
+class EmailValidationException(Exception):
     def __init__(self, error_type, additional_text=None):
         self.error_type = error_type
         self.additional_text = additional_text

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -11,7 +11,7 @@ from corehq.apps.sms.forms import (
 )
 from corehq.apps.sms.models import MessagingEvent
 from corehq.apps.users.models import CommCareUser
-from corehq.messaging.scheduling.exceptions import ContentException
+from corehq.messaging.scheduling.exceptions import EmailValidationException
 from corehq.messaging.scheduling.models import (
     Content as AbstractContent,
     CustomContent,
@@ -216,25 +216,25 @@ class TestContent(TestCase):
         )
 
     def test_email_validation_valid(self):
-        email = RecipientWithEmail("test@example.com")
-        EmailContent().get_recipient_email(email)
+        recipient = MockRecipient("test@example.com")
+        EmailContent().get_recipient_email(recipient)
 
     def test_email_validation_empty_email(self):
-        email = RecipientWithEmail("")
-        with self.assertRaises(ContentException) as e:
-            EmailContent().get_recipient_email(email)
+        recipient = MockRecipient("")
+        with self.assertRaises(EmailValidationException) as e:
+            EmailContent().get_recipient_email(recipient)
         self.assertEqual(e.exception.error_type, MessagingEvent.ERROR_NO_EMAIL_ADDRESS)
 
     def test_email_validation_no_email(self):
-        email = RecipientWithEmail(None)
-        with self.assertRaises(ContentException) as e:
-            EmailContent().get_recipient_email(email)
+        recipient = MockRecipient(None)
+        with self.assertRaises(EmailValidationException) as e:
+            EmailContent().get_recipient_email(recipient)
         self.assertEqual(e.exception.error_type, MessagingEvent.ERROR_NO_EMAIL_ADDRESS)
 
     def test_email_validation_invalid_email(self):
-        email = RecipientWithEmail("bob")
-        with self.assertRaises(ContentException) as e:
-            EmailContent().get_recipient_email(email)
+        recipient = MockRecipient("bob")
+        with self.assertRaises(EmailValidationException) as e:
+            EmailContent().get_recipient_email(recipient)
         self.assertEqual(e.exception.error_type, MessagingEvent.ERROR_INVALID_EMAIL_ADDRESS)
 
 
@@ -248,7 +248,7 @@ class Schedule(AbstractSchedule):
     pass
 
 
-class RecipientWithEmail:
+class MockRecipient:
     def __init__(self, email_address):
         self.email_address = email_address
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-1563

## Product Description
This adds email address validation prior to sending emails using the Conditional Messaging system. This will improve the failure messages for failed events and prevent unnecessary logging to Sentry.

## Technical Summary
Apply standard Django email validation prior to attempting to send emails. Mark the event as an error with context if the email address is not valid.

## Safety Assurance

### Safety story
Added a simple validation in line with existing validation.

### Automated test coverage
Added new tests for the validation to ensure it doesn't fail with a valid email address.

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
