### PR TITLE
Updated text for button on modal to delete repeater config

### DIFF
--- a/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
@@ -111,15 +111,15 @@
             {% trans "Configure" %}
         </a>
         {% endif %}
-        <a class="btn btn-danger" href="#stop_forwarding_{{ repeater.repeater_id }}" data-toggle="modal"><i
-                class="fa fa-remove"></i> {% trans "Stop" %}</a>
+        <a class="btn btn-danger" href="#delete_{{ repeater.repeater_id }}" data-toggle="modal"><i
+                class="fa fa-remove"></i> {% trans "Delete" %}</a>
 
-        <div class="modal fade" id="stop_forwarding_{{ repeater.repeater_id }}">
+        <div class="modal fade" id="delete_{{ repeater.repeater_id }}">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title">{% trans "Stop Forwarding" %}</h4>
+                        <h4 class="modal-title">{% trans "Delete Configuration" %}</h4>
                     </div>
                     <form name="drop_repeater" action="{% url 'drop_repeater' domain repeater.repeater_id %}"
                           method="post">
@@ -127,17 +127,17 @@
                         <div class="modal-body">
                             <p>
                                 {% blocktrans with repeater.name as name %}
-                                    Are you sure you want to stop forwarding to: {{ name }} ?
-                                    <br/>
-                                    Forwarder and its data would not be deleted but no new records would get added for
-                                    this forwarder and it would not appear in this list anymore.
+                                    Are you sure you want to delete the configuration for: {{ name }} ?
+                                    <br/><br />
+                                    Data forwarding records will not be deleted, but no new records will be
+                                    forwarded, and this configuration will no longer appear on this page.
                                 {% endblocktrans %}
                             </p>
                         </div>
                         <div class="modal-footer">
                             <a href="#" data-dismiss="modal" class="btn btn-default">{% trans 'Cancel' %}</a>
                             <button type="submit" class="btn btn-danger"><i
-                                    class="fa fa-remove"></i> {% trans 'Stop Forwarding' %}
+                                    class="fa fa-remove"></i> {% trans 'Delete' %}
                             </button>
                         </div>
                     </form>

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -221,7 +221,7 @@ class EditRepeaterView(BaseRepeaterView):
                 domain=self.domain,
                 repeater_class=self.repeater_class,
                 data=data,
-                submit_btn_text=_("Update Repeater"),
+                submit_btn_text=_("Update Forwarder"),
             )
 
     @method_decorator(domain_admin_required)
@@ -234,7 +234,7 @@ class EditRepeaterView(BaseRepeaterView):
         return SQLRepeater.objects.get(repeater_id=self.kwargs['repeater_id'])
 
     def post_save(self, request, repeater):
-        messages.success(request, _("Repeater Successfully Updated"))
+        messages.success(request, _("Forwarder Successfully Updated"))
         try:
             url = reverse(self.urlname, args=[self.domain, repeater.repeater_id])
         except NoReverseMatch:


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2765

Before
<img width="379" alt="Screen Shot 2023-01-25 at 3 57 43 PM" src="https://user-images.githubusercontent.com/1486591/214689087-41d90cdb-4e64-445c-ada7-9b55978365c8.png">

<img width="629" alt="Screen Shot 2023-01-25 at 3 24 56 PM" src="https://user-images.githubusercontent.com/1486591/214689116-6d9b275d-d048-4f5d-b47f-651af4fc4954.png">

After
<img width="388" alt="Screen Shot 2023-01-25 at 3 57 24 PM" src="https://user-images.githubusercontent.com/1486591/214689148-6e50e482-8693-4d1e-8113-f0dd7b329237.png">
<img width="615" alt="Screen Shot 2023-01-25 at 4 11 53 PM" src="https://user-images.githubusercontent.com/1486591/214691922-e8d63ec9-e712-4e91-b553-2700f677a4eb.png">

## Safety Assurance

### Safety story
Copy changes. Pretty trivial.

### Automated test coverage

Unlikely

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
