### PR TITLE
remove static limit from log message

### DIFF
--- a/corehq/ex-submodules/couchforms/getters.py
+++ b/corehq/ex-submodules/couchforms/getters.py
@@ -46,7 +46,7 @@ def get_instance_and_attachment(request):
             raise MultipartFilenameError()
         else:
             if instance_file.size > settings.MAX_UPLOAD_SIZE:
-                logging.info("Domain {request.domain} attempted to submit a form exceeding 50MB")
+                logging.info("Domain {request.domain} attempted to submit a form exceeding the allowed size")
                 raise PayloadTooLarge()
             if not _valid_file_extension(instance_file):
                 raise InvalidSubmissionFileExtensionError()


### PR DESCRIPTION
## Technical Summary
Remove static limit from log message and rather keep message generic.

See https://github.com/dimagi/commcare-hq/pull/32511#discussion_r1087962037

## Safety Assurance

### Safety story
Text change to internal log message

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
