### PR TITLE
Fix time entry default values

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -411,8 +411,9 @@ hqDefine('cloudcare/js/utils', [
             return;
         }
 
+        let date = moment(selectedTime, dateFormat);
         $el.datetimepicker({
-            date: selectedTime,
+            date: date.isValid() ? date : null,
             format: dateFormat,
             useStrict: true,
             useCurrent: false,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SUPPORT-16195
Introduced in https://github.com/dimagi/commcare-hq/pull/32628.  I neglected to bring over [this code](https://github.com/dimagi/commcare-hq/pull/32628/files#diff-4f03cd5cfcedb9050fc1aaaac032fd594ebfecb173feecdfecfcf2fc9f6902a9L771-L772), which coerced the input string to a moment object.

## Feature Flag


## Safety Assurance

### Safety story
I think local testing should suffice here - I'm restoring old behavior

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
