### PR TITLE
Adds additional workaround for psycopg2 error

### DIFF
--- a/DEV_SETUP_MAC.md
+++ b/DEV_SETUP_MAC.md
@@ -124,6 +124,12 @@
   export LDFLAGS="-L/opt/homebrew/opt/libpq/lib"
   pip install psycopg2-binary
   ```
+  
+  Or try: ([reference](https://rogulski.it/blog/install-psycopg2-on-apple-m1/))
+    ```sh
+    export LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib"
+    export CPPFLAGS="-I/opt/homebrew/opt/openssl@1.1/include"
+  ```
 
 ### M1 Issues
 

--- a/DEV_SETUP_MAC.md
+++ b/DEV_SETUP_MAC.md
@@ -125,7 +125,7 @@
   pip install psycopg2-binary
   ```
   
-  Or try: ([reference](https://rogulski.it/blog/install-psycopg2-on-apple-m1/))
+  Or try: ([reference](https://rogulski.it/blog/install-psycopg2-on-apple-m1/)). Used on Mac OS 12.X Monterey.
     ```sh
     export LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib"
     export CPPFLAGS="-I/opt/homebrew/opt/openssl@1.1/include"


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The existing solution did not work for my machine. The additional commands installs psycopg2 and unblocks the requirement install.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Documentation change only.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
