### PR TITLE
Resolve deprecation warning and set console port

### DIFF
--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -78,3 +78,4 @@ services:
       service: minio
     ports:
       - "9980:9980"
+      - "9981:9981"

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -181,9 +181,10 @@ services:
 
   minio:
     image: minio/minio
-    command: server --address :9980 /data
+    command: server --address :9980 --console-address :9981 /data
     expose:
       - "9980"
+      - "9981"
     healthcheck:
       # https://min.io/docs/minio/linux/operations/monitoring/healthcheck-probe.html#node-liveness
       test: curl -I http://minio:9980/minio/health/live
@@ -194,5 +195,5 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-minio-conf:}/root/.minio
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-minio-data:}/data
     environment:
-      MINIO_ACCESS_KEY: admin-key
-      MINIO_SECRET_KEY: admin-secret
+      MINIO_ROOT_USER: admin-key
+      MINIO_ROOT_PASSWORD: admin-secret


### PR DESCRIPTION
MinIO by default selects a random port for the MinIO Console on each server startup. This does not work with containers since that random port is not exposed, so we set a static port. https://min.io/docs/minio/linux/administration/minio-console.html

## Safety Assurance

### Safety story

Updates container settings only. Does not affect production code.

### Automated test coverage

Tests are run using these container configurations, so the change should be tested indirectly.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
