### PR TITLE
Add github action to verify docs build has no warnings/errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,6 +75,7 @@
 /package.json @dimagi/dependency-watchers
 
 /scripts/docker @millerdev @joxl
+/scripts/test-make-docs.sh @dimagi/dependency-watchers
 /scripts/vellum-to-hq @millerdev
 
 /requirements/ @dimagi/dependency-watchers

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - uses: actions/setup-python@v3
         with:
           python-version: '3.9'

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,0 +1,25 @@
+name: Test commcare-hq docs
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install docs requirements
+        run: pip install -r requirements/docs-requirements.txt
+      - name: Test docs build
+        run: bash ./scripts/test-make-docs.sh
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: make-docs-artifacts
+          path: artifacts
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,10 +1,10 @@
-name: Test commcare-hq docs
+name: commcare-hq docs
 on:
   pull_request:
     branches:
       - master
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/scripts/test-make-docs.sh
+++ b/scripts/test-make-docs.sh
@@ -21,6 +21,7 @@
 WHITELIST_PATTERNS=(
     '^\s*$'  # ignore lines containing only whitespace
     'logger is being changed to' # ignore error when FIX_LOGGER_ERROR_OBFUSCATION is true
+    'yacc table file version is out of date' # warning whenever building docs on a freshly created virtual environment
     # Only whitelist docs build warnings/errors when absolutely necessary
 )
 

--- a/scripts/test-make-docs.sh
+++ b/scripts/test-make-docs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# If the "Test commcare-hq docs" github action is failing, you're in the right
+# place.
+#
+# You have two options:
+#
+# Download the log file that triggered the failure from the
+# github actions artifacts to view newly introduced warnings/errors.
+# --- OR ---
+# Build docs locally to see what warnings/errors
+# you have introduced with your changes. To do so, follow these instructions:
+#
+# 1) Install requirements/docs-requirements.txt ideally using pip-sync:
+#   `pip-sync requirements/docs-requirements.txt`
+# 2) Using bash, run this script:
+#    `bash test-make-docs.sh`
+# 3) Inspect the make-docs-errors.log to understand new warnings/errors:
+#    `cat ./artifacts/make-docs-errors.log`
+
+WHITELIST_PATTERNS=(
+    '^\s*$'  # ignore lines containing only whitespace
+    'logger is being changed to' # ignore error when FIX_LOGGER_ERROR_OBFUSCATION is true
+    # Only whitelist docs build warnings/errors when absolutely necessary
+)
+
+function main {
+    # printf '%s|' - append a pipe character (|) to each commandline arg and write it to STDOUT
+    # "${WHITELIST_PATTERNS[@]}" - expand the contents of Bash Array WHITELIST_PATTERNS as individual args
+    # sed -E 's/\|$//' - remove a single trailing pipe character (|) from any lines on STDIN
+    local whitelist=$(printf '%s|' "${WHITELIST_PATTERNS[@]}" | sed -E 's/\|$//')
+
+    mkdir -p ./artifacts
+
+    # make docs 2>&1 1>/dev/null - redirect STDERR to STDOUT, and then STDOUT to /dev/null
+    # grep -Ev "(${whitelist})" - only match lines that do not match regex patterns of whitelisted items
+    make docs 2>&1 1>/dev/null | grep -Ev "(${whitelist})" | tee ./artifacts/make-docs-errors.log
+
+    cp -r ./docs/_build/html ./artifacts/
+
+    # fail if error log file is not empty
+    if [ -s "./artifacts/make-docs-errors.log" ]; then
+        return 1
+    fi
+}
+
+main "$@"

--- a/scripts/test-make-docs.sh
+++ b/scripts/test-make-docs.sh
@@ -5,18 +5,20 @@
 #
 # You have two options:
 #
-# Download the log file that triggered the failure from the
+# Download the make-docs-errors.log file that triggered the failure from the
 # github actions artifacts to view newly introduced warnings/errors.
 # --- OR ---
-# Build docs locally to see what warnings/errors
-# you have introduced with your changes. To do so, follow these instructions:
+# Build docs locally on your branch to see what warnings/errors
+# you have introduced. To do so, follow these instructions:
 #
 # 1) Install requirements/docs-requirements.txt ideally using pip-sync:
 #   `pip-sync requirements/docs-requirements.txt`
-# 2) Using bash, run this script:
+# 2) Ensure a fresh docs build by deleting any previously generated build
+#    `rm -rf docs/_build`
+# 3) Using bash, run this script:
 #    `bash test-make-docs.sh`
-# 3) Inspect the make-docs-errors.log to understand new warnings/errors:
-#    `cat ./artifacts/make-docs-errors.log`
+# 4) Inspect the terminal output or make-docs-errors.log (they are the same) to understand new warnings/errors:
+#    `cat make-docs-errors.log`
 
 WHITELIST_PATTERNS=(
     '^\s*$'  # ignore lines containing only whitespace


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup to https://github.com/dimagi/commcare-hq/pull/32668

Now that the sphinx build does not contain any warnings or errors, it would be nice to have a github action check that ensures no new warnings/errors are introduced without us being aware. This means if a PR contains changes to docs that introduce warnings/errors, the PR will not pass all checks and need revising.

I also added @dimagi/dependency-watchers as codeowners of the `test-make-docs.sh` script to ensure warnings/errors are not being whitelisted that should instead be addressed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is completely separate from existing code, in that this github action runs in its own sandbox and uses a newly introduced script to test docs. We will be able to see this github action in action on this PR.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests. Just a bash script and github action.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
