### PR TITLE
Add locations to attendees

### DIFF
--- a/corehq/apps/events/forms.py
+++ b/corehq/apps/events/forms.py
@@ -18,12 +18,7 @@ from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
 from corehq.apps.users.dbaccessors import get_all_commcare_users_by_domain
 from corehq.apps.users.forms import PrimaryLocationWidget
 
-from .models import (
-    EVENT_IN_PROGRESS,
-    EVENT_NOT_STARTED,
-    AttendeeCase,
-    AttendeeModel,
-)
+from .models import EVENT_IN_PROGRESS, EVENT_NOT_STARTED, AttendeeModel
 
 TRACK_BY_DAY = "by_day"
 TRACK_BY_EVENT = "by_event"
@@ -208,8 +203,8 @@ class EventForm(forms.Form):
 
     def get_attendee_choices(self):
         return [
-            (attendee.case_id, attendee.name)
-            for attendee in AttendeeCase.objects.by_domain(self.domain)
+            (model.case_id, model.name)
+            for model in AttendeeModel.objects.by_domain(self.domain)
         ]
 
     def _get_possible_attendance_takers_ids(self):

--- a/corehq/apps/events/forms.py
+++ b/corehq/apps/events/forms.py
@@ -206,6 +206,7 @@ class EventForm(forms.Form):
             (user.user_id, user.username) for user in get_all_commcare_users_by_domain(self.domain)
         ]
 
+
 class NewAttendeeForm(forms.Form):
     name = forms.CharField(
         max_length=255,
@@ -213,20 +214,8 @@ class NewAttendeeForm(forms.Form):
         label=gettext_noop('Name'),
     )
 
-    # TODO: Offer external_id?
-    #       Support uniqueness validation like NewMobileWorkerForm.username
-    # external_id = forms.CharField(
-    #     max_length=255,
-    #     required=False,
-    #     label=gettext_noop('Unique ID'),
-    # )
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # TODO: Append other case properties to `self.fields`?
-        #       Practicality: What if there are _many_ case properties?
-        #       Map case property types to field types
-
         self.helper = HQModalFormHelper()
         self.helper.form_tag = False
         self.helper.layout = Layout(

--- a/corehq/apps/events/migrations/0009_attendeemodel.py
+++ b/corehq/apps/events/migrations/0009_attendeemodel.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0008_alter_event__case_id'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AttendeeModel',
+            fields=[
+                ('case_id', models.UUIDField(primary_key=True, serialize=False)),
+                ('domain', models.CharField(max_length=255)),
+                ('name', models.CharField(max_length=255)),
+                ('locations', models.TextField(blank=True, default='')),
+                ('primary_location', models.TextField(blank=True, default=None, null=True)),
+                ('user_id', models.TextField(blank=True, max_length=36, null=True)),
+            ],
+            options={
+                'managed': False,  # Does not create a DB table
+            },
+        ),
+    ]

--- a/corehq/apps/events/models.py
+++ b/corehq/apps/events/models.py
@@ -88,20 +88,17 @@ class AttendanceTrackingConfig(models.Model):
         default=DEFAULT_ATTENDEE_CASE_TYPE,
     )
 
-    @staticmethod
-    def toggle_mobile_worker_attendees(domain, value):
-        config, _created = AttendanceTrackingConfig.objects.get_or_create(domain=domain)
-        config.mobile_worker_attendees = value
-        config.save()
+
+def toggle_mobile_worker_attendees(domain, attendees_enabled):
+    AttendanceTrackingConfig.objects.update_or_create(
+        domain=domain,
+        defaults={'mobile_worker_attendees': attendees_enabled},
+    )
 
 
-@quickcache(['domain'])
-def mobile_workers_can_be_attendees(domain):
-    try:
-        config = AttendanceTrackingConfig.objects.get(pk=domain)
-        return config.mobile_worker_attendees
-    except AttendanceTrackingConfig.DoesNotExist:
-        return False
+def mobile_worker_attendees_enabled(domain):
+    config = AttendanceTrackingConfig.objects.filter(domain=domain).first()
+    return config.mobile_worker_attendees if config else False
 
 
 @quickcache(['domain'])

--- a/corehq/apps/events/static/events/js/edit_attendee.js
+++ b/corehq/apps/events/static/events/js/edit_attendee.js
@@ -1,0 +1,12 @@
+hqDefine('events/js/edit_attendee', [
+    'jquery',
+    'knockout',
+    'hqwebapp/js/initial_page_data',
+    'locations/js/widgets',
+], function (
+    $,
+    ko,
+    initialPageData
+) {
+    // Placeholder for Location & Primary location widgets
+});

--- a/corehq/apps/events/tasks.py
+++ b/corehq/apps/events/tasks.py
@@ -5,11 +5,13 @@ from dimagi.utils.couch import CriticalSection
 
 from corehq.apps.celery import task
 from corehq.apps.events.models import (
-    get_attendee_case_type,
     ATTENDEE_USER_ID_CASE_PROPERTY,
-    AttendeeCase,
+    LOCATION_IDS_CASE_PROPERTY,
+    AttendeeModel,
+    get_attendee_case_type, PRIMARY_LOCATION_ID_CASE_PROPERTY,
 )
-from corehq.apps.hqcase.utils import submit_case_blocks, bulk_update_cases
+from corehq.apps.hqcase.case_helper import CaseHelper
+from corehq.apps.hqcase.utils import bulk_update_cases
 from corehq.apps.users.models import CommCareUser
 
 
@@ -19,24 +21,23 @@ def sync_mobile_worker_attendees(domain_name, user_id):
     Create attendees from mobile workers
     """
     with CriticalSection(['sync_mobile_worker_attendees_' + domain_name]):
-        new_case_blocks = []
         closed_cases = []
-        user_id_case_mapping = get_user_attendee_cases_on_domain(domain_name)
+        user_id_model_mapping = get_user_attendee_models_on_domain(domain_name)
         attendee_case_type = get_attendee_case_type(domain_name)
 
         for user in CommCareUser.by_domain(domain_name):
-            if user.user_id not in user_id_case_mapping:
-                new_case_block = get_case_block_for_user(user, user_id, attendee_case_type)
-                new_case_blocks.append(new_case_block)
-            elif user_id_case_mapping[user.user_id].closed:
-                closed_cases.append(user_id_case_mapping[user.user_id])
+            if user.user_id not in user_id_model_mapping:
+                create_attendee_for_user(
+                    user,
+                    case_type=attendee_case_type,
+                    domain=domain_name,
+                    xform_user_id=user_id,
+                    xform_device_id='corehq.apps.events.tasks.'
+                                    'sync_mobile_worker_attendees',
+                )
+            elif user_id_model_mapping[user.user_id].case.closed:
+                closed_cases.append(user_id_model_mapping[user.user_id].case)
 
-        submit_case_blocks(
-            [cb.as_text() for cb in new_case_blocks],
-            domain=domain_name,
-            user_id=user_id,
-            device_id='corehq.apps.events.tasks.sync_mobile_worker_attendees',
-        )
         reopen_cases(closed_cases)
 
 
@@ -46,28 +47,34 @@ def close_mobile_worker_attendee_cases(domain_name):
     Close attendee cases associated with mobile workers
     """
     with CriticalSection(['close_mobile_worker_attendees_' + domain_name]):
-        case_changes = []
-        user_id_case_mapping = get_user_attendee_cases_on_domain(domain_name)
-        mobile_worker_user_ids = {user.user_id for user in CommCareUser.by_domain(domain_name)}
+        user_id_model_mapping = get_user_attendee_models_on_domain(domain_name)
+        user_ids = set(CommCareUser.ids_by_domain(domain_name))
 
-        for commcare_user_id, case in user_id_case_mapping.items():
-            if commcare_user_id in mobile_worker_user_ids:
-                case_changes.append((case.case_id, {}, True))
+        case_changes = [
+            (model.case_id, {}, True)
+            for user_id, model in user_id_model_mapping.items()
+            if user_id in user_ids
+        ]
 
         if case_changes:
             bulk_update_cases(
                 domain_name,
                 case_changes,
-                device_id='corehq.apps.events.tasks.close_mobile_worker_attendee_cases'
+                device_id='corehq.apps.events.tasks.'
+                          'close_mobile_worker_attendee_cases'
             )
 
 
-def get_user_attendee_cases_on_domain(domain):
-    """Returns a mapping like `{user_id1: case1, user_id2: case2}`. The user_ids's are fetched from the case's
-    `ATTENDEE_USER_ID_CASE_PROPERTY` property, which is a commcare user id
+def get_user_attendee_models_on_domain(domain):
     """
-    cases = AttendeeCase.objects.by_domain(domain, include_closed=True)
-    return {c.get_case_property(ATTENDEE_USER_ID_CASE_PROPERTY): c for c in cases}
+    Returns a mapping like ``{user_id1: model1, user_id2: model2}``.
+
+    AttendeeModel.case is the attendee's CommCareCase.
+    AttendeeModel.user_id is CommCareUser.user_id for attendees that are
+    mobile workers. See AttendeeModel for other useful fields.
+    """
+    models = AttendeeModel.objects.by_domain(domain, include_closed=True)
+    return {m.user_id: m for m in models if m.user_id}
 
 
 def get_case_block_for_user(user, owner_id, attendee_case_type):
@@ -83,6 +90,32 @@ def get_case_block_for_user(user, owner_id, attendee_case_type):
         case_name=case_name,
         update=fields,
     )
+
+
+def create_attendee_for_user(
+    commcare_user,
+    case_type,
+    domain,
+    xform_user_id,
+    xform_device_id,
+):
+    helper = CaseHelper(domain=domain)
+    helper.create_case(
+        {
+            'case_name': commcare_user.username.split('@')[0],
+            'case_type': case_type,
+            'properties': {
+                ATTENDEE_USER_ID_CASE_PROPERTY: commcare_user.user_id,
+                LOCATION_IDS_CASE_PROPERTY:
+                    ' '.join(commcare_user.assigned_location_ids),
+                PRIMARY_LOCATION_ID_CASE_PROPERTY:
+                    commcare_user.location_id or '',
+            }
+        },
+        user_id=xform_user_id,
+        device_id=xform_device_id,
+    )
+
 
 def reopen_cases(cases):
     for case in cases:

--- a/corehq/apps/events/templates/edit_attendee.html
+++ b/corehq/apps/events/templates/edit_attendee.html
@@ -1,0 +1,27 @@
+{% extends 'hqwebapp/bootstrap3/base_section.html' %}
+
+{% load crispy_forms_tags %}
+{% load hq_shared_tags %}
+{% load i18n %}
+
+{% requirejs_main 'events/js/edit_attendee' %}
+
+{% block page_content %}
+  {% initial_page_data "attendee_id" attendee_id %}
+  <form id="attendee_form" class="form-horizontal" name="" method="post">
+    {% csrf_token %}
+    <fieldset>
+      <legend>{% trans 'Attendee' %}</legend>
+      {% crispy form %}
+    </fieldset>
+
+    <div class="form-actions">
+      <div class="col-sm-offset-3 col-md-offset-2 col-sm-9 col-md-8 col-lg-6">
+        <button type="submit" class="btn btn-primary disable-on-submit">
+          {% trans 'Update Attendee' %}
+        </button>
+      </div>
+    </div>
+  </form>
+
+{% endblock %}

--- a/corehq/apps/events/templates/event_attendees.html
+++ b/corehq/apps/events/templates/event_attendees.html
@@ -139,7 +139,11 @@
           </thead>
           <tbody data-bind="foreach: attendees">
           <tr>
-            <td data-bind="text: name"></td>
+            <td>
+              <a data-bind="attr: {href: case_id}">
+                <span data-bind="text: name"></span>
+              </a>
+            </td>
           </tr>
           </tbody>
         </table>

--- a/corehq/apps/events/tests/test_models.py
+++ b/corehq/apps/events/tests/test_models.py
@@ -21,7 +21,6 @@ from ..models import (
     LOCATION_IDS_CASE_PROPERTY,
     PRIMARY_LOCATION_ID_CASE_PROPERTY,
     AttendanceTrackingConfig,
-    AttendeeCase,
     AttendeeModel,
     Event,
     get_attendee_case_type,
@@ -55,12 +54,15 @@ class TestAttendeeCaseManager(TestCase):
 
     def test_manager_returns_open_cases(self):
         with self.get_attendee_cases() as (open_case, closed_case):
-            cases = AttendeeCase.objects.by_domain(DOMAIN)
+            cases = [m.case for m in AttendeeModel.objects.by_domain(DOMAIN)]
             self.assertEqual(cases, [open_case])
 
     def test_manager_returns_closed_cases_as_well(self):
         with self.get_attendee_cases() as (open_case, closed_case):
-            cases = AttendeeCase.objects.by_domain(DOMAIN, include_closed=True)
+            cases = [m.case for m in AttendeeModel.objects.by_domain(
+                DOMAIN,
+                include_closed=True,
+            )]
             self.assertEqual(cases, [open_case, closed_case])
 
 

--- a/corehq/apps/events/urls.py
+++ b/corehq/apps/events/urls.py
@@ -1,19 +1,25 @@
 from django.conf.urls import re_path as url
 
 from .views import (
+    AttendeeEditView,
+    AttendeesConfigView,
     AttendeesListView,
     EventCreateView,
     EventEditView,
     EventsView,
-    AttendeesConfigView,
     paginated_attendees,
 )
 
 urlpatterns = [
     url(r'^list/$', EventsView.as_view(), name=EventsView.urlname),
     url(r'^new/$', EventCreateView.as_view(), name=EventCreateView.urlname),
+    url(r'^attendees/$', AttendeesListView.as_view(),
+        name=AttendeesListView.urlname),
     url(r'^attendees/json/$', paginated_attendees, name='paginated_attendees'),
-    url(r'^attendees/$', AttendeesListView.as_view(), name=AttendeesListView.urlname),
-    url(r'^attendees/config$', AttendeesConfigView.as_view(), name=AttendeesConfigView.urlname),
-    url(r'^(?P<event_id>[\w-]+)/$', EventEditView.as_view(), name=EventEditView.urlname),
+    url(r'^attendees/config/$', AttendeesConfigView.as_view(),
+        name=AttendeesConfigView.urlname),
+    url(r'^attendees/(?P<attendee_id>[\w-]+)$', AttendeeEditView.as_view(),
+        name=AttendeeEditView.urlname),
+    url(r'^(?P<event_id>[\w-]+)/$', EventEditView.as_view(),
+        name=EventEditView.urlname),
 ]

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -30,12 +30,12 @@ from .models import (
     EVENT_IN_PROGRESS,
     EVENT_NOT_STARTED,
     EVENT_STATUS_TRANS,
-    AttendanceTrackingConfig,
     AttendeeModel,
     Event,
     get_attendee_case_type,
     get_paginated_attendees,
-    mobile_workers_can_be_attendees,
+    mobile_worker_attendees_enabled,
+    toggle_mobile_worker_attendees,
 )
 from .tasks import (
     close_mobile_worker_attendee_cases,
@@ -434,14 +434,14 @@ class AttendeesConfigView(JSONResponseMixin, BaseUserSettingsView, BaseEventView
     @allow_remote_invocation
     def get(self, request, *args, **kwargs):
         return self.json_response({
-            "mobile_worker_attendee_enabled": mobile_workers_can_be_attendees(self.domain)
+            "mobile_worker_attendee_enabled": mobile_worker_attendees_enabled(self.domain)
         })
 
     @allow_remote_invocation
     def post(self, request, *args, **kwargs):
         json_data = json.loads(request.body)
         attendees_enabled = json_data['mobile_worker_attendee_enabled']
-        AttendanceTrackingConfig.toggle_mobile_worker_attendees(self.domain, value=attendees_enabled)
+        toggle_mobile_worker_attendees(self.domain, attendees_enabled)
         if attendees_enabled:
             sync_mobile_worker_attendees.delay(self.domain, user_id=self.couch_user.user_id)
         else:

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -35,6 +35,7 @@ from .models import (
     Event,
     get_attendee_case_type,
     get_paginated_attendees,
+    mobile_workers_can_be_attendees,
 )
 from .tasks import (
     close_mobile_worker_attendee_cases,
@@ -433,7 +434,7 @@ class AttendeesConfigView(JSONResponseMixin, BaseUserSettingsView, BaseEventView
     @allow_remote_invocation
     def get(self, request, *args, **kwargs):
         return self.json_response({
-            "mobile_worker_attendee_enabled": AttendanceTrackingConfig.mobile_workers_can_be_attendees(self.domain)
+            "mobile_worker_attendee_enabled": mobile_workers_can_be_attendees(self.domain)
         })
 
     @allow_remote_invocation

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1353,11 +1353,16 @@ class CommtrackUserForm(forms.Form):
         assigned_location_ids = cleaned_data.get('assigned_locations', [])
         if primary_location_id:
             if primary_location_id not in assigned_location_ids:
-                self.add_error('primary_location',
-                               _("Primary location can only be one of user's locations"))
+                self.add_error(
+                    'primary_location',
+                    _("Primary location must be one of the user's locations")
+                )
         if assigned_location_ids and not primary_location_id:
-            self.add_error('primary_location',
-                           _("Primary location can't be empty if user has any locations set"))
+            self.add_error(
+                'primary_location',
+                _("Primary location can't be empty if the user has any "
+                  "locations set")
+            )
 
 
 class DomainRequestForm(forms.Form):

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -6,10 +6,14 @@ from django.test import TestCase
 from django.urls import reverse
 
 from corehq import privileges
-from corehq.apps.events.models import AttendeeCase, AttendanceTrackingConfig, ATTENDEE_USER_ID_CASE_PROPERTY
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es.tests.utils import es_test, populate_user_index
 from corehq.apps.es.users import user_adapter
+from corehq.apps.events.models import (
+    ATTENDEE_USER_ID_CASE_PROPERTY,
+    AttendanceTrackingConfig,
+    AttendeeModel,
+)
 from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.tests.util import delete_all_locations, make_loc
 from corehq.apps.users.audit.change_messages import UserChangeMessage
@@ -28,7 +32,11 @@ from corehq.apps.users.views.mobile.users import MobileWorkerListView
 from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.toggles import FILTERED_BULK_USER_DOWNLOAD, NAMESPACE_DOMAIN
 from corehq.toggles.shortcuts import set_toggle
-from corehq.util.test_utils import flag_enabled, generate_cases, privilege_enabled
+from corehq.util.test_utils import (
+    flag_enabled,
+    generate_cases,
+    privilege_enabled,
+)
 
 
 class TestMobileWorkerListView(TestCase):
@@ -114,7 +122,7 @@ class TestMobileWorkerListView(TestCase):
             }
         })
         user = CouchUser.get_by_username(f'{username}@{self.domain}.commcarehq.org')
-        cases = AttendeeCase.objects.by_domain(self.domain)
+        cases = [m.case for m in AttendeeModel.objects.by_domain(self.domain)]
         if expect_case:
             self.assertTrue(len(cases) > 0)
             created_case = cases[0]

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from django.http import Http404
@@ -10,10 +11,10 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es.tests.utils import es_test, populate_user_index
 from corehq.apps.es.users import user_adapter
 from corehq.apps.events.models import (
-    ATTENDEE_USER_ID_CASE_PROPERTY,
     AttendanceTrackingConfig,
     AttendeeModel,
 )
+from corehq.apps.hqcase.case_helper import CaseHelper
 from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.tests.util import delete_all_locations, make_loc
 from corehq.apps.users.audit.change_messages import UserChangeMessage
@@ -94,24 +95,52 @@ class TestMobileWorkerListView(TestCase):
     @privilege_enabled(privileges.ATTENDANCE_TRACKING)
     def test_commcare_attendee_case_created(self):
         """An attendance tracking case should be created for a mobile worker on creation"""
-        # To ensure the config exists
-        AttendanceTrackingConfig.toggle_mobile_worker_attendees(self.domain, True)
-        self.assert_case_created_on_mobile_worker_creation(expect_case=True)
+        with self.enable_mobile_worker_attendees(), \
+                self.get_mobile_worker() as user:
+            self.assertAttendeeCreatedForUser(user)
 
     @flag_enabled('ATTENDANCE_TRACKING')
     def test_commcare_attendee_case_not_created_due_to_privilege(self):
         """This tests the case where a domain was on a higher plan and used the attendance tracking, but have
         downgraded ever since and now creates a new mobile worker"""
-        AttendanceTrackingConfig.toggle_mobile_worker_attendees(self.domain, True)
-        self.assert_case_created_on_mobile_worker_creation(expect_case=False)
+        with self.enable_mobile_worker_attendees(), \
+                self.get_mobile_worker():
+            self.assertAttendeeNotCreated()
 
     @flag_enabled('ATTENDANCE_TRACKING')
     @privilege_enabled(privileges.ATTENDANCE_TRACKING)
     def test_commcare_attendee_case_not_created_due_to_config(self):
-        # AttendanceTrackingConfig does not exist for this domain yet
-        self.assert_case_created_on_mobile_worker_creation(expect_case=False)
+        # AttendanceTrackingConfig does not exist for this domain
+        self.assertNoAttendanceTrackingConfig()
+        with self.get_mobile_worker():
+            self.assertAttendeeNotCreated()
 
-    def assert_case_created_on_mobile_worker_creation(self, expect_case=True):
+    def assertAttendeeCreatedForUser(self, user):
+        models = AttendeeModel.objects.by_domain(self.domain)
+        self.assertEqual(len(models), 1)
+        self.assertEqual(models[0].user_id, user.user_id)
+
+    def assertAttendeeNotCreated(self):
+        self.assertEqual(AttendeeModel.objects.by_domain(self.domain), [])
+
+    def assertNoAttendanceTrackingConfig(self):
+        self.assertIsNone(
+            AttendanceTrackingConfig.objects.filter(domain=self.domain).first()
+        )
+
+    @contextmanager
+    def enable_mobile_worker_attendees(self):
+        config, __ = AttendanceTrackingConfig.objects.update_or_create(
+            domain=self.domain,
+            defaults={'mobile_worker_attendees': True},
+        )
+        try:
+            yield
+        finally:
+            config.delete()
+
+    @contextmanager
+    def get_mobile_worker(self):
         username = 'test.test'
         self._remote_invoke('create_mobile_worker', {
             "user": {
@@ -122,14 +151,18 @@ class TestMobileWorkerListView(TestCase):
             }
         })
         user = CouchUser.get_by_username(f'{username}@{self.domain}.commcarehq.org')
-        cases = [m.case for m in AttendeeModel.objects.by_domain(self.domain)]
-        if expect_case:
-            self.assertTrue(len(cases) > 0)
-            created_case = cases[0]
-            user_id_case_property = created_case.get_case_property(ATTENDEE_USER_ID_CASE_PROPERTY)
-            self.assertEqual(user.user_id, user_id_case_property)
-        else:
-            self.assertTrue(len(cases) == 0)
+        try:
+            yield user
+        finally:
+            close_user_attendee(self.domain, user.user_id)
+            user.delete(None, None)
+
+
+def close_user_attendee(domain, user_id):
+    for model in AttendeeModel.objects.by_domain(domain):
+        if model.user_id == user_id:
+            helper = CaseHelper(case_id=model.case_id, domain=domain)
+            helper.close()
 
 
 @generate_cases((

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -62,7 +62,7 @@ from corehq.apps.domain.views.base import DomainViewMixin
 from corehq.apps.es import FormES
 from corehq.apps.events.models import (
     get_attendee_case_type,
-    mobile_workers_can_be_attendees,
+    mobile_worker_attendees_enabled,
 )
 from corehq.apps.events.tasks import create_attendee_for_user
 from corehq.apps.groups.models import Group
@@ -781,7 +781,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
         if (
             domain_has_privilege(self.domain, privileges.ATTENDANCE_TRACKING)
             and toggles.ATTENDANCE_TRACKING.enabled(self.domain)
-            and mobile_workers_can_be_attendees(self.domain)
+            and mobile_worker_attendees_enabled(self.domain)
         ):
             self.create_attendee_for_user(couch_user)
 

--- a/migrations.lock
+++ b/migrations.lock
@@ -372,6 +372,7 @@ events
  0006_remove_end_date_constraint
  0007_alter_event_attendee_list_status
  0008_alter_event__case_id
+ 0009_attendeemodel
 export
  0001_initial
  0002_datafile


### PR DESCRIPTION
## Technical Summary

Attendee cases for Attendance Tracking can have locations the same way that Mobile Workers do.

![image](https://user-images.githubusercontent.com/708421/231453317-35733b88-d021-4800-99c9-34b75f033182.png)

Probably easier to review commit-by-commit :fish: :blowfish: :tropical_fish: 

## Feature Flag

Attendance Tracking

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Model covered by tests

### QA Plan

QA will be testing this feature.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
