### PR TITLE
Attendance Tracking: Attendees

### DIFF
--- a/corehq/apps/events/exceptions.py
+++ b/corehq/apps/events/exceptions.py
@@ -1,3 +1,0 @@
-
-class EventNotPersistedError(Exception):
-    pass

--- a/corehq/apps/events/forms.py
+++ b/corehq/apps/events/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 from crispy_forms import layout as crispy
@@ -51,6 +52,13 @@ class CreateEventForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         self.domain = kwargs.pop('domain', None)
+        event = kwargs.pop('event', None)
+
+        if event:
+            kwargs['initial'] = self.compute_initial(event)
+        else:
+            kwargs['initial'] = None
+
         super(CreateEventForm, self).__init__(*args, **kwargs)
 
         self.fields['expected_attendees'].choices = self.get_attendee_choices()
@@ -81,6 +89,31 @@ class CreateEventForm(forms.Form):
             )
         )
 
+    @property
+    def current_values(self):
+        return {
+            'name': self['name'].value(),
+            'start_date': self['start_date'].value(),
+            'end_date': self['end_date'].value(),
+            'attendance_target': self['attendance_target'].value(),
+            'sameday_reg': self['sameday_reg'].value(),
+            'tracking_option': self['tracking_option'].value(),
+            'expected_attendees': self['expected_attendees'].value(),
+        }
+
+    def compute_initial(self, event):
+        return {
+            'name': event.name,
+            'start_date': event.start_date,
+            'end_date': event.end_date,
+            'attendance_target': event.attendance_target,
+            'sameday_reg': event.sameday_reg,
+            'tracking_option': TRACK_BY_DAY if event.track_each_day else TRACK_BY_EVENT,
+            'expected_attendees': [
+                attendee.case_id for attendee in event.get_expected_attendees()
+            ],
+        }
+
     def get_new_event_form(self):
         return CreateEventForm.create(self.cleaned_data)
 
@@ -88,6 +121,13 @@ class CreateEventForm(forms.Form):
         tracking_option = self.cleaned_data.get('tracking_option', TRACK_BY_DAY)
         self.cleaned_data['track_each_day'] = tracking_option == TRACK_BY_DAY
         return self.cleaned_data
+
+    def clean(self):
+        cleaned_data = self.cleaned_data
+        if cleaned_data['end_date'] < cleaned_data['start_date']:
+            raise ValidationError(_("End Date cannot be before Start Date"))
+
+        return cleaned_data
 
     def get_attendee_choices(self):
         return [

--- a/corehq/apps/events/models.py
+++ b/corehq/apps/events/models.py
@@ -8,7 +8,6 @@ from memoized import memoized
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from corehq.apps.es import CaseES
 
-from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 from corehq.util.quickcache import quickcache

--- a/corehq/apps/events/models.py
+++ b/corehq/apps/events/models.py
@@ -38,8 +38,18 @@ EVENT_CASE_TYPE = 'commcare-event'
 ATTENDEE_USER_ID_CASE_PROPERTY = 'commcare_user_id'
 
 
+class EventObjectManager(models.Manager):
+
+    def by_domain(self, domain, most_recent_first=False):
+        if most_recent_first:
+            return super().get_queryset().filter(domain=domain).order_by('start_date')
+        return super().get_queryset().filter(domain=domain)
+
+
 class Event(models.Model):
     """Attendance Tracking Event"""
+    objects = EventObjectManager()
+
     name = models.CharField(max_length=100)
     domain = models.CharField(max_length=255)
     event_id = models.CharField(max_length=255, unique=True)
@@ -65,12 +75,6 @@ class Event(models.Model):
             models.Index(fields=("domain",)),
             models.Index(fields=("manager_id",)),
         )
-
-    @classmethod
-    def by_domain(cls, domain, most_recent_first=False):
-        if most_recent_first:
-            return cls.objects.filter(domain=domain).order_by('start_date')
-        return cls.objects.filter(domain=domain)
 
     @quickcache(['self.event_id'])
     def get_expected_attendees(self):

--- a/corehq/apps/events/models.py
+++ b/corehq/apps/events/models.py
@@ -234,34 +234,6 @@ class AttendeeCase:
 
 
 def get_paginated_attendees(domain, limit, page, query=None):
-
-    def attendee_as_user_dict(case):
-        # TODO: Don't use these properties
-        user_id = case.get_case_property(ATTENDEE_USER_ID_CASE_PROPERTY)
-        if user_id:
-            user = CommCareUser.get_by_user_id(user_id, domain=domain)
-            return {
-                '_id': case.case_id,
-                'first_name': user.first_name,
-                'last_name': user.last_name,
-                'base_username': user.username,
-                'user_id': user_id,
-                'username': user.raw_username,
-            }
-        else:
-            try:
-                first_name, last_name = case.name.split(' ', maxsplit=1)
-            except ValueError:
-                first_name, last_name = case.name, ''
-            return {
-                '_id': case.case_id,
-                'first_name': first_name,
-                'last_name': last_name,
-                'base_username': '',
-                'user_id': '',
-                'username': '',
-            }
-
     case_ids = CommCareCase.objects.get_open_case_ids_in_domain_by_type(
         domain,
         ATTENDEE_CASE_TYPE,
@@ -272,7 +244,7 @@ def get_paginated_attendees(domain, limit, page, query=None):
         cases = CommCareCase.objects.get_cases(case_ids[start:end], domain)
     else:
         cases = CommCareCase.objects.get_cases(case_ids[:limit], domain)
-    return [attendee_as_user_dict(c) for c in cases], total
+    return cases, total
 
 
 def page_to_slice(limit, page):

--- a/corehq/apps/events/models.py
+++ b/corehq/apps/events/models.py
@@ -53,10 +53,21 @@ class Event(models.Model):
             return cls.objects.filter(domain=domain).order_by('start_date')
         return cls.objects.filter(domain=domain)
 
-    def save(self):
+    def save(
+        self,
+        force_insert=False,
+        force_update=False,
+        using=None,
+        update_fields=None,
+    ):
         if not self.event_id:
             self.event_id = uuid.uuid4().hex
-        super(Event, self).save()
+        super().save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields,
+        )
 
     @property
     def status(self):

--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -59,6 +59,8 @@ hqDefine("events/js/event_attendees",[
 
                     if (!self.query()) {
                         self.projectHasAttendees(!!data.attendees.length);
+                    } else {
+                        self.projectHasAttendees(true);
                     }
                     self.showLoadingSpinner(false);
                     self.showPaginationSpinner(false);

--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -10,7 +10,7 @@ hqDefine("events/js/event_attendees",[
     $,
     ko,
     _,
-    initialPageData,
+    initialPageData
 ) {
     'use strict';
     // These are used as css classes, so the values of success/warning/error need to be what they are.

--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -1,0 +1,119 @@
+hqDefine("events/js/event_attendees",[
+    "jquery",
+    "knockout",
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+    "hqwebapp/js/widgets",
+    "hqwebapp/js/components.ko",
+
+], function (
+    $,
+    ko,
+    _,
+    initialPageData,
+) {
+    'use strict';
+    // These are used as css classes, so the values of success/warning/error need to be what they are.
+    var STATUS = {
+        NONE: '',
+        PENDING: 'pending',
+        SUCCESS: 'success',
+        WARNING: 'warning',
+        ERROR: 'danger',
+        DISABLED: 'disabled',
+    };
+    var userModel = function (options) {
+        options = options || {};
+        options = _.defaults(options, {
+            creation_status: STATUS.NONE,
+            creation_error: "",
+            username: '',
+            first_name: '',
+            last_name: '',
+            location_id: '',
+            password: '',
+            user_id: '',
+            force_account_confirmation: false,
+            email: '',
+            send_account_confirmation_email: false,
+            force_account_confirmation_by_sms: false,
+            phone_number: '',
+            is_active: true,
+            is_account_confirmed: true,
+            deactivate_after_date: '',
+        });
+        return options;
+    };
+
+    var usersListModel = function () {
+        var self = {};
+        self.users = ko.observableArray([]);
+
+        self.query = ko.observable('');
+        self.deactivatedOnly = ko.observable(false);
+
+        self.itemsPerPage = ko.observable(5);
+        self.totalItems = ko.observable();
+
+        // Visibility of spinners, messages, and user table
+        self.hasError = ko.observable(false);
+        self.showLoadingSpinner = ko.observable(true);
+        self.showPaginationSpinner = ko.observable(false);
+        self.projectHasUsers = ko.observable(true);
+
+        self.showProjectHasNoUsers = ko.computed(function () {
+            return !self.showLoadingSpinner() && !self.hasError() && !self.projectHasUsers();
+        });
+
+        self.showNoUsers = ko.computed(function () {
+            return !self.showLoadingSpinner() && !self.hasError() && !self.totalItems() && !self.showProjectHasNoUsers();
+        });
+
+        self.showTable = ko.computed(function () {
+            return !self.showLoadingSpinner() && !self.hasError() && !self.showNoUsers() && !self.showProjectHasNoUsers();
+        });
+
+        self.goToPage = function (page) {
+            self.users.removeAll();
+            self.hasError(false);
+            self.showPaginationSpinner(true);
+            $.ajax({
+                method: 'GET',
+                url: initialPageData.reverse('paginated_attendees'),
+                data: {
+                    page: page || 1,
+                    query: self.query(),
+                    limit: self.itemsPerPage(),
+                    showDeactivatedUsers: self.deactivatedOnly(),
+                },
+                success: function (data) {
+                    self.totalItems(data.total);
+                    self.users(_.map(data.users, function (user) {
+                        return userModel(user);
+                    }));
+
+                    if (!self.query()) {
+                        self.projectHasUsers(!!data.users.length);
+                    }
+                    self.showLoadingSpinner(false);
+                    self.showPaginationSpinner(false);
+                    self.hasError(false);
+                },
+                error: function () {
+                    self.showLoadingSpinner(false);
+                    self.showPaginationSpinner(false);
+                    self.hasError(true);
+                },
+            });
+        };
+
+        self.onPaginationLoad = function () {
+            self.goToPage(1);
+        };
+        return self;
+    };
+
+    $(function () {
+        $("#users-list").koApplyBindings(usersListModel());
+    });
+});

--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -13,38 +13,6 @@ hqDefine("events/js/event_attendees",[
     initialPageData
 ) {
     'use strict';
-    // These are used as css classes, so the values of success/warning/error need to be what they are.
-    var STATUS = {
-        NONE: '',
-        PENDING: 'pending',
-        SUCCESS: 'success',
-        WARNING: 'warning',
-        ERROR: 'danger',
-        DISABLED: 'disabled',
-    };
-    var attendeeModel = function (options) {
-        options = options || {};
-        options = _.defaults(options, {
-            creation_status: STATUS.NONE,
-            creation_error: "",
-            username: '',
-            first_name: '',
-            last_name: '',
-            location_id: '',
-            password: '',
-            user_id: '',
-            force_account_confirmation: false,
-            email: '',
-            send_account_confirmation_email: false,
-            force_account_confirmation_by_sms: false,
-            phone_number: '',
-            is_active: true,
-            is_account_confirmed: true,
-            deactivate_after_date: '',
-        });
-        return options;
-    };
-
     var attendeesListModel = function () {
         var self = {};
         self.attendees = ko.observableArray([]);
@@ -87,9 +55,7 @@ hqDefine("events/js/event_attendees",[
                 },
                 success: function (data) {
                     self.totalItems(data.total);
-                    self.attendees(_.map(data.attendees, function (attendee) {
-                        return attendeeModel(attendee);
-                    }));
+                    self.attendees(data.attendees);
 
                     if (!self.query()) {
                         self.projectHasAttendees(!!data.attendees.length);

--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -22,7 +22,7 @@ hqDefine("events/js/event_attendees",[
         ERROR: 'danger',
         DISABLED: 'disabled',
     };
-    var userModel = function (options) {
+    var attendeeModel = function (options) {
         options = options || {};
         options = _.defaults(options, {
             creation_status: STATUS.NONE,
@@ -45,9 +45,9 @@ hqDefine("events/js/event_attendees",[
         return options;
     };
 
-    var usersListModel = function () {
+    var attendeesListModel = function () {
         var self = {};
-        self.users = ko.observableArray([]);
+        self.attendees = ko.observableArray([]);
 
         self.query = ko.observable('');
         self.deactivatedOnly = ko.observable(false);
@@ -55,26 +55,26 @@ hqDefine("events/js/event_attendees",[
         self.itemsPerPage = ko.observable(5);
         self.totalItems = ko.observable();
 
-        // Visibility of spinners, messages, and user table
+        // Visibility of spinners, messages, and attendees table
         self.hasError = ko.observable(false);
         self.showLoadingSpinner = ko.observable(true);
         self.showPaginationSpinner = ko.observable(false);
-        self.projectHasUsers = ko.observable(true);
+        self.projectHasAttendees = ko.observable(true);
 
-        self.showProjectHasNoUsers = ko.computed(function () {
-            return !self.showLoadingSpinner() && !self.hasError() && !self.projectHasUsers();
+        self.showProjectHasNoAttendees = ko.computed(function () {
+            return !self.showLoadingSpinner() && !self.hasError() && !self.projectHasAttendees();
         });
 
-        self.showNoUsers = ko.computed(function () {
-            return !self.showLoadingSpinner() && !self.hasError() && !self.totalItems() && !self.showProjectHasNoUsers();
+        self.showNoAttendees = ko.computed(function () {
+            return !self.showLoadingSpinner() && !self.hasError() && !self.totalItems() && !self.showProjectHasNoAttendees();
         });
 
         self.showTable = ko.computed(function () {
-            return !self.showLoadingSpinner() && !self.hasError() && !self.showNoUsers() && !self.showProjectHasNoUsers();
+            return !self.showLoadingSpinner() && !self.hasError() && !self.showNoAttendees() && !self.showProjectHasNoAttendees();
         });
 
         self.goToPage = function (page) {
-            self.users.removeAll();
+            self.attendees.removeAll();
             self.hasError(false);
             self.showPaginationSpinner(true);
             $.ajax({
@@ -84,16 +84,15 @@ hqDefine("events/js/event_attendees",[
                     page: page || 1,
                     query: self.query(),
                     limit: self.itemsPerPage(),
-                    showDeactivatedUsers: self.deactivatedOnly(),
                 },
                 success: function (data) {
                     self.totalItems(data.total);
-                    self.users(_.map(data.users, function (user) {
-                        return userModel(user);
+                    self.attendees(_.map(data.attendees, function (attendee) {
+                        return attendeeModel(attendee);
                     }));
 
                     if (!self.query()) {
-                        self.projectHasUsers(!!data.users.length);
+                        self.projectHasAttendees(!!data.attendees.length);
                     }
                     self.showLoadingSpinner(false);
                     self.showPaginationSpinner(false);
@@ -114,6 +113,6 @@ hqDefine("events/js/event_attendees",[
     };
 
     $(function () {
-        $("#users-list").koApplyBindings(usersListModel());
+        $("#attendees-list").koApplyBindings(attendeesListModel());
     });
 });

--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -2,12 +2,14 @@ hqDefine("events/js/new_event", [
     "jquery",
     "knockout",
     "hqwebapp/js/multiselect_utils",
+    "hqwebapp/js/initial_page_data",
     "hqwebapp/js/widgets",
     "jquery-ui/ui/widgets/datepicker",
 ], function (
     $,
     ko,
-    multiselectUtils
+    multiselectUtils,
+    initialPageData
 ) {
     $(function () {
         $("#id_start_date").datepicker({
@@ -20,22 +22,23 @@ hqDefine("events/js/new_event", [
             minDate: 0,
         });
 
+        // needs pre-population
         multiselectUtils.createFullMultiselectWidget('id_expected_attendees', {
             selectableHeaderTitle: gettext('Possible Attendees'),
             selectedHeaderTitle: gettext('Expected Attendees'),
             searchItemTitle: gettext('Search Attendees'),
         });
 
-        function eventViewModel() {
+        function eventViewModel(initialData) {
             'use strict';
             var self = {};
 
-            self.name = ko.observable();
-            self.startDate = ko.observable();
-            self.endDate = ko.observable();
-            self.attendanceTarget = ko.observable(1);
-            self.sameDayRegistration = ko.observable();
-            self.trackingOption = ko.observable("by_day");
+            self.name = ko.observable(initialData.name);
+            self.startDate = ko.observable(initialData.start_date);
+            self.endDate = ko.observable(initialData.end_date);
+            self.attendanceTarget = ko.observable(initialData.attendance_target || 1);
+            self.sameDayRegistration = ko.observable(initialData.sameday_reg);
+            self.trackingOption = ko.observable(initialData.tracking_option || "by_day");
 
             self.showTrackingOptions = ko.computed(function () {
                 var startDateValue = self.startDate();
@@ -50,7 +53,7 @@ hqDefine("events/js/new_event", [
             return self;
         }
 
-        var eventModel = eventViewModel();
+        var eventModel = eventViewModel(initialPageData.get('current_values'));
         $('#tracking-event-form').koApplyBindings(eventModel);
     });
 });

--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -1,12 +1,13 @@
 hqDefine("events/js/new_event", [
     "jquery",
     "knockout",
+    "hqwebapp/js/multiselect_utils",
     "hqwebapp/js/widgets",
     "jquery-ui/ui/widgets/datepicker",
-    "hqwebapp/js/components.ko",
 ], function (
     $,
-    ko
+    ko,
+    multiselectUtils
 ) {
     $(function () {
         $("#id_start_date").datepicker({
@@ -19,6 +20,11 @@ hqDefine("events/js/new_event", [
             minDate: 0,
         });
 
+        multiselectUtils.createFullMultiselectWidget('id_expected_attendees', {
+            selectableHeaderTitle: gettext('Possible Attendees'),
+            selectedHeaderTitle: gettext('Expected Attendees'),
+            searchItemTitle: gettext('Search Attendees'),
+        });
 
         function eventViewModel() {
             'use strict';

--- a/corehq/apps/events/templates/event_attendees.html
+++ b/corehq/apps/events/templates/event_attendees.html
@@ -24,7 +24,7 @@
       <i class="fa fa-plus"></i> {% trans "Create Potential Attendee" %}
     </button>
   </div>
-  <div id="users-list" class="ko-template">
+  <div id="attendees-list" class="ko-template">
     <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title">{% trans 'Potential Attendees for this Event' %}</h3>
@@ -35,7 +35,7 @@
             <search-box data-apply-bindings="false"
                         params="value: query,
                                             action: function() { goToPage(1); },
-                                            placeholder: '{% trans_html_attr "Search users..." %}'"></search-box>
+                                            placeholder: '{% trans_html_attr "Search attendees..." %}'"></search-box>
           </div>
         </div>
         <table class="table table-striped table-responsive" style="margin-bottom: 0;" data-bind="visible: showTable">
@@ -45,7 +45,7 @@
             <th class="col-xs-2">{% trans "Last Name" %}</th>
           </tr>
           </thead>
-          <tbody data-bind="foreach: users">
+          <tbody data-bind="foreach: attendees">
           <tr>
             <td data-bind="text: first_name"></td>
             <td data-bind="text: last_name"></td>
@@ -64,7 +64,7 @@
             <a href="#modalReportIssue" data-toggle="modal">report an issue</a>.
           {% endblocktrans %}
         </div>
-        <div class="alert alert-info" data-bind="visible: showProjectHasNoUsers">
+        <div class="alert alert-info" data-bind="visible: showProjectHasNoAttendees">
           {% blocktrans %}
             You currently have no potential attendees.
           {% endblocktrans %}

--- a/corehq/apps/events/templates/event_attendees.html
+++ b/corehq/apps/events/templates/event_attendees.html
@@ -41,14 +41,12 @@
         <table class="table table-striped table-responsive" style="margin-bottom: 0;" data-bind="visible: showTable">
           <thead>
           <tr>
-            <th class="col-xs-3">{% trans "Username" %}</th>
             <th class="col-xs-3">{% trans "First Name" %}</th>
             <th class="col-xs-2">{% trans "Last Name" %}</th>
           </tr>
           </thead>
           <tbody data-bind="foreach: users">
           <tr>
-            <td data-bind="text: username"></td>
             <td data-bind="text: first_name"></td>
             <td data-bind="text: last_name"></td>
           </tr>

--- a/corehq/apps/events/templates/event_attendees.html
+++ b/corehq/apps/events/templates/event_attendees.html
@@ -67,6 +67,11 @@
             You currently have no potential attendees.
           {% endblocktrans %}
         </div>
+        <div class="alert alert-info" data-bind="visible: showNoAttendees">
+          {% blocktrans %}
+            No matching potential attendees found.
+          {% endblocktrans %}
+        </div>
         <pagination data-apply-bindings="false"
                     data-bind="visible: showTable"
                     params="goToPage: goToPage,

--- a/corehq/apps/events/templates/event_attendees.html
+++ b/corehq/apps/events/templates/event_attendees.html
@@ -15,7 +15,7 @@
 
 <p>
   {% blocktrans %}
-    This page list all the project's potential attendees who can be invited to
+    This page lists all the project's potential attendees who can be invited to
     participate in Attendance Tracking Events.
   {% endblocktrans %}
 </p>
@@ -41,20 +41,18 @@
         <table class="table table-striped table-responsive" style="margin-bottom: 0;" data-bind="visible: showTable">
           <thead>
           <tr>
-            <th class="col-xs-3">{% trans "First Name" %}</th>
-            <th class="col-xs-2">{% trans "Last Name" %}</th>
+            <th class="col-xs-3">{% trans "Name" %}</th>
           </tr>
           </thead>
           <tbody data-bind="foreach: attendees">
           <tr>
-            <td data-bind="text: first_name"></td>
-            <td data-bind="text: last_name"></td>
+            <td data-bind="text: name"></td>
           </tr>
           </tbody>
         </table>
         <div class="alert alert-info" data-bind="visible: showLoadingSpinner() && !hasError()">
           <i class="fa fa-spin fa-spinner"></i>
-          {% trans "Loading Workers..." %}
+          {% trans "Loading potential attendees ..." %}
         </div>
         <div class="alert alert-danger" data-bind="visible: hasError">
           {% blocktrans %}

--- a/corehq/apps/events/templates/event_attendees.html
+++ b/corehq/apps/events/templates/event_attendees.html
@@ -19,7 +19,7 @@
     participate in Attendance Tracking Events.
   {% endblocktrans %}
 </p>
- <div class="btn-toolbar" style="margin-bottom: 20px;">
+  <div class="btn-toolbar" style="margin-bottom: 20px;">
     <button type="button" class="btn btn-primary">
       <i class="fa fa-plus"></i> {% trans "Create Potential Attendee" %}
     </button>
@@ -34,11 +34,13 @@
           <div class="col-sm-6">
             <search-box data-apply-bindings="false"
                         params="value: query,
-                                            action: function() { goToPage(1); },
-                                            placeholder: '{% trans_html_attr "Search attendees..." %}'"></search-box>
+                                action: function() { goToPage(1); },
+                                placeholder: '{% trans_html_attr "Search attendees..." %}'"></search-box>
           </div>
         </div>
-        <table class="table table-striped table-responsive" style="margin-bottom: 0;" data-bind="visible: showTable">
+        <table class="table table-striped table-responsive"
+               style="margin-bottom: 0;"
+               data-bind="visible: showTable">
           <thead>
           <tr>
             <th class="col-xs-3">{% trans "Name" %}</th>
@@ -50,7 +52,8 @@
           </tr>
           </tbody>
         </table>
-        <div class="alert alert-info" data-bind="visible: showLoadingSpinner() && !hasError()">
+        <div class="alert alert-info"
+             data-bind="visible: showLoadingSpinner() && !hasError()">
           <i class="fa fa-spin fa-spinner"></i>
           {% trans "Loading potential attendees ..." %}
         </div>
@@ -75,13 +78,11 @@
         <pagination data-apply-bindings="false"
                     data-bind="visible: showTable"
                     params="goToPage: goToPage,
-                          slug: 'mobile-workers',
-                          perPage: itemsPerPage,
-                          totalItems: totalItems,
-                          onLoad: onPaginationLoad,
-                          showSpinner: showPaginationSpinner"
-        >
-      </pagination>
+                            slug: 'mobile-workers',
+                            perPage: itemsPerPage,
+                            totalItems: totalItems,
+                            onLoad: onPaginationLoad,
+                            showSpinner: showPaginationSpinner"></pagination>
       </div>
     </div>
   </div>

--- a/corehq/apps/events/templates/event_attendees.html
+++ b/corehq/apps/events/templates/event_attendees.html
@@ -1,0 +1,87 @@
+{% extends "hqwebapp/base_section.html" %}
+{% load compress %}
+{% load i18n %}
+{% load hq_shared_tags %}
+{% load crispy_forms_tags %}
+
+{% requirejs_main 'events/js/event_attendees' %}
+
+{% block page_title %}
+  {{ current_page.title }}
+{% endblock %}
+
+{% block page_content %}
+{% registerurl 'paginated_attendees' domain %}
+
+<p>
+  {% blocktrans %}
+    This page list all the project's potential attendees who can be invited to
+    participate in Attendance Tracking Events.
+  {% endblocktrans %}
+</p>
+ <div class="btn-toolbar" style="margin-bottom: 20px;">
+    <button type="button" class="btn btn-primary">
+      <i class="fa fa-plus"></i> {% trans "Create Potential Attendee" %}
+    </button>
+  </div>
+  <div id="users-list" class="ko-template">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">{% trans 'Potential Attendees for this Event' %}</h3>
+      </div>
+      <div class="panel-body">
+        <div class="row">
+          <div class="col-sm-6">
+            <search-box data-apply-bindings="false"
+                        params="value: query,
+                                            action: function() { goToPage(1); },
+                                            placeholder: '{% trans_html_attr "Search users..." %}'"></search-box>
+          </div>
+        </div>
+        <table class="table table-striped table-responsive" style="margin-bottom: 0;" data-bind="visible: showTable">
+          <thead>
+          <tr>
+            <th class="col-xs-3">{% trans "Username" %}</th>
+            <th class="col-xs-3">{% trans "First Name" %}</th>
+            <th class="col-xs-2">{% trans "Last Name" %}</th>
+          </tr>
+          </thead>
+          <tbody data-bind="foreach: users">
+          <tr>
+            <td data-bind="text: username"></td>
+            <td data-bind="text: first_name"></td>
+            <td data-bind="text: last_name"></td>
+          </tr>
+          </tbody>
+        </table>
+        <div class="alert alert-info" data-bind="visible: showLoadingSpinner() && !hasError()">
+          <i class="fa fa-spin fa-spinner"></i>
+          {% trans "Loading Workers..." %}
+        </div>
+        <div class="alert alert-danger" data-bind="visible: hasError">
+          {% blocktrans %}
+            <strong>There was an issue contacting the server.</strong>
+            Please check your internet connection.
+            If this issue continues, please
+            <a href="#modalReportIssue" data-toggle="modal">report an issue</a>.
+          {% endblocktrans %}
+        </div>
+        <div class="alert alert-info" data-bind="visible: showProjectHasNoUsers">
+          {% blocktrans %}
+            You currently have no potential attendees.
+          {% endblocktrans %}
+        </div>
+        <pagination data-apply-bindings="false"
+                    data-bind="visible: showTable"
+                    params="goToPage: goToPage,
+                          slug: 'mobile-workers',
+                          perPage: itemsPerPage,
+                          totalItems: totalItems,
+                          onLoad: onPaginationLoad,
+                          showSpinner: showPaginationSpinner"
+        >
+      </pagination>
+      </div>
+    </div>
+  </div>
+{% endblock page_content %}

--- a/corehq/apps/events/templates/events_list.html
+++ b/corehq/apps/events/templates/events_list.html
@@ -39,12 +39,5 @@
     <td data-bind="text: target_attendance"></td>
     <td data-bind="text: status"></td>
     <td data-bind="text: total_attendance"></td>
-    <td>
-      <a data-bind="attr: {href: delete_url}">
-        <button type="button" class="btn btn-danger">
-          <i class="fa fa-close"></i> {% trans "Delete" %}
-        </button>
-      </a>
-    </td>
   </script>
 {% endblock %}

--- a/corehq/apps/events/templates/events_list.html
+++ b/corehq/apps/events/templates/events_list.html
@@ -39,5 +39,12 @@
     <td data-bind="text: target_attendance"></td>
     <td data-bind="text: status"></td>
     <td data-bind="text: total_attendance"></td>
+    <td>
+      <a data-bind="attr: {href: delete_url}">
+        <button type="button" class="btn btn-danger">
+          <i class="fa fa-close"></i> {% trans "Delete" %}
+        </button>
+      </a>
+    </td>
   </script>
 {% endblock %}

--- a/corehq/apps/events/templates/events_list.html
+++ b/corehq/apps/events/templates/events_list.html
@@ -29,7 +29,11 @@
 
 {% block pagination_templates %}
   <script type="text/html" id="base-event-template">
-    <td data-bind="text: name"></td>
+    <td>
+      <a data-bind="attr: {href: edit_url}">
+        <strong data-bind="text: name"></strong>
+      </a>
+    </td>
     <td data-bind="text: start_date"></td>
     <td data-bind="text: end_date"></td>
     <td data-bind="text: target_attendance"></td>

--- a/corehq/apps/events/templates/new_event.html
+++ b/corehq/apps/events/templates/new_event.html
@@ -1,10 +1,13 @@
 {% extends "hqwebapp/base_section.html" %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
+{% load i18n %}
 
 {% requirejs_main 'events/js/new_event' %}
 
 {% block page_content %}
+  {% initial_page_data 'current_values' form.current_values %}
+
   <form id="tracking-event-form" class="form-horizontal disable-on-submit" method="post">
     {% crispy form %}
   </form>

--- a/corehq/apps/events/templates/new_event.html
+++ b/corehq/apps/events/templates/new_event.html
@@ -5,7 +5,7 @@
 {% requirejs_main 'events/js/new_event' %}
 
 {% block page_content %}
-  <form id="tracking-event-form" class="form form-horizontal" method="post">
+  <form id="tracking-event-form" class="form-horizontal disable-on-submit" method="post">
     {% crispy form %}
   </form>
 {% endblock %}

--- a/corehq/apps/events/tests/test_events.py
+++ b/corehq/apps/events/tests/test_events.py
@@ -1,9 +1,11 @@
-from django.test import TestCase
 from datetime import datetime
 
-from corehq.apps.events.models import Event, NOT_STARTED
+from django.test import TestCase
+
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
+
+from ..models import NOT_STARTED, Event
 
 
 class TestEventModel(TestCase):

--- a/corehq/apps/events/tests/test_models.py
+++ b/corehq/apps/events/tests/test_models.py
@@ -1,0 +1,223 @@
+import doctest
+from contextlib import contextmanager
+from datetime import datetime
+
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseFactory, CaseStructure
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
+from corehq.util.test_utils import create_test_case
+
+from ..models import (
+    ATTENDEE_CASE_TYPE,
+    ATTENDEE_USER_ID_CASE_PROPERTY,
+    EVENT_ATTENDEE_CASE_TYPE,
+    NOT_STARTED,
+    AttendeeCase,
+    Event,
+)
+
+DOMAIN = 'test-domain'
+
+
+class TestAttendeeCaseManager(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.factory = CaseFactory(DOMAIN)
+
+    @contextmanager
+    def get_attendee_cases(self):
+        with create_test_case(
+            DOMAIN,
+            ATTENDEE_CASE_TYPE,
+            'Oliver Opencase',
+        ) as open_case, create_test_case(
+            DOMAIN,
+            ATTENDEE_CASE_TYPE,
+            'Clarence Closedcase',
+        ) as closed_case:
+            self.factory.close_case(closed_case.case_id)
+            yield open_case, closed_case
+
+    def test_manager_returns_open_cases(self):
+        with self.get_attendee_cases() as (open_case, closed_case):
+            cases = AttendeeCase.objects.by_domain(DOMAIN)
+            self.assertEqual(cases, [open_case])
+
+
+class TestEventModel(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.factory = CaseFactory(DOMAIN)
+        cls.domain_obj = create_domain(DOMAIN)
+        cls.webuser = WebUser.create(
+            DOMAIN,
+            'funky-user',
+            'mockmock',
+            None,
+            None
+        )
+        cls.webuser.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.webuser.delete(None, None)
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    @contextmanager
+    def _get_attendee(self, username):
+        with self._get_mobile_worker(username) as user:
+            (attendee,) = self.factory.create_or_update_cases([CaseStructure(
+                attrs={
+                    'case_type': ATTENDEE_CASE_TYPE,
+                    'update': {
+                        ATTENDEE_USER_ID_CASE_PROPERTY: user.user_id,
+                    },
+                    'create': True,
+                }
+            )])
+            try:
+                yield attendee
+            finally:
+                CommCareCase.objects.hard_delete_cases(
+                    DOMAIN,
+                    [attendee.case_id],
+                )
+
+    @contextmanager
+    def _get_mobile_worker(self, username):
+        mobile_worker = CommCareUser.create(
+            domain=DOMAIN,
+            username=username,
+            password="*****",
+            created_by=None,
+            created_via=None,
+        )
+        try:
+            yield mobile_worker
+        finally:
+            mobile_worker.delete(None, None)
+
+    def test_create_event(self):
+        today = datetime.utcnow().date()
+        event = Event(
+            domain=DOMAIN,
+            name='test-event',
+            start_date=today,
+            end_date=today,
+            attendance_target=10,
+            sameday_reg=True,
+            track_each_day=False,
+            manager_id=self.webuser.user_id,
+        )
+        event.save()
+
+        self.assertEqual(event.status, NOT_STARTED)
+        self.assertEqual(event.is_open, True)
+        self.assertTrue(event.event_id is not None)
+
+    def test_create_event_with_attendees(self):
+        with self._get_attendee('signmeup') as attendee:
+            today = datetime.utcnow().date()
+            event = Event(
+                domain=DOMAIN,
+                name='test-event',
+                start_date=today,
+                end_date=today,
+                attendance_target=10,
+                sameday_reg=True,
+                track_each_day=False,
+                manager_id=self.webuser.user_id,
+            )
+            event.save()
+            event.set_expected_attendees([attendee])
+
+            event_attendees = event.get_expected_attendees()
+
+            self.assertEqual(len(event_attendees), 1)
+            self.assertEqual(event_attendees[0].type, ATTENDEE_CASE_TYPE)
+            self.assertEqual(event_attendees[0].case_id, attendee.case_id)
+
+            attendee_subcases = event_attendees[0].get_subcases('attendee-host')
+            self.assertEqual(len(attendee_subcases), 1)
+            self.assertEqual(attendee_subcases[0].type, EVENT_ATTENDEE_CASE_TYPE)
+
+            event_subcases = event.case.get_subcases('event-host')
+            self.assertEqual(len(event_subcases), 1)
+            self.assertEqual(event_subcases[0].type, EVENT_ATTENDEE_CASE_TYPE)
+            self.assertEqual(event_subcases[0].case_id, attendee_subcases[0].case_id)
+
+    def test_update_event_attendees(self):
+        with self._get_attendee('at1') as attendee1, \
+                self._get_attendee('at2') as attendee2, \
+                self._get_attendee('at3') as attendee3:
+
+            today = datetime.utcnow().date()
+            event = Event(
+                domain=DOMAIN,
+                name='test-event',
+                start_date=today,
+                end_date=today,
+                attendance_target=10,
+                sameday_reg=True,
+                track_each_day=False,
+                manager_id=self.webuser.user_id,
+            )
+            event.save()
+
+            event.set_expected_attendees([attendee1, attendee2])
+            self.assertEqual(
+                {a.case_id for a in event.get_expected_attendees()},
+                {attendee1.case_id, attendee2.case_id}
+            )
+
+            event.set_expected_attendees([attendee1, attendee3])
+            self.assertEqual(
+                {a.case_id for a in event.get_expected_attendees()},
+                {attendee1.case_id, attendee3.case_id}
+            )
+
+    def test_delete_event_removes_attendees_cases(self):
+        with self._get_attendee('attendee_to_remove') as attendee:
+            today = datetime.utcnow().date()
+            event = Event(
+                domain=DOMAIN,
+                name='test-event',
+                start_date=today,
+                end_date=today,
+                attendance_target=10,
+                sameday_reg=True,
+                track_each_day=False,
+                manager_id=self.webuser.user_id,
+            )
+            event.save()
+            event.set_expected_attendees([attendee])
+
+            ext_case_ids = CommCareCaseIndex.objects.get_extension_case_ids(
+                DOMAIN,
+                [attendee.case_id],
+                include_closed=False,
+            )
+            self.assertEqual(len(ext_case_ids), 1)
+
+            event.delete()
+            ext_case_ids = CommCareCaseIndex.objects.get_extension_case_ids(
+                DOMAIN,
+                [attendee.case_id],
+                include_closed=False,
+            )
+            self.assertEqual(len(ext_case_ids), 0)
+
+
+def test_doctests():
+    import corehq.apps.events.models as module
+    results = doctest.testmod(module, optionflags=doctest.ELLIPSIS)
+    assert results.failed == 0

--- a/corehq/apps/events/tests/test_views.py
+++ b/corehq/apps/events/tests/test_views.py
@@ -1,15 +1,19 @@
+from contextlib import contextmanager
 from datetime import datetime
 from unittest.mock import patch
 
 from django.test import TestCase
 from django.urls import reverse
 
+from casexml.apps.case.mock import CaseFactory, CaseStructure
+
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import HqPermissions, UserRole, WebUser
 from corehq.apps.users.role_utils import UserRolePresets
+from corehq.form_processor.models import CommCareCase
 from corehq.util.test_utils import flag_enabled
 
-from ..models import Event
+from ..models import ATTENDEE_CASE_TYPE, Event
 from ..views import EventCreateView, EventsView
 
 
@@ -121,6 +125,27 @@ class TestEventsCreateView(BaseEventViewTestClass):
 
     urlname = EventCreateView.urlname
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.factory = CaseFactory(cls.domain)
+
+    @contextmanager
+    def _get_attendee(self):
+        (attendee,) = self.factory.create_or_update_cases([
+            CaseStructure(attrs={
+                'case_type': ATTENDEE_CASE_TYPE,
+                'create': True,
+            })
+        ])
+        try:
+            yield attendee
+        finally:
+            CommCareCase.objects.hard_delete_cases(
+                self.domain,
+                [attendee.case_id],
+            )
+
     @flag_enabled('ATTENDANCE_TRACKING')
     @patch.object(Event, 'save')
     def test_user_does_not_have_permission(self, event_save_method):
@@ -151,15 +176,24 @@ class TestEventsCreateView(BaseEventViewTestClass):
     @flag_enabled('ATTENDANCE_TRACKING')
     def test_event_is_created(self):
         self.log_user_in(self.admin_webuser)
+        with self._get_attendee() as attendee_case:
+            data = self._event_data()
+            data['expected_attendees'] = [attendee_case.case_id]
 
-        data = self._event_data()
-        self.client.post(self.endpoint, data)
+            self.client.post(self.endpoint, data)
 
-        event = Event.by_domain(self.domain).first()
+            event = Event.by_domain(self.domain).first()
 
-        self.assertEqual(event.name, data['name'])
-        self.assertEqual(event.domain, self.domain)
-        self.assertEqual(event.manager_id, self.admin_webuser.user_id)
+            self.assertEqual(event.name, data['name'])
+            self.assertEqual(event.domain, self.domain)
+            self.assertEqual(event.manager_id, self.admin_webuser.user_id)
+
+            expected_attendees = event.get_expected_attendees()
+            self.assertEqual(len(expected_attendees), 1)
+            self.assertEqual(
+                expected_attendees[0].case_id,
+                attendee_case.case_id,
+            )
 
     @flag_enabled('ATTENDANCE_TRACKING')
     def test_event_create_fails_with_faulty_data(self):

--- a/corehq/apps/events/tests/test_views.py
+++ b/corehq/apps/events/tests/test_views.py
@@ -1,15 +1,16 @@
-from django.test import TestCase
-from django.urls import reverse
 from datetime import datetime
 from unittest.mock import patch
 
-from corehq.apps.events.models import Event
+from django.test import TestCase
+from django.urls import reverse
+
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.events.views import EventsView, EventCreateView
-from corehq.apps.users.models import WebUser, HqPermissions
-from corehq.util.test_utils import flag_enabled
-from corehq.apps.users.models import UserRole
+from corehq.apps.users.models import HqPermissions, UserRole, WebUser
 from corehq.apps.users.role_utils import UserRolePresets
+from corehq.util.test_utils import flag_enabled
+
+from ..models import Event
+from ..views import EventCreateView, EventsView
 
 
 class BaseEventViewTestClass(TestCase):

--- a/corehq/apps/events/tests/test_views.py
+++ b/corehq/apps/events/tests/test_views.py
@@ -182,7 +182,7 @@ class TestEventsCreateView(BaseEventViewTestClass):
 
             self.client.post(self.endpoint, data)
 
-            event = Event.by_domain(self.domain).first()
+            event = Event.objects.by_domain(self.domain).first()
 
             self.assertEqual(event.name, data['name'])
             self.assertEqual(event.domain, self.domain)

--- a/corehq/apps/events/tests/test_views.py
+++ b/corehq/apps/events/tests/test_views.py
@@ -203,7 +203,13 @@ class TestEventsCreateView(BaseEventViewTestClass):
         faulty_data.pop('name')
 
         response = self.client.post(self.endpoint, faulty_data)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
+        error_html = (
+            '<span id="error_1_id_name" class="help-block">'
+            '<strong>This field is required.</strong>'
+            '</span>'
+        )
+        self.assertIn(error_html, response.content.decode('utf-8'))
 
     def _event_data(self):
         timestamp = datetime.utcnow().date()

--- a/corehq/apps/events/urls.py
+++ b/corehq/apps/events/urls.py
@@ -1,9 +1,17 @@
 from django.conf.urls import re_path as url
 
-from .views import EventCreateView, EventEditView, EventsView
+from .views import (
+    AttendeesListView,
+    EventCreateView,
+    EventEditView,
+    EventsView,
+    paginated_attendees,
+)
 
 urlpatterns = [
-    url(r'^$', EventsView.as_view(), name=EventsView.urlname),
+    url(r'^list/$', EventsView.as_view(), name=EventsView.urlname),
     url(r'^new/$', EventCreateView.as_view(), name=EventCreateView.urlname),
+    url(r'^attendees/json/$', paginated_attendees, name='paginated_attendees'),
+    url(r'^attendees/$', AttendeesListView.as_view(), name=AttendeesListView.urlname),
     url(r'^(?P<event_id>[\w-]+)/$', EventEditView.as_view(), name=EventEditView.urlname),
 ]

--- a/corehq/apps/events/urls.py
+++ b/corehq/apps/events/urls.py
@@ -1,10 +1,9 @@
 from django.conf.urls import re_path as url
 
-from .views import EventCreateView, EventEditView, EventsView, remove_event
+from .views import EventCreateView, EventEditView, EventsView
 
 urlpatterns = [
     url(r'^$', EventsView.as_view(), name=EventsView.urlname),
     url(r'^new/$', EventCreateView.as_view(), name=EventCreateView.urlname),
     url(r'^(?P<event_id>[\w-]+)/$', EventEditView.as_view(), name=EventEditView.urlname),
-    url(r'^remove/(?P<event_id>[\w-]+)/$', remove_event, name='remove_event'),
 ]

--- a/corehq/apps/events/urls.py
+++ b/corehq/apps/events/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import re_path as url
-from corehq.apps.events.views import EventsView, EventCreateView
+
+from .views import EventCreateView, EventsView
 
 urlpatterns = [
     url(r'^$', EventsView.as_view(), name=EventsView.urlname),

--- a/corehq/apps/events/urls.py
+++ b/corehq/apps/events/urls.py
@@ -1,9 +1,10 @@
 from django.conf.urls import re_path as url
 
-from .views import EventCreateView, EventEditView, EventsView
+from .views import EventCreateView, EventEditView, EventsView, remove_event
 
 urlpatterns = [
     url(r'^$', EventsView.as_view(), name=EventsView.urlname),
     url(r'^new/$', EventCreateView.as_view(), name=EventCreateView.urlname),
     url(r'^(?P<event_id>[\w-]+)/$', EventEditView.as_view(), name=EventEditView.urlname),
+    url(r'^remove/(?P<event_id>[\w-]+)/$', remove_event, name='remove_event'),
 ]

--- a/corehq/apps/events/urls.py
+++ b/corehq/apps/events/urls.py
@@ -1,8 +1,9 @@
 from django.conf.urls import re_path as url
 
-from .views import EventCreateView, EventsView
+from .views import EventCreateView, EventEditView, EventsView
 
 urlpatterns = [
     url(r'^$', EventsView.as_view(), name=EventsView.urlname),
     url(r'^new/$', EventCreateView.as_view(), name=EventCreateView.urlname),
+    url(r'^(?P<event_id>[\w-]+)/$', EventEditView.as_view(), name=EventEditView.urlname),
 ]

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -126,11 +126,11 @@ class EventCreateView(BaseEventView):
         context.update({'form': self.form})
         return context
 
-    def post(self, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         form = self.form
 
         if not form.is_valid():
-            return HttpResponseBadRequest()
+            return self.get(request, *args, **kwargs)
 
         event_data = form.cleaned_data
 

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -132,12 +132,15 @@ class EventCreateView(BaseEventView):
         ]
 
     def get_context_data(self, **kwargs):
-        context = super(EventCreateView, self).get_context_data(**kwargs)
-        context.update({'form': self.form})
+        context = super().get_context_data(**kwargs)
+        if self.request.method == 'POST':
+            context['form'] = CreateEventForm(self.request.POST, domain=self.domain)
+        else:
+            context['form'] = CreateEventForm(event=self.event, domain=self.domain)
         return context
 
     def post(self, request, *args, **kwargs):
-        form = self.form
+        form = CreateEventForm(self.request.POST, domain=self.domain)
 
         if not form.is_valid():
             return self.get(request, *args, **kwargs)
@@ -158,13 +161,6 @@ class EventCreateView(BaseEventView):
         event.set_expected_attendees(event_data['expected_attendees'])
 
         return HttpResponseRedirect(reverse(EventsView.urlname, args=(self.domain,)))
-
-    @property
-    def form(self):
-        if self.request.method == 'POST':
-            return CreateEventForm(self.request.POST, domain=self.domain)
-        else:
-            return CreateEventForm(event=self.event, domain=self.domain)
 
     @property
     def event(self):
@@ -203,7 +199,7 @@ class EventEditView(EventCreateView):
         return self.event_obj
 
     def post(self, request, *args, **kwargs):
-        form = self.form
+        form = CreateEventForm(self.request.POST, domain=self.domain)
 
         if not form.is_valid():
             return self.get(request, *args, **kwargs)

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -1,14 +1,14 @@
-from django.utils.translation import gettext_lazy as _
+from django.http import Http404, HttpResponseBadRequest, HttpResponseRedirect
 from django.urls import reverse
-from django.http import HttpResponseRedirect, HttpResponseBadRequest
-from django.http import Http404
+from django.utils.translation import gettext_lazy as _
 
-from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
-from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.events.models import Event
-from corehq.apps.events.forms import CreateEventForm
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq import toggles
+from corehq.apps.domain.views.base import BaseDomainView
+from corehq.apps.hqwebapp.decorators import use_jquery_ui
+from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
+
+from .forms import CreateEventForm
+from .models import Event
 
 
 class BaseEventView(BaseDomainView):

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -90,7 +90,6 @@ class EventsView(BaseEventView, CRUDPaginatedViewMixin):
             'status': event.status,
             'total_attendance': event.total_attendance or '-',
             'edit_url': reverse(EventEditView.urlname, args=(self.domain, event.event_id)),
-            'delete_url': reverse('remove_event', args=(self.domain, event.event_id)),
         }
 
 
@@ -212,11 +211,3 @@ class EventEditView(EventCreateView):
         event.set_expected_attendees(event_update_data['expected_attendees'])
 
         return HttpResponseRedirect(reverse(EventsView.urlname, args=(self.domain,)))
-
-def remove_event(request, *args, **kwargs):
-    event = Event.objects.get(
-        domain=kwargs['domain'],
-        event_id=kwargs['event_id'],
-    )
-    event.delete()
-    return HttpResponseRedirect(reverse(EventsView.urlname, args=(kwargs['domain'],)))

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 from corehq import toggles
 from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
+from corehq.apps.hqwebapp.decorators import use_jquery_ui, use_multiselect
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 
 from .forms import CreateEventForm
@@ -98,6 +98,7 @@ class EventCreateView(BaseEventView):
 
     page_title = _("Add Attendance Tracking Event")
 
+    @use_multiselect
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         return super(EventCreateView, self).dispatch(request, *args, **kwargs)
@@ -114,7 +115,7 @@ class EventCreateView(BaseEventView):
     def parent_pages(self):
         return [
             {
-                'title': EventsView.page_title,
+                'title': _("Events"),
                 'url': reverse(EventsView.urlname, args=[self.domain])
             },
         ]

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -84,8 +84,8 @@ class EventsView(BaseEventView, CRUDPaginatedViewMixin):
         return {
             'id': event.event_id,
             'name': event.name,
-            'start_date': str(event.start_date.date()),
-            'end_date': str(event.end_date.date()),
+            'start_date': str(event.start_date),
+            'end_date': str(event.end_date),
             'target_attendance': event.attendance_target,
             'status': event.status,
             'total_attendance': event.total_attendance or '-',
@@ -144,12 +144,13 @@ class EventCreateView(BaseEventView):
             manager_id=self.request.couch_user.user_id,
         )
         event.save()
+        event.set_expected_attendees(event_data['expected_attendees'])
 
         return HttpResponseRedirect(reverse(EventsView.urlname, args=(self.domain,)))
 
     @property
     def form(self):
         if self.request.method == 'POST':
-            return CreateEventForm(self.request.POST)
+            return CreateEventForm(self.request.POST, domain=self.domain)
         else:
-            return CreateEventForm(initial={})
+            return CreateEventForm(initial={}, domain=self.domain)

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -250,7 +250,7 @@ def paginated_attendees(request, domain):
     page = int(request.GET.get('page', 1))
     query = request.GET.get('query')
 
-    attendees, total = get_paginated_attendees(
+    cases, total = get_paginated_attendees(
         domain=domain,
         limit=limit,
         page=page,
@@ -258,7 +258,6 @@ def paginated_attendees(request, domain):
     )
 
     return JsonResponse({
-        # TODO: Rename "users" key to "attendees"
-        'attendees': attendees,
+        'attendees': [{'_id': c.case_id, 'name': c.name} for c in cases],
         'total': total,
     })

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -90,6 +90,7 @@ class EventsView(BaseEventView, CRUDPaginatedViewMixin):
             'status': event.status,
             'total_attendance': event.total_attendance or '-',
             'edit_url': reverse(EventEditView.urlname, args=(self.domain, event.event_id)),
+            'delete_url': reverse('remove_event', args=(self.domain, event.event_id)),
         }
 
 
@@ -211,3 +212,11 @@ class EventEditView(EventCreateView):
         event.set_expected_attendees(event_update_data['expected_attendees'])
 
         return HttpResponseRedirect(reverse(EventsView.urlname, args=(self.domain,)))
+
+def remove_event(request, *args, **kwargs):
+    event = Event.objects.get(
+        domain=kwargs['domain'],
+        event_id=kwargs['event_id'],
+    )
+    event.delete()
+    return HttpResponseRedirect(reverse(EventsView.urlname, args=(kwargs['domain'],)))

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -259,6 +259,6 @@ def paginated_attendees(request, domain):
 
     return JsonResponse({
         # TODO: Rename "users" key to "attendees"
-        'users': attendees,
+        'attendees': attendees,
         'total': total,
     })

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -89,6 +89,7 @@ class EventsView(BaseEventView, CRUDPaginatedViewMixin):
             'target_attendance': event.attendance_target,
             'status': event.status,
             'total_attendance': event.total_attendance or '-',
+            'edit_url': reverse(EventEditView.urlname, args=(self.domain, event.event_id)),
         }
 
 
@@ -153,4 +154,60 @@ class EventCreateView(BaseEventView):
         if self.request.method == 'POST':
             return CreateEventForm(self.request.POST, domain=self.domain)
         else:
-            return CreateEventForm(initial={}, domain=self.domain)
+            return CreateEventForm(event=self.event, domain=self.domain)
+
+    @property
+    def event(self):
+        return None
+
+
+class EventEditView(EventCreateView):
+    urlname = 'edit_attendance_tracking_event'
+    template_name = "new_event.html"
+    http_method_names = ['get', 'post']
+
+    page_title = _("Edit Attendance Tracking Event")
+    event_obj = None
+
+    @use_multiselect
+    @use_jquery_ui
+    def dispatch(self, request, *args, **kwargs):
+        self.event_obj = Event.objects.get(
+            domain=self.domain,
+            event_id=kwargs['event_id'],
+        )
+        return super().dispatch(request, *args, **kwargs)
+
+    @property
+    def page_name(self):
+        return _("Edit Event")
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=(self.domain, self.event.event_id))
+
+    @property
+    def event(self):
+        if self.event_obj is None:
+            raise Event.DoesNotExist
+        return self.event_obj
+
+    def post(self, request, *args, **kwargs):
+        form = self.form
+
+        if not form.is_valid():
+            return self.get(request, *args, **kwargs)
+
+        event_update_data = form.cleaned_data
+
+        event = self.event
+        event.name = event_update_data['name']
+        event.start_date = event_update_data['start_date']
+        event.end_date = event_update_data['end_date']
+        event.attendance_target = event_update_data['attendance_target']
+        event.sameday_reg = event_update_data['sameday_reg']
+        event.track_each_day = event_update_data['track_each_day']
+        event.save()
+        event.set_expected_attendees(event_update_data['expected_attendees'])
+
+        return HttpResponseRedirect(reverse(EventsView.urlname, args=(self.domain,)))

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -66,7 +66,7 @@ class EventsView(BaseEventView, CRUDPaginatedViewMixin):
 
     @property
     def domain_events(self):
-        return Event.by_domain(self.domain, most_recent_first=True)
+        return Event.objects.by_domain(self.domain, most_recent_first=True)
 
     @property
     def paginated_list(self):

--- a/corehq/apps/users/decorators.py
+++ b/corehq/apps/users/decorators.py
@@ -146,6 +146,7 @@ require_can_edit_or_view_groups = require_permission(
 )
 require_can_view_roles = require_permission('view_roles')
 require_can_login_as = require_permission_raw(lambda user, domain: user.can_login_as(domain))
+require_can_coordinate_events = require_permission('manage_attendance_tracking')
 
 
 def require_permission_to_edit_user(view_func):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -106,7 +106,7 @@ from corehq.tabs.utils import (
     dropdown_dict,
     sidebar_to_dropdown,
 )
-from corehq.apps.events.views import EventsView
+from corehq.apps.events.views import EventsView, AttendeesListView
 
 
 class ProjectReportsTab(UITab):
@@ -2447,20 +2447,28 @@ class AttendanceTrackingTab(UITab):
     view = EventsView.urlname
 
     url_prefix_formats = (
-        '/a/{domain}/settings/events/',
-        '/a/{domain}/settings/events/new',
+        '/a/{domain}/settings/events',
     )
 
     @property
     def dropdown_items(self):
         items = [
-            dropdown_dict(_("Events"), url=reverse(EventsView.urlname, args=(self.domain,)))
+            dropdown_dict(_("Attendees"), url=reverse(AttendeesListView.urlname, args=(self.domain,))),
+            dropdown_dict(_("Events"), url=reverse(EventsView.urlname, args=(self.domain,))),
+            self.divider,
+            dropdown_dict(_("View All"), url=reverse(EventsView.urlname, args=(self.domain,))),
         ]
         return items
 
     @property
     def sidebar_items(self):
         items = [
+            (_("Attendees"), [
+                {
+                    'title': _("Attendee Users"),
+                    'url': reverse(AttendeesListView.urlname, args=(self.domain,)),
+                },
+            ]),
             (_("Events"), [
                 {
                     'title': _("View All Events"),


### PR DESCRIPTION
## Technical Summary

Context: [Spec](https://docs.google.com/document/d/1hU2SQvnfkfxu3RoxhRCKL6IuWl6zO7nuZFEbgF5grrE/edit?pli=1#heading=h.whks7x3gtv74)

Adds UI to list expected attendees for an Attendance Tracking Event.

![image](https://user-images.githubusercontent.com/708421/223602130-a3ed5717-e48d-4e9c-8adb-5e1b8aaaea7d.png)

I kept "Add `remove_event()` view" and "Drop `remove_event()` view" commits so that we can revert the "Drop" commit if we want that option. It might be useful to be able to delete an Event under limited circumstances?

:blowfish: 

## Feature Flag

Attendance Tracking

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Includes tests

### QA Plan

QA planned when feature is more mature.

See comment [here](https://github.com/dimagi/commcare-hq/pull/32705#issuecomment-1463661423).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
