### PR TITLE
Tableau user syncing - various fixes

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -375,27 +375,33 @@ class TableauAPISession(object):
             raise TableauAPIError("Error: API does not work with more than 1000 groups on a single site.")
         return response_body['groups']['group']
 
-    def get_user_on_site(self, username):
+    def get_users_on_site(self):
         '''
-        Returns a dict for the Tableau user with the given username, None if user can't be found:
+        Returns dict of the form:
         {
-            'email': '',
-            'fullName': ...,
-            'id': ...,
-            'name': ...,
-            'siteRole': ...,
+            "username1": {
+                "id": id,
+                "siteRole": role
+            },
+            "username2": {
+                "id": id,
+                "siteRole": role
+            },
             ...
         }
         '''
-        url = self.base_url + f'/sites/{self.site_id}/users?filter=name:eq:{username}'
+        url = self.base_url + f'/sites/{self.site_id}/users'
         response_body = self._make_request(
             self.GET,
-            'Get User on Site',
+            'Get Users on Site',
             url,
             {}
         )
         if response_body['users']:
-            return response_body['users']['user'][0]
+            return {user['name']: {
+                "id": user['id'],
+                "siteRole": user['siteRole']
+            } for user in response_body['users']['user']}
         else:
             return None
 

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -441,10 +441,9 @@ class TableauAPISession(object):
             page_number += 1
         return tableau_users
 
-    def create_group(self, group_name, min_site_role):
+    def create_group(self, group_name):
         '''
-        Creates a Tableau group with the given name, and assigns the given role to the group.
-        Returns the group ID.
+        Creates a Tableau group with the given name. Returns the group ID.
         '''
         response_body = self._make_request(
             self.POST,
@@ -452,8 +451,7 @@ class TableauAPISession(object):
             self.base_url + f'/sites/{self.site_id}/groups',
             {
                 "group": {
-                    "name": f"{group_name}",
-                    "minimumSiteRole": f"{min_site_role}"
+                    "name": f"{group_name}"
                 }
             }
         )

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -379,10 +379,7 @@ class TableauAPISession(object):
         page_size = 100
         page_number = 1
         total_users = sys.maxsize
-        tableau_users = []
-        print(additional_url_path)
         while (page_size * (page_number - 1) < total_users):
-            print(page_number)
             response_body = self._make_request(
                 self.GET,
                 method_name,
@@ -395,9 +392,8 @@ class TableauAPISession(object):
                 total_users = int(response_body['pagination']['totalAvailable'])
                 if total_users == 0:
                     return []
-            tableau_users += response_body['users']['user']
+            yield from response_body['users']['user']
             page_number += 1
-        return tableau_users
 
     def get_users_on_site(self):
         '''
@@ -439,7 +435,7 @@ class TableauAPISession(object):
         '''
         method_name = 'Get Users in Group'
         additional_url_path = f'/sites/{self.site_id}/groups/{group_id}/users'
-        return self._make_paginated_request_for_users(method_name, additional_url_path)
+        return list(self._make_paginated_request_for_users(method_name, additional_url_path))
 
     def create_group(self, group_name):
         '''

--- a/corehq/apps/reports/tests/test_tableau_api_session.py
+++ b/corehq/apps/reports/tests/test_tableau_api_session.py
@@ -313,7 +313,7 @@ class TestTableauAPISession(TestCase):
         api_session = self._sign_in(api_session=api_session)
         name = 'group3'
         mock_request.return_value = self.tableau_instance.create_group_response(name)
-        group_id = api_session.create_group(name, 'Viewer')
+        group_id = api_session.create_group(name)
         self.assertEqual(group_id, 'nm12zx')
 
     @mock.patch('corehq.apps.reports.models.requests.request')

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -677,11 +677,11 @@ def add_on_tableau_details(domain, web_user_dicts):
 
 # Attaches to the import_users method
 def import_tableau_users(domain, web_user_specs):
-    try:
-        session = TableauAPISession.create_session_for_domain(domain)
-    except TableauAPIError as e:
-        _notify_tableau_exception(e, domain)
+    # Skip the Tableau users part of the import if one of the columns is missing
+    if (not web_user_specs or web_user_specs[0].get('tableau_role') is None
+    or web_user_specs[0].get('tableau_groups') is None):
         return
+    session = TableauAPISession.create_session_for_domain(domain)
     known_groups = {}
     for row in web_user_specs:
         username = row.get('username')
@@ -693,7 +693,7 @@ def import_tableau_users(domain, web_user_specs):
             elif user.get_domain_membership(domain):
                 tableau_role = row.get('tableau_role')
                 tableau_groups_txt = row.get('tableau_groups')
-                BAD_VALUES = ['ERROR', 'N/A', None]
+                BAD_VALUES = ['ERROR', 'N/A']
                 if tableau_role in BAD_VALUES or tableau_groups_txt in BAD_VALUES:
                     continue
 

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -580,7 +580,7 @@ def sync_all_tableau_users():
             if remote_HQ_group_id:
                 remote_HQ_group_users = session.get_users_in_group(remote_HQ_group_id)
             else:
-                session.create_group(HQ_TABLEAU_GROUP_NAME, "Viewer")
+                session.create_group(HQ_TABLEAU_GROUP_NAME)
                 remote_HQ_group_users = []
             return remote_HQ_group_users
 

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -697,7 +697,8 @@ def import_tableau_users(domain, web_user_specs):
             elif user.get_domain_membership(domain):
                 tableau_role = row.get('tableau_role')
                 tableau_groups_txt = row.get('tableau_groups')
-                if tableau_role in ('ERROR', 'N/A') or tableau_groups_txt in ('ERROR', 'N/A'):
+                BAD_VALUES = ['ERROR', 'N/A', None]
+                if tableau_role in BAD_VALUES or tableau_groups_txt in BAD_VALUES:
                     continue
 
                 def _get_tableau_group_tuples_from_names(names, known_groups):

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -594,16 +594,13 @@ def sync_all_tableau_users():
         local_users = TableauUser.objects.filter(server=session.tableau_connected_app.server)
 
         # Add/delete/update remote users to match with local reality
-        def _add_new_user_to_HQ_group(session, local_user):
-            new_user_id = _add_tableau_user_remote(session, local_user, local_user.role)
-            session.add_user_to_group(new_user_id, remote_HQ_group_id)
         for local_user in local_users:
             remote_user = session.get_user_on_site(tableau_username(local_user.username))
             if not remote_user:
-                _add_new_user_to_HQ_group(session, local_user)
+                _add_tableau_user_remote(session, local_user, local_user.role)
             elif local_user.tableau_user_id != remote_user['id']:
                 _delete_user_remote(session, remote_user['id'])
-                _add_new_user_to_HQ_group(session, local_user)
+                _add_tableau_user_remote(session, local_user)
             elif local_user.role != remote_user['siteRole']:
                 _update_user_remote(
                     session,

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -591,7 +591,7 @@ def sync_all_tableau_users():
         # Add/delete/update remote users to match with local reality
         for local_user in local_users:
             local_tableau_username = tableau_username(local_user.username)
-            if local_tableau_username not in all_remote_users.keys():
+            if local_tableau_username not in all_remote_users:
                 _add_tableau_user_remote(session, local_user, local_user.role)
             elif local_user.tableau_user_id != all_remote_users[local_tableau_username]['id']:
                 _delete_user_remote(session, all_remote_users[local_tableau_username]['id'])


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR includes various fixes to Tableau User Syncing. Some are in response to [QA](https://dimagi-dev.atlassian.net/browse/USH-2888?atlOrigin=eyJpIjoiZDhlMGM0Zjc5NDRmNDZkNDg4MmEwMTlmYjgxZDM0NDkiLCJwIjoiaiJ9), others are refinements I made to get the feature ready for production use.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I recommend reviewing by commit.

Various notes on some of the fixes:
- before this PR, if the "tableau_groups" or "tableau_role" columns were missing from a bulk web user upload, an error would be thrown. There is a commit to have no errors when this happens instead
- before this PR, having a "+" in a username caused an error with syncing. Tableau does not support filtering a username when there's a plus (a bug with their API), so I've re-written the syncing method to accommodate this.
- According to the [Django docs](https://docs.djangoproject.com/en/4.1/topics/db/transactions/), "you catch and handle exceptions inside an atomic block, you may hide from Django the fact that a problem has happened".  The try/except blocks in the add/update/delete tableau user methods will likely the @atomic decorator from working. An error will be sent to sentry without these blocks anyways, and stopping execution in these methods should be fine, so I've added a commit to remove them.
- Some users need to have a role "Unlicensed", so I've got a commit to remove the minimum role for the "HQ" group.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

TABLEAU_USER_SYNCING. Parent toggles: EMBEDDED_TABLEAU and EMBED_TABLEAU_REPORT_BY_USER.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

This has been tested by QA. 

### Automated test coverage

There are existing tests:
corehq.apps.reports.tests.test_tableau_api_util
corehq.apps.reports.tests.test_tableau_api_session
corehq.apps.user_importer.tests.test_importer:TestWebUserBulkUpload
corehq.apps.users.tests.test_web_user_download

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

This PR implements fixes for bugs arisen during the QA process on the entire Tableau User Syncing feature.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
