### PR TITLE
Update attendance tracking event status

### DIFF
--- a/corehq/apps/events/tests/test_events.py
+++ b/corehq/apps/events/tests/test_events.py
@@ -1,11 +1,11 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.test import TestCase
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
 
-from ..models import NOT_STARTED, Event
+from ..models import Event, IN_PROGRESS, NOT_STARTED, UNDER_REVIEW
 
 
 class TestEventModel(TestCase):
@@ -34,11 +34,36 @@ class TestEventModel(TestCase):
     def test_create_event(self):
         now = datetime.utcnow().date()
 
+        event = self._create_event(start_date=now, end_date=now)
+
+        self.assertEqual(event.status, IN_PROGRESS)
+        self.assertEqual(event.is_open, True)
+        self.assertTrue(event.event_id is not None)
+
+    def test_event_status_set_correctly(self):
+        now = datetime.utcnow()
+        today = now.date()
+
+        yesterday = (now - timedelta(days=1)).date()
+        tomorrow = (now + timedelta(days=1)).date()
+        two_days_from_now = (now + timedelta(days=2)).date()
+
+        not_started_event = self._create_event(start_date=tomorrow, end_date=two_days_from_now)
+        in_progress_event1 = self._create_event(start_date=yesterday, end_date=tomorrow)
+        in_progress_event2 = self._create_event(start_date=today, end_date=tomorrow)
+        under_review_event = self._create_event(start_date=yesterday, end_date=yesterday)
+
+        self.assertTrue(not_started_event.attendee_list_status, NOT_STARTED)
+        self.assertTrue(in_progress_event1.attendee_list_status, IN_PROGRESS)
+        self.assertTrue(in_progress_event2.attendee_list_status, IN_PROGRESS)
+        self.assertTrue(under_review_event.attendee_list_status, UNDER_REVIEW)
+
+    def _create_event(self, start_date, end_date):
         event_data = {
             'domain': self.domain,
             'name': 'test-event',
-            'start_date': now,
-            'end_date': now,
+            'start_date': start_date,
+            'end_date': end_date,
             'attendance_target': 10,
             'sameday_reg': True,
             'track_each_day': False,
@@ -46,7 +71,4 @@ class TestEventModel(TestCase):
         }
         event = Event(**event_data)
         event.save()
-
-        self.assertEqual(event.status, NOT_STARTED)
-        self.assertEqual(event.is_open, True)
-        self.assertTrue(event.event_id is not None)
+        return event

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -98,6 +98,11 @@ class EventsView(BaseEventView, CRUDPaginatedViewMixin):
     @property
     def paginated_list(self):
         start, end = self.skip, self.skip + self.limit
+        events = self.domain_events[start:end]
+        for event in events:
+            event.set_status()
+            event.save(update_fields=['attendee_list_status'])
+
         for event in self.domain_events[start:end]:
             yield {
                 'itemData': self._format_paginated_event(event),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When viewing the list of attendance tracking events, the user should notice the status of the event being either `Not Started`, `In Progress` or `Under review`, depending on the start- and end dates of the respective events.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Event statuses are being updated now. This is done as part of the `GET` call that retrieves a paginated list of events. It might seem awkward to update the event status during a `GET` call, but this is the easiest and quickest implementation for now, since the event list view is the only place where we care about the status of the events at this point. Future requirements might change this implementation to worker-based, but for now that is a bit overkill.

The event status can cycle between `Not Started`, `In Progress` or `Under review`. The [`Completed`](https://docs.google.com/document/d/1BysKjIIfrA-qgyLDe6weq4i_e9VApS0DVXEHVVfk7pQ/edit#heading=h.qide5zi9jjf3) status is not yet being used, since the implementation that will trigger this does not yet exist.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Attendance Tracking

## Safety Assurance
There's no complex things going on. Tests passing is enough safety.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
- Added a unit test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-4917)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
