### PR TITLE
Users can set Form Forwarders to only forward specific forms

### DIFF
--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -120,6 +120,24 @@ class FormRepeaterForm(GenericRepeaterForm):
         widget=forms.SelectMultiple(attrs={'class': 'hqwebapp-select2'}),
         help_text=_('Forms submitted by these users will not be forwarded')
     )
+    white_listed_form_xmlns = forms.CharField(
+        required=False,
+        label=_('XMLNSes of forms to include'),
+        widget=forms.Textarea(),
+        help_text=_(
+            'Separate with commas, spaces or newlines. Leave empty to forward '
+            'all forms.'
+        ),
+    )
+
+    def __init__(self, *args, **kwargs):
+        if kwargs.get('data', {}).get('white_listed_form_xmlns'):
+            # `FormRepeater.white_listed_form_xmlns` is a list, but
+            # `FormRepeaterForm.white_listed_form_xmlns` takes a string.
+            kwargs['data']['white_listed_form_xmlns'] = ', \n'.join(
+                kwargs['data']['white_listed_form_xmlns']
+            )
+        super().__init__(*args, **kwargs)
 
     @property
     @memoized
@@ -133,8 +151,11 @@ class FormRepeaterForm(GenericRepeaterForm):
 
     def get_ordered_crispy_form_fields(self):
         fields = super(FormRepeaterForm, self).get_ordered_crispy_form_fields()
-        fields.append(twbscrispy.PrependedText('include_app_id_param', ''))
-        return fields + ['user_blocklist']
+        return fields + [
+            twbscrispy.PrependedText('include_app_id_param', ''),
+            'user_blocklist',
+            'white_listed_form_xmlns',
+        ]
 
 
 class CaseRepeaterForm(GenericRepeaterForm):

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -1,7 +1,7 @@
 import uuid
 from contextlib import contextmanager
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 from uuid import uuid4
 
 from django.conf import settings
@@ -25,9 +25,9 @@ from ..const import (
     RECORD_SUCCESS_STATE,
 )
 from ..models import (
-    RepeatRecord,
     FormRepeater,
     Repeater,
+    RepeatRecord,
     are_repeat_records_migrated,
     format_response,
     get_all_repeater_types,
@@ -510,3 +510,25 @@ class TestRepeaterModelMethods(RepeaterTestCase):
             self.repeater.send_request(repeat_record, payload)
 
         self.assertTrue(simple_request.called)
+
+
+class TestFormRepeaterAllowedToForward(RepeaterTestCase):
+
+    def test_white_list_empty(self):
+        self.repeater.white_listed_form_xmlns = []
+        payload = Mock(xmlns='http://openrosa.org/formdesigner/abc123')
+        self.assertTrue(self.repeater.allowed_to_forward(payload))
+
+    def test_payload_white_listed(self):
+        self.repeater.white_listed_form_xmlns = [
+            'http://openrosa.org/formdesigner/abc123'
+        ]
+        payload = Mock(xmlns='http://openrosa.org/formdesigner/abc123')
+        self.assertTrue(self.repeater.allowed_to_forward(payload))
+
+    def test_payload_not_white_listed(self):
+        self.repeater.white_listed_form_xmlns = [
+            'http://openrosa.org/formdesigner/abc123'
+        ]
+        payload = Mock(xmlns='http://openrosa.org/formdesigner/def456')
+        self.assertFalse(self.repeater.allowed_to_forward(payload))

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -1,5 +1,6 @@
-from collections import namedtuple
+import re
 import uuid
+from collections import namedtuple
 
 from django.contrib import messages
 from django.http import Http404, HttpResponseRedirect
@@ -8,7 +9,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 from django.views.decorators.http import require_POST
-from corehq.motech.models import ConnectionSettings
+
 from memoized import memoized
 
 from corehq import privileges, toggles
@@ -21,11 +22,12 @@ from corehq.apps.users.decorators import (
 )
 from corehq.apps.users.models import HqPermissions
 from corehq.motech.const import PASSWORD_PLACEHOLDER
+from corehq.motech.models import ConnectionSettings
 
 from ..forms import CaseRepeaterForm, FormRepeaterForm, GenericRepeaterForm
 from ..models import (
-    RepeatRecord,
     Repeater,
+    RepeatRecord,
     are_repeat_records_migrated,
     get_all_repeater_types,
 )
@@ -256,6 +258,10 @@ class AddFormRepeaterView(AddRepeaterView):
             self.add_repeater_form.cleaned_data['include_app_id_param'])
         repeater.user_blocklist = (
             self.add_repeater_form.cleaned_data['user_blocklist'])
+        repeater.white_listed_form_xmlns = [xmlns for xmlns in re.split(
+            r'[, \r\n]',
+            self.add_repeater_form.cleaned_data['white_listed_form_xmlns'],
+        ) if xmlns]
         return repeater
 
 


### PR DESCRIPTION
## Product Description

Adds the ability for Form Forwarders to only forward specific forms. Forms are identified by their XMLNS.

The change preserves current behavior: If no forms are specified, all form submissions are forwarded.

![image](https://user-images.githubusercontent.com/708421/229789959-efa8b3ca-bbdf-40bd-9698-e554e3d22520.png)

## Technical Summary

Context: [SC-2601](https://dimagi-dev.atlassian.net/browse/SC-2601)

The property already exists on `FormRepeater`, and is already used in `FormRepeater.allowed_to_forward()`. This change just exposes the property in the form.

`FormRepeater` has only one subclass, `Dhis2Repeater`. It is not affected by this change.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Tested locally.

### Automated test coverage

Change includes a test to verify behavior.

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2601]: https://dimagi-dev.atlassian.net/browse/SC-2601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ