### PR TITLE
Implement Bulk Case Reassignment

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -80,12 +80,14 @@ def do_import(spreadsheet, config, domain, task=None, record_form_callback=None)
 class _Importer(object):
     def __init__(self, domain, config, task, record_form_callback, import_results=None, multi_domain=False):
         self.domain = domain
-        self.config = config
         self.task = task
         self.record_form_callback = record_form_callback
         self.results = import_results or _ImportResults()
+        self.config = config
+        self.submission_handler = SubmitCaseBlockHandler(
+            domain, self.results, self.config.case_type, self.user, record_form_callback, throttle=False
+        )
         self.owner_accessor = _OwnerAccessor(domain, self.user)
-        self.uncreated_external_ids = set()
         self._unsubmitted_caseblocks = []
         self.multi_domain = multi_domain
         if CASE_IMPORT_DATA_DICTIONARY_VALIDATION.enabled(self.domain):
@@ -93,6 +95,7 @@ class _Importer(object):
         else:
             self.fields_to_validate = {}
         self.field_map = self._create_field_map()
+
 
     def do_import(self, spreadsheet):
         with TaskProgressManager(self.task, src="case_importer") as progress_manager:
@@ -115,7 +118,7 @@ class _Importer(object):
                 except exceptions.CaseRowError as error:
                     self.results.add_error(row_num, error)
 
-            self.commit_caseblocks()
+            self.submission_handler.commit_caseblocks()
             return self.results.to_json()
 
     def import_row(self, row_num, raw_row, import_context):
@@ -136,15 +139,15 @@ class _Importer(object):
             user_id=self.user.user_id,
             owner_accessor=self.owner_accessor,
         )
-        if row.relies_on_uncreated_case(self.uncreated_external_ids):
-            self.commit_caseblocks()
+        if row.relies_on_uncreated_case(self.submission_handler.uncreated_external_ids):
+            self.submission_handler.commit_caseblocks()
         if row.is_new_case and not self.config.create_new_cases:
             return
 
         try:
             if row.is_new_case:
                 if row.external_id:
-                    self.uncreated_external_ids.add(row.external_id)
+                    self.submission_handler.uncreated_external_ids.add(row.external_id)
                 caseblock = row.get_create_caseblock()
                 self.results.add_created(row_num)
             else:
@@ -153,7 +156,7 @@ class _Importer(object):
         except CaseBlockError as e:
             raise exceptions.CaseGeneration(message=str(e))
 
-        self.add_caseblock(RowAndCase(row_num, caseblock))
+        self.submission_handler.add_caseblock(RowAndCase(row_num, caseblock))
 
     def _has_custom_case_import_operations(self):
         return any(
@@ -174,65 +177,6 @@ class _Importer(object):
     @cached_property
     def user(self):
         return CouchUser.get_by_user_id(self.config.couch_user_id)
-
-    def add_caseblock(self, caseblock):
-        self._unsubmitted_caseblocks.append(caseblock)
-        # check if we've reached a reasonable chunksize and if so, submit
-        if len(self._unsubmitted_caseblocks) >= CASEBLOCK_CHUNKSIZE:
-            self.commit_caseblocks()
-
-    def commit_caseblocks(self):
-        if self._unsubmitted_caseblocks:
-            self.submit_and_process_caseblocks(self._unsubmitted_caseblocks)
-            self.results.num_chunks += 1
-            self._unsubmitted_caseblocks = []
-            self.uncreated_external_ids = set()
-
-    def submit_and_process_caseblocks(self, caseblocks):
-        if not caseblocks:
-            return
-        self.pre_submit_hook()
-        try:
-            form, cases = self.submit_case_blocks(caseblocks)
-            if form.is_error:
-                raise Exception("Form error during case import: {}".format(form.problem))
-        except Exception:
-            notify_exception(None, "Case Importer: Uncaught failure submitting caseblocks")
-            for row_number, case in caseblocks:
-                self.results.add_error(row_number, exceptions.ImportErrorMessage())
-        else:
-            if self.record_form_callback:
-                self.record_form_callback(form.form_id)
-            properties = {p for c in cases for p in c.dynamic_case_properties().keys()}
-            if self.config.case_type and len(properties):
-                add_inferred_export_properties.delay(
-                    'CaseImporter',
-                    self.domain,
-                    self.config.case_type,
-                    properties,
-                )
-            else:
-                _soft_assert = soft_assert(notify_admins=True)
-                _soft_assert(
-                    len(properties) == 0,
-                    'error adding inferred export properties in domain '
-                    '({}): {}'.format(self.domain, ", ".join(properties))
-                )
-
-    def pre_submit_hook(self):
-        pass
-
-    def submit_case_blocks(self, caseblocks):
-        return submit_case_blocks(
-            [cb.case.as_text() for cb in caseblocks],
-            self.domain,
-            self.user.username,
-            self.user.user_id,
-            device_id=__name__ + ".do_import",
-            # Skip the rate-limiting
-            # because this importing code will take care of any rate-limiting
-            max_wait=None,
-        )
 
     def _parse_search_id(self, row):
         """ Find and convert the search id in an Excel row """
@@ -336,9 +280,7 @@ class _Importer(object):
 class _TimedAndThrottledImporter(_Importer):
     def __init__(self, domain, config, task, record_form_callback, import_results=None, multi_domain=False):
         super().__init__(domain, config, task, record_form_callback, import_results, multi_domain)
-
-        self._last_submission_duration = 1  # duration in seconds; start with a value of 1s
-        self._total_delayed_duration = 0  # sum of all rate limiter delays, in seconds
+        self.submission_handler.throttle = True
 
     def do_import(self, spreadsheet):
         with TimingContext() as timer:
@@ -351,7 +293,7 @@ class _TimedAndThrottledImporter(_Importer):
             return results
 
     def _report_import_timings(self, timer, results):
-        active_duration = timer.duration - self._total_delayed_duration
+        active_duration = timer.duration - self.submission_handler._total_delayed_duration
         rows_created = results['created_count']
         rows_updated = results['match_count']
         rows_failed = results['failed_count']
@@ -370,7 +312,68 @@ class _TimedAndThrottledImporter(_Importer):
                 'status': status,
             })
 
+
+class SubmitCaseBlockHandler(object):
+
+    def __init__(self, domain, import_results, case_type, user, record_form_callback=None, throttle=False):
+        self.domain = domain
+        self._unsubmitted_caseblocks = []
+        self.results = import_results or _ImportResults()
+        self.uncreated_external_ids = set()
+        self.record_form_callback = record_form_callback
+        self._last_submission_duration = 1  # duration in seconds; start with a value of 1s
+        self._total_delayed_duration = 0  # sum of all rate limiter delays, in seconds
+        self.throttle = throttle
+        self.case_type = case_type
+        self.user = user
+
+    def add_caseblock(self, caseblock):
+        self._unsubmitted_caseblocks.append(caseblock)
+        # check if we've reached a reasonable chunksize and if so, submit
+        if len(self._unsubmitted_caseblocks) >= CASEBLOCK_CHUNKSIZE:
+            self.commit_caseblocks()
+
+    def commit_caseblocks(self):
+        if self._unsubmitted_caseblocks:
+            self.submit_and_process_caseblocks(self._unsubmitted_caseblocks)
+            self.results.num_chunks += 1
+            self._unsubmitted_caseblocks = []
+            self.uncreated_external_ids = set()
+
+    def submit_and_process_caseblocks(self, caseblocks):
+        if not caseblocks:
+            return
+        self.pre_submit_hook()
+        try:
+            form, cases = self.submit_case_blocks(caseblocks)
+            if form.is_error:
+                raise Exception("Form error during case import: {}".format(form.problem))
+        except Exception:
+            notify_exception(None, "Case Importer: Uncaught failure submitting caseblocks")
+            for row_number, case in caseblocks:
+                self.results.add_error(row_number, exceptions.ImportErrorMessage())
+        else:
+            if self.record_form_callback:
+                self.record_form_callback(form.form_id)
+            properties = {p for c in cases for p in c.dynamic_case_properties().keys()}
+            if self.case_type and len(properties):
+                add_inferred_export_properties.delay(
+                    'CaseImporter',
+                    self.domain,
+                    self.case_type,
+                    properties,
+                )
+            else:
+                _soft_assert = soft_assert(notify_admins=True)
+                _soft_assert(
+                    len(properties) == 0,
+                    'error adding inferred export properties in domain '
+                    '({}): {}'.format(self.domain, ", ".join(properties))
+                )
+
     def pre_submit_hook(self):
+        if not self.throttle:
+            return
         if rate_limit_submission(
                 self.domain,
                 delay_rather_than_reject=True,
@@ -390,14 +393,29 @@ class _TimedAndThrottledImporter(_Importer):
             )
             self._total_delayed_duration += self._last_submission_duration
 
+
     def submit_case_blocks(self, caseblocks):
+        if not self.throttle:
+            return self._submit_case_blocks(caseblocks)
         timer = None
         try:
             with TimingContext() as timer:
-                return super().submit_case_blocks(caseblocks)
+                return self._submit_case_blocks(caseblocks)
         finally:
             if timer:
                 self._last_submission_duration = timer.duration
+
+    def _submit_case_blocks(self, caseblocks):
+        return submit_case_blocks(
+            [cb.case.as_text() for cb in caseblocks],
+            self.domain,
+            self.user.username,
+            self.user.user_id,
+            device_id=__name__ + ".do_import",
+            # Skip the rate-limiting
+            # because this importing code will take care of any rate-limiting
+            max_wait=None,
+        )
 
 
 class _CaseImportRow(object):

--- a/corehq/apps/data_interfaces/dispatcher.py
+++ b/corehq/apps/data_interfaces/dispatcher.py
@@ -51,3 +51,10 @@ class EditDataInterfaceDispatcher(ReportDispatcher):
                 if not has_privilege(request, privileges.DATA_CLEANUP):
                     return False
         return request.couch_user.can_edit_data(domain)
+
+
+class BulkEditDataInterfaceDispatcher(EditDataInterfaceDispatcher):
+
+    @classmethod
+    def allowed_renderings(cls):
+        return super(BulkEditDataInterfaceDispatcher, cls).allowed_renderings() + ['bulk']

--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -1,10 +1,12 @@
 from django.contrib.humanize.templatetags.humanize import naturaltime
+from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
 from memoized import memoized
+from soil.util import expose_cached_download
 
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.es import cases as case_es
@@ -19,7 +21,7 @@ from corehq.apps.reports.standard.cases.basic import CaseListMixin
 from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
 from corehq.apps.reports.standard.inspect import SubmitHistoryMixin
 from corehq.util.timezones.utils import parse_date
-from .dispatcher import EditDataInterfaceDispatcher
+from .dispatcher import EditDataInterfaceDispatcher, BulkEditDataInterfaceDispatcher
 
 
 class DataInterface(GenericReportView):
@@ -35,8 +37,12 @@ class DataInterface(GenericReportView):
         return reverse('data_interfaces_default', args=[self.request.project.name])
 
 
+class BulkDataInterface(DataInterface):
+    dispatcher = BulkEditDataInterfaceDispatcher
+
+
 @location_safe
-class CaseReassignmentInterface(CaseListMixin, DataInterface):
+class CaseReassignmentInterface(CaseListMixin, BulkDataInterface):
     name = gettext_noop("Reassign Cases")
     slug = "reassign_cases"
     report_template_path = 'data_interfaces/interfaces/case_management.html'
@@ -48,6 +54,14 @@ class CaseReassignmentInterface(CaseListMixin, DataInterface):
         # FB 183468: Don't allow user cases to be reassigned
         query = query.NOT(case_es.case_type(USERCASE_TYPE))
         return query.run().raw
+
+    @property
+    def template_context(self):
+        context = super(CaseReassignmentInterface, self).template_context
+        context.update({
+            "total_cases": self.total_records,
+        })
+        return context
 
     @property
     @memoized
@@ -90,6 +104,40 @@ class CaseReassignmentInterface(CaseListMixin, DataInterface):
                 display.owner_display,
                 naturaltime(parse_date(es_case['modified_on'])),
             ]
+
+    @property
+    def bulk_response(self):
+        from .views import BulkCaseReassignSatusView
+        from .tasks import bulk_case_reassign_async
+        owner_id = self.request_params.get('new_owner_id', None)
+        if not owner_id:
+            return HttpResponseBadRequest(
+                _("An owner_id needs to be specified to bulk reassign cases")
+            )
+
+        case_ids = [
+            self.get_case(row)['_id']
+            for row in self.es_results['hits'].get('hits', [])
+        ]
+
+        task_ref = expose_cached_download(
+            payload=case_ids, expiry=60 * 60, file_extension=None
+        )
+        task = bulk_case_reassign_async.delay(
+            self.domain,
+            self.request.couch_user.get_id,
+            owner_id,
+            task_ref.download_id
+        )
+        task_ref.set_task(task)
+        if self.request.method != 'POST':
+            return HttpResponseBadRequest()
+        return HttpResponseRedirect(
+            reverse(
+                BulkCaseReassignSatusView.urlname,
+                args=[self.domain, task_ref.download_id]
+            )
+        )
 
 
 class FormManagementMode(object):

--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -127,7 +127,8 @@ class CaseReassignmentInterface(CaseListMixin, BulkDataInterface):
             self.domain,
             self.request.couch_user.get_id,
             owner_id,
-            task_ref.download_id
+            task_ref.download_id,
+            self.request.META['HTTP_REFERER']
         )
         task_ref.set_task(task)
         if self.request.method != 'POST':

--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -109,6 +109,8 @@ class CaseReassignmentInterface(CaseListMixin, BulkDataInterface):
     def bulk_response(self):
         from .views import BulkCaseReassignSatusView
         from .tasks import bulk_case_reassign_async
+        if self.request.method != 'POST':
+            return HttpResponseBadRequest()
         owner_id = self.request_params.get('new_owner_id', None)
         if not owner_id:
             return HttpResponseBadRequest(
@@ -131,8 +133,6 @@ class CaseReassignmentInterface(CaseListMixin, BulkDataInterface):
             self.request.META['HTTP_REFERER']
         )
         task_ref.set_task(task)
-        if self.request.method != 'POST':
-            return HttpResponseBadRequest()
         return HttpResponseRedirect(
             reverse(
                 BulkCaseReassignSatusView.urlname,

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
@@ -132,7 +132,7 @@ hqDefine("data_interfaces/js/case_management",[
                 $modal.find('.modal-body').text("Please select an owner");
                 $modal.modal('show');
             } else {
-                if (self.selectAllMatches) {
+                if (self.selectAllMatches()) {
                     self.updateAllMatches(newOwner);
                     return;
                 }

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_management.js
@@ -4,7 +4,8 @@ hqDefine("data_interfaces/js/case_management",[
     'knockout',
     'case/js/casexml',
     'hqwebapp/js/initial_page_data',
-], function ($, _, ko, casexmlModule, initialPageData) {
+    'reports/js/standard_hq_report',
+], function ($, _, ko, casexmlModule, initialPageData, standardHqReport) {
     var caseManagement = function (o) {
         'use strict';
         var self = {};
@@ -19,12 +20,17 @@ hqDefine("data_interfaces/js/case_management",[
         self.selectedCases = ko.observableArray();
         self.selectedOwners = ko.observableArray();
         self.selectedOwnerTypes = ko.observableArray();
+        self.selectAllMatches = ko.observable(false);
 
         // What we're assigning to
         self.newOwner = ko.observable();
 
         self.isSubmitEnabled = ko.computed(function () {
             return !!self.newOwner();
+        }, self);
+
+        self.selectedCount = ko.computed(function () {
+            return self.selectedCases().length;
         }, self);
 
         self.shouldShowOwners = ko.observable(true);
@@ -99,6 +105,18 @@ hqDefine("data_interfaces/js/case_management",[
             self.selectedCases.removeAll();
         };
 
+        self.updateAllMatches = function (ownerId) {
+            var report = standardHqReport.getStandardHQReport();
+            var params = new URLSearchParams(report.getReportParams());
+            var paramsObject = Object.fromEntries(params.entries());
+            paramsObject['new_owner_id'] = ownerId;
+            var bulkReassignUrl = window.location.href.replace("data/edit", "data/edit/bulk");
+            $.postGo(
+                bulkReassignUrl,
+                paramsObject
+            );
+        };
+
         self.updateCaseOwners = function (form) {
             var newOwner = $(form).find('#reassign_owner_select').val(),
                 $modal = $('#caseManagementStatusModal'),
@@ -114,6 +132,10 @@ hqDefine("data_interfaces/js/case_management",[
                 $modal.find('.modal-body').text("Please select an owner");
                 $modal.modal('show');
             } else {
+                if (self.selectAllMatches) {
+                    self.updateAllMatches(newOwner);
+                    return;
+                }
                 $(form).find("[type='submit']").disableButton();
                 for (var i = 0; i < self.selectedCases().length; i++) {
                     var caseId = self.selectedCases()[i],
@@ -167,6 +189,13 @@ hqDefine("data_interfaces/js/case_management",[
                     webUserName: initialPageData.get("web_username"),
                     formName: gettext("Case Reassignment (via HQ)"),
                 });
+                caseManagementModel.selectAllMatches.subscribe(function (selectAllMatches) {
+                    if (selectAllMatches) {
+                        selectAll();
+                    } else {
+                        selectNone();
+                    }
+                });
                 $(interfaceSelector).koApplyBindings(caseManagementModel);
             }
 
@@ -208,15 +237,21 @@ hqDefine("data_interfaces/js/case_management",[
         // Event handlers for selecting & de-selecting cases
         // Similar to archive_forms.js, would be good to combine the two
         $(document).on("click", interfaceSelector + " a.select-all", function () {
-            $(interfaceSelector).find('input.selected-commcare-case').prop('checked', true).change();
+            caseManagementModel.selectAllMatches(false);
+            selectAll();
             return false;
         });
+
+        function selectAll() {
+            $(interfaceSelector).find('input.selected-commcare-case').prop('checked', true).change();
+        }
 
         function selectNone() {
             $(interfaceSelector).find('input.selected-commcare-case:checked').prop('checked', false).change();
         }
 
         $(document).on("click", interfaceSelector + " a.select-none", function () {
+            caseManagementModel.selectAllMatches(false);
             selectNone();
             return false;
         });

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -6,7 +6,22 @@
   <div id="data-interfaces-reassign-cases">
     <div class="row">
       <form class="well form-inline" style="margin: 1em; display: none;" data-bind="submit: updateCaseOwners, caseReassignmentForm: selectedCases">
-        <label for="reassign_owner_select" class="inline">{% trans 'Reassign selected cases to' %} </label>
+        <label for="reassign_owner_select" class="inline">
+          {% blocktrans %}
+          <!-- ko if: selectAllMatches -->
+            Reassign {{total_cases}} selected cases to
+          <!-- /ko -->
+          <!-- ko ifnot: selectAllMatches -->
+            Reassign <span data-bind="text: selectedCount"></span> selected cases to
+          <!-- /ko -->
+          {% endblocktrans %}
+        </label>
+        <div class="checkbox" style="float:right">
+          <label>
+            <input type="checkbox" data-bind="checked: selectAllMatches" />
+            {% trans 'Select all' %} {{total_cases}} cases
+          </label>
+        </div>
         <span data-bind="visible: shouldShowOwners">
           <select name="reassign_owner"
                   id="reassign_owner_select"

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_reassign_complete_email.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_reassign_complete_email.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+
+<p>Hello,</p>
+
+<p>
+  {% trans "The bulk case reassignment has completed successfully." %}
+</p>
+
+<p>
+  {% blocktrans with case_count=result.case_count report_url=result.report_url %}
+  Succesfully reassigned {{ case_count }} cases.
+  <p>The list of cases that were reassigned can be viewed at <a href='{{ report_url }}'>{{ report_url }}</a>.</p>
+  <p>
+  It's possible that in the report the owner_id is not yet updated, you can open individual cases and confirm
+  the right case owner, the report gets updated with a slight delay.
+  </p>
+  {% endblocktrans %}
+<p>
+  Thank you,<br/>
+  The CommCare HQ Team
+</p>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_reassign_status.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_reassign_status.html
@@ -4,7 +4,16 @@
   {% if result.success %}
     <div class="alert alert-success">
       <h3>{% trans "All cases were reassigned" %}</h3>
-      <p>{% blocktrans with count=result.case_count %}Successfully updated {{ count }} cases.{% endblocktrans %}</p>
+      <p>
+        {% blocktrans with case_count=result.case_count report_url=result.report_url %}
+        Succesfully reassigned {{ case_count }} cases.
+        <p>The list of cases that were reassigned can be viewed at <a href='{{ report_url }}'>{{ report_url }}</a>.</p>
+        <p>
+        It's possible that in the report the owner_id is not yet updated, you can open individual cases and confirm
+        the right case owner, the report gets updated with a slight delay.
+        </p>
+        {% endblocktrans %}
+      </p>
     </div>
     {% if result.errors %}
       <div class="alert alert-danger">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_reassign_status.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_reassign_status.html
@@ -1,0 +1,25 @@
+{% extends "hqwebapp/partials/download_status.html" %}
+{% load i18n %}
+{% block results %}
+  {% if result.success %}
+    <div class="alert alert-success">
+      <h3>{% trans "All cases were reassigned" %}</h3>
+      <p>{% blocktrans with count=result.case_count %}Successfully updated {{ count }} cases.{% endblocktrans %}</p>
+    </div>
+    {% if result.errors %}
+      <div class="alert alert-danger">
+        <h3>{% trans "However, we ran into the following problems:" %}</h3>
+        {% for e in result.errors %}
+          <p>{{ e }}</p>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% else %}
+    <div class="alert alert-danger">
+      <h3>{% trans "Case Reassignment Failed! Details:" %}</h3>
+      {% for e in result.errors %}
+        <p>{{ e }}</p>
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endblock results %}

--- a/corehq/apps/data_interfaces/urls.py
+++ b/corehq/apps/data_interfaces/urls.py
@@ -1,6 +1,9 @@
 from django.conf.urls import include, re_path as url
 
-from corehq.apps.data_interfaces.dispatcher import EditDataInterfaceDispatcher
+from corehq.apps.data_interfaces.dispatcher import (
+    EditDataInterfaceDispatcher,
+    BulkEditDataInterfaceDispatcher,
+)
 from corehq.apps.data_interfaces.views import (
     AddCaseRuleView,
     AutomaticUpdateRuleListView,
@@ -16,6 +19,8 @@ from corehq.apps.data_interfaces.views import (
     default,
     find_by_id,
     xform_management_job_poll,
+    BulkCaseReassignSatusView,
+    case_reassign_job_poll
 )
 from corehq.apps.userreports.views import UCRExpressionListView, UCRExpressionEditView
 
@@ -32,8 +37,12 @@ edit_data_urls = [
         XFormManagementStatusView.as_view(),
         name=XFormManagementStatusView.urlname
     ),
-    url(r'^xform_management/status/poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
-        xform_management_job_poll, name='xform_management_job_poll'),
+    url(r'^xform_management/status/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
+        BulkCaseReassignSatusView.as_view(), name=BulkCaseReassignSatusView.urlname),
+    url(r'^case_reassign/status/poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
+        case_reassign_job_poll, name='case_reassign_job_poll'),
+    url(r'^case_reassign/status/poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
+        case_reassign_job_poll, name='case_reassign_job_poll'),
     url(r'^case_groups/$', CaseGroupListView.as_view(), name=CaseGroupListView.urlname),
     url(r'^case_groups/(?P<group_id>[\w-]+)/$',
         CaseGroupCaseManagementView.as_view(), name=CaseGroupCaseManagementView.urlname),
@@ -47,6 +56,7 @@ edit_data_urls = [
     url(r'^deduplication_rules/edit/(?P<rule_id>\d+)/$', DeduplicationRuleEditView.as_view(),
         name=DeduplicationRuleEditView.urlname),
     EditDataInterfaceDispatcher.url_pattern(),
+    BulkEditDataInterfaceDispatcher.url_pattern(),
 ]
 
 urlpatterns = [

--- a/corehq/apps/data_interfaces/urls.py
+++ b/corehq/apps/data_interfaces/urls.py
@@ -37,10 +37,8 @@ edit_data_urls = [
         XFormManagementStatusView.as_view(),
         name=XFormManagementStatusView.urlname
     ),
-    url(r'^xform_management/status/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
+    url(r'^case_reassign/status/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
         BulkCaseReassignSatusView.as_view(), name=BulkCaseReassignSatusView.urlname),
-    url(r'^case_reassign/status/poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
-        case_reassign_job_poll, name='case_reassign_job_poll'),
     url(r'^case_reassign/status/poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
         case_reassign_job_poll, name='case_reassign_job_poll'),
     url(r'^case_groups/$', CaseGroupListView.as_view(), name=CaseGroupListView.urlname),

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -628,18 +628,15 @@ class BulkCaseReassignSatusView(DataInterfaceSection):
         return reverse(self.urlname, args=self.args, kwargs=self.kwargs)
 
 
-def case_reassign_job_poll(request, domain, download_id,
-        template="data_interfaces/partials/case_reassign_status.html"):
+def case_reassign_job_poll(request, domain, download_id):
     try:
         context = get_download_context(download_id, require_result=True)
     except TaskFailedError as e:
         notify_exception(request, message=str(e))
         return HttpResponseServerError()
-
-    context.update({
-        "case_reassign_url": CaseReassignmentInterface.get_url(domain),
-    })
+    template = "data_interfaces/partials/case_reassign_status.html"
     return render(request, template, context)
+
 
 @login_and_domain_required
 @require_GET

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -21,6 +21,7 @@ from django.views.decorators.http import require_GET
 from couchdbkit import ResourceNotFound
 from memoized import memoized
 from no_exceptions.exceptions import Http403
+from dimagi.utils.logging import notify_exception
 
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
@@ -90,7 +91,7 @@ from corehq.util.view_utils import reverse as reverse_with_params
 from corehq.util.workbook_json.excel import WorkbookJSONError, get_workbook
 
 from .dispatcher import require_form_management_privilege
-from .interfaces import BulkFormManagementInterface, FormManagementMode
+from .interfaces import BulkFormManagementInterface, FormManagementMode, CaseReassignmentInterface
 from ..users.decorators import require_permission
 from ..users.models import HqPermissions
 
@@ -602,6 +603,43 @@ def xform_management_job_poll(request, domain, download_id,
     })
     return render(request, template, context)
 
+
+class BulkCaseReassignSatusView(DataInterfaceSection):
+    urlname = "bulk_case_reassign_status"
+    page_title = gettext_noop("Bulk Case Reassignment Status")
+
+    @property
+    def section_url(self):
+        return CaseReassignmentInterface.get_url(self.domain)
+
+    def get(self, request, *args, **kwargs):
+        context = super(BulkCaseReassignSatusView, self).main_context
+        context.update({
+            'domain': self.domain,
+            'download_id': kwargs['download_id'],
+            'poll_url': reverse('case_reassign_job_poll', args=[self.domain, kwargs['download_id']]),
+            'title': _(self.page_title),
+            'progress_text': _("Reassigning Cases. This may take some time..."),
+            'error_text': _("Bulk Case Reassignment failed for some reason and we have noted this failure."),
+        })
+        return render(request, 'hqwebapp/soil_status_full.html', context)
+
+    def page_url(self):
+        return reverse(self.urlname, args=self.args, kwargs=self.kwargs)
+
+
+def case_reassign_job_poll(request, domain, download_id,
+        template="data_interfaces/partials/case_reassign_status.html"):
+    try:
+        context = get_download_context(download_id, require_result=True)
+    except TaskFailedError as e:
+        notify_exception(request, message=str(e))
+        return HttpResponseServerError()
+
+    context.update({
+        "case_reassign_url": CaseReassignmentInterface.get_url(domain),
+    })
+    return render(request, template, context)
 
 @login_and_domain_required
 @require_GET


### PR DESCRIPTION
## Product Description

This adds a new 'Select all <X> matches' where X is all matches including the ones that are not visible in the reassign report.

This works by passing the report-filters as a request.POST to a new `render_as=bulk` endpoint which can reuse the report's query and results to get the list of cases that need to be reassigned. The reassignment is performed in a celery task and uses some of the case-importer code, specifically the one that handles submission throttling. 

https://dimagi-dev.atlassian.net/browse/SC-2552
<img width="773" alt="Screenshot 2023-03-10 at 3 29 51 PM" src="https://user-images.githubusercontent.com/829142/224286276-d4d86991-dcb2-4f5e-8c8a-6e92674ae7da.png">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA

## Safety Assurance

### Safety story
There is test coverage and I have tested locally both the case reassignment and case import

### Automated test coverage

Tests exist

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
