### PR TITLE
CaseHelper

### DIFF
--- a/corehq/apps/hqcase/case_helper.py
+++ b/corehq/apps/hqcase/case_helper.py
@@ -61,6 +61,7 @@ class CaseHelper:
             """Like a CommCareCase, but briefer."""
             case_id: str
             domain: str
+            user_id: str = ''
 
         if case:
             assert not case_id or case.case_id == case_id, (

--- a/corehq/apps/hqcase/case_helper.py
+++ b/corehq/apps/hqcase/case_helper.py
@@ -1,0 +1,293 @@
+from couchdbkit import ResourceNotFound
+from jsonschema import validate
+
+from casexml.apps.case.mock import CaseBlock, IndexAttrs
+
+from corehq.apps.users.models import CouchUser
+
+from .utils import SYSTEM_FORM_XMLNS, submit_case_blocks
+
+case_block_args_case_properties = {
+    'owner_id',
+    'external_id',
+    'case_type',
+    'case_name',
+}
+
+
+class CaseHelper:
+    """
+    CaseHelper aims to offer a simple interface for simple operations on
+    cases.
+
+    Initialize ``CaseHelper`` with an existing case::
+
+        helper = CaseHelper(case)
+
+    Or create a case using data in the format returned by
+    ``CommCareCase.to_api_json(lite=True)``::
+
+        helper = CaseHelper()
+        helper.create_case({
+            'case_id': uuid4().hex,
+            'domain': 'hawaiian-mythology',
+            'properties': {
+                'case_name': 'Namaka',
+                'case_type': 'child',
+            },
+        })
+
+    Update the case::
+
+        helper.update(properties={'description': 'Goddess of the sea'})
+
+    Add an index::
+
+        helper.update(indices={'mother': {
+            'case_id': mother.case_id,
+            'case_type': mother.type,
+            'relationship': 'child',
+        }})
+
+    Close the case::
+
+        helper.close()
+
+    ``create_case()``, ``update()``, and ``close()`` methods all accept
+    ``user_id``, ``device_id`` and ``xmlns`` parameters to identify
+    who/what called the operation. Under the hood, all operations use
+    ``submit_case_blocks()`` to submit forms.
+
+    """
+
+    def __init__(self, case=None):
+        self.case = case
+
+    def create_case(
+        self,
+        case_api_json,
+        *,
+        user_id=None,
+        device_id='corehq.apps.hqcase.case_helper.CaseHelper',
+        xmlns=SYSTEM_FORM_XMLNS,
+    ):
+        assert self.case is None, 'CaseHelper.case already exists'
+        validate_case_api_json(case_api_json)
+
+        case_block = self._get_create_case_block(case_api_json)
+        kwargs = self._get_submit_kwargs(user_id)
+        xform, cases = submit_case_blocks(
+            [case_block],
+            case_api_json['domain'],
+            device_id=device_id,
+            xmlns=xmlns,
+            **kwargs,
+        )
+        (self.case,) = cases
+
+    def _get_create_case_block(self, case_api_json):
+        kwargs = {
+            arg: case_api_json['properties'][arg]
+            for arg in case_block_args_case_properties
+            if arg in case_api_json['properties']
+        }
+        update = {
+            k: v for k, v in case_api_json['properties'].items()
+            if k not in case_block_args_case_properties
+        }
+        if case_api_json.get('indices'):
+            index = {
+                index_id: IndexAttrs(
+                    case_type=attrs['case_type'],
+                    case_id=attrs['case_id'],
+                    relationship=attrs['relationship'],
+                )
+                for index_id, attrs in case_api_json['indices'].items()
+            }
+            kwargs['index'] = index
+        if case_api_json.get('user_id'):
+            kwargs['user_id'] = case_api_json['user_id']
+        if 'closed' in case_api_json:
+            kwargs['close'] = case_api_json['closed']
+
+        case_block = CaseBlock(
+            case_api_json['case_id'],
+            create=True,
+            update=update,
+            domain=case_api_json['domain'],
+            **kwargs,
+        )
+        return case_block.as_text()
+
+    def update(
+        self,
+        *,
+        properties=None,
+        indices=None,
+        user_id=None,
+        device_id='corehq.apps.hqcase.case_helper.CaseHelper',
+        xmlns=SYSTEM_FORM_XMLNS,
+    ):
+        assert self.case, 'CaseHelper.case is not defined'
+
+        case_block = self._get_update_case_block(properties, indices, user_id)
+        kwargs = self._get_submit_kwargs(user_id)
+        xform, cases = submit_case_blocks(
+            [case_block],
+            self.case.domain,
+            device_id=device_id,
+            xmlns=xmlns,
+            **kwargs,
+        )
+        (self.case,) = cases
+
+    def _get_update_case_block(self, properties, indices, user_id):
+        if properties:
+            kwargs = {
+                arg: properties[arg]
+                for arg in case_block_args_case_properties
+                if arg in properties
+            }
+            update = {
+                k: v for k, v in properties.items()
+                if k not in case_block_args_case_properties
+            }
+            kwargs['update'] = update
+        else:
+            kwargs = {}
+        if indices:
+            index = {
+                index_id: IndexAttrs(
+                    case_type=attrs['case_type'],
+                    case_id=attrs['case_id'],
+                    relationship=attrs['relationship'],
+                )
+                for index_id, attrs in indices.items()
+            }
+            kwargs['index'] = index
+        if user_id:
+            kwargs['user_id'] = user_id
+
+        case_block = CaseBlock(
+            self.case.case_id,
+            domain=self.case.domain,
+            **kwargs,
+        )
+        return case_block.as_text()
+
+    def close(
+        self,
+        *,
+        user_id=None,
+        device_id='corehq.apps.hqcase.case_helper.CaseHelper',
+        xmlns=SYSTEM_FORM_XMLNS,
+    ):
+        assert self.case, 'CaseHelper.case is not defined'
+
+        case_block = CaseBlock(
+            self.case.case_id,
+            close=True,
+        ).as_text()
+        kwargs = self._get_submit_kwargs(user_id)
+        xform, cases = submit_case_blocks(
+            [case_block],
+            self.case.domain,
+            device_id=device_id,
+            xmlns=xmlns,
+            **kwargs,
+        )
+        (self.case,) = cases
+
+    def _get_submit_kwargs(self, user_id):
+        kwargs = {}
+        if user_id:
+            kwargs['user_id'] = user_id
+            try:
+                user = CouchUser.get(user_id)
+                kwargs['username'] = user.username
+            except ResourceNotFound:
+                pass
+        return kwargs
+
+
+def validate_case_api_json(case_api_json):
+    """
+    Checks whether ``case_api_json`` looks like the output of
+    ``CommCareCase.to_api_json(lite=True)``.
+
+    Raises ``jsonschema.ValidationError`` on failure.
+
+    >>> case_api_json = {
+    ...     'case_id': 'a96b328be74e4cbbbc67b087e2a21bf1',
+    ...     'closed': False,
+    ...     'domain': 'test-domain',
+    ...     'indices': {
+    ...         'mother': {
+    ...             'case_id': '1581a5deeff74ce2910d98e472e6d206',
+    ...             'case_type': 'mother',
+    ...             'relationship': 'child',
+    ...         },
+    ...     },
+    ...     'properties': {
+    ...         'case_name': 'Namaka',
+    ...         'case_type': 'child',
+    ...         'external_id': None,
+    ...     },
+    ...     'user_id': '',
+    ... }
+    >>> validate_case_api_json(case_api_json)
+
+    """
+    schema = {
+        'type': 'object',
+        'properties': {
+            'attachments': {'type': 'object'},
+            'case_id': {'type': 'string'},
+            'closed': {'type': 'boolean'},
+            'date_closed': {'type': ['string', 'null']},
+            'date_modified': {'type': 'string'},
+            'domain': {'type': 'string'},
+            'indices': {
+                'type': 'object',
+                'additionalProperties': {
+                    'type': 'object',
+                    'properties': {
+                        'case_id': {'type': 'string'},
+                        'case_type': {'type': 'string'},
+                        'relationship': {'type': 'string'},
+                    },
+                    'required': [
+                        'case_id',
+                        'case_type',
+                        'relationship',
+                    ],
+                }
+            },
+            'properties': {
+                'type': 'object',
+                'properties': {
+                    'case_name': {'type': 'string'},
+                    'case_type': {'type': 'string'},
+                    'date_opened': {},  # `datetime.datetime`
+                    'external_id': {'type': ['string', 'null']},
+                    'owner_id': {'type': 'string'},
+                },
+                'required': [
+                    'case_name',
+                    'case_type',
+                ],
+            },
+            'server_date_modified': {'type': 'string'},
+            'user_id': {'type': 'string'},
+            'xform_ids': {
+                'type': 'array',
+                'items': {'type': 'string'},
+            },
+        },
+        'required': [
+            'case_id',
+            'domain',
+            'properties',
+        ],
+    }
+    validate(instance=case_api_json, schema=schema)

--- a/corehq/apps/hqcase/case_helper.py
+++ b/corehq/apps/hqcase/case_helper.py
@@ -4,6 +4,43 @@ from corehq.apps.users.models import CouchUser
 
 from .api.updates import handle_case_update
 
+# Invalid CommCareCase fields when creating a case:
+invalid_fields = {
+    'case_id',
+    'case_json',
+    'closed',
+    'closed_by',
+    'closed_on',
+    'date_closed',
+    'date_opened',
+    'deleted',
+    'deleted_on',
+    'deletion_id',
+    'domain',
+    'id',
+    'indexed_on',
+    'last_modified',
+    'location_id',
+    'modified_by',
+    'modified_on',
+    'name',
+    'opened_by',
+    'opened_on',
+    'server_last_modified',
+    'server_modified_on',
+    'type',
+}
+# Valid fields when creating a case are:
+# * case_name
+# * case_type
+# * external_id
+# * owner_id
+#
+# Custom case properties are set using the "properties" dictionary.
+#
+# The XForm user ID and device ID are set by passing the `user_id` and
+# `device_id` parameters respectively to `CaseHelper.create_case()`
+
 
 class CaseHelper:
     """
@@ -174,17 +211,6 @@ class CaseHelper:
         {'foo': 'bar'}
 
         """
-        invalid_fields = {
-            'case_id',
-            'domain',
-            'closed',
-            'date_closed',
-            'date_opened',
-            'last_modified',
-            'modified_by',
-            'server_last_modified',
-            'indexed_on',
-        }
         return {k: v for k, v in case_data.items() if k not in invalid_fields}
 
     @staticmethod

--- a/corehq/apps/hqcase/tests/test_case_helper.py
+++ b/corehq/apps/hqcase/tests/test_case_helper.py
@@ -294,7 +294,14 @@ class CaseHelperTests(TestCase):
             self.assertEqual(user.username, commcare_user.username)
 
 
-@generate_cases([(f.name,) for f in CommCareCase._meta.fields], cls=TestCase)
+class TestInvalidFields(TestCase):
+    pass
+
+
+@generate_cases(
+    [(f.name,) for f in CommCareCase._meta.fields],
+    cls=TestInvalidFields,
+)
 def test_invalid_fields(self, field_name):
     if field_name in invalid_fields:
         with self.assertRaises(UserError):

--- a/corehq/apps/hqcase/tests/test_case_helper.py
+++ b/corehq/apps/hqcase/tests/test_case_helper.py
@@ -1,0 +1,203 @@
+import doctest
+from uuid import uuid4
+
+from django.test import TestCase
+
+from contextlib import contextmanager
+
+from jsonschema import ValidationError
+from nose.tools import assert_raises_regexp
+
+from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
+from corehq.form_processor.models import CommCareCase
+
+from ..case_helper import validate_case_api_json, CaseHelper
+
+DOMAIN = 'test-domain'
+
+
+def test_doctests():
+    import corehq.apps.hqcase.case_helper as module
+    results = doctest.testmod(module, optionflags=doctest.ELLIPSIS)
+    assert results.failed == 0
+
+
+class CaseHelperTests(TestCase):
+
+    def test_validate_good(self):
+        with get_child_case() as case:
+            case_api_json = case.to_api_json(lite=True)
+            validate_case_api_json(case_api_json)
+
+    def test_validate_bad(self):
+        with get_child_case() as case:
+            case_api_json = case.to_api_json(lite=True)
+            del case_api_json['properties']['case_name']
+            with assert_raises_regexp(ValidationError,
+                                      "^'case_name' is a required property"):
+                validate_case_api_json(case_api_json)
+
+    def test_create_case(self):
+        with get_mother_case() as mother:
+            case_dict = {
+                'case_id': uuid4().hex,
+                'domain': DOMAIN,
+                'properties': {
+                    'case_name': "Hi'iaka",
+                    'case_type': 'child',
+                },
+                'indices': {
+                    'mother': {
+                        'case_type': mother.type,
+                        'case_id': mother.case_id,
+                        'relationship': 'child',
+                    },
+                },
+            }
+            helper = CaseHelper()
+            self.assertIsNone(helper.case)
+
+            helper.create_case(case_dict)
+            self.assertEqual(len(helper.case.xform_ids), 1)
+            self.assertIsInstance(helper.case, CommCareCase)
+            self.assertEqual(helper.case.case_id, case_dict['case_id'])
+            self.assertEqual(helper.case.domain, case_dict['domain'])
+            self.assertEqual(helper.case.name, case_dict['properties']['case_name'])
+            self.assertEqual(helper.case.type, case_dict['properties']['case_type'])
+            self.assertEqual(helper.case.external_id, None)
+            self.assertEqual(helper.case.owner_id, '')
+            index = helper.case.get_index('mother')
+            self.assertEqual(index.referenced_id, mother.case_id)
+            self.assertEqual(index.referenced_type, mother.type)
+            self.assertEqual(index.relationship, 'child')
+
+    def test_update_property(self):
+        with get_child_case() as case:
+            helper = CaseHelper(case)
+            helper.update(properties={
+                'description': 'Goddess of the sea',
+                'sidekick': 'Moela',
+                'sidekick_kind': 'dog',
+            })
+
+            self.assertEqual(len(helper.case.xform_ids), 2)
+            self.assertEqual(
+                helper.case.get_case_property('sidekick'),
+                'Moela',
+            )
+
+    def test_update_special_property(self):
+        with get_child_case() as case:
+            self.assertEqual(len(case.xform_ids), 1)
+
+            helper = CaseHelper(case)
+            helper.update(properties={
+                'case_name': 'Nāmaka',
+                'external_id': '(136108) 2003 EL61 II',
+            })
+
+            self.assertEqual(len(helper.case.xform_ids), 2)
+            self.assertEqual(helper.case.name, 'Nāmaka')
+            self.assertEqual(helper.case.external_id, '(136108) 2003 EL61 II')
+
+    def test_update_index(self):
+        factory = CaseFactory(DOMAIN)
+        father = factory.create_case(
+            case_type='father',
+            case_name='Ku-waha-ilo',
+        )
+        with get_child_case() as case:
+            self.assertEqual(len(case.xform_ids), 1)
+
+            helper = CaseHelper(case)
+            helper.update(indices={
+                'father': {
+                    'case_type': father.type,
+                    'case_id': father.case_id,
+                    'relationship': 'child',
+                }
+            })
+
+            self.assertEqual(len(helper.case.xform_ids), 2)
+            self.assertEqual(len(helper.case.indices), 2)  # Note: index is added
+            (father_idx, mother_idx) = sorted(
+                helper.case.indices,
+                key=lambda idx: idx.identifier
+            )
+            self.assertEqual(father_idx.identifier, 'father')
+            self.assertEqual(father_idx.referenced_id, father.case_id)
+            self.assertEqual(father_idx.referenced_type, father.type)
+            self.assertEqual(father_idx.relationship, 'child')
+            self.assertEqual(mother_idx.identifier, 'mother')
+
+    def test_close(self):
+        case_dict = {
+            'case_id': uuid4().hex,
+            'domain': DOMAIN,
+            'properties': {
+                'case_name': 'Ku-waha-ilo',
+                'case_type': 'father',
+            },
+        }
+        helper = CaseHelper()
+        helper.create_case(case_dict)
+        helper.close(user_id='c0ffee')
+
+        self.assertEqual(len(helper.case.xform_ids), 2)
+        self.assertTrue(helper.case.closed)
+        self.assertEqual(helper.case.closed_by, 'c0ffee')
+
+    def test_recreating_case(self):
+        with get_child_case() as case:
+            helper = CaseHelper(case)
+            with self.assertRaises(AssertionError):
+                helper.create_case({
+                    'case_id': uuid4().hex,
+                    'domain': DOMAIN,
+                    'properties': {
+                        'case_name': 'Ku-waha-ilo',
+                        'case_type': 'father',
+                    },
+                })
+
+    def test_closing_no_case(self):
+        helper = CaseHelper()
+        with self.assertRaises(AssertionError):
+            helper.close()
+
+
+@contextmanager
+def get_mother_case():
+    factory = CaseFactory(DOMAIN)
+    mother = factory.create_case(
+        case_type='mother',
+        case_name='Haumea',
+    )
+    try:
+        yield mother
+    finally:
+        factory.close_case(mother.case_id)
+
+
+@contextmanager
+def get_child_case():
+    factory = CaseFactory(DOMAIN)
+    with get_mother_case() as mother:
+        struct = CaseStructure(
+            attrs={
+                'case_type': 'child',
+                'case_name': 'Namaka',
+                'create': True,
+            },
+            indices=[CaseIndex(
+                relationship='child',
+                identifier='mother',
+                related_structure=CaseStructure(case_id=mother.case_id),
+                related_type='mother',
+            )],
+        )
+        child, __ = factory.create_or_update_cases([struct])
+        try:
+            yield child
+        finally:
+            factory.close_case(child.case_id)

--- a/corehq/apps/hqcase/tests/test_case_helper.py
+++ b/corehq/apps/hqcase/tests/test_case_helper.py
@@ -197,7 +197,7 @@ class CaseHelperTests(TestCase):
                 'corehq.apps.hqcase.case_helper.CaseHelper',
             )
 
-    def test_close(self):
+    def test_close_with_user_id(self):
         case_dict = {
             'case_name': 'Ku-waha-ilo',
             'case_type': 'father',
@@ -209,6 +209,18 @@ class CaseHelperTests(TestCase):
         self.assertEqual(len(helper.case.xform_ids), 2)
         self.assertTrue(helper.case.closed)
         self.assertEqual(helper.case.closed_by, 'c0ffee')
+
+    def test_close(self):
+        case_dict = {
+            'case_name': 'Ku-waha-ilo',
+            'case_type': 'father',
+        }
+        helper = CaseHelper(domain=DOMAIN)
+        helper.create_case(case_dict)
+        helper.close()
+
+        self.assertTrue(helper.case.closed)
+        self.assertEqual(helper.case.closed_by, '')
 
     def test_recreating_case(self):
         with get_child_case() as case:

--- a/corehq/apps/hqcase/tests/test_case_helper.py
+++ b/corehq/apps/hqcase/tests/test_case_helper.py
@@ -6,7 +6,6 @@ from django.test import TestCase
 from contextlib import contextmanager
 
 from jsonschema import ValidationError
-from nose.tools import assert_raises_regexp
 
 from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
 from corehq.form_processor.models import CommCareCase
@@ -33,8 +32,8 @@ class CaseHelperTests(TestCase):
         with get_child_case() as case:
             case_api_json = case.to_api_json(lite=True)
             del case_api_json['properties']['case_name']
-            with assert_raises_regexp(ValidationError,
-                                      "^'case_name' is a required property"):
+            with self.assertRaisesRegex(ValidationError,
+                                        "^'case_name' is a required property"):
                 validate_case_api_json(case_api_json)
 
     def test_create_case(self):

--- a/corehq/apps/hqcase/tests/test_case_helper.py
+++ b/corehq/apps/hqcase/tests/test_case_helper.py
@@ -1,16 +1,16 @@
 import doctest
-from uuid import uuid4
+from contextlib import contextmanager
 
 from django.test import TestCase
 
-from contextlib import contextmanager
+from casexml.apps.case.const import CASE_INDEX_CHILD
+from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 
-from jsonschema import ValidationError
-
-from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
+from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.models import CommCareCase
 
-from ..case_helper import validate_case_api_json, CaseHelper
+from ..api.core import serialize_case
+from ..case_helper import CaseHelper
 
 DOMAIN = 'test-domain'
 
@@ -23,61 +23,51 @@ def test_doctests():
 
 class CaseHelperTests(TestCase):
 
-    def test_validate_good(self):
+    def test_create_case_format(self):
         with get_child_case() as case:
-            case_api_json = case.to_api_json(lite=True)
-            validate_case_api_json(case_api_json)
+            case_data = serialize_case(case)
+            original_case_id = case_data['case_id']
+            helper = CaseHelper(domain=DOMAIN)
+            helper.create_case(case_data)
+            self.assertIsInstance(helper.case, CommCareCase)
+            self.assertNotEqual(helper.case.case_id, original_case_id)
 
-    def test_validate_bad(self):
-        with get_child_case() as case:
-            case_api_json = case.to_api_json(lite=True)
-            del case_api_json['properties']['case_name']
-            with self.assertRaisesRegex(ValidationError,
-                                        "^'case_name' is a required property"):
-                validate_case_api_json(case_api_json)
-
-    def test_create_case(self):
+    def test_create_child_case(self):
         with get_mother_case() as mother:
-            case_dict = {
-                'case_id': uuid4().hex,
-                'domain': DOMAIN,
-                'properties': {
-                    'case_name': "Hi'iaka",
-                    'case_type': 'child',
-                },
+            case_data = {
+                'case_name': "Hi'iaka",
+                'case_type': 'child',
                 'indices': {
                     'mother': {
                         'case_type': mother.type,
                         'case_id': mother.case_id,
-                        'relationship': 'child',
+                        'relationship': CASE_INDEX_CHILD,
                     },
                 },
             }
-            helper = CaseHelper()
+            helper = CaseHelper(domain=DOMAIN)
             self.assertIsNone(helper.case)
 
-            helper.create_case(case_dict)
+            helper.create_case(case_data)
             self.assertEqual(len(helper.case.xform_ids), 1)
             self.assertIsInstance(helper.case, CommCareCase)
-            self.assertEqual(helper.case.case_id, case_dict['case_id'])
-            self.assertEqual(helper.case.domain, case_dict['domain'])
-            self.assertEqual(helper.case.name, case_dict['properties']['case_name'])
-            self.assertEqual(helper.case.type, case_dict['properties']['case_type'])
+            self.assertEqual(helper.case.name, case_data['case_name'])
+            self.assertEqual(helper.case.type, case_data['case_type'])
             self.assertEqual(helper.case.external_id, None)
             self.assertEqual(helper.case.owner_id, '')
             index = helper.case.get_index('mother')
             self.assertEqual(index.referenced_id, mother.case_id)
             self.assertEqual(index.referenced_type, mother.type)
-            self.assertEqual(index.relationship, 'child')
+            self.assertEqual(index.relationship, CASE_INDEX_CHILD)
 
     def test_update_property(self):
         with get_child_case() as case:
-            helper = CaseHelper(case)
-            helper.update(properties={
+            helper = CaseHelper(case=case, domain=DOMAIN)
+            helper.update({'properties': {
                 'description': 'Goddess of the sea',
                 'sidekick': 'Moela',
                 'sidekick_kind': 'dog',
-            })
+            }})
 
             self.assertEqual(len(helper.case.xform_ids), 2)
             self.assertEqual(
@@ -88,9 +78,8 @@ class CaseHelperTests(TestCase):
     def test_update_special_property(self):
         with get_child_case() as case:
             self.assertEqual(len(case.xform_ids), 1)
-
-            helper = CaseHelper(case)
-            helper.update(properties={
+            helper = CaseHelper(case=case, domain=DOMAIN)
+            helper.update({
                 'case_name': 'Nāmaka',
                 'external_id': '(136108) 2003 EL61 II',
             })
@@ -107,15 +96,14 @@ class CaseHelperTests(TestCase):
         )
         with get_child_case() as case:
             self.assertEqual(len(case.xform_ids), 1)
-
-            helper = CaseHelper(case)
-            helper.update(indices={
+            helper = CaseHelper(case=case, domain=DOMAIN)
+            helper.update({'indices': {
                 'father': {
                     'case_type': father.type,
                     'case_id': father.case_id,
                     'relationship': 'child',
                 }
-            })
+            }})
 
             self.assertEqual(len(helper.case.xform_ids), 2)
             self.assertEqual(len(helper.case.indices), 2)  # Note: index is added
@@ -129,16 +117,92 @@ class CaseHelperTests(TestCase):
             self.assertEqual(father_idx.relationship, 'child')
             self.assertEqual(mother_idx.identifier, 'mother')
 
+    def test_empty_update(self):
+        with get_child_case() as case:
+            self.assertEqual(len(case.xform_ids), 1)
+            helper = CaseHelper(case=case, domain=DOMAIN)
+            helper.update({})
+
+            self.assertEqual(len(helper.case.xform_ids), 1)
+
+    def test_update_case_id(self):
+        with get_child_case() as case:
+            original_case_id = case.case_id
+            helper = CaseHelper(case=case, domain=DOMAIN)
+            helper.update(
+                {'case_id': 'deadbeef'},
+            )
+            self.assertEqual(helper.case.case_id, original_case_id)
+
+    def test_user_id(self):
+        with get_child_case() as case:
+            helper = CaseHelper(case=case, domain=DOMAIN)
+            helper.update(
+                {'case_name': 'Nāmaka'},
+                user_id='c0ffee',
+            )
+            self.assertEqual(helper.case.user_id, 'c0ffee')
+            form_data = helper.case.transactions[-1].form.form_data
+            self.assertEqual(form_data['meta']['userID'], 'c0ffee')
+            self.assertEqual(form_data['meta']['username'], '')
+
+    def test_update_user_id(self):
+        with get_child_case() as case:
+            helper = CaseHelper(case=case, domain=DOMAIN)
+            helper.update(
+                {
+                    'user_id': 'deadbeef',  # ignored
+                    'modified_by': 'deadbeef',  # dropped by _copy_case_data()
+                },
+                user_id='c0ffee',
+            )
+            self.assertEqual(helper.case.user_id, 'c0ffee')
+            form_data = helper.case.transactions[-1].form.form_data
+            self.assertEqual(form_data['meta']['userID'], 'c0ffee')
+            self.assertEqual(form_data['meta']['username'], '')
+
+    def test_username(self):
+        with get_child_case() as case, \
+                get_commcare_user() as user:
+
+            helper = CaseHelper(case=case, domain=DOMAIN)
+            helper.update(
+                {'case_name': 'Nāmaka'},
+                user_id=user.user_id,
+            )
+            self.assertEqual(helper.case.user_id, user.user_id)
+            form_data = helper.case.transactions[-1].form.form_data
+            self.assertEqual(form_data['meta']['userID'], user.user_id)
+            self.assertEqual(form_data['meta']['username'], user.username)
+
+    def test_device_id(self):
+        with get_child_case() as case:
+            helper = CaseHelper(case=case, domain=DOMAIN)
+            helper.update(
+                {'case_name': 'Nāmaka'},
+                device_id='CaseHelperTests',
+            )
+            form_data = helper.case.transactions[-1].form.form_data
+            self.assertEqual(form_data['meta']['deviceID'], 'CaseHelperTests')
+
+    def test_default_device_id(self):
+        with get_child_case() as case:
+            helper = CaseHelper(case=case, domain=DOMAIN)
+            helper.update(
+                {'case_name': 'Nāmaka'},
+            )
+            form_data = helper.case.transactions[-1].form.form_data
+            self.assertEqual(
+                form_data['meta']['deviceID'],
+                'corehq.apps.hqcase.case_helper.CaseHelper',
+            )
+
     def test_close(self):
         case_dict = {
-            'case_id': uuid4().hex,
-            'domain': DOMAIN,
-            'properties': {
-                'case_name': 'Ku-waha-ilo',
-                'case_type': 'father',
-            },
+            'case_name': 'Ku-waha-ilo',
+            'case_type': 'father',
         }
-        helper = CaseHelper()
+        helper = CaseHelper(domain=DOMAIN)
         helper.create_case(case_dict)
         helper.close(user_id='c0ffee')
 
@@ -148,21 +212,75 @@ class CaseHelperTests(TestCase):
 
     def test_recreating_case(self):
         with get_child_case() as case:
-            helper = CaseHelper(case)
+            helper = CaseHelper(case=case, domain=DOMAIN)
             with self.assertRaises(AssertionError):
                 helper.create_case({
-                    'case_id': uuid4().hex,
                     'domain': DOMAIN,
-                    'properties': {
-                        'case_name': 'Ku-waha-ilo',
-                        'case_type': 'father',
-                    },
+                    'case_name': 'Ku-waha-ilo',
+                    'case_type': 'father',
                 })
 
     def test_closing_no_case(self):
-        helper = CaseHelper()
+        helper = CaseHelper(domain=DOMAIN)
         with self.assertRaises(AssertionError):
             helper.close()
+
+    def test_copy_case_data(self):
+        case_data = {
+            'case_id': '38fd8d42168f496d8bf0d69eef4ae9e6',
+            'case_name': 'Namaka',
+            'case_type': 'child',
+            'closed': False,
+            'date_closed': None,
+            'date_opened': '2023-04-06T17:11:12.101045Z',
+            'domain': 'test-domain',
+            'external_id': None,
+            'indexed_on': '2023-04-06T17:11:12.162655Z',
+            'indices': {
+                'mother': {
+                    'case_id': '27268dca9c2a45e1b55a290d67b5cb15',
+                    'case_type': 'mother',
+                    'relationship': 'child',
+                }
+            },
+            'last_modified': '2023-04-06T17:11:12.101045Z',
+            'owner_id': '',
+            'properties': {},
+            'server_last_modified': '2023-04-06T17:11:12.103245Z'
+        }
+        valid_data = CaseHelper._copy_case_data(case_data)
+
+        self.assertNotEqual(id(valid_data), id(case_data))
+        self.assertEqual(valid_data, {
+            'case_name': 'Namaka',
+            'case_type': 'child',
+            'external_id': None,
+            'indices': {
+                'mother': {
+                    'case_id': '27268dca9c2a45e1b55a290d67b5cb15',
+                    'case_type': 'mother',
+                    'relationship': 'child',
+                }
+            },
+            'owner_id': '',
+            'properties': {},
+        })
+
+    def test_get_user_duck_user_id(self):
+        user = CaseHelper._get_user_duck('c0ffee', DOMAIN)
+        self.assertEqual(user.user_id, 'c0ffee')
+        self.assertEqual(user.username, '')
+
+    def test_get_user_duck_none(self):
+        user = CaseHelper._get_user_duck(None, DOMAIN)
+        self.assertEqual(user.user_id, '')
+        self.assertEqual(user.username, '')
+
+    def test_get_user_duck_username(self):
+        with get_commcare_user() as commcare_user:
+            user = CaseHelper._get_user_duck(commcare_user.user_id, DOMAIN)
+            self.assertEqual(user.user_id, commcare_user.user_id)
+            self.assertEqual(user.username, commcare_user.username)
 
 
 @contextmanager
@@ -200,3 +318,14 @@ def get_child_case():
             yield child
         finally:
             factory.close_case(child.case_id)
+
+
+@contextmanager
+def get_commcare_user():
+    user = CommCareUser.create(
+        DOMAIN, f'testy@{DOMAIN}.commcarehq.org', '******', None, None,
+    )
+    try:
+        yield user
+    finally:
+        user.delete(DOMAIN, None, None)


### PR DESCRIPTION
## Technical Summary

I have been looking for a simple way of doing simple operations on cases. `CaseFactory` was the best option I could find, but it is not appropriate for code outside of tests.

So I wrote `CaseHelper`. Copy-pasting from its docstring:

> Initialize `CaseHelper` with an existing case:
> 
> ```python
> helper = CaseHelper(case)
> ```
> 
> Or create a case using data in the format returned by `CommCareCase.to_api_json(lite=True)`:
>
> ```python
> helper = CaseHelper()
> helper.create_case({
>     'case_id': uuid4().hex,
>     'domain': 'hawaiian-mythology',
>     'properties': {
>         'case_name': 'Namaka',
>         'case_type': 'child',
>     },
> })
> ```
> 
> Update the case:
> 
> ```python
> helper.update(properties={'description': 'Goddess of the sea'})
> ```
> 
> Add an index:
> 
> ```python
> helper.update(indices={'mother': {
>     'case_id': mother.case_id,
>     'case_type': mother.type,
>     'relationship': 'child',
> }})
> ```
> 
> Close the case:
> 
> ```python
> helper.close()
> ```
> 
> `create_case()`, `update()`, and `close()` methods all accept `user_id`, `device_id` and `xmlns` parameters to identify who/what called the operation (with reasonable defaults if you don't set them). Under the hood, all operations use `submit_case_blocks()` to submit forms.


## Safety Assurance

### Safety story

This code is not yet used.

### Automated test coverage

Hopefully test coverage is thorough. Please let me know if you can spot anything I missed.

### QA Plan

`CaseHelper` won't be QAed directly, but I would like to use it in the feature I'm working on, which will be QAed.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
