### PR TITLE
Add property labels to data dictionary case data page

### DIFF
--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -266,7 +266,7 @@ def _get_dd_tables(domain, case_type, dynamic_data, timezone):
     dd_props_by_group = list(_get_dd_props_by_group(domain, case_type))
     tables = [
         (group, _table_definition([
-            (p.name, p.description) for p in props
+            (p.name, p.label, p.description) for p in props
         ]))
         for group, props in dd_props_by_group
     ]
@@ -276,7 +276,7 @@ def _get_dd_tables(domain, case_type, dynamic_data, timezone):
     unrecognized = set(dynamic_data.keys()) - props_in_dd
     if unrecognized:
         tables.append((_('Unrecognized'), _table_definition([
-            (p, None) for p in unrecognized
+            (p, None, None) for p in unrecognized
         ])))
 
     return [{
@@ -306,10 +306,11 @@ def _table_definition(props):
     return {
         "layout": list(chunked([
             DisplayConfig(
-                expr=name,
+                expr=prop_name,
+                name=label,
                 description=description,
                 has_history=True
-            ) for name, description in sorted(props)
+            ) for prop_name, label, description in sorted(props)
         ], DYNAMIC_CASE_PROPERTIES_COLUMNS))
     }
 

--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -307,7 +307,7 @@ def _table_definition(props):
         "layout": list(chunked([
             DisplayConfig(
                 expr=prop_name,
-                name=label,
+                name=label or prop_name,
                 description=description,
                 has_history=True
             ) for prop_name, label, description in sorted(props)


### PR DESCRIPTION
## Product Description

If labels are supplied in the data dictionary, display those as the case property names in the data dictionary case data page ([this feature flag](https://www.commcarehq.org/hq/flags/edit/dd_case_data/))

Given a data dictionary config that looks like this:
![image](https://user-images.githubusercontent.com/2367539/219419345-dbd225ee-b145-4614-96f2-b1c04696189a.png)

This is what the current version of the DD case data page looks like (the descriptions are displayed when you hover over the info icon)
![image](https://user-images.githubusercontent.com/2367539/219419192-e2a7ad1c-84be-4862-bbfc-f1d1fbac538b.png)

And this is what it looks like after this PR is applied:
![image](https://user-images.githubusercontent.com/2367539/219418846-28aaec88-5706-4b35-9d4a-45f39233f008.png)

The two changes are that a label is used, if present, and I dropped the thing that turns underscores and dashes into spaces (only for the feature flag)

## Technical Summary

Followup from https://github.com/dimagi/commcare-hq/pull/32158/, using new functionality added in https://github.com/dimagi/commcare-hq/pull/32453

## Feature Flag

Data Dictionary Case Data Page


## Safety Assurance

### Safety story

This is a pre-release feature flag, and the change is small enough that I'm pretty confident in it.

### Automated test coverage

none

### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
