### PR TITLE
"Switching project spaces" bugfix

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -23,7 +23,12 @@ hqDefine("cloudcare/js/formplayer/app", function () {
     FormplayerFrontend.on("before:start", function (app, options) {
         // Make a get call if the csrf token isn't available when the page loads.
         if ($.cookie('XSRF-TOKEN') === undefined) {
-            $.get({url: options.formplayer_url + '/serverup', global: false, xhrFields: { withCredentials: true }});
+            $.get({
+                url: options.formplayer_url + '/serverup',
+                global: false,
+                async: false,
+                xhrFields: { withCredentials: true },
+            });
         }
         var RegionContainer = Marionette.View.extend({
             el: "#menu-container",


### PR DESCRIPTION

## Technical Summary
[USH-2745](https://dimagi-dev.atlassian.net/browse/USH-2745?atlOrigin=eyJpIjoiZWU0YjI3ZTFiODAzNDAxMjlmNWU4OTRkYmI3OWVlZjkiLCJwIjoiaiJ9)
Fixes a bug where, when using a smart link and after logging in, a user can be faced with an endless "Switching project spaces..." message that does not resolve until refreshing the page. This seems to be the result of an XSRF cookie not being set in time for it to be included in the next request to Formplayer. 

This change associates a jQuery `Deferred` promise with an existing request that retrieves the XSRF token, and makes the FormplayerFrontend wait on that promise to resolve before moving on.

## Safety Assurance

### Safety story
All code for the existing request to retrieve a new XSRF token from Formplayer is left in place; this is only a minor addition. The promise that FormplayerFrontend is asked to wait on will resolve when the request to Formplayer _completes_, whether or not the request _succeeds_, so it should never hold up the app indefinitely - and is also set to immediately resolve when no new token is needed.

### QA Plan
Will send to QA to ensure bug is truly resolved and does not introduce any new issues.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-2745]: https://dimagi-dev.atlassian.net/browse/USH-2745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ