### PR TITLE
Ensure pop methods handle exceptions if applicable

### DIFF
--- a/corehq/apps/linked_domain/tests/test_view_helpers.py
+++ b/corehq/apps/linked_domain/tests/test_view_helpers.py
@@ -42,6 +42,11 @@ from corehq.apps.linked_domain.view_helpers import (
     get_upstream_and_downstream_keywords,
     get_upstream_and_downstream_reports,
     get_upstream_and_downstream_ucr_expressions,
+    pop_app,
+    pop_fixture,
+    pop_keyword,
+    pop_report,
+    pop_ucr_expression,
 )
 from corehq.apps.sms.models import Keyword, KeywordAction
 from corehq.apps.userreports.const import UCR_NAMED_EXPRESSION
@@ -885,3 +890,21 @@ class TestBuildPullableViewModels(BaseLinkedDomainTest):
             link=self.domain_link, date=datetime.utcnow(), model=model_type, model_detail=model_detail
         )
         sync_event.save()
+
+
+class PopDataModelsTests(TestCase):
+
+    def test_pop_app_returns_none_if_does_not_exist(self):
+        self.assertIsNone(pop_app('unknown', {}))
+
+    def test_pop_fixture_returns_none_if_does_not_exist(self):
+        self.assertIsNone(pop_fixture('unknown', {}, 'pop-test'))
+
+    def test_pop_report_returns_none_if_does_not_exist(self):
+        self.assertIsNone(pop_report('unknown', {}))
+
+    def test_pop_keyword_returns_none_if_does_not_exist(self):
+        self.assertIsNone(pop_keyword(0, {}))
+
+    def test_pop_ucr_expression_returns_none_if_does_not_exist(self):
+        self.assertIsNone(pop_ucr_expression(0, {}))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14413

QA ran into [this issue](https://dimagi-dev.atlassian.net/browse/QA-4819?focusedCommentId=251830&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-251830) on the linked projects page when testing an unrelated change. After investigating the relevant [sentry error](https://dimagi.sentry.io/issues/3867862042/?environment=staging&project=136860&query=is%3Aunresolved+domain%3Aqa-automation&referrer=issue-stream&statsPeriod=1h), it seemed the issue was introduced as part of migrating lookup tables from couch to sql. The method we used to find lookup tables previously returned None in the case the lookup table was not found, whereas now an exception `Fixture.DoesNotExist` was raised. This exception needed to be caught and dealt with.

This did bring up one or two related questions:

1) given that we obtain a list of valid objects to pull from the upstream domain prior to getting to this point of the linked projects logic, why do we care about trying to find an object if it isn't in that list?

2) similarly, if we have a list of objects we can pull, why do we iterate through DomainLinkHistiory objects?

The broad answer to both of these is that the original workflow required explicitly linking objects in an upstream domain to a downstream domain prior to being able to pull changes downstream, which is a workflow that has been phased out for all data models **except for apps**. This meant that to obtain the list of data models that the downstream domain could pull, we would have to iterate through `DomainLinkHistory` objects to ensure that object has been linked/pulled previously. This also meant that in the event the object that has been pulled previously was not found in the list, we would want to attempt to find this object in the database.

I see this PR as a quick fix for the current bug, but a few tasks that can be made into tickets:
- refactor this code to reflect that apps are the only data model dependent on iterating through `DomainLinkHistory`
- [bigger task] support automatically linking apps (remove the need to explicitly link apps prior to pushing/pulling)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I added some automated testing for these pop methods, though did not feel it was worth fleshing out this test suite entirely (I only covered the case that this 500 error highlights).

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
