### PR TITLE
Ze/bulk import all case types

### DIFF
--- a/corehq/apps/case_importer/const.py
+++ b/corehq/apps/case_importer/const.py
@@ -5,6 +5,8 @@
 # a few other fields as well. Also 300 is a nice round number.
 MAX_CASE_IMPORTER_COLUMNS = 300
 
+# Special case type used to identify when doing a bulk case import
+ALL_CASE_TYPE_IMPORT = 'commcare-all-case-types'
 
 class LookupErrors(object):
     NotFound, MultipleResults = list(range(2))

--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -80,7 +80,7 @@ def _merge_import_results(result_list):
     # errors together for the final result
     result['errors'] = {}
     for r in result_list:
-        new_errors = set(result['errors']) - set(r['errors'])
+        new_errors = set(r['errors']) - set(result['errors'])
         for new_error in new_errors:
             result['errors'][new_error] = r['errors'][new_error]
 

--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -17,11 +17,12 @@ from .util import (
     ImporterConfig,
     exit_celery_with_error_message,
     get_importer_error_message,
+    merge_dicts
 )
 
 
 @task(queue='case_import_queue')
-def bulk_import_async(config_dict, domain, excel_id):
+def bulk_import_async(config_list_json, domain, excel_id):
     case_upload = CaseUpload.get(excel_id)
     # case_upload.trigger_upload fires off this task right before saving the CaseUploadRecord
     # because CaseUploadRecord needs to be saved with the task id firing off the task creates.
@@ -29,13 +30,17 @@ def bulk_import_async(config_dict, domain, excel_id):
     # which causes unpredictable/undesirable error behavior
     case_upload.wait_for_case_upload_record()
     result_stored = False
-    config = ImporterConfig.from_json(config_dict)
     try:
         case_upload.check_file()
-        with case_upload.get_spreadsheet() as spreadsheet:
-            result = do_import(spreadsheet, config, domain, task=bulk_import_async,
-                               record_form_callback=case_upload.record_form)
+        all_results = []
+        for index, config_json in enumerate(config_list_json):
+            config = ImporterConfig.from_json(config_json)
+            with case_upload.get_spreadsheet(index) as spreadsheet:
+                result = do_import(spreadsheet, config, domain, task=bulk_import_async,
+                                record_form_callback=case_upload.record_form)
+                all_results.append(result)
 
+        result = _merge_import_results(all_results)
         _alert_on_result(result, domain)
         # save the success result into the CaseUploadRecord
         case_upload.store_task_result(make_task_status_success(result))
@@ -66,6 +71,20 @@ def _alert_on_result(result, domain):
         )
         alert = AbnormalUsageAlert(source="case importer", domain=domain, message=message)
         send_abnormal_usage_alert.delay(alert)
+
+
+def _merge_import_results(result_list):
+    result = merge_dicts(result_list, keys_to_exclude=['errors'])
+
+    # The errors key will be a dict, so we need to make sure to merge all unique
+    # errors together for the final result
+    result['errors'] = {}
+    for r in result_list:
+        new_errors = set(result['errors']) - set(r['errors'])
+        for new_error in new_errors:
+            result['errors'][new_error] = r['errors'][new_error]
+
+    return result
 
 
 metrics_gauge_task(

--- a/corehq/apps/case_importer/templates/case_importer/excel_config.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_config.html
@@ -7,10 +7,31 @@
 {% block page_content %}
   {% include 'case_importer/partials/help_message.html' %}
 
+  {% initial_page_data 'is_bulk_import' is_bulk_import %}
+  {% if is_bulk_import %}
+    <div class="alert alert-warning">
+      {% blocktrans %}
+      <p>
+        <i class="fa fa-warning"></i>
+        A bulk case import for multiple case types has been detected. For bulk case imports:
+      </p>
+      <ul>
+        <li>Excel mapping is disabled.</li>
+        <li>New cases for new case types cannot be created.</li>
+      </ul>
+      <p>
+        If this is incorrect, then please rename the Excel sheets so that they do not share the same
+        name as the case types in the project.
+      </p>
+      {% endblocktrans %}
+    </div>
+  {% endif %}
+
   <form class="form-horizontal form-report"
         action="{% url "excel_fields" domain %}"
         method="post">
     {% csrf_token %}
+    <input type="hidden" name="is_bulk_import" value="{{is_bulk_import}}" />
 
     <fieldset>
       <legend>{% trans "Case Type to Update/Create" %}</legend>
@@ -20,15 +41,19 @@
         </label>
         <div class="col-sm-6">
           <select class="form-control hqwebapp-select2" name="case_type" id="case_type">
-            <option disabled>{% trans "Used in existing applications:" %}</option>
-            {% for case_type in case_types_from_apps %}
-              <option value="{{case_type|escape}}">{{case_type|escape}}</option>
-            {% endfor %}
+            {% if is_bulk_import %}
+              <option value="{{ bulk_import_case_type }}">{{ bulk_import_case_type }}</option>
+            {% else %}
+              <option disabled>{% trans "Used in existing applications:" %}</option>
+              {% for case_type in case_types_from_apps %}
+                <option value="{{case_type|escape}}">{{case_type|escape}}</option>
+              {% endfor %}
 
-            <option disabled>{% trans "From unknown or deleted applications:" %}</option>
-            {% for case_type in unrecognized_case_types %}
-              <option value="{{case_type|escape}}">{{case_type|escape}}</option>
-            {% endfor %}
+              <option disabled>{% trans "From unknown or deleted applications:" %}</option>
+              {% for case_type in unrecognized_case_types %}
+                <option value="{{case_type|escape}}">{{case_type|escape}}</option>
+              {% endfor %}
+            {% endif %}
           </select>
         </div>
       </div>
@@ -64,7 +89,8 @@
                                            }, {
                                                id: 'external_id',
                                                text: '{% trans_html_attr 'External ID' %}',
-                                           }]"></select-toggle>
+                                           }],
+                                           disabled: {{ is_bulk_import|JSON }}"></select-toggle>
         </div>
       </div>
 

--- a/corehq/apps/case_importer/templates/case_importer/excel_fields.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_fields.html
@@ -16,6 +16,17 @@
 
 {% block page_content %}
   {% include 'case_importer/partials/help_message.html' %}
+  {% if is_bulk_import %}
+    <div class="alert alert-warning">
+      <p>
+        <i class="fa fa-warning"></i>
+        {% blocktrans %}
+          Excel mapping is disabled for bulk case imports. Excel columns will be used to directly
+          map to the relevant case properties.
+        {% endblocktrans %}
+      </p>
+    </div>
+  {% endif %}
 
   {% initial_page_data 'excel_fields' excel_fields %}
   {% initial_page_data 'case_field_specs' case_field_specs %}
@@ -31,6 +42,7 @@
     <input type="hidden" name="create_new_cases" value="{{create_new_cases}}" />
 
     <fieldset>
+      {% if not is_bulk_import %}
       <legend>
         {% trans "Match Excel Columns to Case Properties" %}
         <button type="button" class="btn btn-default pull-right" id="autofill" title="{% trans_html_attr 'Reset file-to-case-property matching to default' %}">
@@ -57,6 +69,7 @@
       <a id="js-add-mapping" class="btn btn-default" href="#">
         <i class="fa fa-plus"></i> {% trans "Add another matching" %}
       </a>
+      {% endif %}
     </fieldset>
 
     <div class="form-actions">

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -62,8 +62,8 @@ class CaseUpload(object):
             raise ImporterFileNotFound('file not found in cache')
         open_spreadsheet_download_ref(tempfile)
 
-    def get_spreadsheet(self):
-        return get_spreadsheet(self.get_tempfile())
+    def get_spreadsheet(self, worksheet_index=0):
+        return get_spreadsheet(self.get_tempfile(), worksheet_index)
 
     def trigger_upload(self, domain, config, comment=None):
         """

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -87,7 +87,7 @@ class CaseUpload(object):
             task_id=task.task_id,
             couch_user_id=config_list[0].couch_user_id,  # Will be the same for all configs in a bulk import,
                                                          # so we can use the first one in the list.
-            case_type=ALL_CASE_TYPE_IMPORT,
+            case_type=config_list[0].case_type,
             upload_file_meta=case_upload_file_meta,
         ).save()
 

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -18,6 +18,7 @@ from corehq.apps.case_importer.util import (
     get_spreadsheet,
     open_spreadsheet_download_ref,
 )
+from corehq.apps.case_importer.const import ALL_CASE_TYPE_IMPORT
 
 
 class CaseUpload(object):
@@ -65,7 +66,7 @@ class CaseUpload(object):
     def get_spreadsheet(self, worksheet_index=0):
         return get_spreadsheet(self.get_tempfile(), worksheet_index)
 
-    def trigger_upload(self, domain, config, comment=None):
+    def trigger_upload(self, domain, config_list, comment=None):
         """
         Save a CaseUploadRecord and trigger a task that runs the upload
 
@@ -77,14 +78,16 @@ class CaseUpload(object):
         with open(self.get_tempfile(), 'rb') as f:
             case_upload_file_meta = persistent_file_store.write_file(f, original_filename, domain)
 
-        task = bulk_import_async.delay(config.to_json(), domain, self.upload_id)
+        config_list_json = [c.to_json() for c in config_list]
+        task = bulk_import_async.delay(config_list_json, domain, self.upload_id)
         CaseUploadRecord(
             domain=domain,
             comment=comment,
             upload_id=self.upload_id,
             task_id=task.task_id,
-            couch_user_id=config.couch_user_id,
-            case_type=config.case_type,
+            couch_user_id=config_list[0].couch_user_id,  # Will be the same for all configs in a bulk import,
+                                                         # so we can use the first one in the list.
+            case_type=ALL_CASE_TYPE_IMPORT,
             upload_file_meta=case_upload_file_meta,
         ).save()
 

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -18,7 +18,6 @@ from corehq.apps.case_importer.util import (
     get_spreadsheet,
     open_spreadsheet_download_ref,
 )
-from corehq.apps.case_importer.const import ALL_CASE_TYPE_IMPORT
 
 
 class CaseUpload(object):

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -218,3 +218,23 @@ def get_interned_exception(message):
     In tests, it's important that the error message is exactly the same object.
     """
     return Exception(message)
+
+
+def merge_dicts(dict_list, keys_to_exclude):
+    """
+    Merges the values from two or more dicts together into a single dict.
+
+    :param keys_to_exclude: Dict keys to not merge into the final result.
+    """
+
+    result = {}
+    for d in dict_list:
+        for key, value in d.items():
+            if key in keys_to_exclude:
+                continue
+
+            if key in result:
+                result[key] += value
+            else:
+                result[key] = value
+    return result

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -94,7 +94,7 @@ class WorksheetWrapper(object):
         self._worksheet = worksheet
 
     @classmethod
-    def from_workbook(cls, workbook):
+    def from_workbook(cls, workbook, worksheet_index=0):
         if not isinstance(workbook, Workbook):
             raise AssertionError(
                 "WorksheetWrapper.from_workbook called without Workbook object")
@@ -102,7 +102,7 @@ class WorksheetWrapper(object):
             raise SpreadsheetFileInvalidError(
                 _("It seems as though your spreadsheet contains no sheets. Please resave it and try again."))
         else:
-            return cls(workbook.worksheets[0])
+            return cls(workbook.worksheets[worksheet_index])
 
     @cached_property
     def _headers_by_index(self):
@@ -170,10 +170,10 @@ def open_spreadsheet_download_ref(filename):
 
 
 @contextmanager
-def get_spreadsheet(filename):
+def get_spreadsheet(filename, worksheet_index=0):
     try:
         with open_any_workbook(filename) as workbook:
-            yield WorksheetWrapper.from_workbook(workbook)
+            yield WorksheetWrapper.from_workbook(workbook, worksheet_index)
     except SpreadsheetFileEncrypted as e:
         raise ImporterExcelFileEncrypted(str(e))
     except SpreadsheetFileNotFound as e:

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -225,6 +225,17 @@ def merge_dicts(dict_list, keys_to_exclude):
     Merges the values from two or more dicts together into a single dict.
 
     :param keys_to_exclude: Dict keys to not merge into the final result.
+
+    Below is a given example. When calling the function with the following params:
+    merge_dicts([
+        {'one': 1, 'two': 'two'},
+        {'one': 1, 'two': 'two', 'three': [3]},
+        {'three': [3]},
+        {'four': 'four'}],
+        keys_to_exclude='four')
+
+    This will output a result as follows:
+    {'one': 2, 'two': 'twotwo', 'three': [3, 3]}
     """
 
     result = {}

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -228,11 +228,10 @@ def _process_excel_mapping(domain, spreadsheet, search_column):
     # 'domain' case property cannot be created if domain mirror flag is enabled,
     # as this enables a multi-domain case import.
     # see: https://dimagi-dev.atlassian.net/browse/USH-81
+    mirroring_enabled = False
     if 'domain' in excel_fields and DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
         excel_fields.remove('domain')
         mirroring_enabled = True
-    else:
-        mirroring_enabled = False
 
     return columns, excel_fields, mirroring_enabled
 

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -12,7 +12,6 @@ from django.views.decorators.http import require_POST
 from dimagi.utils.logging import notify_error
 from dimagi.utils.web import json_response
 
-from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
 from corehq.apps.app_manager.helpers.validators import validate_property
 from corehq.apps.case_importer import base
 from corehq.apps.case_importer import util as importer_util
@@ -185,10 +184,11 @@ def _process_file_and_get_upload(uploaded_file_handle, request, domain, max_colu
     case_upload.check_file()
 
     worksheet_titles = _get_workbook_sheet_names(case_upload)
-    case_types_from_apps = sorted(get_case_types_from_apps(domain))
+    case_types_from_apps = sorted(get_case_types_for_domain_es(domain))
 
     # It is a bulk import if every sheet name is a case type in the project space.
     # This does introduce the limitation that new cases for new case types cannot be bulk imported
+    # unless they are first added to an application or the Data Dictionary
     is_bulk_import = len(set(worksheet_titles) - set(case_types_from_apps)) == 0
     columns = []
     try:

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -30,7 +30,7 @@ from corehq.apps.case_importer.suggested_fields import (
     get_suggested_case_fields,
 )
 from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
-from corehq.apps.case_importer.util import get_importer_error_message
+from corehq.apps.case_importer.util import get_importer_error_message, RESERVED_FIELDS
 from corehq.apps.domain.decorators import api_auth
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.locations.permissions import conditionally_location_safe
@@ -253,11 +253,12 @@ def _create_bulk_configs(domain, request, case_upload):
     worksheet_titles = _get_workbook_sheet_names(case_upload)
     for index, title in enumerate(worksheet_titles):
         with case_upload.get_spreadsheet(index) as spreadsheet:
-            columns, excel_fields, mirroring_enabled = _process_excel_mapping(
+            _, excel_fields, _ = _process_excel_mapping(
                 domain,
                 spreadsheet,
                 request.POST['search_field']
             )
+            excel_fields = list(set(excel_fields) - set(RESERVED_FIELDS))
             config = importer_util.ImporterConfig.from_dict({
                 'couch_user_id': request.couch_user._id,
                 'excel_fields': excel_fields,

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -276,7 +276,9 @@ def excel_fields(request, domain):
         this is the type they will be created as. When updating
         existing cases, this is the type that we will search for.
         If the wrong case type is used when looking up existing cases,
-        we will not update them.
+        we will not update them. For a bulk import, this will be displayed
+        as the special value for bulk case import/export, and the fetching of
+        the case types will be handled in the next step.
 
     create_new_cases:
         A boolean that controls whether or not the user wanted
@@ -287,11 +289,13 @@ def excel_fields(request, domain):
         Which column of the Excel file we are using to specify either
         case ids or external ids. This is, strangely, required. If
         creating new cases only you would expect these to be blank with
-        the create_new_cases flag set.
+        the create_new_cases flag set. This will default to case ids only
+        when doing a bulk import.
 
     search_field:
         Either case id or external id, determines which type of
-        identification we are using to match to cases.
+        identification we are using to match to cases. If doing a bulk import,
+        we will default to using case id only.
 
     """
     case_type = request.POST['case_type']
@@ -344,7 +348,8 @@ def excel_commit(request, domain):
     Step three of three.
 
     This page is submitted with the list of column to
-    case property mappings for this upload.
+    case property mappings for this upload. If it is a bulk case import however,
+    this is where we will generate the configs for each case type in the import file.
 
     The config variable is an ImporterConfig object that
     has everything gathered from previous steps, with the

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -383,7 +383,7 @@ def excel_commit(request, domain):
         config = importer_util.ImporterConfig.from_request(request)
         all_configs = [config]
 
-    case_upload.trigger_upload(domain, all_configs)
+    case_upload.trigger_upload(domain, all_configs, is_bulk=(case_type == ALL_CASE_TYPE_IMPORT))
     request.session.pop(EXCEL_SESSION_ID, None)
 
     return HttpResponseRedirect(base.ImportCases.get_url(domain))

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -126,11 +126,12 @@ def _process_spreadsheet_columns(spreadsheet, max_columns=None):
     row_count = spreadsheet.max_row
 
     if invalid_column_names:
-        error_message = format_html(
-            _("Column names must be <a target='_blank' href='https://www.w3schools.com/xml/xml_elements.asp'>"
-              "valid XML elements</a> and cannot start with a number or contain spaces or most special characters."
-              " Please update the following: {}.").format(
-                ', '.join(invalid_column_names)))
+        error_message = format_html(_(
+            'Column names correspond to <a target="_blank" href="https://confl'
+            'uence.dimagi.com/display/commcarepublic/Case+Configuration">case '
+            'property names</a>. They must start with a letter, and can only '
+            'contain letters, numbers and underscores. Please update the '
+            'following: {}.').format(', '.join(invalid_column_names)))
         raise ImporterRawError(error_message)
 
     if row_count == 0:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
On the second step of an Excel import, when changing the config settings, there will now be a banner to notify the user if a bulk case import has been detected, along with the limitiations of doing so. The config settings will default to the special `commcare-all-case-types` case type used to identify a bulk case import and the user will be unable to change the column used to identify cases (defaults to `case_id`).

![Screenshot from 2023-03-31 09-24-25](https://user-images.githubusercontent.com/122617251/229052400-cae2f61c-145f-450c-a317-3bacf1c09b00.png)

On the third step of the import process, a banner is presented to the user to notify them that they will be unable to do Excel mapping.
![Screenshot from 2023-03-31 09-24-35](https://user-images.githubusercontent.com/122617251/229052837-69c78fb4-4161-4244-8f39-3bca1f997b0c.png)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2556).

This adds the ability for a user to do a bulk case import. The required format for the Excel document will be that each sheet name needs to be a case type, with the relevant cases to import in that sheet.

The system will automatically detect if a bulk case import is being done by checking if each sheet name matches a case type in the project. A limitation of this however, is that the user will be unable to create new cases for new case types.

Excel mapping is also disabled for bulk case imports, and the system will make use of the default mapping for each case type when doing an import.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing has been done to ensure no impact on normal case imports. Also, has been QA passed.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests exist for the entire import process.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Link to QA ticket [here](https://dimagi-dev.atlassian.net/browse/QA-4954).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
