### PR TITLE
Bump sphinx from 5.3.0 to 6.1.3

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -618,7 +618,7 @@ sortedcontainers==2.3.0
     # via intervaltree
 soupsieve==2.0.1
     # via beautifulsoup4
-sphinx==5.3.0
+sphinx==6.1.3
     # via
     #   -r docs-requirements.in
     #   myst-parser

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -494,7 +494,7 @@ socketpool==0.5.3
     # via -r base-requirements.in
 sortedcontainers==2.3.0
     # via intervaltree
-sphinx==5.3.0
+sphinx==6.1.3
     # via
     #   -r docs-requirements.in
     #   myst-parser


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup to https://github.com/dimagi/commcare-hq/pull/32694.

Looking at [the changelog](https://www.sphinx-doc.org/en/master/changes.html), there is an incompatible change related to jquery in themes/extensions, but our theme lib sphinx-rtd-theme version 1.2.0 claims to [support sphinx 6](https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html#dependency-changes), so this should not be an issue. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only impacts docs build.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
