### PR TITLE
[USH-2911] download reports permission fix

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -262,6 +262,9 @@ class HqPermissions(DocumentSchema):
         if self.edit_apps:
             self.view_apps = True
 
+        if not (self.view_reports or self.view_report_list):
+            self.download_reports = False
+
     @classmethod
     @memoized
     def permission_names(cls):

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -11,11 +11,11 @@ class UserRolePresets:
     ATTENDANCE_COORDINATOR = "Attendance Coordinator"
 
     INITIAL_ROLES = {
-        READ_ONLY: lambda: HqPermissions(view_reports=True, download_report=True),
+        READ_ONLY: lambda: HqPermissions(view_reports=True, download_reports=True),
         APP_EDITOR: lambda: HqPermissions(edit_apps=True,
                                           view_apps=True,
                                           view_reports=True,
-                                          download_report=True),
+                                          download_reports=True),
         FIELD_IMPLEMENTER: lambda: HqPermissions(edit_commcare_users=True,
                                                  view_commcare_users=True,
                                                  edit_groups=True,
@@ -24,7 +24,7 @@ class UserRolePresets:
                                                  view_locations=True,
                                                  edit_shared_exports=True,
                                                  view_reports=True,
-                                                 download_report=True),
+                                                 download_reports=True),
         BILLING_ADMIN: lambda: HqPermissions(edit_billing=True),
         MOBILE_WORKER: lambda: HqPermissions(access_mobile_endpoints=True,
                                              report_an_issue=True,

--- a/corehq/apps/users/role_utils.py
+++ b/corehq/apps/users/role_utils.py
@@ -11,8 +11,11 @@ class UserRolePresets:
     ATTENDANCE_COORDINATOR = "Attendance Coordinator"
 
     INITIAL_ROLES = {
-        READ_ONLY: lambda: HqPermissions(view_reports=True),
-        APP_EDITOR: lambda: HqPermissions(edit_apps=True, view_apps=True, view_reports=True),
+        READ_ONLY: lambda: HqPermissions(view_reports=True, download_report=True),
+        APP_EDITOR: lambda: HqPermissions(edit_apps=True,
+                                          view_apps=True,
+                                          view_reports=True,
+                                          download_report=True),
         FIELD_IMPLEMENTER: lambda: HqPermissions(edit_commcare_users=True,
                                                  view_commcare_users=True,
                                                  edit_groups=True,
@@ -20,7 +23,8 @@ class UserRolePresets:
                                                  edit_locations=True,
                                                  view_locations=True,
                                                  edit_shared_exports=True,
-                                                 view_reports=True),
+                                                 view_reports=True,
+                                                 download_report=True),
         BILLING_ADMIN: lambda: HqPermissions(edit_billing=True),
         MOBILE_WORKER: lambda: HqPermissions(access_mobile_endpoints=True,
                                              report_an_issue=True,

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -434,23 +434,42 @@ hqDefine('users/js/roles',[
                         checkboxPermission: self.permissions.edit_reports,
                         checkboxText: gettext("Allow role to create and edit reports in report builder."),
                     },
-                    {
-                        visibilityRestraint: true,
-                        text: hasEmbeddedTableau ? gettext("Access All CommCare Reports") : gettext("Access All Reports"),
-                        checkboxLabel: "access-all-reports-checkbox",
-                        checkboxPermission: self.reportPermissions.all,
-                        checkboxText: hasEmbeddedTableau
-                            ? gettext("Allow role to view all CommCare reports. Excludes embedded Tableau reports")
-                            : gettext("Allow role to access all reports."),
-                    },
-                    {
-                        visibilityRestraint: self.canSeeAnyReports,
-                        text: gettext("Download and Email Reports"),
-                        checkboxLabel: "download-and-email-reports-checkbox",
-                        checkboxPermission: self.permissions.download_reports,
-                        checkboxText: gettext("Allow role to download and email report data."),
-                    },
-                ];
+                ]
+                if (toggles.toggleEnabled('USER_CONFIGURABLE_REPORTS')) {
+                    if (toggles.toggleEnabled('UCR_UPDATED_NAMING')) {
+                        self.reports.push({
+                            visibilityRestraint: self.permissions.access_all_locations,
+                            text: gettext("Create and Edit Custom Web Reports"),
+                            checkboxLabel: "create-and-edit-configurable-reports-checkbox",
+                            checkboxPermission: self.permissions.edit_ucrs,
+                            checkboxText: gettext("Allow role to create and edit custom web reports."),
+                        });
+                    } else {
+                        self.reports.push({
+                            visibilityRestraint: self.permissions.access_all_locations,
+                            text: gettext("Create and Edit Configurable Reports"),
+                            checkboxLabel: "create-and-edit-configurable-reports-checkbox",
+                            checkboxPermission: self.permissions.edit_ucrs,
+                            checkboxText: gettext("Allow role to create and edit configurable reports."),
+                        });
+                    }
+                }
+                self.reports.push({
+                    visibilityRestraint: true,
+                    text: hasEmbeddedTableau ? gettext("Access All CommCare Reports") : gettext("Access All Reports"),
+                    checkboxLabel: "access-all-reports-checkbox",
+                    checkboxPermission: self.reportPermissions.all,
+                    checkboxText: hasEmbeddedTableau
+                        ? gettext("Allow role to view all CommCare reports. Excludes embedded Tableau reports")
+                        : gettext("Allow role to access all reports."),
+                });
+                self.reports.push({
+                    visibilityRestraint: self.canSeeAnyReports,
+                    text: gettext("Download and Email Reports"),
+                    checkboxLabel: "download-and-email-reports-checkbox",
+                    checkboxPermission: self.permissions.download_reports,
+                    checkboxText: gettext("Allow role to download and email report data."),
+                });
                 if (toggles.toggleEnabled('EMBEDDED_TABLEAU')) {
                     self.reports.push({
                         visibilityRestraint: true,
@@ -459,23 +478,6 @@ hqDefine('users/js/roles',[
                         checkboxPermission: self.tableauPermissions.all,
                         checkboxText: gettext("Allow role to access all embedded Tableau reports."),
                     });
-                }
-                if (toggles.toggleEnabled('UCR_UPDATED_NAMING')) {
-                    self.ucrs = [{
-                        visibilityRestraint: self.permissions.access_all_locations,
-                        text: gettext("Create and Edit Custom Web Reports"),
-                        checkboxLabel: "create-and-edit-configurable-reports-checkbox",
-                        checkboxPermission: self.permissions.edit_ucrs,
-                        checkboxText: gettext("Allow role to create and edit custom web reports."),
-                    }];
-                } else {
-                    self.ucrs = [{
-                        visibilityRestraint: self.permissions.access_all_locations,
-                        text: gettext("Create and Edit Configurable Reports"),
-                        checkboxLabel: "create-and-edit-configurable-reports-checkbox",
-                        checkboxPermission: self.permissions.edit_ucrs,
-                        checkboxText: gettext("Allow role to create and edit configurable reports."),
-                    }];
                 }
                 self.registryPermissions = [
                     selectPermissionModel(

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -522,11 +522,6 @@ hqDefine('users/js/roles',[
                 data.permissions.view_tableau = data.tableauPermissions.all;
                 data.permissions.view_tableau_list = unwrapItemList(data.tableauPermissions.specific);
 
-                // Set download_reports to true only if the user can see reports
-                data.permissions.download_reports = data.permissions.download_reports && (
-                    data.permissions.view_reports || data.permissions.view_report_list.length !== 0
-                );
-
                 data.permissions.manage_data_registry = data.manageRegistryPermission.all;
                 data.permissions.manage_data_registry_list = unwrapItemList(data.manageRegistryPermission.specific);
 

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -96,7 +96,6 @@ hqDefine('users/js/roles',[
                         };
                     }),
                 };
-                data.permissions.download_reports = true;  // the user must explicitly disable this when visible
 
                 data.tableauPermissions = {
                     all: data.permissions.view_tableau,

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -443,6 +443,13 @@ hqDefine('users/js/roles',[
                             ? gettext("Allow role to view all CommCare reports. Excludes embedded Tableau reports")
                             : gettext("Allow role to access all reports."),
                     },
+                    {
+                        visibilityRestraint: self.canSeeAnyReports,
+                        text: gettext("Download and Email Reports"),
+                        checkboxLabel: "download-and-email-reports-checkbox",
+                        checkboxPermission: self.permissions.download_reports,
+                        checkboxText: gettext("Allow role to download and email report data."),
+                    },
                 ];
                 if (toggles.toggleEnabled('EMBEDDED_TABLEAU')) {
                     self.reports.push({

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -168,22 +168,6 @@
               </div>
             </div>
 
-              <div class="form-group" data-bind="visible: canSeeAnyReports">
-              <label class="col-sm-4 control-label">
-                {% trans "Download and Email Reports" %}
-              </label>
-              <div class="col-sm-8 controls">
-                <div class="form-check">
-                  <input type="checkbox"
-                    id="download-and-email-reports-checkbox"
-                    data-bind="checked: permissions.download_reports, disable: !$root.allowEdit" />
-                  <label for="download-and-email-reports-checkbox">
-                    {% trans "Allow role to download and email report data." %}
-                  </label>
-                </div>
-              </div>
-            </div>
-
             {% if request|toggle_enabled:"EMBEDDED_TABLEAU" %}
               <div class="form-group" data-bind="visible: !tableauPermissions.all()">
                 <label class="col-sm-4 control-label">

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -129,21 +129,6 @@
                 </div>
               </div>
             </div>
-            {% if request|toggle_enabled:"USER_CONFIGURABLE_REPORTS" %}
-            <div data-bind="foreach: ucrs">
-              <div class="form-group" data-bind="visible: visibilityRestraint">
-                <label class="col-sm-4 control-label" data-bind="text: text"></label>
-                <div class="col-sm-8 controls">
-                  <div class="form-check">
-                    <input type="checkbox"
-                           data-bind="attr:{id: checkboxLabel}, checked: checkboxPermission, disable: !$root.allowEdit" />
-                    <label data-bind="attr:{for: checkboxLabel}, text: checkboxText">
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </div>
-            {% endif %}
             <div class="form-group" data-bind="visible: !reportPermissions.all()">
               <label class="col-sm-4 control-label">
                 {% trans "Access Specific Reports" %}

--- a/corehq/apps/users/tests/test_models_role.py
+++ b/corehq/apps/users/tests/test_models_role.py
@@ -43,7 +43,7 @@ class CaseWithDomainAndRole(BaseEventSetupCase):
         super().setUpClass()
         cls.domain_name = "pets"
         cls.role_name = "test-role"
-        cls.domain = Domain(name=cls.domain_name)
+        cls.domain = Domain.get_or_create_with_name(name=cls.domain_name, is_active=True)
         cls.domain.save()
         cls.addClassCleanup(cls.domain.delete)
 

--- a/corehq/apps/users/tests/test_models_role.py
+++ b/corehq/apps/users/tests/test_models_role.py
@@ -340,3 +340,29 @@ class HqPermissionsTest(SimpleTestCase):
         self.hq_permissions.normalize()
         for view_permission_name in edit_view_permission_dict.values():
             self.assertTrue(getattr(self.hq_permissions, view_permission_name))
+
+    def test_download_reports_removed_when_view_reports_false(self):
+        self.hq_permissions.view_reports = False
+        self._check_normalized_permission("download_reports", expect_changed=True)
+
+    def test_download_reports_not_removed_when_view_reports_true(self):
+        self.hq_permissions.view_reports = True
+        self._check_normalized_permission("download_reports", expect_changed=False)
+
+    def test_download_reports_not_removed_when_view_reports_list(self):
+        self.hq_permissions.view_reports = False
+        self.hq_permissions.view_report_list = ["a"]
+        self._check_normalized_permission("download_reports", expect_changed=False)
+
+    def _check_normalized_permission(self, permission, initial_value=True, expect_changed=True):
+        setattr(self.hq_permissions, permission, initial_value)
+        self.hq_permissions.normalize()
+        if expect_changed:
+            self.assertNotEqual(getattr(self.hq_permissions, permission), initial_value)
+        else:
+            self.assertEqual(getattr(self.hq_permissions, permission), initial_value)
+
+        # Test that the inverse value isn't affected
+        setattr(self.hq_permissions, permission, not initial_value)
+        self.hq_permissions.normalize()
+        self.assertEqual(getattr(self.hq_permissions, permission), not initial_value)


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-2911

## Product Description
Other than fixing the bug described in the ticket this also changes the order of report permissions slightly by moving the 'Create and Edit Configurable Reports' permission above the 'Access All Reports' permission:

#### Before
![image](https://user-images.githubusercontent.com/249606/222735989-3559356e-33dc-4fda-a9ad-44e3e96125b8.png)

#### After
![image](https://user-images.githubusercontent.com/249606/222735806-e263475d-fd7b-454a-9647-c90088279330.png)


## Technical Summary
Fixes a bug were the checkbox for 'Download Reports' was always true regardless of the backend value.

This also updates preset roles to have the 'Download Reports' permission enabled if the role also has 'View Reports'. This won't be applied to existing roles.

Easiest review by commit.

## Safety Assurance

### Safety story
Mostly refactoring or straight forward changes. I have confirmed that the permission
is saved and loaded correctly and correctly displayed on the UI.

### Automated test coverage
Test added for the permission normalization change.

### QA Plan
I feel that my local QA has been sufficient.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
