### PR TITLE
Skip some github actions steps if secrets are unavailable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,9 @@ jobs:
         docker version
         docker-compose version
     - name: Docker login
+      env:
+        TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      if: env.TOKEN != ''
       uses: docker/login-action@v1
       with:
         username: dimagi
@@ -45,6 +48,9 @@ jobs:
         KAFKA_HOSTNAME: kafka
       run: scripts/docker test --noinput --stop -v --divided-we-run=${{ matrix.NOSE_DIVIDED_WE_RUN }} --divide-depth=1 --with-timing --with-flaky --threshold=10 --max-test-time=29
     - name: "Codecov upload"
+      env:
+        TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      if: env.TOKEN != ''
       uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Dependabot test runs need not fail if `DOCKERHUB_TOKEN` or `CODECOV_TOKEN` are not set. The dockerhub login and codecov upload will be skipped in that case.

Dockerhub access will count toward our public API access limits when the dockerhub login is skipped. This should not matter since the volume of dockerhub PRs is low.

Each checked secret is assigned to an intermediate environment variable because [secrets cannot be directly referenced in `if:` conditionals](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets).

## Motivation

It's difficult to make tests run on dependabot PRs. Often dependabot rebases the PR if it is closed and then reopened, which means the triggered test run is lost in the commit history from pre-rebase.

## Safety Assurance

### Safety story

Changes github actions configuration only. Dependabot will be allowed to run tests, which means that third-party code may be executed in tests before changes are reviewed. No [dependabot secrets](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-encrypted-secrets-for-dependabot) are set as of this writing, so tests run by dependabot will not have access to any secrets.

Another concern with running untrusted third-party code in our actions is the `GITHUB_TOKEN` access permissions. These can be viewed under `GITHUB_TOKEN Permissions` in the _Set up job_ section of each job run log ([example](https://github.com/dimagi/commcare-hq/actions/runs/3969110236/jobs/6803156141#step:1:17)). The `GITHUB_TOKEN` permissions for test runs in this repository are read-only.

See also [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions).

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations