### PR TITLE
Not all DomainLinkHistory models are apps.

### DIFF
--- a/corehq/apps/linked_domain/management/commands/unlink_apps.py
+++ b/corehq/apps/linked_domain/management/commands/unlink_apps.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand
 from couchdbkit import ResourceNotFound
 
 from corehq.apps.app_manager.models import Application
+from corehq.apps.linked_domain.const import MODEL_APP
 from corehq.apps.linked_domain.models import DomainLink, DomainLinkHistory
 
 
@@ -53,7 +54,10 @@ class Command(BaseCommand):
     @staticmethod
     def hide_domain_link_history(linked_domain, linked_app_id, master_domain):
         domain_link = DomainLink.all_objects.get(linked_domain=linked_domain, master_domain=master_domain)
-        for history in DomainLinkHistory.objects.filter(link=domain_link):
+        for history in DomainLinkHistory.objects.filter(
+            link=domain_link,
+            model=MODEL_APP,
+        ):
             if history.model_detail['app_id'] == linked_app_id:
                 history.hidden = True
                 history.save()


### PR DESCRIPTION
## Technical Summary

Fixes a small bug in the `unlink_apps` management command.

This filter currently assumes that all `DomainLinkHistory` instances are for linked apps. They aren't. There are several things that now use `DomainLinkHistory` since this management command was written. This change fixes that assumption.

## Safety Assurance

### Safety story

* Small.
* Seldom-used management command.
* Tested manually.

### Automated test coverage

Not covered by tests.

### QA Plan

No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
