### PR TITLE
Add placeholder and pattern to daterange picker widget

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -339,6 +339,29 @@ describe('Entries', function () {
         assert.equal(utils.convertTwoDigitYear("not-a-date"), "not-a-date");
     });
 
+    it('Should coerce user input dates to moment objects', function () {
+        let assertParsesAs = function (userInput, expected) {
+            let res = utils.parseInputDate(userInput);
+            assert.isTrue(moment.isMoment(res));
+            assert.equal(
+                res.toISOString(),
+                moment(expected, "YYYY-MM-DD").toISOString()
+            );
+        };
+
+        assertParsesAs("03/04/20", "2020-03-04");
+        assertParsesAs("2020-03-04", "2020-03-04");
+    });
+
+    it('Should fail to interpret invalid date inputs', function () {
+        let assertInvalid = function (userInput, expected) {
+            assert.isNull(utils.parseInputDate(userInput));
+        };
+
+        assertInvalid("23/01/2022");
+        assertInvalid("3/4/20");  // TODO
+    });
+
     it('Should return TimeEntry', function () {
         questionJSON.datatype = constants.TIME;
         questionJSON.answer = '12:30';

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* globals moment */
 
 describe('Entries', function () {
     var constants = hqImport("cloudcare/js/form_entry/const"),
@@ -355,7 +356,7 @@ describe('Entries', function () {
     });
 
     it('Should fail to interpret invalid date inputs', function () {
-        let assertInvalid = function (userInput, expected) {
+        let assertInvalid = function (userInput) {
             assert.isNull(utils.parseInputDate(userInput));
         };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -350,6 +350,7 @@ describe('Entries', function () {
         };
 
         assertParsesAs("03/04/20", "2020-03-04");
+        assertParsesAs("3/4/20", "2020-03-04");
         assertParsesAs("2020-03-04", "2020-03-04");
     });
 
@@ -359,7 +360,8 @@ describe('Entries', function () {
         };
 
         assertInvalid("23/01/2022");
-        assertInvalid("3/4/20");  // TODO
+        assertInvalid("23/1/22");
+        assertInvalid("23-1-22");
     });
 
     it('Should return TimeEntry', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -379,17 +379,19 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             });
             this.ui.dateRange.on('change', function () {
                 // Validate free-text input
-                var $input = $(this),
+                var start, end,
+                    $input = $(this),
                     oldValue = $input.val(),
                     parts = _.map(oldValue.split(separator), cloudcareUtils.parseInputDate),
                     newValue = '';
 
                 if (_.every(parts, part => part !== null))  {
                     if (parts.length === 1) { // condition where only one valid date is typed in rather than a range
-                        newValue = oldValue + separator + oldValue;
+                        start = end = parts[0];
                     } else if (parts.length === 2) {
-                        newValue = parts[0].format(dateFormat) + separator + parts[1].format(dateFormat);
+                        [start, end] = parts;
                     }
+                    newValue = start.format(dateFormat) + separator + end.format(dateFormat);
                 }
                 if (oldValue !== newValue) {
                     $input.val(newValue).trigger('change');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -370,6 +370,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 autoUpdateInput: false,
                 "autoApply": true,
             });
+            this.ui.dateRange.attr("placeholder", [dateFormat, dateFormat].join(separator));
             this.ui.dateRange.on('cancel.daterangepicker', function () {
                 $(this).val('').trigger('change');
             });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -15,16 +15,14 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
     var separator = " to ",
         serverSeparator = "__",
         serverPrefix = "__range__",
-        dateFormat = "MM/DD/YYYY",
-        // A list of acceptable date formats, in order of preference
-        dateFormats = ['MM/DD/YYYY', 'YYYY-MM-DD', 'MM-DD-YYYY', 'MM/DD/YY', 'MM-DD-YY', moment.defaultFormat],
+        dateFormat = cloudcareUtils.dateFormat,
         selectDelimiter = "#,#"; // Formplayer also uses this
 
     var toIsoDate = function (dateString) {
-        return moment(dateString, dateFormats, true).format('YYYY-MM-DD');
+        return cloudcareUtils.parseInputDate(dateString).format('YYYY-MM-DD');
     };
     var toUiDate = function (dateString) {
-        return moment(dateString, dateFormats, true).format(dateFormat);
+        return cloudcareUtils.parseInputDate(dateString).format(dateFormat);
     };
 
     var encodeValue = function (model, searchForBlank) {
@@ -361,7 +359,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 escapeMarkup: function (m) { return DOMPurify.sanitize(m); },
             });
             this.ui.hqHelp.hqHelp();
-            cloudcareUtils.initDatePicker(this.ui.date, this.model.get('value'), dateFormat);
+            cloudcareUtils.initDatePicker(this.ui.date, this.model.get('value'));
             this.ui.dateRange.daterangepicker({
                 locale: {
                     format: dateFormat,
@@ -380,13 +378,13 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 $(this).val(picker.startDate.format(dateFormat) + separator + picker.endDate.format(dateFormat)).trigger('change');
             });
             this.ui.dateRange.on('change', function () {
-                // Validate free-text input. Accept anything moment can recognize as a date, reformatting for ES.
+                // Validate free-text input
                 var $input = $(this),
                     oldValue = $input.val(),
-                    parts = _.map(oldValue.split(separator), function (v) { return moment(v, dateFormats, true); }),
+                    parts = _.map(oldValue.split(separator), cloudcareUtils.parseInputDate),
                     newValue = '';
 
-                if (_.every(parts, function (part) { return part.isValid(); }))  {
+                if (_.every(parts, part => part !== null))  {
                     if (parts.length === 1) { // condition where only one valid date is typed in rather than a range
                         newValue = oldValue + separator + oldValue;
                     } else if (parts.length === 2) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -17,7 +17,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         serverPrefix = "__range__",
         dateFormat = "MM/DD/YYYY",
         // A list of acceptable date formats, in order of preference
-        dateFormats = ['YYYY-MM-DD', 'MM/DD/YYYY', 'MM-DD-YYYY', 'MM/DD/YY', 'MM-DD-YY', moment.defaultFormat],
+        dateFormats = ['MM/DD/YYYY', 'YYYY-MM-DD', 'MM-DD-YYYY', 'MM/DD/YY', 'MM-DD-YY', moment.defaultFormat],
         selectDelimiter = "#,#"; // Formplayer also uses this
 
     var toIsoDate = function (dateString) {
@@ -383,7 +383,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 // Validate free-text input. Accept anything moment can recognize as a date, reformatting for ES.
                 var $input = $(this),
                     oldValue = $input.val(),
-                    parts = _.map(oldValue.split(separator), function (v) { return moment(v, dateFormats); }),
+                    parts = _.map(oldValue.split(separator), function (v) { return moment(v, dateFormats, true); }),
                     newValue = '';
 
                 if (_.every(parts, function (part) { return part.isValid(); }))  {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -370,7 +370,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 autoUpdateInput: false,
                 "autoApply": true,
             });
-            this.ui.dateRange.attr("placeholder", [dateFormat, dateFormat].join(separator));
+            this.ui.dateRange.attr("placeholder", dateFormat + separator + dateFormat);
+            let separatorChars = _.unique(separator).join("");
+            this.ui.dateRange.attr("pattern", "^[\\d\\/\\-" + separatorChars + "]*$");
             this.ui.dateRange.on('cancel.daterangepicker', function () {
                 $(this).val('').trigger('change');
             });

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -376,7 +376,7 @@ hqDefine('cloudcare/js/utils', [
 
     /** Coerce an input date string to a moment object */
     var parseInputDate = function (dateString) {
-        if (!moment.isMoment(dateString) || dateString instanceof Date) {
+        if (!moment.isMoment(dateString)) {
             dateString = convertTwoDigitYear(dateString);
         }
         let dateObj = moment(dateString, dateFormats, true);

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -372,10 +372,7 @@ hqDefine('cloudcare/js/utils', [
     };
 
     var dateFormat = 'MM/DD/YYYY';
-    var dateFormats = ['MM/DD/YYYY', 'YYYY-MM-DD',  // strict formats first
-                       'M/D/YYYY', 'M/D/YY',
-                       'M-D-YYYY', 'M-D-YY',
-                       moment.defaultFormat];
+    var dateFormats = ['MM/DD/YYYY', 'YYYY-MM-DD', 'M/D/YYYY', 'M/D/YY', 'M-D-YYYY', 'M-D-YY', moment.defaultFormat];
 
     /** Coerce an input date string to a moment object */
     var parseInputDate = function (dateString) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -372,7 +372,10 @@ hqDefine('cloudcare/js/utils', [
     };
 
     var dateFormat = 'MM/DD/YYYY';
-    var dateFormats = ['MM/DD/YYYY', 'YYYY-MM-DD', 'MM-DD-YYYY', 'MM/DD/YY', 'MM-DD-YY', moment.defaultFormat];
+    var dateFormats = ['MM/DD/YYYY', 'YYYY-MM-DD',  // strict formats first
+                       'M/D/YYYY', 'M/D/YY',
+                       'M-D-YYYY', 'M-D-YY',
+                       moment.defaultFormat];
 
     /** Coerce an input date string to a moment object */
     var parseInputDate = function (dateString) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -371,13 +371,23 @@ hqDefine('cloudcare/js/utils', [
         return inputDate;
     };
 
-    var initDatePicker = function ($el, selectedDate, dateFormat) {
+    var dateFormat = 'MM/DD/YYYY';
+    var dateFormats = ['MM/DD/YYYY', 'YYYY-MM-DD', 'MM-DD-YYYY', 'MM/DD/YY', 'MM-DD-YY', moment.defaultFormat];
+
+    /** Coerce an input date string to a moment object */
+    var parseInputDate = function (dateString) {
+        if (!moment.isMoment(dateString) || dateString instanceof Date) {
+            dateString = convertTwoDigitYear(dateString);
+        }
+        let dateObj = moment(dateString, dateFormats, true);
+        return dateObj.isValid() ? dateObj : null;
+    };
+
+    var initDatePicker = function ($el, selectedDate) {
         if (!$el.length) {
             return;
         }
 
-        dateFormat = dateFormat || "MM/DD/YYYY";
-        let formats = _.union([dateFormat], ["MM/DD/YYYY", "MM/DD/YY", "YYYY-MM-DD"]);
         $el.datetimepicker({
             date: selectedDate,
             useCurrent: false,
@@ -386,19 +396,13 @@ hqDefine('cloudcare/js/utils', [
             showTodayButton: true,
             debug: true,
             format: dateFormat,
-            extraFormats: formats,
+            extraFormats: dateFormats,
             useStrict: true,
             icons: {
                 today: 'glyphicon glyphicon-calendar',
             },
             tooltips: dateTimePickerTooltips,
-            parseInputDate: function (dateString) {
-                if (!moment.isMoment(dateString) || dateString instanceof Date) {
-                    dateString = convertTwoDigitYear(dateString);
-                }
-                let dateObj = moment(dateString, formats, true);
-                return dateObj.isValid() ? dateObj : null;
-            },
+            parseInputDate: parseInputDate,
         });
 
         $el.on("focusout", $el.data("DateTimePicker").hide);
@@ -406,15 +410,15 @@ hqDefine('cloudcare/js/utils', [
         $el.attr("pattern", "[0-9-/]+");
     };
 
-    var initTimePicker = function ($el, selectedTime, dateFormat) {
+    var initTimePicker = function ($el, selectedTime, timeFormat) {
         if (!$el.length) {
             return;
         }
 
-        let date = moment(selectedTime, dateFormat);
+        let date = moment(selectedTime, timeFormat);
         $el.datetimepicker({
             date: date.isValid() ? date : null,
-            format: dateFormat,
+            format: timeFormat,
             useStrict: true,
             useCurrent: false,
             showClear: true,
@@ -427,7 +431,9 @@ hqDefine('cloudcare/js/utils', [
     };
 
     return {
+        dateFormat: dateFormat,
         convertTwoDigitYear: convertTwoDigitYear,
+        parseInputDate: parseInputDate,
         initDatePicker: initDatePicker,
         initTimePicker: initTimePicker,
         getFormUrl: getFormUrl,


### PR DESCRIPTION
## Product Description
Adds a placeholder text with the expected format to the date range widget:
![image](https://user-images.githubusercontent.com/2367539/225035026-53966d8b-fbf7-4619-af0e-694da3ef4ccf.png)
It also adds loose validation so things like "Jan 1, 2022" will show up red when the user starts typing them

## Technical Summary
https://dimagi-dev.atlassian.net/browse/QA-4867

## Feature Flag
Case Search: Enable synchronous mobile searching and case claiming

## Safety Assurance

### Safety story


### Automated test coverage

n/a

### QA Plan

Grew out of QA on https://github.com/dimagi/commcare-hq/pull/32628
https://dimagi-dev.atlassian.net/browse/QA-4867

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change