### PR TITLE
fix on change behavior for media entries

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -924,6 +924,11 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         var self = this;
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
             this.answer(newValue.replace(constants.FILE_PREFIX, ""));
+        } else {
+            self.file(null);
+            self.answer(constants.NO_ANSWER);
+            self.rawAnswer(constants.NO_ANSWER);
+            self.question.error(null);
         }
     };
     FileEntry.prototype.onAnswerChange = function (newValue) {
@@ -950,26 +955,17 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             // corresponds to validateFile check in Formplayer
             // any changes made here should also be made in Formplayer
             if (badExtension && badMime) {
-                self.file(null);
-                self.answer(constants.NO_ANSWER);
-                self.rawAnswer(constants.NO_ANSWER);
                 self.question.error(gettext("Invalid file type chosen. Please select a valid multimedia file."));
                 return;
             }
             // corresponds to MAX_BYTES_PER_ATTACHMENT var in Formplayer and limits file uploads to 3MB
             // any changes made here should also be made in Formplayer
             if (self.file().size > 3000000) {
-                self.answer(constants.NO_ANSWER);
                 self.question.error(gettext("The file you selected exceeds the size limit of 3MB. Please select a file that is smaller than 3MB."));
                 return;
             }
             self.question.error(null);
             self.question.onchange();
-        } else {
-            self.file(null);
-            self.answer(constants.NO_ANSWER);
-            self.rawAnswer(constants.NO_ANSWER);
-            self.question.error(null);
         }
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -910,12 +910,23 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         };
 
         self.file = ko.observable();
-
+        self.extensionsMap = {
+            "image/*,.pdf": ["jpg", "jpeg", "png", "pdf"],
+            "audio/*": ["3ga","mp3", "wav", "amr", "qcp","ogg"],
+            "video/*": ["3gpp", "3gp", "3gp2", "3g2", "mp4","mpg4", "mpeg4", "m4v", "mpg", "mpeg"]
+        }
     }
     FileEntry.prototype = Object.create(EntrySingleAnswer.prototype);
     FileEntry.prototype.constructor = EntrySingleAnswer;
     FileEntry.prototype.onPreProcess = function (newValue) {
+        var self = this;
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
+            const ext = newValue.slice(newValue.lastIndexOf(".")+1);
+            const acceptedExts = self.extensionsMap[self.accept];
+            if (!self.extensionsMap[self.accept].includes(ext.toLowerCase())) {
+                self.question.error(gettext("Invalid file type chosen. Please select a valid multimedia file."));
+                return;
+            }
             this.answer(newValue.replace(constants.FILE_PREFIX, ""));
         }
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -916,7 +916,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     FileEntry.prototype.constructor = EntrySingleAnswer;
     FileEntry.prototype.onAnswerChange = function (newValue) {
         var self = this;
-        if (self.answer() && self.answer().match(/([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12}).[a-z]{3}/)) {
+        if (self.answer() && self.answer().match(/([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12}).[a-z0-9]{3}/)) {
             return
         }
         if (newValue !== constants.NO_ANSWER && newValue !== "") {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -910,6 +910,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         };
 
         self.file = ko.observable();
+        // corresponds to SUPPORTED_FILE_EXTS var in Formplayer, a list of valid file extensions
         self.extensionsMap = {
             "image/*,.pdf": ["jpg", "jpeg", "png", "pdf"],
             "audio/*": ["3ga","mp3", "wav", "amr", "qcp","ogg"],
@@ -939,13 +940,14 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
             var $input = $('#' + self.entryId);
             self.file($input[0].files[0]);
+            // corresponds to MAX_BYTES_PER_ATTACHMENT var in Formplayer and limits file uploads to 3MB
             if (self.file().size > 3000000) {
                 self.answer(constants.NO_ANSWER);
                 self.question.error(gettext("The file you selected exceeds the size limit of 3MB. Please select a file that is smaller than 3MB."));
                 return;
             }
             self.question.error(null);
-            this.question.onchange();
+            self.question.onchange();
         } else {
             self.file(null);
             self.answer(constants.NO_ANSWER);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -916,7 +916,8 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     FileEntry.prototype.constructor = EntrySingleAnswer;
     FileEntry.prototype.onAnswerChange = function (newValue) {
         var self = this;
-        if (self.answer() && self.answer().match(/([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12}).[a-z0-9]{3}/)) {
+        // file has already been assigned a unique id and another request should not be sent to formplayer
+        if (self.answer() && self.answer().match(/([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12}).[A-Za-z0-9]{3}/)) {
             return
         }
         if (newValue !== constants.NO_ANSWER && newValue !== "") {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -923,12 +923,6 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     FileEntry.prototype.onPreProcess = function (newValue) {
         var self = this;
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
-            const ext = newValue.slice(newValue.lastIndexOf(".") + 1);
-            const acceptedExts = self.extensionsMap[self.accept];
-            if (!acceptedExts.includes(ext.toLowerCase())) {
-                self.question.error(gettext("Invalid file type chosen. Please select a valid multimedia file."));
-                return;
-            }
             this.answer(newValue.replace(constants.FILE_PREFIX, ""));
         }
     };
@@ -946,6 +940,27 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             if (self.file().size > 3000000) {
                 self.answer(constants.NO_ANSWER);
                 self.question.error(gettext("The file you selected exceeds the size limit of 3MB. Please select a file that is smaller than 3MB."));
+                return;
+            }
+            let badExtension = false;
+            let badMime = true;
+            const ext = newValue.slice(newValue.lastIndexOf(".") + 1);
+            const acceptedExts = self.extensionsMap[self.accept];
+            badExtension = !acceptedExts.includes(ext.toLowerCase());
+
+            for (acc of self.accept.split(",")) {
+                if (self.file().type.match(acc)) {
+                    badMime = false;
+                    break;
+                }
+            }
+            // corresponds to validateFile check in Formplayer
+            // any changes made here should also be made in Formplayer
+            if (badExtension && badMime) {
+                self.file(null);
+                self.answer(constants.NO_ANSWER);
+                self.rawAnswer(constants.NO_ANSWER);
+                self.question.error(gettext("Invalid file type chosen. Please select a valid multimedia file."));
                 return;
             }
             self.question.error(null);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -914,6 +914,11 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     }
     FileEntry.prototype = Object.create(EntrySingleAnswer.prototype);
     FileEntry.prototype.constructor = EntrySingleAnswer;
+    FileEntry.prototype.onPreProcess = function (newValue) {
+        if (newValue !== constants.NO_ANSWER && newValue !== "") {
+            this.answer(newValue.replace(constants.FILE_PREFIX, ""));
+        }
+    }
     FileEntry.prototype.onAnswerChange = function (newValue) {
         var self = this;
         // file has already been assigned a unique id and another request should not be sent to formplayer
@@ -922,8 +927,13 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         }
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
             var $input = $('#' + self.entryId);
-            self.answer(newValue.replace(constants.FILE_PREFIX, ""));
             self.file($input[0].files[0]);
+            if (self.file().size > 3000000) {
+                self.answer(constants.NO_ANSWER);
+                self.question.error(gettext("The file you selected exceeds the size limit of 3MB. Please select a file that is smaller than 3MB."));
+                return;
+            }
+            self.question.error(null);
             this.question.onchange();
         } else {
             self.file(null);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -916,15 +916,18 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     FileEntry.prototype.constructor = EntrySingleAnswer;
     FileEntry.prototype.onAnswerChange = function (newValue) {
         var self = this;
-        if (newValue !== constants.NO_ANSWER) {
+        if (self.answer() && self.answer().match(/([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12}).[a-z]{3}/)) {
+            return
+        }
+        if (newValue !== constants.NO_ANSWER && newValue !== "") {
             var $input = $('#' + self.entryId);
             self.answer(newValue.replace(constants.FILE_PREFIX, ""));
             self.file($input[0].files[0]);
+            this.question.onchange();
         } else {
-            self.answer(newValue);
             self.file(null);
+            self.answer(constants.NO_ANSWER);
         }
-        this.question.onchange();
     };
 
     /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -908,7 +908,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.xformParams = function () {
             return { file: self.file() };
         };
-
+        self.formplayerProcessed = false;
         self.file = ko.observable();
         // corresponds to SUPPORTED_FILE_EXTS var in Formplayer, a list of valid file extensions
         // any changes made here should also be made in Formplayer
@@ -923,7 +923,11 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     FileEntry.prototype.onPreProcess = function (newValue) {
         var self = this;
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
-            this.answer(newValue.replace(constants.FILE_PREFIX, ""));
+            // input has changed and validation will be checked
+            if (newValue !== self.answer()) {
+                self.question.formplayerProcessed = false;
+            }
+            self.answer(newValue.replace(constants.FILE_PREFIX, ""));
         } else {
             self.file(null);
             self.answer(constants.NO_ANSWER);
@@ -933,8 +937,8 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     };
     FileEntry.prototype.onAnswerChange = function (newValue) {
         var self = this;
-        // file has already been assigned a unique id and another request should not be sent to formplayer
-        if (self.answer() && self.answer().match(/^(\w{8}-)(\w{4}-){3}(\w{12})\.\w{3,4}$/)) {
+        // file has already been validated and assigned a unique id. another request should not be sent to formplayer
+        if (self.question.formplayerProcessed) {
             return;
         }
         if (newValue !== constants.NO_ANSWER && newValue !== "") {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -918,7 +918,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         var self = this;
         // file has already been assigned a unique id and another request should not be sent to formplayer
         if (self.answer() && self.answer().match(/^(\w{8}-)(\w{4}-){3}(\w{12})\.\w{3,4}$/)) {
-            return
+            return;
         }
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
             var $input = $('#' + self.entryId);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -950,7 +950,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             const acceptedExts = self.extensionsMap[self.accept];
             badExtension = !acceptedExts.includes(ext.toLowerCase());
 
-            for (acc of self.accept.split(",")) {
+            for (const acc of self.accept.split(",")) {
                 if (self.file().type.match(acc)) {
                     badMime = false;
                     break;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -935,13 +935,6 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
             var $input = $('#' + self.entryId);
             self.file($input[0].files[0]);
-            // corresponds to MAX_BYTES_PER_ATTACHMENT var in Formplayer and limits file uploads to 3MB
-            // any changes made here should also be made in Formplayer
-            if (self.file().size > 3000000) {
-                self.answer(constants.NO_ANSWER);
-                self.question.error(gettext("The file you selected exceeds the size limit of 3MB. Please select a file that is smaller than 3MB."));
-                return;
-            }
             let badExtension = false;
             let badMime = true;
             const ext = newValue.slice(newValue.lastIndexOf(".") + 1);
@@ -961,6 +954,13 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                 self.answer(constants.NO_ANSWER);
                 self.rawAnswer(constants.NO_ANSWER);
                 self.question.error(gettext("Invalid file type chosen. Please select a valid multimedia file."));
+                return;
+            }
+            // corresponds to MAX_BYTES_PER_ATTACHMENT var in Formplayer and limits file uploads to 3MB
+            // any changes made here should also be made in Formplayer
+            if (self.file().size > 3000000) {
+                self.answer(constants.NO_ANSWER);
+                self.question.error(gettext("The file you selected exceeds the size limit of 3MB. Please select a file that is smaller than 3MB."));
                 return;
             }
             self.question.error(null);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -908,7 +908,6 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.xformParams = function () {
             return { file: self.file() };
         };
-        self.formplayerProcessed = false;
         self.file = ko.observable();
         // corresponds to SUPPORTED_FILE_EXTS var in Formplayer, a list of valid file extensions
         // any changes made here should also be made in Formplayer

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -918,7 +918,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
             this.answer(newValue.replace(constants.FILE_PREFIX, ""));
         }
-    }
+    };
     FileEntry.prototype.onAnswerChange = function (newValue) {
         var self = this;
         // file has already been assigned a unique id and another request should not be sent to formplayer

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -913,17 +913,17 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.extensionsMap = {
             "image/*,.pdf": ["jpg", "jpeg", "png", "pdf"],
             "audio/*": ["3ga","mp3", "wav", "amr", "qcp","ogg"],
-            "video/*": ["3gpp", "3gp", "3gp2", "3g2", "mp4","mpg4", "mpeg4", "m4v", "mpg", "mpeg"]
-        }
+            "video/*": ["3gpp", "3gp", "3gp2", "3g2", "mp4","mpg4", "mpeg4", "m4v", "mpg", "mpeg"],
+        };
     }
     FileEntry.prototype = Object.create(EntrySingleAnswer.prototype);
     FileEntry.prototype.constructor = EntrySingleAnswer;
     FileEntry.prototype.onPreProcess = function (newValue) {
         var self = this;
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
-            const ext = newValue.slice(newValue.lastIndexOf(".")+1);
+            const ext = newValue.slice(newValue.lastIndexOf(".") + 1);
             const acceptedExts = self.extensionsMap[self.accept];
-            if (!self.extensionsMap[self.accept].includes(ext.toLowerCase())) {
+            if (!acceptedExts.includes(ext.toLowerCase())) {
                 self.question.error(gettext("Invalid file type chosen. Please select a valid multimedia file."));
                 return;
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -955,9 +955,9 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                     break;
                 }
             }
-            // corresponds to validateFile check in Formplayer
-            // any changes made here should also be made in Formplayer
-            if (badExtension && badMime) {
+            // similar to validateFile check in Formplayer
+            // though this check is more strict than the one in Formplayer
+            if (badExtension || badMime) {
                 self.question.error(gettext("Invalid file type chosen. Please select a valid multimedia file."));
                 return;
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -911,6 +911,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
 
         self.file = ko.observable();
         // corresponds to SUPPORTED_FILE_EXTS var in Formplayer, a list of valid file extensions
+        // any changes made here should also be made in Formplayer
         self.extensionsMap = {
             "image/*,.pdf": ["jpg", "jpeg", "png", "pdf"],
             "audio/*": ["3ga","mp3", "wav", "amr", "qcp","ogg"],
@@ -941,6 +942,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             var $input = $('#' + self.entryId);
             self.file($input[0].files[0]);
             // corresponds to MAX_BYTES_PER_ATTACHMENT var in Formplayer and limits file uploads to 3MB
+            // any changes made here should also be made in Formplayer
             if (self.file().size > 3000000) {
                 self.answer(constants.NO_ANSWER);
                 self.question.error(gettext("The file you selected exceeds the size limit of 3MB. Please select a file that is smaller than 3MB."));

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -917,7 +917,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     FileEntry.prototype.onAnswerChange = function (newValue) {
         var self = this;
         // file has already been assigned a unique id and another request should not be sent to formplayer
-        if (self.answer() && self.answer().match(/([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12}).[A-Za-z0-9]{3}/)) {
+        if (self.answer() && self.answer().match(/^(\w{8}-)(\w{4}-){3}(\w{12})\.\w{3,4}$/)) {
             return
         }
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
@@ -928,6 +928,8 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         } else {
             self.file(null);
             self.answer(constants.NO_ANSWER);
+            self.rawAnswer(constants.NO_ANSWER);
+            self.question.error(null);
         }
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -955,8 +955,8 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                     break;
                 }
             }
-            // similar to validateFile check in Formplayer
-            // though this check is more strict than the one in Formplayer
+            // corresponds to validateFile check in Formplayer
+            // any changes made here should also be made in Formplayer
             if (badExtension || badMime) {
                 self.question.error(gettext("Invalid file type chosen. Please select a valid multimedia file."));
                 return;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -598,6 +598,9 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         // If the question has ever been answered, set this to true.
         self.hasAnswered = false;
 
+        // if media question has been processed in FP successfully set to true
+        self.formplayerProcessed = false;
+
         // pendingAnswer is a copy of an answer being submitted, so that we know not to reconcile a new answer
         // until the question has received a response from the server.
         self.pendingAnswer = ko.observable(constants.NO_PENDING_ANSWER);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -203,7 +203,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
                     if (options.target.pendingAnswer &&
                             options.target.pendingAnswer() !== constants.NO_PENDING_ANSWER) {
                         // There is a request in progress
-                        if (utils.answersEqual(options.data.answer, options.target.pendingAnswer())) {
+                        if (options.target.entry.templateType === "file" || utils.answersEqual(options.data.answer, options.target.pendingAnswer())) {
                             // We can now mark it as not dirty
                             options.data.answer = _.clone(options.target.pendingAnswer());
                             options.target.pendingAnswer(constants.NO_PENDING_ANSWER);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -25,6 +25,8 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
             return _.isEqual(answer1, answer2);
         } else if (answer1 === answer2) {
             return true;
+        } else if(answer1.slice(answer1.lastIndexOf(".")) === answer2.slice(answer2.lastIndexOf("."))) {
+            return true;
         }
         return false;
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -25,7 +25,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
             return _.isEqual(answer1, answer2);
         } else if (answer1 === answer2) {
             return true;
-        } else if(answer1.slice(answer1.lastIndexOf(".")) === answer2.slice(answer2.lastIndexOf("."))) {
+        } else if (answer1 && answer2 && answer1.slice(answer1.lastIndexOf(".")) === answer2.slice(answer2.lastIndexOf("."))) {
             return true;
         }
         return false;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -25,8 +25,6 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
             return _.isEqual(answer1, answer2);
         } else if (answer1 === answer2) {
             return true;
-        } else if (answer1 && answer2 && answer1.slice(answer1.lastIndexOf(".")) === answer2.slice(answer2.lastIndexOf("."))) {
-            return true;
         }
         return false;
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -336,6 +336,7 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
                     'oneQuestionPerScreen': oneQuestionPerScreen,
                 }, q.entry.xformParams()),
                 function (resp) {
+                    q.formplayerProcessed = true;
                     $.publish('session.reconcile', [resp, q]);
                     if (self.answerCallback !== undefined) {
                         self.answerCallback(self.session_id);
@@ -346,6 +347,7 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
                 },
                 constants.BLOCK_SUBMIT,
                 function () {
+                    q.formplayerProcessed = false;
                     q.serverError(
                         gettext("We were unable to save this answer. Please try again later."));
                     q.pendingAnswer(constants.NO_PENDING_ANSWER);


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This stops loading spinner on media questions from spinning indefinitely.

<img src="https://user-images.githubusercontent.com/42388648/219436863-33a30028-04ad-4629-b8b3-9e72f81f4b35.gif" width="350"><img src="https://user-images.githubusercontent.com/42388648/225985114-f8a040bf-685e-49cc-a5fc-ce57b97324ea.gif" width="350">




## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/QA-4800
FP is assigning a new id/name to uploaded media files, so the call to `answersEqual` will never evaluate to true.
For example when I upload `valid_image.jpg` what comes back from FP is something like `ef636b6b-4e6a-454a-8a16-7e2cf7e973c7.jpg`. This change compares the file extensions, so in this case ".jpg" === ".jpg" evaluates to true and the answer is marked as not dirty/clean and loading spinner is replace by a green check.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
USH: Support signature, image, audio, and video questions in Web Apps

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
part of QA for web apps media upload
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
