### PR TITLE
Create django migration for fixing deleted apps

### DIFF
--- a/corehq/apps/app_manager/migrations/0026_conditional_case_update_deleted_apps.py
+++ b/corehq/apps/app_manager/migrations/0026_conditional_case_update_deleted_apps.py
@@ -1,0 +1,22 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _migrate_to_conditional_case_update(apps, schema_editor):
+    call_command("migrate_to_conditional_case_update", "--deleted-apps-only")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('app_manager', '0025_migrate_to_search_filter_flag'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _migrate_to_conditional_case_update,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -133,6 +133,7 @@ app_manager
  0023_applicationreleaselog
  0024_applicationreleaselog_info
  0025_migrate_to_search_filter_flag
+ 0026_conditional_case_update_deleted_apps
 auditcare
  0001_sqlmodels
  0002_uniques


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR finishes the "save only edited form fields" migration by including the [the migration command for specifically deleted apps](https://github.com/dimagi/commcare-hq/pull/32512) in a Django migration. This way it will be run for 3rd-party environments.

I'm curious whether you all think this needs an announcement in some kind of changelog, and if so, how to go about that.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The migration checks to see if the command has been run on an environment before, so this migration should be limited to 3rd-party environments and not run on staging, prod, India, swiss.

On production:
```
In [3]: get_migration_complete(ALL_DOMAINS, "migrate_to_conditional_case_update")
Out[3]: True
```

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

I confirmed in a shell above that the migration has been marked "completed" so the migration won't run during deploy ad block it. And this migration has already been run on production so it won't break anything.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [X] The migrations in this code can be safely applied first independently of the code

Related to the PRs to remove app manager wrap functions: #32108 and #32075.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
