### PR TITLE
Accessibility: Screen reader fixes for mapbox geocoder widget 

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -302,7 +302,8 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                 self.entryId,
                 self.geocoderItemCallback,
                 self.geocoderOnClearCallback,
-                initialPageData
+                initialPageData,
+                self._inputOnKeyDown
             );
         };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -92,7 +92,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         inputEl.on('keydown', _.debounce((e) => {
             inputOnKeyDown(e);
 
-            if (e.keyCode === 38 || e.keyCode === 40) {
+            if (e.key === "ArrowUp" || e.key === "ArrowDown") {
                 $("#geocoder-option-sr").html("<p>" + $("ul.suggestions li.active").text() + "</p>");
             }
         }, 200));

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -89,7 +89,11 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         // Must add the form-control class to the input created by mapbox in order to edit.
         var inputEl = $('input.mapboxgl-ctrl-geocoder--input');
         inputEl.addClass('form-control');
-        inputEl.on('keydown', _.debounce(self._inputOnKeyDown, 200));
+        inputEl.on('keydown', _.debounce((e) => {
+            if (e.keyCode === 38 || e.keyCode === 40) {
+                $("#geocoder-option-sr").html("<p>" + $("ul.suggestions li.active").text() + "</p>");
+            }
+        }, 200));
     };
 
     /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -73,7 +73,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
      * @param {Object} clearCallBack - function to call back after clearing the input
      * @param {Object} initialPageData - initial_page_data object
      */
-    module.renderMapboxInput = function (divId, itemCallback, clearCallBack, initialPageData) {
+    module.renderMapboxInput = function (divId, itemCallback, clearCallBack, initialPageData, inputOnKeyDown) {
         var defaultGeocoderLocation = initialPageData.get('default_geocoder_location') || {};
         var geocoder = new MapboxGeocoder({
             accessToken: initialPageData.get("mapbox_access_token"),
@@ -90,6 +90,8 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         var inputEl = $('input.mapboxgl-ctrl-geocoder--input');
         inputEl.addClass('form-control');
         inputEl.on('keydown', _.debounce((e) => {
+            inputOnKeyDown(e);
+
             if (e.keyCode === 38 || e.keyCode === 40) {
                 $("#geocoder-option-sr").html("<p>" + $("ul.suggestions li.active").text() + "</p>");
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -104,6 +104,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
             }
         }, 200));
 
+        // This fixes the geocoder first value not getting read by screen-reader.
         geocoder.on('results', (items) => {
             if (items && items.features) {
                 $("#" + divId + "-sr").html("<p>" + items.features[0].place_name + "</p>");

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -86,8 +86,9 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         }
         geocoder.on('clear', clearCallBack);
         geocoder.addTo('#' + divId);
+        const divEl = $("#" + divId);
         // Must add the form-control class to the input created by mapbox in order to edit.
-        var inputEl = $('input.mapboxgl-ctrl-geocoder--input');
+        var inputEl = divEl.find('input.mapboxgl-ctrl-geocoder--input');
         inputEl.addClass('form-control');
         inputEl.on('keydown', _.debounce((e) => {
             if (inputOnKeyDown) {
@@ -95,7 +96,8 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
             }
 
             if (e.key === "ArrowUp" || e.key === "ArrowDown") {
-                $("#geocoder-option-sr").html("<p>" + $("ul.suggestions li.active").text() + "</p>");
+                const currentOption = divEl.find("ul.suggestions li.active").text();
+                $("#" + divId + "-sr").html("<p>" + currentOption + "</p>");
             }
         }, 200));
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -88,6 +88,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         geocoder.on('clear', clearCallBack);
         geocoder.addTo('#' + divId);
         const divEl = $("#" + divId);
+        const liveRegionEl = $("#" + divId + "-sr[role='region']");
         // Must add the form-control class to the input created by mapbox in order to edit.
         var inputEl = divEl.find('input.mapboxgl-ctrl-geocoder--input');
         inputEl.addClass('form-control');
@@ -100,14 +101,14 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
             // screen reader live region with the current highlighted value.
             if (e.key === "ArrowUp" || e.key === "ArrowDown") {
                 const currentOption = divEl.find("ul.suggestions li.active").text();
-                $("#" + divId + "-sr").html("<p>" + currentOption + "</p>");
+                liveRegionEl.html("<p>" + currentOption + "</p>");
             }
         }, 200));
 
         // This fixes the geocoder first value not getting read by screen-reader.
         geocoder.on('results', (items) => {
             if (items && items.features) {
-                $("#" + divId + "-sr").html("<p>" + items.features[0].place_name + "</p>");
+                liveRegionEl.html("<p>" + items.features[0].place_name + "</p>");
             }
         });
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -103,6 +103,12 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
                 $("#" + divId + "-sr").html("<p>" + currentOption + "</p>");
             }
         }, 200));
+
+        geocoder.on('results', (items) => {
+            if (items && items.features) {
+                $("#" + divId + "-sr").html("<p>" + items.features[0].place_name + "</p>");
+            }
+        });
     };
 
     /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -90,7 +90,9 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         var inputEl = $('input.mapboxgl-ctrl-geocoder--input');
         inputEl.addClass('form-control');
         inputEl.on('keydown', _.debounce((e) => {
-            inputOnKeyDown(e);
+            if (inputOnKeyDown) {
+                inputOnKeyDown(e);
+            }
 
             if (e.key === "ArrowUp" || e.key === "ArrowDown") {
                 $("#geocoder-option-sr").html("<p>" + $("ul.suggestions li.active").text() + "</p>");

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -105,7 +105,8 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
             }
         }, 200));
 
-        // This fixes the geocoder first value not getting read by screen-reader.
+        // This populates the "region" html node with the first option, so that it is read by
+        // screen readers on focus.
         geocoder.on('results', (items) => {
             if (items && items.features) {
                 liveRegionEl.html("<p>" + items.features[0].place_name + "</p>");

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -72,6 +72,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
      * @param {Object} itemCallback - function to call back after new search
      * @param {Object} clearCallBack - function to call back after clearing the input
      * @param {Object} initialPageData - initial_page_data object
+     * @param {function|undefined} inputOnKeyDown - inputOnKeyDown function (optional)
      */
     module.renderMapboxInput = function (divId, itemCallback, clearCallBack, initialPageData, inputOnKeyDown) {
         var defaultGeocoderLocation = initialPageData.get('default_geocoder_location') || {};
@@ -95,6 +96,8 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
                 inputOnKeyDown(e);
             }
 
+            // This captures arrow up/down events on geocoder input box and updates the
+            // screen reader live region with the current highlighted value.
             if (e.key === "ArrowUp" || e.key === "ArrowDown") {
                 const currentOption = divEl.find("ul.suggestions li.active").text();
                 $("#" + divId + "-sr").html("<p>" + currentOption + "</p>");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -394,9 +394,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         },
 
         templateContext: function () {
-            var description = md.render(this.options.collection.description);
+            var description = md.render(this.options.collection.description.trim());
             return {
-                title: this.options.title,
+                title: this.options.title.trim(),
                 description: DOMPurify.sanitize(description),
             };
         },

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -404,6 +404,7 @@
 </script>
 
 <script type="text/html" id="address-entry-ko-template">
+  <div role="region" aria-live="polite" id="geocoder-option-sr" class="sr-only"></div>
   <div data-bind="attr: { id: entryId }"></div>
 </script>
 

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -404,6 +404,7 @@
 </script>
 
 <script type="text/html" id="address-entry-ko-template">
+  <!-- ARIA live region for highlighted geocoder values, populated via javascript -->
   <div role="region" aria-live="polite" class="sr-only" data-bind="attr: { id: entryId+'-sr' }"></div>
   <div data-bind="attr: { id: entryId }"></div>
 </script>

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -404,7 +404,7 @@
 </script>
 
 <script type="text/html" id="address-entry-ko-template">
-  <div role="region" aria-live="polite" id="geocoder-option-sr" class="sr-only"></div>
+  <div role="region" aria-live="polite" class="sr-only" data-bind="attr: { id: entryId+'-sr' }"></div>
   <div data-bind="attr: { id: entryId }"></div>
 </script>
 

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -88,6 +88,7 @@
     </fieldset>
 
     <% } else if (input == "address") { %>
+    <!-- ARIA live region for highlighted geocoder values, populated via javascript -->
     <div role="region" aria-live="polite" class="sr-only" id="<%- id %>_mapbox-sr"></div>
     <div class="query-field" value="<%- value %>" id="<%- id %>_mapbox" data-address="<%- id %>">
     </div>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -3,10 +3,14 @@
 
 <script type="text/template" id="query-view-list-template">
   <form>
-    <h2 tabindex="0"><%- title %></h2>
-    <div id="query-description" tabindex="0">
-      <%= description %>
-    </div>
+    {% if title %}
+      <h2 tabindex="0"><%- title %></h2>
+    {% endif %}
+    {% if description %}
+      <div id="query-description" tabindex="0">
+        <%= description %>
+      </div>
+    {% endif %}
     <table class="table table-hover table-striped table-bordered">
       <tbody id="query-properties">
       </tbody>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -11,7 +11,7 @@
         <%= description %>
       </div>
     {% endif %}
-    <table class="table table-hover table-striped table-bordered">
+    <table class="table table-hover table-striped table-bordered" role="presentation">
       <tbody id="query-properties">
       </tbody>
     </table>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -88,6 +88,7 @@
     </fieldset>
 
     <% } else if (input == "address") { %>
+    <div role="region" aria-live="polite" class="sr-only" id="<%- id %>-sr"></div>
     <div class="query-field" value="<%- value %>" id="<%- id %>_mapbox" data-address="<%- id %>">
     </div>
 

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -88,7 +88,7 @@
     </fieldset>
 
     <% } else if (input == "address") { %>
-    <div role="region" aria-live="polite" class="sr-only" id="<%- id %>-sr"></div>
+    <div role="region" aria-live="polite" class="sr-only" id="<%- id %>_mapbox-sr"></div>
     <div class="query-field" value="<%- value %>" id="<%- id %>_mapbox" data-address="<%- id %>">
     </div>
 

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -3,14 +3,14 @@
 
 <script type="text/template" id="query-view-list-template">
   <form>
-    {% if title %}
+    <% if (title.length > 0) {%>
       <h2 tabindex="0"><%- title %></h2>
-    {% endif %}
-    {% if description %}
+    <% } %>
+    <% if (description.length > 0) {%>
       <div id="query-description" tabindex="0">
         <%= description %>
       </div>
-    {% endif %}
+    <% } %>
     <table class="table table-hover table-striped table-bordered" role="presentation">
       <tbody id="query-properties">
       </tbody>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This PR adds screen-reader compatibility to the Mapbox geocoder widget's dropdown list menu on keyboard navigation using arrow keys.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Ticket Link](https://dimagi-dev.atlassian.net/browse/USH-568)

The Mapbox Geocoder widget does not have good screen-reader compatibility and the options in dropdown list of the widget are not read on using arrow key navigation. The library also does not exposes any configuration option to get the currently highlighted option from the dropdown. The mapbox widget uses an unordered list to render the dropdown and the highlighted choice is marked with `active` class. This PR uses a keyboard event listener to get arrow up and down key events and update an `aria-live` region with the currently highlighted list item with `active` class and the screen-reader announces the aria-live region text. 

https://user-images.githubusercontent.com/31195143/220108701-1f46ed70-dcd3-4581-a0ab-8a8c07e3db26.mp4

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally with Voiceover and NVDA screen readers.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-4838

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
