### PR TITLE
Raise Exception on DHIS2 Payloads That Have Additional Errors

### DIFF
--- a/corehq/motech/dhis2/entities_helpers.py
+++ b/corehq/motech/dhis2/entities_helpers.py
@@ -406,11 +406,10 @@ def create_relationship(requests, relationship_spec):
     response = requests.post(endpoint, json=relationship_spec.as_dict(), raise_for_status=True)
     num_imported = response.json()['response']['imported']
     if num_imported != 1:
-        from corehq.motech.views import MotechLogListView
         raise Dhis2Exception(_(
             'DHIS2 created {n} relationships. Errors from DHIS2 can be found '
             'in Remote API Logs: {url}'
-        ).format(n=num_imported, url=reverse(MotechLogListView.urlname)))
+        ).format(n=num_imported, url=absolute_reverse(MotechLogListView.urlname, args=[requests.domain_name])))
 
 
 def get_or_generate_value(requests, attr_id, value_source_config, case_trigger_info):


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

DHIS2 payloads can sometimes have errors, despite showing a successful 200 response. Added further checks for errors in payload response to mark the payload as failed if any additional errors are found. This helps in making it easier to identify problematic payloads.

Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2470).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DHIS2 Integration.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Added necessary unit tests.
- Did test locally to ensure payloads with additional errors are marked as failed.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Automated tests created to ensure correct exceptions are thrown when there is a payload error.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
