### PR TITLE
Adds a case_id property to Event

### DIFF
--- a/corehq/apps/events/forms.py
+++ b/corehq/apps/events/forms.py
@@ -122,9 +122,7 @@ class CreateEventForm(forms.Form):
             'expected_attendees': [
                 attendee.case_id for attendee in event.get_expected_attendees()
             ],
-            'attendance_takers': [
-                str(attendance_taker_id) for attendance_taker_id in event.attendance_taker_ids
-            ],
+            'attendance_takers': event.attendance_taker_ids,
         }
 
     def get_new_event_form(self):

--- a/corehq/apps/events/migrations/0004_event_id_case_id.py
+++ b/corehq/apps/events/migrations/0004_event_id_case_id.py
@@ -1,0 +1,135 @@
+import uuid
+
+from django.db import migrations, models
+from django.forms.models import model_to_dict
+
+from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
+
+from corehq.apps.events.models import (
+    EVENT_ATTENDEE_CASE_TYPE,
+    EVENT_CASE_TYPE,
+    get_attendee_case_type,
+)
+from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
+
+
+def _recreate_events(apps, schema_editor):
+    """
+    Avoids orphaned event cases
+    """
+    # This Event model only has data, no properties or methods, which is
+    # why we need all the functions below.
+    Event = apps.get_model("events", "Event")
+    db_alias = schema_editor.connection.alias
+    for event in Event.objects.using(db_alias).all():
+        case_factory = CaseFactory(domain=event.domain)
+        event_dict = model_to_dict(event)
+        attendees = _get_expected_attendees(event)
+        _delete_old_style(case_factory, event)
+
+        new_event = Event(**event_dict)
+        new_event.save()
+        _set_expected_attendees(case_factory, new_event, attendees)
+
+
+def _get_old_case_id(event):
+    return event.event_id.hex + '-0'
+
+
+def _get_expected_attendees(event):
+    old_case_id = _get_old_case_id(event)
+    ext_case_ids = CommCareCaseIndex.objects.get_extension_case_ids(
+        event.domain,
+        [old_case_id],
+        include_closed=False,
+    )
+    return CommCareCase.objects.get_cases(ext_case_ids, event.domain)
+
+
+def _delete_old_style(case_factory, event):
+    old_case_id = _get_old_case_id(event)
+    _close_ext_cases(case_factory, event)
+    case_factory.close_case(old_case_id)
+    event.delete()
+
+
+def _close_ext_cases(case_factory, event):
+    old_case_id = _get_old_case_id(event)
+    ext_case_ids = CommCareCaseIndex.objects.get_extension_case_ids(
+        event.domain,
+        [old_case_id],
+        include_closed=False,
+    )
+    case_factory.create_or_update_cases([
+        CaseStructure(case_id=case_id, attrs={'close': True})
+        for case_id in ext_case_ids
+    ])
+
+
+def _set_expected_attendees(case_factory, event, attendees):
+    event_case_id = event._case_id.hex
+    event_group_id = event.event_id.hex
+    attendee_case_type = get_attendee_case_type(event.domain)
+    attendee_case_ids = (c.case_id for c in attendees)
+    case_structures = []
+    for case_id in attendee_case_ids:
+        event_host = CaseStructure(case_id=event_case_id)
+        attendee_host = CaseStructure(case_id=case_id)
+        case_structures.append(CaseStructure(
+            indices=[
+                CaseIndex(
+                    relationship='extension',
+                    identifier='event-host',
+                    related_structure=event_host,
+                    related_type=EVENT_CASE_TYPE,
+                ),
+                CaseIndex(
+                    relationship='extension',
+                    identifier='attendee-host',
+                    related_structure=attendee_host,
+                    related_type=attendee_case_type,
+                ),
+            ],
+            attrs={
+                'case_type': EVENT_ATTENDEE_CASE_TYPE,
+                'owner_id': event_group_id,
+                'create': True,
+            },
+        ))
+    case_factory.create_or_update_cases(case_structures)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0003_event_attendance_taker_ids'),
+    ]
+
+    operations = [
+        migrations.RemoveIndex(
+            model_name='event',
+            name='commcare_ev_event_i_c27a78_idx',
+        ),
+        migrations.RemoveField(
+            model_name='event',
+            name='id',
+        ),
+        migrations.AddField(
+            model_name='event',
+            name='_case_id',
+            field=models.UUIDField(default=uuid.uuid4),
+        ),
+        migrations.AlterField(
+            model_name='event',
+            name='event_id',
+            field=models.UUIDField(
+                default=uuid.uuid4,
+                primary_key=True,
+                serialize=False,
+            ),
+        ),
+        migrations.RunPython(
+            _recreate_events,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/corehq/apps/events/migrations/0005_rename_alter_event__attendance_taker_ids.py
+++ b/corehq/apps/events/migrations/0005_rename_alter_event__attendance_taker_ids.py
@@ -1,0 +1,24 @@
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0004_event_id_case_id'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='event',
+            old_name='attendance_taker_ids',
+            new_name='_attendance_taker_ids',
+        ),
+        migrations.AlterField(
+            model_name='event',
+            name='_attendance_taker_ids',
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.UUIDField(), blank=True, default=list,
+                null=True, size=None),
+        ),
+    ]

--- a/corehq/apps/events/models.py
+++ b/corehq/apps/events/models.py
@@ -104,8 +104,8 @@ class Event(models.Model):
         choices=ATTENDEE_LIST_STATUS_CHOICES,
         default=NOT_STARTED,
     )
-    attendance_taker_ids = ArrayField(
-        models.CharField(max_length=255),
+    _attendance_taker_ids = ArrayField(
+        models.UUIDField(),
         blank=True,
         null=True,
         default=list
@@ -131,6 +131,14 @@ class Event(models.Model):
             return self.event_id.hex
         except AttributeError:
             return self.event_id
+
+    @property
+    def attendance_taker_ids(self):
+        return [uuid.hex for uuid in self._attendance_taker_ids]
+
+    @attendance_taker_ids.setter
+    def attendance_taker_ids(self, value):
+        self._attendance_taker_ids = [uuid.UUID(hex=v) for v in value]
 
     def get_fake_case_sharing_group(self, user_id):
         """

--- a/corehq/apps/events/tests/test_models.py
+++ b/corehq/apps/events/tests/test_models.py
@@ -1,6 +1,7 @@
 import doctest
 from contextlib import contextmanager
 from datetime import datetime
+from uuid import UUID, uuid4
 
 from django.test import TestCase
 
@@ -334,8 +335,8 @@ class EventCaseTests(TestCase):
     def tearDown(self):
         try:
             self.event.delete()
-        except:
-            pass
+        except AssertionError:
+            pass  # self.event is already deleted
 
     def test_case(self):
         with self.assertRaises(CaseNotFound):
@@ -353,6 +354,32 @@ class EventCaseTests(TestCase):
 
     def test_delete_without_case(self):
         self.event.delete()  # Does not raise error
+
+    def test_default_uuids(self):
+        today = datetime.utcnow().date()
+        unsaved_event = Event(
+            name='Test Event Too',
+            domain=DOMAIN,
+            start_date=today,
+            end_date=today,
+            attendance_target=0,
+        )
+        self.assertIsInstance(unsaved_event.event_id, UUID)
+        self.assertIsInstance(unsaved_event._case_id, UUID)
+
+    def test_uuid_hex_string(self):
+        today = datetime.utcnow().date()
+        case_id_hex_string = uuid4().hex
+        unsaved_event = Event(
+            name='Test Event 33.3',
+            _case_id=case_id_hex_string,
+            domain=DOMAIN,
+            start_date=today,
+            end_date=today,
+            attendance_target=0,
+        )
+        self.assertIsInstance(unsaved_event._case_id, str)
+        self.assertEqual(unsaved_event.case_id, case_id_hex_string)
 
 
 def test_doctests():

--- a/corehq/apps/events/tests/test_models.py
+++ b/corehq/apps/events/tests/test_models.py
@@ -8,6 +8,7 @@ from casexml.apps.case.mock import CaseFactory, CaseStructure
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 from corehq.util.test_utils import create_test_case
 
@@ -284,7 +285,7 @@ class TestCaseSharingGroup(TestCase):
         with self._get_event([self.commcare_user.user_id]) as event:
             groups = list(get_user_case_sharing_groups_for_events(self.commcare_user))
             self.assertEqual(len(groups), 1)
-            self.assertEqual(groups[0]._id, event.event_id)
+            self.assertEqual(groups[0]._id, event.group_id)
             self.assertEqual(groups[0].name, f"{event.name} Event")
 
     def test_no_user_case_sharing_groups_for_events(self):
@@ -315,6 +316,43 @@ class GetAttendeeCaseTypeTest(TestCase):
             yield
         finally:
             config.delete()
+
+
+class EventCaseTests(TestCase):
+
+    def setUp(self):
+        today = datetime.utcnow().date()
+        self.event = Event(
+            name='Test Event',
+            domain=DOMAIN,
+            start_date=today,
+            end_date=today,
+            attendance_target=0,
+        )
+        self.event.save()
+
+    def tearDown(self):
+        try:
+            self.event.delete()
+        except:
+            pass
+
+    def test_case(self):
+        with self.assertRaises(CaseNotFound):
+            CommCareCase.objects.get_case(self.event.case_id, DOMAIN)
+
+        event_case = self.event.case  # Creates case
+        case = CommCareCase.objects.get_case(self.event.case_id, DOMAIN)
+        self.assertEqual(event_case, case)
+
+    def test_delete_with_case(self):
+        __ = self.event.case
+        self.event.delete()
+        case = CommCareCase.objects.get_case(self.event.case_id, DOMAIN)
+        self.assertTrue(case.closed)
+
+    def test_delete_without_case(self):
+        self.event.delete()  # Does not raise error
 
 
 def test_doctests():

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -92,15 +92,19 @@ class EventsView(BaseEventView, CRUDPaginatedViewMixin):
         return self.paginate_crud_response
 
     def _format_paginated_event(self, event: Event):
+        edit_url = reverse(EventEditView.urlname, args=(
+            self.domain,
+            event.event_id.hex,
+        ))
         return {
-            'id': event.event_id,
+            'id': event.event_id.hex,
             'name': event.name,
             'start_date': str(event.start_date),
             'end_date': str(event.end_date),
             'target_attendance': event.attendance_target,
             'status': event.status,
             'total_attendance': event.total_attendance or '-',
-            'edit_url': reverse(EventEditView.urlname, args=(self.domain, event.event_id)),
+            'edit_url': edit_url,
             'total_attendance_takers': event.get_total_attendance_takers() or '-'
         }
 
@@ -193,7 +197,7 @@ class EventEditView(EventCreateView):
 
     @property
     def page_url(self):
-        return reverse(self.urlname, args=(self.domain, self.event.event_id))
+        return reverse(self.urlname, args=(self.domain, self.event.event_id.hex))
 
     @property
     def event(self):

--- a/migrations.lock
+++ b/migrations.lock
@@ -362,6 +362,7 @@ events
  0001_add_events_model
  0002_attendancetrackingconfig
  0003_event_attendance_taker_ids
+ 0004_event_id_case_id
 export
  0001_initial
  0002_datafile

--- a/migrations.lock
+++ b/migrations.lock
@@ -363,6 +363,7 @@ events
  0002_attendancetrackingconfig
  0003_event_attendance_taker_ids
  0004_event_id_case_id
+ 0005_rename_alter_event__attendance_taker_ids
 export
  0001_initial
  0002_datafile


### PR DESCRIPTION
## Technical Summary

Follows up [this comment](https://github.com/dimagi/commcare-hq/pull/32755#issuecomment-1476046391) on PR #32755 

* Uses `UUIDField` for UUIDs.
* Drops the unused Event.id primary key, and uses `event_id` as a primary key instead.
* Adds a `_case_id` field that stores a UUID for the Event's case.
* Adds a `case_id` property that returns `_case_id` as a string.
* Adds a `group_id` property that returns `event_id` as a string.
* Fixes a bug in `delete()`

(I may have got a little carried away with the migration, all for the sake of preserving a tiny amount of test data.)

## Feature Flag

Attendance Tracking

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Includes test coverage

### QA Plan

This feature will be QAed

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

The migration uses the new code, but because this feature is still in active development, production data does not exist, and only a tiny amount to test data exists in any environment.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
