### PR TITLE
Revert "Revert "Use new instance connector definitions""

### DIFF
--- a/corehq/apps/app_manager/app_schemas/casedb_schema.py
+++ b/corehq/apps/app_manager/app_schemas/casedb_schema.py
@@ -63,7 +63,7 @@ def get_registry_schema(form):
 
     return {
         "id": "registry",
-        "uri": "jr://instance/remote",
+        "uri": "jr://instance/remote/registry",
         "name": "registry_case",
         "path": "/results/case",
         "structure": {},

--- a/corehq/apps/app_manager/app_schemas/tests/test_schema.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_schema.py
@@ -694,7 +694,7 @@ class RegistrySchemaTest(BaseSchemaTest):
         schema = get_registry_schema(village)
         self.assert_has_kv_pairs(schema, {
             "id": "registry",
-            "uri": "jr://instance/remote",
+            "uri": "jr://instance/remote/registry",
             "name": "registry_case",
             "path": "/results/case",
             "structure": {},

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -86,11 +86,6 @@ class EntryInstances(PostProcessor):
 
     See docs/apps/instances.rst"""
 
-    IGNORED_INSTANCES = {
-        'jr://instance/remote',
-        'jr://instance/search-input',
-    }
-
     @time_method()
     def update_suite(self):
         for entry in self.suite.entries:
@@ -235,7 +230,7 @@ class EntryInstances(PostProcessor):
         used = {(instance.id, instance.src) for instance in entry.instances}
         instance_order_updated = EntryInstances.update_instance_order(entry)
         for instance in instances:
-            if instance.src in EntryInstances.IGNORED_INSTANCES:
+            if EntryInstances._should_ignore_instance(instance):
                 continue
             if (instance.id, instance.src) not in used:
                 entry.instances.append(
@@ -257,6 +252,15 @@ class EntryInstances(PostProcessor):
         sorted_instances = sorted(entry.instances, key=lambda instance: instance.id)
         if sorted_instances != entry.instances:
             entry.instances = sorted_instances
+
+    @staticmethod
+    def _should_ignore_instance(instance):
+        for prefix in {
+            'jr://instance/remote/',
+        }:
+            if instance.src.startswith(prefix):
+                return True
+        return False
 
     @staticmethod
     def update_instance_order(entry):
@@ -308,9 +312,10 @@ INSTANCE_KWARGS_BY_ID = {
     'ledgerdb': dict(id='ledgerdb', src='jr://instance/ledgerdb'),
     'casedb': dict(id='casedb', src='jr://instance/casedb'),
     'commcaresession': dict(id='commcaresession', src='jr://instance/session'),
-    'registry': dict(id='registry', src='jr://instance/remote'),
-    'selected_cases': dict(id='selected_cases', src='jr://instance/selected-entities'),
-    'search_selected_cases': dict(id='search_selected_cases', src='jr://instance/selected-entities'),
+    'registry': dict(id='registry', src='jr://instance/remote/registry'),
+    'selected_cases': dict(id='selected_cases', src='jr://instance/selected-entities/selected_cases'),
+    'search_selected_cases': dict(id='search_selected_cases',
+                                  src='jr://instance/selected-entities/search_selected_cases'),
 }
 
 
@@ -328,12 +333,16 @@ def generic_fixture_instances(app, instance_name):
 
 @register_factory('search-input')
 def search_input_instances(app, instance_name):
-    return Instance(id=instance_name, src='jr://instance/search-input')
+    try:
+        _, query_datum_id = instance_name.split(':', 1)
+    except ValueError:
+        query_datum_id = instance_name
+    return Instance(id=instance_name, src=f'jr://instance/search-input/{query_datum_id}')
 
 
 @register_factory('results')
 def remote_instances(app, instance_name):
-    return Instance(id=instance_name, src='jr://instance/remote')
+    return Instance(id=instance_name, src=f'jr://instance/remote/{instance_name}')
 
 
 @register_factory('commcare')

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -88,9 +88,7 @@ class EntryInstances(PostProcessor):
 
     IGNORED_INSTANCES = {
         'jr://instance/remote',
-        'jr://instance/remote/remote',
         'jr://instance/search-input',
-        'jr://instance/search-input/search-input',
     }
 
     @time_method()
@@ -333,9 +331,10 @@ def generic_fixture_instances(app, instance_name):
 def search_input_instances(app, instance_name):
     try:
         _, query_datum_id = instance_name.split(':', 1)
+        src = f'jr://instance/search-input/{query_datum_id}'
     except ValueError:
-        query_datum_id = instance_name
-    return Instance(id=instance_name, src=f'jr://instance/search-input/{query_datum_id}')
+        src = 'jr://instance/search-input'  # legacy instance
+    return Instance(id=instance_name, src=src)
 
 
 @register_factory('results')

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -86,6 +86,11 @@ class EntryInstances(PostProcessor):
 
     See docs/apps/instances.rst"""
 
+    IGNORED_INSTANCES = {
+        'jr://instance/remote',
+        'jr://instance/search-input',
+    }
+
     @time_method()
     def update_suite(self):
         for entry in self.suite.entries:
@@ -230,7 +235,7 @@ class EntryInstances(PostProcessor):
         used = {(instance.id, instance.src) for instance in entry.instances}
         instance_order_updated = EntryInstances.update_instance_order(entry)
         for instance in instances:
-            if EntryInstances._should_ignore_instance(instance):
+            if instance.src in EntryInstances.IGNORED_INSTANCES:  # ignore legacy instances
                 continue
             if (instance.id, instance.src) not in used:
                 entry.instances.append(
@@ -252,15 +257,6 @@ class EntryInstances(PostProcessor):
         sorted_instances = sorted(entry.instances, key=lambda instance: instance.id)
         if sorted_instances != entry.instances:
             entry.instances = sorted_instances
-
-    @staticmethod
-    def _should_ignore_instance(instance):
-        for prefix in {
-            'jr://instance/remote/',
-        }:
-            if instance.src.startswith(prefix):
-                return True
-        return False
 
     @staticmethod
     def update_instance_order(entry):

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -88,7 +88,9 @@ class EntryInstances(PostProcessor):
 
     IGNORED_INSTANCES = {
         'jr://instance/remote',
+        'jr://instance/remote/remote',
         'jr://instance/search-input',
+        'jr://instance/search-input/search-input',
     }
 
     @time_method()

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2/multi_no_actions.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2/multi_no_actions.xml
@@ -19,7 +19,7 @@
                 </data>
             </instance>
             <instance src="jr://instance/session" id="commcaresession"/>
-            <instance src="jr://instance/selected-entities" id="selected_cases"/>
+            <instance src="jr://instance/selected-entities/selected_cases" id="selected_cases"/>
             <bind nodeset="/data/question1" type="xsd:string"/>
             <itext>
                 <translation lang="en" default="">

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2/multi_open_update_case.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2/multi_open_update_case.xml
@@ -29,7 +29,7 @@
                 </data>
             </instance>
             <instance src="jr://instance/session" id="commcaresession"/>
-            <instance src="jr://instance/selected-entities" id="selected_cases"/>
+            <instance src="jr://instance/selected-entities/selected_cases" id="selected_cases"/>
             <bind nodeset="/data/question1" type="xsd:string" required="true()"/>
             <itext>
                 <translation lang="en" default="">

--- a/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
@@ -16,7 +16,7 @@
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
-    <instance id="search_selected_cases" src="jr://instance/selected-entities"/>
+    <instance id="search_selected_cases" src="jr://instance/selected-entities/search_selected_cases"/>
     <session>
       <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/multiple-referrals/phone/search/{app_id}/">
         <title>

--- a/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
@@ -16,6 +16,7 @@
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
+      <instance id="results" src="jr://instance/remote/results"/>
     <instance id="search_selected_cases" src="jr://instance/selected-entities/search_selected_cases"/>
     <session>
       <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/multiple-referrals/phone/search/{app_id}/">

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -19,6 +19,7 @@
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="locations" src="jr://fixture/locations"/>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
+    <instance id="results" src="jr://instance/remote/results"/>
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -17,6 +17,7 @@
     <instance id="item-list:trees" src="jr://fixture/item-list:trees"/>
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="locations" src="jr://fixture/locations"/>
+    <instance id="results" src="jr://instance/remote/results"/>
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -16,6 +16,7 @@
     <instance id="item-list:moons" src="jr://fixture/item-list:moons"/>
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
+    <instance id="results" src="jr://instance/remote/results"/>
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -17,6 +17,7 @@
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="locations" src="jr://fixture/locations"/>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
+    <instance id="results" src="jr://instance/remote/results"/>
     <session>
       <query url="https://www.example.com/a/test_domain/phone/search/123/"
              default_search="false"

--- a/corehq/apps/app_manager/tests/data/suite/smart_link_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/smart_link_remote_request.xml
@@ -13,6 +13,7 @@
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
+    <instance id="results" src="jr://instance/remote/results"/>
     <session>
       <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/test_domain/phone/search/{app_id}/">
         <title>

--- a/corehq/apps/app_manager/tests/data/suite_inline_search/shadow_module_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_inline_search/shadow_module_entry.xml
@@ -13,6 +13,7 @@
         </command>
         <instance id="casedb" src="jr://instance/casedb"/>
         <instance id="commcaresession" src="jr://instance/session"/>
+        <instance id="results:inline" src="jr://instance/remote/results:inline"/>
         <session>
             <query default_search="false" storage-instance="results:inline" template="case"
                    url="http://localhost:8000/a/test_domain/phone/search/456/">

--- a/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
@@ -8,6 +8,7 @@
         </command>
         <instance id="commcaresession" src="jr://instance/session"/>
         <instance id="item-list:colors" src="jr://fixture/item-list:colors"/>
+        <instance id="results" src="jr://instance/remote/results"/>
         <session>
           <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="results" template="case" default_search="false">
             <title>

--- a/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_entry.xml
@@ -8,6 +8,7 @@
     </command>
     <instance id="commcaresession" src="jr://instance/session"/>
     <instance id="item-list:textures" src="jr://fixture/item-list:textures"/>
+    <instance id="results" src="jr://instance/remote/results"/>
     <session>
       <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/test_domain/phone/search/456/">
         <title>

--- a/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_remote_request.xml
@@ -13,6 +13,7 @@
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
     <instance id="item-list:textures" src="jr://fixture/item-list:textures"/>
+    <instance id="results" src="jr://instance/remote/results"/>
     <session>
       <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/test_domain/phone/search/456/">
         <title>

--- a/corehq/apps/app_manager/tests/test_advanced_suite.py
+++ b/corehq/apps/app_manager/tests/test_advanced_suite.py
@@ -385,6 +385,7 @@ class AdvancedSuiteTest(SimpleTestCase, SuiteMixin):
             </command>
             <instance id="casedb" src="jr://instance/casedb"/>
             <instance id="commcaresession" src="jr://instance/session"/>
+            <instance id="results" src="jr://instance/remote/results"/>
             <session>
               <query url="http://localhost:8000/a/domain/phone/search/123/"
                 storage-instance="results" template="case" default_search="false">

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -194,7 +194,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
               </text>
             </command>
             <instance id="casedb" src="jr://instance/casedb"/>
-            <instance id="selected_cases" src="jr://instance/selected-entities"/>
+            <instance id="selected_cases" src="jr://instance/selected-entities/selected_cases"/>
             <session>
                 <query url="http://localhost:8000/a/test_domain/phone/search/123/"
                     storage-instance="{RESULTS_INSTANCE_INLINE}"

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -556,6 +556,7 @@ class InlineSearchChildModuleTest(SimpleTestCase, SuiteMixin):
             </command>
             <instance id="casedb" src="jr://instance/casedb"/>
             <instance id="commcaresession" src="jr://instance/session"/>
+            <instance id="results:inline" src="jr://instance/remote/results:inline"/>
             <session>
               <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']"
                 value="./@case_id" detail-select="m0_case_short"/>

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -100,6 +100,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             </command>
             <instance id="casedb" src="jr://instance/casedb"/>
             <instance id="commcaresession" src="jr://instance/session"/>
+            <instance id="results:inline" src="jr://instance/remote/results:inline"/>
             <session>
                 <query url="http://localhost:8000/a/test_domain/phone/search/123/"
                     storage-instance="{RESULTS_INSTANCE_INLINE}" template="case" default_search="false">
@@ -142,6 +143,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                 <locale id="case_lists.m0"/>
               </text>
             </command>
+            <instance id="results:inline" src="jr://instance/remote/results:inline"/>
             <session>
                 <query url="http://localhost:8000/a/test_domain/phone/search/123/"
                     storage-instance="{RESULTS_INSTANCE_INLINE}" template="case" default_search="false">
@@ -194,6 +196,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
               </text>
             </command>
             <instance id="casedb" src="jr://instance/casedb"/>
+            <instance id="results:inline" src="jr://instance/remote/results:inline"/>
             <instance id="selected_cases" src="jr://instance/selected-entities/selected_cases"/>
             <session>
                 <query url="http://localhost:8000/a/test_domain/phone/search/123/"
@@ -387,6 +390,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             </command>
             <instance id="casedb" src="jr://instance/casedb"/>
             <instance id="commcaresession" src="jr://instance/session"/>
+            <instance id="results:inline" src="jr://instance/remote/results:inline"/>
             <session>
               <datum id="case_id_case"
                 nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']"
@@ -556,6 +560,7 @@ class InlineSearchChildModuleTest(SimpleTestCase, SuiteMixin):
             </command>
             <instance id="casedb" src="jr://instance/casedb"/>
             <instance id="commcaresession" src="jr://instance/session"/>
+            <instance id="results:inline" src="jr://instance/remote/results:inline"/>
             <session>
               <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']"
                 value="./@case_id" detail-select="m0_case_short"/>

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -148,6 +148,7 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
         self.assertXmlPartialEqual(
             """
             <partial>
+            <instance id="search-input:results" src="jr://instance/search-input/results"/>
             </partial>
             """,
             self.factory.app.create_suite(),

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -180,7 +180,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session/query[2]")
 
         self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='commcaresession']")
-        self.assertXmlDoesNotHaveXpath(suite, "./entry[1]/instance[@id='registry']")
+        self.assertXmlHasXpath(suite, "./entry[1]/instance[@id='registry']")
 
     def test_form_linking_from_registry_module(self, *args):
         self.form.post_form_workflow = WORKFLOW_FORM

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -546,6 +546,7 @@ class InlineSearchDataRegistryModuleTest(SimpleTestCase, SuiteMixin):
               </text>
             </command>
             <instance id="commcaresession" src="jr://instance/session"/>
+            <instance id="results:inline" src="jr://instance/remote/results:inline"/>
             <session>
                 <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="{RESULTS_INSTANCE_INLINE}"
                     template="case" default_search="false">

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1661,7 +1661,7 @@ class XForm(WrappedNode):
         if form.get_module().is_multi_select():
             self.add_instance(
                 'selected_cases',
-                'jr://instance/selected-entities'
+                'jr://instance/selected-entities/selected_cases'
             )
             default_case_management = False
         else:


### PR DESCRIPTION
## Technical Summary
Reimplements https://github.com/dimagi/commcare-hq/pull/32202
Original ticket: https://dimagi-dev.atlassian.net/browse/USH-2084

One addition change is the suggestion [here](https://github.com/dimagi/commcare-hq/pull/32202#discussion_r1119746926) from the last PR, which is the cause for all the test changes
## Feature Flag 
Case claim / data registries / multi-select case list

## Safety Assurance

### Safety story
This will go through QA to include accommodations to specific references to `instance('search-input')` to accomidate old functionality along with the new

### Automated test coverage
There's decent test coverage of suite generation. Tests updated in this PR.

### QA Plan
Yes to QA: https://dimagi-dev.atlassian.net/browse/QA-4564

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change