### PR TITLE
Add correct implementation of to_python in ES adapters

### DIFF
--- a/corehq/apps/analytics/tests/test_partner_analytics_utils.py
+++ b/corehq/apps/analytics/tests/test_partner_analytics_utils.py
@@ -34,7 +34,6 @@ from corehq.apps.es.tests.utils import es_test
 from corehq.apps.es.users import user_adapter
 from corehq.apps.users.models import Invitation, WebUser
 from corehq.form_processor.tests.utils import create_form_for_test
-from corehq.pillows.user import transform_user_for_elasticsearch
 from corehq.pillows.xform import transform_xform_for_elasticsearch
 
 
@@ -117,8 +116,7 @@ class TestPartnerAnalyticsDataUtils(TestCase):
             except ResourceNotFound:
                 pass
         for user in cls.users:
-            elastic_user = transform_user_for_elasticsearch(user.to_json())
-            user_adapter.index(elastic_user, refresh=True)
+            user_adapter.index(user, refresh=True)
             cls.addClassCleanup(delete_user, user)
 
         invitations = [

--- a/corehq/apps/cloudcare/tests/test_esaccessors.py
+++ b/corehq/apps/cloudcare/tests/test_esaccessors.py
@@ -7,7 +7,6 @@ from corehq.apps.cloudcare.esaccessors import login_as_user_query
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.es.users import user_adapter
 from corehq.apps.users.models import CommCareUser
-from corehq.pillows.user import transform_user_for_elasticsearch
 
 
 @es_test(requires=[user_adapter])
@@ -33,11 +32,8 @@ class TestLoginAsUserQuery(SimpleTestCase):
             is_active=True,
         )
 
-        with patch('corehq.pillows.user.get_group_id_name_map_by_user', return_value=[]):
-            user_adapter.index(
-                transform_user_for_elasticsearch(user.to_json()),
-                refresh=True
-            )
+        with patch('corehq.apps.groups.dbaccessors.get_group_id_name_map_by_user', return_value=[]):
+            user_adapter.index(user, refresh=True)
         return user
 
     def test_login_as_user_query_username(self):

--- a/corehq/apps/data_interfaces/tests/test_case_deduplication.py
+++ b/corehq/apps/data_interfaces/tests/test_case_deduplication.py
@@ -34,7 +34,6 @@ from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.tasks import tag_cases_as_deleted_and_remove_indices
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.pillows.case_search import transform_case_for_elasticsearch
-from corehq.pillows.user import transform_user_for_elasticsearch
 from corehq.pillows.xform import get_xform_pillow
 from corehq.util.test_utils import flag_enabled, set_parent_case
 
@@ -857,11 +856,8 @@ class TestDeduplicationRuleRuns(TestCase):
             )
 
     def _send_user_to_es(self, user):
-        with patch('corehq.pillows.user.get_group_id_name_map_by_user', return_value=[]):
-            user_adapter.index(
-                transform_user_for_elasticsearch(user.to_json()),
-                refresh=True
-            )
+        with patch('corehq.apps.groups.dbaccessors.get_group_id_name_map_by_user', return_value=[]):
+            user_adapter.index(user, refresh=True)
         return user
 
     def get_case_property_value(self, case, property_value):

--- a/corehq/apps/enterprise/tests/test_enterprise_mobile_worker_settings.py
+++ b/corehq/apps/enterprise/tests/test_enterprise_mobile_worker_settings.py
@@ -18,7 +18,6 @@ from corehq.apps.es.tests.utils import es_test
 from corehq.apps.es.users import user_adapter
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.utils import TestFormMetadata
-from corehq.pillows.user import transform_user_for_elasticsearch
 from corehq.util.test_utils import make_es_ready_form
 
 
@@ -172,8 +171,7 @@ class TestEnterpriseMobileWorkerSettings(TestCase):
 
         for user in cls.users:
             fresh_user = CommCareUser.get_by_user_id(user.user_id)
-            elastic_user = transform_user_for_elasticsearch(fresh_user.to_json())
-            user_adapter.index(elastic_user, refresh=True)
+            user_adapter.index(fresh_user, refresh=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -443,6 +443,20 @@ class ElasticDocumentAdapter(BaseAdapter):
         raise NotImplementedError(f"{cls.__name__} is abstract")
 
     @classmethod
+    def from_multi(cls, doc):
+        """Transform a Python model object or a model dict into the json-serializable (``dict``)
+        format suitable for indexing in Elasticsearch.
+
+        :param doc: document (instance of a Python model) or to_json of that doc
+        :returns: ``tuple`` of ``(doc_id, source_dict)`` suitable for being
+                  indexed/updated/deleted in Elasticsearch
+
+        **NOTE** This calling from_python is temprory and will be removed in next commits
+        when from_multi is implemented in all the adapters
+        """
+        return cls.from_python(doc)
+
+    @classmethod
     def to_json(cls, doc):
         """Convenience method that returns the full "from python" document
         (including the ``_id`` key, if present) as it would be returned by an

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -685,7 +685,7 @@ class ElasticDocumentAdapter(BaseAdapter):
                      ``elasticsearch.Elasticsearch.index()`` method.
         """
         # TODO: remove **kw and standardize which arguments HQ uses
-        doc_id, source = self.from_python(doc)
+        doc_id, source = self.from_multi(doc)
         self._verify_doc_id(doc_id)
         self._verify_doc_source(source)
         self._index(doc_id, source, refresh, **kw)

--- a/corehq/apps/es/exceptions.py
+++ b/corehq/apps/es/exceptions.py
@@ -19,3 +19,13 @@ class TaskMissing(TaskError):
 
 class IndexNotMultiplexedException(Exception):
     pass
+
+
+class UnknownDocException(Exception):
+    def __init__(self, expected_cls, actual):
+        msg = f"Expected doc to be of type {expected_cls.__name__}, got {actual.__class__.__name__}"
+        super().__init__(msg)
+
+
+class InvalidDictForAdapter(Exception):
+    pass

--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -1876,6 +1876,54 @@ class TestFromMultiInElasticUser(TestCase):
         self.assertEqual(es_user, commcare_user)
 
 
+@es_test(requires=[domain_adapter], setup_class=True)
+class TestFromMultiInDomain(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'from-multi-domain-tests'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+
+    def test_from_multi_works_with_domain_objects(self):
+        domain_adapter.from_multi(self.domain_obj)
+
+    def test_from_multi_works_with_user_dicts(self):
+        domain_adapter.from_multi(self.domain_obj.to_json())
+
+    def test_from_multi_raises_for_other_objects(self):
+        self.assertRaises(UnknownDocException, domain_adapter.from_multi, set)
+
+    def test_from_python_raises_for_other_objects(self):
+        self.assertRaises(UnknownDocException, domain_adapter.from_python, set)
+        self.assertRaises(UnknownDocException, domain_adapter.from_python, self.domain_obj.to_json())
+
+    def test_from_multi_is_same_as_transform_domain_for_es(self):
+        # this test can be safely removed when transform_domain_for_elasticsearch is removed
+        domain_id, domain = domain_adapter.from_multi(self.domain_obj)
+        domain['_id'] = domain_id
+        self.assertEqual(transform_domain_for_elasticsearch(self.domain_obj.to_json()), domain)
+
+    def test_index_can_handle_domain_dicts(self):
+        domain_dict = self.domain_obj.to_json()
+        domain_adapter.index(domain_dict, refresh=True)
+        self.addCleanup(domain_adapter.delete, self.domain_obj._id)
+
+        domain = domain_adapter.to_json(self.domain_obj)
+        es_domain = domain_adapter.search({})['hits']['hits'][0]['_source']
+
+        self.assertEqual(es_domain, domain)
+
+    def test_index_can_handle_domain_objects(self):
+        domain_adapter.index(self.domain_obj, refresh=True)
+        self.addCleanup(domain_adapter.delete, self.domain_obj._id)
+
+        domain = domain_adapter.to_json(self.domain_obj)
+        es_domain = domain_adapter.search({})['hits']['hits'][0]['_source']
+
+        self.assertEqual(es_domain, domain)
+
+
 class OneshotIterable:
 
     def __init__(self, items):

--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -1848,6 +1848,7 @@ class TestFromMultiInElasticUser(TestCase):
         self.assertRaises(InvalidDictForAdapter, user_adapter.from_multi, {})
 
     def test_from_multi_is_same_as_transform_user_for_es(self):
+        # this test can be safely removed when transform_user_for_elasticsearch is removed
         commcare_user_id, commcare_user = user_adapter.from_multi(self.user)
         commcare_user['_id'] = commcare_user_id
         web_user_id, web_user = user_adapter.from_multi(self.web_user)
@@ -1856,7 +1857,7 @@ class TestFromMultiInElasticUser(TestCase):
         self.assertEqual(transform_user_for_elasticsearch(self.web_user.to_json()), web_user)
 
     def test_index_can_handle_user_dicts(self):
-        user_dict = transform_user_for_elasticsearch(self.user.to_json())
+        user_dict = self.user.to_json()
         user_adapter.index(user_dict, refresh=True)
         self.addCleanup(user_adapter.delete, self.user._id)
 

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -33,7 +33,7 @@ from . import filters, queries
 from .client import ElasticDocumentAdapter, create_document_adapter
 from .es_query import HQESQuery
 from .index.settings import IndexSettingsKey
-from .transient_util import get_adapter_mapping, from_dict_with_possible_id
+from .transient_util import get_adapter_mapping
 
 
 class UserES(HQESQuery):
@@ -81,6 +81,16 @@ class ElasticUser(ElasticDocumentAdapter):
         return get_adapter_mapping(self)
 
     @classmethod
+    def from_python(cls, couch_user):
+        """
+        :param couch_user: an instance of ``CouchUser``
+        :raises ``UnknownDocException`` if ``couch_user`` is not an instance of ``CouchUser``
+        """
+        from corehq.apps.users.models import CouchUser
+        if not isinstance(couch_user, CouchUser):
+            raise UnknownDocException(CouchUser, couch_user)
+        return cls.from_multi(couch_user)
+
     @classmethod
     def from_multi(cls, user):
         """

--- a/corehq/apps/reports/tests/test_case_list_report.py
+++ b/corehq/apps/reports/tests/test_case_list_report.py
@@ -14,7 +14,6 @@ from corehq.apps.users.models import (
     WebUser,
 )
 from corehq.form_processor.models import CommCareCase
-from corehq.pillows.user import transform_user_for_elasticsearch
 
 
 @es_test(requires=[case_adapter, group_adapter, user_adapter], setup_class=True)
@@ -65,7 +64,7 @@ class TestCaseListReport(TestCase):
     @classmethod
     def _send_users_to_es(cls):
         for user_obj in cls.user_list:
-            user_adapter.index(transform_user_for_elasticsearch(user_obj.to_json()), refresh=True)
+            user_adapter.index(user_obj, refresh=True)
 
     @classmethod
     def _send_cases_to_es(cls):

--- a/corehq/apps/reports/tests/test_enterprise_user_filter.py
+++ b/corehq/apps/reports/tests/test_enterprise_user_filter.py
@@ -11,7 +11,6 @@ from corehq.apps.reports.filters.controllers import (
 )
 from corehq.apps.reports.filters.users import EnterpriseUserFilter
 from corehq.apps.users.models import CommCareUser, WebUser
-from corehq.pillows.user import transform_user_for_elasticsearch
 
 
 @es_test(requires=[user_adapter], setup_class=True)
@@ -44,10 +43,7 @@ class BaseEnterpriseUserFilterTest(TestCase):
         create_enterprise_permissions(cls.web_user.username, 'state', ['county'], ['staging'])
 
         for user_obj in cls.mobile_users:
-            user_adapter.index(
-                transform_user_for_elasticsearch(user_obj.to_json()),
-                refresh=True
-            )
+            user_adapter.index(user_obj, refresh=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -72,7 +72,6 @@ from corehq.blobs.mixin import BlobMetaRef
 from corehq.form_processor.models import CaseTransaction, CommCareCase
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.case import transform_case_for_elasticsearch
-from corehq.pillows.user import transform_user_for_elasticsearch
 from corehq.pillows.utils import MOBILE_USER_TYPE, WEB_USER_TYPE
 from corehq.pillows.xform import transform_xform_for_elasticsearch
 from corehq.util.test_utils import make_es_ready_form
@@ -1004,7 +1003,7 @@ class TestUserESAccessors(TestCase):
 
     def _send_user_to_es(self, is_active=True):
         self.user.is_active = is_active
-        user_adapter.index(transform_user_for_elasticsearch(self.user.to_json()), refresh=True)
+        user_adapter.index(self.user, refresh=True)
 
     def test_active_user_query(self):
         self._send_user_to_es()

--- a/corehq/apps/reports/tests/test_filters.py
+++ b/corehq/apps/reports/tests/test_filters.py
@@ -27,7 +27,6 @@ from corehq.apps.users.models import (
     DomainMembership,
     WebUser,
 )
-from corehq.pillows.user import transform_user_for_elasticsearch
 
 
 class TestEmwfPagination(SimpleTestCase):
@@ -264,10 +263,7 @@ class TestEMWFilterOutput(TestCase):
 
     def _send_users_to_es(self):
         for user_obj in self.user_list:
-            user_adapter.index(
-                transform_user_for_elasticsearch(user_obj.to_json()),
-                refresh=True
-            )
+            user_adapter.index(user_obj, refresh=True)
 
     def test_with_active_slug(self):
         mobile_user_and_group_slugs = ['t__0']

--- a/corehq/apps/users/signals.py
+++ b/corehq/apps/users/signals.py
@@ -29,13 +29,7 @@ def _update_user_in_es(couch_user):
     if couch_user.to_be_deleted():
         user_adapter.delete(couch_user.user_id)
     else:
-        user_adapter.index(_transform_for_es(couch_user))
-
-
-def _transform_for_es(couch_user):
-    """Implemented separately for test patching."""
-    from corehq.pillows.user import transform_user_for_elasticsearch
-    return transform_user_for_elasticsearch(couch_user.to_json())
+        user_adapter.index(couch_user)
 
 
 def apply_correct_demo_mode(sender, couch_user, **kwargs):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Going down the line we aim to reach a point where we directly pass in the High-level objects to the adapter and it should be able to transform and index it without any issues.
This is one of the steps in that direction.
Ideally, we would want `from_python` to deal take python objects as inputs and then transform them. Since pillows entirely work on dicts, it becomes a requirement for now to support both python objects and dicts in the index function of the adapter. So we introduce a new function `from_multi` which can take in multiple formats and do the transformation on them and return the required dict. `from_python` then calls `from_multi` but `from_python` is only restricted to use high-level python objects.

Review by commit 🐟 

(I might adding more commits that will replace transform functions from tests and code, I might add them as separated PR
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14329
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The changes should be a no-op as the added functions are copies of transform functions but changes have been tested locally
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Changes covered by tests
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
