### PR TITLE
include patient_case in search output if resource type matches

### DIFF
--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -187,6 +187,26 @@ class TestFHIRSearchView(BaseFHIRViewTest):
             }
         )
 
+    @flag_enabled('FHIR_INTEGRATION')
+    def test_search_patient(self):
+        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Patient"]) + f"?patient_id={PERSON_CASE_ID}"
+        response = self.client.get(url)
+        self.assertEqual(
+            response.json(),
+            {
+                "resourceType": "Bundle",
+                "type": "searchset",
+                "entry": [
+                    {
+                        "fullUrl": get_endpoint_url(BASE_URL, f'/Patient/{PERSON_CASE_ID}/'),
+                        "search": {
+                            "mode": "match"
+                        }
+                    }
+                ]
+            }
+        )
+
 
 def _setup_cases(owner_id):
     submit_case_blocks([

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -102,6 +102,8 @@ def search_view(request, domain, fhir_version_name, resource_type):
 
     cases = CommCareCase.objects.get_reverse_indexed_cases(
         domain, [patient_case_id], case_types=case_types_for_resource_type, is_closed=False)
+    if patient_case.type in case_types_for_resource_type:
+        cases.append(patient_case)
     response = {
         'resourceType': "Bundle",
         "type": "searchset",


### PR DESCRIPTION
## Technical Summary
Small change to the FHIR search API to include the patient if it matches the requested resource type.

I believe this is the correct behaviour.

## Feature Flag
FHIR

## Safety Assurance

### Safety story
updated unit tests

### Automated test coverage
Unit test added

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
