### PR TITLE
Revert "Change Update Translations PR/commit text to skip CI"

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -50,9 +50,11 @@ jobs:
           branch-suffix: short-commit-hash
           commit-message: |
             Update translations
-
-            [ci skip]
           title: 'Update Translations'
           labels: product/invisible
           body: |
             GitHub Actions automatically ran update-translations.sh and used [create-pull-request](https://github.com/peter-evans/create-pull-request) to open this pull request.
+
+            Please **close and reopen** this pull request to have tests run.<sup>†</sup>
+
+            <sup>†</sup> Workaround for [this GitHub Actions constraint](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)


### PR DESCRIPTION
Reverts dimagi/commcare-hq#31872

With recent permission changes to the main commcare repo, we now need tests in the automated Translation PR to pass if we want to merge them in (without needing an admin) as part of our weekly deploy process.

There's plans to make this process even more seamless so the PR doesn't need to be manually closed/reopened for the tests to run but for now this will be enough. 