### PR TITLE
removed managehostedccz reference in js

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
@@ -12,7 +12,6 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
     _,
     initialPageData,
     assertProperties,
-    toggles
 ) {
     'use strict';
     $(function () {
@@ -28,16 +27,6 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
             self.appName = details.app_name;
             self.version = details.version;
             self.profileName = details.profile_name;
-            var showHostedCCZLink = toggles.toggleEnabled('MANAGE_CCZ_HOSTING');
-            if (showHostedCCZLink) {
-                self.hostedCCZLink = (
-                    initialPageData.reverse('manage_hosted_ccz') +
-                    "?app_id=" + details.app_id + "&version=" + details.version +
-                    "&profile_id=" + details.build_profile_id
-                );
-            } else {
-                self.hostedCCZLink = null;
-            }
             self.domId = "restriction_" + self.id;
             self.errorMessage = ko.observable();
             self.ajaxInProgress = ko.observable(false);

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
@@ -4,7 +4,6 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
     'underscore',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/assert_properties',
-    'hqwebapp/js/toggles',
     'translations/js/app_translations',
 ], function (
     $,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No user facing effects

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This [ticket](https://dimagi-dev.atlassian.net/browse/SAAS-14257) describes a url to the manage releases by app profile throwing a 500 error. The problem was a hyperlink to deleted code. This fix removes the js associated with managegostedccz.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Specific to the RELEASE_BUILDS_PER_PROFILE feature flag.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I browsed the Manage Releases By App Profile page locally and was no longer able to see the hyperlink. The page was working as intended and I could actually access the page.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests are unnecessary here since this is only the removal of a hyperlink.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
