### PR TITLE
Move `_handle_attendance_tracking_role()` to `StaticToggle.save_fn`

### DIFF
--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, call, patch
 
 from django.test import SimpleTestCase, TransactionTestCase
 
+from corehq.util.test_utils import flag_enabled
 from dimagi.utils.parsing import json_format_date
 
 from corehq.apps.accounting.exceptions import SubscriptionAdjustmentError
@@ -146,9 +147,8 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         self._assertInitialRoles()
         self._assertStdUsers()
 
-    @patch('corehq.apps.toggle_ui.views.ATTENDANCE_TRACKING.enabled')
-    def test_add_attendance_coordinator_role_for_domain(self, attendance_tracking_enabled):
-        attendance_tracking_enabled.return_value = True
+    @flag_enabled('ATTENDANCE_TRACKING')
+    def test_add_attendance_coordinator_role_for_domain(self):
         subscription = Subscription.new_domain_subscription(
             self.account, self.domain.name, self.community_plan,
             web_user=self.admin_username
@@ -165,9 +165,8 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         ).exists()
         self.assertTrue(pm_role_created)
 
-    @patch('corehq.apps.toggle_ui.views.ATTENDANCE_TRACKING.enabled')
-    def test_archive_attendance_coordinator_role_when_downgrading(self, attendance_tracking_enabled):
-        attendance_tracking_enabled.return_value = True
+    @flag_enabled('ATTENDANCE_TRACKING')
+    def test_archive_attendance_coordinator_role_when_downgrading(self):
         subscription = Subscription.new_domain_subscription(
             self.account, self.domain.name, self.advanced_plan,
             web_user=self.admin_username

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -28,6 +28,8 @@ class UserRolePresets:
     }
 
     PRIVILEGED_ROLES = {
+        # ATTENDANCE_COORDINATOR is not a custom role. It is only
+        # available to domains on higher subscription plans.
         ATTENDANCE_COORDINATOR: lambda: HqPermissions(
             manage_attendance_tracking=True,
             edit_groups=True,


### PR DESCRIPTION
## Technical Summary

This change uses the existing mechanism we have for actions that need to be taken when a toggle is enabled or disabled.

## Feature Flag

`ATTENDANCE_TRACKING`

## Safety Assurance

### Safety story

Functionality not changed.

### Automated test coverage

Called functions have tests already.

### QA Plan

No QA planned for this PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
