### PR TITLE
Replace CaseFactory with CaseHelper

### DIFF
--- a/corehq/apps/events/migrations/0008_alter_event__case_id.py
+++ b/corehq/apps/events/migrations/0008_alter_event__case_id.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0007_alter_event_attendee_list_status'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='event',
+            name='_case_id',
+            field=models.UUIDField(default=None, null=True),
+        ),
+    ]

--- a/corehq/apps/events/tests/test_models.py
+++ b/corehq/apps/events/tests/test_models.py
@@ -386,13 +386,17 @@ class EventCaseTests(TestCase):
         except AssertionError:
             pass  # self.event is already deleted
 
-    def test_case(self):
-        with self.assertRaises(CaseNotFound):
-            CommCareCase.objects.get_case(self.event.case_id, DOMAIN)
-
+    def test_case_creates_case(self):
+        self.assertIsNone(self.event._case_id)
         event_case = self.event.case  # Creates case
         case = CommCareCase.objects.get_case(self.event.case_id, DOMAIN)
         self.assertEqual(event_case, case)
+
+    def test_case_id_creates_case(self):
+        self.assertIsNone(self.event._case_id)
+        case_id = self.event.case_id  # Creates case
+        self.assertIsInstance(case_id, str)
+        self.assertIsInstance(self.event._case_id, UUID)
 
     def test_delete_with_case(self):
         __ = self.event.case
@@ -413,7 +417,7 @@ class EventCaseTests(TestCase):
             attendance_target=0,
         )
         self.assertIsInstance(unsaved_event.event_id, UUID)
-        self.assertIsInstance(unsaved_event._case_id, UUID)
+        self.assertIsNone(unsaved_event._case_id)
 
     def test_uuid_hex_string(self):
         today = datetime.utcnow().date()

--- a/corehq/apps/events/tests/test_models.py
+++ b/corehq/apps/events/tests/test_models.py
@@ -378,7 +378,7 @@ class EventCaseTests(TestCase):
             end_date=today,
             attendance_target=0,
         )
-        self.event.save()
+        self.event.save()  # Creates case
 
     def tearDown(self):
         try:
@@ -386,38 +386,41 @@ class EventCaseTests(TestCase):
         except AssertionError:
             pass  # self.event is already deleted
 
-    def test_case_creates_case(self):
-        self.assertIsNone(self.event._case_id)
-        event_case = self.event.case  # Creates case
+    def test_delete_closes_case(self):
         case = CommCareCase.objects.get_case(self.event.case_id, DOMAIN)
-        self.assertEqual(event_case, case)
+        self.assertFalse(case.closed)
 
-    def test_case_id_creates_case(self):
-        self.assertIsNone(self.event._case_id)
-        case_id = self.event.case_id  # Creates case
-        self.assertIsInstance(case_id, str)
-        self.assertIsInstance(self.event._case_id, UUID)
-
-    def test_delete_with_case(self):
-        __ = self.event.case
         self.event.delete()
         case = CommCareCase.objects.get_case(self.event.case_id, DOMAIN)
         self.assertTrue(case.closed)
 
-    def test_delete_without_case(self):
-        self.event.delete()  # Does not raise error
-
     def test_default_uuids(self):
         today = datetime.utcnow().date()
-        unsaved_event = Event(
+        event = Event(
             name='Test Event Too',
             domain=DOMAIN,
             start_date=today,
             end_date=today,
             attendance_target=0,
         )
-        self.assertIsInstance(unsaved_event.event_id, UUID)
-        self.assertIsNone(unsaved_event._case_id)
+        self.assertIsInstance(event.event_id, UUID)
+        self.assertIsNone(event._case_id)
+
+    def test_save_creates_case(self):
+        today = datetime.utcnow().date()
+        event = Event(
+            name='Test Event Too',
+            domain=DOMAIN,
+            start_date=today,
+            end_date=today,
+            attendance_target=0,
+        )
+        self.assertIsNone(event._case_id)
+
+        event.save()
+        self.assertIsInstance(event._case_id, UUID)
+
+        event.delete()
 
     def test_uuid_hex_string(self):
         today = datetime.utcnow().date()

--- a/migrations.lock
+++ b/migrations.lock
@@ -371,6 +371,7 @@ events
  0005_rename_alter_event__attendance_taker_ids
  0006_remove_end_date_constraint
  0007_alter_event_attendee_list_status
+ 0008_alter_event__case_id
 export
  0001_initial
  0002_datafile


### PR DESCRIPTION
## Technical Summary

Uses the new `CaseHelper` class to simplify operations on cases, and to move away from `CaseFactory`.

**NOTE:** At the time this PR is opened, the base branch is not `master`. This change follows on from PR #32825 in order for migrations to be merged in sequence.

## Feature Flag

Attendance Tracking

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Covered by tests

### QA Plan

Not specifically, although the next round of Attendance Tracking QA will implicitly cover this change.

### Migrations

Small migration changes the default value of a field.

- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
