### PR TITLE
Fix two year date correction

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -333,8 +333,8 @@ describe('Entries', function () {
     });
 
     it('Should convert two-digit dates to four-digit dates', function () {
-        assert.equal(utils.convertTwoDigitYear("03-04-50"), "03-04-1950");
-        assert.equal(utils.convertTwoDigitYear("03-04-28"), "03-04-2028");
+        assert.equal(utils.convertTwoDigitYear("03-04-50"), "03/04/1950");
+        assert.equal(utils.convertTwoDigitYear("03-04-28"), "03/04/2028");
         assert.equal(utils.convertTwoDigitYear("3/4/1928"), "3/4/1928");
         assert.equal(utils.convertTwoDigitYear("not-a-date"), "not-a-date");
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -365,7 +365,7 @@ hqDefine('cloudcare/js/utils', [
                 if (inputYear > new Date().getFullYear() + 10) {
                     inputYear -= 100;
                 }
-                inputDate = [parts[0], parts[1], inputYear].join("-");
+                inputDate = [parts[0], parts[1], inputYear].join("/");
             }
         }
         return inputDate;

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -359,13 +359,13 @@ hqDefine('cloudcare/js/utils', [
     var convertTwoDigitYear = function (inputDate) {
         var parts = inputDate.split(/\D/);
         if (parts.length === 3 && parts.join("").length <= 6) {
-            let [day, month, year] = parts;
+            let [month, day, year] = parts;
             if (year.length === 2) {
                 year = Math.floor(new Date().getFullYear() / 100) + year;
                 if (year > new Date().getFullYear() + 10) {
                     year -= 100;
                 }
-                inputDate = [day, month, year].join("/");
+                inputDate = [month, day, year].join("/");
             }
         }
         return inputDate;

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -359,13 +359,13 @@ hqDefine('cloudcare/js/utils', [
     var convertTwoDigitYear = function (inputDate) {
         var parts = inputDate.split(/\D/);
         if (parts.length === 3 && parts.join("").length <= 6) {
-            var inputYear = parts[2];
-            if (inputYear.length === 2) {
-                inputYear = Math.floor(new Date().getFullYear() / 100) + inputYear;
-                if (inputYear > new Date().getFullYear() + 10) {
-                    inputYear -= 100;
+            let [day, month, year] = parts;
+            if (year.length === 2) {
+                year = Math.floor(new Date().getFullYear() / 100) + year;
+                if (year > new Date().getFullYear() + 10) {
+                    year -= 100;
                 }
-                inputDate = [parts[0], parts[1], inputYear].join("/");
+                inputDate = [day, month, year].join("/");
             }
         }
         return inputDate;


### PR DESCRIPTION
## Product Description
Fix a bug where dates typed out manually with only two digits for the year were being discarded.

## Technical Summary
Fixes an issue @Jtang-1 discovered
https://github.com/dimagi/commcare-hq/pull/32628#discussion_r1132782527
Oddly enough the two-year date correction returned a date format different from what was input, `DD-MM-YYYY`, though the expected format is `DD/MM/YYYY`.  This meant that when I made this widget use strict interpretation, anything that went through the two-year correction would be recognized as invalid.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Local testing, automated tests

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

This also came up in QA here: https://dimagi-dev.atlassian.net/browse/QA-4887

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
