### PR TITLE
Resolve search bar issue in sphinx docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinxcontrib_django',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -623,6 +623,7 @@ sphinx==6.1.3
     #   -r docs-requirements.in
     #   myst-parser
     #   sphinx-rtd-theme
+    #   sphinxcontrib-jquery
 sphinx-rtd-theme==1.2.0
     # via -r docs-requirements.in
 sphinxcontrib-applehelp==1.0.2
@@ -633,7 +634,7 @@ sphinxcontrib-django==0.5.1
     # via -r docs-requirements.in
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
-sphinxcontrib-jquery==2.0.0
+sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -746,6 +747,5 @@ setuptools==67.3.2
     #   gunicorn
     #   pip-tools
     #   python-termstyle
-    #   sphinxcontrib-jquery
     #   zope-event
     #   zope-interface

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -499,6 +499,7 @@ sphinx==6.1.3
     #   -r docs-requirements.in
     #   myst-parser
     #   sphinx-rtd-theme
+    #   sphinxcontrib-jquery
 sphinx-rtd-theme==1.2.0
     # via -r docs-requirements.in
 sphinxcontrib-applehelp==1.0.2
@@ -509,7 +510,7 @@ sphinxcontrib-django==0.5.1
     # via -r docs-requirements.in
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
-sphinxcontrib-jquery==2.0.0
+sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -593,6 +594,5 @@ setuptools==67.3.2
     #   django-websocket-redis
     #   gevent
     #   gunicorn
-    #   sphinxcontrib-jquery
     #   zope-event
     #   zope-interface


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14476

We were hitting a "ReferenceError: jQuery is not defined" error when loading pages in https://commcare-hq.readthedocs.io/, which also broke the search bar behavior entirely. I came across https://github.com/readthedocs/sphinx_rtd_theme/issues/1434 which seemed similar to our issue, and the resolution was to upgrade `sphinxcontrib-jquery` to 4.1.

This still didn't resolve the JQuery/search bar issue, but thanks to lots of help from @benjaoming, the issue was resolved by adding `sphinx_rtd_theme` as an extension, as this was a potential known issue mentioned in v1.2 of `sphinx-rtd-theme`.

benjaoming also pointed out that we use a legacy configuration in our conf.py file, and created https://github.com/dimagi/commcare-hq/pull/32760 to resolve this.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
