### PR TITLE
Attempt to fix intermittent test failure

### DIFF
--- a/corehq/tests/test_nose_timing.py
+++ b/corehq/tests/test_nose_timing.py
@@ -1,3 +1,4 @@
+import gc
 import time
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
@@ -22,7 +23,12 @@ class TimingPluginTesterBase(PluginTester, TestCase):
                 "--max-test-time=0.05",
                 "-v",
             ]
-            super().setUp()
+            gc.disable()
+            try:
+                # time-critical tests are run in here
+                super().setUp()
+            finally:
+                gc.enable()
             fh.seek(0)
             print("---- begin test output ----")
             print(self.output)


### PR DESCRIPTION
`TestTeardownExceedsSumOfOtherLimits.test_time_limit2` has been failing recently on Github Actions. A common feature of all observed failures is that the "setup" phase of the test (which ends in `TimingPlugin.startTest`) takes an inexplicably long time. A typical failure includes this unexpected output:

```
  ERROR: runTest2 (corehq.tests.test_nose_timing.TestTeardownExceedsSumOfOtherLimits.makeSuite.<locals>.Test)
    ...
  AssertionError: setup time limit (0.05) exceeded: 0.7901391983032227
```

The theory of this attempted fix is that garbage collection triggered during that "setup" phase is causing the failure. It is a bit strange that the failure has always occurred in the same place. It is unclear why garbage collection would run so consistently. This fix disables garbage collection for the time-critical section of all `TimingPlugin` tests, so it should theoretically prevent garbage collection from interfering with any of them.

The test failure was reproducible by calling `gc.collect()` during the "setup" phase of the test (it is possible to make nearly all other `TimingPlugin` tests in the suite fail in a similar way with that call too).

## Safety Assurance

### Safety story

Tests only.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
