### PR TITLE
Disable tracking options instead of hiding it

### DIFF
--- a/corehq/apps/events/forms.py
+++ b/corehq/apps/events/forms.py
@@ -81,8 +81,10 @@ class CreateEventForm(forms.Form):
                     crispy.Field('attendance_target', data_bind="value: attendanceTarget"),
                     crispy.Field('sameday_reg', data_bind="checked: sameDayRegistration"),
                     crispy.Div(
-                        crispy.Field('tracking_option', data_bind="checked: trackingOption"),
-                        data_bind="visible: showTrackingOptions",
+                        crispy.Field(
+                            'tracking_option',
+                            data_bind="checked: trackingOption, attr: {disabled: !showTrackingOptions()}",
+                        )
                     ),
                     'expected_attendees',
                     hqcrispy.FormActions(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
We now always show the `Attendance recording options`, but disbale them if they are not applicable.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This change is a twofold fix.
1. It doesn't surprise the user with a new field that suddenly shows up because of different start- and end dates.
2. It fixes the issue where part of the calendar widget is being obscured by an input field (see screenshot_1), since now there's more space.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Attendance Tracking

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Screenshot 1 (spacing issue)
![screenshot_1](https://user-images.githubusercontent.com/64970009/227900376-d355353c-a056-497f-aceb-c1f7ca091395.png)

## What it looks like now (when disabled)
![Screenshot from 2023-03-27 11-19-56](https://user-images.githubusercontent.com/64970009/227901008-6a42d058-fb21-4545-a8d0-942f0de1f95e.png)

