### PR TITLE
Update importlib-metadata and its super-dependency Markdown

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -281,7 +281,7 @@ idna==2.10
     # via requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==4.12.0
+importlib-metadata==6.0.0
     # via markdown
 intervaltree==3.1.0
     # via ddtrace
@@ -342,7 +342,7 @@ mako==1.2.2
     #   oic
 mando==0.6.4
     # via radon
-markdown==3.3.6
+markdown==3.4.1
     # via -r base-requirements.in
 markupsafe==1.1.1
     # via

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -240,7 +240,7 @@ idna==2.10
     # via requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==4.12.0
+importlib-metadata==6.0.0
     # via markdown
 intervaltree==3.1.0
     # via ddtrace
@@ -289,7 +289,7 @@ mako==1.2.2
     # via
     #   alembic
     #   oic
-markdown==3.3.6
+markdown==3.4.1
     # via -r base-requirements.in
 markdown-it-py==1.1.0
     # via

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -241,7 +241,7 @@ idna==2.10
     # via
     #   -r prod-requirements.in
     #   requests
-importlib-metadata==4.12.0
+importlib-metadata==6.0.0
     # via markdown
 intervaltree==3.1.0
     # via ddtrace
@@ -295,7 +295,7 @@ mako==1.2.2
     # via
     #   alembic
     #   oic
-markdown==3.3.6
+markdown==3.4.1
     # via -r base-requirements.in
 markupsafe==1.1.1
     # via

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -225,7 +225,7 @@ httplib2==0.20.4
     #   google-auth-httplib2
 idna==2.10
     # via requests
-importlib-metadata==4.12.0
+importlib-metadata==6.0.0
     # via markdown
 intervaltree==3.1.0
     # via ddtrace
@@ -275,7 +275,7 @@ mako==1.2.2
     # via
     #   alembic
     #   oic
-markdown==3.3.6
+markdown==3.4.1
     # via -r base-requirements.in
 markupsafe==1.1.1
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -246,7 +246,7 @@ httplib2==0.20.4
     #   google-auth-httplib2
 idna==2.10
     # via requests
-importlib-metadata==4.12.0
+importlib-metadata==6.0.0
     # via markdown
 intervaltree==3.1.0
     # via ddtrace
@@ -298,7 +298,7 @@ mako==1.2.2
     #   oic
 mando==0.6.4
     # via radon
-markdown==3.3.6
+markdown==3.4.1
     # via -r base-requirements.in
 markupsafe==1.1.1
     # via


### PR DESCRIPTION
## Technical Summary
https://github.com/python/importlib_metadata/compare/v4.12.0...v6.0.0#diff-ff3c479edefad986d2fe6fe7ead575a46b086e3bbcf0ccc86d85efc4a4c63c79R1-R36

https://github.com/Python-Markdown/markdown/compare/3.3.6...3.4.1#diff-84af137a545202e075365344f298393c7205a24c2e1c09abe190046a7c43e2b7R6-R17

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Markdown update is a minor version update, and none of the items in the changelog seem like they would change any behavior we'd rely on.

importlib-metadata is a backfill which is only used by Markdown, and Markdown claims implicitly to be compatible with it (no explicit exclusion of this version in the range it supports); it's theoretically possible it could break something in Markdown, but I think the chances are low.

### Automated test coverage

There are at least some tests of the `markdown.markdown` utility, so if it no longer worked at all, tests would catch that.

### QA Plan

No plan to QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
