### PR TITLE
Remove unnecessary content_length parameter

### DIFF
--- a/corehq/util/download.py
+++ b/corehq/util/download.py
@@ -59,7 +59,7 @@ def get_download_response(payload, content_length, content_type, download, filen
     ranges = None
     if request and "HTTP_RANGE" in request.META:
         try:
-            ranges = parse_range_header(request.META['HTTP_RANGE'], content_length)
+            ranges = parse_range_header(request.META['HTTP_RANGE'])
         except ValueError:
             pass
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Looking at the implementation of `parse_range_header` in werkzeug (https://github.com/pallets/werkzeug/blob/1.0.1/src/werkzeug/http.py#L660), the second parameter `make_inclusive` is unused, so I don't think there is any reason for us to be passing a second parameter to this method, especially one that represents the `content_length`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
