### PR TITLE
Custom assertions in app manager

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -66,6 +66,13 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
 
     yield id_strings.current_language(), lang
 
+
+    for id, custom_assertion in enumerate(app.custom_assertions):
+        yield (
+            id_strings.app_custom_assertion_locale(id),
+            clean_trans(custom_assertion.text, langs)
+        )
+
     for module in app.get_modules():
         yield from _create_module_details_app_strings(module, langs)
 

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -66,7 +66,6 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
 
     yield id_strings.current_language(), lang
 
-
     for id, custom_assertion in enumerate(app.custom_assertions):
         yield (
             id_strings.custom_assertion_locale(id),

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -74,6 +74,12 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
             _maybe_add_index(clean_trans(module.name, langs), app)
         )
 
+        for id, custom_assertion in enumerate(module.custom_assertions):
+            yield (
+                id_strings.module_custom_assertion_locale(module, id),
+                clean_trans(custom_assertion.text, langs)
+            )
+
         yield from _create_icon_audio_app_strings(
             module,
             lang,

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -463,7 +463,7 @@ def _create_forms_app_strings(
 
         for id, custom_assertion in enumerate(form.custom_assertions):
             yield (
-                id_strings.custom_assertion_locale(module, form, id),
+                id_strings.form_custom_assertion_locale(module, form, id),
                 clean_trans(custom_assertion.text, langs)
             )
 

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -69,7 +69,7 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
 
     for id, custom_assertion in enumerate(app.custom_assertions):
         yield (
-            id_strings.app_custom_assertion_locale(id),
+            id_strings.custom_assertion_locale(id),
             clean_trans(custom_assertion.text, langs)
         )
 
@@ -83,7 +83,7 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
 
         for id, custom_assertion in enumerate(module.custom_assertions):
             yield (
-                id_strings.module_custom_assertion_locale(module, id),
+                id_strings.custom_assertion_locale(id, module),
                 clean_trans(custom_assertion.text, langs)
             )
 
@@ -476,7 +476,7 @@ def _create_forms_app_strings(
 
         for id, custom_assertion in enumerate(form.custom_assertions):
             yield (
-                id_strings.form_custom_assertion_locale(module, form, id),
+                id_strings.custom_assertion_locale(id, module, form),
                 clean_trans(custom_assertion.text, langs)
             )
 

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -190,3 +190,7 @@ class AppValidationError(AppManagerException):
 
 class DangerousXmlException(Exception):
     pass
+
+
+class AppMisconfigurationError(AppManagerException):
+    """Errors in app configuration that are the user's responsibility"""

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -215,3 +215,11 @@ class CommCareFeatureSupportMixin(object):
             toggles.USH_EMPTY_CASE_LIST_TEXT.enabled(self.domain)
             and self._require_minimum_version('2.54')
         )
+
+    @property
+    def supports_module_assertions(self):
+        # form-level assertions have been supported longer
+        return (
+            toggles.CUSTOM_ASSERTIONS.enabled(self.domain)
+            and self._require_minimum_version('2.54')
+        )

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -283,19 +283,12 @@ def search_property_required_text(module, search_prop):
 def search_property_validation_text(module, search_prop, index):
     return f"search_property.m{module.id}.{search_prop}.validation.{index}.text"
 
-
-@pattern('custom_assertion.m%d.f%d.%d')
-def form_custom_assertion_locale(module, form, id):
-    return 'custom_assertion.m{module.id}.f{form.id}.{id}'.format(module=module, form=form, id=id)
-
-
-@pattern('custom_assertion.m%d.%d')
-def module_custom_assertion_locale(module, id):
-    return 'custom_assertion.m{module.id}.{id}'.format(module=module, id=id)
-
-
-@pattern('custom_assertion.root.%d')
-def app_custom_assertion_locale(id):
+@pattern('custom_assertion.%s.%d')
+def custom_assertion_locale(id, module=None, form=None):
+    if module and form:
+        return 'custom_assertion.m{module.id}.f{form.id}.{id}'.format(module=module, form=form, id=id)
+    if module:
+        return 'custom_assertion.m{module.id}.{id}'.format(module=module, id=id)
     return 'custom_assertion.root.{id}'.format(id=id)
 
 

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -283,6 +283,7 @@ def search_property_required_text(module, search_prop):
 def search_property_validation_text(module, search_prop, index):
     return f"search_property.m{module.id}.{search_prop}.validation.{index}.text"
 
+
 @pattern('custom_assertion.%s.%d')
 def custom_assertion_locale(id, module=None, form=None):
     if module and form:

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -294,6 +294,11 @@ def module_custom_assertion_locale(module, id):
     return 'custom_assertion.m{module.id}.{id}'.format(module=module, id=id)
 
 
+@pattern('custom_assertion.root.%d')
+def app_custom_assertion_locale(id):
+    return 'custom_assertion.root.{id}'.format(id=id)
+
+
 @pattern('referral_lists.m%d')
 def referral_list_locale(module):
     """1.0 holdover"""

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -285,8 +285,13 @@ def search_property_validation_text(module, search_prop, index):
 
 
 @pattern('custom_assertion.m%d.f%d.%d')
-def custom_assertion_locale(module, form, id):
+def form_custom_assertion_locale(module, form, id):
     return 'custom_assertion.m{module.id}.f{form.id}.{id}'.format(module=module, form=form, id=id)
+
+
+@pattern('custom_assertion.m%d.%d')
+def module_custom_assertion_locale(module, id):
+    return 'custom_assertion.m{module.id}.{id}'.format(module=module, id=id)
 
 
 @pattern('referral_lists.m%d')

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -107,5 +107,28 @@ hqDefine("app_manager/js/app_view", function () {
                 initializeMultimediaTab();
             });
         }
+
+        // Custom Assertions
+        (function () {
+            var $form = $("#custom-assertions-form");
+            var $saveContainer = $form.find("#custom-assertions-save-btn");
+            var saveButton = hqImport("hqwebapp/js/main").initSaveButton({
+                save: function () {
+                    saveButton.ajax({
+                        url: $form.attr('action'),
+                        data: {
+                            custom_assertions: $form.find('input[name="custom_assertions"]').val(),
+                        },
+                        type: 'POST',
+                    });
+                },
+            });
+            $form.on('change', function () {
+                saveButton.fire('change');
+            });
+            saveButton.ui.appendTo($saveContainer);
+            hqImport("app_manager/js/section_changer").attachToForm($saveContainer);
+        })();
+
     });
 });

--- a/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
@@ -1,6 +1,7 @@
 /* globals ko */
-hqDefine('app_manager/js/forms/custom_assertions', function () {
+hqDefine('app_manager/js/custom_assertions', function () {
     'use strict';
+    var initialPageData = hqImport("hqwebapp/js/initial_page_data").get;
 
     var customAssertion = function (test, text) {
         var self = {};
@@ -47,5 +48,13 @@ hqDefine('app_manager/js/forms/custom_assertions', function () {
         return self;
     };
 
-    return customAssertions();
+    $(function () {
+        if (hqImport('hqwebapp/js/toggles').toggleEnabled('CUSTOM_ASSERTIONS')) {
+            var assertions = customAssertions().wrap({
+                'customAssertions': initialPageData('custom_assertions'),
+            });
+            $('#custom-assertions').koApplyBindings(assertions);
+        }
+    });
+
 });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -142,13 +142,6 @@ hqDefine("app_manager/js/forms/form_view", function () {
             $('#custom-instances').koApplyBindings(customInstances);
         }
 
-        if (hqImport('hqwebapp/js/toggles').toggleEnabled('CUSTOM_ASSERTIONS')) {
-            var customAssertions = hqImport('app_manager/js/forms/custom_assertions').wrap({
-                customAssertions: initialPageData('custom_assertions'),
-            });
-            $('#custom-assertions').koApplyBindings(customAssertions);
-        }
-
         // Case Management > Data dictionary descriptions for case properties
         $('.property-description').popover();
 

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -1,20 +1,23 @@
-from looseversion import LooseVersion
+from urllib.parse import quote, urljoin
 
 from django.urls import reverse
 
-from urllib.parse import quote, urljoin
+from looseversion import LooseVersion
 
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.exceptions import MediaResourceError
 from corehq.apps.app_manager.suite_xml.features.scheduler import (
     SchedulerFixtureContributor,
 )
+from corehq.apps.app_manager.suite_xml.post_process.endpoints import (
+    EndpointsHelper,
+)
 from corehq.apps.app_manager.suite_xml.post_process.instances import (
     EntryInstances,
 )
-from corehq.apps.app_manager.suite_xml.post_process.menu import GridMenuHelper
-from corehq.apps.app_manager.suite_xml.post_process.endpoints import (
-    EndpointsHelper,
+from corehq.apps.app_manager.suite_xml.post_process.menu import (
+    GridMenuHelper,
+    RootMenuAssertionsHelper,
 )
 from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
     RemoteRequestsHelper,
@@ -107,6 +110,8 @@ class SuiteGenerator(object):
             WorkflowHelper(self.suite, self.app, self.modules).update_suite()
         if self.app.use_grid_menus:
             GridMenuHelper(self.suite, self.app, self.modules).update_suite()
+        if self.app.custom_assertions:
+            RootMenuAssertionsHelper(self.suite, self.app, self.modules).update_suite()
 
         EntryInstances(self.suite, self.app, self.modules).update_suite()
         ResourceOverrideHelper(self.suite, self.app, self.modules).update_suite()

--- a/corehq/apps/app_manager/suite_xml/post_process/menu.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/menu.py
@@ -1,28 +1,38 @@
-"""
-GridMenuHelper
------------------
-
-This is pretty simple: it just adds a root menu if one isn't already present.
-"""
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml.contributors import PostProcessor
+from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
 from corehq.apps.app_manager.suite_xml.xml_models import Menu, Text
 from corehq.util.timer import time_method
 
 
+def _get_root_menu(menus):
+    for menu in menus:
+        if menu.id == id_strings.ROOT:
+            return menu
+
+
 class GridMenuHelper(PostProcessor):
+    """This is pretty simple: it just adds a root menu if one isn't already present."""
 
     @time_method()
     def update_suite(self):
-        """
-        Ensure that there exists at least one menu where id="root".
-        """
-        if not self._contains_root_menu(self.suite.menus):
+        """Ensure that there exists at least one menu where id="root"."""
+        if not _get_root_menu(self.suite.menus):
             self.suite.menus.append(Menu(id=id_strings.ROOT, text=Text(), style="grid"))
 
-    @staticmethod
-    def _contains_root_menu(menus):
-        for menu in menus:
-            if menu.id == id_strings.ROOT:
-                return True
-        return False
+
+class RootMenuAssertionsHelper(PostProcessor):
+    """Set app-level custom assertions on root menu, creating one if necessary"""
+
+    @time_method()
+    def update_suite(self):
+        root_menu = _get_root_menu(self.suite.menus)
+        if not root_menu:
+            root_menu = Menu(id=id_strings.ROOT, text=Text())
+            self.suite.menus.append(root_menu)
+
+        for id, assertion in enumerate(self.app.custom_assertions):
+            root_menu.assertions.append(EntriesHelper.get_assertion(
+                assertion.test,
+                id_strings.app_custom_assertion_locale(id),
+            ))

--- a/corehq/apps/app_manager/suite_xml/post_process/menu.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/menu.py
@@ -34,5 +34,5 @@ class RootMenuAssertionsHelper(PostProcessor):
         for id, assertion in enumerate(self.app.custom_assertions):
             root_menu.assertions.append(EntriesHelper.get_assertion(
                 assertion.test,
-                id_strings.app_custom_assertion_locale(id),
+                id_strings.custom_assertion_locale(id),
             ))

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -370,7 +370,7 @@ class EntriesHelper(object):
     @staticmethod
     def add_custom_assertions(entry, form):
         for id, assertion in enumerate(form.custom_assertions):
-            locale_id = id_strings.custom_assertion_locale(form.get_module(), form, id)
+            locale_id = id_strings.form_custom_assertion_locale(form.get_module(), form, id)
             entry.assertions.append(EntriesHelper.get_assertion(assertion.test, locale_id))
 
     @staticmethod

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -370,7 +370,7 @@ class EntriesHelper(object):
     @staticmethod
     def add_custom_assertions(entry, form):
         for id, assertion in enumerate(form.custom_assertions):
-            locale_id = id_strings.form_custom_assertion_locale(form.get_module(), form, id)
+            locale_id = id_strings.custom_assertion_locale(id, form.get_module(), form)
             entry.assertions.append(EntriesHelper.get_assertion(assertion.test, locale_id))
 
     @staticmethod

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -29,6 +29,7 @@ from corehq.apps.app_manager.exceptions import (
 from corehq.apps.app_manager.suite_xml.contributors import (
     SuiteContributorByModule,
 )
+from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
 from corehq.apps.app_manager.suite_xml.utils import get_module_locale_id
 from corehq.apps.app_manager.suite_xml.xml_models import (
     Command,
@@ -191,6 +192,13 @@ class MenuContributor(SuiteContributorByModule):
             training_menu.commands.extend(commands)
         else:
             menu.commands.extend(commands)
+
+        for id, assertion in enumerate(module.custom_assertions):
+            menu.assertions.append(EntriesHelper.get_assertion(
+                assertion.test,
+                id_strings.module_custom_assertion_locale(module, id),
+            ))
+
         return menu
 
     @staticmethod

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -196,7 +196,7 @@ class MenuContributor(SuiteContributorByModule):
         for id, assertion in enumerate(module.custom_assertions):
             menu.assertions.append(EntriesHelper.get_assertion(
                 assertion.test,
-                id_strings.module_custom_assertion_locale(module, id),
+                id_strings.custom_assertion_locale(id, module),
             ))
 
         return menu

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -619,6 +619,7 @@ class MenuMixin(XmlObject):
     relevant = XPathField('@relevant')
     style = StringField('@style')
     commands = NodeListField('command', Command)
+    assertions = NodeListField('assertions/assert', Assertion)
 
 
 class Menu(MenuMixin, DisplayNode, IdNode):

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -72,11 +72,6 @@
       <script src="{% static 'app_manager/js/forms/custom_instances.js' %}"></script>
     {% endcompress %}
   {% endif %}
-  {% if request|toggle_enabled:"CUSTOM_ASSERTIONS"%}
-    {% compress js %}
-      <script src="{% static 'app_manager/js/forms/custom_assertions.js' %}"></script>
-    {% endcompress %}
-  {% endif %}
   {% if allow_form_copy and request|toggle_enabled:"COPY_FORM_TO_APP" %}
     {% compress js %}
       <script src="{% static 'app_manager/js/forms/copy_form_to_app.js' %}"></script>
@@ -129,7 +124,6 @@
   {% initial_page_data 'case_config_options' case_config_options %}
   {% initial_page_data 'current_language' lang %}
   {% initial_page_data 'custom_instances' custom_instances %}
-  {% initial_page_data 'custom_assertions' custom_assertions %}
   {% initial_page_data 'default_language' app.default_language %}
   {% initial_page_data 'enable_release_notes' form.enable_release_notes %}
   {% initial_page_data 'form_filter' form.form_filter %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/custom_assertions.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/custom_assertions.html
@@ -1,4 +1,7 @@
 {% load i18n %}
+{% load hq_shared_tags %}
+{% initial_page_data 'custom_assertions' custom_assertions %}
+<script src="{% static 'app_manager/js/custom_assertions.js' %}"></script>
 <label class="control-label col-sm-2">
   {% trans "Custom Assertions" %}
   <span class="hq-help-template"

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -268,6 +268,11 @@
               </div>
             </div>
             {% endif %}
+
+            {% if request|toggle_enabled:'CUSTOM_ASSERTIONS' %}
+              {% include "app_manager/partials/forms/custom_assertions.html" %}
+            {% endif %}
+
           </div><!-- end .panel-body -->
         </div><!-- end .panel -->
       {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -269,7 +269,7 @@
             </div>
             {% endif %}
 
-            {% if request|toggle_enabled:'CUSTOM_ASSERTIONS' %}
+            {% if app.supports_module_assertions %}
               {% include "app_manager/partials/forms/custom_assertions.html" %}
             {% endif %}
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -221,7 +221,7 @@
       <li><a href="#add-ons" data-toggle="tab">{% trans "Add-ons" %}</a></li>
     {% endif %}
     <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
-    {% if not is_linked_app and not is_remote_app and request|toggle_enabled:'CUSTOM_ASSERTIONS' %}
+    {% if not is_linked_app and not is_remote_app and app.supports_module_assertions %}
       <li><a href="#custom-assertions-tab" data-toggle="tab">{% trans "Custom Assertions" %}</a></li>
     {% endif %}
   </ul>
@@ -330,7 +330,7 @@
       {% include 'app_manager/partials/settings/commcare_settings.html' %}
     </div>
 
-    {% if not is_linked_app and not is_remote_app and request|toggle_enabled:'CUSTOM_ASSERTIONS' %}
+    {% if not is_linked_app and not is_remote_app and app.supports_module_assertions %}
       <div class="tab-pane" id="custom-assertions-tab">
         <form action="{% url 'edit_app_attr' domain app.id 'custom_assertions' %}"
               id="custom-assertions-form"

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -221,6 +221,9 @@
       <li><a href="#add-ons" data-toggle="tab">{% trans "Add-ons" %}</a></li>
     {% endif %}
     <li><a href="#commcare-settings" data-toggle="tab">{% trans "Advanced Settings" %}</a></li>
+    {% if not is_linked_app and not is_remote_app and request|toggle_enabled:'CUSTOM_ASSERTIONS' %}
+      <li><a href="#custom-assertions-tab" data-toggle="tab">{% trans "Custom Assertions" %}</a></li>
+    {% endif %}
   </ul>
   <div class="tab-content appmanager-tab-content">
     {% if is_linked_app %}
@@ -326,5 +329,17 @@
     <div class="tab-pane" id="commcare-settings">
       {% include 'app_manager/partials/settings/commcare_settings.html' %}
     </div>
+
+    {% if not is_linked_app and not is_remote_app and request|toggle_enabled:'CUSTOM_ASSERTIONS' %}
+      <div class="tab-pane" id="custom-assertions-tab">
+        <form action="{% url 'edit_app_attr' domain app.id 'custom_assertions' %}"
+              id="custom-assertions-form"
+              method="POST">{% csrf_token %}
+          <div id="custom-assertions-save-btn"></div>
+          {% include "app_manager/partials/forms/custom_assertions.html" %}
+        </form>
+      </div>
+    {% endif %}
+
   </div>
 </div>

--- a/corehq/apps/app_manager/tests/test_suite_assertions.py
+++ b/corehq/apps/app_manager/tests/test_suite_assertions.py
@@ -58,7 +58,6 @@ class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
         self.assertEqual(fr_app_strings[f'custom_assertion.{entity_code}.0'], "fr-0")
         self.assertEqual(fr_app_strings[f'custom_assertion.{entity_code}.1'], "fr-1")
 
-
     def test_custom_form_assertions(self, *args):
         factory = AppFactory()
         module, form = factory.new_basic_module('m0', 'case1')
@@ -80,3 +79,14 @@ class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
             "menu[@id='m0']/assertions"
         )
         self._assert_translations(factory.app, 'm0')
+
+    def test_custom_app_assertions(self, *args):
+        factory = AppFactory()
+        module, form = factory.new_basic_module('m0', 'case1')
+        factory.app.custom_assertions = self._custom_assertions
+        self.assertXmlPartialEqual(
+            self._get_expected_xml('root'),
+            factory.app.create_suite(),
+            "menu[@id='root']/assertions"
+        )
+        self._assert_translations(factory.app, 'root')

--- a/corehq/apps/app_manager/tests/test_suite_assertions.py
+++ b/corehq/apps/app_manager/tests/test_suite_assertions.py
@@ -24,33 +24,36 @@ class DefaultSuiteAssertionsTest(SimpleTestCase, SuiteMixin):
 
 @patch_get_xform_resource_overrides()
 class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
-    def test_custom_assertions(self, *args):
-        factory = AppFactory()
-        module, form = factory.new_basic_module('m0', 'case1')
-
-        tests = ["foo = 'bar' and baz = 'buzz'", "count(instance('casedb')/casedb/case[@case_type='friend']) > 0"]
-
-        form.custom_assertions = [
-            CustomAssertion(test=test, text={'en': "en-{}".format(id), "fr": "fr-{}".format(id)})
-            for id, test in enumerate(tests)
+    def setUp(self):
+        _assertion_0 = "foo = 'bar' and baz = 'buzz'"
+        _assertion_1 = "count(instance('casedb')/casedb/case[@case_type='friend']) > 0"
+        self._custom_assertions = [
+            CustomAssertion(test=_assertion_0, text={'en': "en-0", "fr": "fr-0"}),
+            CustomAssertion(test=_assertion_1, text={'en': "en-1", "fr": "fr-1"}),
         ]
-        assertions_xml = [
-            """
-                <assert test="{test}">
-                    <text>
-                        <locale id="custom_assertion.m0.f0.{id}"/>
-                    </text>
-                </assert>
-            """.format(test=test, id=id) for id, test in enumerate(tests)
-        ]
-        self.assertXmlPartialEqual(
-            """
+        self._assertions_xml = f"""
             <partial>
                 <assertions>
-                    {assertions}
+                    <assert test="{_assertion_0}">
+                        <text>
+                            <locale id="custom_assertion.m0.f0.0"/>
+                        </text>
+                    </assert>
+                    <assert test="{_assertion_1}">
+                        <text>
+                            <locale id="custom_assertion.m0.f0.1"/>
+                        </text>
+                    </assert>
                 </assertions>
             </partial>
-            """.format(assertions="".join(assertions_xml)),
+        """
+
+    def test_custom_form_assertions(self, *args):
+        factory = AppFactory()
+        module, form = factory.new_basic_module('m0', 'case1')
+        form.custom_assertions = self._custom_assertions
+        self.assertXmlPartialEqual(
+            self._assertions_xml,
             factory.app.create_suite(),
             "entry/assertions"
         )

--- a/corehq/apps/app_manager/tests/test_suite_assertions.py
+++ b/corehq/apps/app_manager/tests/test_suite_assertions.py
@@ -50,6 +50,15 @@ class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
             </partial>
         """
 
+    def _assert_translations(self, app, entity_code):
+        en_app_strings = commcare_translations.loads(app.create_app_strings('en'))
+        self.assertEqual(en_app_strings[f'custom_assertion.{entity_code}.0'], "en-0")
+        self.assertEqual(en_app_strings[f'custom_assertion.{entity_code}.1'], "en-1")
+        fr_app_strings = commcare_translations.loads(app.create_app_strings('fr'))
+        self.assertEqual(fr_app_strings[f'custom_assertion.{entity_code}.0'], "fr-0")
+        self.assertEqual(fr_app_strings[f'custom_assertion.{entity_code}.1'], "fr-1")
+
+
     def test_custom_form_assertions(self, *args):
         factory = AppFactory()
         module, form = factory.new_basic_module('m0', 'case1')
@@ -59,13 +68,7 @@ class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
             factory.app.create_suite(),
             "entry/assertions"
         )
-
-        en_app_strings = commcare_translations.loads(module.get_app().create_app_strings('en'))
-        self.assertEqual(en_app_strings['custom_assertion.m0.f0.0'], "en-0")
-        self.assertEqual(en_app_strings['custom_assertion.m0.f0.1'], "en-1")
-        fr_app_strings = commcare_translations.loads(module.get_app().create_app_strings('fr'))
-        self.assertEqual(fr_app_strings['custom_assertion.m0.f0.0'], "fr-0")
-        self.assertEqual(fr_app_strings['custom_assertion.m0.f0.1'], "fr-1")
+        self._assert_translations(factory.app, 'm0.f0')
 
     def test_custom_module_assertions(self, *args):
         factory = AppFactory()
@@ -76,3 +79,4 @@ class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
             factory.app.create_suite(),
             "menu[@id='m0']/assertions"
         )
+        self._assert_translations(factory.app, 'm0')

--- a/corehq/apps/app_manager/tests/test_suite_assertions.py
+++ b/corehq/apps/app_manager/tests/test_suite_assertions.py
@@ -12,7 +12,7 @@ from corehq.apps.app_manager.tests.util import (
 
 
 @patch_get_xform_resource_overrides()
-class SuiteAssertionsTest(SimpleTestCase, SuiteMixin):
+class DefaultSuiteAssertionsTest(SimpleTestCase, SuiteMixin):
     file_path = ('data', 'suite')
 
     def test_case_assertions(self, *args):
@@ -21,6 +21,9 @@ class SuiteAssertionsTest(SimpleTestCase, SuiteMixin):
     def test_no_case_assertions(self, *args):
         self._test_generic_suite('app_no_case_sharing', 'suite-no-case-sharing')
 
+
+@patch_get_xform_resource_overrides()
+class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
     def test_custom_assertions(self, *args):
         factory = AppFactory()
         module, form = factory.new_basic_module('m0', 'case1')

--- a/corehq/apps/app_manager/tests/test_suite_assertions.py
+++ b/corehq/apps/app_manager/tests/test_suite_assertions.py
@@ -25,23 +25,25 @@ class DefaultSuiteAssertionsTest(SimpleTestCase, SuiteMixin):
 @patch_get_xform_resource_overrides()
 class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
     def setUp(self):
-        _assertion_0 = "foo = 'bar' and baz = 'buzz'"
-        _assertion_1 = "count(instance('casedb')/casedb/case[@case_type='friend']) > 0"
+        self._assertion_0 = "foo = 'bar' and baz = 'buzz'"
+        self._assertion_1 = "count(instance('casedb')/casedb/case[@case_type='friend']) > 0"
         self._custom_assertions = [
-            CustomAssertion(test=_assertion_0, text={'en': "en-0", "fr": "fr-0"}),
-            CustomAssertion(test=_assertion_1, text={'en': "en-1", "fr": "fr-1"}),
+            CustomAssertion(test=self._assertion_0, text={'en': "en-0", "fr": "fr-0"}),
+            CustomAssertion(test=self._assertion_1, text={'en': "en-1", "fr": "fr-1"}),
         ]
-        self._assertions_xml = f"""
+
+    def _get_expected_xml(self, entity_code):
+        return f"""
             <partial>
                 <assertions>
-                    <assert test="{_assertion_0}">
+                    <assert test="{self._assertion_0}">
                         <text>
-                            <locale id="custom_assertion.m0.f0.0"/>
+                            <locale id="custom_assertion.{entity_code}.0"/>
                         </text>
                     </assert>
-                    <assert test="{_assertion_1}">
+                    <assert test="{self._assertion_1}">
                         <text>
-                            <locale id="custom_assertion.m0.f0.1"/>
+                            <locale id="custom_assertion.{entity_code}.1"/>
                         </text>
                     </assert>
                 </assertions>
@@ -53,7 +55,7 @@ class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
         module, form = factory.new_basic_module('m0', 'case1')
         form.custom_assertions = self._custom_assertions
         self.assertXmlPartialEqual(
-            self._assertions_xml,
+            self._get_expected_xml('m0.f0'),
             factory.app.create_suite(),
             "entry/assertions"
         )
@@ -64,3 +66,13 @@ class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
         fr_app_strings = commcare_translations.loads(module.get_app().create_app_strings('fr'))
         self.assertEqual(fr_app_strings['custom_assertion.m0.f0.0'], "fr-0")
         self.assertEqual(fr_app_strings['custom_assertion.m0.f0.1'], "fr-1")
+
+    def test_custom_module_assertions(self, *args):
+        factory = AppFactory()
+        module, form = factory.new_basic_module('m0', 'case1')
+        module.custom_assertions = self._custom_assertions
+        self.assertXmlPartialEqual(
+            self._get_expected_xml('m0'),
+            factory.app.create_suite(),
+            "menu[@id='m0']/assertions"
+        )

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -80,7 +80,7 @@ from corehq.apps.app_manager.views.utils import (
     capture_user_errors,
     clear_xmlns_app_id_cache,
     get_langs,
-    handle_custom_assertions,
+    validate_custom_assertions,
     update_linked_app,
     validate_langs,
 )
@@ -932,7 +932,7 @@ def edit_app_attr(request, domain, app_id, attr):
             app.cloudcare_enabled = False
 
     if should_edit('custom_assertions'):
-        handle_custom_assertions(hq_settings[attr], app, lang)
+        app.custom_assertions = validate_custom_assertions(hq_settings[attr], app.custom_assertions, lang)
 
     def require_remote_app():
         if not is_remote_app(app):

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -77,6 +77,7 @@ from corehq.apps.app_manager.util import (
 from corehq.apps.app_manager.util import enable_usercase as enable_usercase_util
 from corehq.apps.app_manager.views.utils import (
     back_to_main,
+    capture_user_errors,
     clear_xmlns_app_id_cache,
     get_langs,
     handle_custom_assertions,
@@ -812,6 +813,7 @@ def get_app_ui_translations(request, domain):
 @no_conflict_require_POST
 @require_can_edit_apps
 @track_domain_request(calculated_prop='cp_n_saved_app_changes')
+@capture_user_errors
 def edit_app_attr(request, domain, app_id, attr):
     """
     Called to edit any (supported) app attribute, given by attr

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -51,6 +51,7 @@ from corehq.apps.app_manager.decorators import (
     require_deploy_apps,
 )
 from corehq.apps.app_manager.exceptions import (
+    AppMisconfigurationError,
     FormNotFoundException,
     XFormValidationFailed,
     ModuleNotFoundException,
@@ -100,8 +101,7 @@ from corehq.apps.app_manager.views.utils import (
     form_has_submissions,
     get_langs,
     handle_custom_icon_edits,
-    handle_custom_assertions,
-    InvalidSessionEndpoint,
+    validate_custom_assertions,
     set_session_endpoint,
 )
 from corehq.apps.app_manager.xform import (
@@ -375,11 +375,10 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
     if should_edit('enable_release_notes'):
         form.enable_release_notes = request.POST['enable_release_notes'] == 'true'
         if not form.is_release_notes_form and form.enable_release_notes:
-            return json_response(
-                {'message': _("You can't enable a form as release notes without allowing it as "
-                    "a release notes form <TODO messaging>")},
-                status_code=400
-            )
+            raise AppMisconfigurationError(_(
+                "You can't enable a form as release notes without allowing it as "
+                "a release notes form <TODO messaging>"
+            ))
     if (should_edit("form_links_xpath_expressions")
             and should_edit("form_links_form_ids")
             and domain_has_privilege(domain, privileges.FORM_LINK_WORKFLOW)):
@@ -428,9 +427,8 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
                     )
                 )
         except etree.XMLSyntaxError as error:
-            return json_response(
-                {'message': _("There was an issue with your custom instances: {}").format(error)},
-                status_code=400
+            raise AppMisconfigurationError(
+                _("There was an issue with your custom instances: {}").format(error)
             )
 
         form.custom_instances = [
@@ -447,19 +445,11 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
         form.shadow_parent_form_id = request.POST['shadow_parent']
 
     if should_edit("custom_icon_form"):
-        error_message = handle_custom_icon_edits(request, form, lang)
-        if error_message:
-            return json_response(
-                {'message': error_message},
-                status_code=400
-            )
+        handle_custom_icon_edits(request, form, lang)
 
     if should_edit('session_endpoint_id'):
         raw_endpoint_id = request.POST['session_endpoint_id']
-        try:
-            set_session_endpoint(form, raw_endpoint_id, app)
-        except InvalidSessionEndpoint as e:
-            return json_response({'message': str(e)}, status_code=400)
+        set_session_endpoint(form, raw_endpoint_id, app)
 
     if should_edit('function_datum_endpoints'):
         if request.POST['function_datum_endpoints']:

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -95,6 +95,7 @@ from corehq.apps.app_manager.views.schedules import get_schedule_context
 from corehq.apps.app_manager.views.utils import (
     CASE_TYPE_CONFLICT_MSG,
     back_to_main,
+    capture_user_errors,
     clear_xmlns_app_id_cache,
     form_has_submissions,
     get_langs,
@@ -268,6 +269,7 @@ def edit_form_attr(request, domain, app_id, form_unique_id, attr):
 
 @no_conflict_require_POST
 @require_permission(HqPermissions.edit_apps, login_decorator=None)
+@capture_user_errors
 def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
     """
     Called to edit any (supported) form attribute, given by attr
@@ -439,12 +441,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
         ]
 
     if should_edit("custom_assertions"):
-        error_message = handle_custom_assertions(request.POST.get('custom_assertions'), form, lang)
-        if error_message:
-            return json_response(
-                {'message': error_message},
-                status_code=400
-            )
+        handle_custom_assertions(request.POST.get('custom_assertions'), form, lang)
 
     if should_edit("shadow_parent"):
         form.shadow_parent_form_id = request.POST['shadow_parent']

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -439,7 +439,11 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
         ]
 
     if should_edit("custom_assertions"):
-        handle_custom_assertions(request.POST.get('custom_assertions'), form, lang)
+        form.custom_assertions = validate_custom_assertions(
+            request.POST.get('custom_assertions'),
+            form.custom_assertions,
+            lang,
+        )
 
     if should_edit("shadow_parent"):
         form.shadow_parent_form_id = request.POST['shadow_parent']

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -62,7 +62,6 @@ from corehq.apps.app_manager.models import (
     AppEditingError,
     ArbitraryDatum,
     CaseReferences,
-    CustomAssertion,
     CustomIcon,
     CustomInstance,
     DeleteFormRecord,
@@ -100,6 +99,7 @@ from corehq.apps.app_manager.views.utils import (
     form_has_submissions,
     get_langs,
     handle_custom_icon_edits,
+    handle_custom_assertions,
     InvalidSessionEndpoint,
     set_session_endpoint,
 )
@@ -438,35 +438,13 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
             ) for instance in instances
         ]
 
-    if should_edit('custom_assertions'):
-        assertions = json.loads(request.POST.get('custom_assertions'))
-        try:  # validate that custom assertions can be added into the XML
-            for assertion in assertions:
-                etree.fromstring(
-                    '<assertion test="{test}"><text><locale id="abc.def"/>{text}</text></assertion>'.format(
-                        **assertion
-                    )
-                )
-        except etree.XMLSyntaxError as error:
+    if should_edit("custom_assertions"):
+        error_message = handle_custom_assertions(request, form, lang)
+        if error_message:
             return json_response(
-                {'message': _("There was an issue with your custom assertions: {}").format(error)},
+                {'message': error_message},
                 status_code=400
             )
-
-        existing_assertions = {assertion.test: assertion for assertion in form.custom_assertions}
-        new_assertions = []
-        for assertion in assertions:
-            try:
-                new_assertion = existing_assertions[assertion.get('test')]
-                new_assertion.text[lang] = assertion.get('text')
-            except KeyError:
-                new_assertion = CustomAssertion(
-                    test=assertion.get('test'),
-                    text={lang: assertion.get('text')}
-                )
-            new_assertions.append(new_assertion)
-
-        form.custom_assertions = new_assertions
 
     if should_edit("shadow_parent"):
         form.shadow_parent_form_id = request.POST['shadow_parent']

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -439,7 +439,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
         ]
 
     if should_edit("custom_assertions"):
-        error_message = handle_custom_assertions(request, form, lang)
+        error_message = handle_custom_assertions(request.POST.get('custom_assertions'), form, lang)
         if error_message:
             return json_response(
                 {'message': error_message},

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -100,7 +100,7 @@ from corehq.apps.app_manager.views.utils import (
     capture_user_errors,
     clear_xmlns_app_id_cache,
     get_langs,
-    handle_custom_assertions,
+    validate_custom_assertions,
     handle_custom_icon_edits,
     handle_shadow_child_modules,
     set_session_endpoint,
@@ -773,7 +773,11 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
         set_session_endpoint(module, raw_endpoint_id, app)
 
     if should_edit('custom_assertions'):
-        handle_custom_assertions(request.POST.get('custom_assertions'), module, lang)
+        module.custom_assertions = validate_custom_assertions(
+            request.POST.get('custom_assertions'),
+            module.custom_assertions,
+            lang,
+        )
 
     handle_media_edits(request, module, should_edit, resp, lang)
     handle_media_edits(request, module.case_list_form, should_edit, resp, lang, prefix='case_list_form_')

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -94,6 +94,7 @@ from corehq.apps.app_manager.views.media_utils import (
 from corehq.apps.app_manager.views.utils import (
     back_to_main,
     bail,
+    capture_user_errors,
     clear_xmlns_app_id_cache,
     get_langs,
     handle_custom_assertions,
@@ -579,6 +580,7 @@ def _case_list_form_not_allowed_reasons(module):
 @no_conflict_require_POST
 @require_can_edit_apps
 @track_domain_request(calculated_prop='cp_n_saved_app_changes')
+@capture_user_errors
 def edit_module_attr(request, domain, app_id, module_unique_id, attr):
     """
     Called to edit any (supported) module attribute, given by attr

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -777,7 +777,7 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
             return HttpResponseBadRequest(str(e))
 
     if should_edit('custom_assertions'):
-        handle_custom_assertions(request, module, lang)
+        handle_custom_assertions(request.POST.get('custom_assertions'), module, lang)
 
     handle_media_edits(request, module, should_edit, resp, lang)
     handle_media_edits(request, module.case_list_form, should_edit, resp, lang, prefix='case_list_form_')

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -643,8 +643,7 @@ def report_build_time(domain, app_id, build_type):
         })
 
 
-# TODO factor this out better - accept only what we need from request, and don't modify form here
-def handle_custom_assertions(custom_assertions_string, form, lang):
+def validate_custom_assertions(custom_assertions_string, existing_assertions, lang):
     assertions = json.loads(custom_assertions_string)
     try:  # validate that custom assertions can be added into the XML
         for assertion in assertions:
@@ -656,7 +655,7 @@ def handle_custom_assertions(custom_assertions_string, form, lang):
     except etree.XMLSyntaxError as error:
         raise AppMisconfigurationError(_("There was an issue with your custom assertions: {}").format(error))
 
-    existing_assertions = {assertion.test: assertion for assertion in form.custom_assertions}
+    existing_assertions = {assertion.test: assertion for assertion in existing_assertions}
     new_assertions = []
     for assertion in assertions:
         try:
@@ -669,7 +668,7 @@ def handle_custom_assertions(custom_assertions_string, form, lang):
             )
         new_assertions.append(new_assertion)
 
-    form.custom_assertions = new_assertions
+    return new_assertions
 
 
 def capture_user_errors(view_fn):

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -7,12 +7,11 @@ from functools import partial, wraps
 from lxml import etree
 
 from django.contrib import messages
-from django.http import Http404, HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect, JsonResponse
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
-from dimagi.utils.web import json_response
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import (
@@ -678,5 +677,5 @@ def capture_user_errors(view_fn):
         try:
             return view_fn(request, *args, **kwargs)
         except AppMisconfigurationError as e:
-            return json_response({'message': str(e)}, status_code=400)
+            return JsonResponse({'message': str(e)}, status=400)
     return inner

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -646,8 +646,8 @@ def report_build_time(domain, app_id, build_type):
 
 
 # TODO factor this out better - accept only what we need from request, and don't modify form here
-def handle_custom_assertions(request, form, lang):
-    assertions = json.loads(request.POST.get('custom_assertions'))
+def handle_custom_assertions(custom_assertions_string, form, lang):
+    assertions = json.loads(custom_assertions_string)
     try:  # validate that custom assertions can be added into the XML
         for assertion in assertions:
             etree.fromstring(

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -300,7 +300,7 @@ def handle_custom_icon_edits(request, form_or_module, lang):
         if icon_form:
             # validate that only of either text or xpath should be present
             if (icon_text_body and icon_xpath) or (not icon_text_body and not icon_xpath):
-                return _("Please enter either text body or xpath for custom icon")
+                raise AppMisconfigurationError(_("Please enter either text body or xpath for custom icon"))
 
             # a form should have just one custom icon for now
             # so this just adds a new one with params or replaces the existing one with new params
@@ -589,21 +589,17 @@ def handle_shadow_child_modules(app, shadow_parent):
     return changes
 
 
-class InvalidSessionEndpoint(Exception):
-    pass
-
-
 def set_session_endpoint(module_or_form, raw_endpoint_id, app):
     raw_endpoint_id = raw_endpoint_id.strip()
     cleaned_id = slugify(raw_endpoint_id)
     if cleaned_id != raw_endpoint_id:
-        raise InvalidSessionEndpoint(_(
+        raise AppMisconfigurationError(_(
             "'{invalid_id}' is not a valid session endpoint ID. It must contain only "
             "lowercase letters, numbers, underscores, and hyphens. Try {valid_id}."
         ).format(invalid_id=raw_endpoint_id, valid_id=cleaned_id))
 
     if _is_duplicate_endpoint_id(cleaned_id, module_or_form.session_endpoint_id, app):
-        raise InvalidSessionEndpoint(_(
+        raise AppMisconfigurationError(_(
             "Session endpoint IDs must be unique. '{endpoint_id}' is already in-use"
         ).format(endpoint_id=cleaned_id))
 


### PR DESCRIPTION
## Product Description
The goal of this work is to allow app builders to codify expectations they have about the mobile worker and the information in their restore.
This PR expands the `CUSTOM_ASSERTIONS` feature flag ("Inject custom assertions into the suite") - confluence page [here](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=saas&title=User+defined+assert+blocks).
That same widget is now available on the module and app settings pages:

![image](https://user-images.githubusercontent.com/2367539/232137033-7c6fc40c-6727-4023-bf2f-d7fee9b45fe7.png)

![image](https://user-images.githubusercontent.com/2367539/232137114-be06dd29-459d-4b10-84a3-3a6d88db4e25.png)

## Technical Summary
https://docs.google.com/document/d/112St-i7h7jZHpqxcAU-d6VASftXKLfiFnqkS3ovsEVU/edit
This is the two HQ dev ticket in this jira epic: https://dimagi-dev.atlassian.net/browse/USH-2905

Since this is hidden behind a feature flag that doesn't appear to be in real use, I hope to do QA on master once the mobile side is ready.  Reviewers: please flag if there's anything you don't think is adequately protected by the feature flag to allow post facto QA.

## Feature Flag
CUSTOM_ASSERTIONS: Inject custom assertions into the suite

## Safety Assurance

### Safety story
Local testing, plus this is behind a feature flag, so we can QA separately

### Automated test coverage
Suite file tests included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Holding off for mobile component, to test the two together

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

I PR'd the model changes in advance (https://github.com/dimagi/commcare-hq/pull/32793), so we should be able to roll back this PR if needed, without risking weirdness around Document schemas changing

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
