### PR TITLE
Adds size limit to attachments for form submission API

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -1,11 +1,13 @@
 import json
 import os
 from io import BytesIO
+import copy
 
 from django.test import TestCase
 from django.test.client import Client
 from django.test.utils import override_settings
 from django.urls import reverse
+from django.conf import settings
 
 from unittest.mock import patch
 
@@ -17,7 +19,10 @@ from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.util.json import CommCareJSONEncoder
 from corehq.util.test_utils import TestFileMixin, softer_assert
 
-from couchforms.exceptions import InvalidSubmissionFileExtensionError
+from couchforms.exceptions import (
+    InvalidSubmissionFileExtensionError,
+    AttachmentSizeTooLarge,
+)
 
 
 class BaseSubmissionTest(TestCase):
@@ -165,6 +170,28 @@ class SubmissionTest(BaseSubmissionTest):
         self.assertEqual(
             list_attachments(new_form),
             [("file", b"text file"), ("image", b"other fake image")])
+
+    def test_submit_invalid_attachment_size(self):
+        file_data = BytesIO(b"a" * (settings.MAX_UPLOAD_SIZE_ATTACHMENT + 1))
+        expected_error = AttachmentSizeTooLarge()
+        response = self._submit(
+            'simple_form.xml',
+            attachments={"file": file_data},
+            url=reverse("receiver_secure_post", args=[self.domain]),
+        )
+        self.assertEqual(response.status_code, expected_error.status_code)
+        self.assertEqual(response.content.decode('utf-8'), expected_error.message)
+
+    def test_submit_valid_attachment_size_multiple(self):
+        file_data = BytesIO(b"a" * (settings.MAX_UPLOAD_SIZE_ATTACHMENT - 1))
+        response = self._submit(
+            'simple_form.xml',
+            attachments={"file": file_data, "image": copy.copy(file_data)},
+            url=reverse("receiver_secure_post", args=[self.domain]),
+        )
+        self.assertEqual(response.status_code, 201)
+        form = XFormInstance.objects.get_form(response['X-CommCareHQ-FormID'])
+        self.assertEqual(len(form.get_attachments()), 3)
 
 
 @patch('corehq.apps.receiverwrapper.views.domain_requires_auth', return_value=True)

--- a/corehq/ex-submodules/couchforms/exceptions.py
+++ b/corehq/ex-submodules/couchforms/exceptions.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from couchforms.const import MAGIC_PROPERTY
 
 
@@ -67,4 +68,12 @@ class InvalidSubmissionFileExtensionError(UnprocessableFormSubmission):
             "submitting form xml. You may also do a normal (non-multipart) "
             "with the xml submission as the request body instead\n",
             422
+        )
+
+
+class AttachmentSizeTooLarge(BadSubmissionRequest):
+    def __init__(self):
+        super().__init__(
+            f"Attachment exceeds {settings.MAX_UPLOAD_SIZE_ATTACHMENT/(1024*1024):,.0f}MB size limit\n",
+            413
         )

--- a/corehq/ex-submodules/couchforms/getters.py
+++ b/corehq/ex-submodules/couchforms/getters.py
@@ -10,6 +10,7 @@ from couchforms.exceptions import (
     MultipartFilenameError,
     PayloadTooLarge,
     InvalidSubmissionFileExtensionError,
+    AttachmentSizeTooLarge,
 )
 from dimagi.utils.parsing import string_to_utc_datetime
 from dimagi.utils.web import get_ip, get_site_domain
@@ -53,6 +54,8 @@ def get_instance_and_attachment(request):
             instance = instance_file.read()
             for key, item in request.FILES.items():
                 if key != MAGIC_PROPERTY:
+                    if _valid_attachment_size(item) is False:
+                        raise AttachmentSizeTooLarge()
                     attachments[key] = item
         if not instance:
             raise MultipartEmptyPayload()
@@ -71,6 +74,10 @@ def _valid_file_extension(file):
         return False
     file_extension = file.name.rsplit(".", 1)[-1]
     return file_extension == 'xml'
+
+
+def _valid_attachment_size(file):
+    return file.size <= settings.MAX_UPLOAD_SIZE_ATTACHMENT
 
 
 def get_location(request=None):

--- a/corehq/ex-submodules/couchforms/getters.py
+++ b/corehq/ex-submodules/couchforms/getters.py
@@ -54,7 +54,7 @@ def get_instance_and_attachment(request):
             instance = instance_file.read()
             for key, item in request.FILES.items():
                 if key != MAGIC_PROPERTY:
-                    if _valid_attachment_size(item) is False:
+                    if _attachment_exceeds_size_limit(item):
                         raise AttachmentSizeTooLarge()
                     attachments[key] = item
         if not instance:
@@ -76,8 +76,8 @@ def _valid_file_extension(file):
     return file_extension == 'xml'
 
 
-def _valid_attachment_size(file):
-    return file.size <= settings.MAX_UPLOAD_SIZE_ATTACHMENT
+def _attachment_exceeds_size_limit(file):
+    return file.size > settings.MAX_UPLOAD_SIZE_ATTACHMENT
 
 
 def get_location(request=None):

--- a/settings.py
+++ b/settings.py
@@ -1033,6 +1033,9 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = None
 # consider migrating to `DATA_UPLOAD_MAX_MEMORY_SIZE` which is universally applied
 MAX_UPLOAD_SIZE = 10 * 1024 * 1024
 
+# Size limit on attachment other than the xml form.
+MAX_UPLOAD_SIZE_ATTACHMENT = 15 * 1024 * 1024
+
 # Exports use a lot of fields to define columns. See: https://dimagi-dev.atlassian.net/browse/HI-365
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 5000
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This adds size limit to attachments other than form xml to the submission API at the django layer. The size limit is 15MB per attachment (same as in the mobile app).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
JIRA Ticket: [INDIV-101](https://dimagi-dev.atlassian.net/browse/INDIV-101)
Basic reason is to have some limit and 15MB was chosen as it is quite reasonable and already present at the mobile app.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Changes made are covered by the unit tests.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
New test cases were added for the changes made.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Don't think QA is necessary for this change, however I am open for thoughts on this.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[INDIV-101]: https://dimagi-dev.atlassian.net/browse/INDIV-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ