### PR TITLE
Add options and logging to audit_case_search_config

### DIFF
--- a/corehq/apps/app_manager/management/commands/audit_case_search_config.py
+++ b/corehq/apps/app_manager/management/commands/audit_case_search_config.py
@@ -68,8 +68,8 @@ class Command(BaseCommand):
                                                         module.get("unique_id"),
                                                         attr))
 
-        result_domains = {b.domain for b in results}
-        result_apps = {b.app_id for b in results}
+        result_domains = {r.domain for r in results}
+        result_apps = {r.app_id for r in results}
         summary = (f"\n{datetime.now()}\n"
                    f"Found {len(results)} '{attr}' properties"
                    f" in {len(result_apps)} apps"

--- a/corehq/apps/app_manager/management/commands/audit_case_search_config.py
+++ b/corehq/apps/app_manager/management/commands/audit_case_search_config.py
@@ -27,9 +27,15 @@ class Command(BaseCommand):
             action='store',
             help='Audit a single domain',
         )
+        parser.add_argument(
+            'attr',
+            type=str,
+            help='Which config option or attribute to find',
+        )
 
     def handle(self, **options):
         include_builds = options['include_builds']
+        attr = options['attr']
         if options['domain']:
             domains = [options['domain']]
         else:
@@ -43,7 +49,7 @@ class Command(BaseCommand):
                 for index, module in enumerate(doc.get("modules", [])):
                     if module.get("search_config", {}):
                         for prop in module.get("search_config", {}).get("properties", []):
-                            if prop.get("allow_blank_value", False):
+                            if prop.get(attr, False):
                                 results.append(PropertyInfo(domain,
                                                             doc.get("copy_of") or app_id,
                                                             doc.get("version"),
@@ -52,6 +58,9 @@ class Command(BaseCommand):
 
         result_domains = {b.domain for b in results}
         result_apps = {b.app_id for b in results}
-        print(f"Found {len(results)} properties in {len(result_apps)} apps in {len(result_domains)} domains")
+        print(f"Found {len(results)} {attr} properties"
+              f" in {len(result_apps)} apps"
+              f" in {len(result_domains)} domains\n")
+
         for result in results:
             print(result)

--- a/corehq/apps/app_manager/management/commands/audit_case_search_config.py
+++ b/corehq/apps/app_manager/management/commands/audit_case_search_config.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from datetime import datetime
 
 from django.core.management.base import BaseCommand
 
@@ -6,6 +7,8 @@ from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.management.commands.helpers import get_all_app_ids
 from corehq.toggles import SYNC_SEARCH_CASE_CLAIM
 from corehq.util.log import with_progress_bar
+
+CASE_SEARCH_AUDIT_LOG = "case_search_audit_log.txt"
 
 PropertyInfo = namedtuple("PropertyInfo", "domain app_id version module_unique_id name")
 
@@ -58,9 +61,18 @@ class Command(BaseCommand):
 
         result_domains = {b.domain for b in results}
         result_apps = {b.app_id for b in results}
-        print(f"Found {len(results)} {attr} properties"
-              f" in {len(result_apps)} apps"
-              f" in {len(result_domains)} domains\n")
+        summary = (f"\n{datetime.now()}\n"
+                   f"Found {len(results)} '{attr}' properties"
+                   f" in {len(result_apps)} apps"
+                   f" in {len(result_domains)} domains\n")
+        print(summary)
 
+        with open(CASE_SEARCH_AUDIT_LOG, 'a') as f:
+            f.write(str(datetime.now()))
+            f.write(summary)
         for result in results:
-            print(result)
+            self.log(result)
+
+    def log(self, result):
+        with open(CASE_SEARCH_AUDIT_LOG, 'a') as f:
+            f.write(f"{str(result)}\n")


### PR DESCRIPTION
## Technical Summary
Modifications made here to the `audit_case_search_config` command may be useful in the future, or otherwise are a record of how data was pulled for [USH-2633](https://dimagi-dev.atlassian.net/browse/USH-2633). Builds on https://github.com/dimagi/commcare-hq/pull/32616 with options to look for in search config or search property attributes. Logs the domain name, app ID, module ID, and property name (if applicable) for each usage of the given attribute.

## Safety Assurance

### Safety story
Read-only for existing data and logs to a file specific to this command.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-2633]: https://dimagi-dev.atlassian.net/browse/USH-2633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ