### PR TITLE
Update pip, setuptools, packaging to latest versions

### DIFF
--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -33,6 +33,7 @@ WHITELIST = [
     ("logentry_admin.admin", "ugettext_lazy() is deprecated"),
     ("nose.importer", "the imp module is deprecated"),
     ("nose.util", "inspect.getargspec() is deprecated"),
+    ("pkg_resources", "pkg_resources.declare_namespace"),
     ("tastypie", "django.conf.urls.url() is deprecated"),
     ("tastypie", "request.is_ajax() is deprecated"),
     ("nose.suite", "'collections.abc'"),

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -370,7 +370,7 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
-packaging==20.4
+packaging==23.0
     # via
     #   build
     #   sphinx
@@ -460,9 +460,7 @@ pynacl==1.5.0
 pyopenssl==23.0.0
     # via -r sso-requirements.in
 pyparsing==2.4.7
-    # via
-    #   httplib2
-    #   packaging
+    # via httplib2
 pyphonetics==0.5.3
     # via -r base-requirements.in
 pypng==0.20220715.0
@@ -585,7 +583,6 @@ six==1.16.0
     #   jsonobject-couchdbkit
     #   jsonpath-ng
     #   mando
-    #   packaging
     #   pyjwkest
     #   python-dateutil
     #   pyzxcvbn
@@ -720,9 +717,9 @@ zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.3.1
+pip==23.0.1
     # via pip-tools
-setuptools==65.5.1
+setuptools==67.3.2
     # via
     #   django-websocket-redis
     #   gevent

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -313,7 +313,7 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
-packaging==20.9
+packaging==23.0
     # via sphinx
 phonenumberslite==8.12.48
     # via -r base-requirements.in
@@ -373,9 +373,7 @@ pyjwt==2.4.0
 pynacl==1.5.0
     # via pygithub
 pyparsing==2.4.7
-    # via
-    #   httplib2
-    #   packaging
+    # via httplib2
 pyphonetics==0.5.3
     # via -r base-requirements.in
 pypng==0.20220715.0
@@ -585,7 +583,7 @@ zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.5.1
+setuptools==67.3.2
     # via
     #   django-websocket-redis
     #   gevent

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -596,9 +596,9 @@ zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.0.4
+pip==23.0.1
     # via -r prod-requirements.in
-setuptools==65.5.1
+setuptools==67.3.2
     # via
     #   django-websocket-redis
     #   gevent

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -537,7 +537,7 @@ zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.5.1
+setuptools==67.3.2
     # via
     #   django-websocket-redis
     #   gevent

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -321,7 +321,7 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
-packaging==21.3
+packaging==23.0
     # via build
 pep517==0.10.0
     # via build
@@ -387,9 +387,7 @@ pynacl==1.5.0
 pyopenssl==23.0.0
     # via -r sso-requirements.in
 pyparsing==3.0.7
-    # via
-    #   httplib2
-    #   packaging
+    # via httplib2
 pyphonetics==0.5.3
     # via -r base-requirements.in
 pypng==0.20220715.0
@@ -602,9 +600,9 @@ zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.3.1
+pip==23.0.1
     # via pip-tools
-setuptools==65.5.1
+setuptools==67.3.2
     # via
     #   django-websocket-redis
     #   gevent


### PR DESCRIPTION
## Technical Summary

Applies these updates:
- https://github.com/pypa/packaging/compare/21.3..23.0
- https://github.com/pypa/setuptools/compare/v65.5.1..v67.3.2
- https://github.com/pypa/pip/compare/21.3..23.0

## Safety Assurance

### Safety story
These are changes to relatively stable packaging libraries. `packaging` is used within our codebase opportunistically for its `Version` parse, but that doesn't seem to have changed in the changelogs.

### Automated test coverage

Other than the use of pip in the install process, these libraries aren't specifically tested to my knowledge.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
