### PR TITLE
Do not run daily exports above row threshold

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -98,7 +98,8 @@ CASE_CREATE_ELEMENTS = ['case_name', 'owner_id', 'case_type']
 FORM_EXPORT = 'form'
 CASE_EXPORT = 'case'
 SMS_EXPORT = 'sms'
-MAX_EXPORTABLE_ROWS = 100000
+MAX_NORMAL_EXPORT_SIZE = 100000
+MAX_DAILY_EXPORT_SIZE = 1000000
 CASE_SCROLL_SIZE = 10000
 
 # When a question is missing completely from a form/case this should be the value
@@ -135,3 +136,6 @@ class SharingOption(object):
 
 
 UNKNOWN_EXPORT_OWNER = 'unknown'
+
+EXPORT_FAILURE_TOO_LARGE = 'too_large'
+EXPORT_FAILURE_UNKNOWN = 'unknown'

--- a/corehq/apps/export/exceptions.py
+++ b/corehq/apps/export/exceptions.py
@@ -1,7 +1,3 @@
-
-
-
-
 class ExportAppException(Exception):
     pass
 
@@ -28,3 +24,7 @@ class RejectedStaleExport(Exception):
 
 class InvalidLoginException(Exception):
     pass
+
+
+class ExportTooLargeException(Exception):
+    """Export exceeds size limit"""

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -6,6 +6,7 @@ from collections import Counter
 
 from couchdbkit import ResourceConflict
 
+from corehq.apps.export.exceptions import ExportTooLargeException
 from corehq.util.metrics import metrics_counter, metrics_track_errors
 from couchexport.export import FormattedRow, get_writer
 from couchexport.models import Format
@@ -443,9 +444,9 @@ def rebuild_export(export_instance, progress_tracker):
     export_size = get_export_size(export_instance, filters)
     include_hyperlinks = export_size < MAX_NORMAL_EXPORT_SIZE
     if export_size > MAX_DAILY_EXPORT_SIZE:
-        raise ValueError(
-            f"{export_instance} is {export_size} rows. Exceeds the "
-            f"{MAX_DAILY_EXPORT_SIZE} size limit.")
+        raise ExportTooLargeException(
+            f"{export_instance.name} is {export_size} rows. Exceeds the limit "
+            f"of {MAX_DAILY_EXPORT_SIZE} rows.")
     es_filters = [f.to_es_filter() for f in filters]
     with TransientTempfile() as temp_path:
         export_file = get_export_file([export_instance], es_filters, temp_path,

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -232,7 +232,7 @@ hqDefine("export/js/export_list", [
             self.taskStatus.percentComplete();
             self.taskStatus.started(true);
             self.taskStatus.success(false);
-            self.taskStatus.failed(false);
+            self.taskStatus.failed(null);
             var tick = function () {
                 $.ajax({
                     method: 'GET',

--- a/corehq/apps/export/templates/export/partials/export_list_controller.html
+++ b/corehq/apps/export/templates/export/partials/export_list_controller.html
@@ -5,7 +5,7 @@
 
 {% if request|toggle_enabled:"PAGINATED_EXPORTS" %}
   <div class="alert alert-info">
-    {% blocktrans with max_rows=max_exportable_rows|intcomma %}
+    {% blocktrans with max_rows=max_normal_export_size|intcomma %}
       These exports are paginated. That means exports that have over {{ max_rows }} rows will be split into multiple files.
     {% endblocktrans %}
   </div>

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -349,6 +349,14 @@
               {% endblocktrans %}
             </p>
 
+            <p class="text-danger"
+               data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.failed() == 'too_large'">
+              <i class="fa fa-exclamation-triangle"></i>
+              {% blocktrans with max_rows=max_daily_export_size|intcomma %}
+                Your export exceeds the limit of {{ max_rows }} rows. Please see <a href="https://confluence.dimagi.com/display/commcarepublic/Selecting+Tools+for+CommCare+Data+Processing+and+Analysis" data-toggle="modal">documentation</a> for more information.
+              {% endblocktrans %}
+            </p>
+
             <p class="text-success"
                data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished() && emailedExport.taskStatus.success()">
               <i class="fa fa-check"></i>
@@ -358,7 +366,7 @@
             </p>
 
             <p class="text-danger"
-               data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished() && emailedExport.taskStatus.failed()">
+               data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished() && emailedExport.taskStatus.failed() == 'unknown'">
               <i class="fa fa-exclamation-triangle"></i>
               <strong>
                 {% trans "Data update failed!" %}

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -133,7 +133,7 @@ class WriterTest(SimpleTestCase):
         self.assertTrue(export_save.called)
 
     @patch('corehq.apps.export.models.FormExportInstance.save')
-    @patch('corehq.apps.export.export.MAX_EXPORTABLE_ROWS', 2)
+    @patch('corehq.apps.export.export.MAX_NORMAL_EXPORT_SIZE', 2)
     @flag_enabled('PAGINATED_EXPORTS')
     def test_paginated_table(self, export_save):
         export_instance = FormExportInstance(

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -34,7 +34,7 @@ from corehq.apps.analytics.tasks import (
 )
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.models import Domain
-from corehq.apps.export.const import MAX_EXPORTABLE_ROWS
+from corehq.apps.export.const import MAX_NORMAL_EXPORT_SIZE
 from corehq.apps.export.exceptions import (
     ExportAsyncException,
     ExportFormValidationException,
@@ -267,12 +267,12 @@ def _check_export_size(domain, export_instances, export_filters):
     count = 0
     for instance in export_instances:
         count += get_export_size(instance, export_filters)
-    if count > MAX_EXPORTABLE_ROWS and not PAGINATED_EXPORTS.enabled(domain):
+    if count > MAX_NORMAL_EXPORT_SIZE and not PAGINATED_EXPORTS.enabled(domain):
         raise ExportAsyncException(
             _("This export contains %(row_count)s rows. Please change the "
               "filters to be less than %(max_rows)s rows.") % {
                 'row_count': count,
-                'max_rows': MAX_EXPORTABLE_ROWS
+                'max_rows': MAX_NORMAL_EXPORT_SIZE
             }
         )
 

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -546,7 +546,7 @@ def _get_task_status_json(export_instance_id):
     failure_reason = None
     if status.failed():
         failure_reason = EXPORT_FAILURE_TOO_LARGE if \
-            status.exception == ExportTooLargeException else \
+            isinstance(status.exception, ExportTooLargeException) else \
             EXPORT_FAILURE_UNKNOWN
 
     return {

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -167,7 +167,7 @@ def get_task_status(task, is_multiple_download_task=False):
             is_ready = True
             context_result = result and result.get('messages')
         elif result and isinstance(result, Exception):
-            exception = result.__class__
+            exception = result
             context_error = six.text_type(result)
             if '\t' in context_error:
                 context_error = [err for err in context_error.split('\t') if err]

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -22,7 +22,7 @@ class STATES(object):
     failed = 3
 
 
-class TaskStatus(namedtuple('TaskStatus', ['result', 'error', 'state', 'progress'])):
+class TaskStatus(namedtuple('TaskStatus', ['result', 'error', 'state', 'progress', 'exception'])):
     def missing(self):
         return self.state == STATES.missing
 
@@ -146,6 +146,7 @@ def get_multiple_task_progress(task):
 def get_task_status(task, is_multiple_download_task=False):
     context_result = None
     context_error = None
+    exception = None
     is_ready = False
     failed = False
 
@@ -166,6 +167,7 @@ def get_task_status(task, is_multiple_download_task=False):
             is_ready = True
             context_result = result and result.get('messages')
         elif result and isinstance(result, Exception):
+            exception = result.__class__
             context_error = six.text_type(result)
             if '\t' in context_error:
                 context_error = [err for err in context_error.split('\t') if err]
@@ -203,6 +205,7 @@ def get_task_status(task, is_multiple_download_task=False):
         result=context_result,
         error=context_error,
         progress=progress,
+        exception=exception
     )
 
 

--- a/corehq/ex-submodules/soil/tests/test_get_task_status.py
+++ b/corehq/ex-submodules/soil/tests/test_get_task_status.py
@@ -22,6 +22,7 @@ class GetTaskStatusTest(SimpleTestCase):
         )), TaskStatus(
             result=None,
             error=None,
+            exception=None,
             state=STATES.missing,
             progress=TaskProgress(
                 current=None,
@@ -48,6 +49,7 @@ class GetTaskStatusTest(SimpleTestCase):
         )), TaskStatus(
             result=None,
             error=None,
+            exception=None,
             state=STATES.started,
             progress=TaskProgress(
                 current=17076,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
![Screen Shot 2023-02-14 at 2 56 42 PM](https://user-images.githubusercontent.com/15785053/219079198-4018bf91-9337-4a8e-8e8a-59337004eb6e.png)
(imagine 1,000,000 rows instead of 2 rows)
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14379

At the moment, we don't have any concrete limits on how large a daily export can be. This PR aims to add a limit of 1,000,000 rows, and if the export exceeds this size, the entry for this export will have an error explaining to the user why the export failed (see above). 

Recently, this problem became more severe because there are a handful of daily export tasks that generate files around 3.5GB. This quickly led to disk space issues on our celery machines. Excel has [its own limits](https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3) for how large of a file it can open, so by setting our limit to 1,000,000 rows, we are just beneath that. 

If this change stands as is, I can update [the docs](https://confluence.dimagi.com/display/commcarepublic/Selecting+Tools+for+CommCare+Data+Processing+and+Analysis) for daily exports. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. The actual change to prevent running the export is straightforward, so the biggest risk is a UI bug coming out of these changes.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Can do a post-deploy QA, but this change should go out 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
