### PR TITLE
Add attendance tracking column to permissions table

### DIFF
--- a/corehq/apps/users/templates/users/roles_and_permissions.html
+++ b/corehq/apps/users/templates/users/roles_and_permissions.html
@@ -123,6 +123,11 @@
             {% trans "Data Registries" %}
           </th>
           {% endif %}
+          {% if request|toggle_enabled:"ATTENDANCE_TRACKING" %}
+          <th class="text-center">
+            {% trans "Attendance Tracking" %}
+          </th>
+          {% endif %}
           <th>{% trans "Actions" %}</th>
         </tr>
         </thead>
@@ -238,6 +243,14 @@
               </span>
             </div>
           </td>
+          {% endif %}
+          {% if request|toggle_enabled:"ATTENDANCE_TRACKING" %}
+            <td class="text-center">
+              <div data-bind="visible: permissions.manage_attendance_tracking,
+                                        permissionIcon: {
+                                          manage: permissions.manage_attendance_tracking,
+                                        }"></div>
+            </td>
           {% endif %}
           <td>
             <button class="btn btn-default" data-bind="visible: $data._id, click: $data._id ? $root.setRoleBeingEdited : null">

--- a/corehq/apps/users/templates/users/roles_and_permissions.html
+++ b/corehq/apps/users/templates/users/roles_and_permissions.html
@@ -123,7 +123,7 @@
             {% trans "Data Registries" %}
           </th>
           {% endif %}
-          {% if request|toggle_enabled:"ATTENDANCE_TRACKING" %}
+          {% if request|request_has_privilege:"ATTENDANCE_TRACKING" and request|toggle_enabled:"ATTENDANCE_TRACKING" %}
           <th class="text-center">
             {% trans "Attendance Tracking" %}
           </th>
@@ -244,7 +244,7 @@
             </div>
           </td>
           {% endif %}
-          {% if request|toggle_enabled:"ATTENDANCE_TRACKING" %}
+          {% if request|request_has_privilege:"ATTENDANCE_TRACKING" and request|toggle_enabled:"ATTENDANCE_TRACKING" %}
             <td class="text-center">
               <div data-bind="visible: permissions.manage_attendance_tracking,
                                         permissionIcon: {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Small UI change that adds a new column in the "Roles and Permissions" page to show which roles have the `manage_attendance_tracking` permission enabled.

![Screenshot from 2023-04-13 16-58-30](https://user-images.githubusercontent.com/122617251/231800981-15d0fcef-ee59-4b48-bded-53be5123d9e5.png)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2686).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ATTENDANCE_TRACKING`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Small UI change, have done local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
