### PR TITLE
Return 204 response, not True, on empty payload

### DIFF
--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -21,6 +21,7 @@ from corehq.motech.dhis2.events_helpers import send_dhis2_event
 from corehq.motech.dhis2.exceptions import Dhis2Exception
 from corehq.motech.exceptions import ConfigurationError
 from corehq.motech.repeater_helpers import (
+    RepeaterResponse,
     get_relevant_case_updates_from_form_json,
 )
 from corehq.motech.repeaters.models import (
@@ -144,7 +145,7 @@ class Dhis2Repeater(FormRepeater, Dhis2Instance):
                 except (RequestException, HTTPError, ConfigurationError) as err:
                     requests.notify_error(f"Error sending Events to {self}: {err}")
                     raise
-        return True
+        return RepeaterResponse(204, "No content")
 
     def _validate_dhis2_form_config(self):
         for config in self.dhis2_config.get('form_configs', []):

--- a/corehq/motech/fhir/repeater_helpers.py
+++ b/corehq/motech/fhir/repeater_helpers.py
@@ -103,7 +103,7 @@ def send_resources(
     if not info_resources_list:
         # Either the payload had no data to be forwarded, or resources
         # were all patients to be registered: Nothing left to send.
-        return True
+        return RepeaterResponse(204, "No content")
 
     if len(info_resources_list) == 1:
         info, resource = info_resources_list[0]

--- a/corehq/motech/fhir/tests/test_repeater_helpers.py
+++ b/corehq/motech/fhir/tests/test_repeater_helpers.py
@@ -420,7 +420,8 @@ class TestWhenToBundle(TestCase):
             FHIR_VERSION_4_0_1,
             repeater_id='abc123',
         )
-        self.assertEqual(response, True)
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.reason, 'No content')
 
     def test_one_to_send(self):
         info = CaseTriggerInfo(


### PR DESCRIPTION
## Technical Summary

Fixes a bug where we expect a Response instance, and we are getting a boolean.

* [Jira](https://dimagi-dev.atlassian.net/browse/SC-2704)
* [Sentry](https://dimagi.sentry.io/issues/4063364013/events/00b6c3bdb786465b959787819fd7e3dc/?project=136860)

Currently, when `Repeater.send_request()` is called on a subclass of `Repeater` and the payload does not result in a request being sent (for example because the payload is filtered out or empty) some subclasses return a 204 response, and some just return `True`.

The 204 response is useful, because the repeat records report can tell the user what happened. Boolean values are not as useful.

So to fix this bug, given the choice between accommodating boolean values, or making sure that overrides of `Repeater.send_request()` return a 204 response when there is no payload to send, I went with the 204 response.

## Safety Assurance

### Safety story

* Small change.
* Brings "special" behavior in line with "usual" behavior.

### Automated test coverage

Test updated.

### QA Plan

No QA plan.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
