### PR TITLE
Use ellipsis instead of undefined

### DIFF
--- a/corehq/apps/callcenter/sync_usercase.py
+++ b/corehq/apps/callcenter/sync_usercase.py
@@ -62,14 +62,19 @@ class _UserCaseHelper(object):
         self._user_case_changed(fields)
 
     def update_user_case(self, case, fields, close):
+        kwargs = {}
+        if 'owner_id' in fields:
+            kwargs['owner_id'] = fields.pop('owner_id')
+        if 'case_type' in fields:
+            kwargs['case_type'] = fields.pop('case_type')
+        if 'name' in fields:
+            kwargs['case_name'] = fields.pop('name')
         self.case_blocks.append(CaseBlock(
             create=False,
             case_id=case.case_id,
-            owner_id=fields.pop('owner_id', CaseBlock.undefined),
-            case_type=fields.pop('case_type', CaseBlock.undefined),
-            case_name=fields.pop('name', CaseBlock.undefined),
             close=close,
-            update=fields
+            update=fields,
+            **kwargs,
         ))
         self._user_case_changed(fields)
 

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -528,12 +528,15 @@ class _CaseImportRow(object):
         return self.external_id
 
     def _get_caseblock_kwargs(self):
-        return {
+        kwargs = {
             'update': self.fields_to_update,
             'index': self._get_parent_index(),
-            'date_opened': self._get_date_opened() or CaseBlock.undefined,
-            'external_id': self._get_external_id() or CaseBlock.undefined,
         }
+        if date_opened := self._get_date_opened():
+            kwargs['date_opened'] = date_opened
+        if external_id := self._get_external_id():
+            kwargs['external_id'] = external_id
+        return kwargs
 
     def get_create_caseblock(self):
         return CaseBlock(

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -88,16 +88,16 @@ class BaseJsonCaseChange(jsonobject.JsonObject):
 
     def get_caseblock(self, case_db):
 
-        def _if_specified(value):
-            return value if value is not None else CaseBlock.undefined
+        def get_kwargs(*attribs):
+            return {
+                a: getattr(self, a)
+                for a in attribs
+                if getattr(self, a) is not None
+            }
 
         return CaseBlock(
             case_id=self.get_case_id(case_db),
             user_id=self.user_id,
-            case_type=_if_specified(self.case_type),
-            case_name=_if_specified(self.case_name),
-            external_id=_if_specified(self.external_id),
-            owner_id=_if_specified(self.owner_id),
             create=self._is_case_creation,
             update=dict(self.properties),
             close=self.close,
@@ -108,6 +108,7 @@ class BaseJsonCaseChange(jsonobject.JsonObject):
                     relationship=index.relationship
                 ) for name, index in self.indices.items()
             },
+            **get_kwargs('case_type', 'case_name', 'external_id', 'owner_id'),
         ).as_text()
 
 

--- a/corehq/apps/hqcase/tests/test_case_api_updates.py
+++ b/corehq/apps/hqcase/tests/test_case_api_updates.py
@@ -1,0 +1,50 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.hqcase.api.updates import JsonCaseCreation
+
+
+class GetCaseBlockTests(SimpleTestCase):
+
+    def setUp(self):
+        self.data = {
+            'case_name': 'Mark Renton',
+            'case_type': 'trainspotter',
+            'properties': {
+                'age': '26',
+            },
+            'owner_id': 'abc123',
+            'user_id': 'abc123',
+        }
+
+    def test_kwargs(self):
+        json_case = JsonCaseCreation(self.data)
+        case_block = json_case.get_caseblock(case_db=None)
+        self.assertIn('<case_name>Mark Renton</case_name>', case_block)
+        self.assertNotIn('<external_id', case_block)
+
+    def test_kwargs_incl_external_id(self):
+        case_data = self.data | {'external_id': 'Ewan McGregor'}
+        json_case = JsonCaseCreation(case_data)
+        case_block = json_case.get_caseblock(case_db=None)
+        # `case_block` is something like:
+        #
+        #     <case case_id=""
+        #           date_modified="YYYY-MM-DDTHH:MM:SS.SSSSSSZ"
+        #           user_id="abc123"
+        #           xmlns="http://commcarehq.org/case/transaction/v2">
+        #       <create>
+        #         <case_type>trainspotter</case_type>
+        #         <case_name>Mark Renton</case_name>
+        #         <owner_id>abc123</owner_id>
+        #       </create>
+        #       <update>
+        #         <external_id>Ewan McGregor</external_id>
+        #         <age>26</age>
+        #       </update>
+        #     </case>
+        #
+        self.assertIn('<case_type>trainspotter</case_type>', case_block)
+        self.assertIn('<case_name>Mark Renton</case_name>', case_block)
+        self.assertIn('<owner_id>abc123</owner_id>', case_block)
+        self.assertIn('<external_id>Ewan McGregor</external_id>', case_block)
+        self.assertIn('<age>26</age>', case_block)

--- a/corehq/apps/hqcase/tests/test_case_sharing.py
+++ b/corehq/apps/hqcase/tests/test_case_sharing.py
@@ -123,9 +123,10 @@ class CaseSharingTest(TestCase):
 
     def get_update_block(self, case_id, owner_id=None, update=None):
         update = update or {}
+        kwargs = {'owner_id': owner_id} if owner_id else {}
         case_block = CaseBlock.deprecated_init(
             case_id=case_id,
             update=update,
-            owner_id=owner_id or CaseBlock.undefined,
+            **kwargs,
         ).as_text()
         return case_block

--- a/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
@@ -127,7 +127,7 @@ class CaseBlock(object):
             result['close'] = {}
 
         if all(val is ... for val in result['update'].values()):
-                result['update'] = ...
+            result['update'] = ...
 
         if self.index:
             result['index'] = {}

--- a/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
@@ -19,20 +19,19 @@ class CaseBlock(object):
     """
     see https://github.com/dimagi/commcare/wiki/casexml20 for spec
     """
-    undefined = object()
     _built_ins = {'case_type', 'case_name', 'owner_id'}
 
     def __init__(
         self,
         case_id,
         date_modified=None,
-        user_id=undefined,
-        owner_id=undefined,
-        external_id=undefined,
-        case_type=undefined,
-        case_name=undefined,
+        user_id=...,
+        owner_id=...,
+        external_id=...,
+        case_type=...,
+        case_name=...,
         create=False,
-        date_opened=undefined,
+        date_opened=...,
         update=None,
         close=False,
         index=None,
@@ -47,13 +46,12 @@ class CaseBlock(object):
             case_id = case_id.decode('utf-8')
         if isinstance(user_id, bytes):
             user_id = user_id.decode('utf-8')
-        # todo: can we use None instead of CaseBlock.undefined, throughout?
-        owner_id = CaseBlock.undefined if owner_id is None else owner_id
+        owner_id = ... if owner_id is None else owner_id
         self.update = copy.copy(update) if update else {}
         now = datetime.utcnow()
         self.date_modified = date_modified or now
         if date_opened_deprecated_behavior:
-            self.date_opened = (now.date() if create and date_opened is CaseBlock.undefined
+            self.date_opened = (now.date() if create and date_opened is ...
                                 else date_opened)
         else:
             self.date_opened = date_opened
@@ -87,7 +85,7 @@ class CaseBlock(object):
 
     def _check_for_duplicate_properties(self):
         for property_name, passed_value in self._updatable_built_ins():
-            if passed_value is not CaseBlock.undefined and property_name in self.update:
+            if passed_value is not ... and property_name in self.update:
                 raise CaseBlockError("Key '{}' specified twice".format(property_name))
 
     @staticmethod
@@ -117,7 +115,7 @@ class CaseBlock(object):
         })
 
         create_or_update = {key: val for key, val in self._updatable_built_ins()
-                            if val is not CaseBlock.undefined}
+                            if val is not ...}
         if self.create:
             for key in self._built_ins:
                 create_or_update.setdefault(key, "")
@@ -128,8 +126,8 @@ class CaseBlock(object):
         if self.close:
             result['close'] = {}
 
-        if all(val is CaseBlock.undefined for val in result['update'].values()):
-                result['update'] = CaseBlock.undefined
+        if all(val is ... for val in result['update'].values()):
+                result['update'] = ...
 
         if self.index:
             result['index'] = {}
@@ -220,13 +218,13 @@ class _DictToXML(object):
     def build(self, block, dct):
         if '_attrib' in dct:
             for (key, value) in dct['_attrib'].items():
-                if value is not CaseBlock.undefined:
+                if value is not ...:
                     block.set(key, self.fmt(value))
         if '_text' in dct:
             block.text = six.text_type(dct['_text'])
 
         for (key, value) in sorted(list(dct.items()), key=self.sort_key):
-            if value is not CaseBlock.undefined and not key.startswith('_'):
+            if value is not ... and not key.startswith('_'):
                 elem = ElementTree.Element(key)
                 block.append(elem)
                 if isinstance(value, dict):

--- a/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/tests/test_case_block.py
@@ -73,3 +73,43 @@ class CaseBlockTest(SimpleTestCase):
             '</case>'
         )
         self.assertEqual(actual, expected)
+
+    def test_owner_id_is_none(self):
+        case_block = CaseBlock(
+            case_id=self.CASE_ID,
+            owner_id=None,
+        )
+        self.assertEqual(case_block.owner_id, ...)
+
+    def test_date_opened_default(self):
+        case_block = CaseBlock(
+            case_id=self.CASE_ID,
+        )
+        self.assertEqual(case_block.date_opened, ...)
+
+    def test_date_opened_given(self):
+        day_one = datetime(year=1970, month=1, day=1)
+        case_block = CaseBlock(
+            case_id=self.CASE_ID,
+            date_opened=day_one,
+        )
+        self.assertEqual(case_block.date_opened, day_one)
+
+    def test_date_opened_deprecated_given(self):
+        day_one = datetime(year=1970, month=1, day=1)
+        case_block = CaseBlock(
+            case_id=self.CASE_ID,
+            date_opened=day_one,
+            create=True,
+            date_opened_deprecated_behavior=True,
+        )
+        self.assertEqual(case_block.date_opened, day_one)
+
+    def test_date_opened_deprecated_now(self):
+        now = datetime.utcnow().date()
+        case_block = CaseBlock(
+            case_id=self.CASE_ID,
+            create=True,
+            date_opened_deprecated_behavior=True,
+        )
+        self.assertEqual(case_block.date_opened, now)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -637,7 +637,7 @@ class SyncTokenUpdateTest(BaseSyncTest):
         # create an irrelevent child and close the parent
         child_id = uuid.uuid4().hex
         self.device.post_changes([
-            CaseStructure(case_id=parent_id, attrs={'close': True, 'owner_id': CaseBlock.undefined}),
+            CaseStructure(case_id=parent_id, attrs={'close': True}),
             CaseStructure(
                 case_id=child_id,
                 attrs={

--- a/corehq/motech/fhir/tasks.py
+++ b/corehq/motech/fhir/tasks.py
@@ -238,7 +238,6 @@ def build_case_block(resource_type, resource, suggested_case_id):
         case_id=case.case_id if case else suggested_case_id,
         owner_id=owner_id,
         case_type=case_type,
-        date_opened=CaseBlock.undefined,
         external_id=external_id,
         **caseblock_kwargs,
     )

--- a/corehq/motech/fhir/tasks.py
+++ b/corehq/motech/fhir/tasks.py
@@ -207,6 +207,16 @@ def claim_service_request(requests, service_request, case_id, attempt=0):
 
 
 def build_case_block(resource_type, resource, suggested_case_id):
+    """
+    Returns a `CaseBlock` to create or update a case corresponding to a
+    FHIR resource.
+
+    :param resource_type: A FHIRResourceType
+    :param resource: A dict
+    :param suggested_case_id: Used if `resource` doesn't correspond to a
+        case already.
+    :return: A CaseBlock
+    """
     domain = resource_type.domain
     case_type = resource_type.case_type.name
     owner_id = resource_type.import_config.owner_id

--- a/corehq/motech/fhir/tasks.py
+++ b/corehq/motech/fhir/tasks.py
@@ -222,23 +222,25 @@ def build_case_block(resource_type, resource, suggested_case_id):
     owner_id = resource_type.import_config.owner_id
     case = None
 
+    caseblock_kwargs = get_caseblock_kwargs(resource_type, resource)
+    if 'id' in resource:
+        external_id = resource['id']
+        caseblock_kwargs['external_id'] = external_id
+    else:
+        external_id = None
     case_id = get_case_id_or_none(resource)
-    external_id = resource['id'] if 'id' in resource else CaseBlock.undefined
     if case_id:
         case = get_case_by_id(domain, case_id)
         # If we have a case_id we can be pretty sure we can get a case
         # ... unless it's been deleted. If so, fall back on external_id.
-    if case is None and external_id != CaseBlock.undefined:
-        # external_id will almost always be set.
+    if case is None and external_id:
         case = get_case_by_external_id(domain, external_id, case_type)
 
-    caseblock_kwargs = get_caseblock_kwargs(resource_type, resource)
     return CaseBlock(
         create=case is None,
         case_id=case.case_id if case else suggested_case_id,
         owner_id=owner_id,
         case_type=case_type,
-        external_id=external_id,
         **caseblock_kwargs,
     )
 

--- a/corehq/motech/fhir/tests/test_tasks.py
+++ b/corehq/motech/fhir/tests/test_tasks.py
@@ -778,6 +778,7 @@ class TestBuildCaseBlock(TestCaseWithResourceType):
             }
         ))
         resource = {
+            'id': '12345',
             'identifier': [{
                 'system': SYSTEM_URI_CASE_ID,
                 'value': case_id,
@@ -792,6 +793,7 @@ class TestBuildCaseBlock(TestCaseWithResourceType):
         )
         self.assertFalse(case_block.create)
         self.assertEqual(case_block.case_id, case_id)
+        self.assertEqual(case_block.external_id, '12345')
 
     def test_resource_has_case_id_in_other_domain(self):
         case_id = str(uuid4())
@@ -849,6 +851,7 @@ class TestBuildCaseBlock(TestCaseWithResourceType):
         )
         self.assertFalse(case_block.create)
         self.assertEqual(case_block.case_id, case_id)
+        self.assertEqual(case_block.external_id, '12345')
 
     def test_resource_has_external_id_in_other_domain(self):
         case_id = str(uuid4())
@@ -877,6 +880,7 @@ class TestBuildCaseBlock(TestCaseWithResourceType):
             )
             self.assertTrue(case_block.create)
             self.assertEqual(case_block.case_id, suggested_case_id)
+            self.assertEqual(case_block.external_id, '12345')
 
     def test_same_external_id_different_case_type(self):
         case_id = str(uuid4())


### PR DESCRIPTION
## Technical Summary

This refactor scratches an itch that I've had for ages. We are [already using ellipsis to mean "not set"](https://github.com/dimagi/commcare-hq/blob/7e6cea347aa37412b541dd199be22a4785035def/corehq/apps/receiverwrapper/util.py#L31). This change applies that approach to `CaseBlock`.

**NOTE:** Base branch is not master (at the time this PR was opened) to avoid a merge conflict.

:blowfish: :tropical_fish: :dolphin:  

## Feature Flag

N/A

## Safety Assurance

### Safety story

Just a refactor. Does not change functionality.

### Automated test coverage

Covered by a lot of existing tests.

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
