### PR TITLE
Add fail_hard option to admin restore and add a hint in app-manager report module

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3314,7 +3314,7 @@ AutoFilterConfig = namedtuple('AutoFilterConfig', ['slug', 'filter_function', 's
 def get_auto_filter_configurations():
     return [
         AutoFilterConfig('case_sharing_group', _filter_by_case_sharing_group_id,
-                         _("The user's case sharing group")),
+                         _("The user's case sharing group (filter must be of choice_provider type)")),
         AutoFilterConfig('location_id', _filter_by_location_id, _("The user's assigned location")),
         AutoFilterConfig('location_ids', _filter_by_location_ids, _("All of the user's assigned locations")),
         AutoFilterConfig('parent_location_id', _filter_by_parent_location_id,

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -206,6 +206,7 @@ def get_restore_params(request, domain):
         'user_id': request.GET.get('user_id'),
         'skip_fixtures': skip_fixtures,
         'auth_type': getattr(request, 'auth_type', None),
+        'fail_hard': request.GET.get('fail_hard') == 'true',
     }
 
 
@@ -215,7 +216,8 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
                          cache_timeout=None, overwrite_cache=False,
                          as_user=None, device_id=None, user_id=None,
                          openrosa_version=None,
-                         skip_fixtures=False, auth_type=None):
+                         skip_fixtures=False, auth_type=None,
+                         fail_hard=False):
     """
     :param domain: Domain being restored from
     :param couch_user: User performing restore
@@ -234,6 +236,8 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     :param skip_fixtures: Do not include fixtures in sync payload
     :param auth_type: The type of auth that was used to authenticate the request.
         Used to determine if the request is coming from an actual user or as part of some automation.
+    :param fail_hard: In case of exceptions, fail hardly by raising exception instead of logging
+        silently.
     :return: Tuple of (http response, timing context or None)
     """
 
@@ -297,6 +301,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
             app=app,
             device_id=device_id,
             openrosa_version=openrosa_version,
+            fail_hard=fail_hard,
         ),
         cache_settings=RestoreCacheSettings(
             force_cache=force_cache or async_restore_enabled,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -292,7 +292,8 @@ class RestoreParams(object):
             include_item_count=False,
             device_id=None,
             app=None,
-            openrosa_version=None):
+            openrosa_version=None,
+            fail_hard=False):
         self.sync_log_id = sync_log_id
         self.version = version
         self.state_hash = state_hash
@@ -301,6 +302,7 @@ class RestoreParams(object):
         self.device_id = device_id
         self.openrosa_version = (LooseVersion(openrosa_version)
             if isinstance(openrosa_version, str) else openrosa_version)
+        self.fail_hard = fail_hard
 
     @property
     def app_id(self):


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/SC-2684

Provides a `fail_hard` param in admin-restore to debug issues with the restore/sync.
 

## Technical Summary
The exceptions during a restore are swallowed silently resulting in a very difficult debugging exercise when an error occurs. This option will help debug issues better by forcing a 500 on error which a dev can look at.

This also addresses an underlying issue where a UCR filter set in the app-manager needed to match the actual UCR filter type by providing a hint to the user. The other option is to validate these settings, but it's much higher LOE item.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance


### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

NA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
