### PR TITLE
Abort early if app not found

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -28,7 +28,12 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                 if (!params.preview) {
                     // Make sure the user has access to the app
                     if (!appCollection.find(function (app) {
-                        return app.id === params.appId || app.get('copy_of') === params.copyOf;
+                        if (app.id && app.id === params.appId) {
+                            return true;
+                        }
+                        if (app.get('copy_of') && app.get('copy_of') === params.copyOf) {
+                            return true;
+                        }
                     })) {
                         FormplayerFrontend.trigger(
                             'showError',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -32,7 +32,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                     })) {
                         FormplayerFrontend.trigger(
                             'showError',
-                            gettext('Permission Denied')
+                            gettext('The application could not be found')
                         );
                         FormplayerFrontend.trigger('navigateHome');
                         defer.reject();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -36,6 +36,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                         );
                         FormplayerFrontend.trigger('navigateHome');
                         defer.reject();
+                        return;
                     }
                 }
 


### PR DESCRIPTION
## Technical Summary
While looking at web apps code I noticed that even if we can't find the app for the request we still go ahead and make the request for Formplayer.

This changes the method to return early if the app is not found.

## Safety Assurance

### Safety story
I think this is a safe change. I have tested it locally - you can just access a web apps URL with a fake `app_id` param.

### Automated test coverage
None at present. I'm going to try and add some.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
