### PR TITLE
Downgrade Sphinx to <6.0.0

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -623,6 +623,7 @@ sphinx==6.1.3
     #   -r docs-requirements.in
     #   myst-parser
     #   sphinx-rtd-theme
+    #   sphinxcontrib-jquery
 sphinx-rtd-theme==1.2.0
     # via -r docs-requirements.in
 sphinxcontrib-applehelp==1.0.2
@@ -633,7 +634,7 @@ sphinxcontrib-django==0.5.1
     # via -r docs-requirements.in
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
-sphinxcontrib-jquery==2.0.0
+sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -746,6 +747,5 @@ setuptools==67.3.2
     #   gunicorn
     #   pip-tools
     #   python-termstyle
-    #   sphinxcontrib-jquery
     #   zope-event
     #   zope-interface

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -618,7 +618,7 @@ sortedcontainers==2.3.0
     # via intervaltree
 soupsieve==2.0.1
     # via beautifulsoup4
-sphinx==6.1.3
+sphinx==5.3.0
     # via
     #   -r docs-requirements.in
     #   myst-parser

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -499,6 +499,7 @@ sphinx==6.1.3
     #   -r docs-requirements.in
     #   myst-parser
     #   sphinx-rtd-theme
+    #   sphinxcontrib-jquery
 sphinx-rtd-theme==1.2.0
     # via -r docs-requirements.in
 sphinxcontrib-applehelp==1.0.2
@@ -509,7 +510,7 @@ sphinxcontrib-django==0.5.1
     # via -r docs-requirements.in
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
-sphinxcontrib-jquery==2.0.0
+sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -593,6 +594,5 @@ setuptools==67.3.2
     #   django-websocket-redis
     #   gevent
     #   gunicorn
-    #   sphinxcontrib-jquery
     #   zope-event
     #   zope-interface

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -494,7 +494,7 @@ socketpool==0.5.3
     # via -r base-requirements.in
 sortedcontainers==2.3.0
     # via intervaltree
-sphinx==6.1.3
+sphinx==5.3.0
     # via
     #   -r docs-requirements.in
     #   myst-parser


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14476

It appears that `sphinx-rtd-theme` has a bug with v6 of `sphinx`, likely related to [the breaking change introduced in v6 of sphinx](https://www.sphinx-doc.org/en/master/changes.html#id46). I don't think it helped that we were still using an older version of `sphinxcontrib-jquery`, but [after upgrading to the recommended v4.1](https://github.com/pulp/pulpcore/issues/3569#issuecomment-1470189536), I was still experiencing issues with the search bar and the same `ReferenceError: jQuery is not defined` error.

I also confirmed that when disabling the `sphinx-rtd-theme` and rebuilding docs, the search functionality works fine on v6 of sphinx.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
