### PR TITLE
set_location() and unset_location() save the user

### DIFF
--- a/corehq/apps/callcenter/tests/test_location_owners.py
+++ b/corehq/apps/callcenter/tests/test_location_owners.py
@@ -61,27 +61,22 @@ class CallCenterLocationOwnerTest(TestCase):
 
     def test_no_location_sync(self):
         self.user.unset_location()
-        self.user.save()
         sync_call_center_user_case(self.user, self.domain.name)
         self.assertCallCenterCaseOwner("")
 
     def test_location_sync(self):
         self.user.set_location(self.root_location)
-        self.user.save()
         self.assertCallCenterCaseOwner(self.root_location._id)
 
     def test_location_change_sync(self):
         self.user.set_location(self.root_location)
-        self.user.save()
 
         # Test changing to another location
         self.user.set_location(self.child_location)
-        self.user.save()
         self.assertCallCenterCaseOwner(self.child_location._id)
 
         # Test changing to no location
         self.user.unset_location()
-        self.user.save()
         self.assertCallCenterCaseOwner("")
 
     def test_ancestor_location_sync(self):
@@ -91,16 +86,13 @@ class CallCenterLocationOwnerTest(TestCase):
         self.domain.save()
 
         self.user.set_location(self.grandchild_location)
-        self.user.save()
         self.assertCallCenterCaseOwner(self.root_location._id)
 
         self.user.unset_location()
-        self.user.save()
         # Call center case owner should be "" if the user's location is not set
         self.assertCallCenterCaseOwner("")
 
         self.user.set_location(self.child_location)
-        self.user.save()
         # owner should be the highest ancestor if there aren't any further ancestors
         self.assertCallCenterCaseOwner(self.root_location._id)
 


### PR DESCRIPTION
## Technical Summary

Tiny. `user.set_location()` and `user.unset_location()` already save the user. No need to save twice.

## Safety Assurance

### Safety story

Drops unnecessary calls in a unit test.

### Automated test coverage

Is a test.

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
