### PR TITLE
Nit: Added some newlines

### DIFF
--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -33,9 +33,20 @@ ALLOWED_CASE_IDENTIFIER_TYPES = [
 ]
 
 
-def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
-                       xmlns=None, attachments=None, form_id=None,
-                       submission_extras=None, case_db=None, device_id=None, form_name=None, max_wait=...):
+def submit_case_blocks(
+    case_blocks,
+    domain,
+    username="system",
+    user_id=None,
+    xmlns=None,
+    attachments=None,
+    form_id=None,
+    submission_extras=None,
+    case_db=None,
+    device_id=None,
+    form_name=None,
+    max_wait=...,
+):
     """
     Submits casexml in a manner similar to how they would be submitted from a phone.
 
@@ -104,8 +115,14 @@ def get_case_by_identifier(domain, identifier):
     return None
 
 
-def submit_case_block_from_template(domain, template, context, xmlns=None,
-        user_id=None, device_id=None):
+def submit_case_block_from_template(
+    domain,
+    template,
+    context,
+    xmlns=None,
+    user_id=None,
+    device_id=None,
+):
     case_block = render_to_string(template, context)
     # Ensure the XML is formatted properly
     # An exception is raised if not
@@ -120,7 +137,13 @@ def submit_case_block_from_template(domain, template, context, xmlns=None,
     )
 
 
-def _get_update_or_close_case_block(case_id, case_properties=None, close=False, owner_id=None, domain=None):
+def _get_update_or_close_case_block(
+    case_id,
+    case_properties=None,
+    close=False,
+    owner_id=None,
+    domain=None,
+):
     kwargs = {
         'create': False,
         'user_id': SYSTEM_USER_ID,
@@ -136,8 +159,17 @@ def _get_update_or_close_case_block(case_id, case_properties=None, close=False, 
     return CaseBlock.deprecated_init(case_id, **kwargs)
 
 
-def update_case(domain, case_id, case_properties=None, close=False,
-                xmlns=None, device_id=None, form_name=None, owner_id=None, max_wait=...):
+def update_case(
+    domain,
+    case_id,
+    case_properties=None,
+    close=False,
+    xmlns=None,
+    device_id=None,
+    form_name=None,
+    owner_id=None,
+    max_wait=...,
+):
     """
     Updates or closes a case (or both) by submitting a form.
     domain - the case's domain

--- a/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
@@ -23,10 +23,24 @@ class CaseBlock(object):
     undefined = object()
     _built_ins = {'case_type', 'case_name', 'owner_id'}
 
-    def __init__(self, case_id, date_modified=None, user_id=undefined,
-                 owner_id=undefined, external_id=undefined, case_type=undefined,
-                 case_name=undefined, create=False, date_opened=undefined, update=None,
-                 close=False, index=None, strict=True, date_opened_deprecated_behavior=False, domain=None):
+    def __init__(
+        self,
+        case_id,
+        date_modified=None,
+        user_id=undefined,
+        owner_id=undefined,
+        external_id=undefined,
+        case_type=undefined,
+        case_name=undefined,
+        create=False,
+        date_opened=undefined,
+        update=None,
+        close=False,
+        index=None,
+        strict=True,
+        date_opened_deprecated_behavior=False,
+        domain=None,
+    ):
         """
         When `date_opened_deprecated_behavior`, a date_opened YYYY-MM-DD value is inserted on new cases.
         This is deprecated behavior, because it prevents the superior default behavior from kicking in.


### PR DESCRIPTION
## Technical Summary

Only adds a few newlines, to make the code a little more readable. No change to functionality.

## Feature Flag

N/A

## Safety Assurance

### Safety story

No code change, just whitespace.

### Automated test coverage

`CaseBlock` and `submit_case_blocks()` are tested extensively, fwiw.

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
