### PR TITLE
detect instaces with whitespace around instance names

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -393,7 +393,7 @@ def get_all_instances_referenced_in_xpaths(app, xpaths):
     return instances, unknown_instance_ids
 
 
-instance_re = re.compile(r"""instance\(['"]([\w\-:]+)['"]\)""", re.UNICODE)
+instance_re = re.compile(r"""instance\(\s*['"]([\w\-:]+)['"]\s*\)""", re.UNICODE)
 
 
 def get_instance_names(xpath):

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -11,13 +11,14 @@ from corehq.apps.app_manager.models import (
     Itemset,
     ShadowModule,
 )
+from corehq.apps.app_manager.suite_xml.post_process.instances import get_instance_names
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
     patch_get_xform_resource_overrides,
 )
 from corehq.apps.locations.models import LocationFixtureConfiguration
-from corehq.util.test_utils import flag_enabled
+from corehq.util.test_utils import flag_enabled, generate_cases
 
 
 @patch_get_xform_resource_overrides()
@@ -234,3 +235,16 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
             suite,
             f"./remote-request[1]/instance[@id='{instance_id}']",
         )
+
+
+@generate_cases([
+    ("instance('test')/rows/row", {"test"}),
+    ("instance('test')/rows/row/0 != instance('test')/rows/row/1", {"test"}),
+    ("instance('one')/rows/row/0 != instance('two')/rows/row/1", {"one", "two"}),
+    ("instance( 'test' )/something", {"test"}),
+    ("""instance(
+        'search-input:results'
+    )/input/field[@name = 'first_name']""", {"search-input:results"}),
+], SuiteInstanceTests)
+def test_get_instance_names(self, xpath, expected_names):
+    self.assertEqual(get_instance_names(xpath), expected_names)


### PR DESCRIPTION
## Technical Summary
This fixes the regex to also match instance declarations with whitespace (see tests for examples).

I discovered this when looking at some USH apps which have instance delcations with whitespaces.

## Safety Assurance

### Safety story
This regex change is safe but it is possible it will cause app builds to fail if we now detect instances that are not supported which were not detected before.

### Automated test coverage
Tests added in this PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
