### PR TITLE
Fix tableau view

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -550,7 +550,6 @@ def login_required(view_func):
         if not (user.is_authenticated and user.is_active):
             return redirect_for_login_or_domain(request)
 
-        # User's login and domain have been validated - it's safe to call the view function
         return view_func(request, *args, **kwargs)
     return _inner
 

--- a/corehq/apps/reports/standard/tableau.py
+++ b/corehq/apps/reports/standard/tableau.py
@@ -10,7 +10,7 @@ import requests
 
 from corehq import toggles
 from corehq.apps.reports.models import TableauVisualization
-from corehq.apps.domain.decorators import login_required
+from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views.base import BaseDomainView
 
 
@@ -69,14 +69,14 @@ class TableauView(BaseDomainView):
         return super().get(request, *args, **kwargs)
 
 
-@login_required
+@login_and_domain_required
 @require_POST
 def tableau_visualization_ajax(request, domain):
     from requests_toolbelt.adapters import host_header_ssl
-    visualiation_data = {data: value[0] for data, value in dict(request.POST).items()}
-    server_name = visualiation_data.pop('server_name')
-    validate_hostname = visualiation_data.pop('validate_hostname')
-    target_site = visualiation_data.pop('target_site')
+    visualization_data = {data: value[0] for data, value in dict(request.POST).items()}
+    server_name = visualization_data.pop('server_name')
+    validate_hostname = visualization_data.pop('validate_hostname')
+    target_site = visualization_data.pop('target_site')
 
     if toggles.EMBED_TABLEAU_REPORT_BY_USER.enabled(domain):
         # An equivalent Tableau user with the username "HQ/{username}" must exist.

--- a/corehq/apps/reports/static/reports/js/tableau.js
+++ b/corehq/apps/reports/static/reports/js/tableau.js
@@ -11,6 +11,7 @@ hqDefine("reports/js/tableau", function () {
                 validate_hostname: initialPageData.get("validate_hostname"),
                 server_name: initialPageData.get("server_address"),
                 target_site: initialPageData.get("target_site"),
+                viz_id: initialPageData.get("viz_id"),
             },
             dataType: 'json',
             success: function (data) {

--- a/corehq/apps/reports/templates/reports/tableau_template.html
+++ b/corehq/apps/reports/templates/reports/tableau_template.html
@@ -12,6 +12,7 @@
 {% initial_page_data "server_address" server_address %}
 {% initial_page_data "target_site" target_site %}
 {% initial_page_data "view_url" view_url %}
+{% initial_page_data "viz_id" viz_id %}
 {% registerurl 'tableau_visualization_ajax' request.domain %}
 
 <script src="https://{{ validate_hostname }}/javascripts/api/tableau-2.5.0.min.js"></script>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Fixes a couple security problems with Embedded Tableau core that Ethan noticed in a dev capacity building session.

Jira: [USH-2945](https://dimagi-dev.atlassian.net/browse/USH-2945?atlOrigin=eyJpIjoiMWM5YTBkZWFlNTAzNGVkYmE1MDNmODM4MDljNmUyOTEiLCJwIjoiaiJ9).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The view `tableau_visualization_ajax` is accessible via a URL, but only has "login" authentication. Ethan pointed about that this should be `login_and_domain_required`, forcing the user the be authed on the domain.

Also, the check that the user has access to the visualization, `can_view_tableau_viz`, needs to be done inside the view, since it's accessible via a separate URL and could potentially have requests made against it separate from `TableauView`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

EMBEDDED_TABLEAU

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Flagging as medium risk since it has to do with permissions/security and if this somehow breaks the Tableau view, it would probably be a P2.

I tested by deploying this to staging and ensuring some test Tableau reports were still visible.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-2945]: https://dimagi-dev.atlassian.net/browse/USH-2945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ