### PR TITLE
fix 'old metadata' reporting and convert to DD metric

### DIFF
--- a/corehq/ex-submodules/couchforms/util.py
+++ b/corehq/ex-submodules/couchforms/util.py
@@ -2,10 +2,7 @@ from io import BytesIO
 
 from django.test.client import Client
 
-from corehq.util.soft_assert import soft_assert
 from corehq.util.test_utils import unit_testing_only
-
-legacy_notification_assert = soft_assert(notify_admins=True, exponential_backoff=False)
 
 
 @unit_testing_only

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -46,7 +46,6 @@ from couchforms import openrosa_response
 from couchforms.const import DEVICE_LOG_XMLNS
 from couchforms.models import DefaultAuthContext, UnfinishedSubmissionStub
 from couchforms.signals import successful_form_received
-from couchforms.util import legacy_notification_assert
 from couchforms.openrosa_response import OpenRosaResponse, ResponseNature
 from dimagi.utils.logging import notify_exception, log_signal_errors
 from phonelog.utils import process_device_log, SumoLogicLog
@@ -144,8 +143,7 @@ class SubmissionPost(object):
 
     def _post_process_form(self, xform):
         self._set_submission_properties(xform)
-        found_old = scrub_meta(xform)
-        legacy_notification_assert(not found_old, 'Form with old metadata submitted', xform.form_id)
+        scrub_meta(xform)
 
     def _get_success_message(self, instance, cases=None):
         '''

--- a/corehq/form_processor/utils/metadata.py
+++ b/corehq/form_processor/utils/metadata.py
@@ -3,6 +3,7 @@ from copy import copy
 
 from jsonobject.api import re_date
 
+from corehq.util.metrics import metrics_counter
 from dimagi.utils.parsing import json_format_datetime
 from corehq.util.dates import iso_string_to_datetime
 
@@ -11,7 +12,11 @@ def scrub_meta(xform):
     if not hasattr(xform, 'form'):
         return
 
-    scrub_form_meta(xform.form_id, xform.form)
+    found_old = scrub_form_meta(xform.form_id, xform.form)
+    if found_old:
+        metrics_counter('commcare.xform_submissions.old_metadata', tags={
+            'domain': xform.domain,
+        })
 
 
 def scrub_form_meta(form_id, form_data):


### PR DESCRIPTION
## Technical Summary
The soft assert was not being fired due to a bug in the code (not returning the value from `scrub_meta` - thanks @esoergel for pointing that out).

This probably isn't an issue anymore but there's no harm in leaving this for a bit longer to be sure. Also, we can't remove the 'scrub_meta' function without fixing a lot of unit test data.

## Safety Assurance

### Safety story
Well tested code and a non-functional change

### Automated test coverage
Existing coverage

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
