### PR TITLE
User Syncing FF - Remove extra unnecessary parent toggle, and add help link

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2355,7 +2355,8 @@ TABLEAU_USER_SYNCING = StaticToggle(
     Each time a user is added/deleted/updated on HQ, an equivalent Tableau user with the username "HQ/{username}"
     will be added/deleted/updated on the linked Tableau server.
     """,
-    parent_toggles=[EMBEDDED_TABLEAU, EMBED_TABLEAU_REPORT_BY_USER]
+    parent_toggles=[EMBED_TABLEAU_REPORT_BY_USER],
+    help_link='https://confluence.dimagi.com/display/USH/Tableau+User+Syncing',
 )
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Small changes to improve the TABLEAU_USER_SYCNING FF description, as described by Jason [here](https://dimagi-dev.atlassian.net/browse/USH-3045?focusedCommentId=257876).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The TABLEAU_USER_SYNCING FF doesn't need to have an EMBEDDED_TABLEAU parent toggle because EMBED_TABLEAU_REPORT_BY_USER already does. This causes two FFs to be showing in the flag's description.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

EMBEDDED_TABLEAU is a parent toggle of EMBED_TABLEAU_REPORT_BY_USER, so it doesn't need to be a parent toggle of TABLEAU_USER_SYNCING.

Otherwise this is just a UI change,

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Unnecessary.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
