### PR TITLE
move case usage report above db calls

### DIFF
--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -343,13 +343,13 @@ class SubmissionPost(object):
                         raise
                     else:
                         instance.initial_processing_complete = True
+                        report_case_usage(self.domain, len(case_stock_result.case_models))
                         openrosa_kwargs['error_message'] = self.save_processed_models(case_db, xforms,
                                                                                       case_stock_result)
                         if openrosa_kwargs['error_message']:
                             openrosa_kwargs['error_nature'] = ResponseNature.POST_PROCESSING_FAILURE
                         cases = case_stock_result.case_models
                         ledgers = case_stock_result.stock_result.models_to_save
-                        report_case_usage(self.domain, len(cases))
                         openrosa_kwargs['success_message'] = self._get_success_message(instance, cases=cases)
                 elif instance.is_error:
                     submission_type = 'error'


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Just moves this call up a few lines so that it happens before the db save. I accessed it directly instead of sharing the variable because I wasn't sure if the save call mutates the `case_stock_result`, so I wanted the access in response to get any potential updates.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This code is well tested and just moves a single call

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
