### PR TITLE
error message if formplayer is offline

### DIFF
--- a/corehq/apps/app_manager/tests/test_xform.py
+++ b/corehq/apps/app_manager/tests/test_xform.py
@@ -87,7 +87,7 @@ class ValidateXFormTests(SimpleTestCase):
         with self.assertRaises(XFormValidationError):
             validate_xform(xml)
 
-    def test_successful(self, mock_validate_form, _):
+    def test_successful(self, mock_validate_form):
         xml = '''
         <html>
             <head>

--- a/corehq/apps/app_manager/tests/test_xform.py
+++ b/corehq/apps/app_manager/tests/test_xform.py
@@ -87,7 +87,6 @@ class ValidateXFormTests(SimpleTestCase):
         with self.assertRaises(XFormValidationError):
             validate_xform(xml)
 
-    @patch('corehq.apps.hqadmin.service_checks.check_formplayer')
     def test_successful(self, mock_validate_form, _):
         xml = '''
         <html>

--- a/corehq/apps/app_manager/tests/test_xform.py
+++ b/corehq/apps/app_manager/tests/test_xform.py
@@ -65,7 +65,6 @@ class ValidateXFormTests(SimpleTestCase):
 
         mock_validate_form.side_effect = FormplayerAPIException
 
-        # rendered_form = etree.tostring(xml, encoding='utf-8')
         with self.assertRaises(XFormValidationFailed):
             validate_xform(xml)
 
@@ -88,7 +87,8 @@ class ValidateXFormTests(SimpleTestCase):
         with self.assertRaises(XFormValidationError):
             validate_xform(xml)
 
-    def test_successful(self, mock_validate_form):
+    @patch('corehq.apps.hqadmin.service_checks.check_formplayer')
+    def test_successful(self, mock_validate_form, _):
         xml = '''
         <html>
             <head>
@@ -105,5 +105,5 @@ class ValidateXFormTests(SimpleTestCase):
         mock_validate_form.return_value = validation_result
         try:
             validate_xform(xml)
-        except (XFormValidationFailed, FormValidationResult) as e:
+        except XFormValidationFailed as e:
             self.fail(f"validate_xform raised {e} unexpectedly")

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -631,6 +631,10 @@ def autoset_owner_id_for_advanced_action(action):
 
 
 def validate_xform(source):
+    from corehq.apps.hqadmin.service_checks import check_formplayer
+    if not check_formplayer().success:
+        raise XFormValidationFailed("Unable to connect to Formplayer")
+
     if isinstance(source, str):
         source = source.encode("utf-8")
     # normalize and strip comments

--- a/corehq/apps/formplayer_api/form_validation.py
+++ b/corehq/apps/formplayer_api/form_validation.py
@@ -54,7 +54,7 @@ def validate_form(form_xml):
         )
     except RequestException as e:
         notify_exception(None, "Error calling Formplayer form validation endpoint")
-        raise FormplayerAPIException(e)
+        raise FormplayerAPIException(e) from e
 
     try:
         response.raise_for_status()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2481)

This aims at providing better information to users when the formplayer service is offline. When a user tries to update the app version, and formplayer is down, then they will be given an appropriate error message as follows:

![Screenshot from 2023-03-08 15-50-23](https://user-images.githubusercontent.com/122617251/223730899-ff5b8011-57d4-44ad-a530-18cb467d40fc.png)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Small UI change, have done local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
