### PR TITLE
Automate removing branches from staging.yml

### DIFF
--- a/.github/workflows/remove-branch-from-staging.yml
+++ b/.github/workflows/remove-branch-from-staging.yml
@@ -1,0 +1,20 @@
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  update-staging-yml:
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install dev requirements
+        run: pip install -r requirements/dev-requirements.txt
+      - name: Update staging.yml
+        run: bash scripts/remove-branch-from-staging.sh ${{ github.event.pull_request.head }}

--- a/scripts/remove-branch-from-staging.sh
+++ b/scripts/remove-branch-from-staging.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+# sed -i '' "/ $1 /d" scripts/staging.yml
+# git add scripts/staging.yml
+# git commit -m "Removed $1 from staging.yml"
+# git push origin master
+
+# NOTE: start with testing to ensure expected diffs
+sed "/ $1 /d" scripts/staging.yml > scripts/test-staging.yml
+diff scripts/staging.yml scripts/test-staging.yml


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Whenever a PR is merged and the branch is deleted, if the branch is not also removed from `scripts/staging.yml` file it results in an error that we need to manually resolve when rebuilding staging.

We should be able to rely on a github action to run whenever a PR is merged that will remove the branch from `scripts/staging.yml` if applicable, and don't need to worry about if the branch is deleted or not.

The one unknown I still have is if the github action will have write permission to this repository, especially directly on master. Seems like a big risk to allow that.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
