### PR TITLE
Update AT event editing

### DIFF
--- a/corehq/apps/events/forms.py
+++ b/corehq/apps/events/forms.py
@@ -119,7 +119,7 @@ class CreateEventForm(forms.Form):
     def determine_field_availability(self, event):
         event_not_started = True
         event_in_progress = False
-        attendees_not_registered = False
+        attendees_not_registered = True
 
         if event:
             event_not_started = event.attendee_list_status == NOT_STARTED

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -32,7 +32,8 @@ from .models import (
     get_attendee_case_type,
     get_paginated_attendees,
     ATTENDED_DATE_CASE_PROPERTY,
-    NOT_STARTED
+    NOT_STARTED,
+    IN_PROGRESS
 )
 
 from .tasks import (
@@ -140,7 +141,7 @@ class EventsView(BaseEventView, CRUDPaginatedViewMixin):
             # dates are not serializable for django templates
             'start_date': str(event.start_date),
             'end_date': str(event.end_date) if event.end_date else '-',
-            'is_editable': event.end_date > today if event.end_date else True,
+            'is_editable': event.status in [NOT_STARTED, IN_PROGRESS],
             'show_attendance': event.status != NOT_STARTED,
             'target_attendance': event.attendance_target,
             'status': event.status,
@@ -248,7 +249,7 @@ class EventEditView(EventCreateView):
         return self.event_obj
 
     def post(self, request, *args, **kwargs):
-        form = CreateEventForm(self.request.POST, domain=self.domain)
+        form = CreateEventForm(self.request.POST, domain=self.domain, event=self.event)
 
         if not form.is_valid():
             return self.get(request, *args, **kwargs)


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2663)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This change will
1. fix an issue where an event cannot be edited after it already started
2. fix an issue where you cannot go to the edit event page if the event ends today
3. allow the user to edit only specific fields of an event after it started. If no attendees were registered, we allow the editing of attendees, but after the first one is registered, we disallow it. From then on only the `end date`, `attendance takers` and `same day registration` fields are editable.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
See the product description. Nothing much more than this.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Attendance Tracking

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

### What it looks like when the event is already in progress and no attendee were registerd yet
![image](https://user-images.githubusercontent.com/64970009/229993677-bc8b9d2f-0a8a-4f3d-9877-a3bd5796a079.png)

### What it looks like when the event is already in progress and attendees were registerd
![image](https://user-images.githubusercontent.com/64970009/229993874-70413591-7bf5-4db2-a1d4-cc4d4b82847f.png)

