### PR TITLE
Support range for form attachment download

### DIFF
--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -824,7 +824,8 @@ def download_daily_saved_export(req, domain, export_instance_id):
 
     payload = export_instance.get_payload(stream=True)
     format = Format.from_format(export_instance.export_format)
-    return get_download_response(payload, export_instance.file_size, format.mimetype, format.download, export_instance.filename, req)
+    return get_download_response(payload, export_instance.file_size, format.mimetype,
+                                 format.download, export_instance.filename, req)
 
 
 @require_GET

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -824,7 +824,7 @@ def download_daily_saved_export(req, domain, export_instance_id):
 
     payload = export_instance.get_payload(stream=True)
     format = Format.from_format(export_instance.export_format)
-    return get_download_response(payload, export_instance.file_size, format, export_instance.filename, req)
+    return get_download_response(payload, export_instance.file_size, format.mimetype, format.download, export_instance.filename, req)
 
 
 @require_GET

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -11,7 +11,6 @@ from django.views.generic import View
 import pytz
 from memoized import memoized
 
-from couchexport.models import Format
 from dimagi.utils.web import get_url_base, json_response
 from soil import DownloadBase
 from soil.progress import get_task_status
@@ -384,9 +383,8 @@ class DataFileDownloadDetail(BaseProjectDataView):
         except (DataFile.DoesNotExist, NotFound):
             raise Http404
 
-        format = Format('', data_file.content_type, '', True)
         return get_download_response(
-            blob, data_file.content_length, format, data_file.filename, request
+            blob, data_file.content_length, data_file.content_type, True, data_file.filename, request
         )
 
     def delete(self, request, *args, **kwargs):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -98,7 +98,6 @@ from corehq.apps.users.dbaccessors import get_all_user_rows
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import (
     CommCareUser,
-    CouchUser,
     HqPermissions,
     WebUser,
 )
@@ -111,7 +110,6 @@ from corehq.blobs import CODES, NotFound, get_blob_db, models
 from corehq.form_processor.exceptions import AttachmentNotFound, CaseNotFound
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import CommCareCase, XFormInstance
-from corehq.form_processor.utils.general import use_sqlite_backend
 from corehq.form_processor.utils.xform import resave_form
 from corehq.motech.generic_inbound.utils import revert_api_request_from_form
 from corehq.tabs.tabclasses import ProjectReportsTab

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -4,7 +4,6 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import cmp_to_key, wraps
-from wsgiref.util import FileWrapper
 
 from django.conf import settings
 from django.contrib import messages
@@ -18,7 +17,6 @@ from django.http import (
     HttpResponseNotFound,
     HttpResponseRedirect,
     JsonResponse,
-    StreamingHttpResponse,
 )
 from django.shortcuts import render
 from django.template.loader import render_to_string
@@ -120,6 +118,7 @@ from corehq.tabs.tabclasses import ProjectReportsTab
 from corehq.toggles import VIEW_FORM_ATTACHMENT
 from corehq.util import cmp
 from corehq.util.couch import get_document_or_404
+from corehq.util.download import get_download_response
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import (
     get_timezone_for_request,
@@ -1482,9 +1481,13 @@ def get_form_attachment_response(request, domain, instance_id=None, attachment_i
     except AttachmentNotFound:
         raise Http404
 
-    return StreamingHttpResponse(
-        streaming_content=FileWrapper(content.content_stream),
-        content_type=content.content_type
+    return get_download_response(
+        payload=content.content_stream,
+        content_length=content.content_length,
+        content_type=content.content_type,
+        download=False,
+        filename=attachment_id,
+        request=request
     )
 
 

--- a/corehq/form_processor/models/attachment.py
+++ b/corehq/form_processor/models/attachment.py
@@ -147,6 +147,7 @@ class Attachment(IsImageMixin):
 class AttachmentContent:
     content_type = attr.ib()
     content_stream = attr.ib()
+    content_length = attr.ib()
 
     @property
     def content_body(self):

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -927,7 +927,7 @@ class CaseAttachment(PartitionedModel, models.Model, SaveStateMixin, IsImageMixi
     @classmethod
     def get_content(cls, case_id, name):
         att = cls.objects.get_attachment_by_name(case_id, name)
-        return AttachmentContent(att.content_type, att.open())
+        return AttachmentContent(att.content_type, att.open(), att.content_length)
 
     def __str__(self):
         return str(

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -122,7 +122,7 @@ class XFormInstanceManager(RequireDBManager):
 
     def get_attachment_content(self, form_id, attachment_name):
         meta = self.get_attachment_by_name(form_id, attachment_name)
-        return AttachmentContent(meta.content_type, meta.open())
+        return AttachmentContent(meta.content_type, meta.open(), meta.content_length)
 
     def get_forms_with_attachments_meta(self, form_ids, ordered=False):
         assert isinstance(form_ids, list)

--- a/corehq/util/download.py
+++ b/corehq/util/download.py
@@ -46,11 +46,12 @@ class RangedFileWrapper(object):
             yield data
 
 
-def get_download_response(payload, content_length, content_format, filename, request=None):
+def get_download_response(payload, content_length, content_type, download, filename, request=None):
     """
     :param payload: File like object.
     :param content_length: Size of payload in bytes
-    :param content_format: ``couchexport.models.Format`` instance
+    :param content_type: Content Type
+    :param download: Boolean for if its a download request
     :param filename: Name of the download
     :param request: The request. Used to determine if a range response should be given.
     :return: HTTP response
@@ -65,8 +66,8 @@ def get_download_response(payload, content_length, content_format, filename, req
     if ranges and len(ranges.ranges) != 1:
         ranges = None
 
-    response = StreamingHttpResponse(content_type=content_format.mimetype)
-    if content_format.download:
+    response = StreamingHttpResponse(content_type=content_type)
+    if download:
         response['Content-Disposition'] = safe_filename_header(filename)
 
     response["Content-Length"] = content_length


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
As a followup to https://github.com/dimagi/commcare-hq/pull/30801 (and then https://github.com/dimagi/commcare-hq/pull/32490) where we added a view for user to listen to form attachments without downloading, this PR addresses issues with Chrome not letting user seek on the media player by supporting range wise download.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR updates the form attachment response to return range based response when it is requested.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
For the [modified view](https://github.com/dimagi/commcare-hq/blob/db656d4205126deb9f1fd6874c500f40b82a49e1/corehq/apps/api/object_fetch_api.py#L133), Tested locally that normal attachment download still works as before on form data page and via the link directly (in case multimedia download is available in data exports), and confirmed that I could now seek the audio attachment on the player.

The changes to existing function `get_download_response` and its usages were simple, so didn't test that out functionally and relying on tests for those.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
