### PR TITLE
Multiplexing adapter bulk and tombstone processing

### DIFF
--- a/corehq/apps/es/README.rst
+++ b/corehq/apps/es/README.rst
@@ -36,6 +36,8 @@ of that value should be removed from the CommCare HQ codebase entirely in order
 to decouple it from application logic.
 
 
+.. _creating-elasticsearch-index-migrations:
+
 Creating Elasticsearch Index Migrations
 '''''''''''''''''''''''''''''''''''''''
 
@@ -280,10 +282,9 @@ Reindex Procedure Details
 1. Configure multiplexing on an index by passing in ``secondary`` index name to
    ``create_document_adapter``.
 
-   - Ensure that there is a migration in place for creating the index.
-
-     **Note** Tooling around this is a WIP
-
+   - Ensure that there is a migration in place for creating the index (see
+     `Creating Elasticsearch Index Migrations <creating-elasticsearch-index-migrations_>`__
+     above).
    - *(Optional)* If the reindex involves other meta-index changes (shards,
      mappings, etc), also update those configurations at this time.
 
@@ -508,7 +509,7 @@ Using this adapter in practice might look as follows:
     )
     books_adapter.index(new_book)
     # fetch existing
-    classic_book = books_adapter.fetch("978-0345391803")
+    classic_book = books_adapter.get("978-0345391803")
 
 
 Tombstone
@@ -549,10 +550,6 @@ A sample tombstone document would look like
     {
       "__is_tombstone__" : True
     }
-
-Current mapping does not index ``__is_tombstone__`` property but it would be added
-to mappings before we start reindexing. This would help us in ensuring that we
-can ignore them in the ES queries.
 
 
 Code Documentation

--- a/corehq/apps/es/app_config.py
+++ b/corehq/apps/es/app_config.py
@@ -5,32 +5,6 @@ class ElasticAppConfig(AppConfig):
 
     name = 'corehq.apps.es'
 
-    def __init__(self, *args, **kw):
-        super().__init__(*args, **kw)
-        self.document_adapters = {}
-
     def ready(self):
         from .transient_util import populate_doc_adapter_map
         populate_doc_adapter_map()
-        self.verify_indexes()
-
-    def verify_indexes(self):
-        for adapter in _adapters_at_startup:
-            value = self.document_adapters.setdefault(adapter.index_name, adapter)
-            if value is not adapter:
-                raise RegistryError(
-                    f"multiple document adapters registered for the same "
-                    f"index: {value}, {adapter}"
-                )
-        # TODO: perform index verification
-
-
-def register_document_adapter(adapter):
-    _adapters_at_startup.append(adapter)
-
-
-class RegistryError(Exception):
-    pass
-
-
-_adapters_at_startup = []

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -1194,6 +1194,12 @@ class ElasticMultiplexAdapter(BaseAdapter):
         for seq, action in sorted(flatten(by_id)):
             yield action
 
+    def bulk_index(self, docs, **bulk_kw):
+        return ElasticDocumentAdapter.bulk_index(self, docs, **bulk_kw)
+
+    def bulk_delete(self, doc_ids, **bulk_kw):
+        return ElasticDocumentAdapter.bulk_delete(self, doc_ids, **bulk_kw)
+
     def delete(self, doc_id, refresh=False):
         """Delete on primary, index tombstone on secondary."""
         self.primary.delete(doc_id, refresh)

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -1099,7 +1099,7 @@ class ElasticMultiplexAdapter(BaseAdapter):
                         secondary_del_fails[doc_id] = error
                     else:
                         deduped_errs.setdefault(doc_id, error)
-            tombstone_ids = set(secondary_del_fails) - primary_del_fail_ids
+            tombstone_ids = secondary_del_fails.keys() - primary_del_fail_ids
             if tombstone_ids:
                 # add tombstones on secondary
                 try:
@@ -1148,7 +1148,7 @@ class ElasticMultiplexAdapter(BaseAdapter):
         - Any ``index`` action supersedes all prior actions for the same
           document ``_id``.
         - Any ``delete`` action supersedes previous ``delete`` actions for the
-          same document ``_id``, but does not superseded ``index`` actions.
+          same document ``_id``, but does not supersede ``index`` actions.
 
         For any unique document ``_id`` present in the original actions, there
         are only three possible action permutations yielded by this method:
@@ -1179,7 +1179,7 @@ class ElasticMultiplexAdapter(BaseAdapter):
 
         def flatten(by_id):
             """Iterate pruned actions, yielding ``(seq, action)`` tuples to
-            support sorting the actions in in their original order.
+            support sorting the actions in their original order.
             This could also be converted into a nested generator expression
             (instead of a this inline function definition), but the function
             implementation is easier to read.

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -23,7 +23,6 @@ from corehq.util.es.elasticsearch import (
 )
 from corehq.util.metrics import metrics_counter
 
-from .app_config import register_document_adapter
 from .const import (
     INDEX_CONF_REINDEX,
     INDEX_CONF_STANDARD,
@@ -1311,8 +1310,8 @@ def _elastic_hosts():
 
 
 def create_document_adapter(cls, index_name, type_, *, secondary=None):
-    """Creates, registers and returns a document adapter instance for the
-    parameters provided.
+    """Creates and returns a document adapter instance for the parameters
+    provided.
 
     :param cls: an ``ElasticDocumentAdapter`` subclass
     :param index_name: the name of the index that the adapter interacts with
@@ -1332,7 +1331,6 @@ def create_document_adapter(cls, index_name, type_, *, secondary=None):
         secondary_adapter = cls(runtime_name(secondary), type_)
         doc_adapter = ElasticMultiplexAdapter(doc_adapter, secondary_adapter)
 
-    register_document_adapter(doc_adapter)
     return doc_adapter
 
 

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -659,7 +659,7 @@ class ElasticDocumentAdapter(BaseAdapter):
             if scroll_id:
                 self._es.clear_scroll(body={"scroll_id": [scroll_id]}, ignore=(404,))
 
-    def index(self, doc, refresh=False, **kw):
+    def index(self, doc, refresh=False):
         """Index (send) a new document in (to) Elasticsearch
 
         Equivalent to the legacy
@@ -668,19 +668,16 @@ class ElasticDocumentAdapter(BaseAdapter):
         :param doc: the (Python model) document to index
         :param refresh: ``bool`` refresh the effected shards to make this
                         operation visible to search
-        :param **kw: extra parameters passed directly to the underlying
-                     ``elasticsearch.Elasticsearch.index()`` method.
         """
-        # TODO: remove **kw and standardize which arguments HQ uses
         doc_id, source = self.from_python(doc)
         self._verify_doc_id(doc_id)
         self._verify_doc_source(source)
-        self._index(doc_id, source, refresh, **kw)
+        self._index(doc_id, source, refresh)
 
-    def _index(self, doc_id, source, refresh, **kw):
+    def _index(self, doc_id, source, refresh):
         """Perform the low-level (3rd party library) index operation."""
         self._es.index(self.index_name, self.type, source, doc_id,
-                       refresh=self._refresh_value(refresh), **kw)
+                       refresh=self._refresh_value(refresh))
 
     def update(self, doc_id, fields, return_doc=False, refresh=False,
                _upsert=False, retry_on_conflict=None):
@@ -1211,7 +1208,7 @@ class ElasticMultiplexAdapter(BaseAdapter):
             resp = list(exc.errors[0].values())[0]
             raise NotFoundError(resp.pop("status"), str(resp), resp) from exc
 
-    def index(self, doc, refresh=False, **kw):
+    def index(self, doc, refresh=False):
         """Index into both primary and secondary via the ``bulk()`` method in
         order to perform both actions in a single HTTP request.
         """

--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from corehq.apps.es.utils import check_task_progress
 
 from corehq.util.es.elasticsearch import (
+    BulkIndexError,
     Elasticsearch,
     ElasticsearchException,
     NotFoundError,
@@ -1633,15 +1634,27 @@ class TestBulkActionItem(SimpleTestCase):
         )
 
 
+@es_test
 class TestElasticMultiplexAdapter(SimpleTestCase, ESTestHelpers):
 
     ARG = object()
     VALUE = object()
 
     adapter = ElasticMultiplexAdapter(
-        TestDocumentAdapter("primary", "doc"),
-        TestDocumentAdapter("secondary", "doc"),
+        TestDocumentAdapter("test_primary", "doc"),
+        TestDocumentAdapter("test_secondary", "doc"),
     )
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        for adapter in [cls.adapter.primary, cls.adapter.secondary]:
+            try:
+                manager.index_delete(adapter.index_name)
+            except NotFoundError:
+                pass
+            manager.index_create(adapter.index_name, {"settings": {"number_of_shards": 1}})
+            cls.addClassCleanup(manager.index_delete, adapter.index_name)
 
     def test_to_json(self):
         doc = self._make_doc()
@@ -1707,6 +1720,158 @@ class TestElasticMultiplexAdapter(SimpleTestCase, ESTestHelpers):
         s_mock.assert_not_called()
 
     # Elastic index write methods (multiplexed between both adapters)
+    def test_bulk(self):
+        doc_1 = self._make_doc()
+        doc_2 = self._make_doc()
+        # setup and verify state
+        self.adapter.index(doc_1)
+        self.assertPrimaryAndSecondaryDocIdsEqual([doc_1.id])
+        # test
+        successes, errors = self.adapter.bulk([
+            BulkActionItem.delete(doc_1),
+            BulkActionItem.index(doc_2),
+        ])
+        self.addCleanup(self.adapter.delete, doc_2.id)
+        self.assertEqual(2, successes)
+        self.assertEqual([], errors)
+        self.assertPrimaryAndSecondaryDocIdsEqual([doc_2.id])
+
+    def test_bulk_returns_when_raise_errors_is_false(self):
+        doc_ids = [self._make_doc().id for x in range(2)]
+        # verify state
+        self.assertPrimaryAndSecondaryDocIdsEqual([])
+        # test
+        actions = [BulkActionItem.delete_id(id) for id in doc_ids]
+        success, errors = self.adapter.bulk(actions, raise_errors=False)
+        self.assertEqual(0, success)
+        self.assertEqual(len(actions), len(errors))
+
+    def test_bulk_raises_when_raise_errors_is_not_false(self):
+        doc_ids = [self._make_doc().id for x in range(2)]
+        # verify state
+        self.assertPrimaryAndSecondaryDocIdsEqual([])
+        # test
+        actions = [BulkActionItem.delete_id(id) for id in doc_ids]
+        with self.assertRaises(BulkIndexError) as test:
+            self.adapter.bulk(actions)
+        self.assertEqual(len(actions), len(test.exception.errors))
+
+    def test_bulk_action_delete_does_not_create_tombstones_if_missing_on_primary(self):
+        missing = self._make_doc()
+        # verify state
+        self.assertPrimaryAndSecondaryDocIdsEqual([])
+        # test
+        with self.assertRaises(BulkIndexError) as test:
+            self.adapter.bulk([BulkActionItem.delete(missing)])
+        error, = test.exception.errors
+        self.assertTrue(self.adapter._is_delete_not_found(error))
+        self.assertPrimaryAndSecondaryDocIdsEqual([])
+
+    def test_bulk_action_delete_does_not_create_tombstones_if_exists_on_secondary(self):
+        doc = self._make_doc()
+        # setup and verify state
+        self.adapter.index(doc)
+        self.assertPrimaryAndSecondaryDocIdsEqual([doc.id])
+        # test
+        successes, errors = self.adapter.bulk([BulkActionItem.delete(doc)])
+        self.assertEqual(1, successes)
+        self.assertEqual([], errors)
+        self.assertPrimaryAndSecondaryDocIdsEqual([])
+
+    def test_bulk_action_delete_creates_tombstones_if_missing_on_secondary(self):
+        doc = self._make_doc()
+        # setup and verify a not-synced secondary condition
+        self.adapter.primary.index(doc, refresh=True)
+        self.assertTrue(self.adapter.primary.exists(doc.id))
+        self.assertFalse(self.adapter.secondary.exists(doc.id))
+        # test
+        successes, errors = self.adapter.bulk([BulkActionItem.delete(doc)])
+        self.addCleanup(self.adapter.secondary.delete, doc.id)
+        self.assertEqual(1, successes)
+        self.assertEqual([], errors)
+        self.assertFalse(self.adapter.primary.exists(doc.id))
+        self.assertEqual(
+            dict(_id=doc.id, **Tombstone.create_document()),
+            self.adapter.secondary.get(doc.id),
+        )
+
+    def test__parse_bulk_error_for_delete(self):
+        self.assertEqual(
+            self.adapter._parse_bulk_error(
+                {"delete": {"_id": "abc", "_index": "test_index"}}
+            ),
+            ("abc", "test_index"),
+        )
+
+    def test__parse_bulk_error_for_index(self):
+        self.assertEqual(
+            self.adapter._parse_bulk_error(
+                {"index": {"_id": "abc", "_index": "test_index"}}
+            ),
+            ("abc", "test_index"),
+        )
+
+    def test__is_delete_not_found(self):
+        self.assertTrue(self.adapter._is_delete_not_found(
+            {"delete": {"status": 404}}
+        ))
+
+    def test__is_delete_not_found_returns_false_for_non_404_delete_error(self):
+        self.assertFalse(self.adapter._is_delete_not_found(
+            {"delete": {"status": 401}}
+        ))
+
+    def test__is_delete_not_found_returns_false_for_index_error(self):
+        self.assertFalse(self.adapter._is_delete_not_found(
+            {"index": {"status": 404}}
+        ))
+
+    def test__iter_pruned_actions_prunes_all_but_last_delete_for_id(self):
+        dupe_doc = TestDoc("1")
+        actions = [
+            BulkActionItem.delete(dupe_doc),
+            BulkActionItem.delete(dupe_doc),
+            BulkActionItem.index(TestDoc("2")),
+            BulkActionItem.delete(dupe_doc),
+            BulkActionItem.delete(TestDoc("3")),
+        ]
+        # final delete action for 'dup_doc' supersedes prior deletes for doc
+        self.assertEqual(
+            actions[2:],
+            list(self.adapter._iter_pruned_actions(actions)),
+        )
+
+    def test__iter_pruned_actions_prunes_all_but_last_index_for_id(self):
+        dupe_doc = TestDoc("1")
+        actions = [
+            BulkActionItem.delete(TestDoc("2")),
+            BulkActionItem.index(dupe_doc),
+            BulkActionItem.delete(dupe_doc),
+            BulkActionItem.index(dupe_doc),
+        ]
+        # final index action for 'dup_doc' supersedes all prior actions for doc
+        self.assertEqual(
+            [actions[0], actions[-1]],
+            list(self.adapter._iter_pruned_actions(actions)),
+        )
+
+    def test__iter_pruned_actions_prunes_all_but_last_index_and_later_delete_for_id(self):
+        dupe_doc = TestDoc("1")
+        actions = [
+            BulkActionItem.delete(dupe_doc),
+            BulkActionItem.index(dupe_doc),
+            BulkActionItem.delete(TestDoc("2")),
+            BulkActionItem.index(dupe_doc),
+            BulkActionItem.delete(TestDoc("3")),
+            BulkActionItem.delete(dupe_doc),
+        ]
+        # last index action followed by a final delete action for 'dup_doc'
+        # supersede all prior actions for doc
+        self.assertEqual(
+            actions[2:],
+            list(self.adapter._iter_pruned_actions(actions)),
+        )
+
     def test_bulk_index(self):
         docs = [self._make_doc() for x in range(3)]
         bulk_actions = [BulkActionItem.index(doc) for doc in docs]
@@ -1766,6 +1931,19 @@ class TestElasticMultiplexAdapter(SimpleTestCase, ESTestHelpers):
         p_mock.assert_called_once_with(doc_id, to_update, return_doc=True, refresh=False, _upsert=False)
 
         s_mock.assert_called_once_with(doc_id, p_mock.return_value, _upsert=True)
+
+    def assertPrimaryAndSecondaryDocIdsEqual(self, expected):
+        unordered = set(expected)  # use a set to check for unordered equality
+        if len(expected) != len(unordered):
+            # this would be a usage error, not a test failure
+            raise ValueError(f"Invalid expectation (multiple documents with "
+                             f"the same ID): {expected}")
+        for adapter in [self.adapter.primary, self.adapter.secondary]:
+            manager.index_refresh(adapter.index_name)
+            got = set(d["_id"] for d in adapter.search({})["hits"]["hits"])
+            mismatch_msg = (f"{adapter.index_name} adapter document mismatch: "
+                            f"expected={unordered!r}, got={got!r}")
+            self.assertEqual(unordered, got, mismatch_msg)
 
 
 @contextmanager

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -176,8 +176,7 @@ class BulkElasticProcessor(ElasticProcessor, BulkPillowProcessor):
                     self.index_info.alias,
                     self.index_info.type,
                     es_actions,
-                    raise_on_error=False,
-                    raise_on_exception=False,
+                    raise_errors=False,
                 )
         except Exception as e:
             pillow_logging.exception("Elastic bulk error: %s", e)

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -484,7 +484,7 @@ class SubmissionPost(object):
             for case_model in case_models
         ]
         try:
-            _, errors = case_search_adapter.bulk(actions, raise_on_error=False, raise_on_exception=False)
+            _, errors = case_search_adapter.bulk(actions, raise_errors=False)
         except Exception as e:
             errors = [str(e)]
 

--- a/corehq/util/es/interface.py
+++ b/corehq/util/es/interface.py
@@ -35,7 +35,7 @@ class ElasticsearchInterface:
         doc_adapter = self._get_doc_adapter(index_alias, doc_type)
         return doc_adapter.get_docs(doc_ids)
 
-    def index_doc(self, index_alias, doc_type, doc_id, doc, params=None):
+    def index_doc(self, index_alias, doc_type, doc_id, doc):
         doc_adapter = self._get_doc_adapter(index_alias, doc_type)
         if doc.get("_id", object()) != doc_id:
             # TODO: raise an exception
@@ -43,8 +43,7 @@ class ElasticsearchInterface:
             # scenario if it happens.  Raising an exception here could cause a
             # regression in production code so this is left "as built" for now.
             doc["_id"] = doc_id
-        kw = {} if params is None else params
-        doc_adapter.index(doc, **kw)
+        doc_adapter.index(doc)
 
     def update_doc_fields(self, index_alias, doc_type, doc_id, fields, params=None):
         doc_adapter = self._get_doc_adapter(index_alias, doc_type)


### PR DESCRIPTION
## Technical Summary

Last bit of multiplexing logic required for properly processing tombstones in all scenarios. Tombstones are no longer created on _every_ delete, but rather only if the secondary index does not have the document yet. Once both indexes are synchronized (reindex complete), tombstones will no longer be created.

Review: commit by commit :tropical_fish: 

Jira: [SAAS-13574](https://dimagi-dev.atlassian.net/browse/SAAS-13574)

## Safety Assurance

### Safety story

Changes multiplexing logic only, which is not yet enabled (remains a task for a future PR).

### Automated test coverage

Full test coverage.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-13574]: https://dimagi-dev.atlassian.net/browse/SAAS-13574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ