### PR TITLE
Add management command to fix broken app docs

### DIFF
--- a/corehq/apps/app_manager/management/commands/fix_unwrappable_apps.py
+++ b/corehq/apps/app_manager/management/commands/fix_unwrappable_apps.py
@@ -1,0 +1,45 @@
+from corehq.apps.app_manager.dbaccessors import wrap_app
+from corehq.apps.app_manager.management.commands.helpers import (
+    AppMigrationCommandBase,
+    get_all_app_ids,
+    get_deleted_app_ids,
+)
+
+
+class Command(AppMigrationCommandBase):
+    help = """
+    Short-lived command from 2023-03-02 to fix unwrappable apps caused by
+    removing an overridden wrap method before it had been applied. The scope is
+    believed to be small, so this approach is preferable to re-migrating
+    everything.
+    https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/125/SUPPORT-16128
+    https://dimagi-dev.atlassian.net/browse/SUPPORT-16045
+    """
+    chunk_size = 5
+    DOMAIN_LIST_FILENAME = 'fix_unwrappable_apps-domains.txt'
+    DOMAIN_PROGRESS_NUMBER_FILENAME = 'fix_unwrappable_apps-progress.txt'
+
+    def migrate_app(self, app_doc):
+        changed = False
+        for i, module in enumerate(app_doc['modules']):
+            for prop in module['search_config']['properties']:
+                required = prop.get('required')
+                if required and isinstance(required, str):
+                    prop['required'] = {'test': required}
+                    changed = True
+
+                old_validations = prop.pop('validation', None)  # it was changed to plural
+                if old_validations:
+                    prop['validations'] = [{
+                        'test': old['xpath'],
+                        'text': old['message'],
+                    } for old in old_validations if old.get('xpath')]
+                    changed = True
+
+        wrap_app(app_doc)  # this will be logged if it raises an exception
+
+        if changed:
+            return app_doc
+
+    def get_app_ids(self, domain=None):
+        return list(get_deleted_app_ids(domain)) + list(get_all_app_ids())


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SUPPORT-16128
This is a management command based on [Addison's gist](https://gist.github.com/AddisonDunn/b150862a5b33b69113684daeaf2371a6#file-fix_unwrappable_apps_16045-py-L16-L17) to fix applications which weren't fully migrated before a `wrap` method was removed.  I figured I'd do it this way and merge it in to master in case anything pops up in the future, it'd be a simple command to run.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
We've used the various pieces of this command many times in the past - this just strings those together.  I can also do a dry run which will confirm whether the change does actually resolve the issue.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
