### PR TITLE
Ze/submitter type case history

### DIFF
--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -90,6 +90,7 @@ from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import absolute_reverse, get_case_or_404, reverse
 
 from .basic import CaseListReport
+from .utils import get_submitter_type
 
 # Number of columns in case property history popup
 DYNAMIC_CASE_PROPERTIES_COLUMNS = 4
@@ -333,6 +334,7 @@ def form_to_json(domain, form, timezone):
             "username": form.metadata.username if form.metadata else '',
         },
         'readable_name': form_name,
+        'submitter_type': get_submitter_type(form.metadata, domain) if form.metadata else 'Unknown',
     }
 
 

--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -90,7 +90,7 @@ from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import absolute_reverse, get_case_or_404, reverse
 
 from .basic import CaseListReport
-from .utils import get_submitter_type
+from .utils import get_user_type
 
 # Number of columns in case property history popup
 DYNAMIC_CASE_PROPERTIES_COLUMNS = 4
@@ -334,7 +334,7 @@ def form_to_json(domain, form, timezone):
             "username": form.metadata.username if form.metadata else '',
         },
         'readable_name': form_name,
-        'submitter_type': get_submitter_type(form.metadata, domain) if form.metadata else 'Unknown',
+        'user_type': get_user_type(form.metadata, domain) if form.metadata else 'Unknown',
     }
 
 

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -179,13 +179,13 @@ def query_location_restricted_forms(query, request):
     return query.filter(form_es.user_id(accessible_ids))
 
 
-def get_submitter_type(form_metadata, domain=None):
-    submitter_type = 'Unknown'
+def get_user_type(form_metadata, domain=None):
+    user_type = 'Unknown'
     if getattr(form_metadata, 'userID', None):
         doc_info = get_doc_info_by_id(domain, form_metadata.userID)
         if doc_info:
-            submitter_type = doc_info.type_display
+            user_type = doc_info.type_display
     elif form_metadata.username == 'system':
-        submitter_type = 'System'
+        user_type = 'System'
 
-    return submitter_type
+    return user_type

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -11,6 +11,7 @@ from corehq.apps.locations.dbaccessors import (
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
 from corehq.apps.reports.models import HQUserType
+from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 
 
 def _get_special_owner_ids(domain, admin, unknown, web, demo, commtrack):
@@ -176,3 +177,15 @@ def query_location_restricted_cases(query, request):
 def query_location_restricted_forms(query, request):
     accessible_ids = _get_location_accessible_ids(request)
     return query.filter(form_es.user_id(accessible_ids))
+
+
+def get_submitter_type(form_metadata, domain=None):
+    submitter_type = 'Unknown'
+    if getattr(form_metadata, 'userID', None):
+        doc_info = get_doc_info_by_id(domain, form_metadata.userID)
+        if doc_info:
+            submitter_type = doc_info.type_display
+    elif form_metadata.username == 'system':
+        submitter_type = 'System'
+
+    return submitter_type

--- a/corehq/apps/reports/static/reports/js/case_details.js
+++ b/corehq/apps/reports/static/reports/js/case_details.js
@@ -49,6 +49,7 @@ hqDefine("reports/js/case_details", [
         self.userID = ko.observable(data.user.id);
         self.username = ko.observable(self.format_user(data.user.username));
         self.readable_name = ko.observable(data.readable_name);
+        self.submitter_type = ko.observable(data.submitter_type);
 
         return self;
     };

--- a/corehq/apps/reports/static/reports/js/case_details.js
+++ b/corehq/apps/reports/static/reports/js/case_details.js
@@ -49,7 +49,7 @@ hqDefine("reports/js/case_details", [
         self.userID = ko.observable(data.user.id);
         self.username = ko.observable(self.format_user(data.user.username));
         self.readable_name = ko.observable(data.readable_name);
-        self.submitter_type = ko.observable(data.submitter_type);
+        self.user_type = ko.observable(data.user_type);
 
         return self;
     };

--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -159,6 +159,7 @@
                       <th class="col-sm-2">{% trans "Received" %} ({{ tz_abbrev }})</th>
                       <th class="col-sm-2">{% trans "Form" %}</th>
                       <th class="col-sm-2">{% trans "User" %}</th>
+                      <th class="col-sm-2">{% trans "Submitter Type" %}</th>
                     </tr>
                     </thead>
                     <tbody data-bind="foreach: xforms">
@@ -171,6 +172,9 @@
                       <td>
                         <span data-bind="text: username"></span>
                         <div class="pull-right"><i class="fa fa-chevron-right"></i></div>
+                      </td>
+                      <td>
+                        <span data-bind="text: submitter_type"></span>
                       </td>
                     </tr>
                     </tbody>

--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -159,7 +159,7 @@
                       <th class="col-sm-2">{% trans "Received" %} ({{ tz_abbrev }})</th>
                       <th class="col-sm-2">{% trans "Form" %}</th>
                       <th class="col-sm-2">{% trans "User" %}</th>
-                      <th class="col-sm-2">{% trans "Submitter Type" %}</th>
+                      <th class="col-sm-2">{% trans "User Type" %}</th>
                     </tr>
                     </thead>
                     <tbody data-bind="foreach: xforms">
@@ -174,7 +174,7 @@
                         <div class="pull-right"><i class="fa fa-chevron-right"></i></div>
                       </td>
                       <td>
-                        <span data-bind="text: submitter_type"></span>
+                        <span data-bind="text: user_type"></span>
                       </td>
                     </tr>
                     </tbody>

--- a/corehq/apps/reports/tests/test_util.py
+++ b/corehq/apps/reports/tests/test_util.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from django.core.cache import cache
 from django.test import SimpleTestCase
@@ -12,6 +12,7 @@ from corehq.form_processor.exceptions import XFormNotFound
 from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.util.test_utils import TestFileMixin, get_form_ready_to_save
+from corehq.apps.reports.standard.cases.utils import get_user_type
 
 DOMAIN = 'test_domain'
 USER_ID = "5bc1315c-da6f-466d-a7c4-4580bc84a7b9"
@@ -39,6 +40,26 @@ class TestSummarizeUserCounts(SimpleTestCase):
             summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=4),
             {'a': 1, 'b': 10, 'c': 2, (): 0},
         )
+
+
+class TestGetUserType(SimpleTestCase):
+    def setUp(self):
+        self.form_metadata = Mock(userID=None, username='foobar')
+
+    def test_unknown_user(self):
+        self.assertEqual(get_user_type(self.form_metadata), 'Unknown')
+
+    def test_system_user(self):
+        self.form_metadata.username = 'system'
+        self.assertEqual(get_user_type(self.form_metadata), 'System')
+
+    @patch(
+        'corehq.apps.reports.standard.cases.utils.get_doc_info_by_id',
+        return_value=Mock(type_display='Foobar')
+    )
+    def test_display_user(self, _):
+        self.form_metadata.userID = '1234'
+        self.assertEqual(get_user_type(self.form_metadata), 'Foobar')
 
 
 def test_get_user_id():

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -184,6 +184,7 @@ def get_paged_changes_to_case_property(case, case_property_name, start=0, per_pa
 def get_case_history(case):
     from casexml.apps.case.xform import extract_case_blocks
     from corehq.apps.reports.display import xmlns_to_name
+    from corehq.apps.reports.standard.cases.utils import get_submitter_type
 
     changes = defaultdict(dict)
     for form in XFormInstance.objects.get_forms(case.xform_ids, case.domain):
@@ -193,6 +194,9 @@ def get_case_history(case):
             'Form Name': name,
             'Form Received On': form.received_on,
             'Form Submitted By': form.metadata.username,
+            'Form Submitter Type': (
+                get_submitter_type(form.metadata, case.domain) if form.metadata else 'Unknown'
+            ),
         }
         case_blocks = extract_case_blocks(form)
         for block in case_blocks:

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -184,7 +184,7 @@ def get_paged_changes_to_case_property(case, case_property_name, start=0, per_pa
 def get_case_history(case):
     from casexml.apps.case.xform import extract_case_blocks
     from corehq.apps.reports.display import xmlns_to_name
-    from corehq.apps.reports.standard.cases.utils import get_submitter_type
+    from corehq.apps.reports.standard.cases.utils import get_user_type
 
     changes = defaultdict(dict)
     for form in XFormInstance.objects.get_forms(case.xform_ids, case.domain):
@@ -194,8 +194,8 @@ def get_case_history(case):
             'Form Name': name,
             'Form Received On': form.received_on,
             'Form Submitted By': form.metadata.username,
-            'Form Submitter Type': (
-                get_submitter_type(form.metadata, case.domain) if form.metadata else 'Unknown'
+            'Form User Type': (
+                get_user_type(form.metadata, case.domain) if form.metadata else 'Unknown'
             ),
         }
         case_blocks = extract_case_blocks(form)


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2559).

This adds a new "Submitter Type" column to the case history table in the case data page. This column displays whether it was a mobile worker, web user, or the system that made a particular submission.

This is also expanded to the case history download, which adds the "Submitter Type" column to the data that gets downloaded.

![Screenshot from 2023-02-23 17-40-46](https://user-images.githubusercontent.com/122617251/220956507-a150d5be-32a2-4ea5-9057-cb50ae213ee2.png)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Have done local testing.
- Added unit tests.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Have implemented unit tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
