### PR TITLE
Fix meta.next URL in web user list view

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -275,16 +275,14 @@ class CommCareUserResource(v0_1.CommCareUserResource):
 class WebUserResource(v0_1.WebUserResource):
 
     def get_resource_uri(self, bundle_or_obj=None, url_name='api_dispatch_detail'):
-        if isinstance(bundle_or_obj, Bundle):
-            domain = bundle_or_obj.request.domain
-            obj = bundle_or_obj.obj
-        elif bundle_or_obj is None:
-            return None
-
-        return reverse('api_dispatch_detail', kwargs=dict(resource_name=self._meta.resource_name,
-                                                          domain=domain,
-                                                          api_name=self._meta.api_name,
-                                                          pk=obj._id))
+        if bundle_or_obj is None:
+            return super().get_resource_uri(None, url_name)
+        return reverse('api_dispatch_detail', kwargs={
+            'resource_name': self._meta.resource_name,
+            'domain': bundle_or_obj.request.domain,
+            'api_name': self._meta.api_name,
+            'pk': bundle_or_obj.obj._id,
+        })
 
 
 class AdminWebUserResource(v0_1.UserResource):

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -375,6 +375,12 @@ class TestWebUserResource(APIResourceTest):
         api_users = json.loads(response.content)['objects']
         self.assertEqual(len(api_users), 2)
 
+        response = self._assert_auth_get_resource('%s?limit=1' % (self.list_endpoint))
+        self.assertEqual(response.status_code, 200)
+        response_json = json.loads(response.content)
+        self.assertEqual(len(response_json['objects']), 1)
+        self.assertEqual(response_json['meta']['next'], "?limit=1&offset=1")
+
         # username filter
         response = self._assert_auth_get_resource('%s?web_username=%s' % (self.list_endpoint, 'anotherguy'))
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Product Description
This fixes the web user API's "next" URL, which was previously always `null`

![image](https://user-images.githubusercontent.com/2367539/225115844-59bc34c6-fb44-4c1d-b405-95973cfa481c.png)

This was introduced a decade ago in the v0.5 version of this API, in an attempt to add the resource URI to each object:

![image](https://user-images.githubusercontent.com/2367539/225116095-b1efec43-6969-48cf-9de9-a07d6f6bad99.png)

This change should result in both URLs working.

It only affects API users

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3008

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Local testing - there aren't that many different ways I can imagine this being called.

### Automated test coverage

Included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
