### PR TITLE
Support for OR filter in Case List API

### DIFF
--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -88,11 +88,12 @@ def get_list(domain, params):
 
     cases_in_result = len(hits)
     if cases_in_result and es_result.total > cases_in_result:
-        encodeable = URLEncodeableDict(params, **{
+        mutable = QueryDict('', mutable=True)
+        mutable.update(params, **{
             INDEXED_AFTER: hits[-1]["@indexed_on"],
             LAST_CASE_ID: hits[-1]["_id"],
         })
-        cursor = urlencode(encodeable)
+        cursor = mutable.urlencode()
         ret['next'] = {'cursor': b64encode(cursor.encode('utf-8'))}
 
     return ret
@@ -149,39 +150,3 @@ def _get_query_filter(domain, query):
         return build_filter_from_xpath(domain, query)
     except CaseFilterError as e:
         raise UserError(f'Bad query: {e}')
-
-
-class URLEncodeableDict(dict):
-    """
-    ``URLEncodeableDict.items()`` preserves multiple values of a key by
-    repeating the key for each value.
-
-    Intended for use with ``urlencode()``.
-
-    Problem:
-
-    >>> qd = QueryDict('foo=one&bar=two&bar=three')
-    >>> list(qd.lists())
-    [('foo', ['one']), ('bar', ['two', 'three'])]
-    >>> urlencode(qd)
-    'foo=%5B%27one%27%5D&bar=%5B%27two%27%2C+%27three%27%5D'
-    >>> urlencode(qd.items())
-    'foo=one&bar=three'
-
-    Solution:
-
-    >>> ued = URLEncodeableDict(qd)
-    >>> list(ued.items())
-    [('foo', 'one'), ('bar', 'two'), ('bar', 'three')]
-    >>> urlencode(ued)
-    'foo=one&bar=two&bar=three'
-
-    """
-
-    def items(self):
-        for key, value in super().items():
-            if isinstance(value, list):
-                for v in value:
-                    yield key, v
-            else:
-                yield key, value

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -72,8 +72,9 @@ def get_list(domain, params):
     if 'cursor' in params:
         params_string = b64decode(params['cursor']).decode('utf-8')
         params = QueryDict(params_string, mutable=True)
-        last_date = params.pop(INDEXED_AFTER, None)
-        last_id = params.pop(LAST_CASE_ID, None)
+        # QueryDict.pop() returns a list
+        last_date = params.pop(INDEXED_AFTER, [None])[0]
+        last_id = params.pop(LAST_CASE_ID, [None])[0]
         query = _get_cursor_query(domain, params, last_date, last_id)
     else:
         query = _get_query(domain, params)
@@ -87,10 +88,10 @@ def get_list(domain, params):
 
     cases_in_result = len(hits)
     if cases_in_result and es_result.total > cases_in_result:
-        cursor = urlencode({**params, **{
+        cursor = urlencode(dict(params.items(), **{
             INDEXED_AFTER: hits[-1]["@indexed_on"],
             LAST_CASE_ID: hits[-1]["_id"],
-        }})
+        }))
         ret['next'] = {'cursor': b64encode(cursor.encode('utf-8'))}
 
     return ret

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -77,6 +77,7 @@ def get_list(domain, params):
         last_id = params.pop(LAST_CASE_ID, [None])[0]
         query = _get_cursor_query(domain, params, last_date, last_id)
     else:
+        params = params.copy()  # Makes params mutable for pagination below
         query = _get_query(domain, params)
 
     es_result = query.run()
@@ -88,12 +89,11 @@ def get_list(domain, params):
 
     cases_in_result = len(hits)
     if cases_in_result and es_result.total > cases_in_result:
-        mutable = QueryDict('', mutable=True)
-        mutable.update(params, **{
+        params.update({
             INDEXED_AFTER: hits[-1]["@indexed_on"],
             LAST_CASE_ID: hits[-1]["_id"],
         })
-        cursor = mutable.urlencode()
+        cursor = params.urlencode()
         ret['next'] = {'cursor': b64encode(cursor.encode('utf-8'))}
 
     return ret

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -71,7 +71,7 @@ COMPOUND_FILTERS = {
 def get_list(domain, params):
     if 'cursor' in params:
         params_string = b64decode(params['cursor']).decode('utf-8')
-        params = unpack_query_dict(QueryDict(params_string))
+        params = QueryDict(params_string, mutable=True)
         last_date = params.pop(INDEXED_AFTER, None)
         last_id = params.pop(LAST_CASE_ID, None)
         query = _get_cursor_query(domain, params, last_date, last_id)
@@ -96,22 +96,6 @@ def get_list(domain, params):
     return ret
 
 
-def unpack_query_dict(query_dict):
-    """
-    Unpacks a ``QueryDict`` so that the values of duplicate keys are not
-    lost.
-
-    >>> qd = QueryDict('foo=one&bar=two&bar=three')
-    >>> unpack_query_dict(qd)
-    {'foo': 'one', 'bar': ['two', 'three']}
-
-    """
-    def unpack(list_):
-        return list_[0] if len(list_) == 1 else list_
-
-    return {k: unpack(v) for k, v in query_dict.lists()}
-
-
 def _get_cursor_query(domain, params, last_date, last_id):
     query = _get_query(domain, params)
     return query.filter(
@@ -134,13 +118,13 @@ def _get_query(domain, params):
              .size(page_size)
              .sort("@indexed_on")
              .sort("_id", reset_sort=False))
-    for key, val in params.items():
-        if isinstance(val, list):
+    for key, val in params.lists():
+        if len(val) == 1:
+            query = query.filter(_get_filter(domain, key, val[0]))
+        else:
             # e.g. key='owner_id', val=['abc123', 'def456']
             filter_list = [_get_filter(domain, key, v) for v in val]
             query = query.filter(filters.OR(*filter_list))
-        else:
-            query = query.filter(_get_filter(domain, key, val))
     return query
 
 

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -76,7 +76,7 @@ class TestCaseListAPI(TestCase):
         super().tearDownClass()
 
     def test_pagination(self):
-        query_dict = QueryDict('limit=3&case_type=person')
+        query_dict = QueryDict('limit=3&case_type=person&case_type=household')
         res = get_list(self.domain, query_dict)
         self.assertItemsEqual(res.keys(), ['next', 'cases', 'matching_records'])
         self.assertEqual(res['matching_records'], 5)
@@ -88,6 +88,7 @@ class TestCaseListAPI(TestCase):
         cursor = b64decode(res['next']['cursor']).decode('utf-8')
         self.assertIn('limit=3', cursor)
         self.assertIn('case_type=person', cursor)
+        self.assertIn('case_type=household', cursor)
         self.assertIn('indexed_on.gte', cursor)
         self.assertIn('last_case_id', cursor)
 
@@ -153,3 +154,9 @@ def test_bad_requests(self, querystring, error_msg):
         params = QueryDict(querystring)
         get_list(self.domain, params)
     self.assertEqual(str(e.exception), error_msg)
+
+
+def test_doctests():
+    import corehq.apps.hqcase.api.get_list
+    results = doctest.testmod(corehq.apps.hqcase.api.get_list)
+    assert results.failed == 0

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -1,5 +1,4 @@
 import datetime
-import doctest
 import uuid
 from base64 import b64decode
 
@@ -154,9 +153,3 @@ def test_bad_requests(self, querystring, error_msg):
         params = QueryDict(querystring)
         get_list(self.domain, params)
     self.assertEqual(str(e.exception), error_msg)
-
-
-def test_doctests():
-    import corehq.apps.hqcase.api.get_list
-    results = doctest.testmod(corehq.apps.hqcase.api.get_list)
-    assert results.failed == 0

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -26,7 +26,7 @@ from corehq.util.es.elasticsearch import NotFoundError
 from corehq.util.view_utils import reverse
 
 from .api.core import SubmissionError, UserError, serialize_case, serialize_es_case
-from .api.get_list import get_list, unpack_query_dict
+from .api.get_list import get_list
 from .api.get_bulk import get_bulk
 from .api.updates import handle_case_update
 from .tasks import delete_exploded_case_task, explode_case_task
@@ -154,7 +154,7 @@ def _handle_bulk_fetch(request):
 
 def _handle_list_view(request):
     try:
-        res = get_list(request.domain, unpack_query_dict(request.GET))
+        res = get_list(request.domain, request.GET)
     except UserError as e:
         return JsonResponse({'error': str(e)}, status=400)
 

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -26,7 +26,7 @@ from corehq.util.es.elasticsearch import NotFoundError
 from corehq.util.view_utils import reverse
 
 from .api.core import SubmissionError, UserError, serialize_case, serialize_es_case
-from .api.get_list import get_list
+from .api.get_list import get_list, unpack_query_dict
 from .api.get_bulk import get_bulk
 from .api.updates import handle_case_update
 from .tasks import delete_exploded_case_task, explode_case_task
@@ -154,7 +154,7 @@ def _handle_bulk_fetch(request):
 
 def _handle_list_view(request):
     try:
-        res = get_list(request.domain, request.GET.dict())
+        res = get_list(request.domain, unpack_query_dict(request.GET))
     except UserError as e:
         return JsonResponse({'error': str(e)}, status=400)
 


### PR DESCRIPTION
## Technical Summary

Context: [SC-2201](https://dimagi-dev.atlassian.net/browse/SC-2201)

This change adds support for an `OR` filter in the Case List API. (It is a partial implementation of the Jira ticket above.)

If a Case List API request is made with parameters with multiple values, currently all but the last value is discarded. This change preserves all values, and filters them with an `OR`.

e.g. Request params `type=person&owner_id=abc123&owner_id=def456`: Currently the Case List API returns the cases of type "person" with owner_id "def456". This change will return the cases of type "person" with owner_id "abc123" OR "def456".

commcare-export PR coming soon to correspond with this one.

fyi @joxl or anyone on the SAAS team responsible for the API.

## Safety Assurance

### Safety story

* Behavior covered by tests
* New behavior is a closer match to principle of least surprise. (API no longer ignores filter values.)

### Automated test coverage

Tests included

### QA Plan

No QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2201]: https://dimagi-dev.atlassian.net/browse/SC-2201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ