### PR TITLE
Remove advanced query search function

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -314,7 +314,7 @@ class ESQuery(object):
     def get_query(self):
         return self.es_query['query']['bool']['must']
 
-    def search_string_query(self, search_string, default_fields=None):
+    def search_string_query(self, search_string, default_fields):
         """Accepts a user-defined search string"""
         return self.set_query(
             queries.search_string_query(search_string, default_fields)

--- a/corehq/apps/es/tests/test_queries.py
+++ b/corehq/apps/es/tests/test_queries.py
@@ -24,19 +24,19 @@ class TestQueries(TestCase):
         self.assertHasQuery(query, {"fancy_query": {"foo": "bar"}})
 
     def test_null_query_string_queries(self):
-        query = HQESQuery('forms').search_string_query("")
+        query = HQESQuery('forms').search_string_query("", ["name"])
         self.assertHasQuery(query, {"match_all": {}})
 
-        query = HQESQuery('forms').search_string_query(None)
+        query = HQESQuery('forms').search_string_query(None, ["name"])
         self.assertHasQuery(query, {"match_all": {}})
 
     def test_basic_query_string_query(self):
-        query = HQESQuery('forms').search_string_query("foo")
+        query = HQESQuery('forms').search_string_query("foo", ["name"])
         self.assertHasQuery(query, {
             "query_string": {
                 "query": "*foo*",
                 "default_operator": "AND",
-                "fields": None,
+                "fields": ["name"],
             }
         })
 
@@ -52,14 +52,15 @@ class TestQueries(TestCase):
         })
 
     def test_complex_query_with_fields(self):
+        # complex queries should be flattened to individual search terms to avoid potential ES injection
         default_fields = ['name', 'type', 'date']
         query = (HQESQuery('forms')
                  .search_string_query("name: foo", default_fields))
         self.assertHasQuery(query, {
-            "simple_query_string": {
-                "query": "name: foo",
+            "query_string": {
+                "query": "*name* *foo*",
                 "default_operator": "AND",
-                "fields": None,
+                "fields": ['name', 'type', 'date'],
             }
         })
 

--- a/corehq/apps/toggle_ui/utils.py
+++ b/corehq/apps/toggle_ui/utils.py
@@ -21,4 +21,5 @@ def get_subscription_info(domain):
 
 @quickcache(['domain'], timeout=60 * 10)
 def has_dimagi_user(domain):
-    return UserES().web_users().domain(domain).search_string_query('@dimagi.com').count()
+    search_fields = ["base_username", "username"]
+    return UserES().web_users().domain(domain).search_string_query('@dimagi.com', search_fields).count()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Removes advanced [query search](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-simple-query-string-query.html) function for primarily the search bar in the Mobile Workers page but also for a bunch of places that wasn't really meant to have that capability in the first place (mobile worker search in the web app, searching for specific app builds in app builder, web user search, drop down menus for some reports, etc.). 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13977)

This PR removes advanced query syntax for a few different places (around 14) since it looks like some of them weren't intended to support it in the first place and also mostly because it was vulnerable to injections when using advanced syntax (the query was being set equal to the unsanitized user input as long as it had a "special character"). The advanced search was also using the ` _all` field, with one of fields being the password (hash) field and while an exploit hasn't been found this is a safety measure to make it inaccessible just in case there is one. 

I've gone through and identified all places that reference `simple_string_query` and found that none are reliant on having this advanced syntax be available (many of them are just some iteration of mobile worker search), nor did any of them require the default fields to be `None` (which becomes the `_all` field), except for one instance where it was explicitly searching for dimagi emails, which I've changed to just search against `username` and `base_username` fields. This was also the only instance where the query string passed wasn't user input. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Not only specific to this feature flag but it does touch on FF related to EMWF.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging. Existing data isn't impacted since this changes only relates to how ES search queries operate. Additionally, the change shouldn't break anything because most of these places weren't really supposed to have advanced syntax available anyway. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Modified existing tests to reflect changes. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Would this need QA?

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
