### PR TITLE
Fix user syncing invite error

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -356,7 +356,6 @@ class ConditionalCaseUpdate(DocumentSchema):
 
 
 class UpdateCaseAction(FormAction):
-    # TODO: migrate from dict(property_name: question_path) to dict(property_name: ConditionalCaseUpdate)
     update = SchemaDictProperty(ConditionalCaseUpdate)
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Relatively small PR.

When delivery tried to start using Tableau User Syncing, someone ran into a 500 error trying to accept a web user invite while the FF was on but the domain was not fully configured yet for the feature. This PR addresses that underlying error.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The error was triggered by a call to `add_tableau_user` [here](https://github.com/dimagi/commcare-hq/blob/984801e9a17fb6aa7dab28cca03de44a4a59903b/corehq/apps/users/models.py#L2381-L2385), which resulted in a `TableauConnectedApp.DoesNotExist` error because a Tableau Connected App, part of necessary config for Tableau User Syncing, was not set up. That error blocked the completion of the web user invite and the web user being added to the domain. Furthermore, in the case of the support ticket, somehow this messed with the cache and the delivery member wasn't able to access _any_ domain until they cleared it.

We don't want this error to block anything and so I've added simple code that sends the error to sentry and stops execution of the Tableau portion but allows the web user invite acceptance workflow to finish.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

EMBEDDED_TABLEAU, TABLEAU_USER_SYNCING

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Behind a FF, and only catches an error.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

I think unnecessary.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
