### PR TITLE
add epoch_millis to xform date formats

### DIFF
--- a/corehq/pillows/mappings/xform_mapping.py
+++ b/corehq/pillows/mappings/xform_mapping.py
@@ -10,6 +10,8 @@ XFORM_INDEX = form_adapter.index_name
 XFORM_ES_TYPE = form_adapter.type
 XFORM_ALIAS = prefix_for_tests("xforms")
 
+XFORM_DATE_FORMATS_STRING = "epoch_millis||" + DATE_FORMATS_STRING
+
 XFORM_MAPPING = {
     "_meta": {
         "created": "2013-08-13"
@@ -95,7 +97,7 @@ XFORM_MAPPING = {
                             "type": "string"
                         },
                         "@date_modified": {
-                            "format": DATE_FORMATS_STRING,
+                            "format": XFORM_DATE_FORMATS_STRING,
                             "type": "date"
                         },
                         "@user_id": {
@@ -111,7 +113,7 @@ XFORM_MAPPING = {
                             "type": "string"
                         },
                         "date_modified": {
-                            "format": DATE_FORMATS_STRING,
+                            "format": XFORM_DATE_FORMATS_STRING,
                             "type": "date"
                         },
                         "user_id": {
@@ -155,11 +157,11 @@ XFORM_MAPPING = {
                             "type": "string"
                         },
                         "timeEnd": {
-                            "format": DATE_FORMATS_STRING,
+                            "format": XFORM_DATE_FORMATS_STRING,
                             "type": "date"
                         },
                         "timeStart": {
-                            "format": DATE_FORMATS_STRING,
+                            "format": XFORM_DATE_FORMATS_STRING,
                             "type": "date"
                         },
                         "userID": {
@@ -179,7 +181,7 @@ XFORM_MAPPING = {
             "type": "boolean"
         },
         "inserted_at": {
-            "format": DATE_FORMATS_STRING,
+            "format": XFORM_DATE_FORMATS_STRING,
             "type": "date"
         },
         "partial_submission": {
@@ -190,11 +192,11 @@ XFORM_MAPPING = {
             "type": "string"
         },
         "received_on": {
-            "format": DATE_FORMATS_STRING,
+            "format": XFORM_DATE_FORMATS_STRING,
             "type": "date"
         },
         "server_modified_on": {
-            "format": DATE_FORMATS_STRING,
+            "format": XFORM_DATE_FORMATS_STRING,
             "type": "date"
         },
         "submit_ip": {


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This came up when reindexing the form index, certain forms have dates (at least `date_modified`) in millis from the epoch, and were therefore unable to be added into the new index causing the reindex to fail.

This brings the xforms index mapping in line with what is live in production (at least for these fields). I did not add it to the `DATE_FORMATS_ARR` because it is not a valid format for dynamic dates, which is where the list is used earlier in the mapping.

I know that the mappings and way we manage them have been changing a lot lately, so I am not sure if this is the preferred way to change these fields. Let me know if there is a better way.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just matches existing mappings found by querying the mapping API.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
