### PR TITLE
Bump Django minimum version to 3.2.18

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -35,7 +35,7 @@ django-transfer
 django-two-factor-auth
 django-user-agents
 django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
-django>=3.2.14,<4.0
+django>=3.2.18,<4.0
 djangorestframework
 dropbox
 elasticsearch2>=2.0.0,<3.0.0  # we will be deprecating support for ES2 soon

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -114,7 +114,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==3.2.17
+django==3.2.18
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -95,7 +95,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==3.2.17
+django==3.2.18
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -99,7 +99,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==3.2.17
+django==3.2.18
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -91,7 +91,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==3.2.17
+django==3.2.18
     # via
     #   -r base-requirements.in
     #   django-appconf

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -100,7 +100,7 @@ diff-match-patch==20200713
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==3.2.17
+django==3.2.18
     # via
     #   -r base-requirements.in
     #   django-appconf


### PR DESCRIPTION
## Technical Summary

Change minimum Django version to 3.2.18 and update requirements.

Jira: [SAAS-14401](https://dimagi-dev.atlassian.net/browse/SAAS-14401)

## Safety Assurance

### Safety story

Upgraded to 3.2.17 just last week without issue.

### Automated test coverage

Good test coverage for Django dependency.

### QA Plan

No QA.

### Rollback instructions

- [ ] This PR can be reverted after deploy with no further considerations

Special consideration would be required to downgrade below 3.2.18.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-14401]: https://dimagi-dev.atlassian.net/browse/SAAS-14401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ