### PR TITLE
Mobile Worker Bulk Download UI Change

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1665,8 +1665,9 @@ class UserFilterForm(forms.Form):
                     type="submit",
                     css_class="btn btn-primary",
                 ),
-                crispy.HTML(
-                    "<p style='display:inline' data-bind='html: buttonHTML'>Calculating download size.</p>"
+                crispy.Div(
+                    data_bind="template: {name: 'ko-template-download-statistics'}",
+                    style="display: inline;",
                 )
             ),
         )

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1661,10 +1661,12 @@ class UserFilterForm(forms.Form):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
-                    _("Download All Users"),
+                    _("Download"),
                     type="submit",
                     css_class="btn btn-primary",
-                    data_bind="html: buttonHTML",
+                ),
+                crispy.HTML(
+                    "<p style='display:inline' data-bind='html: buttonHTML'>Calculating download size.</p>"
                 )
             ),
         )

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1569,7 +1569,7 @@ class UserFilterForm(forms.Form):
         required=False,
         label=gettext_noop("Columns"),
         choices=COLUMNS_CHOICES,
-        widget=SelectToggle(choices=COLUMNS_CHOICES, apply_bindings=False),
+        widget=SelectToggle(choices=COLUMNS_CHOICES, attrs={'ko_value': 'columns'}),
     )
     domains = forms.MultipleChoiceField(
         required=False,

--- a/corehq/apps/users/static/users/js/filtered_download.js
+++ b/corehq/apps/users/static/users/js/filtered_download.js
@@ -36,7 +36,7 @@ hqDefine('users/js/filtered_download', [
             if (self.count() === null) {
                 return "<i class='fa fa-spin fa-spinner'></i>";
             }
-            var template = self.count()[USER_COUNT] === 1 ? gettext("Download <%- user_count %> user") : gettext("Download <%- user_count %> users");
+            var template = self.count()[USER_COUNT] === 1 ? gettext("<%- user_count %> user") : gettext("<%- user_count %> users");
             if (self.count()[1] !== 0) {
                 template += self.count()[GROUPS_COUNT] === 1 ? gettext(" and <%- groups_count %> group") : gettext(" and <%- groups_count %> groups");
             }

--- a/corehq/apps/users/static/users/js/filtered_download.js
+++ b/corehq/apps/users/static/users/js/filtered_download.js
@@ -16,6 +16,9 @@ hqDefine('users/js/filtered_download', [
     function FiltersModel(options) {
         var self = {};
 
+        const USER_COUNT = 0;
+        const GROUPS_COUNT = 1;
+
         self.role_id = ko.observable();
         self.search_string = ko.observable();
         self.location_id = ko.observable();
@@ -33,9 +36,13 @@ hqDefine('users/js/filtered_download', [
             if (self.count() === null) {
                 return "<i class='fa fa-spin fa-spinner'></i>";
             }
-            var template = self.count() === 1 ? gettext("Download <%- count %> user") : gettext("Download <%- count %> users");
+            var template = self.count()[USER_COUNT] === 1 ? gettext("Download <%- user_count %> user") : gettext("Download <%- user_count %> users");
+            if (self.count()[1] !== 0) {
+                template += self.count()[GROUPS_COUNT] === 1 ? gettext(" and <%- groups_count %> group") : gettext(" and <%- groups_count %> groups");
+            }
             return _.template(template)({
-                count: self.count(),
+                user_count: self.count()[USER_COUNT],
+                groups_count: self.count()[GROUPS_COUNT],
             });
         });
 

--- a/corehq/apps/users/static/users/js/filtered_download.js
+++ b/corehq/apps/users/static/users/js/filtered_download.js
@@ -30,10 +30,13 @@ hqDefine('users/js/filtered_download', [
 
         self.user_count = ko.observable(null);
         self.group_count = ko.observable(null);
-        self.buttonHTML = ko.computed(function () {
-            if (self.user_count() === null) {
-                return "<i class='fa fa-spin fa-spinner'></i>";
-            }
+        self.areStatsLoading = ko.computed(function () {
+            return self.user_count() === null;
+        });
+        self.haveStatsLoaded = ko.computed(function () {
+            return !self.areStatsLoading();
+        });
+        self.statsText = ko.computed(function () {
             var template = self.user_count() === 1 ? gettext("<%- user_count %> user") : gettext("<%- user_count %> users");
             if (self.group_count() !== 0) {
                 template += self.group_count() === 1 ? gettext(" and <%- group_count %> group") : gettext(" and <%- group_count %> groups");

--- a/corehq/apps/users/static/users/js/filtered_download.js
+++ b/corehq/apps/users/static/users/js/filtered_download.js
@@ -16,9 +16,6 @@ hqDefine('users/js/filtered_download', [
     function FiltersModel(options) {
         var self = {};
 
-        const USER_COUNT = 0;
-        const GROUPS_COUNT = 1;
-
         self.role_id = ko.observable();
         self.search_string = ko.observable();
         self.location_id = ko.observable();
@@ -31,23 +28,25 @@ hqDefine('users/js/filtered_download', [
             return self.domains() && self.domains().length > 0;
         });
 
-        self.count = ko.observable(null);
+        self.user_count = ko.observable(null);
+        self.group_count = ko.observable(null);
         self.buttonHTML = ko.computed(function () {
-            if (self.count() === null) {
+            if (self.user_count() === null) {
                 return "<i class='fa fa-spin fa-spinner'></i>";
             }
-            var template = self.count()[USER_COUNT] === 1 ? gettext("<%- user_count %> user") : gettext("<%- user_count %> users");
-            if (self.count()[1] !== 0) {
-                template += self.count()[GROUPS_COUNT] === 1 ? gettext(" and <%- groups_count %> group") : gettext(" and <%- groups_count %> groups");
+            var template = self.user_count() === 1 ? gettext("<%- user_count %> user") : gettext("<%- user_count %> users");
+            if (self.group_count() !== 0) {
+                template += self.group_count() === 1 ? gettext(" and <%- group_count %> group") : gettext(" and <%- group_count %> groups");
             }
             return _.template(template)({
-                user_count: self.count()[USER_COUNT],
-                groups_count: self.count()[GROUPS_COUNT],
+                user_count: self.user_count(),
+                group_count: self.group_count(),
             });
         });
 
         self.countUsers = function () {
-            self.count(null);
+            self.user_count(null);
+            self.group_count(null);
             var data = {
                 search_string: self.search_string(),
                 domains: self.domains(),
@@ -65,7 +64,8 @@ hqDefine('users/js/filtered_download', [
                 url: options.url,
                 data: data,
                 success: function (data) {
-                    self.count(data.count);
+                    self.user_count(data.user_count);
+                    self.group_count(data.group_count);
                 },
                 error: function () {
                     alert(gettext("Error determining number of matching users"));

--- a/corehq/apps/users/static/users/js/filtered_download.js
+++ b/corehq/apps/users/static/users/js/filtered_download.js
@@ -38,7 +38,7 @@ hqDefine('users/js/filtered_download', [
         });
         self.statsText = ko.computed(function () {
             var template = self.user_count() === 1 ? gettext("<%- user_count %> user") : gettext("<%- user_count %> users");
-            if (self.group_count() !== 0) {
+            if (self.group_count() !== 0 && self.columns() !== 'usernames') {
                 template += self.group_count() === 1 ? gettext(" and <%- group_count %> group") : gettext(" and <%- group_count %> groups");
             }
             return _.template(template)({

--- a/corehq/apps/users/templates/users/filter_and_download.html
+++ b/corehq/apps/users/templates/users/filter_and_download.html
@@ -7,5 +7,16 @@
 
 {% block page_content %}
   {% initial_page_data 'count_users_url' count_users_url %}
+  <script type="text/html" id="ko-template-download-statistics">
+    <span class="label label-default">
+      <!-- ko if: areStatsLoading -->
+        <i class="fa fa-spinner fa-spin"></i> {% trans 'Calculating download size...' %}
+      <!-- /ko -->
+      <!-- ko if: haveStatsLoaded -->
+        <i class="fa fa-info-circle"></i>
+        <!-- ko text: statsText --><!-- /ko -->
+      <!-- /ko -->
+    </span>
+  </script>
   {% crispy form %}
 {% endblock %}

--- a/corehq/apps/users/tests/test_commcare_users_lookup.py
+++ b/corehq/apps/users/tests/test_commcare_users_lookup.py
@@ -44,7 +44,7 @@ class UserCountTest(TestCase):
         content = json.loads(response.content)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(content, {'count': [5, 1]})
+        self.assertEqual(content, {'user_count': 5, 'group_count': 1})
 
     @mock.patch('corehq.apps.users.dbaccessors.count_web_users_by_filters')
     @mock.patch('corehq.apps.users.dbaccessors.count_invitations_by_filters')
@@ -58,4 +58,4 @@ class UserCountTest(TestCase):
         content = json.loads(response.content)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(content, {'count': 6})
+        self.assertEqual(content, {'user_count': 6, 'group_count': 0})

--- a/corehq/apps/users/tests/test_commcare_users_lookup.py
+++ b/corehq/apps/users/tests/test_commcare_users_lookup.py
@@ -1,0 +1,61 @@
+import json
+from unittest import mock
+from django.test import TestCase, RequestFactory
+from corehq.apps.domain.models import Domain
+from corehq.apps.groups.models import Group
+from corehq.apps.users.models import WebUser
+from corehq.apps.users.views.mobile.users import _count_users
+
+
+class UserCountTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(UserCountTest, cls).setUpClass()
+        cls.domain_name = 'test-domain'
+        cls.domain = Domain.get_or_create_with_name(cls.domain_name, is_active=True)
+        cls.addClassCleanup(cls.domain.delete)
+
+        cls.user = WebUser.create(cls.domain_name,
+                                  'test_user_',
+                                  'test',
+                                  None,
+                                  None)
+        cls.user.is_authenticated = True
+        cls.addClassCleanup(cls.user.delete, cls.domain_name, deleted_by=None)
+
+    def create_group(self):
+        self.group = Group({"name": "test", "domain": self.domain_name})
+        self.group.save()
+        self.addClassCleanup(self.group.delete)
+
+    def create_request(self, user_type):
+        request = RequestFactory().get('/', {'user_type': user_type})
+        request.user = self.user
+        return request
+
+    @mock.patch('corehq.apps.users.dbaccessors.count_mobile_users_by_filters')
+    def test_count_users_mobile_worker_return_value(self, mock_count_mobile_users):
+        mock_count_mobile_users.return_value = 5
+        self.create_group()
+        user_type = 'mobile'
+        request = self.create_request(user_type)
+
+        response = _count_users(request, self.domain_name, user_type)
+        content = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content, {'count': [5, 1]})
+
+    @mock.patch('corehq.apps.users.dbaccessors.count_web_users_by_filters')
+    @mock.patch('corehq.apps.users.dbaccessors.count_invitations_by_filters')
+    def test_count_users_web_user_return_value(self, mock_count_web_users, mock_count_invitations):
+        mock_count_web_users.return_value = 4
+        mock_count_invitations.return_value = 2
+        user_type = 'web'
+        request = self.create_request(user_type)
+
+        response = _count_users(request, self.domain_name, user_type)
+        content = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content, {'count': 6})

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -318,7 +318,7 @@ class TestCountWebUsers(TestCase):
             password='badpassword',
         )
         result = self.client.get(reverse(self.view, kwargs={'domain': self.domain}))
-        self.assertEqual(json.loads(result.content)['count'], 2)
+        self.assertEqual(json.loads(result.content)['user_count'], 2)
 
     def test_admin_location_user_sees_all_web_users(self):
         self.client.login(
@@ -326,4 +326,4 @@ class TestCountWebUsers(TestCase):
             password='badpassword',
         )
         result = self.client.get(reverse(self.view, kwargs={'domain': self.domain}))
-        self.assertEqual(json.loads(result.content)['count'], 2)
+        self.assertEqual(json.loads(result.content)['user_count'], 2)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1379,8 +1379,9 @@ def _count_users(request, domain, user_type):
     (is_cross_domain, domains_list) = get_domains_from_user_filters(domain, user_filters)
     for current_domain in domains_list:
         if user_type == MOBILE_USER_TYPE:
-            user_count += count_mobile_users_by_filters(current_domain, user_filters)
-            user_count += len(load_memoizer(current_domain).groups)
+            user_count = count_mobile_users_by_filters(current_domain, user_filters)
+            group_count = len(load_memoizer(current_domain).groups)
+            user_count = (user_count, group_count)
         else:
             user_count += count_web_users_by_filters(current_domain, user_filters)
             user_count += count_invitations_by_filters(current_domain, user_filters)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -71,7 +71,7 @@ from corehq.apps.users.account_confirmation import (
 )
 from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.apps.users.audit.change_messages import UserChangeMessage
-from corehq.apps.users.bulk_download import get_domains_from_user_filters
+from corehq.apps.users.bulk_download import get_domains_from_user_filters, load_memoizer
 from corehq.apps.users.dbaccessors import get_user_docs_by_username
 from corehq.apps.users.decorators import (
     require_can_edit_commcare_users,
@@ -1380,6 +1380,7 @@ def _count_users(request, domain, user_type):
     for current_domain in domains_list:
         if user_type == MOBILE_USER_TYPE:
             user_count += count_mobile_users_by_filters(current_domain, user_filters)
+            user_count += len(load_memoizer(current_domain).groups)
         else:
             user_count += count_web_users_by_filters(current_domain, user_filters)
             user_count += count_invitations_by_filters(current_domain, user_filters)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1376,18 +1376,19 @@ def _count_users(request, domain, user_type):
         return HttpResponseBadRequest("Invalid Request")
 
     user_count = 0
+    group_count = 0
     (is_cross_domain, domains_list) = get_domains_from_user_filters(domain, user_filters)
     for current_domain in domains_list:
         if user_type == MOBILE_USER_TYPE:
-            user_count = count_mobile_users_by_filters(current_domain, user_filters)
-            group_count = len(load_memoizer(current_domain).groups)
-            user_count = (user_count, group_count)
+            user_count += count_mobile_users_by_filters(current_domain, user_filters)
+            group_count += len(load_memoizer(current_domain).groups)
         else:
             user_count += count_web_users_by_filters(current_domain, user_filters)
             user_count += count_invitations_by_filters(current_domain, user_filters)
 
     return JsonResponse({
-        'count': user_count
+        'user_count': user_count,
+        'group_count': group_count,
     })
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Previously, we had a user count show up on the download button. This changes that to text that shows up next to the button that includes the size of the groups download as well.

This is what the bulk download looks like before the changes:
![image](https://user-images.githubusercontent.com/81161564/215071555-cb374dfe-f9d7-4d74-8a49-c0ad3e27c174.png)

This is what the bulk download looks like after the changes:
![image](https://user-images.githubusercontent.com/81161564/215071482-4073decb-0d4a-4f24-8cc1-9be26aa468be.png)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[This ticket ](https://dimagi-dev.atlassian.net/browse/SAAS-13931) describes a failing download and a larger amount of entries being downloaded than what is being shown on the button. It can be a frustrating experience for users to see differing information when downloading and while the information shown on the button was accurate, it did not account for groups, which automatically downloads with the mobile workers. This change is meant to provide more clarity to the user as to what they are downloading.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I am confident that this change is safe because of local testing. I tested for four different cases,
- 1 user and no groups
- many users and 1 group
- no users and 1 group
- no users and many groups

I believe that these cases would include any and different types of text that users will see and I made sure that the numbers were correct.

This will also go through QA, since it's a UI change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Wrote two tests that can be found in test_commcare_users_lookup that ensure that the count of users and groups is correct whether we are counting mobile workers or web users.


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[Link to QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-4734)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
