### PR TITLE
Prevent api key auth in request data for new API

### DIFF
--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -32,7 +32,7 @@ from corehq.form_processor.models import CaseAttachment, CommCareCase
 
 class CaseAttachmentAPI(View):
 
-    @method_decorator(api_auth)
+    @method_decorator(api_auth())
     def get(self, request, domain, case_id=None, attachment_id=None):
         """
         https://github.com/dimagi/commcare/wiki/CaseAttachmentAPI

--- a/corehq/apps/api/resources/messaging_event/view.py
+++ b/corehq/apps/api/resources/messaging_event/view.py
@@ -18,7 +18,7 @@ from corehq.apps.sms.models import MessagingSubEvent, SMS, Email
 
 @csrf_exempt
 @allow_cors(['OPTIONS', 'GET'])
-@api_auth
+@api_auth()
 @require_can_edit_data
 @requires_privilege_with_fallback(privileges.API_ACCESS)
 @api_throttle

--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -25,7 +25,7 @@ from ..dbaccessors import (
 
 
 @json_error
-@api_auth
+@api_auth()
 @api_throttle
 def list_apps(request, domain):
     def app_to_json(app):

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -60,7 +60,7 @@ def case_uploads(request, domain):
     return json_response(case_uploads_json)
 
 
-@api_auth
+@api_auth()
 @require_GET
 @require_can_edit_data
 @conditionally_location_safe(location_safe_case_imports_enabled)

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -305,7 +305,7 @@ def excel_commit(request, domain):
 @waf_allow('XSS_BODY')
 @csrf_exempt
 @require_POST
-@api_auth
+@api_auth()
 @require_can_edit_data
 def bulk_case_upload_api(request, domain, **kwargs):
     try:

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -319,6 +319,7 @@ class HQApiKeyAuthentication(ApiKeyAuthentication):
                 if username and api_key:
                     metrics_counter('commcare.auth.credentials_in_data', tags={
                         'domain': getattr(request, 'domain', None),
+                        'request_method': request.method,
                     })
             else:
                 username, api_key = None, None

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -385,12 +385,8 @@ def two_factor_exempt(view_func):
     return wraps(view_func)(wrapped_view)
 
 
-# Use api_auth or api_auth_with_scope decorators to allow -
-# any auth type basic, digest, session, apikey, or oauth
-api_auth = get_multi_auth_decorator(default=DIGEST)
-
-
-def api_auth_with_scope(oauth_scopes):
+def api_auth(*, allow_querystring_auth=True, oauth_scopes=None):
+    """Allow any auth type basic, digest, session, apikey, or oauth"""
     return get_multi_auth_decorator(default=DIGEST, oauth_scopes=oauth_scopes)
 
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -408,7 +408,13 @@ api_key_auth = login_or_api_key_ex(allow_sessions=False)
 basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=False)
 
 
-def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sessions=True, oauth_scopes=None, allow_creds_in_data=True):
+def get_auth_decorator_map(
+        allow_cc_users=False,
+        require_domain=True,
+        allow_sessions=True,
+        oauth_scopes=None,
+        allow_creds_in_data=True,
+):
     # get a mapped set of decorators for different auth types with the specified parameters
     oauth_scopes = oauth_scopes or ['access_apis']
     decorator_function_kwargs = {

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -181,8 +181,8 @@ class LoginAndDomainMixin(object):
         return super(LoginAndDomainMixin, self).dispatch(*args, **kwargs)
 
 
-def api_key():
-    api_auth_class = HQApiKeyAuthentication()
+def _api_key(allow_creds_in_data=True):
+    api_auth_class = HQApiKeyAuthentication(allow_creds_in_data=allow_creds_in_data)
 
     def real_decorator(view):
         def wrapper(request, *args, **kwargs):
@@ -322,9 +322,9 @@ def login_or_formplayer_ex(allow_cc_users=False, allow_sessions=True, require_do
     )
 
 
-def login_or_api_key_ex(allow_cc_users=False, allow_sessions=True, require_domain=True):
+def login_or_api_key_ex(allow_cc_users=False, allow_sessions=True, require_domain=True, allow_creds_in_data=True):
     return _login_or_challenge(
-        api_key(),
+        _api_key(allow_creds_in_data=allow_creds_in_data),
         allow_cc_users=allow_cc_users,
         api_key=True,
         allow_sessions=allow_sessions,
@@ -343,7 +343,7 @@ def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True, require_domain
     )
 
 
-def get_multi_auth_decorator(default, allow_formplayer=False, oauth_scopes=None):
+def get_multi_auth_decorator(default, allow_formplayer=False, oauth_scopes=None, allow_creds_in_data=True):
     """
     :param allow_formplayer: If True this will allow one additional auth mechanism which is used
          by Formplayer:
@@ -366,7 +366,11 @@ def get_multi_auth_decorator(default, allow_formplayer=False, oauth_scopes=None)
                 )
                 return HttpResponseForbidden()
             request.auth_type = authtype  # store auth type on request for access in views
-            function_wrapper = get_auth_decorator_map(allow_cc_users=True, oauth_scopes=oauth_scopes)[authtype]
+            function_wrapper = get_auth_decorator_map(
+                allow_cc_users=True,
+                oauth_scopes=oauth_scopes,
+                allow_creds_in_data=allow_creds_in_data,
+            )[authtype]
             return function_wrapper(fn)(request, *args, **kwargs)
         return _inner
     return decorator
@@ -385,9 +389,13 @@ def two_factor_exempt(view_func):
     return wraps(view_func)(wrapped_view)
 
 
-def api_auth(*, allow_querystring_auth=True, oauth_scopes=None):
+def api_auth(*, allow_creds_in_data=True, oauth_scopes=None):
     """Allow any auth type basic, digest, session, apikey, or oauth"""
-    return get_multi_auth_decorator(default=DIGEST, oauth_scopes=oauth_scopes)
+    return get_multi_auth_decorator(
+        default=DIGEST,
+        oauth_scopes=oauth_scopes,
+        allow_creds_in_data=allow_creds_in_data,
+    )
 
 
 # Use these decorators on views to allow sesson-auth or an extra authorization method
@@ -400,7 +408,7 @@ api_key_auth = login_or_api_key_ex(allow_sessions=False)
 basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=False)
 
 
-def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sessions=True, oauth_scopes=None):
+def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sessions=True, oauth_scopes=None, allow_creds_in_data=True):
     # get a mapped set of decorators for different auth types with the specified parameters
     oauth_scopes = oauth_scopes or ['access_apis']
     decorator_function_kwargs = {
@@ -411,7 +419,8 @@ def get_auth_decorator_map(allow_cc_users=False, require_domain=True, allow_sess
     return {
         DIGEST: login_or_digest_ex(**decorator_function_kwargs),
         BASIC: login_or_basic_ex(**decorator_function_kwargs),
-        API_KEY: login_or_api_key_ex(**decorator_function_kwargs),
+        API_KEY: login_or_api_key_ex(allow_creds_in_data=allow_creds_in_data,
+                                     **decorator_function_kwargs),
         OAUTH2: login_or_oauth2_ex(oauth_scopes=oauth_scopes, **decorator_function_kwargs),
         FORMPLAYER: login_or_formplayer_ex(**decorator_function_kwargs),
     }
@@ -517,7 +526,7 @@ def api_domain_view(view):
     See http://manage.dimagi.com/default.asp?225116#1137527
     """
     @wraps(view)
-    @api_key()
+    @_api_key()
     @login_and_domain_required
     def _inner(request, domain, *args, **kwargs):
         if request.user.is_authenticated:

--- a/corehq/apps/domain/tests/test_api_key_auth.py
+++ b/corehq/apps/domain/tests/test_api_key_auth.py
@@ -1,8 +1,11 @@
-from django.test import RequestFactory
-
-from nose.tools import assert_equal
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
 
 from corehq.apps.domain.auth import HQApiKeyAuthentication
+from corehq.apps.domain.decorators import api_auth
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import HQApiKey, WebUser
 
 USERNAME = "joel@lastofus.com"
 API_KEY = "123abc"
@@ -36,3 +39,48 @@ def test_credentials_in_POST():
     request = RequestFactory().post('/myapi/', {'username': USERNAME, 'api_key': API_KEY})
     assert has_credentials(request)
     assert not has_credentials(request, allow_creds_in_data=False)
+
+
+class AuthenticationTestBase(TestCase):
+    domain = 'api-key-test'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.factory = RequestFactory()
+        cls.domain_obj = create_domain(name=cls.domain)
+        cls.user = WebUser.create(cls.domain, USERNAME, 'password', None, None)
+        cls.api_key = HQApiKey.objects.create(user=cls.user.get_django_user()).key
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def call_api(self, request, allow_creds_in_data):
+
+        @api_auth(allow_creds_in_data=allow_creds_in_data)
+        def api_view(request, domain):
+            return HttpResponse()
+
+        request.user = AnonymousUser()  # middleware normally does this
+        return api_view(request, self.domain)
+
+    def test_credentials_in_META(self):
+        request = self.factory.get('/myapi/')
+        request.META['HTTP_AUTHORIZATION'] = f"ApiKey {USERNAME}:{self.api_key}"
+
+        res = self.call_api(request, allow_creds_in_data=True)
+        self.assertEqual(res.status_code, 200)
+
+        res = self.call_api(request, allow_creds_in_data=False)
+        self.assertEqual(res.status_code, 200)
+
+    def test_credentials_in_data(self):
+        request = self.factory.get(f'/myapi/?username={USERNAME}&api_key={self.api_key}')
+
+        res = self.call_api(request, allow_creds_in_data=True)
+        self.assertEqual(res.status_code, 200)
+
+        res = self.call_api(request, allow_creds_in_data=False)
+        self.assertEqual(res.status_code, 401)

--- a/corehq/apps/domain/tests/test_api_key_auth.py
+++ b/corehq/apps/domain/tests/test_api_key_auth.py
@@ -8,27 +8,31 @@ USERNAME = "joel@lastofus.com"
 API_KEY = "123abc"
 
 
-def has_credentials(request):
-    actual = HQApiKeyAuthentication().extract_credentials(request)
+def has_credentials(request, allow_creds_in_data=True):
+    actual = HQApiKeyAuthentication(allow_creds_in_data=allow_creds_in_data).extract_credentials(request)
     return actual == (USERNAME, API_KEY)
 
 
 def test_no_auth():
     request = RequestFactory().get('/myapi/')
     assert not has_credentials(request)
+    assert not has_credentials(request, allow_creds_in_data=False)
 
 
 def test_credentials_in_META():
     request = RequestFactory().get('/myapi/')
     request.META['HTTP_AUTHORIZATION'] = f"ApiKey {USERNAME}:{API_KEY}"
     assert has_credentials(request)
+    assert has_credentials(request, allow_creds_in_data=False)
 
 
 def test_credentials_in_GET():
     request = RequestFactory().get(f'/myapi/?username={USERNAME}&api_key={API_KEY}')
     assert has_credentials(request)
+    assert not has_credentials(request, allow_creds_in_data=False)
 
 
 def test_credentials_in_POST():
     request = RequestFactory().post('/myapi/', {'username': USERNAME, 'api_key': API_KEY})
     assert has_credentials(request)
+    assert not has_credentials(request, allow_creds_in_data=False)

--- a/corehq/apps/domain/tests/test_api_key_auth.py
+++ b/corehq/apps/domain/tests/test_api_key_auth.py
@@ -48,14 +48,10 @@ class AuthenticationTestBase(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.factory = RequestFactory()
-        cls.domain_obj = create_domain(name=cls.domain)
+        domain_obj = create_domain(name=cls.domain)
+        cls.addClassCleanup(domain_obj.delete)
         cls.user = WebUser.create(cls.domain, USERNAME, 'password', None, None)
         cls.api_key = HQApiKey.objects.create(user=cls.user.get_django_user()).key
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.domain_obj.delete()
-        super().tearDownClass()
 
     def call_api(self, request, allow_creds_in_data):
 

--- a/corehq/apps/domain/tests/test_api_key_auth.py
+++ b/corehq/apps/domain/tests/test_api_key_auth.py
@@ -1,0 +1,34 @@
+from django.test import RequestFactory
+
+from nose.tools import assert_equal
+
+from corehq.apps.domain.auth import HQApiKeyAuthentication
+
+USERNAME = "joel@lastofus.com"
+API_KEY = "123abc"
+
+
+def has_credentials(request):
+    actual = HQApiKeyAuthentication().extract_credentials(request)
+    return actual == (USERNAME, API_KEY)
+
+
+def test_no_auth():
+    request = RequestFactory().get('/myapi/')
+    assert not has_credentials(request)
+
+
+def test_credentials_in_META():
+    request = RequestFactory().get('/myapi/')
+    request.META['HTTP_AUTHORIZATION'] = f"ApiKey {USERNAME}:{API_KEY}"
+    assert has_credentials(request)
+
+
+def test_credentials_in_GET():
+    request = RequestFactory().get(f'/myapi/?username={USERNAME}&api_key={API_KEY}')
+    assert has_credentials(request)
+
+
+def test_credentials_in_POST():
+    request = RequestFactory().post('/myapi/', {'username': USERNAME, 'api_key': API_KEY})
+    assert has_credentials(request)

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -176,7 +176,8 @@ class LoginOrChallengeDBTest(TestCase, AuthTestMixin):
 
 
 def _get_auth_mock(succeed=True):
-    def mock_auth_decorator(allow_cc_users=False, allow_sessions=True, require_domain=True, oauth_scopes=None):
+    def mock_auth_decorator(allow_cc_users=False, allow_sessions=True, require_domain=True,
+                            oauth_scopes=None, allow_creds_in_data=True):
         def _outer(fn):
             @wraps(fn)
             def inner(request, *args, **kwargs):

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -200,7 +200,6 @@ class ApiAuthTest(SimpleTestCase, AuthTestMixin):
     def test_api_auth_no_auth(self):
         decorated_view = api_auth()(sample_view)
         request = _get_request()
-        # result = decorated_view(request, self.domain_name)
         self.assertForbidden(decorated_view(request, self.domain_name))
 
     def _do_auth_test(self, auth_header, decorator_to_mock):

--- a/corehq/apps/domain/tests/test_auth_decorators.py
+++ b/corehq/apps/domain/tests/test_auth_decorators.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from corehq.apps.api.cors import ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_ALLOW, ACCESS_CONTROL_ALLOW_HEADERS, \
     ACCESS_CONTROL_ALLOW_METHODS
 from corehq.apps.api.decorators import allow_cors
-from corehq.apps.domain.decorators import _login_or_challenge, api_auth, api_auth_with_scope
+from corehq.apps.domain.decorators import _login_or_challenge, api_auth
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser, CommCareUser
 
@@ -198,13 +198,13 @@ class ApiAuthTest(SimpleTestCase, AuthTestMixin):
     domain_name = 'api-auth-test'
 
     def test_api_auth_no_auth(self):
-        decorated_view = api_auth(sample_view)
+        decorated_view = api_auth()(sample_view)
         request = _get_request()
         # result = decorated_view(request, self.domain_name)
         self.assertForbidden(decorated_view(request, self.domain_name))
 
     def _do_auth_test(self, auth_header, decorator_to_mock):
-        decorated_view = api_auth(sample_view)
+        decorated_view = api_auth()(sample_view)
         request = _get_request()
         request.META['HTTP_AUTHORIZATION'] = auth_header
         with patch(decorator_to_mock, mock_successful_auth):
@@ -226,7 +226,7 @@ class ApiAuthTest(SimpleTestCase, AuthTestMixin):
 
     def test_api_auth_oauth_with_scope(self):
         decorator_to_mock = 'corehq.apps.domain.decorators.login_or_oauth2_ex'
-        decorated_view = api_auth_with_scope(['my_scope'])(sample_view)
+        decorated_view = api_auth(oauth_scopes=['my_scope'])(sample_view)
         request = _get_request()
         request.META['HTTP_AUTHORIZATION'] = 'bearer myToken'
         with patch(decorator_to_mock, mock_successful_auth):
@@ -237,7 +237,7 @@ class ApiAuthTest(SimpleTestCase, AuthTestMixin):
     def test_api_auth_formplayer(self):
         # formplayer auth is governed under different rules so can't use the shared function
         decorator_to_mock = 'corehq.apps.domain.decorators.login_or_formplayer_ex'
-        decorated_view = api_auth(sample_view)
+        decorated_view = api_auth()(sample_view)
         request = _get_request()
         request.META['HTTP_X_MAC_DIGEST'] = 'fomplayerAuth'
         with patch(decorator_to_mock, mock_successful_auth):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -784,7 +784,7 @@ def can_download_daily_saved_export(export, domain, couch_user):
 
 @location_safe
 @csrf_exempt
-@api_auth
+@api_auth()
 @require_GET
 def download_daily_saved_export(req, domain, export_instance_id):
     with CriticalSection(['export-last-accessed-{}'.format(export_instance_id)]):

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -366,7 +366,7 @@ class DataFileDownloadList(BaseProjectDataView):
         return HttpResponseRedirect(reverse(self.urlname, kwargs={'domain': self.domain}))
 
 
-@method_decorator(api_auth, name='dispatch')
+@method_decorator(api_auth(), name='dispatch')
 class DataFileDownloadDetail(BaseProjectDataView):
     urlname = 'download_data_file'
 

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -417,7 +417,7 @@ class AsyncUploadFixtureAPIResponse(UploadFixtureAPIResponse):
 @waf_allow('XSS_BODY')
 @csrf_exempt
 @require_POST
-@api_auth
+@api_auth()
 @require_can_edit_fixtures
 @api_throttle
 def upload_fixture_api(request, domain, **kwargs):
@@ -433,7 +433,7 @@ def upload_fixture_api(request, domain, **kwargs):
 
 
 @csrf_exempt
-@api_auth
+@api_auth()
 @require_can_edit_fixtures
 def fixture_api_upload_status(request, domain, download_id, **kwargs):
     """

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -82,7 +82,7 @@ class ExplodeCasesView(BaseProjectSettingsView, TemplateView):
 @waf_allow('XSS_BODY')
 @csrf_exempt
 @allow_cors(['OPTIONS', 'GET', 'POST', 'PUT'])
-@api_auth
+@api_auth(allow_querystring_auth=False)
 @require_permission(HqPermissions.edit_data)
 @require_permission(HqPermissions.access_api)
 @CASE_API_V0_6.required_decorator()
@@ -103,7 +103,7 @@ def case_api(request, domain, case_id=None):
 @waf_allow('XSS_BODY')
 @csrf_exempt
 @allow_cors(['OPTIONS', 'GET', 'POST'])
-@api_auth
+@api_auth(allow_querystring_auth=False)
 @require_permission(HqPermissions.edit_data)
 @require_permission(HqPermissions.access_api)
 @CASE_API_V0_6.required_decorator()

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -82,7 +82,7 @@ class ExplodeCasesView(BaseProjectSettingsView, TemplateView):
 @waf_allow('XSS_BODY')
 @csrf_exempt
 @allow_cors(['OPTIONS', 'GET', 'POST', 'PUT'])
-@api_auth(allow_querystring_auth=False)
+@api_auth(allow_creds_in_data=False)
 @require_permission(HqPermissions.edit_data)
 @require_permission(HqPermissions.access_api)
 @CASE_API_V0_6.required_decorator()
@@ -103,7 +103,7 @@ def case_api(request, domain, case_id=None):
 @waf_allow('XSS_BODY')
 @csrf_exempt
 @allow_cors(['OPTIONS', 'GET', 'POST'])
-@api_auth(allow_querystring_auth=False)
+@api_auth(allow_creds_in_data=False)
 @require_permission(HqPermissions.edit_data)
 @require_permission(HqPermissions.access_api)
 @CASE_API_V0_6.required_decorator()

--- a/corehq/apps/mobile_auth/views.py
+++ b/corehq/apps/mobile_auth/views.py
@@ -78,7 +78,7 @@ def fetch_key_records(request, domain):
     return HttpResponse(payload)
 
 
-@api_auth
+@api_auth()
 @domain_admin_required
 @require_GET
 def admin_fetch_key_records(request, domain):

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -208,7 +208,7 @@ def _record_metrics(tags, submission_type, response, timer=None, xform=None):
 
 @waf_allow('XSS_BODY')
 @csrf_exempt
-@api_auth
+@api_auth()
 @require_permission(HqPermissions.edit_data)
 @require_permission(HqPermissions.access_api)
 @require_POST

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -172,7 +172,7 @@ def _can_view_form_attachment():
                 response = HttpResponseForbidden()
             return response
 
-        return api_auth(_inner)
+        return api_auth()(_inner)
     return decorator
 
 

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -58,7 +58,7 @@ from corehq.apps.change_feed.data_sources import (
     get_document_store_for_doc_type,
 )
 from corehq.apps.domain.decorators import (
-    api_auth_with_scope,
+    api_auth,
     login_and_domain_required,
 )
 from corehq.apps.domain.models import AllowedUCRExpressionSettings, Domain
@@ -1469,7 +1469,7 @@ def process_url_params(params, columns):
     return ExportParameters(format_, keyword_filters, sql_filters)
 
 
-@api_auth_with_scope(['reports:view'])
+@api_auth(oauth_scopes=['reports:view'])
 @require_permission(HqPermissions.view_reports)
 @swallow_programming_errors
 @api_throttle

--- a/corehq/motech/generic_inbound/views.py
+++ b/corehq/motech/generic_inbound/views.py
@@ -175,7 +175,7 @@ class ConfigurableAPIEditView(BaseProjectSettingsView):
 @csrf_exempt
 @allow_cors(list(RequestLog.RequestMethod))
 @require_http_methods(list(RequestLog.RequestMethod))
-@api_auth
+@api_auth(allow_querystring_auth=False)
 @requires_privilege_with_fallback(privileges.API_ACCESS)
 @require_permission(HqPermissions.edit_data)
 @require_permission(HqPermissions.access_api)

--- a/corehq/motech/generic_inbound/views.py
+++ b/corehq/motech/generic_inbound/views.py
@@ -175,7 +175,7 @@ class ConfigurableAPIEditView(BaseProjectSettingsView):
 @csrf_exempt
 @allow_cors(list(RequestLog.RequestMethod))
 @require_http_methods(list(RequestLog.RequestMethod))
-@api_auth(allow_querystring_auth=False)
+@api_auth(allow_creds_in_data=False)
 @requires_privilege_with_fallback(privileges.API_ACCESS)
 @require_permission(HqPermissions.edit_data)
 @require_permission(HqPermissions.access_api)


### PR DESCRIPTION
## Product Description
This prevents users from authenticating with username and API key included in GET or POST data when using the v0.6 case API or the generic inbound API.  This is a system provided by tastypie, but it's undesirable, as it lumps auth parameters and query parameters into a single namespace.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2704 
The commits should be granular, that's the easiest way to review.  At a high level view, it:

* Makes the `@api_auth` decorator and underlying `HQApiKeyAuthentication` class accept a parameter `allow_creds_in_data`, which can be set to `False` to disallow this type of auth (I'd love a more concise name for that parameter if you've got ideas).
* Disables that method for the new APIs mentioned above
* Logs usage of that method for later analysis - maybe we can remove it!  I couldn't find any mention of it on confluence.
* Adds some tests

## Feature Flag
Enable the v0.6 Case API

## Safety Assurance

### Safety story
This protects against an undocumented method in a new API - I don't believe usage is widespread yet, and I don't think anyone uses that auth method other than QA.

### Automated test coverage

included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
