### PR TITLE
Fetch staging-branches repo

### DIFF
--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -41,11 +41,17 @@ do
 done
 
 function rebuildstaging() {
-    mkdir -p ./artifacts
-    echo "saving commcare-hq-staging.yml from staging-branches in artifacts/staging.yml"
-    curl --silent https://raw.githubusercontent.com/dimagi/staging-branches/main/commcare-hq-staging.yml > artifacts/staging.yml
+    REPO_ROOT='artifacts/staging-branches'
+    if [[ ! -d "$REPO_ROOT/.git" ]]
+    then
+        git clone https://github.com/dimagi/staging-branches.git "$REPO_ROOT"
+    else
+        git --git-dir "$REPO_ROOT/.git" pull origin main
+    fi
+
+    git --git-dir "$REPO_ROOT/.git" show
     echo "rebuilding staging branch..."
-    git-build-branch artifacts/staging.yml "$@"
+    git-build-branch "$REPO_ROOT/commcare-hq-staging.yml" "$@"
 }
 
 args=''


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Following up on https://github.com/dimagi/commcare-hq/pull/32731 with a different way to fetch the latest file.  This clones the git repo locally.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Affects only the workflow to deploy staging

### Automated test coverage

none

### QA Plan

N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

This can be reverted without affecting prod, but we'd need to coordinate a couple things to fix the staging build

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
