### PR TITLE
Fix tests

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -252,13 +252,6 @@ function runserver {
     su cchq -c "./manage.py runserver $@ 0.0.0.0:8000"
 }
 
-if [ -n "$GITHUB_ACTIONS" ]; then
-    # change cchq UID and GID to match those used by Github Actions to clone the repo
-    echo "changing cchq UID:GID (`id -u cchq`:`id -g cchq`) to 1001:123"
-    groupmod -g 123 cchq
-    usermod -u 1001 -g 123 cchq
-fi
-
 source /mnt/commcare-hq-ro/scripts/datadog-utils.sh  # provides send_metric_to_datadog
 source /mnt/commcare-hq-ro/scripts/bash-utils.sh  # provides logmsg, log_group_{begin,end}, func_text and truthy
 
@@ -365,6 +358,7 @@ fi
 mkdir -p lib/sharedfiles
 ln -sf /mnt/lib/sharedfiles /sharedfiles
 chown cchq:cchq lib/sharedfiles
+su cchq -c "/usr/bin/git config --global --add safe.directory /mnt/commcare-hq-ro"
 
 cd commcare-hq
 ln -sf docker/localsettings.py localsettings.py

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -315,7 +315,6 @@ else
     fi
     # Own the new dirs after the overlay is mounted.
     chown cchq:cchq commcare-hq lib/{overlay,node_modules,staticfiles}
-    git config --global --add safe.directory '*'  # disable directory safety checks
 fi
 # New state of /mnt (depending on value of DOCKER_HQ_OVERLAY):
 #
@@ -359,6 +358,7 @@ fi
 mkdir -p lib/sharedfiles
 ln -sf /mnt/lib/sharedfiles /sharedfiles
 chown cchq:cchq lib/sharedfiles
+git config --global --add safe.directory '*'  # disable directory safety checks
 
 cd commcare-hq
 ln -sf docker/localsettings.py localsettings.py

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -252,6 +252,13 @@ function runserver {
     su cchq -c "./manage.py runserver $@ 0.0.0.0:8000"
 }
 
+if [ -n "$GITHUB_ACTIONS" ]; then
+    # change cchq UID and GID to match those used by Github Actions to clone the repo
+    echo "changing cchq UID:GID (`id -u cchq`:`id -g cchq`) to 1001:123"
+    groupmod -g 123 cchq
+    usermod -u 1001 -g 123 cchq
+fi
+
 source /mnt/commcare-hq-ro/scripts/datadog-utils.sh  # provides send_metric_to_datadog
 source /mnt/commcare-hq-ro/scripts/bash-utils.sh  # provides logmsg, log_group_{begin,end}, func_text and truthy
 
@@ -358,7 +365,6 @@ fi
 mkdir -p lib/sharedfiles
 ln -sf /mnt/lib/sharedfiles /sharedfiles
 chown cchq:cchq lib/sharedfiles
-git config --global --add safe.directory '*'  # disable directory safety checks
 
 cd commcare-hq
 ln -sf docker/localsettings.py localsettings.py

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -315,6 +315,7 @@ else
     fi
     # Own the new dirs after the overlay is mounted.
     chown cchq:cchq commcare-hq lib/{overlay,node_modules,staticfiles}
+    git config --global --add safe.directory '*'  # disable directory safety checks
 fi
 # New state of /mnt (depending on value of DOCKER_HQ_OVERLAY):
 #

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -139,10 +139,10 @@ function run_tests {
         log_group_end  # only log group end on success (notice: `set -e`)
         if [ "$TEST" == "python-sharded-and-javascript" ]; then
             su cchq -c scripts/test-prod-entrypoints.sh
-            su cchq -c scripts/test-make-requirements.sh
-            su cchq -c scripts/test-serializer-pickle-files.sh
+            scripts/test-make-requirements.sh
+            scripts/test-serializer-pickle-files.sh
             [ "$TEST_MIGRATIONS" ] && su cchq -c scripts/test-django-migrations.sh
-            su cchq -c scripts/track-dependency-status.sh
+            scripts/track-dependency-status.sh
         fi
         delta=$(($(date +%s) - $now))
 
@@ -361,6 +361,7 @@ mkdir -p lib/sharedfiles /home/cchq
 ln -sf /mnt/lib/sharedfiles /sharedfiles
 chown cchq:cchq lib/sharedfiles /home/cchq
 su cchq -c "/usr/bin/git config --global --add safe.directory /mnt/commcare-hq-ro"
+/usr/bin/git config --global --add safe.directory /mnt/commcare-hq-ro
 
 cd commcare-hq
 ln -sf docker/localsettings.py localsettings.py

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -183,8 +183,6 @@ function _run_tests {
     esac
 
     function _test_python {
-        echo "whoami: `whoami`"
-        ls -al
         ./manage.py create_kafka_topics
         if [ -n "$CI" ]; then
             logmsg INFO "coverage run manage.py test ${py_test_args[*]}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -355,9 +355,9 @@ fi
 #       │   └── staticfiles -> /mnt/lib/staticfiles
 #       └── staticfiles
 
-mkdir -p lib/sharedfiles
+mkdir -p lib/sharedfiles /home/cchq
 ln -sf /mnt/lib/sharedfiles /sharedfiles
-chown cchq:cchq lib/sharedfiles
+chown cchq:cchq lib/sharedfiles /home/cchq
 su cchq -c "/usr/bin/git config --global --add safe.directory /mnt/commcare-hq-ro"
 
 cd commcare-hq

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -183,6 +183,8 @@ function _run_tests {
     esac
 
     function _test_python {
+        echo "whoami: `whoami`"
+        ls -al
         ./manage.py create_kafka_topics
         if [ -n "$CI" ]; then
             logmsg INFO "coverage run manage.py test ${py_test_args[*]}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -137,11 +137,13 @@ function run_tests {
         argv_str=$(printf ' %q' "$TEST" "$@")
         su cchq -c "/bin/bash ../run_tests $argv_str" 2>&1
         log_group_end  # only log group end on success (notice: `set -e`)
-        [ "$TEST" == "python-sharded-and-javascript" ] && scripts/test-prod-entrypoints.sh
-        [ "$TEST" == "python-sharded-and-javascript" ] && scripts/test-make-requirements.sh
-        [ "$TEST" == "python-sharded-and-javascript" ] && scripts/test-serializer-pickle-files.sh
-        [ "$TEST" == "python-sharded-and-javascript" -o "$TEST_MIGRATIONS" ] && scripts/test-django-migrations.sh
-        [ "$TEST" == "python-sharded-and-javascript" ] && scripts/track-dependency-status.sh
+        if [ "$TEST" == "python-sharded-and-javascript" ]; then
+            su cchq -c scripts/test-prod-entrypoints.sh
+            su cchq -c scripts/test-make-requirements.sh
+            su cchq -c scripts/test-serializer-pickle-files.sh
+            [ "$TEST_MIGRATIONS" ] && su cchq -c scripts/test-django-migrations.sh
+            su cchq -c scripts/track-dependency-status.sh
+        fi
         delta=$(($(date +%s) - $now))
 
         send_timing_metric_to_datadog "tests" $delta


### PR DESCRIPTION
Add /mnt/commcare-hq-ro as safe directory for the `cchq` user in the test container.

~Change the UID and GID of the cchq user in the container so it matches those used by Github Actions to clone the repo.~ Worked in some cases, but not all. See [test results](https://github.com/dimagi/commcare-hq/actions/runs/4105978175).

It is unclear what caused tests to begin failing. The [most recent successful test run](https://github.com/dimagi/commcare-hq/actions/runs/4099483311/jobs/7069434578) apparently used `git version 2.39.1` , which is the same version used by the failed test runs on this PR.

## Safety Assurance

### Safety story

Small change to github actions test runner script to fix failing tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
