### PR TITLE
Minor requirements updates

### DIFF
--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -10,6 +10,7 @@ gnureadline
 git-build-branch
 
 # documentation
+myst-parser
 Sphinx
 sphinx-rtd-theme
 docutils

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -1,22 +1,22 @@
 -r test-requirements.in
 
-fixture
-sniffer
-psutil>5.1.3  # for memory profiling
 django-extensions
-ipython  # for nicer django shell experience
-wheel
-gnureadline
+fixture
 git-build-branch
+gnureadline
+ipython  # for nicer django shell experience
+psutil>5.1.3  # for memory profiling
+sniffer
+wheel
 
 # documentation
+docutils
 myst-parser
 Sphinx
 sphinx-rtd-theme
-docutils
 sphinxcontrib-django
 
 # linting/formatting
 flake8
-yapf
 isort
+yapf

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -1,4 +1,5 @@
 -r test-requirements.in
+-r docs-requirements.in
 
 django-extensions
 fixture
@@ -8,13 +9,6 @@ ipython  # for nicer django shell experience
 psutil>5.1.3  # for memory profiling
 sniffer
 wheel
-
-# documentation
-docutils
-myst-parser
-Sphinx
-sphinx-rtd-theme
-sphinxcontrib-django
 
 # linting/formatting
 flake8

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -201,6 +201,7 @@ djangorestframework==3.13.1
 docutils==0.18.1
     # via
     #   -r dev-requirements.in
+    #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
 dropbox==11.36.0
@@ -300,6 +301,7 @@ jedi==0.18.1
 jinja2==3.1.2
     # via
     #   -r base-requirements.in
+    #   myst-parser
     #   sphinx
 jmespath==0.10.0
     # via
@@ -346,6 +348,10 @@ mando==0.6.4
     # via radon
 markdown==3.4.1
     # via -r base-requirements.in
+markdown-it-py==2.2.0
+    # via
+    #   mdit-py-plugins
+    #   myst-parser
 markupsafe==2.1.2
     # via
     #   jinja2
@@ -355,6 +361,12 @@ matplotlib-inline==0.1.3
     # via ipython
 mccabe==0.6.1
     # via flake8
+mdit-py-plugins==0.3.5
+    # via myst-parser
+mdurl==0.1.2
+    # via markdown-it-py
+myst-parser==0.19.1
+    # via -r dev-requirements.in
 nose==1.3.7
     # via
     #   -r test-requirements.in
@@ -498,6 +510,7 @@ pyyaml==6.0
     # via
     #   -r base-requirements.in
     #   git-build-branch
+    #   myst-parser
 pyzxcvbn==0.8.0
     # via -r base-requirements.in
 qrcode==7.4.2
@@ -607,6 +620,7 @@ soupsieve==2.0.1
 sphinx==5.3.0
     # via
     #   -r dev-requirements.in
+    #   myst-parser
     #   sphinx-rtd-theme
 sphinx-rtd-theme==1.2.0
     # via -r dev-requirements.in

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -155,7 +155,9 @@ django-crispy-forms==1.10.0
 django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3
-    # via -r dev-requirements.in
+    # via
+    #   -r dev-requirements.in
+    #   -r docs-requirements.in
 django-field-audit==1.2.4
     # via -r base-requirements.in
 django-formtools==2.3
@@ -200,7 +202,6 @@ djangorestframework==3.13.1
     # via -r base-requirements.in
 docutils==0.18.1
     # via
-    #   -r dev-requirements.in
     #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
@@ -366,7 +367,7 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 myst-parser==0.19.1
-    # via -r dev-requirements.in
+    # via -r docs-requirements.in
 nose==1.3.7
     # via
     #   -r test-requirements.in
@@ -619,17 +620,17 @@ soupsieve==2.0.1
     # via beautifulsoup4
 sphinx==5.3.0
     # via
-    #   -r dev-requirements.in
+    #   -r docs-requirements.in
     #   myst-parser
     #   sphinx-rtd-theme
 sphinx-rtd-theme==1.2.0
-    # via -r dev-requirements.in
+    # via -r docs-requirements.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-django==0.5.1
-    # via -r dev-requirements.in
+    # via -r docs-requirements.in
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
 sphinxcontrib-jquery==2.0.0

--- a/requirements/docs-requirements.in
+++ b/requirements/docs-requirements.in
@@ -1,7 +1,6 @@
 -r base-requirements.in
 
 django-extensions
-docutils
 myst-parser
 Sphinx
 sphinxcontrib-django

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -178,7 +178,6 @@ djangorestframework==3.13.1
     # via -r base-requirements.in
 docutils==0.18.1
     # via
-    #   -r docs-requirements.in
     #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Commits are sorted in order of my confidence that they should be merged, from most to least.

#### More confident commits

I noticed that I couldn't build documentation with dev-requirements, which was annoying and due to the lack of myst-parser. I resolved this in 9125f8298d9aee2dcf84f2b14b2ba781ca4bf5be.

I then just sorted requirements in dev-requirements alphabetically in 7a5c33650878bdb135bc994eb4ffd49e6cd0437a. 

#### Less confident commits

From there, I was eyeing the `docutils` dependency wondering if we actually need to explicitly include that for docs builds. As far as I could tell, we didn't directly reference it anywhere, but am unsure if I'm missing something? Anyway I removed the explicit dependency in 357aa3ca67fad06a240d1f8311e3558f4182a16e

After that, I was trying to grapple with why we specify doc requirements in dev-requirements.in, rather than including them from the actual docs-requirements.in file. I didn't have a good answer, so I made that change in 6ca95b2ae0972f05c6fad4f4c4dd85f8c77f4577.

That's my thought process in a nutshell. The docs build continued to work as I made these changes, so seems safe.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
At most, only impacting docs and dev requirements. Adding to that that we have a workflow check to ensure the docs build succeeds, this seems like a very safe change.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
