### PR TITLE
Soft delete connection settings instead of delete

### DIFF
--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -222,7 +222,7 @@ class ConnectionSettingsListView(BaseProjectSettingsView, CRUDPaginatedViewMixin
         if connection_settings.used_by:
             raise Http409
 
-        connection_settings.delete()
+        connection_settings.soft_delete()
         return {
             'itemData': self._get_item_data(connection_settings),
             'template': 'connection-settings-deleted-template',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Since we are soft deleting Repeaters we also built utilities around soft deleting connection settings but it was missed to be added in the views. Because of which when we try to deleted a connection settings it erroring out because we have a constraint in DB as it being used by a Repeater which is soft deleted.
The PR fixes that issue.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally, and a very small change affecting connection settings delete functionality.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
