### PR TITLE
add label for changes to app_manger xml_models

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -12,6 +12,9 @@ rules:
   - labels: ['reindex/migration']
     patterns: ['migrations.lock|**/migrations/**|corehq/pillows/mappings/**|**/_design/**|corehq/couchapps/**']
 
+  - labels: [ 'Core Compatibility' ]
+    patterns: ['corehq/apps/app_manager/suite_xml/xml_models.py']
+
   - labels: ['dependencies']
     patterns: ['requirements/**|package.json|yarn.lock']
 


### PR DESCRIPTION
## Technical Summary
Changes to automated PR labels to flag `suite.xml` changes as potentially affecting Mobile / Formplayer.

This was an outcome from a recent retro "Empty case list text feature".

The goal is to provide better cues for reviewers and PR authors. We could bundle this into the 'high risk' label but I felt it deserves it's own label.