### PR TITLE
add id purge and batch size to reindex query

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -365,7 +365,8 @@ class ElasticManageAdapter(BaseAdapter):
         elif "*" in index:
             raise ValueError(f"refusing to operate with index wildcards: {index}")
 
-    def reindex(self, source, dest, wait_for_completion=False, refresh=False):
+    def reindex(self, source, dest, wait_for_completion=False,
+                refresh=False, batch_size=1000, purge_ids=False):
         """
         Starts the reindex process in elastic search cluster
 
@@ -373,6 +374,14 @@ class ElasticManageAdapter(BaseAdapter):
         :param dest: ``str`` name of the destination index
         :param wait_for_completion: ``bool`` would block the request until reindex is complete
         :param refresh: ``bool`` refreshes index
+        :param batch_size: ``int`` the size of the scroll batch used by the reindex process. larger
+                           batches may process more quickly but risk errors if the documents are too
+                           large. 1000 is the recommended maximum and elasticsearch default, and can 
+                           be reduced if you encounter scroll timeouts.
+        :param purge_ids: ``bool`` adds an inline script to remove the _id field from documents source.
+                          these cause errors on reindexing the doc, but the script slows down the reindex
+                          substantially, so it is only recommended to enable this if you have run into
+                          the specific error it is designed to resolve.
 
         :returns: None if wait_for_completion is True else would return task_id of reindex task
         """
@@ -383,6 +392,7 @@ class ElasticManageAdapter(BaseAdapter):
         reindex_body = {
             "source": {
                 "index": source,
+                "size": batch_size
             },
             "dest": {
                 "index": dest,
@@ -391,6 +401,9 @@ class ElasticManageAdapter(BaseAdapter):
             },
             "conflicts": "proceed"
         }
+
+        if purge_ids:
+            reindex_body["script"] = {"inline": "if (ctx._source._id) {ctx._source.remove('_id')}"}
         reindex_info = self._es.reindex(
             reindex_body,
             wait_for_completion=wait_for_completion,

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -152,6 +152,6 @@ class Command(BaseCommand):
         sub_cmd = options['sub_command']
         cmd_func = options.get('func')
         if sub_cmd == 'start':
-            cmd_func(options['index_cname'])
+            cmd_func(options['index_cname'], options['batch_size'], options['purge_ids'])
         else:
             cmd_func(options['task_id'])


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-14330

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This fixes two issues I ran into during the xforms reindex without changing any default behavior.

First, some docs in the index contained an `_id` field in the doc source, which is a reserved property in ES, only allowed in doc metadata. I am not sure how those docs were allowed in, perhaps a difference between ES 1 and ES 2. The purge script adds a lot of time to the reindex so I defaulted it off. However, if we run into this issue in another old index like cases, it could be useful.

Second, I made the scroll batch size configurable because I ran into an issue where the scroll timed out, and had to reduce that size to allow it to complete (to 100). Again, this lengthens the time the reindex takes, so I left 1000 as the default.

I made the changes in both reindex commands because I wanted to ensure feature parity while we are in this transition state.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This only allows changing options in the reindex query without changing any behavior.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
