### PR TITLE
Add closing of mobile attendee cases

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -262,7 +262,7 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
     @staticmethod
     def response_attendance_tracking(domain, _new_plan_version):
         archive_attendance_coordinator_role_for_domain(domain=domain.name)
-        attendance_tracking_tasks.close_mobile_worker_attendee_cases(domain.name)
+        attendance_tracking_tasks.close_mobile_worker_attendee_cases.delay(domain.name)
 
     @staticmethod
     def response_data_cleanup(domain, new_plan_version):

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -194,7 +194,7 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         )
 
         subscription.change_plan(self.community_plan, web_user=self.admin_username)
-        close_mobile_worker_attendee_cases_mock.assert_called_once()
+        close_mobile_worker_attendee_cases_mock.delay.assert_called_once()
 
     def _change_std_roles(self):
         for u in self.user_roles:

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -185,6 +185,17 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         ).first()
         self.assertTrue(role.is_archived)
 
+    @flag_enabled('ATTENDANCE_TRACKING')
+    @patch('corehq.apps.events.tasks.close_mobile_worker_attendee_cases')
+    def test_close_mobile_worker_attendee_cases_when_downgrading(self, close_mobile_worker_attendee_cases_mock):
+        subscription = Subscription.new_domain_subscription(
+            self.account, self.domain.name, self.advanced_plan,
+            web_user=self.admin_username
+        )
+
+        subscription.change_plan(self.community_plan, web_user=self.admin_username)
+        close_mobile_worker_attendee_cases_mock.assert_called_once()
+
     def _change_std_roles(self):
         for u in self.user_roles:
             user_role = UserRole.objects.by_couch_id(u.get_id)

--- a/corehq/apps/events/tasks.py
+++ b/corehq/apps/events/tasks.py
@@ -21,7 +21,7 @@ def sync_mobile_worker_attendees(domain_name, user_id):
     with CriticalSection(['sync_mobile_worker_attendees_' + domain_name]):
         new_case_blocks = []
         closed_cases = []
-        user_id_case_mapping = get_existing_cases_by_user_ids(domain_name)
+        user_id_case_mapping = get_user_attendee_cases_on_domain(domain_name)
         attendee_case_type = get_attendee_case_type(domain_name)
 
         for user in CommCareUser.by_domain(domain_name):
@@ -47,7 +47,7 @@ def close_mobile_worker_attendee_cases(domain_name):
     """
     with CriticalSection(['close_mobile_worker_attendees_' + domain_name]):
         case_changes = []
-        user_id_case_mapping = get_existing_cases_by_user_ids(domain_name)
+        user_id_case_mapping = get_user_attendee_cases_on_domain(domain_name)
         mobile_worker_user_ids = {user.user_id for user in CommCareUser.by_domain(domain_name)}
 
         for commcare_user_id, case in user_id_case_mapping.items():
@@ -61,7 +61,8 @@ def close_mobile_worker_attendee_cases(domain_name):
                 device_id='corehq.apps.events.tasks.close_mobile_worker_attendee_cases'
             )
 
-def get_existing_cases_by_user_ids(domain):
+
+def get_user_attendee_cases_on_domain(domain):
     """Returns a mapping like `{user_id1: case1, user_id2: case2}`. The user_ids's are fetched from the case's
     `ATTENDEE_USER_ID_CASE_PROPERTY` property, which is a commcare user id
     """

--- a/corehq/apps/events/tests/test_tasks.py
+++ b/corehq/apps/events/tests/test_tasks.py
@@ -166,7 +166,6 @@ class TestTasks(TestCase):
         for case in cases:
             assert_method(case.closed)
 
-    @classmethod
     def _create_non_mobile_worker_attendee_case(self):
         case_id = uuid.uuid4().hex
         caseblock = CaseBlock(

--- a/corehq/apps/events/tests/test_tasks.py
+++ b/corehq/apps/events/tests/test_tasks.py
@@ -1,6 +1,6 @@
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.events.models import AttendeeCase, ATTENDEE_USER_ID_CASE_PROPERTY
-from corehq.apps.events.tasks import get_existing_cases_by_user_ids
+from corehq.apps.events.tasks import get_user_attendee_cases_on_domain
 from corehq.apps.events import tasks
 from corehq.apps.users.models import HqPermissions, UserRole, WebUser
 from corehq.apps.users.models import CommCareUser
@@ -68,10 +68,10 @@ class TestTasks(TestCase):
         """Test that the `sync_mobile_worker_attendees` task creates `commcare-attendee` cases for mobile
         workers
         """
-        user_id_case_mapping = get_existing_cases_by_user_ids(self.domain)
+        user_id_case_mapping = get_user_attendee_cases_on_domain(self.domain)
         user_ids = list(user_id_case_mapping.keys())
         tasks.sync_mobile_worker_attendees(domain_name=self.domain, user_id=self.webuser.user_id)
-        user_id_case_mapping = get_existing_cases_by_user_ids(self.domain)
+        user_id_case_mapping = get_user_attendee_cases_on_domain(self.domain)
         user_ids = list(user_id_case_mapping.keys())
 
         self.assertEqual(len(user_ids), 2)
@@ -120,7 +120,7 @@ class TestTasks(TestCase):
         self._create_non_mobile_worker_attendee_case()
 
         # Let's make sure they're all open
-        user_id_case_mapping = get_existing_cases_by_user_ids(self.domain)
+        user_id_case_mapping = get_user_attendee_cases_on_domain(self.domain)
         self.assertEqual(len(user_id_case_mapping), 3)
 
         for case in user_id_case_mapping.values():
@@ -130,7 +130,7 @@ class TestTasks(TestCase):
         tasks.close_mobile_worker_attendee_cases(domain_name=self.domain)
 
         # Only those with the `ATTENDEE_USER_ID_CASE_PROPERTY` property should be closed
-        user_id_case_mapping = get_existing_cases_by_user_ids(self.domain)
+        user_id_case_mapping = get_user_attendee_cases_on_domain(self.domain)
         for case in user_id_case_mapping.values():
             if case.get_case_property(ATTENDEE_USER_ID_CASE_PROPERTY):
                 self.assertTrue(case.closed)

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -94,6 +94,7 @@ def submit_case_blocks(
         max_wait=max_wait,
         **submission_extras
     )
+
     return result.xform, result.cases
 
 

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -94,7 +94,6 @@ def submit_case_blocks(
         max_wait=max_wait,
         **submission_extras
     )
-
     return result.xform, result.cases
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When clicking on the "Disable Mobile Worker Attendee" or when downgrading to a non-privileged plan, the associated attendee cases for mobile workers will be closed

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR adds the closing of attendee cases when disabling mobile worker attendees and when downgrading to a non-privileged plan.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Attendance Tracking

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Unittests

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
