### PR TITLE
api key expiration

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -778,7 +778,8 @@ class UserDomainsResource(CorsResourceMixin, Resource):
             if isinstance(immediate_http_response.response, HttpUnauthorized):
                 raise ImmediateHttpResponse(
                     response=HttpUnauthorized(
-                        content='Username or API Key is incorrect', content_type='text/plain'
+                        content='Username or API Key is incorrect, expired or deactivated',
+                        content_type='text/plain'
                     )
                 )
             else:

--- a/corehq/apps/domain/static/domain/js/internal_subscription_management.js
+++ b/corehq/apps/domain/static/domain/js/internal_subscription_management.js
@@ -1,7 +1,7 @@
 hqDefine('domain/js/internal_subscription_management', [
     'jquery',
     'knockout',
-    'jquery-ui/ui/widgets/datepicker',
+    'hqwebapp/js/widgets',
 ], function (
     $,
     ko
@@ -18,6 +18,5 @@ hqDefine('domain/js/internal_subscription_management', [
             return date.toJSON().slice(0, 10);
         });
         $('#subscription_management').koApplyBindings(viewModel);
-        $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
     });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/widgets.js
@@ -4,6 +4,7 @@ hqDefine("hqwebapp/js/widgets",[
         '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
         'hqwebapp/js/initial_page_data',
         'select2/dist/js/select2.full.min',
+        'jquery-ui/ui/widgets/datepicker',
     ], function ($, _, MapboxGeocoder, initialPageData) {
         var init = function () {
             var MAPBOX_ACCESS_TOKEN = initialPageData.get(
@@ -98,6 +99,8 @@ hqDefine("hqwebapp/js/widgets",[
                     geocoder.setInput(getGeocoderValue());
                 }
             });
+
+            $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
         };
 
         var parseEmails = function (input) {

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -267,6 +267,10 @@ class HQApiKeyForm(forms.Form):
         required=False,
         help_text=gettext_lazy("Limit the key's access to a single project space")
     )
+    expiration_date = forms.DateTimeField(
+        required=False,
+        help_text=gettext_lazy("Date and time the API key should expire on")
+    )
 
     def __init__(self, *args, **kwargs):
         self.couch_user = kwargs.pop('couch_user')
@@ -282,6 +286,7 @@ class HQApiKeyForm(forms.Form):
                 crispy.Field('name'),
                 crispy.Field('domain'),
                 crispy.Field('ip_allowlist'),
+                crispy.Field('expiration_date', css_class='date-picker'),
             ),
             hqcrispy.FormActions(
                 StrictButton(
@@ -302,6 +307,7 @@ class HQApiKeyForm(forms.Form):
                 ip_allowlist=self.cleaned_data['ip_allowlist'],
                 user=user,
                 domain=self.cleaned_data['domain'] or '',
+                expiration_date=self.cleaned_data['expiration_date'],
             )
             return new_key
 

--- a/corehq/apps/settings/static/settings/js/user_api_keys.js
+++ b/corehq/apps/settings/static/settings/js/user_api_keys.js
@@ -4,6 +4,7 @@ hqDefine("settings/js/user_api_keys", [
     'underscore',
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/crud_paginated_list",
+    "jquery-ui/ui/widgets/datepicker",
 ], function (
     $,
     ko,
@@ -56,6 +57,8 @@ hqDefine("settings/js/user_api_keys", [
         var paginatedListModel = ApiKeyListModel();
         ko.applyBindings(paginatedListModel, $('#editable-paginated-list').get(0));
         paginatedListModel.init();
+
+        $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
     });
 
     return 1;

--- a/corehq/apps/settings/static/settings/js/user_api_keys.js
+++ b/corehq/apps/settings/static/settings/js/user_api_keys.js
@@ -4,13 +4,14 @@ hqDefine("settings/js/user_api_keys", [
     'underscore',
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/crud_paginated_list",
-    "jquery-ui/ui/widgets/datepicker",
+    'hqwebapp/js/widgets',
 ], function (
     $,
     ko,
     _,
     initialPageData,
-    CRUDPaginatedList
+    CRUDPaginatedList,
+    widgets,
 ) {
 
     var ApiKeyListModel = function () {
@@ -57,8 +58,7 @@ hqDefine("settings/js/user_api_keys", [
         var paginatedListModel = ApiKeyListModel();
         ko.applyBindings(paginatedListModel, $('#editable-paginated-list').get(0));
         paginatedListModel.init();
-
-        $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
+        widgets.init();
     });
 
     return 1;

--- a/corehq/apps/settings/tasks.py
+++ b/corehq/apps/settings/tasks.py
@@ -1,0 +1,56 @@
+from celery.schedules import crontab
+
+from corehq.apps.celery import periodic_task
+from corehq.apps.hqwebapp.tasks import send_html_email_async
+from corehq.apps.settings.views import ApiKeyView
+from corehq.apps.users.models import HQApiKey
+from corehq.const import USER_DATETIME_FORMAT
+from corehq.util.timezones.conversions import ServerTime
+from corehq.util.view_utils import absolute_reverse
+
+from datetime import datetime, timedelta
+
+from django.conf import settings
+from django.template.loader import render_to_string
+
+import pytz
+
+
+def _to_utc(value):
+    return (ServerTime(value)
+            .user_time(pytz.timezone('UTC'))
+            .done()
+            .strftime(USER_DATETIME_FORMAT)) if value else '-'
+
+
+@periodic_task(
+    run_every=crontab(hour=23, minute=0),
+    queue='background_queue',
+)
+def notify_about_to_expire_api_keys():
+
+    manager = HQApiKey.all_objects
+
+    keys_about_to_expire = manager.all() \
+        .filter(is_active=True) \
+        .exclude(expiration_date=None) \
+        .exclude(expiration_date__lt=datetime.now()) \
+        .exclude(expiration_date__gt=datetime.today() + timedelta(days=5))
+
+    url = absolute_reverse(ApiKeyView.urlname)
+
+    for key in keys_about_to_expire:
+        params = {
+            "key_name": key.name,
+            "last_used": _to_utc(key.last_used),
+            "expiration_date": _to_utc(key.expiration_date),
+            "url": url,
+        }
+
+        text_content = render_to_string("settings/email/about_to_expire_api_key.txt", params)
+        html_content = render_to_string("settings/email/about_to_expire_api_key.html", params)
+        subject = "Api key about to expire"
+
+        send_html_email_async.delay(subject, key.user.email, html_content,
+                                    text_content=text_content,
+                                    email_from=settings.DEFAULT_FROM_EMAIL)

--- a/corehq/apps/settings/templates/settings/email/about_to_expire_api_key.html
+++ b/corehq/apps/settings/templates/settings/email/about_to_expire_api_key.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% blocktrans %}
+  <p>
+    Your api key "{{ key_name }}" (last used: {{ last_used }}) will expire on {{ expiration_date }}. Go to {{ url }} to generate
+    a new key if needed.
+  </p>
+
+  <p>
+    Thanks,<br />
+    CommCare HQ
+  </p>
+{% endblocktrans %}

--- a/corehq/apps/settings/templates/settings/email/about_to_expire_api_key.txt
+++ b/corehq/apps/settings/templates/settings/email/about_to_expire_api_key.txt
@@ -1,0 +1,8 @@
+{% load i18n %}
+{% blocktrans %}
+Your api key "{{ key_name }}" (last used: {{ last_used }}) will expire on {{ expiration_date }}.
+Go to {{ url }} to generate a new key if needed.
+
+Thanks,
+CommCare HQ
+{% endblocktrans %}

--- a/corehq/apps/settings/templates/settings/user_api_keys.html
+++ b/corehq/apps/settings/templates/settings/user_api_keys.html
@@ -14,22 +14,23 @@
     <td data-bind="text: last_used"></td>
     <td data-bind="text: expiration_date"></td>
     <td>
-      <span class="label label-success" data-bind="visible: is_active">{% trans "Active" %}</span>
-      <span class="label label-danger" data-bind="hidden: is_active">{% trans "Inactive" %}</span>
+      <span class="label label-success" data-bind="visible: status == 'active'">{% trans "Active" %}</span>
+      <span class="label label-warning" data-bind="visible: status == 'inactive'">{% trans "Inctive" %}</span>
+      <span class="label label-danger" data-bind="visible: status == 'expired'">{% trans "Expired" %}</span>
       <small class="help-block" data-bind="hidden: is_active, text: deactivated_on" />
     </td>
     <td>
 
-      <button class="btn btn-default" data-bind="visible: is_active, click: $root.deactivate">
+      <button class="btn btn-default" data-bind="visible: status == 'active', click: $root.deactivate">
         <i class="fa fa-pause"></i> {% trans "Deactivate" %}
       </button>
-      <button class="btn btn-default" data-bind="hidden: is_active, click: $root.activate">
+      <button class="btn btn-default" data-bind="visible: status == 'inactive', click: $root.activate">
         <i class="fa fa-toggle-right"></i> {% trans "Activate" %}
       </button>
 
       <button type="button"
               data-toggle="modal"
-              data-bind="attr: {'data-target': '#delete-key-' + id}"
+              data-bind="attr: {'data-target': '#delete-key-' + id}, hidden: status == 'active'"
               class="btn btn-danger">
         <i class="fa fa-remove"></i> {% trans "Delete" %}
       </button>

--- a/corehq/apps/settings/templates/settings/user_api_keys.html
+++ b/corehq/apps/settings/templates/settings/user_api_keys.html
@@ -12,6 +12,7 @@
     <td data-bind="text: ip_allowlist"></td>
     <td data-bind="text: created"></td>
     <td data-bind="text: last_used"></td>
+    <td data-bind="text: expiration_date"></td>
     <td>
       <span class="label label-success" data-bind="visible: is_active">{% trans "Active" %}</span>
       <span class="label label-danger" data-bind="hidden: is_active">{% trans "Inactive" %}</span>
@@ -78,6 +79,7 @@
     <td data-bind="text: ip_allowlist"></td>
     <td data-bind="text: created"></td>
     <td data-bind="text: last_used"></td>
+    <td data-bind="text: expiration_date"></td>
     <td>
       <span class="label label-success">{% trans "Active" %}</span>
     </td>

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -2,6 +2,7 @@ import json
 import re
 from base64 import b64encode
 from io import BytesIO
+from datetime import datetime
 
 import pytz
 from django.conf import settings
@@ -700,6 +701,13 @@ class ApiKeyView(BaseMyAccountView, CRUDPaginatedViewMixin):
         else:
             copy_msg = _("Copy this in a secure place. It will not be shown again.")
             key = f"{api_key.key} ({copy_msg})",
+
+        if api_key.expiration_date and api_key.expiration_date < datetime.now():
+            status = "expired"
+        elif api_key.is_active:
+            status = "active"
+        else:
+            status = "inactive"
         return {
             "id": api_key.id,
             "name": api_key.name,
@@ -712,6 +720,7 @@ class ApiKeyView(BaseMyAccountView, CRUDPaginatedViewMixin):
             "created": self._to_user_time(api_key.created),
             "last_used": self._to_user_time(api_key.last_used),
             "expiration_date": self._to_user_time(api_key.expiration_date),
+            "status": status,
             "deactivated_on": self._to_user_time(api_key.deactivated_on),
             "is_active": api_key.is_active,
         }

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -44,6 +44,7 @@ from corehq.apps.domain.extension_points import has_custom_clean_password
 from corehq.apps.domain.forms import clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
+from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.utils import sign
 from corehq.apps.hqwebapp.views import (
     BaseSectionPageView,
@@ -623,6 +624,10 @@ class ApiKeyView(BaseMyAccountView, CRUDPaginatedViewMixin):
 
     template_name = "settings/user_api_keys.html"
 
+    @use_jquery_ui  # for datepicker
+    def dispatch(self, request, *args, **kwargs):
+        return super(ApiKeyView, self).dispatch(request, *args, **kwargs)
+
     @property
     def allowed_actions(self):
         return [
@@ -666,6 +671,7 @@ class ApiKeyView(BaseMyAccountView, CRUDPaginatedViewMixin):
             _("IP Allowlist"),
             _("Created"),
             _("Last Used"),
+            _("Expiration Date"),
             _("Status"),
             _("Actions"),
         ]
@@ -705,6 +711,7 @@ class ApiKeyView(BaseMyAccountView, CRUDPaginatedViewMixin):
             ),
             "created": self._to_user_time(api_key.created),
             "last_used": self._to_user_time(api_key.last_used),
+            "expiration_date": self._to_user_time(api_key.expiration_date),
             "deactivated_on": self._to_user_time(api_key.deactivated_on),
             "is_active": api_key.is_active,
         }

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2951,7 +2951,9 @@ class UserReportingMetadataStaging(models.Model):
 
 class ApiKeyManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset().filter(is_active=True)
+        return super().get_queryset()\
+            .filter(is_active=True)\
+            .exclude(expiration_date__lt=datetime.now())
 
 
 class HQApiKey(models.Model):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2966,7 +2966,7 @@ class HQApiKey(models.Model):
     role_id = models.CharField(max_length=40, blank=True, default='')
     is_active = models.BooleanField(default=True)
     deactivated_on = models.DateTimeField(blank=True, null=True)
-    expiration_date = models.DateTimeField(blank=True, null=True)  # Not yet used
+    expiration_date = models.DateTimeField(blank=True, null=True)
     # Not update with every request. Can be a couple of seconds out of date
     last_used = models.DateTimeField(blank=True, null=True)
 


### PR DESCRIPTION
## Product Description
An expiration date for api keys already existed in the database but could not be set in the ui. I added a field in
the api key creation form that uses a date picker.

![image](https://user-images.githubusercontent.com/1946138/228022917-bcd6521c-3e8d-42f2-9a8c-f1d3522a7c9c.png)

The api key table now has an additional column showing the expiration date. Since both the active flag and the
expiration date effect if a key can be used it can get a bit confusing from a users perspective to figure out what 
the status is. To make it easier I changed the ui behavior to the following after discussing it with Clayton:

* If the active flag is true and the key is not expired (no expiration date, or the date is in the future): 
  * status: active
  * allowed actions: deactivate
* If the active flag is false and the key is not expired
  * status: inactive
  * allowed actions: activate, delete
* If the active flag is true or false and the key is expired
  * status: expired
  * allowed actions: delete

This will also make delete a two step process if the key is currently active: deactivate, then delete.

![image](https://user-images.githubusercontent.com/1946138/228022421-1c972e69-c022-428d-a1d9-7483737496a0.png)

In addition to showing the expiration date in the view, a daily task will send out email reminders to the key owner,
if a key will expire in the next 5 days.

```
Your api key "expires_thursday" (last used: -) will expire on Mar 30, 2023 00:00 UTC. Go to https://staging.commcarehq.org/account/api_keys/ to generate a new key if needed.

Thanks,
CommCare HQ

```

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-2402

## Feature Flag
No feature flag

## Safety Assurance

### Safety story

Manually tested following scenarios on staging:

1. Create and use key without expiration date successfully
2. Disable it and check that it does not work anymore
3. Create and successfully use key with expiration date in the future
4. Disable it and check that it does not work anymore
5. Create key with expiration date set to today and check that it does not work
7. Create key with expiration date in the past and check that it cannot be used
8. Email for key about the expire was received no matter if they are in-/active

### Automated test coverage

Added more cases to `corehq/apps/api/tests/test_auth.py` for expired and unexpired keys.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
