### PR TITLE
Upgrade prompt-toolkit to 3.0.36 in remaining cases

### DIFF
--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -333,7 +333,7 @@ polib==1.1.1
     # via -r base-requirements.in
 prometheus-client==0.14.1
     # via -r base-requirements.in
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.36
     # via click-repl
 protobuf==3.18.3
     # via

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -309,7 +309,7 @@ polib==1.1.1
     # via -r base-requirements.in
 prometheus-client==0.14.1
     # via -r base-requirements.in
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.36
     # via click-repl
 protobuf==3.18.3
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -345,7 +345,7 @@ polib==1.1.1
     # via -r base-requirements.in
 prometheus-client==0.14.1
     # via -r base-requirements.in
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.36
     # via click-repl
 protobuf==3.18.3
     # via


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This upgrade has basically been live since last June via the [ipython upgrade](https://github.com/dimagi/commcare-hq/pull/32614/files#diff-331b6c5f96969e74c8e7a8005562874f87c881af39dca96dbfa17b3426fc38c8R343), so no harm in upgrading the remaining cases.

The latest version of the library is 3.0.37, but they mention some [breaking changes](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/CHANGELOG) that might impact [click-repl](https://pypi.org/project/click-repl/#history), who hasn't made a new release in a couple of years (but there is recent activity). I haven't looked at the usage of prompt-toolkit in click-repl, but figure it is easy enough to wait. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
