### PR TITLE
Add ReindexCouchViews migration operation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -125,13 +125,22 @@ Label descriptions can be seen on the GitHub `labels`_ page or in the
 Reindex / migration
 ~~~~~~~~~~~~~~~~~~~
 Any PR that will require a database migration or some kind of data reindexing to be done
-must be labeled with the `reindex/migration` label. This label will get automatically applied
+must be labeled with the **reindex/migration** label. This label will get automatically applied
 if the PR changes `certain files`_ but it can also be added manually.
+
+It is necessary to manually add a `ReindexCouchViews`_ Django migration operation, which may
+also require adding a new migration file, if the **reindex/migration** label is added to a PR on
+account of Couch ``_design`` doc changes (or if a new Elasticsearch index is added, but this
+will soon change). A change log entry should be published in `commcare-cloud`_ to alert
+operators to run the migration before deploying if it may disrupt the normal deploy cycle (if it
+will run for a long time on any environment, for example).
 
 Any PR with this label will fail the `required-labels` check. This is intentional to prevent
 premature merging of the PR.
 
 .. _certain files: .github/labels.yml#L12-L13
+.. _ReindexCouchViews: corehq/ex-submodules/dimagi/utils/couch/migration_operations.py
+.. _commcare-cloud: https://github.com/dimagi/commcare-cloud/
 
 Risk
 ~~~~

--- a/corehq/ex-submodules/dimagi/utils/couch/migration_operations.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration_operations.py
@@ -1,0 +1,26 @@
+from django.core.management import call_command
+from django.db.migrations import RunPython
+
+
+class ReindexCouchViews(RunPython):
+    """Reindex Couch DB views and Elasticsearch indexes
+
+    Use as needed whenever Couch views are changed and need to be
+    reindexed. This operation may take a long time, depending on what is
+    being reindexed.
+
+    It is planned for the Elasticsearch index building features to move
+    to migration operations dedicated that purpose alone.
+    See corehq/apps/es/migration_operations.py
+    """
+
+    def __init__(self):
+        super().__init__(self.run, RunPython.noop)
+
+    def deconstruct(self):
+        return (self.__class__.__qualname__, [], {})
+
+    def run(self, apps, schema_editor):
+        call_command("preindex_everything", 8)
+        call_command("sync_finish_couchdb_hq")
+        call_command("ptop_es_manage", flip_all_aliases=True)

--- a/manage.py
+++ b/manage.py
@@ -19,6 +19,7 @@ def main():
         GeventCommand('run_blob_migration'),
         GeventCommand('check_blob_logs'),
         GeventCommand('preindex_everything'),
+        GeventCommand('migrate'),
         GeventCommand('migrate_multi'),
         GeventCommand('prime_views'),
         GeventCommand('ptop_preindex'),


### PR DESCRIPTION
Prepare for removing the automatic reindex operations from deploy logic.

See https://github.com/dimagi/commcare-hq/issues/32510

FYI @dimagi/team-commcare-hq, this introduces a new migration process when Couch views are changed or Elasticsearch indexes are added to a PR.

## Safety Assurance

### Safety story

Adds a very simple migration operation that delegates to other frequently used management commands.

### Automated test coverage

No new tests added.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations