### PR TITLE
Add comments for clarity. Change "Client Grant" label to "Client Credentials Grant"

### DIFF
--- a/corehq/motech/const.py
+++ b/corehq/motech/const.py
@@ -11,10 +11,27 @@ OAUTH2_CLIENT = "oauth2_client"
 AUTH_TYPES = (
     (BASIC_AUTH, "HTTP Basic"),
     (DIGEST_AUTH, "HTTP Digest"),
-    (BEARER_AUTH, "Bearer Token"),
     (OAUTH1, "OAuth1"),
+
+    # https://oauth.net/2/grant-types/client-credentials/
+    # https://www.rfc-editor.org/rfc/rfc6749#section-4.4
+    (OAUTH2_CLIENT, "OAuth 2.0 Client Credentials Grant"),
+
+    # aka "Resource Owner Password Credentials" grant type
+    # Considered legacy
+    # > ... should only be used when ... other authorization grant types
+    # > are not available
+    # https://oauth.net/2/grant-types/password/
+    # https://www.rfc-editor.org/rfc/rfc6749#section-1.3.3
     (OAUTH2_PWD, "OAuth 2.0 Password Grant"),
-    (OAUTH2_CLIENT, "OAuth 2.0 Client Grant"),
+
+    # This is not a grant type / authentication flow. It is a type of
+    # access token. HQ implements this option by requesting a new token
+    # before every API request. Users probably want to choose "OAuth 2.0
+    # Client Credentials Grant" instead.
+    # https://oauth.net/2/bearer-tokens/
+    # https://www.rfc-editor.org/rfc/rfc6750
+    (BEARER_AUTH, "Bearer Token"),
 )
 AUTH_TYPES_REQUIRE_USERNAME = (
     BASIC_AUTH,

--- a/corehq/motech/migrations/0012_alter_connectionsettings_auth_type.py
+++ b/corehq/motech/migrations/0012_alter_connectionsettings_auth_type.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('motech', '0011_connectionsettings_is_deleted'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='connectionsettings',
+            name='auth_type',
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    (None, 'None'),
+                    ('basic', 'HTTP Basic'),
+                    ('digest', 'HTTP Digest'),
+                    ('oauth1', 'OAuth1'),
+                    ('oauth2_client', 'OAuth 2.0 Client Credentials Grant'),
+                    ('oauth2_pwd', 'OAuth 2.0 Password Grant'),
+                    ('bearer', 'Bearer Token')
+                ],
+                max_length=16,
+                null=True,
+            ),
+        ),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -608,6 +608,7 @@ motech
  0009_auto_20211122_2011
  0010_auto_20211124_1931
  0011_connectionsettings_is_deleted
+ 0012_alter_connectionsettings_auth_type
 notifications
  0001_squashed_0003_auto_20160504_2049 (3 squashed migrations)
  0002_auto_20160505_2058


### PR DESCRIPTION
## Technical Summary

Tiny. Does not affect functionality. Changes a label in `ConnectionSettings.auth_type` to make it easier to google. Also adds some code comments about what options mean and where to find more info.

Prompted by investigation into [SC-2648](https://dimagi-dev.atlassian.net/browse/SC-2648)

## Feature Flag

N/A

## Safety Assurance

### Safety story

Does not affect functionality. The migration is only to change the label of an option choice. (The choice value is unchanged.)

### Automated test coverage

N/A

### QA Plan

N/A

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

(To be clear, the migration has no effect; it just changes a label.)
<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2648]: https://dimagi-dev.atlassian.net/browse/SC-2648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ