### PR TITLE
Add temporary workaround for deprecation warnings

### DIFF
--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -158,6 +158,8 @@ def augment_warning_messages():
         message += f"\nmodule: {module} line {lineno}"
         if category and issubclass(category, DeprecationWarning):
             message += POSSIBLE_RESOLUTIONS
+            if os.environ.get("CCHQ_STRICT_WARNINGS") and os.environ.get('CCHQ_TESTING') != '1':
+                message += STRICT_WARNINGS_WORKAROUND
 
         stacklevel += 1
         return real_warn(message, category, stacklevel, source)
@@ -198,4 +200,9 @@ Possible resolutions:
   path or to add a whitelist item that uniquely matches the deprecation
   warning, use the `corehq.tests.util.warnings.filter_warnings()`
   decorator to filter the specific warning in tests that trigger it.
+"""
+
+STRICT_WARNINGS_WORKAROUND = """
+Workaround: prepend the command with 'env -u CCHQ_STRICT_WARNINGS ' to
+disable strict warnings if none of these resolutions are appropriate.
 """


### PR DESCRIPTION
Sometimes one simply wants to run a command using an old code version where none of the suggested resolutions are appropriate. For example, when running a historical migration. This should make the easy workaround more obvious when CCHQ_STRICT_WARNINGS is set.

## Safety Assurance

### Safety story

Trivial change that only affects development workflows. Tested locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations