### PR TITLE
Handle ResourceConflict when adding failed login attempts

### DIFF
--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -52,4 +52,10 @@ def add_failed_attempt(sender, credentials, token_failure=False, **kwargs):
         user.attempt_date = date.today()
 
     user.login_attempts += 1
-    user.save()
+
+    try:
+        user.save()
+    except ResourceConflict:
+        # swallow this exception due ensure the user still sees an auth failed
+        # error on their end, not a 500
+        return

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -57,6 +57,6 @@ def add_failed_attempt(sender, credentials, token_failure=False, **kwargs):
     try:
         user.save()
     except ResourceConflict:
-        # swallow this exception due ensure the user still sees an auth failed
-        # error on their end, not a 500
+        # swallow this exception to ensure the user still sees an auth failed
+        # error, not a 500
         return

--- a/corehq/apps/hqwebapp/signals.py
+++ b/corehq/apps/hqwebapp/signals.py
@@ -1,8 +1,9 @@
 from datetime import date
 
-from couchdbkit import ResourceConflict
 from django.contrib.auth.signals import user_logged_in, user_login_failed
 from django.dispatch import receiver
+
+from couchdbkit import ResourceConflict
 
 from corehq.apps.users.models import CouchUser
 from corehq.util.metrics import metrics_counter

--- a/corehq/apps/hqwebapp/tests/test_signals.py
+++ b/corehq/apps/hqwebapp/tests/test_signals.py
@@ -1,12 +1,14 @@
-from couchdbkit import ResourceConflict
-from django.test import TestCase
-from unittest.mock import patch
 from datetime import date, timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from couchdbkit import ResourceConflict
 
 from corehq.apps.users.models import CouchUser
 
-from ..signals import add_failed_attempt
 from .. import signals
+from ..signals import add_failed_attempt
 
 
 class FakeUser(CouchUser):

--- a/corehq/apps/hqwebapp/tests/test_signals.py
+++ b/corehq/apps/hqwebapp/tests/test_signals.py
@@ -1,3 +1,4 @@
+from couchdbkit import ResourceConflict
 from django.test import TestCase
 from unittest.mock import patch
 from datetime import date, timedelta
@@ -52,3 +53,10 @@ class TestFailedLoginSignal(TestCase):
 
         self.assertEqual(user.login_attempts, 5001)
         self.assertEqual(user.attempt_date, self.today)
+
+    def test_resource_conflict_on_save_is_handled(self):
+        user = FakeUser(attempt_date=self.today, login_attempts=5000)
+        credentials = {'username': 'test-user'}
+
+        with (patch.object(FakeUser, 'save', side_effect=ResourceConflict)):
+            add_failed_attempt(None, credentials)  # should not raise ResourceConflict

--- a/corehq/apps/hqwebapp/tests/test_signals.py
+++ b/corehq/apps/hqwebapp/tests/test_signals.py
@@ -57,8 +57,9 @@ class TestFailedLoginSignal(TestCase):
         self.assertEqual(user.attempt_date, self.today)
 
     def test_resource_conflict_on_save_is_handled(self):
-        user = FakeUser(attempt_date=self.today, login_attempts=5000)
+        user = FakeUser(attempt_date=self.today, login_attempts=1)
         credentials = {'username': 'test-user'}
 
-        with (patch.object(FakeUser, 'save', side_effect=ResourceConflict)):
+        with (patch.object(signals.CouchUser, 'get_by_username', return_value=user),
+              patch.object(FakeUser, 'save', side_effect=ResourceConflict)):
             add_failed_attempt(None, credentials)  # should not raise ResourceConflict


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14375

If a user's auth is failing, and multiple requests are received around the same time, a resource conflict can be hit when attempting to update failed login attempts. We want to swallow this exception and ensure a response indicating failed auth is returned to the user instead of a 500 error.

It is worth thinking about this from a malicious perspective, in that if an attack were attempted it would be a barrage of requests and likely result in lots of `ResourceConflict` exceptions. However this change does not leave us any more vulnerable to that, so I think it is still worth merging as is. 

The first commit is the important part of the PR, and the second commit is just isort.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
