### PR TITLE
Fully removed the toggles dependency to fix an import bug

### DIFF
--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -12,7 +12,6 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
     _,
     assertProperties,
     initialPageData,
-    toggles,
     uiElementKeyValueList
 ) {
     function Choice(choice) {


### PR DESCRIPTION
## Technical Summary
Fixes a bug introduced by https://github.com/dimagi/commcare-hq/pull/32647, where the toggles dependency was only partially removed. This caused dependencies listed after toggles (`uiElementKeyValueList`) to reference the wrong module.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Local testing to verify that this fixed the javascript issue.

### Automated test coverage

No Automated tests

### QA Plan

No QA required.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
