### PR TITLE
Updated nodeset filter UI to keep 'Add Filter' button until it's clicked

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
@@ -22,7 +22,7 @@ hqDefine('app_manager/js/details/detail_tab_nodeset', function () {
             return !self.nodesetCaseType();
         });
 
-        self.showFilter = ko.observable(!!self.nodesetFilter());
+        self.showFilter = ko.observable(!!self.nodesetFilter());    // show button if there's no saved filter
 
         self.ui = $(_.template($("#module-case-detail-tab-nodeset-template").text())());
         self.ui.koApplyBindings(self);
@@ -35,7 +35,6 @@ hqDefine('app_manager/js/details/detail_tab_nodeset', function () {
             self.fire('change');
             if (newValue) {
                 self.nodeset("");
-                self.showFilter(true);
             } else {
                 self.nodesetFilter("");
                 self.showFilter(false);


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2916

Minor change to UI flow so that "Add Filter" button doesn't disappear when you change the nodeset's case type.

## Feature Flag
Nodesets in case detail

## Safety Assurance

### Safety story
Quite small. Discovered during adoption support, fix tested by AE team.

### Automated test coverage

No

### QA Plan

No


### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
