### PR TITLE
Fix UCR evaluator today function; add a test

### DIFF
--- a/corehq/apps/userreports/expressions/utils.py
+++ b/corehq/apps/userreports/expressions/utils.py
@@ -35,7 +35,7 @@ FUNCTIONS = DEFAULT_FUNCTIONS
 FUNCTIONS.update({
     'timedelta_to_seconds': lambda x: x.total_seconds() if isinstance(x, timedelta) else None,
     'range': safe_range,
-    'today': date.today(),
+    'today': date.today,
     'days': lambda t: t.days,
     'round': round
 })

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1101,6 +1101,7 @@ class RelatedDocExpressionDbTest(TestCase):
     ({}, "a + b", {"a": Decimal(2), "b": Decimal(3)}, Decimal(5)),
     ({}, "a + b", {"a": Decimal(2.2), "b": Decimal(3.1)}, Decimal(5.3)),
     ({}, "range(3)", {}, [0, 1, 2]),
+    ({}, "today()", {}, date.today()),
     (
         {'dob': "2022-01-01T14:44:23.001567Z"},
         "f'{d}'[:-6] + '%03d' % round(int(f'{d:%f}')/1000) + 'Z'",


### PR DESCRIPTION
## Product Description

This fixes the below UCR expression which returns `null` instead of today's date.

```
{
  "type": "evaluator",
  "statement": "today()",
  "context variables": {}
}
```
 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The reason it returns None is because there is an exception that's swallowed up, caused by `date.today()` not being a callable.

The added test covers this bug.


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally

### Automated test coverage

Added a new test case
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
