### PR TITLE
Revert "Incomplete forms P3 fix"

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -5,11 +5,17 @@ hqDefine("cloudcare/js/formplayer/apps/controller", function () {
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
         settingsViews = hqImport("cloudcare/js/formplayer/layout/views/settings"),
         views = hqImport("cloudcare/js/formplayer/apps/views");
+
     return {
         listApps: function () {
-            $.when(FormplayerFrontend.getChannel().request("appselect:apps")).done(function (apps) {
+            $.when(FormplayerFrontend.getChannel().request("appselect:apps")).done(function (appCollection) {
+                let apps = appCollection.toJSON();
+                let isIncompleteFormsDisabled = (app) => (app.profile.properties || {})['cc-show-incomplete'] === 'no';
+                let isAllIncompleteFormsDisabled = apps.every(isIncompleteFormsDisabled);
+
                 var appGridView = views.GridView({
-                    collection: apps,
+                    collection: appCollection,
+                    shouldShowIncompleteForms: !isAllIncompleteFormsDisabled,
                 });
                 FormplayerFrontend.regions.getRegion('main').show(appGridView);
             });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
@@ -100,6 +100,16 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
         syncKeyAction: _.extend(BaseAppView.syncKeyAction),
         restoreAsKeyAction: _.extend(BaseAppView.restoreAsKeyAction),
         settingsKeyAction: _.extend(BaseAppView.settingsKeyAction),
+
+        initialize: function (options) {
+            this.shouldShowIncompleteForms = options.shouldShowIncompleteForms;
+        },
+
+        templateContext: function () {
+            return {
+                shouldShowIncompleteForms: this.shouldShowIncompleteForms,
+            };
+        },
     });
 
     /**
@@ -134,7 +144,7 @@ hqDefine("cloudcare/js/formplayer/apps/views", function () {
                 appName;
             appName = currentApp.get('name');
             return {
-                showIncompleteForms: function () {
+                shouldShowIncompleteForms: function () {
                     return FormplayerFrontend.getChannel()
                         .request('getAppDisplayProperties')['cc-show-incomplete'] === 'yes';
                 },

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -10,6 +10,7 @@
     <div class="js-application-container">
 
     </div>
+    <% if (shouldShowIncompleteForms) { %>
     <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
       <div class="js-incomplete-sessions-item appicon appicon-incomplete" role="link" tabindex="0" aria-labelledby="grid-template-incomplete-forms-heading">
         <i class="ff ff-incomplete-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>
@@ -19,6 +20,7 @@
         </div>
       </div>
     </div>
+    <% } %>
 
     <div class=" grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
       <div class="js-sync-item appicon appicon-sync" role="link" tabindex="0" aria-labelledby="grid-template-sync-heading">
@@ -65,7 +67,7 @@
           </div>
         </div>
       </div>
-      <% if (showIncompleteForms()) { %>
+      <% if (shouldShowIncompleteForms()) { %>
       <div class=" grid-item col-xs-6 col-sm-4 formplayer-request">
         <div class="js-incomplete-sessions-item appicon appicon-incomplete" role="link" tabindex="0" aria-labelledby="single-app-incomplete-forms-heading">
           <i class="ff ff-incomplete-bg appicon-icon appicon-icon-bg" aria-hidden="true"></i>


### PR DESCRIPTION
## Technical Summary
Restores https://github.com/dimagi/commcare-hq/pull/32424 and https://github.com/dimagi/commcare-hq/pull/32441

No changes to code. Change communication was sent out to inform of this change and required actions.

## Safety Assurance

Same as https://github.com/dimagi/commcare-hq/pull/32424 in addition to QA.

The "Incomplete Forms" setting is default to off. Apps that have this setting set to default (off) will have incomplete forms hidden after this change is implemented. [Change Communication ](https://dimagi-dev.atlassian.net/browse/USH-2813) have been circulated with directions to prevent incomplete forms from being hidden.

### QA Plan
Will initiate QA. QA was not performed on the initial PR.
[QA-4753](https://dimagi-dev.atlassian.net/browse/QA-4753)
### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[QA-4753]: https://dimagi-dev.atlassian.net/browse/QA-4753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ