### PR TITLE
remove <a> tag that was left behind in code removal

### DIFF
--- a/corehq/apps/domain/templates/domain/manage_releases_by_app_profile.html
+++ b/corehq/apps/domain/templates/domain/manage_releases_by_app_profile.html
@@ -12,7 +12,6 @@
   {% initial_page_data 'appVersionOnlyShowReleased' True %}
   {% initial_page_data 'buildProfilesPerApp' build_profiles_per_app %}
   {% registerurl 'toggle_release_restriction_by_app_profile' domain '---'%}
-  {% registerurl 'manage_hosted_ccz' domain %}
   {% registerurl "paginate_releases" domain '---' %}
     <ul class="nav nav-tabs sticky-tabs">
       <li><a data-toggle="tab" href="#search-form" id="search-tab">{% trans "Search" %}</a></li>
@@ -50,10 +49,6 @@
           <td data-bind="text: version"></td>
           <td data-bind="text: status"></td>
           <td>
-            <a type="button" class="btn btn-default" data-bind="attr: { href: hostedCCZLink },
-              visible: hostedCCZLink" target="_blank">
-              {% trans 'View Hostings' %}
-            </a>
             <button type="button" class="btn btn-default"
                     data-bind="click: toggleRestriction, css: buttonClass,
                                       disable: ajaxInProgress">


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Users will no longer be able to see the hyperlink that would take them to ccz on the manage releases by app profile page 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This [ticket](https://dimagi-dev.atlassian.net/browse/SAAS-14257) describes a url to the manage releases by app profile throwing a 500 error. The problem was a hyperlink to deleted code. This fix removes that hyperlink.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Specific to the RELEASE_BUILDS_PER_PROFILE feature flag.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I browsed the Manage Releases By App Profile page locally and was no longer able to see the hyperlink. The page was working as intended and I could actually access the page.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests are unnecessary here since this is only the removal of a hyperlink. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
