### PR TITLE
Switch to HubSpot new token model

### DIFF
--- a/corehq/apps/analytics/README.md
+++ b/corehq/apps/analytics/README.md
@@ -88,7 +88,7 @@ Any changes to user properties related to the registration forms should be made 
 
 #### Testing
 
-To start testing, run Celery and update `HUBSPOT_API_KEY` and `HUBSPOT_ID` in `settings.ANALYTICS_IDS`. Hubspot provides a public demo portal with API access for testing. The credentials for this are available on their [API overview page](http://developers.hubspot.com/docs/overview). If you need to test using our production portal the credentials can be found in dimagi_shared keepass. Let marketing know before testing on production portal and clean up after the testing is finished
+To start testing, run Celery and update `HUBSPOT_ACCESS_TOKEN` and `HUBSPOT_ID` in `settings.ANALYTICS_IDS`. Hubspot provides a public demo portal with API access for testing. The credentials for this are available on their [API overview page](http://developers.hubspot.com/docs/overview). If you need to test using our production portal the credentials can be found in dimagi_shared keepass. Let marketing know before testing on production portal and clean up after the testing is finished
 
 When troubleshooting in Hubspot's portal, it's often useful to create lists based on key events.
 

--- a/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
+++ b/corehq/apps/analytics/management/commands/blocked_hubspot_users_summary.py
@@ -12,7 +12,7 @@ from corehq.apps.es import UserES
 
 class Command(BaseCommand):
     help = "Manually cleans up blocked Hubspot contacts"
-    api_key = None
+    access_token = None
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -31,10 +31,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        self.api_key = settings.ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
+        self.access_token = settings.ANALYTICS_IDS.get('HUBSPOT_ACCESS_TOKEN', None)
 
-        if not self.api_key:
-            self.stdout.write("No HubSpot API key found.")
+        if not self.access_token:
+            self.stdout.write("No HubSpot access token found.")
             return
 
         blocked_domains = get_blocked_hubspot_domains()

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -86,7 +86,7 @@ HUBSPOT_COOKIE = 'hubspotutk'
 HUBSPOT_THRESHOLD = 300
 
 
-HUBSPOT_ENABLED = settings.ANALYTICS_IDS.get('HUBSPOT_API_KEY', False)
+HUBSPOT_ENABLED = settings.ANALYTICS_IDS.get('HUBSPOT_ACCESS_TOKEN', False)
 KISSMETRICS_ENABLED = settings.ANALYTICS_IDS.get('KISSMETRICS_KEY', False)
 
 
@@ -173,24 +173,24 @@ def batch_track_on_hubspot(users_json):
 
 def _hubspot_post(url, data):
     """
-    Lightweight wrapper to add hubspot api key and post data if the HUBSPOT_API_KEY is defined
+    Lightweight wrapper to add hubspot api key and post data if the HUBSPOT_ACCESS_TOKEN is defined
     :param url: url to post to
     :param data: json data payload
     :return:
     """
-    api_key = settings.ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
-    if api_key:
+    access_token = settings.ANALYTICS_IDS.get('HUBSPOT_ACCESS_TOKEN', None)
+    if access_token:
         headers = {
-            'content-type': 'application/json'
+            'content-type': 'application/json',
+            'authorization': 'Bearer %s' % access_token
         }
-        params = {'hapikey': api_key}
-        response = _send_post_data(url, params, data, headers)
+        response = _send_post_data(url, data, headers)
         log_response('HS', data, response)
         response.raise_for_status()
 
 
-def _send_post_data(url, params, data, headers):
-    response = requests.post(url, params=params, data=data, headers=headers)
+def _send_post_data(url, data, headers):
+    response = requests.post(url, data=data, headers=headers)
     metrics_counter('commcare.hubspot.track_data_post', tags={'status_code': response.status_code})
     return response
 
@@ -206,14 +206,14 @@ def _get_user_hubspot_id(web_user, retry_num=0):
     if retry_num > 0:
         time.sleep(10)  # wait 10 seconds if this is another retry attempt
 
-    api_key = settings.ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
-    if api_key and hubspot_enabled_for_user(web_user):
+    access_token = settings.ANALYTICS_IDS.get('HUBSPOT_ACCESS_TOKEN', None)
+    if access_token and hubspot_enabled_for_user(web_user):
         try:
             req = requests.get(
                 "https://api.hubapi.com/contacts/v1/contact/email/{}/profile".format(
                     six.moves.urllib.parse.quote(web_user.username)
                 ),
-                params={'hapikey': api_key},
+                headers={'authorization': 'Bearer %s' % access_token},
             )
             if req.status_code == 404:
                 return None
@@ -232,7 +232,7 @@ def _get_user_hubspot_id(web_user, retry_num=0):
                 'commcare.hubspot.get_user_hubspot_id.success'
             )
             return req.json().get("vid", None)
-    elif api_key and retry_num == 0:
+    elif access_token and retry_num == 0:
         metrics_counter(
             'commcare.hubspot.get_user_hubspot_id.rejected'
         )

--- a/corehq/apps/analytics/utils/hubspot.py
+++ b/corehq/apps/analytics/utils/hubspot.py
@@ -121,13 +121,13 @@ def _delete_hubspot_contact(vid, retry_num=0):
     if retry_num > 0:
         time.sleep(10)  # wait 10 seconds if this is another retry attempt
 
-    api_key = settings.ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
-    if api_key:
+    access_token = settings.ANALYTICS_IDS.get('HUBSPOT_ACCESS_TOKEN', None)
+    if access_token:
         try:
             req = requests.delete(
                 f'https://api.hubapi.com/contacts/v1/contact/vid/{vid}',
-                params={
-                    'hapikey': api_key,
+                headers={
+                    'authorization': 'Bearer %s' % access_token,
                 }
             )
             if req.status_code == 404:
@@ -163,13 +163,15 @@ def _get_contacts_from_hubspot(list_of_emails, retry_num=0, record_metrics=True)
     if retry_num > 0:
         time.sleep(10)  # wait 10 seconds if this is another retry attempt
 
-    api_key = settings.ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
-    if api_key:
+    access_token = settings.ANALYTICS_IDS.get('HUBSPOT_ACCESS_TOKEN', None)
+    if access_token:
         try:
             req = requests.get(
                 "https://api.hubapi.com/contacts/v1/contact/emails/batch/",
+                headers={
+                    'authorization': 'Bearer %s' % access_token,
+                },
                 params={
-                    'hapikey': api_key,
                     'email': list_of_emails,
                 },
             )

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -114,7 +114,7 @@ def js_api_keys(request):
         # set to an empty string rather than delete. otherwise a strange race
         # happens in redis, throwing an error
         api_keys['ANALYTICS_IDS']['HUBSPOT_API_ID'] = ''
-        api_keys['ANALYTICS_IDS']['HUBSPOT_API_KEY'] = ''
+        api_keys['ANALYTICS_IDS']['HUBSPOT_ACCESS_TOKEN'] = ''
 
     return api_keys
 

--- a/corehq/util/tests/test_context_processors.py
+++ b/corehq/util/tests/test_context_processors.py
@@ -21,7 +21,7 @@ def _mock_is_hubspot_js_allowed_for_request(request):
 @override_settings(ANALYTICS_IDS={
     'GOOGLE_ANALYTICS_API_ID': 'UA-for-tests-only',
     'HUBSPOT_API_ID': 'test_api_id',
-    'HUBSPOT_API_KEY': 'test_api_key',
+    'HUBSPOT_ACCESS_TOKEN': 'test_api_key',
 })
 class TestJsApiKeys(SimpleTestCase):
 
@@ -50,8 +50,8 @@ class TestJsApiKeys(SimpleTestCase):
 
         blocked_js_keys = js_api_keys(blocked_request)
         self.assertEqual(blocked_js_keys['ANALYTICS_IDS'].get('HUBSPOT_API_ID'), '')
-        self.assertEqual(blocked_js_keys['ANALYTICS_IDS'].get('HUBSPOT_API_KEY'), '')
+        self.assertEqual(blocked_js_keys['ANALYTICS_IDS'].get('HUBSPOT_ACCESS_TOKEN'), '')
 
         normal_js_keys = js_api_keys(blocked_request)
         self.assertIsNotNone(normal_js_keys['ANALYTICS_IDS'].get('HUBSPOT_API_ID'))
-        self.assertIsNotNone(normal_js_keys['ANALYTICS_IDS'].get('HUBSPOT_API_KEY'))
+        self.assertIsNotNone(normal_js_keys['ANALYTICS_IDS'].get('HUBSPOT_ACCESS_TOKEN'))

--- a/settings.py
+++ b/settings.py
@@ -777,7 +777,7 @@ AUDIT_ADMIN_VIEWS = False
 ANALYTICS_IDS = {
     'GOOGLE_ANALYTICS_API_ID': '',
     'KISSMETRICS_KEY': '',
-    'HUBSPOT_API_KEY': '',
+    'HUBSPOT_ACCESS_TOKEN': '',
     'HUBSPOT_API_ID': '',
     'GTM_ID': '',
     'DRIFT_ID': '',


### PR DESCRIPTION
HubSpot is deprecating the global API key in favor of tokens with
granular permissions, which they call 'Private Apps'.

Update the code with the new authorization model, and change the
variable name accordingly.

## Technical Summary

https://dimagi-dev.atlassian.net/browse/SAAS-14435

## Safety Assurance

### Safety story

The change has been tested on staging and appears to be working as expected.

### Automated test coverage

The current tests have not been impacted by this change, which is limited to the authentication aspect of the requests to HubSpot, and they remain sufficient.

### QA Plan

No QA seems necessary for this change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
