### PR TITLE
Fix 500 error when bulk archiving forms in Manage Forms

### DIFF
--- a/corehq/apps/data_interfaces/urls.py
+++ b/corehq/apps/data_interfaces/urls.py
@@ -37,6 +37,8 @@ edit_data_urls = [
         XFormManagementStatusView.as_view(),
         name=XFormManagementStatusView.urlname
     ),
+    url(r'^xform_management/status/poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
+        xform_management_job_poll, name='xform_management_job_poll'),
     url(r'^case_reassign/status/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
         BulkCaseReassignSatusView.as_view(), name=BulkCaseReassignSatusView.urlname),
     url(r'^case_reassign/status/poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR fixes [this 500 error](https://dimagi-dev.atlassian.net/browse/SUPPORT-16300) when attempting to use the bulk archive function in Data > Edit Data > Manage Forms

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira ticket](https://dimagi-dev.atlassian.net/browse/SAAS-14487)

This PR undoes a portion of [this PR](https://github.com/dimagi/commcare-hq/pull/32711), specifically where it deletes the url path for `xform_management_job_poll`. I'm not 100% sure why this was deleted, since the import statement and the original `xform_management_job_poll` function was still included in the PR but I'm guessing Sravan had thought that it wasn't being used. @sravfeyn please correct me if I'm mistaken in re-adding this deleted line. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
