### PR TITLE
Hide couchdb unclosed socket warnings in tests

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -938,13 +938,7 @@ ignore:the imp module is deprecated::celery.utils.imports,
 ignore:unclosed:ResourceWarning'
 ```
 
-Personal whitelist items may also be added in localsettings.py. For example:
-
-```py
-from warnings import filterwarnings  # noqa: E402
-filterwarnings("ignore", "unclosed", ResourceWarning)
-del filterwarnings
-```
+Personal whitelist items may also be added in localsettings.py.
 
 
 ### Running tests by tag

--- a/testsettings.py
+++ b/testsettings.py
@@ -1,4 +1,5 @@
 import os
+from warnings import filterwarnings
 
 import settingshelper as helper
 from settings import *  # noqa: F403
@@ -74,6 +75,8 @@ ENABLE_PRELOGIN_SITE = True
 # override dev_settings
 CACHE_REPORTS = True
 
+# Hide couchdb 'unclosed socket' warnings
+filterwarnings("ignore", r"unclosed.*socket.*raddr=\([^) ]* 5984\)", ResourceWarning)
 
 def _set_logging_levels(levels):
     import logging


### PR DESCRIPTION
## Product Description
Removes unnecessary warning from tests - no user-facing effects

## Technical Summary

Test output is spammed with a bunch of lines that look like this:
```
Exception ignored in: <socket.socket fd=13, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 45450), raddr=('127.0.0.1', 5984)>
ResourceWarning: unclosed <socket.socket fd=13, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 45450), raddr=('127.0.0.1', 5984)>
```
This comes from unclosed session inside couchdbkit.  These are safe to ignore - here's what a `requests` dev says about it:

> You don't have to. The warning is just that: a warning. No error occurs when you see it, and it is not an indication of the program doing the wrong thing. It's entirely expected behaviour, and this is working as designed. However, if you're concerned about them, you may call close.

(I'm not linking the thread, to avoid github connecting the conversations)

Shout-out to Martin for asking about it, @millerdev for the fix, and @gherceg for connecting the dots

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

This change only affects the `testsettings` file, so it can only impact dev environments

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
