### PR TITLE
Conditional alert stop sending broadcast when the condition becomes false

### DIFF
--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -681,11 +681,10 @@ class CaseTimedScheduleInstance(CaseScheduleInstanceMixin, AbstractTimedSchedule
         )
 
     def additional_deactivation_condition_reached(self):
-        return_condition = super().additional_deactivation_condition_reached()
-
         from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 
+        additional_deactivation_condition_reached = super().additional_deactivation_condition_reached()
         rule = AutomaticUpdateRule.objects.get(pk=self.rule_id)
         criteria_match = rule.criteria_match(self.case, datetime.utcnow())
 
-        return return_condition and criteria_match
+        return additional_deactivation_condition_reached and criteria_match

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -674,10 +674,14 @@ class CaseTimedScheduleInstance(CaseScheduleInstanceMixin, AbstractTimedSchedule
     last_reset_case_property_value = models.TextField(null=True)
 
     def additional_deactivation_condition_reached(self):
+        return_condition = super().additional_deactivation_condition_reached(self)
+
         from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 
         rule = AutomaticUpdateRule.objects.get(pk=self.rule_id)
-        return rule.criteria_match(self.case_id, datetime.utcnow())
+        criteria_match = rule.criteria_match(self.case, datetime.utcnow())
+
+        return return_condition and criteria_match
 
     class Meta(AbstractTimedScheduleInstance.Meta):
         db_table = 'scheduling_casetimedscheduleinstance'

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -673,6 +673,12 @@ class CaseTimedScheduleInstance(CaseScheduleInstanceMixin, AbstractTimedSchedule
     # See corehq.apps.data_interfaces.models.CreateScheduleInstanceActionDefinition.reset_case_property_name
     last_reset_case_property_value = models.TextField(null=True)
 
+    def additional_deactivation_condition_reached(self):
+        from corehq.apps.data_interfaces.models import AutomaticUpdateRule
+
+        rule = AutomaticUpdateRule.objects.get(pk=self.rule_id)
+        return rule.criteria_match(self.case_id, datetime.utcnow())
+
     class Meta(AbstractTimedScheduleInstance.Meta):
         db_table = 'scheduling_casetimedscheduleinstance'
         index_together = AbstractTimedScheduleInstance.Meta.index_together

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -673,8 +673,15 @@ class CaseTimedScheduleInstance(CaseScheduleInstanceMixin, AbstractTimedSchedule
     # See corehq.apps.data_interfaces.models.CreateScheduleInstanceActionDefinition.reset_case_property_name
     last_reset_case_property_value = models.TextField(null=True)
 
+    class Meta(AbstractTimedScheduleInstance.Meta):
+        db_table = 'scheduling_casetimedscheduleinstance'
+        index_together = AbstractTimedScheduleInstance.Meta.index_together
+        unique_together = (
+            ('case_id', 'timed_schedule_id', 'recipient_type', 'recipient_id'),
+        )
+
     def additional_deactivation_condition_reached(self):
-        return_condition = super().additional_deactivation_condition_reached(self)
+        return_condition = super().additional_deactivation_condition_reached()
 
         from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 
@@ -682,10 +689,3 @@ class CaseTimedScheduleInstance(CaseScheduleInstanceMixin, AbstractTimedSchedule
         criteria_match = rule.criteria_match(self.case, datetime.utcnow())
 
         return return_condition and criteria_match
-
-    class Meta(AbstractTimedScheduleInstance.Meta):
-        db_table = 'scheduling_casetimedscheduleinstance'
-        index_together = AbstractTimedScheduleInstance.Meta.index_together
-        unique_together = (
-            ('case_id', 'timed_schedule_id', 'recipient_type', 'recipient_id'),
-        )

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -94,15 +94,11 @@ def run_auto_update_rules_for_case(case, get_rules=None):
         rule.run_rule(case, utcnow())
 
 
-def _get_cached_rule(domain, rule_id):
+def get_cached_rule(domain, rule_id):
     rules = AutomaticUpdateRule.by_domain_cached(domain, AutomaticUpdateRule.WORKFLOW_SCHEDULING)
     rules = [rule for rule in rules if rule.pk == rule_id]
     if len(rules) == 1:
         return rules[0]
-
-
-def get_cached_rule(domain, rule_id):
-    return _get_cached_rule(domain, rule_id)
 
 
 def _sync_case_for_messaging_rule(domain, case_id, rule_id):
@@ -112,7 +108,7 @@ def _sync_case_for_messaging_rule(domain, case_id, rule_id):
     except CaseNotFound:
         clear_messaging_for_case(domain, case_id)
         return
-    rule = _get_cached_rule(domain, rule_id)
+    rule = get_cached_rule(domain, rule_id)
     if rule:
         rule.run_rule(case, utcnow())
         MessagingRuleProgressHelper(rule_id).increment_current_case_count()
@@ -155,7 +151,7 @@ def set_rule_complete(rule_id):
 @no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE, acks_late=True,
                 soft_time_limit=15 * settings.CELERY_TASK_SOFT_TIME_LIMIT)
 def run_messaging_rule(domain, rule_id):
-    rule = _get_cached_rule(domain, rule_id)
+    rule = get_cached_rule(domain, rule_id)
     if not rule:
         return
     progress_helper = MessagingRuleProgressHelper(rule_id)
@@ -171,7 +167,7 @@ def run_messaging_rule(domain, rule_id):
 @no_result_task(queue=settings.CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE, acks_late=True,
                 soft_time_limit=15 * settings.CELERY_TASK_SOFT_TIME_LIMIT)
 def run_messaging_rule_for_shard(domain, rule_id, db_alias):
-    rule = _get_cached_rule(domain, rule_id)
+    rule = get_cached_rule(domain, rule_id)
     if not rule:
         return
 

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -101,6 +101,10 @@ def _get_cached_rule(domain, rule_id):
         return rules[0]
 
 
+def get_cached_rule(domain, rule_id):
+    return _get_cached_rule(domain, rule_id)
+
+
 def _sync_case_for_messaging_rule(domain, case_id, rule_id):
     case_load_counter("messaging_rule_sync", domain)()
     try:


### PR DESCRIPTION
## Product Description
Conditional alert's start broadcasting on a schedule once a condition goes from false to true. But this broadcast does not stop when the condition becomes false. This PR adds support to stop conditional alert schedule once a condition becomes false.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-2155](https://dimagi-dev.atlassian.net/browse/USH-2155)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
[QA-4866](https://dimagi-dev.atlassian.net/browse/QA-4866)
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-2155]: https://dimagi-dev.atlassian.net/browse/USH-2155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[QA-4866]: https://dimagi-dev.atlassian.net/browse/QA-4866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ