### PR TITLE
Drop unused const

### DIFF
--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -36,24 +36,6 @@ from ..models import (
 
 DOMAIN = 'test-domain'
 
-ALL_REPEATERS = [
-    'FormRepeater',
-    'CaseRepeater',
-    'CreateCaseRepeater',
-    'UpdateCaseRepeater',
-    'ReferCaseRepeater',
-    'DataRegistryCaseUpdateRepeater',
-    'ShortFormRepeater',
-    'AppStructureRepeater',
-    'UserRepeater',
-    'LocationRepeater',
-    'FHIRRepeater',
-    'OpenmrsRepeater',
-    'Dhis2Repeater',
-    'Dhis2EntityRepeater',
-    'CaseExpressionRepeater'
-]
-
 
 def test_get_all_repeater_types():
     types = get_all_repeater_types()


### PR DESCRIPTION
## Technical Summary

Tiny. Drops an unused const from a test module

## Safety Assurance

### Safety story

* Only affects a test module
* Drops a thing that isn't used

### Automated test coverage

* Not covered by tests (being unused an all :smirk: )

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
