### PR TITLE
Make placeholder domain for URLs in documentation

### DIFF
--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -96,7 +96,7 @@ PASSWORD_RESET_DONE_KWARGS = {
 
 urlpatterns = [
     url(r'^domain/select/$', select, name='domain_select'),
-    url(r'^domain/select_redirect/$', select, {'do_not_redirect': True}, name='domain_select_redirect'),
+    url(r'^domain/select_redirect/$', select, {'always_show_list': True}, name='domain_select_redirect'),
     url('^accept_all_invitations/$', accept_all_invitations, name='accept_all_invitations'),
     url(r'^domain/transfer/(?P<guid>\w+)/activate$',
         ActivateTransferDomainView.as_view(), name='activate_transfer_domain'),

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -22,7 +22,15 @@ def covid19(request):
 # Domain not required here - we could be selecting it for the first time. See notes domain.decorators
 # about why we need this custom login_required decorator
 @login_required
-def select(request, do_not_redirect=False, next_view=None):
+def select(request, always_show_list=False, next_view=None):
+    """
+    Show list of user's domains and open invitations. Can also redirect to
+    specific views and/or auto-select the most recently used domain.
+
+    :param always_show_list: always show list of domains to select (if False,
+    automatically go to last used domain)
+    :param next_view: view to jump to or to link to, defaults to homepage
+    """
     if not hasattr(request, 'couch_user'):
         return redirect('registration_domain')
 
@@ -53,7 +61,7 @@ def select(request, do_not_redirect=False, next_view=None):
     domain_select_template = "domain/select.html"
     last_visited_domain = request.session.get('last_visited_domain')
     if open_invitations \
-       or do_not_redirect \
+       or always_show_list \
        or not last_visited_domain:
         return render(request, domain_select_template, additional_context)
     else:
@@ -165,4 +173,4 @@ def redirect_to_domain(request):
         match = resolve(resolvable_path)
     except Resolver404:
         raise Http404()
-    return select(request, next_view=match.url_name)
+    return select(request, always_show_list=True, next_view=match.url_name)

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -34,9 +34,8 @@ def select(request, always_show_list=False, next_view=None):
         return redirect('registration_domain')
 
     # next_view must be a url that expects exactly one parameter, a domain name
-    next_view = next_view or request.GET.get('next_view')
     show_invitations = False
-    if not next_view:
+    if next_view is None:
         next_view = "domain_homepage"
         show_invitations = True
     domain_links = get_domain_links(request.couch_user, view_name=next_view)

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -69,8 +69,8 @@ def select(request, do_not_redirect=False, next_view=None):
                 or domain_obj.is_snapshot
             ):
                 try:
-                    return HttpResponseRedirect(reverse(next_view or 'dashboard_default',
-                                                args=[last_visited_domain]))
+                    return HttpResponseRedirect(
+                        reverse(next_view, args=[last_visited_domain]))
                 except Http404:
                     pass
 

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -86,7 +86,7 @@ def accept_all_invitations(request):
     return HttpResponseRedirect(reverse('domain_select_redirect'))
 
 
-@quickcache(['couch_user.username'])
+@quickcache(['couch_user.username', 'view_name'])
 def get_domain_links_for_dropdown(couch_user, view_name="domain_homepage"):
     # Returns dicts with keys 'name', 'display_name', and 'url'
     return _domains_to_links(Domain.active_for_user(couch_user), view_name)

--- a/corehq/apps/enterprise/tasks.py
+++ b/corehq/apps/enterprise/tasks.py
@@ -57,13 +57,13 @@ def clear_enterprise_permissions_cache_for_all_users(config_id, domain=None):
         config = EnterprisePermissions.objects.get(id=config_id)
     except EnterprisePermissions.DoesNotExist:
         return
-    from corehq.apps.domain.views.base import get_enterprise_links_for_dropdown
+    from corehq.apps.hqwebapp.templatetags.hq_shared_tags import has_enterprise_links
     from corehq.apps.users.models import CouchUser
     domains = [domain] if domain else config.account.get_domains()
     for domain in domains:
         for user_id in CouchUser.ids_by_domain(domain):
             user = CouchUser.get_by_user_id(user_id)
-            get_enterprise_links_for_dropdown.clear(user)
+            has_enterprise_links.clear(user)
 
 
 @task()

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -26,6 +26,7 @@ from corehq import privileges
 from corehq.apps.hqwebapp.exceptions import AlreadyRenderedException, TemplateTagJSONException
 from corehq.apps.hqwebapp.models import MaintenanceAlert
 from corehq.motech.utils import pformat_json
+from corehq.util.quickcache import quickcache
 
 register = template.Library()
 
@@ -113,12 +114,10 @@ def domains_for_user(context, request, selected_domain=None):
     Cache the entire string alongside the couch_user's doc_id that can get invalidated when
     the user doc updates via save.
     """
-
-    from corehq.apps.domain.views.base import get_domain_links_for_dropdown, get_enterprise_links_for_dropdown
     domain_links = get_domain_links_for_dropdown(request.couch_user)
 
     # Enterprise permissions projects aren't in the dropdown, but show a hint they exist
-    show_all_projects_link = bool(get_enterprise_links_for_dropdown(request.couch_user))
+    show_all_projects_link = has_enterprise_links(request.couch_user)
 
     # Too many domains and they won't all fit in the dropdown
     dropdown_limit = 20
@@ -137,6 +136,18 @@ def domains_for_user(context, request, selected_domain=None):
             context, request
         )
     )
+
+
+@quickcache(['couch_user.username'])
+def get_domain_links_for_dropdown(couch_user):
+    from corehq.apps.domain.views.base import get_domain_links
+    return get_domain_links(couch_user)
+
+
+@quickcache(['couch_user.username'])
+def has_enterprise_links(couch_user):
+    from corehq.apps.domain.views.base import get_enterprise_links
+    return bool(get_enterprise_links(couch_user))
 
 
 @register.simple_tag

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -107,6 +107,18 @@ def cachebuster(url):
     return resource_versions.get(url, "")
 
 
+@quickcache(['couch_user.username'])
+def get_domain_links_for_dropdown(couch_user):
+    from corehq.apps.domain.views.base import get_domain_links
+    return get_domain_links(couch_user)
+
+
+@quickcache(['couch_user.username'])
+def has_enterprise_links(couch_user):
+    from corehq.apps.domain.views.base import get_enterprise_links
+    return bool(get_enterprise_links(couch_user))
+
+
 @register.simple_tag(takes_context=True)
 def domains_for_user(context, request, selected_domain=None):
     """
@@ -136,18 +148,6 @@ def domains_for_user(context, request, selected_domain=None):
             context, request
         )
     )
-
-
-@quickcache(['couch_user.username'])
-def get_domain_links_for_dropdown(couch_user):
-    from corehq.apps.domain.views.base import get_domain_links
-    return get_domain_links(couch_user)
-
-
-@quickcache(['couch_user.username'])
-def has_enterprise_links(couch_user):
-    from corehq.apps.domain.views.base import get_enterprise_links
-    return bool(get_enterprise_links(couch_user))
 
 
 @register.simple_tag

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1378,9 +1378,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             return None
 
     def clear_quickcache_for_user(self):
-        from corehq.apps.domain.views.base import (
+        from corehq.apps.hqwebapp.templatetags.hq_shared_tags import (
             get_domain_links_for_dropdown,
-            get_enterprise_links_for_dropdown,
+            has_enterprise_links,
         )
         from corehq.apps.sms.util import is_user_contact_active
 
@@ -1396,7 +1396,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             is_user_contact_active.clear(domain, self.user_id)
         Domain.active_for_couch_user.clear(self)
         get_domain_links_for_dropdown.clear(self)
-        get_enterprise_links_for_dropdown.clear(self)
+        has_enterprise_links.clear(self)
 
     @classmethod
     @quickcache(['userID', 'domain'])

--- a/urls.py
+++ b/urls.py
@@ -12,7 +12,7 @@ from corehq.apps.app_manager.views.formdesigner import ping
 from corehq.apps.app_manager.views.phone import list_apps
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.utils import legacy_domain_re
-from corehq.apps.domain.views.base import covid19
+from corehq.apps.domain.views.base import covid19, redirect_to_domain
 from corehq.apps.domain.views.feedback import submit_feedback
 from corehq.apps.domain.views.pro_bono import ProBonoStaticView
 from corehq.apps.domain.views.settings import logo
@@ -104,6 +104,7 @@ urlpatterns = [
     url(r'^analytics/', include('corehq.apps.analytics.urls')),
     url(r'^api/', include(user_api_urlpatterns)),
     url(r'^register/', include('corehq.apps.registration.urls')),
+    url(r'^a/DOMAIN/', redirect_to_domain),
     url(r'^a/(?P<domain>%s)/' % legacy_domain_re, include(domain_specific)),
     url(r'^account/', include('corehq.apps.settings.urls')),
     url(r'^sso/(?P<idp_slug>[\w-]+)/', include('corehq.apps.sso.urls')),


### PR DESCRIPTION
## Product Description
This PR (currently on staging if you want to try it out) makes URLs like this work:
https://staging.commcarehq.org/a/DOMAIN/settings/users/roles/
You can click on that URL and it'll show you a list of your domains, letting you select one, whereupon you'll be redirected to the proper link on that domain.

## Technical Summary
This makes use of the existing `select_domain` view.  Go commit-by-commit for a coherent picture

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This has been on staging for months with no one noticing, which I guess means something.  I've also tested it out there and locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
