### PR TITLE
[B5 / Phase 1 / Step 3] Add bootstrap5 _thread_local utils and decorator

### DIFF
--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -3,6 +3,8 @@ from functools import wraps
 
 from django.urls import get_resolver
 
+from corehq.apps.hqwebapp.utils.bootstrap import set_bootstrap_version5
+
 
 def use_daterangepicker(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
@@ -211,6 +213,27 @@ def use_ko_validation(view_func):
         request.use_ko_validation = True
         return view_func(class_based_view, request, *args, **kwargs)
     return _wrapped
+
+
+def use_bootstrap5(view_func):
+    """Use this decorator on the dispatch method of a TemplateView subclass
+    to enable Boostrap 5 features for the included template.
+
+    Example:
+        @use_bootstrap5
+        def dispatch(self, request, *args, **kwargs):
+            return super().dispatch(request, *args, **kwargs)
+
+    Or alternatively:
+        @method_decorator(use_bootstrap5, name='dispatch')
+        class MyViewClass(MyViewSubclass):
+            ...
+    """
+    @wraps(view_func)
+    def _inner(request, *args, **kwargs):
+        set_bootstrap_version5()
+        return view_func(request, *args, **kwargs)
+    return _inner
 
 
 def waf_allow(kind, hard_code_pattern=None):

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap.py
@@ -1,0 +1,24 @@
+from testil import eq
+
+from corehq.apps.hqwebapp.utils.bootstrap import (
+    get_bootstrap_version,
+    set_bootstrap_version5,
+    set_bootstrap_version3,
+    BOOTSTRAP_3,
+    BOOTSTRAP_5,
+)
+
+
+def test_default_bootstrap_version():
+    eq(get_bootstrap_version(), BOOTSTRAP_3)
+
+
+def test_set_bootstrap_version5():
+    set_bootstrap_version5()
+    eq(get_bootstrap_version(), BOOTSTRAP_5)
+
+
+def test_set_bootstrap_version3():
+    set_bootstrap_version5()
+    set_bootstrap_version3()
+    eq(get_bootstrap_version(), BOOTSTRAP_3)

--- a/corehq/apps/hqwebapp/utils/bootstrap.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap.py
@@ -1,0 +1,22 @@
+import threading
+
+_thread_local = threading.local()
+
+BOOTSTRAP_3 = 'bootstrap_3'
+BOOTSTRAP_5 = 'bootstrap_5'
+
+
+def get_bootstrap_version():
+    try:
+        bootstrap_version = _thread_local.BOOTSTRAP_VERSION
+    except AttributeError:
+        bootstrap_version = BOOTSTRAP_3
+    return bootstrap_version
+
+
+def set_bootstrap_version3():
+    _thread_local.BOOTSTRAP_VERSION = BOOTSTRAP_3
+
+
+def set_bootstrap_version5():
+    _thread_local.BOOTSTRAP_VERSION = BOOTSTRAP_5

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -11,6 +11,7 @@ from corehq.apps.accounting.models import BillingAccount, SubscriptionType
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.utils.hubspot import is_hubspot_js_allowed_for_request
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
+from corehq.apps.hqwebapp.utils import bootstrap
 
 COMMCARE = 'commcare'
 COMMTRACK = 'commtrack'
@@ -283,4 +284,10 @@ def sentry(request):
             "environment": settings.SERVER_ENVIRONMENT,
             "release": settings.COMMCARE_RELEASE
         }
+    }
+
+
+def bootstrap5(request):
+    return {
+        "use_bootstrap5": bootstrap.get_bootstrap_version() == bootstrap.BOOTSTRAP_5,
     }

--- a/settings.py
+++ b/settings.py
@@ -1231,6 +1231,7 @@ TEMPLATES = [
                 'corehq.util.context_processors.emails',
                 'corehq.util.context_processors.status_page',
                 'corehq.util.context_processors.sentry',
+                'corehq.util.context_processors.bootstrap5',
             ],
             'debug': DEBUG,
             'loaders': [


### PR DESCRIPTION
## Technical Summary
This adds utils to set the bootstrap version in `_thread_local`, tests for those utils, a context processor to set `use_bootstrap5` in the `request`, and a new decorator to turn on the bootstrap5 state in a view.

## Safety Assurance

### Safety story
safe changes. no active workflows were affected by this change

### Automated test coverage
Yes

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
