### PR TITLE
Best guess at adding new Q6a to Vectorlink report

### DIFF
--- a/custom/abt/reports/flagspecs_v2019.yml
+++ b/custom/abt/reports/flagspecs_v2019.yml
@@ -798,6 +798,17 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning_fr: "Problème signalé: pas de fiches de sotck séparés pour les insecticides périmés "
     warning_por: "Problema reportado: Nao ha separacao de cartoes de estoque de insecticida expirado."
     responsible_follow_up: "District Coordinator"
+  - question: [insecticide_expire_separate]
+    comment: [separate_cards_batch_comments]
+    base_path: [stock_audit_grp, Q6]
+    flag_name: "6a. Have the insecticides that expire during the spray campaign or before next year's campaign been physically separated from the other insecticides and clearly marked in the store?"
+    flag_name_fr: "6a. Est-ce que les insecticides qui expirent pendant cette campagne de pulvérisation ou avant la campagne de l'année prochaine sont physiquement séparés des autres insecticides et clairement identifiés dans le magasin?"
+    flag_name_por: "6a. Os insecticidas que expiram durante a época de pulverização foram fisicamente separados dos outros que estão no armazém?"
+    answer: "no"
+    warning: "Problem reported: Expiring insecticide not physically separated from others."
+    warning_fr: "Problème signalé: les insecticides périmés ne sont pas séparés physiquement des autres insecticides dans le magasin"
+    warning_por: "Problema reportado: Insecticida expirado nao esta fisicamente separado de outros."
+    responsible_follow_up: "District Coordinator"
   - question: [expired_insecticides_separate]
     comment: [expired_insecticides_separate_comments]
     base_path: [stock_audit_grp, Q7]

--- a/custom/abt/reports/flagspecs_v2019.yml
+++ b/custom/abt/reports/flagspecs_v2019.yml
@@ -798,23 +798,12 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning_fr: "Problème signalé: pas de fiches de sotck séparés pour les insecticides périmés "
     warning_por: "Problema reportado: Nao ha separacao de cartoes de estoque de insecticida expirado."
     responsible_follow_up: "District Coordinator"
-  - question: [insecticide_expire_separate]
-    comment: [separate_cards_batch_comments]
-    base_path: [stock_audit_grp, Q6]
+  - question: [expired_insecticides_separate]
+    comment: [expired_insecticides_separate_comments]
+    base_path: [stock_audit_grp, Q6a]
     flag_name: "6a. Have the insecticides that expire during the spray campaign or before next year's campaign been physically separated from the other insecticides and clearly marked in the store?"
     flag_name_fr: "6a. Est-ce que les insecticides qui expirent pendant cette campagne de pulvérisation ou avant la campagne de l'année prochaine sont physiquement séparés des autres insecticides et clairement identifiés dans le magasin?"
     flag_name_por: "6a. Os insecticidas que expiram durante a época de pulverização foram fisicamente separados dos outros que estão no armazém?"
-    answer: "no"
-    warning: "Problem reported: Expiring insecticide not physically separated from others."
-    warning_fr: "Problème signalé: les insecticides périmés ne sont pas séparés physiquement des autres insecticides dans le magasin"
-    warning_por: "Problema reportado: Insecticida expirado nao esta fisicamente separado de outros."
-    responsible_follow_up: "District Coordinator"
-  - question: [expired_insecticides_separate]
-    comment: [expired_insecticides_separate_comments]
-    base_path: [stock_audit_grp, Q7]
-    flag_name: "7. Have insecticides that expire during the spray season been physically separated from the other insecticides in the store room?"
-    flag_name_fr: "7. Est-ce-que les insecticides qui expirent pendant la saison de pulvérisation ont été physiquement séparés des autres insecticides dans le magasin?"
-    flag_name_por: "7. Os insecticidas que expiram durante a época de pulverização foram fisicamente separados dos outros estão no armazem?"
     answer: "no"
     warning: "Problem reported: Expiring insecticide not physically separated from others."
     warning_fr: "Problème signalé: les insecticides périmés ne sont pas séparés physiquement des autres insecticides dans le magasin"


### PR DESCRIPTION
## Technical Summary

Context: [SC-2670](https://dimagi-dev.atlassian.net/browse/SC-2670)

Adds a new form question to `flagspecs_v2019.yml`, which is used to build Vectorlink custom report "Supervisory Report 2019".

## Feature Flag

N/A

## Safety Assurance

### Safety story

- 🔼 Tiny change to add one question
- 🔼 Custom report, only available to Abt Vectorlink project spaces
- 🔽 Vectorlink reports can't be tested locally

### Automated test coverage

Not covered by tests

### QA Plan

No QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2670]: https://dimagi-dev.atlassian.net/browse/SC-2670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ