### PR TITLE
Removed APP_ANALYTICS flag

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -199,12 +199,10 @@ hqDefine("cloudcare/js/formplayer/app", function () {
                 CloudcareUtils.showError(message, $("#cloudcare-notifications"), resp.reportToHq);
             }
         };
-        if (Toggles.toggleEnabled('APP_ANALYTICS')) {
-            Kissmetrics.track.event('Viewed Form', {
-                domain: data.domain,
-                name: data.title,
-            });
-        }
+        Kissmetrics.track.event('Viewed Form', {
+            domain: data.domain,
+            name: data.title,
+        });
         data.onsubmit = function (resp) {
             if (resp.status === "success") {
                 var $alert;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -137,34 +137,30 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
         if (menuResponse.type === "commands") {
             return views.MenuListView(menuData);
         } else if (menuResponse.type === "query") {
-            if (toggles.toggleEnabled('APP_ANALYTICS')) {
-                var props = {
-                    domain: FormplayerFrontend.getChannel().request('currentUser').domain,
-                };
-                if (menuResponse.breadcrumbs && menuResponse.breadcrumbs.length) {
-                    props.name = menuResponse.breadcrumbs[menuResponse.breadcrumbs.length - 1];
-                }
-                kissmetrics.track.event('Case Search', props);
+            var props = {
+                domain: FormplayerFrontend.getChannel().request('currentUser').domain,
+            };
+            if (menuResponse.breadcrumbs && menuResponse.breadcrumbs.length) {
+                props.name = menuResponse.breadcrumbs[menuResponse.breadcrumbs.length - 1];
             }
+            kissmetrics.track.event('Case Search', props);
             urlObject.setQueryData({}, false, false);
             return QueryView(menuData);
         } else if (menuResponse.type === "entities") {
-            if (toggles.toggleEnabled('APP_ANALYTICS')) {
-                var searchText = urlObject.search;
-                var event = "Viewed Case List";
-                if (searchText) {
-                    event = "Searched Case List";
-                }
-                var eventData = {
-                    domain: FormplayerFrontend.getChannel().request("currentUser").domain,
-                    name: menuResponse.title,
-                };
-                var fields = _.pick(utils.getCurrentQueryInputs(), function (v) { return !!v; });
-                if (!_.isEmpty(fields)) {
-                    eventData.searchFields = _.sortBy(_.keys(fields)).join(",");
-                }
-                kissmetrics.track.event(event, eventData);
+            var searchText = urlObject.search;
+            var event = "Viewed Case List";
+            if (searchText) {
+                event = "Searched Case List";
             }
+            var eventData = {
+                domain: FormplayerFrontend.getChannel().request("currentUser").domain,
+                name: menuResponse.title,
+            };
+            var fields = _.pick(utils.getCurrentQueryInputs(), function (v) { return !!v; });
+            if (!_.isEmpty(fields)) {
+                eventData.searchFields = _.sortBy(_.keys(fields)).join(",");
+            }
+            kissmetrics.track.event(event, eventData);
             if (/search_command\.m\d+/.test(menuResponse.queryKey) && menuResponse.currentPage === 0) {
                 kissmetrics.track.event('Started Case Search', {
                     'Split Screen Case Search': toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_test.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_test.js
@@ -8,7 +8,6 @@ describe('Render a case list', function () {
         hqImport("hqwebapp/js/initial_page_data").register(
             "toggles_dict",
             {
-                APP_ANALYTICS: true,
                 CHANGE_FORM_LANGUAGE: false,
             }
         );

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2032,14 +2032,6 @@ CHANGE_FORM_LANGUAGE = StaticToggle(
     help_link="https://confluence.dimagi.com/display/saas/Change+Form+Language"
 )
 
-APP_ANALYTICS = StaticToggle(
-    'app_analytics',
-    'Allow user to use app analytics in web apps',
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-    help_link="https://confluence.dimagi.com/display/saas/App+Analytics",
-)
-
 BLOCKED_EMAIL_DOMAIN_RECIPIENTS = StaticToggle(
     'blocked_email_domain_recipients',
     'Block any outgoing email addresses that have an email domain which '


### PR DESCRIPTION
## Technical Summary
While doing some troubleshooting with delivery, I realized that this flag gates about 5 types of events in web apps (which were added for the purpose of delivery analysis) and does not gate another 20+ types of events in web apps (which were added for various product/developer reasons).

This flag was originally added for the sake of limited the volume of analytics events, but given the number of events it doesn't flag, it isn't meaningfully doing so. It's also confusing which events are controlled by the flag and which aren't. As an example of ambiguity, the flag was gating the "Viewed Form" event (removed in `app.js`) but was not gating [these events for form submission](https://github.com/dimagi/commcare-hq/blob/d6281d74870abe8b37e14d371715d56a3a89a587/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js#L249-L257).

Review without whitespace, this is pretty minor.

## Feature Flag
This removes APP_ANALYTICS

## Safety Assurance

### Safety story
This is straightforward code removal, although in a historically risky area.

### Automated test coverage

Nothing meaningful.

### QA Plan

Not requesting QA. I'll do a smoke test on staging (or locally, if I fix my local formplayer) (applying do not merge label in the meantime). This is contrary to USH best practice of QAing all web apps changes, so reviewers feel free to push back or suggest other steps that would make you comfortable with this change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
