### PR TITLE
Strip tags to address XSS vulnerability

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -14,7 +14,7 @@ from django.http import (
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.safestring import mark_safe
-from django.utils.html import format_html, strip_tags
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy
 from django.utils.translation import gettext as _
 from django.views import View
@@ -1155,7 +1155,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
         try:
             detail = getattr(module, '{0}_details'.format(detail_type))
         except AttributeError:
-            return HttpResponseBadRequest("Unknown detail type '%s'" % strip_tags(detail_type))
+            return HttpResponseBadRequest(format_html("Unknown detail type '{}'", detail_type))
 
     lang = request.COOKIES.get('lang', app.langs[0])
     if short is not None:

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -14,7 +14,7 @@ from django.http import (
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.safestring import mark_safe
-from django.utils.html import format_html
+from django.utils.html import format_html, strip_tags
 from django.utils.translation import gettext_lazy
 from django.utils.translation import gettext as _
 from django.views import View
@@ -1155,7 +1155,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
         try:
             detail = getattr(module, '{0}_details'.format(detail_type))
         except AttributeError:
-            return HttpResponseBadRequest("Unknown detail type '%s'" % detail_type)
+            return HttpResponseBadRequest("Unknown detail type '%s'" % strip_tags(detail_type))
 
     lang = request.COOKIES.get('lang', app.langs[0])
     if short is not None:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No visible user facing change

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/INDIV-90
During an audit, possibility of XSS attack was highlighted for view "edit_module_detail_screens". 
I believe by UI one can't pass anything for `detail_type` but through injection one could change the value of param to whatever needed.
The value put in for `detail_type` was `"case"rhb7c<script>alert(document.cookie)</script>gsyy5` which resulted in a popup in browser displaying the cookie.
Using strip_tags was one way to get rid of scrip tag or any tags since they aren't expected to be in detail_type, which should unblock us for now.
Another solution would be limiting the error message to just say "Unknown detail type" but I wanted to push for to understand what should be done for such scenarios so that they can be done at all places in HQ, at least as a practice in future if not now.
I could not find anything in contribution guidelines, at least here, https://github.com/dimagi/commcare-hq/blob/master/STANDARDS.rst

After striping tags I see the error message directly without any browser popup. Earlier the popup would appear and the error message on UI would show up after the pop up was closed.

![Screenshot from 2023-03-14 15-29-01](https://user-images.githubusercontent.com/3864163/224967413-85dd3af5-40b1-47e8-8d90-75d4a7bb6c22.png)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.
And like I said, I don't believe the detail_type can be set from the UI so this should not impact anything.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
