### PR TITLE
allow xform backup pillow

### DIFF
--- a/corehq/apps/es/transient_util.py
+++ b/corehq/apps/es/transient_util.py
@@ -115,16 +115,16 @@ def populate_doc_adapter_map():
 
     if settings.UNIT_TESTING:
         from pillowtop.tests.utils import TEST_INDEX_INFO
-        _add_test_adapter("PillowTop", TEST_INDEX_INFO.index,
+        add_dynamic_adapter("PillowTop", TEST_INDEX_INFO.index,
                         TEST_INDEX_INFO.type, TEST_INDEX_INFO.mapping,
                         TEST_INDEX_INFO.alias)
 
         from corehq.apps.es.tests.utils import TEST_ES_INFO, TEST_ES_MAPPING
-        _add_test_adapter("UtilES", TEST_ES_INFO.alias, TEST_ES_INFO.type,
+        add_dynamic_adapter("UtilES", TEST_ES_INFO.alias, TEST_ES_INFO.type,
                         TEST_ES_MAPPING, TEST_ES_INFO.alias)
 
 
-def _add_test_adapter(descriptor, index_, type_, mapping_, alias):
+def add_dynamic_adapter(descriptor, index_, type_, mapping_, alias):
 
     class Adapter(ElasticDocumentAdapter):
         mapping = mapping_

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -152,17 +152,15 @@ def get_xform_to_elasticsearch_pillow(pillow_id='XFormToElasticsearchPillow', nu
         index_info = ElasticsearchIndexInfo.wrap(raw_info)
         index_info.index = kwargs['index_name']
         index_info.alias = kwargs['index_alias']
-        from corehq.apps.es.registry import register
-        from corehq.apps.es.transient_util import add_dynamic_es_adapter
-        register(index_info, index_info.alias)
-        add_dynamic_es_adapter(
+        from corehq.apps.es.transient_util import add_dynamic_adapter
+        add_dynamic_adapter(
             "XFormBackfill", index_info.index, index_info.type, index_info.mapping, index_info.alias
         )
 
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, index_info, FORM_TOPICS)
     form_processor = ElasticProcessor(
         elasticsearch=get_es_new(),
-        index_info=XFORM_INDEX_INFO,
+        index_info=index_info,
         doc_prep_fn=transform_xform_for_elasticsearch,
         doc_filter_fn=xform_pillow_filter,
         change_filter_fn=is_couch_change_for_sql_domain

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -26,6 +26,7 @@ from couchforms.const import RESERVED_WORDS, DEVICE_LOG_XMLNS
 from couchforms.geopoint import GeoPoint
 from pillowtop.checkpoints.manager import KafkaPillowCheckpoint, get_checkpoint_for_elasticsearch_pillow
 from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
+from pillowtop.es_utils import ElasticsearchIndexInfo
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.form import FormSubmissionMetadataTrackerProcessor
 from pillowtop.processors.elastic import BulkElasticProcessor, ElasticProcessor


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This allows the index for the xform pillow to be set dynamically, similar to how it has already been implemented for the case search pillow. It will have no effect until a pillow using that constructor is added in localsettings.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This constructor is not currently in use, but should be safe when it is in use because it will only affect the backfill pillow, and uses a well understood process.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
