### PR TITLE
Create tombstones on every delete request

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -1092,7 +1092,7 @@ class ElasticMultiplexAdapter(BaseAdapter):
                 # apply the chunk to both indexes in parallel
                 payload.append(self.primary._render_bulk_action(action))
                 if action.is_delete:
-                    # Always create a tombstone on secondary index when delete delete is issued on primary
+                    # Always create a tombstone on secondary index when delete is issued on primary
                     if action.doc is None:
                         doc_id = action.doc_id
                     else:

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -1091,40 +1091,31 @@ class ElasticMultiplexAdapter(BaseAdapter):
             for action in chunk:
                 # apply the chunk to both indexes in parallel
                 payload.append(self.primary._render_bulk_action(action))
-                payload.append(self.secondary._render_bulk_action(action))
+                if action.is_delete:
+                    # Always create a tombstone on secondary index when delete delete is issued on primary
+                    if action.doc is None:
+                        doc_id = action.doc_id
+                    else:
+                        doc_id = self.from_python(action.doc)[0]
+                    payload.append(
+                        self.secondary._render_bulk_action(
+                            BulkActionItem.index(Tombstone(doc_id)),
+                            forbid_tombstones=False
+                        )
+                    )
+                else:
+                    payload.append(self.secondary._render_bulk_action(action))
             _, chunk_errs = bulk(self._es, payload, chunk_size=len(payload),
                                  refresh=refresh, raise_on_error=False,
                                  raise_on_exception=raise_errors)
             deduped_errs = {}
-            primary_del_fail_ids = set()
-            secondary_del_fails = {}
             for error in chunk_errs:
                 doc_id, index_name = self._parse_bulk_error(error)
-                if index_name == self.primary.index_name:
-                    deduped_errs[doc_id] = error
-                    if self._is_delete_not_found(error):
-                        # don't add tombstones for deletes that failed on the
-                        # primary index
-                        primary_del_fail_ids.add(doc_id)
+                if index_name == self.primary.index_name and self._is_delete_not_found(error):
+                    # Ignore error raised while deleting an non-existent doc on primary
+                    pass
                 else:
-                    if self._is_delete_not_found(error):
-                        secondary_del_fails[doc_id] = error
-                    else:
-                        deduped_errs.setdefault(doc_id, error)
-            tombstone_ids = secondary_del_fails.keys() - primary_del_fail_ids
-            if tombstone_ids:
-                # add tombstones on secondary
-                try:
-                    _, make_tstone_errs = self.secondary._bulk(
-                        self._iter_tombstone_bulk_payload(tombstone_ids),
-                        refresh=False,
-                        raise_errors=raise_errors,
-                    )
-                except BulkIndexError as exc:
-                    make_tstone_errs = exc.errors
-                for error in make_tstone_errs:
-                    doc_id, _ = self._parse_bulk_error(error)
-                    deduped_errs.setdefault(doc_id, secondary_del_fails[doc_id])
+                    deduped_errs.setdefault(doc_id, error)
 
             errors.extend(deduped_errs.values())
             if raise_errors and errors:
@@ -1132,13 +1123,6 @@ class ElasticMultiplexAdapter(BaseAdapter):
                 raise BulkIndexError(f"{len(errors)} document(s) failed to index.", errors)
             success_count += (len(chunk) - len(deduped_errs))
         return success_count, errors
-
-    def _iter_tombstone_bulk_payload(self, doc_ids):
-        for doc_id in doc_ids:
-            yield self.secondary._render_bulk_action(
-                BulkActionItem.index(Tombstone(doc_id)),
-                forbid_tombstones=False,
-            )
 
     @staticmethod
     def _parse_bulk_error(error):

--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -1731,52 +1731,39 @@ class TestElasticMultiplexAdapter(SimpleTestCase, ESTestHelpers):
             BulkActionItem.delete(doc_1),
             BulkActionItem.index(doc_2),
         ])
-        self.addCleanup(self.adapter.delete, doc_2.id)
+        self.addCleanup(self.adapter.secondary.bulk_delete, [doc_1.id, doc_2.id])
+        self.addCleanup(self.adapter.primary.delete, doc_2.id)
         self.assertEqual(2, successes)
         self.assertEqual([], errors)
-        self.assertPrimaryAndSecondaryDocIdsEqual([doc_2.id])
+        self.assertIndexDocIds(self.adapter.primary, [doc_2.id])
+        self.assertIndexDocIds(self.adapter.secondary, [doc_1.id, doc_2.id])
 
     def test_bulk_returns_when_raise_errors_is_false(self):
         doc_ids = [self._make_doc().id for x in range(2)]
         # verify state
         self.assertPrimaryAndSecondaryDocIdsEqual([])
         # test
-        actions = [BulkActionItem.delete_id(id) for id in doc_ids]
-        success, errors = self.adapter.bulk(actions, raise_errors=False)
-        self.assertEqual(0, success)
-        self.assertEqual(len(actions), len(errors))
+        from corehq.apps.es import client
+        error_from_bulk = [{"delete": {"status": 500, "_id": "abc", "_index": "test_index"}}]
+        return_val = (0, error_from_bulk)
+        with (patch.object(client, "bulk", return_value=return_val)):
+            actions = [BulkActionItem.delete_id(id) for id in doc_ids]
+            self.adapter.bulk(actions, raise_errors=False)
 
     def test_bulk_raises_when_raise_errors_is_not_false(self):
         doc_ids = [self._make_doc().id for x in range(2)]
         # verify state
         self.assertPrimaryAndSecondaryDocIdsEqual([])
-        # test
-        actions = [BulkActionItem.delete_id(id) for id in doc_ids]
-        with self.assertRaises(BulkIndexError) as test:
-            self.adapter.bulk(actions)
-        self.assertEqual(len(actions), len(test.exception.errors))
 
-    def test_bulk_action_delete_does_not_create_tombstones_if_missing_on_primary(self):
-        missing = self._make_doc()
-        # verify state
-        self.assertPrimaryAndSecondaryDocIdsEqual([])
         # test
-        with self.assertRaises(BulkIndexError) as test:
-            self.adapter.bulk([BulkActionItem.delete(missing)])
-        error, = test.exception.errors
-        self.assertTrue(self.adapter._is_delete_not_found(error))
-        self.assertPrimaryAndSecondaryDocIdsEqual([])
+        from corehq.apps.es import client
+        error_from_bulk = [{"delete": {"status": 500, "_id": "abc", "_index": "test_index"}}]
+        return_val = (0, error_from_bulk)
 
-    def test_bulk_action_delete_does_not_create_tombstones_if_exists_on_secondary(self):
-        doc = self._make_doc()
-        # setup and verify state
-        self.adapter.index(doc)
-        self.assertPrimaryAndSecondaryDocIdsEqual([doc.id])
-        # test
-        successes, errors = self.adapter.bulk([BulkActionItem.delete(doc)])
-        self.assertEqual(1, successes)
-        self.assertEqual([], errors)
-        self.assertPrimaryAndSecondaryDocIdsEqual([])
+        with (patch.object(client, "bulk", return_value=return_val)):
+            actions = [BulkActionItem.delete_id(id) for id in doc_ids]
+            with self.assertRaises(BulkIndexError):
+                self.adapter.bulk(actions)
 
     def test_bulk_action_delete_creates_tombstones_if_missing_on_secondary(self):
         doc = self._make_doc()
@@ -1879,7 +1866,8 @@ class TestElasticMultiplexAdapter(SimpleTestCase, ESTestHelpers):
         self.assertPrimaryAndSecondaryDocIdsEqual([])
         # test
         self.adapter.bulk_index(docs)
-        self.addCleanup(self.adapter.bulk_delete, doc_ids)
+        self.addCleanup(self.adapter.primary.bulk_delete, doc_ids)
+        self.addCleanup(self.adapter.secondary.bulk_delete, doc_ids)
         self.assertPrimaryAndSecondaryDocIdsEqual(doc_ids)
 
     def test_bulk_delete(self):
@@ -1890,26 +1878,20 @@ class TestElasticMultiplexAdapter(SimpleTestCase, ESTestHelpers):
         self.assertPrimaryAndSecondaryDocIdsEqual(doc_ids)
         # test
         self.adapter.bulk_delete(doc_ids)
-        self.assertPrimaryAndSecondaryDocIdsEqual([])
+        self.assertIndexDocIds(self.adapter.primary, [])
+        self.assertIndexDocIds(self.adapter.secondary, doc_ids)
+        self.addCleanup(self.adapter.secondary.bulk_delete, doc_ids)
 
     def test_delete(self):
         doc = self._make_doc()
         # setup and verify a synced secondary condition
         self.adapter.index(doc, refresh=True)
         self.assertPrimaryAndSecondaryDocIdsEqual([doc.id])
-        # test
+        # test delete leaves tombstones on secondary
         self.adapter.delete(doc.id)
-        self.assertPrimaryAndSecondaryDocIdsEqual([])
-
-    def test_delete_raises_notfounderror_on_failure(self):
-        doc = self._make_doc()
-        # verify state
-        self.assertPrimaryAndSecondaryDocIdsEqual([])
-        # test
-        with self.assertRaises(NotFoundError) as test:
-            self.adapter.delete(doc.id)
-        self.assertEqual(test.exception.status_code, 404)
-        self.assertPrimaryAndSecondaryDocIdsEqual([])
+        self.assertIndexDocIds(self.adapter.primary, [])
+        self.assertIndexDocIds(self.adapter.secondary, [doc.id])
+        self.addCleanup(self.adapter.secondary.delete, doc.id)
 
     def test_delete_creates_tombstone_when_missing_in_secondary(self):
         doc = self._make_doc()
@@ -1919,12 +1901,13 @@ class TestElasticMultiplexAdapter(SimpleTestCase, ESTestHelpers):
         self.assertFalse(self.adapter.secondary.exists(doc.id))
         # test
         self.adapter.delete(doc.id)
-        self.addCleanup(self.adapter.secondary.delete, doc.id)
         self.assertFalse(self.adapter.primary.exists(doc.id))
         self.assertEqual(
             dict(_id=doc.id, **Tombstone.create_document()),
             self.adapter.secondary.get(doc.id),
         )
+        # Delete tombstone created on secondary
+        self.addCleanup(self.adapter.secondary.delete, doc.id)
 
     def test_index(self):
         doc = self._make_doc()
@@ -1932,8 +1915,10 @@ class TestElasticMultiplexAdapter(SimpleTestCase, ESTestHelpers):
         self.assertPrimaryAndSecondaryDocIdsEqual([])
         # test
         self.adapter.index(doc)
-        self.addCleanup(self.adapter.delete, doc.id)
         self.assertPrimaryAndSecondaryDocIdsEqual([doc.id])
+
+        self.addCleanup(self.adapter.primary.delete, doc.id)
+        self.addCleanup(self.adapter.secondary.delete, doc.id)
 
     def test_index_raises_transporterror_on_failure(self):
         doc = self._make_doc()
@@ -1973,6 +1958,14 @@ class TestElasticMultiplexAdapter(SimpleTestCase, ESTestHelpers):
             mismatch_msg = (f"{adapter.index_name} adapter document mismatch: "
                             f"expected={unordered!r}, got={got!r}")
             self.assertEqual(unordered, got, mismatch_msg)
+
+    def assertIndexDocIds(self, adapter, expected):
+        unordered = set(expected)
+        manager.index_refresh(adapter.index_name)
+        got = set(d["_id"] for d in adapter.search({})["hits"]["hits"])
+        mismatch_msg = (f"{adapter.index_name} adapter document mismatch: "
+            f"expected={unordered!r}, got={got!r}")
+        self.assertEqual(unordered, got, mismatch_msg)
 
 
 @contextmanager


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
@calellowitz pointed out a scenario in https://github.com/dimagi/commcare-hq/pull/32644#issuecomment-1442240635 where we might risk having different states in primary and secondary indexes. This PR attempts to fix that issue by creating tombstones every time a delete request is issued on the primary.
Since we will be deleting all tombstones on every switchover of the secondary index to the primary index, we can handle scenarios where we try to delete non-existent docs on the primary index and tombstones created them in the secondary index.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14486
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests are updated/added based on the changes
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
