### PR TITLE
upgrade setuptools to 65.5.1 in docs-requirements

### DIFF
--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -584,7 +584,7 @@ zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==53.0.0
+setuptools==65.5.1
     # via
     #   django-websocket-redis
     #   gevent


### PR DESCRIPTION
## Technical Summary
I seemed to have missed setting the `setuptools` version to `65.5.1` in `docs-requirements` in [this PR](https://github.com/dimagi/commcare-hq/pull/32463). Updating it now so our security notifications go away!

## Safety Assurance

### Safety story
Tests pass ✅ 

### Automated test coverage
Yes

### QA Plan
N/A


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
