### PR TITLE
Include All Related Cases Bug Fix

### DIFF
--- a/corehq/apps/case_search/tests/test_get_related_cases.py
+++ b/corehq/apps/case_search/tests/test_get_related_cases.py
@@ -141,12 +141,12 @@ class TestGetRelatedCases(BaseCaseSearchTest):
         EXPECTED_PARTIAL_RELATED_CASES = (source_cases_related["PATH_RELATED_CASE_ID"]
             | source_cases_related["CHILD_CASE_ID"])
         self._assert_case_ids(EXPECTED_PARTIAL_RELATED_CASES, partial_related_cases)
-        self._assert_is_related_case_tag(partial_related_cases)
+        self._assert_is_only_related_case_tag(source_cases, partial_related_cases)
 
         all_related_cases = get_related_cases_helper(include_all_related_cases=True)
         EXPECTED_ALL_RELATED_CASES = set().union(*source_cases_related.values())
         self._assert_case_ids(EXPECTED_ALL_RELATED_CASES, all_related_cases)
-        self._assert_is_related_case_tag(all_related_cases)
+        self._assert_is_only_related_case_tag(source_cases, all_related_cases)
 
     def test_get_related_cases_expanded_results(self):
         """Test that `get_and_tag_related_cases` includes related cases for cases loaded
@@ -333,6 +333,10 @@ class TestGetRelatedCases(BaseCaseSearchTest):
         if result_ids:
             self.assertEqual(1, max(result_ids.values()), result_ids)  # no duplicates
 
-    def _assert_is_related_case_tag(self, related_cases):
-        for case in related_cases:
-            self.assertEqual(case.case_json[IS_RELATED_CASE], 'true')
+    def _assert_is_only_related_case_tag(self, primary_cases, related_cases):
+        related_case_ids = {case.case_id for case in related_cases}
+        for case in primary_cases:
+            if case.case_id in related_case_ids:
+                self.assertEqual(case.case_json[IS_RELATED_CASE], 'true')
+            else:
+                self.assertEqual(hasattr(case.case_json, IS_RELATED_CASE), False)

--- a/corehq/apps/case_search/tests/test_get_related_cases.py
+++ b/corehq/apps/case_search/tests/test_get_related_cases.py
@@ -334,9 +334,7 @@ class TestGetRelatedCases(BaseCaseSearchTest):
             self.assertEqual(1, max(result_ids.values()), result_ids)  # no duplicates
 
     def _assert_is_only_related_case_tag(self, primary_cases, related_cases):
-        related_case_ids = {case.case_id for case in related_cases}
         for case in primary_cases:
-            if case.case_id in related_case_ids:
-                self.assertEqual(case.case_json[IS_RELATED_CASE], 'true')
-            else:
-                self.assertEqual(hasattr(case.case_json, IS_RELATED_CASE), False)
+            self.assertEqual(hasattr(case.case_json, IS_RELATED_CASE), False)
+        for case in related_cases:
+            self.assertEqual(case.case_json[IS_RELATED_CASE], 'true')

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -279,19 +279,21 @@ def get_and_tag_related_cases(helper, app_id, case_types, cases,
     if custom_related_case_property:
         expanded_case_results.extend(get_expanded_case_results(helper, custom_related_case_property, cases))
 
-    results = expanded_case_results
+    unfiltered_results = expanded_case_results
     top_level_cases = cases + expanded_case_results
 
     related_cases = get_related_cases_result(helper, app, case_types, top_level_cases, include_all_related_cases)
     if related_cases:
-        results.extend(related_cases)
-    for case in related_cases:
-        _tag_is_related_case(case)
+        unfiltered_results.extend(related_cases)
 
     initial_case_ids = {case.case_id for case in cases}
-    return list({
-        case.case_id: case for case in results if case.case_id not in initial_case_ids
+    results = list({
+        case.case_id: case for case in unfiltered_results if case.case_id not in initial_case_ids
     }.values())
+    for case in results:
+        _tag_is_related_case(case)
+    return results
+
 
 
 def get_related_cases_result(helper, app, case_types, source_cases, include_all_related_cases):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -138,10 +138,8 @@ class _RegistryQueryHelper:
     def get_all_related_live_cases(self, initial_cases):
         all_cases = self.registry_helper.get_multi_domain_case_hierarchy(self.couch_user, initial_cases)
         initial_case_ids = {case.case_id for case in initial_cases}
-        result = list({
-            case.case_id: case for case in all_cases if case.case_id not in initial_case_ids
-        }.values())
-        return result
+        return list(case for case in all_cases if case.case_id not in initial_case_ids)
+
 
 class CaseSearchQueryBuilder:
     """Compiles the case search object for the view"""

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -57,9 +57,16 @@ def get_case_search_results_from_request(domain, app_id, couch_user, request_dic
 def get_case_search_results(domain, case_types, criteria,
                             app_id=None, couch_user=None, registry_slug=None,
                             custom_related_case_property=None, include_all_related_cases=None):
-
     helper = _get_helper(couch_user, domain, case_types, registry_slug)
 
+    cases = get_primary_case_search_results(helper, domain, case_types, criteria)
+    if app_id:
+        cases.extend(get_and_tag_related_cases(helper, app_id, case_types, cases,
+            custom_related_case_property, include_all_related_cases))
+    return cases
+
+
+def get_primary_case_search_results(helper, domain, case_types, criteria):
     builder = CaseSearchQueryBuilder(domain, case_types, helper.query_domains)
     try:
         search_es = builder.build_query(criteria)
@@ -81,9 +88,6 @@ def get_case_search_results(domain, case_types, criteria,
         raise
 
     cases = [helper.wrap_case(hit, include_score=True) for hit in hits]
-    if app_id:
-        cases.extend(get_and_tag_related_cases(helper, app_id, case_types, cases,
-            custom_related_case_property, include_all_related_cases))
     return cases
 
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -431,6 +431,6 @@ def _get_case_search_cases(helper, case_ids):
     results = helper.get_base_queryset().case_ids(case_ids).run().hits
     return [helper.wrap_case(result) for result in results]
 
-
+# Warning: '_tag_is_related_case' may cause the relevant user-defined properties to be overwritten.
 def _tag_is_related_case(case):
     case.case_json[IS_RELATED_CASE] = "true"

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -399,7 +399,7 @@ def wrap_case_search_hit(hit, include_score=False):
     with a matching name. Fields like "doc_type" and "@indexed_on" are
     ignored.
 
-    Warning: `include_score=True` or `is_related_case=True` may cause
+    Warning: `include_score=True` may cause
     the relevant user-defined properties to be overwritten.
 
     :returns: A `CommCareCase` instance.


### PR DESCRIPTION
## Product Description
Bug fix related to: https://github.com/dimagi/commcare-hq/pull/32587

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Bug found from: https://dimagi-dev.atlassian.net/browse/QA-4966
Two issues caused this:
  - `get_all_related_live_cases` for `_RegistryQueryHelper` included the "primary" cases in its return
  - `get_and_tag_related_cases` was tagging cases before "primary" cases were filtered out from results. If results contained cases that were also "primary" cases, then it was tagged as a "related case". 
  
With this logic, if the "primary" cases contained a parent and their respective child, neither will be tagged as a "related case".

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
https://www.commcarehq.org/hq/flags/edit/case_claim_autolaunch/
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing that only related cases are tagged with Data Registry workflow.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added unit tests that verifies:
- related cases are tagged but primary case search results are not tagged as `commcare_is_related_case`
- Data Registry logic for getting related cases do not include primary case search results

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-4975
### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [X] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
