### PR TITLE
Linked project spaces - specific tableau report permissions

### DIFF
--- a/corehq/apps/linked_domain/tests/test_update_roles.py
+++ b/corehq/apps/linked_domain/tests/test_update_roles.py
@@ -124,13 +124,14 @@ class TestUpdateRoles(BaseLinkedDomainTest):
             server=server,
         )
 
-        # Set upstream role's permission list
-        self.role.set_permissions(HqPermissions(view_tableau_list=[str(upstream_viz_1.id)]).to_list())
-        # Set downstream role's permission list
+        self.upstream_tableau_role = UserRole.create(self.domain,
+                                   'tableau_test',
+                                   HqPermissions(view_tableau_list=[str(upstream_viz_1.id)]))
+        # Downstream role
         UserRole.create(
-            self.linked_domain, 'test', HqPermissions(
+            self.linked_domain, 'tableau_test', HqPermissions(
                 view_tableau_list=[str(downstream_viz_1.id), str(downstream_viz_2.id), str(downstream_viz_3.id)]),
-            upstream_id=self.role.get_id
+            upstream_id=self.upstream_tableau_role.get_id
         )
 
         update_user_roles(self.domain_link)
@@ -138,7 +139,7 @@ class TestUpdateRoles(BaseLinkedDomainTest):
         # viz_1 should be included because it's linked upstream viz was in upstream role's permission list, and
         # viz_3 should be included because it's in the downstream role's permission list and isn't linked upstream
         self.assertListEqual([str(downstream_viz_1.id), str(downstream_viz_3.id)],
-                             roles['test'].permissions.view_tableau_list)
+                             roles['tableau_test'].permissions.view_tableau_list)
 
 
 class TestUpdateRolesRemote(TestCase):

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -266,12 +266,10 @@ def update_user_roles(domain_link):
         if role.upstream_id:
             local_roles_by_upstream_id[role.upstream_id] = role
 
-    if EMBEDDED_TABLEAU.enabled(domain_link.linked_domain):
+    is_embedded_tableau_enabled = EMBEDDED_TABLEAU.enabled(domain_link.linked_domain)
+    if is_embedded_tableau_enabled:
         visualizations_for_linked_domain = TableauVisualization.objects.filter(
             domain=domain_link.linked_domain)
-        EMBEDDED_TABLEAU_enabled = True
-    else:
-        EMBEDDED_TABLEAU_enabled = False
 
     # Update downstream roles based on upstream roles
     for role_def in master_results:
@@ -287,7 +285,7 @@ def update_user_roles(domain_link):
         role.save()
 
         permissions = HqPermissions.wrap(role_def["permissions"])
-        if EMBEDDED_TABLEAU_enabled:
+        if is_embedded_tableau_enabled:
             permissions.view_tableau_list = _get_new_tableau_report_permissions(
                 visualizations_for_linked_domain, permissions, role.permissions)
         role.set_permissions(permissions.to_list())

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -557,9 +557,9 @@ def _get_new_tableau_report_permissions(downstream_domain_visualizations, upstre
                                         original_downstream_permissions):
     new_downstream_view_tableau_list = []
     for viz in downstream_domain_visualizations:
-        # Enable permissions for visualization if the viz is enabled in the linked upstream viz
-        # OR if the viz is enabled in the downstream project and doesn't have an upstream linked viz.
-        if ((viz.upstream_id and viz.upstream_id in upstream_permissions.view_tableau_list)
-        or (not viz.upstream_id and str(viz.id) in original_downstream_permissions.view_tableau_list)):
+        upstream_viz_enabled = viz.upstream_id and viz.upstream_id in upstream_permissions.view_tableau_list
+        no_upstream_viz_and_viz_enabled_downstream = (not viz.upstream_id
+            and str(viz.id) in original_downstream_permissions.view_tableau_list)
+        if upstream_viz_enabled or no_upstream_viz_and_viz_enabled_downstream:
             new_downstream_view_tableau_list.append(str(viz.id))
     return new_downstream_view_tableau_list


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

([Jira](https://dimagi-dev.atlassian.net/browse/USH-2257?atlOrigin=eyJpIjoiY2VjOWMxNTAzYTA5NDU0MmE2ZDM3ZTk4MWM3Y2E3YmEiLCJwIjoiaiJ9)) The delivery team has noticed that when doing a user roles push/pull for a linked project space the list of specific Tableau report permissions gets cleared, i.e.:

![Screenshot 2023-04-05 at 4 00 28 PM](https://user-images.githubusercontent.com/6729291/230194706-da63d20f-6d2e-4ed4-ba28-9c38cacf153f.png)

This occurred because we never added linked domains support for Tableau report permissions, which requires special attention.

This PR adds this support, which I hope is comprehensive.


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The logic of how to handle a sync of Tableau report permissions is given in one of the code comments:
        # Enable permissions for visualization if the viz is enabled in the linked upstream viz
        # OR if the viz is enabled in the downstream project and doesn't have an upstream linked viz.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

EMBEDDED_TALBEAU

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Only affects domains with the EMBEDDED_TABLEAU FF and that sync user roles using the linked domains feature. If it does affect anything, it'll probably just cause an error or be pretty visible on the downstream domain's permissions list. Though this could _potentially_ have security concerns if something weren't caught early in this feature's adoption and web users synced without verifying afterwards.


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added!

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
