### PR TITLE
Improve es_test decorator

### DIFF
--- a/corehq/apps/es/tests/test_test_utils.py
+++ b/corehq/apps/es/tests/test_test_utils.py
@@ -50,6 +50,25 @@ dogs_adapter = TestDocumentAdapter("dogs", "dog")
 pigs_adapter = TestDocumentAdapter("pigs", "pig")
 
 
+def test_setup_tolerates_existing_index():
+
+    @es_test(requires=[cats_adapter])
+    class TestCatsRequired(SimpleTestCase):
+        def test_index_exists(self):
+            assert_index_exists(cats_adapter)
+
+    dirty_test = TestCatsRequired()
+    dirty_test.setUp()
+    dirty_test.test_index_exists()
+    # dirty test never cleans up
+    tolerant_test = TestCatsRequired()
+    tolerant_test.setUp()  # does not raise "index_already_exists_exception"
+    tolerant_test.test_index_exists()
+    tolerant_test.doCleanups()
+    # tolerant test still cleans up
+    assert_not_index_exists(cats_adapter)
+
+
 def test_setup_cleanup_index():
 
     @es_test(requires=[pigs_adapter])

--- a/corehq/apps/es/tests/test_test_utils.py
+++ b/corehq/apps/es/tests/test_test_utils.py
@@ -7,12 +7,12 @@ from .utils import TestDocumentAdapter, es_test, es_test_attr, temporary_index
 from ..client import manager
 
 
-class TestSetupAndTeardown(SimpleTestCase):
+class TestSetupAndCleanups(SimpleTestCase):
 
     class TestSimpleTestCase(SimpleTestCase):
         """Use a subclass of ``SimpleTestCase`` for making discrete calls to
-        {setUp,tearDown}Class so we can't break other tests if we use it in a
-        non-standard way.
+        setUp[Class]/do[Class]Cleanups so we can't break other tests if we use it
+        in a non-standard way.
         """
 
     def test_no_setup(self):
@@ -20,13 +20,12 @@ class TestSetupAndTeardown(SimpleTestCase):
         with patch.object(manager, "index_create") as mock:
             test.setUp()
         mock.assert_not_called()
-        test.tearDown()
 
-    def test_no_teardown(self):
+    def test_no_cleanups(self):
         test = es_test(self.TestSimpleTestCase)()
         test.setUp()
         with patch.object(manager, "index_delete") as mock:
-            test.tearDown()
+            test.doCleanups()
         mock.assert_not_called()
 
     def test_no_class_setup(self):
@@ -35,12 +34,14 @@ class TestSetupAndTeardown(SimpleTestCase):
             Test.setUpClass()
         mock.assert_not_called()
         Test.tearDownClass()
+        Test.doClassCleanups()
 
-    def test_no_class_teardown(self):
+    def test_no_class_cleanups(self):
         Test = es_test(self.TestSimpleTestCase)
         Test.setUpClass()
         with patch.object(manager, "index_delete") as mock:
             Test.tearDownClass()
+            Test.doClassCleanups()
         mock.assert_not_called()
 
 
@@ -49,7 +50,7 @@ dogs_adapter = TestDocumentAdapter("dogs", "dog")
 pigs_adapter = TestDocumentAdapter("pigs", "pig")
 
 
-def test_setup_teardown_index():
+def test_setup_cleanup_index():
 
     @es_test(requires=[pigs_adapter])
     class Test(SimpleTestCase):
@@ -60,11 +61,11 @@ def test_setup_teardown_index():
     test = Test()
     test.setUp()
     test.test_index_exists()
-    test.tearDown()
+    test.doCleanups()
     assert_not_index_exists(pigs_adapter)
 
 
-def test_setup_teardown_class_index():
+def test_setup_cleanup_class_index():
 
     @es_test(requires=[pigs_adapter], setup_class=True)
     class Test(SimpleTestCase):
@@ -74,7 +75,7 @@ def test_setup_teardown_class_index():
     assert_not_index_exists(pigs_adapter)
     Test.setUpClass()
     Test().test_index_exists()
-    Test.tearDownClass()
+    Test.doClassCleanups()
     assert_not_index_exists(pigs_adapter)
 
 
@@ -122,30 +123,12 @@ def assert_not_index_exists(adapter):
         f"AssertionError: {adapter.index_name!r} unexpectedly found in {indexes!r}"
 
 
-@es_test(requires=[cats_adapter], setup_class=True)
-class TestNoSetupTeardownMethods:
-
-    def test_test_instantiation_should_not_raise_attributeerror(self):
-        """Tests that custom test case classes which lack setup and teardown
-        methods do not raise an AttributeError
-        """
-
-
 @es_test_attr
 def test_setup_class_expects_classmethod():
     with assert_raises_regex(ValueError, "^'setup_class' expects a classmethod"):
         @es_test(requires=[pigs_adapter], setup_class=True)
         class TestExpectsClassmethod:
             def setUpClass(self):
-                pass
-
-
-@es_test_attr
-def test_teardown_class_expects_classmethod():
-    with assert_raises_regex(ValueError, "^'setup_class' expects a classmethod"):
-        @es_test(requires=[pigs_adapter], setup_class=True)
-        class TestExpectsClassmethod:
-            def tearDownClass(self):
                 pass
 
 

--- a/corehq/apps/es/tests/test_test_utils.py
+++ b/corehq/apps/es/tests/test_test_utils.py
@@ -25,6 +25,7 @@ class TestSetupAndCleanups(SimpleTestCase):
         test = es_test(self.TestSimpleTestCase)()
         test.setUp()
         with patch.object(manager, "index_delete") as mock:
+            test.tearDown()
             test.doCleanups()
         mock.assert_not_called()
 
@@ -64,6 +65,7 @@ def test_setup_tolerates_existing_index():
     tolerant_test = TestCatsRequired()
     tolerant_test.setUp()  # does not raise "index_already_exists_exception"
     tolerant_test.test_index_exists()
+    tolerant_test.tearDown()
     tolerant_test.doCleanups()
     # tolerant test still cleans up
     assert_not_index_exists(cats_adapter)
@@ -80,6 +82,7 @@ def test_setup_cleanup_index():
     test = Test()
     test.setUp()
     test.test_index_exists()
+    test.tearDown()
     test.doCleanups()
     assert_not_index_exists(pigs_adapter)
 
@@ -94,6 +97,7 @@ def test_setup_cleanup_class_index():
     assert_not_index_exists(pigs_adapter)
     Test.setUpClass()
     Test().test_index_exists()
+    Test.tearDownClass()
     Test.doClassCleanups()
     assert_not_index_exists(pigs_adapter)
 

--- a/corehq/apps/es/tests/utils.py
+++ b/corehq/apps/es/tests/utils.py
@@ -170,7 +170,7 @@ def _decorate_test_function(test, operations):
                 created.append(operation)
             return test(*args, **kw)
         finally:
-            for operation in created:
+            for operation in reversed(created):
                 operation.reverse_run()
 
     return wrapper


### PR DESCRIPTION
## Technical Summary

Changes the behavior the the `es_test` decorator when called with adapters.

1. Performs index cleanup via `add[Class]Cleanup()` method instead of `tearDown[Class]()`.
2. Can only perform setup/teardown on test case classes that implement an `add[Class]Cleanup()` method (the previous implementation did not require test case classes to comply with _any_ interface).
3. Is tolerant of an existing test index (now deletes and recreates rather than resulting in an Elastic exception).

Item :three: (7634eddc645) is temporary and will be reverted once tests are refactored to clean up after themselves.

Review: commit by commit.

## Safety Assurance

### Safety story

Tests only.

### Automated test coverage

Includes new test util tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
