### PR TITLE
Form validation should fail if name too long

### DIFF
--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -3619,6 +3619,7 @@ class ConditionalAlertForm(Form):
     name = TrimmedCharField(
         label=gettext_lazy("Name"),
         required=True,
+        max_length=126,
     )
 
     def __init__(self, domain, rule, *args, **kwargs):


### PR DESCRIPTION
## Technical Summary

Context: 
* [Forum](https://forum.dimagi.com/t/error-500-when-trying-to-save-a-new-conditional-alert/9604)
* [Sentry](https://sentry.io/organizations/dimagi/issues/3907415845/?query=+domain%3Afmoh-echis-staging&referrer=issue-stream&statsPeriod=7d)

A user tried to save an `AutomaticUpdateRule` with a 139-character-long `name` value.

This change adds validation to ensure `max_length` for name matches the model's field size. crispy-forms prevents the user from entering more than 126 characters.

## Safety Assurance

### Safety story

* Tested locally
* Tiny

### Automated test coverage

Not covered by tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
