### PR TITLE
Bump myst-parser from 0.15.2 to 0.18.1

### DIFF
--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -18,7 +18,6 @@ attrs==21.4.0
     # via
     #   -r base-requirements.in
     #   jsonschema
-    #   markdown-it-py
 babel==2.9.1
     # via sphinx
 beaker==1.11.0
@@ -291,7 +290,7 @@ mako==1.2.2
     #   oic
 markdown==3.4.1
     # via -r base-requirements.in
-markdown-it-py==1.1.0
+markdown-it-py==2.2.0
     # via
     #   mdit-py-plugins
     #   myst-parser
@@ -300,9 +299,11 @@ markupsafe==2.1.2
     #   jinja2
     #   mako
     #   werkzeug
-mdit-py-plugins==0.2.8
+mdit-py-plugins==0.3.4
     # via myst-parser
-myst-parser==0.15.2
+mdurl==0.1.2
+    # via markdown-it-py
+myst-parser==0.18.1
     # via -r docs-requirements.in
 oauthlib==3.1.0
     # via
@@ -543,6 +544,7 @@ twilio==7.12.0
 typing-extensions==4.1.1
     # via
     #   django-countries
+    #   myst-parser
     #   oic
     #   qrcode
 ua-parser==0.10.0


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The [changelog](https://github.com/executablebooks/MyST-Parser/blob/master/CHANGELOG.md) mentions a few possible breaking changes in between these versions, but after closer inspection they do not appear to impact us. I checked the docs build output for `WARNING reference target not found` to determine if we use auto-generated anchor links in the way they describe, but did not see that message anywhere and assume we are safe.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Built and opened the docs locally without issue.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
