### PR TITLE
Add packaging as an explicit dependency

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -68,6 +68,7 @@ lxml
 markdown
 oic
 openpyxl
+packaging
 phonenumberslite
 pickle5  # For Pythons pre 3.8.3. Can be removed when no environment will ever revert to < 3.8
 Pillow

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -388,6 +388,7 @@ openpyxl==3.0.9
     #   commcaretranslationchecker
 packaging==23.0
     # via
+    #   -r base-requirements.in
     #   build
     #   sphinx
 parso==0.8.3

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -317,7 +317,9 @@ openpyxl==3.0.9
     #   -r base-requirements.in
     #   commcaretranslationchecker
 packaging==23.0
-    # via sphinx
+    # via
+    #   -r base-requirements.in
+    #   sphinx
 phonenumberslite==8.12.48
     # via -r base-requirements.in
 pickle5==0.0.11

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -316,6 +316,8 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
+packaging==23.0
+    # via -r base-requirements.in
 parso==0.8.3
     # via jedi
 pexpect==4.8.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -292,6 +292,8 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
+packaging==23.0
+    # via -r base-requirements.in
 phonenumberslite==8.12.48
     # via -r base-requirements.in
 pickle5==0.0.11

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -323,7 +323,9 @@ openpyxl==3.0.9
     #   -r base-requirements.in
     #   commcaretranslationchecker
 packaging==23.0
-    # via build
+    # via
+    #   -r base-requirements.in
+    #   build
 pep517==0.10.0
     # via build
 phonenumberslite==8.12.48


### PR DESCRIPTION

## Product Description
No visible change

## Technical Summary

`packaging` is called from the application code, but it is included in only the most tenuous way: pip-tools (which we install for pip-sync during deploy) lists it as a dependency.

This makes that implicit dependency explicit, but otherwise changes nothing.

## Safety Assurance

### Safety story
This simply encodes more explicitly a dependency that is already getting installed by other means, so it should result it literally no immediate difference. (The difference is when exactly in the setup process for a new machine it gets installed, and also protects against some future where pip-tools doesn't depend on packaging anymore, for example.)

### Automated test coverage

There is testing of this package, so if I'm very wrong and there's a change, that would catch it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
