### PR TITLE
Ze/make location alert conditional

### DIFF
--- a/corehq/apps/locations/tests/test_permissions.py
+++ b/corehq/apps/locations/tests/test_permissions.py
@@ -219,7 +219,7 @@ class TestAccessRestrictions(LocationHierarchyTestCase):
         ):
             self._assert_url_returns_status(url, status_code)
 
-    @mock.patch('corehq.apps.users.views.mobile.users.get_locations_with_cases', return_value={})
+    @mock.patch('corehq.apps.users.views.mobile.users.get_locations_with_single_user', return_value={})
     def test_can_edit_worker(self, _):
         self._assert_edit_user_gives_status(self.boston_worker, 200)
 

--- a/corehq/apps/users/templates/users/partials/edit_commtrack_user_settings.html
+++ b/corehq/apps/users/templates/users/partials/edit_commtrack_user_settings.html
@@ -10,24 +10,26 @@
     {% crispy commtrack.update_form %}
   </fieldset>
   {% if not request.is_view_only %}
-    {% if locations_with_cases %}
+    {% if locations_with_single_user %}
       <div class="alert alert-warning">
         <p>
           {% blocktrans %}
-            There are cases in the following assigned locations which may need to be migrated:
+            The user is the only one that is assigned to the following locations with cases:
           {% endblocktrans %}
         </p>
-        {% for location, case_count in locations_with_cases.items %}
+        {% for location, case_count in locations_with_single_user.items %}
           <ul>
             <li>{{ location }}: {{ case_count }}</li>
           </ul>
         {% endfor %}
+        Moving the user's location may result in no user having jurisdiction in one or more
+        of these locations.
       </div>
     {% else %}
       <div class="alert alert-info">
         <p>
           {% blocktrans %}
-            There are no cases in any of the user's assigned locations that need to be migrated.
+            The user shares all assigned locations with one or more other users.
           {% endblocktrans %}
         </p>
       </div>

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -143,7 +143,7 @@ from soil.exceptions import TaskFailedError
 from soil.util import get_download_context
 from .custom_data_fields import UserFieldsView
 from ..utils import log_user_groups_change
-from corehq.apps.users.views.utils import get_locations_with_cases
+from corehq.apps.users.views.utils import get_locations_with_single_user
 
 BULK_MOBILE_HELP_SITE = ("https://confluence.dimagi.com/display/commcarepublic"
                          "/Create+and+Manage+CommCare+Mobile+Workers#Createand"
@@ -298,7 +298,11 @@ class EditCommCareUserView(BaseEditUserView):
             ),
             'demo_restore_date': naturaltime(demo_restore_date_created(self.editable_user)),
             'group_names': [g.name for g in self.groups],
-            "locations_with_cases": get_locations_with_cases(self.domain, self.editable_user.assigned_location_ids)
+            'locations_with_single_user': get_locations_with_single_user(
+                self.domain,
+                self.editable_user.assigned_location_ids,
+                self.editable_user.user_id
+            )
         }
         if self.commtrack_form.errors:
             messages.error(self.request, _(

--- a/corehq/apps/users/views/utils.py
+++ b/corehq/apps/users/views/utils.py
@@ -13,7 +13,8 @@ from corehq.apps.users.util import log_user_change
 from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.apps.es.cases import CaseES
 from corehq.apps.es.aggregations import TermsAggregation
-from corehq.apps.users.dbaccessors import get_all_commcare_users_by_domain
+from corehq.apps.es.users import UserES
+from corehq.apps.es import filters
 
 
 def get_editable_role_choices(domain, couch_user, allow_admin_role):
@@ -115,17 +116,37 @@ def log_commcare_user_locations_changes(request, user, old_location_id, old_assi
 
 
 def _get_location_ids_with_single_user(domain, location_ids, user_id):
-    other_commcare_user_ids = [user.user_id for user in get_all_commcare_users_by_domain(domain)]
     # Remove the user's ID, as we want to see which other CommCare users share any of the given location_ids
-    other_commcare_user_ids.remove(user_id)
+    user_query = (
+        UserES()
+        .domain(domain)
+        .mobile_users()
+        .location(location_ids)
+    )
+    user_query.filter(filters.NOT(filters.doc_id(user_id)))
+    other_commcare_user_ids = user_query.get_ids()
+
+    case_query = (
+        CaseES()
+        .domain(domain)
+        .owner(location_ids)
+        .user(other_commcare_user_ids)
+        .aggregation(TermsAggregation('by_location', 'owner_id')
+        .size(0))
+    ).run()
+    return list(set(location_ids) - set(case_query.aggregations.by_location.keys))
+
+
+def _get_location_case_counts_with_single_user(domain, location_ids):
     query = (CaseES()
             .domain(domain)
             .owner(location_ids)
-            .user(other_commcare_user_ids)
             .aggregation(TermsAggregation('by_location', 'owner_id')
             .size(0))
     ).run()
-    return list(set(location_ids) - set(query.aggregations.by_location.keys))
+    locations = SQLLocation.objects.filter(location_id__in=location_ids)
+    counts = query.aggregations.by_location.counts_by_bucket()
+    return locations, counts
 
 
 def get_locations_with_single_user(domain, location_ids, user_id):
@@ -141,15 +162,7 @@ def get_locations_with_single_user(domain, location_ids, user_id):
     location_ids_with_single_user = _get_location_ids_with_single_user(domain, location_ids, user_id)
     locations_with_single_user = dict()
     if location_ids_with_single_user:
-        query = (CaseES()
-                .domain(domain)
-                .owner(location_ids_with_single_user)
-                .aggregation(TermsAggregation('by_location', 'owner_id')
-                .size(0))
-        ).run()
-
-        locations = SQLLocation.objects.filter(location_id__in=location_ids_with_single_user)
-        counts = query.aggregations.by_location.counts_by_bucket()
+        locations, counts = _get_location_case_counts_with_single_user(domain, location_ids_with_single_user)
         for location in locations:
             if location.location_id in counts:
                 locations_with_single_user[location.name] = counts[location.location_id]

--- a/corehq/apps/users/views/utils.py
+++ b/corehq/apps/users/views/utils.py
@@ -13,6 +13,7 @@ from corehq.apps.users.util import log_user_change
 from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.apps.es.cases import CaseES
 from corehq.apps.es.aggregations import TermsAggregation
+from corehq.apps.users.dbaccessors import get_all_commcare_users_by_domain
 
 
 def get_editable_role_choices(domain, couch_user, allow_admin_role):
@@ -113,26 +114,46 @@ def log_commcare_user_locations_changes(request, user, old_location_id, old_assi
         )
 
 
-def get_locations_with_cases(domain, location_ids):
-    """
-    Takes a list of location IDs and returns how many cases are assigned to each location
-    :param domain: The domain to search in
-    :param location_ids: A list of location IDs to get case counts on
-    :returns A dict with location names as the key, and the number of cases assigned to it as the value
-    """
+def _get_location_ids_with_single_user(domain, location_ids, user_id):
+    other_commcare_user_ids = [user.user_id for user in get_all_commcare_users_by_domain(domain)]
+    # Remove the user's ID, as we want to see which other CommCare users share any of the given location_ids
+    other_commcare_user_ids.remove(user_id)
     query = (CaseES()
             .domain(domain)
             .owner(location_ids)
+            .user(other_commcare_user_ids)
             .aggregation(TermsAggregation('by_location', 'owner_id')
-            .size(0)))
-    counts = query.run().aggregations.by_location.counts_by_bucket()
-    locations_with_cases = dict()
-    if counts:
-        locations = SQLLocation.objects.filter(location_id__in=location_ids)
+            .size(0))
+    ).run()
+    return list(set(location_ids) - set(query.aggregations.by_location.keys))
+
+
+def get_locations_with_single_user(domain, location_ids, user_id):
+    """
+    Takes a list of location IDs and returns all the given location IDs
+    where the user ID is the only one that has cases there.
+    :param domain: The domain to search in.
+    :param location_ids: A list of location IDs to get case counts on.
+    :param user_id: The user ID to check given location_ids with as the only assigned user with cases.
+    :returns A dict with location names as the key, and the number of cases assigned to them as the value.
+    """
+    # Get locations where only given user_id has cases in list of locations
+    location_ids_with_single_user = _get_location_ids_with_single_user(domain, location_ids, user_id)
+    locations_with_single_user = dict()
+    if location_ids_with_single_user:
+        query = (CaseES()
+                .domain(domain)
+                .owner(location_ids_with_single_user)
+                .aggregation(TermsAggregation('by_location', 'owner_id')
+                .size(0))
+        ).run()
+
+        locations = SQLLocation.objects.filter(location_id__in=location_ids_with_single_user)
+        counts = query.aggregations.by_location.counts_by_bucket()
         for location in locations:
             if location.location_id in counts:
-                locations_with_cases[location.name] = counts[location.location_id]
+                locations_with_single_user[location.name] = counts[location.location_id]
             else:
-                locations_with_cases[location.name] = 0
+                locations_with_single_user[location.name] = 0
 
-    return locations_with_cases
+    return locations_with_single_user


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2641).

This changes the alert banner found on the "Location" tab when editing a mobile worker. The alert will now be conditional, only showing the assigned locations where the user in question is the only one assigned to them.

![Screenshot from 2023-03-13 22-51-10](https://user-images.githubusercontent.com/122617251/224829317-9677819b-2038-4113-8d61-76905a6dde5a.png)

If the user shares all their assigned locations with one or more other users, then the following info banner will be shown.

![user_shares_all_locations](https://user-images.githubusercontent.com/122617251/224828925-37edc496-4cb9-4dc8-9ce1-24db10de3a48.png)

The wording of the alert has also been updated to lessen the confusion from this alert and better relay to the user the potential consequences of moving a user's location.



## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Have done local testing.
- Implemented automated tests.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests have been created for helper function.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
