### PR TITLE
remove question mark from checkbox option

### DIFF
--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -167,7 +167,7 @@
                        id="det-config-checkbox"
                        data-bind="checked: show_det_config_download,
                                   attr: { disabled: !{{ has_api_access|JSON }}}" />
-                {% trans "Generate a Data Export Tool config file?" %}
+                {% trans "Generate a Data Export Tool config file" %}
               </label>
               {% trans "Download a Data Export Tool configuration file for this export" as det_help %}
               <span class="hq-help-template"


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
<img width="625" alt="Screenshot 2023-03-17 at 12 18 25 PM" src="https://user-images.githubusercontent.com/15785053/225999583-035ad9ac-5ef8-41f7-aa47-3c9c7a1182c7.png">

Remove the question mark in the option "Generate a Data Export Tool config file" (not the actual info question mark icon that explains what this is for, just the text "?")
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I don't think a question mark is necessary for the "Generate a Data Export Tool config file" option. It is already a checkbox, so it feels like it is an implied option. Similar to the other options that do not have question marks like "Create a Daily Saved Export", I think it is fine to remove this one too.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
