### PR TITLE
Homogenize case search and form entry datepickers

### DIFF
--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -136,7 +136,7 @@ class SearchCriteria:
         for v in values:
             match = pattern.match(v)
             if not match:
-                raise CaseFilterError(_('Invalid date range format, {}'), self.key)
+                raise CaseFilterError(_('Invalid date range format, {}').format(v), self.key)
 
 
 def criteria_dict_to_criteria_list(criteria_dict):

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -742,30 +742,15 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
      * date picker between the three types of Entry.
      */
     function DateTimeEntryBase(question, options) {
-        var self = this,
-            thisYear = new Date().getFullYear(),
-            minDate,
-            maxDate,
-            yearEnd,
-            yearStart;
+        var self = this;
 
         EntrySingleAnswer.call(self, question, options);
-
-        // Set year ranges
-        yearEnd = thisYear + 10;
-        yearStart = thisYear - 100;
-        // Set max date to 10 years in the future
-        maxDate = moment(yearEnd, 'YYYY').toDate();
-        // Set min date to 100 years in the past
-        minDate = moment(yearStart, 'YYYY').toDate();
 
         self.afterRender = function () {
             self.$picker = $('#' + self.entryId);
             cloudcareUtils.initDateTimePicker(self.$picker, _.extend({
                 date: self.answer() ? self.convertServerToClientFormat(self.answer()) : constants.NO_ANSWER,
                 format: self.clientFormat,
-                minDate: minDate,
-                maxDate: maxDate,
                 keepInvalid: true,
                 parseInputDate: function (date) {
                     var d = moment(date, self.clientFormat);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -748,15 +748,10 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
 
         self.afterRender = function () {
             self.$picker = $('#' + self.entryId);
-            cloudcareUtils.initDateTimePicker(self.$picker, _.extend({
-                date: self.answer() ? self.convertServerToClientFormat(self.answer()) : constants.NO_ANSWER,
-                format: self.clientFormat,
-                keepInvalid: true,
-                parseInputDate: function (date) {
-                    var d = moment(date, self.clientFormat);
-                    return d.isValid() ? d : null;
-                },
-            }, self.extraOptions));
+
+            var answer = self.answer() ? self.convertServerToClientFormat(self.answer()) : constants.NO_ANSWER;
+            self.initWidget(self.$picker, answer);
+
             self.$picker.on("dp.change", function (e) {
                 if (!e.date) {
                     self.answer(constants.NO_ANSWER);
@@ -768,6 +763,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     }
     DateTimeEntryBase.prototype = Object.create(EntrySingleAnswer.prototype);
     DateTimeEntryBase.prototype.constructor = EntrySingleAnswer;
+    DateTimeEntryBase.prototype.initWidget = undefined;  // overridden in subclasses
     DateTimeEntryBase.prototype.convertServerToClientFormat = function (date) {
         return moment(date, this.serverFormat).format(this.clientFormat);
     };
@@ -780,9 +776,6 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     // Formatting string should be in moment format: https://momentjs.com/docs/#/displaying/format/
     DateTimeEntryBase.prototype.serverFormat = undefined;
 
-    // Extra options to pass to datetimepicker widget
-    DateTimeEntryBase.prototype.extraOptions = {};
-
     function DateEntry(question, options) {
         this.templateType = 'date';
         DateTimeEntryBase.call(this, question, options);
@@ -792,6 +785,9 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     // This is format equates to 12/31/2016 and is used by the datetimepicker
     DateEntry.prototype.clientFormat = 'MM/DD/YYYY';
     DateEntry.prototype.serverFormat = 'YYYY-MM-DD';
+    DateEntry.prototype.initWidget = function ($element, answer) {
+        cloudcareUtils.initDatePicker($element, answer);
+    };
 
     function TimeEntry(question, options) {
         this.templateType = 'time';
@@ -814,7 +810,9 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
 
     TimeEntry.prototype.clientFormat = 'HH:mm';
     TimeEntry.prototype.serverFormat = 'HH:mm';
-    TimeEntry.prototype.extraOptions = {showTodayButton: false};
+    TimeEntry.prototype.initWidget = function ($element, answer) {
+        cloudcareUtils.initTimePicker($element, answer, this.clientFormat);
+    };
 
     function EthiopianDateEntry(question, options) {
         var self = this,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -341,9 +341,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 escapeMarkup: function (m) { return DOMPurify.sanitize(m); },
             });
             this.ui.hqHelp.hqHelp();
-            cloudcareUtils.initDateTimePicker(this.ui.date, {
-                format: dateFormat,
-            });
+            cloudcareUtils.initDatePicker(this.ui.date, this.model.get('value'), dateFormat);
             this.ui.dateRange.daterangepicker({
                 locale: {
                     format: dateFormat,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -380,7 +380,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 // Validate free-text input. Accept anything moment can recognize as a date, reformatting for ES.
                 var $input = $(this),
                     oldValue = $input.val(),
-                    parts = _.map(oldValue.split(separator), function (v) { return moment(v); }),
+                    parts = _.map(oldValue.split(separator), function (v) { return moment(v, dateFormats); }),
                     newValue = '';
 
                 if (_.every(parts, function (part) { return part.isValid(); }))  {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -169,7 +169,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 audioUrl: audioUri ? FormplayerFrontend.getChannel().request('resourceMap', audioUri, appId) : "",
                 value: value,
                 errorMessage: this.errorMessage,
-                dateFormat: dateFormat,
             };
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -169,6 +169,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 audioUrl: audioUri ? FormplayerFrontend.getChannel().request('resourceMap', audioUri, appId) : "",
                 value: value,
                 errorMessage: this.errorMessage,
+                dateFormat: dateFormat,
             };
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -67,10 +67,10 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     // or default value ("2023-02-14 to 2023-02-17")
                     // coerce to "02/14/2023 to 02/17/2023", as used by the widget
                     value = (value.replace("__range__", "")
-                             .replace(separator, serverSeparator)  // only used for default values
-                             .split(serverSeparator)
-                             .map(toUiDate)
-                             .join(separator));
+                        .replace(separator, serverSeparator)  // only used for default values
+                        .split(serverSeparator)
+                        .map(toUiDate)
+                        .join(separator));
                 }
             } else {
                 value = undefined;

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -366,44 +366,62 @@ hqDefine('cloudcare/js/utils', [
         return inputDate;
     };
 
-    var initDateTimePicker = function ($el, extraOptions) {
+    var initDatePicker = function ($el, selectedDate) {
         if (!$el.length) {
             return;
         }
 
-        extraOptions = extraOptions || {};
-        $el.datetimepicker(_.extend({
+        var dateFormat = "MM/DD/YYYY";
+        $el.datetimepicker({
+            date: selectedDate,
             useCurrent: false,
+            keepInvalid: true,
             showClear: true,
             showClose: true,
             showTodayButton: true,
             debug: true,
+            format: dateFormat,
             extraFormats: ["MM/DD/YYYY", "MM/DD/YY"],
             icons: {
                 today: 'glyphicon glyphicon-calendar',
             },
             tooltips: dateTimePickerTooltips,
-        }, extraOptions));
-
-        var picker = $el.data("DateTimePicker");
-        picker.parseInputDate(function (dateString) {
-            if (!moment.isMoment(dateString) || dateString instanceof Date) {
-                dateString = convertTwoDigitYear(dateString);
-            }
-            if (extraOptions.parseInputDate) {
-                return extraOptions.parseInputDate(dateString);
-            }
-            let dateObj = picker.getMoment(dateString);     // undocumented/private datetimepicker function
-            return dateObj.isValid() ? dateObj : "";
+            parseInputDate: function (dateString) {
+                if (!moment.isMoment(dateString) || dateString instanceof Date) {
+                    dateString = convertTwoDigitYear(dateString);
+                }
+                let dateObj = moment(dateString, dateFormat);
+                return dateObj.isValid() ? dateObj : null;
+            },
         });
 
-        $el.on("focusout", picker.hide);
+        $el.on("focusout", $el.data("DateTimePicker").hide);
+    };
+
+    var initTimePicker = function ($el, selectedTime, dateFormat) {
+        if (!$el.length) {
+            return;
+        }
+
+        $el.datetimepicker({
+            date: selectedTime,
+            format: dateFormat,
+            keepInvalid: true,
+            useCurrent: false,
+            showClear: true,
+            showClose: true,
+            debug: true,
+            tooltips: dateTimePickerTooltips,
+        });
+
+        $el.on("focusout", $el.data("DateTimePicker").hide);
     };
 
     return {
         dateTimePickerTooltips: dateTimePickerTooltips,
         convertTwoDigitYear: convertTwoDigitYear,
-        initDateTimePicker: initDateTimePicker,
+        initDatePicker: initDatePicker,
+        initTimePicker: initTimePicker,
         getFormUrl: getFormUrl,
         getSubmitUrl: getSubmitUrl,
         showError: showError,

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -420,7 +420,6 @@ hqDefine('cloudcare/js/utils', [
     };
 
     return {
-        dateTimePickerTooltips: dateTimePickerTooltips,
         convertTwoDigitYear: convertTwoDigitYear,
         initDatePicker: initDatePicker,
         initTimePicker: initTimePicker,

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -396,6 +396,8 @@ hqDefine('cloudcare/js/utils', [
         });
 
         $el.on("focusout", $el.data("DateTimePicker").hide);
+        $el.attr("placeholder", dateFormat);
+        $el.attr("pattern", "[0-9-/]+");
     };
 
     var initTimePicker = function ($el, selectedTime, dateFormat) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -375,13 +375,13 @@ hqDefine('cloudcare/js/utils', [
         $el.datetimepicker({
             date: selectedDate,
             useCurrent: false,
-            keepInvalid: true,
             showClear: true,
             showClose: true,
             showTodayButton: true,
             debug: true,
             format: dateFormat,
-            extraFormats: ["MM/DD/YYYY", "MM/DD/YY"],
+            extraFormats: ["MM/DD/YYYY", "MM/DD/YY", "YYYY-MM-DD"],
+            useStrict: true,
             icons: {
                 today: 'glyphicon glyphicon-calendar',
             },
@@ -406,7 +406,7 @@ hqDefine('cloudcare/js/utils', [
         $el.datetimepicker({
             date: selectedTime,
             format: dateFormat,
-            keepInvalid: true,
+            useStrict: true,
             useCurrent: false,
             showClear: true,
             showClose: true,

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -366,12 +366,12 @@ hqDefine('cloudcare/js/utils', [
         return inputDate;
     };
 
-    var initDatePicker = function ($el, selectedDate) {
+    var initDatePicker = function ($el, selectedDate, dateFormat) {
         if (!$el.length) {
             return;
         }
 
-        var dateFormat = "MM/DD/YYYY";
+        dateFormat = dateFormat || "MM/DD/YYYY";
         $el.datetimepicker({
             date: selectedDate,
             useCurrent: false,

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -313,6 +313,34 @@ hqDefine('cloudcare/js/utils', [
         }
     };
 
+    var dateTimePickerTooltips = {     // use default text, but enable translations
+        today: gettext('Go to today'),
+        clear: gettext('Clear selection'),
+        close: gettext('Close the picker'),
+        selectMonth: gettext('Select Month'),
+        prevMonth: gettext('Previous Month'),
+        nextMonth: gettext('Next Month'),
+        selectYear: gettext('Select Year'),
+        prevYear: gettext('Previous Year'),
+        nextYear: gettext('Next Year'),
+        selectDecade: gettext('Select Decade'),
+        prevDecade: gettext('Previous Decade'),
+        nextDecade: gettext('Next Decade'),
+        prevCentury: gettext('Previous Century'),
+        nextCentury: gettext('Next Century'),
+        pickHour: gettext('Pick Hour'),
+        incrementHour: gettext('Increment Hour'),
+        decrementHour: gettext('Decrement Hour'),
+        pickMinute: gettext('Pick Minute'),
+        incrementMinute: gettext('Increment Minute'),
+        decrementMinute: gettext('Decrement Minute'),
+        pickSecond: gettext('Pick Second'),
+        incrementSecond: gettext('Increment Second'),
+        decrementSecond: gettext('Decrement Second'),
+        togglePeriod: gettext('Toggle Period'),
+        selectTime: gettext('Select Time'),
+    }
+
     /**
      *  Convert two-digit year to four-digit year.
      *  Differs from JavaScript's two-year parsing to better match CommCare,
@@ -354,33 +382,7 @@ hqDefine('cloudcare/js/utils', [
             icons: {
                 today: 'glyphicon glyphicon-calendar',
             },
-            tooltips: {     // use default text, but enable translations
-                today: gettext('Go to today'),
-                clear: gettext('Clear selection'),
-                close: gettext('Close the picker'),
-                selectMonth: gettext('Select Month'),
-                prevMonth: gettext('Previous Month'),
-                nextMonth: gettext('Next Month'),
-                selectYear: gettext('Select Year'),
-                prevYear: gettext('Previous Year'),
-                nextYear: gettext('Next Year'),
-                selectDecade: gettext('Select Decade'),
-                prevDecade: gettext('Previous Decade'),
-                nextDecade: gettext('Next Decade'),
-                prevCentury: gettext('Previous Century'),
-                nextCentury: gettext('Next Century'),
-                pickHour: gettext('Pick Hour'),
-                incrementHour: gettext('Increment Hour'),
-                decrementHour: gettext('Decrement Hour'),
-                pickMinute: gettext('Pick Minute'),
-                incrementMinute: gettext('Increment Minute'),
-                decrementMinute: gettext('Decrement Minute'),
-                pickSecond: gettext('Pick Second'),
-                incrementSecond: gettext('Increment Second'),
-                decrementSecond: gettext('Decrement Second'),
-                togglePeriod: gettext('Toggle Period'),
-                selectTime: gettext('Select Time'),
-            },
+            tooltips: dateTimePickerTooltips,
         }, extraOptions));
 
         var picker = $el.data("DateTimePicker");
@@ -395,12 +397,11 @@ hqDefine('cloudcare/js/utils', [
             return dateObj.isValid() ? dateObj : "";
         });
 
-        $el.on("focusout", function () {
-            picker.hide();
-        });
+        $el.on("focusout", picker.hide);
     };
 
     return {
+        dateTimePickerTooltips: dateTimePickerTooltips,
         convertTwoDigitYear: convertTwoDigitYear,
         initDateTimePicker: initDateTimePicker,
         getFormUrl: getFormUrl,

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -372,6 +372,7 @@ hqDefine('cloudcare/js/utils', [
         }
 
         dateFormat = dateFormat || "MM/DD/YYYY";
+        let formats = _.union([dateFormat], ["MM/DD/YYYY", "MM/DD/YY", "YYYY-MM-DD"]);
         $el.datetimepicker({
             date: selectedDate,
             useCurrent: false,
@@ -380,7 +381,7 @@ hqDefine('cloudcare/js/utils', [
             showTodayButton: true,
             debug: true,
             format: dateFormat,
-            extraFormats: ["MM/DD/YYYY", "MM/DD/YY", "YYYY-MM-DD"],
+            extraFormats: formats,
             useStrict: true,
             icons: {
                 today: 'glyphicon glyphicon-calendar',
@@ -390,7 +391,7 @@ hqDefine('cloudcare/js/utils', [
                 if (!moment.isMoment(dateString) || dateString instanceof Date) {
                     dateString = convertTwoDigitYear(dateString);
                 }
-                let dateObj = moment(dateString, dateFormat);
+                let dateObj = moment(dateString, formats, true);
                 return dateObj.isValid() ? dateObj : null;
             },
         });

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -339,7 +339,7 @@ hqDefine('cloudcare/js/utils', [
         decrementSecond: gettext('Decrement Second'),
         togglePeriod: gettext('Toggle Period'),
         selectTime: gettext('Select Time'),
-    }
+    };
 
     /**
      *  Convert two-digit year to four-digit year.

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -537,10 +537,8 @@
 </script>
 <script type="text/html" id="date-entry-ko-template">
   <div class="input-group">
-    <input type="text" class="form-control" pattern="[0-9-/]+" data-bind="attr: {
-      id: entryId,
-      'aria-required': $parent.required() ? 'true' : 'false',
-      placeholder: clientFormat }"/>
+    <input type="text" class="form-control"
+      data-bind="attr: {id: entryId, 'aria-required': $parent.required() ? 'true' : 'false'}"/>
     <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
   </div>
 </script>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -61,9 +61,7 @@
     <div class="input-group">
       <input id="<%- text ? text : "" %>"
              type="text"
-             pattern="[0-9-/]+"
              class="date query-field form-control"
-             placeholder="<%- dateFormat %>"
              value="<%- value %>"
              <% if (required) { %> aria-required="true"<% } %>>
       <span class="input-group-addon"><i class="fa fa-calendar"></i></span>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -61,7 +61,9 @@
     <div class="input-group">
       <input id="<%- text ? text : "" %>"
              type="text"
+             pattern="[0-9-/]+"
              class="date query-field form-control"
+             placeholder="<%- dateFormat %>"
              value="<%- value %>"
              <% if (required) { %> aria-required="true"<% } %>>
       <span class="input-group-addon"><i class="fa fa-calendar"></i></span>


### PR DESCRIPTION
## Product Description

Switches the date format used in case search to MM/DD/YYYY to be consistent with form entry.  This applies to the date selector and the date range selector.  This is now displayed as placeholder text for clarity.

It also rejiggers the initialization and parsing of date strings for the widgets in both case search and form entry, attempting to get rid of some weirdness (previously, "Jan 1, 2023" would be interpreted as "01/20/2023"), and make it accept multiple formats.

![image](https://user-images.githubusercontent.com/2367539/219195994-19393c1e-5a1a-472f-8816-9196bb8016fb.png)

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2831

## Feature Flag
Case Search: Enable synchronous mobile searching and case claiming

## Safety Assurance

### Safety story
Local testing, plus this will be going through QA

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-4817

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
