### PR TITLE
Accessibility: Added Pagination Widget on Incomplete Forms page

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -14,7 +14,7 @@ hqDefine("cloudcare/js/formplayer/constants", function () {
             GRID: 'grid',
             LIST: 'list',
         },
-        DEFAULT_INCOMPLETE_FORMS_PAGE_SIZE: 20,
+        DEFAULT_INCOMPLETE_FORMS_PAGE_SIZE: 10,
 
         MULTI_SELECT_ADD: 'add',
         MULTI_SELECT_REMOVE: 'remove',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/controller.js
@@ -20,6 +20,7 @@ hqDefine("cloudcare/js/formplayer/sessions/controller", function () {
                 var sessionListView = Views({
                     collection: sessions,
                     pageNumber: pageNumber,
+                    pageSize: pageSize,
                     totalPages: totalPages,
                     listSessions: listSessions
                 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/controller.js
@@ -7,7 +7,7 @@ hqDefine("cloudcare/js/formplayer/sessions/controller", function () {
         listSessions: function listSessions(pageNumber, pageSize) {
             /* eslint-disable */
             if (pageSize == null) {
-                pageSize = constants.DEFAULT_INCOMPLETE_FORMS_PAGE_SIZE;
+                pageSize = parseInt($.cookie("sessions-per-page-limit")) || constants.DEFAULT_INCOMPLETE_FORMS_PAGE_SIZE;
             }
             /* eslint-disable */
             if (pageNumber == null) {
@@ -16,23 +16,15 @@ hqDefine("cloudcare/js/formplayer/sessions/controller", function () {
             var fetchingSessions = FormplayerFrontend.getChannel().request("sessions", pageNumber, pageSize);
 
             $.when(fetchingSessions).done(function (sessions) {
-
+                var totalPages = Math.max(1, Math.ceil(sessions.totalSessions / pageSize));
                 var sessionListView = Views({
                     collection: sessions,
+                    pageNumber: pageNumber,
+                    totalPages: totalPages,
+                    listSessions: listSessions
                 });
 
                 FormplayerFrontend.regions.getRegion('main').show(sessionListView);
-                var totalPages = Math.max(1, Math.ceil(sessions.totalSessions / pageSize));
-                if (totalPages > 1) {
-                    $('#sessions-paginator').bootpag({
-                        page: pageNumber + 1,
-                        total: totalPages,
-                        maxVisible: Math.min(totalPages, 5),
-                        firstLastUse: true,
-                    }).on("page", function (event, page) {
-                        listSessions(page - 1, pageSize);
-                    });
-                }
             });
         },
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -63,14 +63,8 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
         tagName: "div",
         childView: SessionView,
         childViewContainer: "tbody",
-        getTemplate: function () {
-            var user = FormplayerFrontend.getChannel().request('currentUser');
-            var id = "#session-view-list-web-apps-template";
-            if (user.environment === constants.PREVIEW_APP_ENVIRONMENT) {
-                id = "#session-view-list-preview-template";
-            }
-            return _.template($(id).html() || "");
-        },
+        template: _.template($("#session-view-list-template").html() || ""),
+
         initialize: function (options) {
             this.model = new Backbone.Model({
                 page: options.pageNumber + 1 || 1,
@@ -128,6 +122,7 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
             }
         },
         templateContext: function () {
+            var user = FormplayerFrontend.getChannel().request('currentUser');
             var paginationConfig = utils.paginateOptions(this.options.pageNumber, this.options.totalPages);
             return {
                 total: this.collection.totalSessions,
@@ -139,6 +134,7 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
                 rowRange: [10, 25, 50, 100],
                 limit: this.model.get("limit"),
                 pageNumLabel: _.template(gettext("Page <%-num%>")),
+                isPreviewEnv: user.environment === constants.PREVIEW_APP_ENVIRONMENT,
             };
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -77,10 +77,10 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
         },
         events: {
             'click @ui.paginators': 'onClickPageNumber',
-            'click @ui.paginationGoButton': 'paginationGoAction',
-            'change @ui.sessionsPerPageLimit': 'onPerPageLimitChange',
-            'keypress @ui.paginationGoTextBox': 'paginationGoKeyAction',
             'keypress @ui.paginators': 'paginateKeyAction',
+            'click @ui.paginationGoButton': 'paginationGoAction',
+            'keypress @ui.paginationGoTextBox': 'paginationGoKeyAction',
+            'change @ui.sessionsPerPageLimit': 'onPerPageLimitChange',
         },
         ui: {
             paginators: '.js-page',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -68,7 +68,7 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
         initialize: function (options) {
             this.model = new Backbone.Model({
                 page: options.pageNumber + 1 || 1,
-                limit: parseInt($.cookie("sessions-per-page-limit")) || 10,
+                limit: options.pageSize,
             });
             this.model.on('change', function () {
                 this.options.listSessions(this.model.get('page') - 1, this.model.get("limit"));

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -1,8 +1,9 @@
-/*global Marionette, moment */
+/*global Backbone, Marionette, moment */
 
 hqDefine("cloudcare/js/formplayer/sessions/views", function () {
     var constants = hqImport("cloudcare/js/formplayer/constants"),
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
+        FormplayerUtils = hqImport("cloudcare/js/formplayer/utils/utils"),
         utils = hqImport("cloudcare/js/formplayer/utils/utils");
 
     var SessionView = Marionette.View.extend({
@@ -69,6 +70,76 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
                 id = "#session-view-list-preview-template";
             }
             return _.template($(id).html() || "");
+        },
+        initialize: function (options) {
+            this.model = new Backbone.Model({
+                page: options.pageNumber + 1 || 1,
+                limit: parseInt($.cookie("sessions-per-page-limit")) || 10,
+            });
+            this.model.on('change', function () {
+                this.options.listSessions(this.model.get('page') - 1, this.model.get("limit"));
+                this.render.bind(this);
+            }.bind(this));
+        },
+        events: {
+            'click @ui.paginators': 'onClickPageNumber',
+            'click @ui.paginationGoButton': 'paginationGoAction',
+            'change @ui.sessionsPerPageLimit': 'onPerPageLimitChange',
+            'keypress @ui.paginationGoTextBox': 'paginationGoKeyAction',
+            'keypress @ui.paginators': 'paginateKeyAction',
+        },
+        ui: {
+            paginators: '.js-page',
+            paginationGoButton: '#pagination-go-button',
+            paginationGoTextBox: '.module-go-container',
+            paginationGoText: '#goText',
+            sessionsPerPageLimit: '.per-page-limit',
+        },
+        onClickPageNumber: function (e) {
+            e.preventDefault();
+            var page = $(e.currentTarget).data("id");
+            this.model.set('page', page + 1);
+        },
+        onPerPageLimitChange: function (e) {
+            e.preventDefault();
+            var sessionsPerPage = this.ui.sessionsPerPageLimit.val();
+            this.model.set("limit", Number(sessionsPerPage));
+            this.model.set("page", 1);
+            FormplayerUtils.savePerPageLimitCookie("sessions", this.model.get("limit"));
+        },
+        paginationGoAction: function (e) {
+            e.preventDefault();
+            var goText = Number(this.ui.paginationGoText.val());
+            var pageNo = utils.paginationGoPageNumber(goText, this.options.totalPages);
+            this.model.set('page', pageNo);
+        },
+        paginateKeyAction: function (e) {
+            // Pressing Enter on a pagination control activates it.
+            if (e.which === 13 || e.keyCode === 13) {
+                e.stopImmediatePropagation();
+                this.onClickPageNumber(e);
+            }
+        },
+        paginationGoKeyAction: function (e) {
+            // Pressing Enter in the go box activates it.
+            if (e.which === 13 || e.keyCode === 13) {
+                e.stopImmediatePropagation();
+                this.paginationGoAction(e);
+            }
+        },
+        templateContext: function () {
+            var paginationConfig = utils.paginateOptions(this.options.pageNumber, this.options.totalPages);
+            return {
+                total: this.collection.totalSessions,
+                totalPages: this.options.totalPages,
+                currentPage: this.model.get('page') - 1,
+                startPage: paginationConfig.startPage,
+                endPage: paginationConfig.endPage,
+                pageCount: paginationConfig.pageCount,
+                rowRange: [10, 25, 50, 100],
+                limit: this.model.get("limit"),
+                pageNumLabel: _.template(gettext("Page <%-num%>")),
+            };
         },
     });
 

--- a/corehq/apps/cloudcare/templates/formplayer/session_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/session_list.html
@@ -3,24 +3,14 @@
 
 <script src="{% static 'bootpag/lib/jquery.bootpag.min.js' %}"></script>
 
-<script type="text/template" id="session-view-list-preview-template">
+<script type="text/template" id="session-view-list-template">
+  <% if(isPreviewEnv) { %>
   <div class="breadcrumb-form-container">
     <ol class="breadcrumb breadcrumb-form">
       <li class="breadcrumb-text">{% trans "Incomplete Forms" %}</li>
     </ol>
   </div>
-  <div class="module-menu-container module-menu-bar-offset">
-    <table class="table module-table">
-      <tbody>
-      </tbody>
-    </table>
-  </div>
-  <% if (endPage) { %>
-    {% include 'formplayer/pagination.html' %}
-  <% } %>
-</script>
-
-<script type="text/template" id="session-view-list-web-apps-template">
+  <% } else { %>
   <div class="module-banner alert alert-info">
     <span>
         {% blocktrans %}
@@ -29,10 +19,13 @@
         {% endblocktrans %}
     </span>
   </div>
+  <% } %>
   <div class="module-menu-container module-menu-bar-offset">
+    <% if (!isPreviewEnv) { %>
     <div class="page-header menu-header">
       <h1 class="page-title">{% trans "Incomplete Forms" %}</h1>
     </div>
+    <% } %>
     <table class="table module-table">
       <tbody>
       </tbody>

--- a/corehq/apps/cloudcare/templates/formplayer/session_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/session_list.html
@@ -32,7 +32,9 @@
     </table>
   </div>
   <% if (endPage) { %>
-    {% include 'formplayer/pagination.html' %}
+    {% block pagination_templates %}
+      {% include 'formplayer/pagination.html' %}
+    {% endblock %}
   <% } %>
 </script>
 

--- a/corehq/apps/cloudcare/templates/formplayer/session_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/session_list.html
@@ -1,8 +1,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<script src="{% static 'bootpag/lib/jquery.bootpag.min.js' %}"></script>
-
 <script type="text/template" id="session-view-list-template">
   <% if(isPreviewEnv) { %>
   <div class="breadcrumb-form-container">

--- a/corehq/apps/cloudcare/templates/formplayer/session_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/session_list.html
@@ -28,12 +28,12 @@
       <tbody>
       </tbody>
     </table>
+    <% if (endPage) { %>
+      {% block pagination_templates %}
+        {% include 'formplayer/pagination.html' %}
+      {% endblock %}
+    <% } %>
   </div>
-  <% if (endPage) { %>
-    {% block pagination_templates %}
-      {% include 'formplayer/pagination.html' %}
-    {% endblock %}
-  <% } %>
 </script>
 
 <script type="text/template" id="session-view-item-template">

--- a/corehq/apps/cloudcare/templates/formplayer/session_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/session_list.html
@@ -15,9 +15,9 @@
       </tbody>
     </table>
   </div>
-  <div class="pull-right">
-      <ul id="sessions-paginator" class="pagination-sm"></ul>
-  </div>
+  <% if (endPage) { %>
+    {% include 'formplayer/pagination.html' %}
+  <% } %>
 </script>
 
 <script type="text/template" id="session-view-list-web-apps-template">
@@ -38,9 +38,9 @@
       </tbody>
     </table>
   </div>
-  <div class="pull-right">
-      <ul id="sessions-paginator" class="pagination-lg"></ul>
-  </div>
+  <% if (endPage) { %>
+    {% include 'formplayer/pagination.html' %}
+  <% } %>
 </script>
 
 <script type="text/template" id="session-view-item-template">

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
         "backbone.marionette": "4.1.3",
         "backbone.radio": "^2.0.0",
         "blazy": "1.8.2",
-        "bootpag": "1.0.7",
         "bootstrap": "3.4.1",
         "bootstrap-daterangepicker": "3.0.3",
         "bootstrap-switch": "3.3.2",


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The incomplete forms page on web apps used an external library for pagination which had bad accessibility for screen-readers. This PR replaces it with the pagination widget which has better accessibility for screen-readers.

![Screenshot 2023-02-01 at 4 08 14 PM](https://user-images.githubusercontent.com/31195143/216031662-f224fafd-e50a-4660-b173-9e71cb0a4fbd.png)




## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Ticket Link
](https://dimagi-dev.atlassian.net/browse/USH-940)
The bootpag jquery plugin which was initially used for pagination on this page did not have HTML elements which provided labels for screen-readers for pagination buttons. From this discussion on this [PR](https://github.com/dimagi/commcare-hq/pull/29455#issuecomment-813555454), it seemed fit to use the in-house pagination code over an external library. The pagination code on HQ has labels for different page numbers and the pagination buttons.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally with Voiceover screen reader on Mac

https://user-images.githubusercontent.com/31195143/216041266-c1da3028-8905-4f13-863e-6bcaba517cf1.mp4


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-4797)

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
