### PR TITLE
Resolve bug in scripts/rebuildstaging

### DIFF
--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -49,7 +49,7 @@ function rebuildstaging() {
         git -C $REPO_ROOT pull origin main
     fi
 
-    git --git-dir "$REPO_ROOT/.git" show -n 1 -- commcare-hq-staging.yml
+    git -C $REPO_ROOT show -n 1 -- commcare-hq-staging.yml
     echo "rebuilding staging branch..."
     git-build-branch "$REPO_ROOT/commcare-hq-staging.yml" "$@"
 }

--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -44,12 +44,12 @@ function rebuildstaging() {
     REPO_ROOT='artifacts/staging-branches'
     if [[ ! -d "$REPO_ROOT/.git" ]]
     then
-        git clone https://github.com/dimagi/staging-branches.git $REPO_ROOT
+        git clone https://github.com/dimagi/staging-branches.git "$REPO_ROOT"
     else
-        git -C $REPO_ROOT pull origin main
+        git -C "$REPO_ROOT" pull origin main
     fi
 
-    git -C $REPO_ROOT show -n 1 -- commcare-hq-staging.yml
+    git -C "$REPO_ROOT" show -n 1 -- commcare-hq-staging.yml
     echo "rebuilding staging branch..."
     git-build-branch "$REPO_ROOT/commcare-hq-staging.yml" "$@"
 }

--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -46,7 +46,7 @@ function rebuildstaging() {
     then
         git clone https://github.com/dimagi/staging-branches.git "$REPO_ROOT"
     else
-        git --git-dir "$REPO_ROOT/.git" pull origin main
+        git -C $REPO_ROOT pull origin main
     fi
 
     git --git-dir "$REPO_ROOT/.git" show -n 1 -- commcare-hq-staging.yml

--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -44,7 +44,7 @@ function rebuildstaging() {
     REPO_ROOT='artifacts/staging-branches'
     if [[ ! -d "$REPO_ROOT/.git" ]]
     then
-        git clone https://github.com/dimagi/staging-branches.git "$REPO_ROOT"
+        git clone https://github.com/dimagi/staging-branches.git $REPO_ROOT
     else
         git -C $REPO_ROOT pull origin main
     fi


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
There were reports of issues with `git-build-branch` failing due to a deleted branch being on staging that was no longer there. I experienced this issue myself, and saw that after `git --git-dir "$REPO_ROOT/.git" pull origin main` was run, `commcare-hq-staging.yml` was checked out into my commcare-hq directory, not `artifacts/staging-branches/` like $REPO_ROOT was set to.

The issue appears to be due to `--git-dir`. To use this option in the context of pulling updates from origin, you would need to either use both `--git-dir` _and_ `--work-tree`, or use `-C`. Git's [docs](https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git.html) for `--git-dir` also mention:
> If you just want to run git as if it was started in \<path\> then use git -C <path>.

I think the `git show` command can use just `--git-dir` without any issues, since the working tree is not used in that command, but to be consistent I decided to use `-C` in that command as well.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
