### PR TITLE
Postgres to use health check in hq-compose

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -33,7 +33,7 @@ services:
     privileged: true  # allows mount inside container
     depends_on:
       postgres:
-        condition: service_started
+        condition: service_healthy
       couch:
         condition: service_healthy
       redis:


### PR DESCRIPTION
## Technical Summary

The Postgres container should use a health check in `hq-compose.yml` as it does in `hq-compose-runserver.yml`.

Context: [This question](https://github.com/dimagi/commcare-hq/pull/32386#discussion_r1104270409) from @snopoke 

## Safety Assurance

### Safety story

* Tested locally.
* Only affects dev environments.

### Automated test coverage

Not covered by tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
