### PR TITLE
Use the username of mobile workers as the case_name for attendee cases

### DIFF
--- a/corehq/apps/events/tasks.py
+++ b/corehq/apps/events/tasks.py
@@ -71,7 +71,7 @@ def get_user_attendee_cases_on_domain(domain):
 
 
 def get_case_block_for_user(user, owner_id, attendee_case_type):
-    case_name = ' '.join((user.first_name, user.last_name))
+    case_name = user.username
     fields = {
         ATTENDEE_USER_ID_CASE_PROPERTY: user.user_id,
     }

--- a/corehq/apps/events/tasks.py
+++ b/corehq/apps/events/tasks.py
@@ -71,7 +71,7 @@ def get_user_attendee_cases_on_domain(domain):
 
 
 def get_case_block_for_user(user, owner_id, attendee_case_type):
-    case_name = user.username
+    case_name = user.username.split('@')[0]
     fields = {
         ATTENDEE_USER_ID_CASE_PROPERTY: user.user_id,
     }

--- a/corehq/apps/events/tests/test_tasks.py
+++ b/corehq/apps/events/tests/test_tasks.py
@@ -76,10 +76,10 @@ class TestTasks(TestCase):
 
         self.assertEqual(len(user_ids), 2)
         # The case_name for mobile workers should be their username
-        mobile_worker_case = AttendeeCase.objects.by_domain(self.domain)[0]
-        commcare_user_id = mobile_worker_case.case_json['commcare_user_id']
-        commcare_user = CommCareUser.get_by_user_id(commcare_user_id)
-        self.assertEqual(mobile_worker_case.name, commcare_user.username)
+        for mobile_worker_case in AttendeeCase.objects.by_domain(self.domain):
+            commcare_user_id = mobile_worker_case.case_json['commcare_user_id']
+            commcare_user = CommCareUser.get_by_user_id(commcare_user_id)
+            self.assertEqual(mobile_worker_case.name, commcare_user.username.split('@')[0])
 
     def test_duplicate_cases_not_created(self):
         # Let's call this to create initial cases

--- a/corehq/apps/events/tests/test_tasks.py
+++ b/corehq/apps/events/tests/test_tasks.py
@@ -66,7 +66,7 @@ class TestTasks(TestCase):
 
     def test_cases_created_for_mobile_workers(self):
         """Test that the `sync_mobile_worker_attendees` task creates `commcare-attendee` cases for mobile
-        workers
+        workers.
         """
         user_id_case_mapping = get_user_attendee_cases_on_domain(self.domain)
         user_ids = list(user_id_case_mapping.keys())
@@ -75,6 +75,11 @@ class TestTasks(TestCase):
         user_ids = list(user_id_case_mapping.keys())
 
         self.assertEqual(len(user_ids), 2)
+        # The case_name for mobile workers should be their username
+        mobile_worker_case = AttendeeCase.objects.by_domain(self.domain)[0]
+        commcare_user_id = mobile_worker_case.case_json['commcare_user_id']
+        commcare_user = CommCareUser.get_by_user_id(commcare_user_id)
+        self.assertEqual(mobile_worker_case.name, commcare_user.username)
 
     def test_duplicate_cases_not_created(self):
         # Let's call this to create initial cases

--- a/corehq/apps/events/tests/test_views.py
+++ b/corehq/apps/events/tests/test_views.py
@@ -239,7 +239,7 @@ class TestAttendeesConfigView(BaseEventViewTestClass):
         self.assertEqual(json_data['mobile_worker_attendee_enabled'], False)
 
     @flag_enabled('ATTENDANCE_TRACKING')
-    @patch('corehq.apps.events.views.tasks.sync_mobile_worker_attendees')
+    @patch('corehq.apps.events.views.sync_mobile_worker_attendees')
     def test_post_updates_attendance_tracking_config(self, sync_mobile_worker_attendees_mock):
         config, _created = AttendanceTrackingConfig.objects.get_or_create(domain=self.domain)
         update_value = not config.mobile_worker_attendees
@@ -257,7 +257,7 @@ class TestAttendeesConfigView(BaseEventViewTestClass):
         self.assertEqual(config.mobile_worker_attendees, update_value)
 
     @flag_enabled('ATTENDANCE_TRACKING')
-    @patch('corehq.apps.events.views.tasks.sync_mobile_worker_attendees')
+    @patch('corehq.apps.events.views.sync_mobile_worker_attendees')
     def test_enable_mobile_worker_attendee_triggers_task(self, sync_mobile_worker_attendees_mock):
         config, _created = AttendanceTrackingConfig.objects.get_or_create(domain=self.domain)
         self.log_user_in(self.role_webuser)


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Use the username for mobile workers as the case name. We do this since the username is unique, so it will be easy to find the correct mobile worker attendee

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Attendance Tracking

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
