### PR TITLE
Event.event_id always has a value

### DIFF
--- a/corehq/apps/events/models.py
+++ b/corehq/apps/events/models.py
@@ -353,8 +353,6 @@ class Event(models.Model):
         using=None,
         update_fields=None,
     ):
-        if not self.event_id:
-            self.event_id = uuid.uuid4().hex
         self.set_status()
         super().save(
             force_insert=force_insert,


### PR DESCRIPTION
## Technical Summary

`Event.event_id` always has a value. It is set when the model is initialized.

We know this from [EventCaseTests.test_default_uuids()](https://github.com/dimagi/commcare-hq/blob/f20d5a7d6c0ec4cd737bbd8661ed24f64b0fc41c/corehq/apps/events/tests/test_models.py#L415) and from Django docs on [Field.default](https://docs.djangoproject.com/en/3.2/ref/models/fields/#django.db.models.Field.default).

## Feature Flag

Attendance Tracking

## Safety Assurance

### Safety story

* Tiny
* Validated by unit test

### Automated test coverage

Covered by tests

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
