### PR TITLE
Set attendee location on create

### DIFF
--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -4,6 +4,7 @@ hqDefine("events/js/event_attendees",[
     'underscore',
     'hqwebapp/js/initial_page_data',
     'jquery.rmi/jquery.rmi',
+    'locations/js/widgets',
     "hqwebapp/js/widgets",
     "hqwebapp/js/components.ko", // for pagination
 ], function (
@@ -11,7 +12,8 @@ hqDefine("events/js/event_attendees",[
     ko,
     _,
     initialPageData,
-    RMI
+    RMI,
+    locationsWidgets
 ) {
     'use strict';
 
@@ -32,6 +34,7 @@ hqDefine("events/js/event_attendees",[
             creationStatus: STATUS_CSS.NONE,
             creationError: '',
             name: '',
+            location_id: '',
             case_id: '',
         });
 
@@ -169,6 +172,12 @@ hqDefine("events/js/event_attendees",[
 
         self.initializeAttendee = function () {
             self.stagedAttendee(attendeeModel({}));
+
+            var $locationSelect = $("#id_location_id");
+            if ($locationSelect.length) {
+                locationsWidgets.initAutocomplete($locationSelect);
+            }
+
         };
 
         self.submitNewAttendee = function () {

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -5,8 +5,6 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_GET
 
-from memoized import memoized
-
 from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views.base import BaseDomainView
@@ -24,6 +22,8 @@ from .models import (
     EVENT_IN_PROGRESS,
     EVENT_NOT_STARTED,
     EVENT_STATUS_TRANS,
+    LOCATION_IDS_CASE_PROPERTY,
+    PRIMARY_LOCATION_ID_CASE_PROPERTY,
     AttendeeModel,
     Event,
     get_attendee_case_type,
@@ -282,23 +282,33 @@ class AttendeesListView(JSONResponseMixin, BaseEventView):
     def page_context(self):
         context = super().page_context
         if self.request.method == "POST":
-            context['new_attendee_form'] = NewAttendeeForm(self.request.POST)
+            form = NewAttendeeForm(self.request.POST, domain=self.domain)
         else:
-            context['new_attendee_form'] = NewAttendeeForm()
-        return context
+            form = NewAttendeeForm(domain=self.domain)
+        return context | {'new_attendee_form': form}
 
     @allow_remote_invocation
     def create_attendee(self, data):
         form_data = data['attendee'] | {
             'domain': self.domain,
         }
-        form = NewAttendeeForm(form_data)
+        form = NewAttendeeForm(form_data, domain=self.domain)
         if form.is_valid():
+            if form.cleaned_data['location_id']:
+                properties = {
+                    LOCATION_IDS_CASE_PROPERTY:
+                        form.cleaned_data['location_id'],
+                    PRIMARY_LOCATION_ID_CASE_PROPERTY:
+                        form.cleaned_data['location_id'],
+                }
+            else:
+                properties = {}
             helper = CaseHelper(domain=self.domain)
             helper.create_case({
                 'case_type': get_attendee_case_type(self.domain),
                 'case_name': form.cleaned_data['name'],
                 'owner_id': self.request.couch_user.user_id,
+                'properties': properties,
             })
             return {
                 'success': True,

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1,5 +1,3 @@
-from corehq.apps.accounting.utils.subscription import is_domain_enterprise
-from corehq.apps.enterprise.dispatcher import EnterpriseReportDispatcher
 from django.conf import settings
 from django.http import Http404
 from django.urls import reverse
@@ -11,18 +9,17 @@ from django_prbac.utils import has_privilege
 from memoized import memoized
 from six.moves.urllib.parse import urlencode
 
-from corehq.apps.enterprise.views import ManageEnterpriseMobileWorkersView
-from corehq.apps.users.decorators import get_permission_name
 from corehq import privileges, toggles
 from corehq.apps.accounting.dispatcher import (
     AccountingAdminInterfaceDispatcher,
 )
-from corehq.apps.accounting.models import Invoice, Subscription, BillingAccount
+from corehq.apps.accounting.models import BillingAccount, Invoice, Subscription
 from corehq.apps.accounting.utils import (
     domain_has_privilege,
     domain_is_on_trial,
     is_accounting_admin,
 )
+from corehq.apps.accounting.utils.subscription import is_domain_enterprise
 from corehq.apps.accounting.views import (
     TriggerAutopaymentsView,
     TriggerDowngradeView,
@@ -34,9 +31,10 @@ from corehq.apps.app_manager.dbaccessors import (
 from corehq.apps.app_manager.util import is_remote_app
 from corehq.apps.builds.views import EditMenuView
 from corehq.apps.domain.views.internal import ProjectLimitsView
-from corehq.apps.domain.views.releases import (
-    ManageReleasesByLocation,
-)
+from corehq.apps.domain.views.releases import ManageReleasesByLocation
+from corehq.apps.enterprise.dispatcher import EnterpriseReportDispatcher
+from corehq.apps.enterprise.views import ManageEnterpriseMobileWorkersView
+from corehq.apps.events.views import AttendeesListView, EventsView
 from corehq.apps.hqadmin.reports import (
     DeployHistoryReport,
     DeviceLogSoftAssertReport,
@@ -77,6 +75,7 @@ from corehq.apps.translations.integrations.transifex.utils import (
     transifex_details_available_for_domain,
 )
 from corehq.apps.userreports.util import has_report_builder_access
+from corehq.apps.users.decorators import get_permission_name
 from corehq.apps.users.permissions import (
     can_download_data_files,
     can_view_sms_exports,
@@ -101,11 +100,7 @@ from corehq.motech.openmrs.views import OpenmrsImporterView
 from corehq.motech.views import ConnectionSettingsListView, MotechLogListView
 from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD
 from corehq.tabs.uitab import UITab
-from corehq.tabs.utils import (
-    dropdown_dict,
-    sidebar_to_dropdown,
-)
-from corehq.apps.events.views import EventsView, AttendeesListView
+from corehq.tabs.utils import dropdown_dict, sidebar_to_dropdown
 
 
 class ProjectReportsTab(UITab):
@@ -331,8 +326,8 @@ class SetupTab(UITab):
             DefaultConsumptionView,
             SMSSettingsView,
         )
-        from corehq.apps.programs.views import ProgramListView
         from corehq.apps.products.views import ProductListView
+        from corehq.apps.programs.views import ProgramListView
 
         if self.project.commtrack_enabled:
             dropdown_items = [(_(view.page_title), view) for view in (
@@ -374,17 +369,17 @@ class SetupTab(UITab):
             DefaultConsumptionView,
             SMSSettingsView,
         )
-        from corehq.apps.programs.views import (
-            ProgramListView,
-            NewProgramView,
-            EditProgramView,
-        )
         from corehq.apps.products.views import (
-            ProductListView,
-            NewProductView,
             EditProductView,
+            NewProductView,
             ProductFieldsView,
+            ProductListView,
             UploadProductView,
+        )
+        from corehq.apps.programs.views import (
+            EditProgramView,
+            NewProgramView,
+            ProgramListView,
         )
 
         if self.project.commtrack_enabled:
@@ -588,12 +583,16 @@ class ProjectDataTab(UITab):
 
         if self.can_edit_commcare_data:
             edit_section = None
-            from corehq.apps.data_interfaces.dispatcher import EditDataInterfaceDispatcher
+            from corehq.apps.data_interfaces.dispatcher import (
+                EditDataInterfaceDispatcher,
+            )
             edit_section = EditDataInterfaceDispatcher.navigation_sections(
                 request=self._request, domain=self.domain)
 
             if self.can_use_data_cleanup:
-                from corehq.apps.data_interfaces.views import AutomaticUpdateRuleListView
+                from corehq.apps.data_interfaces.views import (
+                    AutomaticUpdateRuleListView,
+                )
                 automatic_update_rule_list_view = {
                     'title': _(AutomaticUpdateRuleListView.page_title),
                     'url': reverse(AutomaticUpdateRuleListView.urlname, args=[self.domain]),
@@ -604,7 +603,9 @@ class ProjectDataTab(UITab):
                     edit_section = [(gettext_lazy('Edit Data'), [automatic_update_rule_list_view])]
 
             if self.can_deduplicate_cases:
-                from corehq.apps.data_interfaces.views import DeduplicationRuleListView
+                from corehq.apps.data_interfaces.views import (
+                    DeduplicationRuleListView,
+                )
                 deduplication_list_view = {
                     'title': _(DeduplicationRuleListView.page_title),
                     'url': reverse(DeduplicationRuleListView.urlname, args=[self.domain]),
@@ -625,7 +626,9 @@ class ProjectDataTab(UITab):
                 'subpages': [],
             })
         if self.couch_user.is_superuser or toggles.IS_CONTRACTOR.enabled(self.couch_user.username):
-            from corehq.apps.case_search.models import case_search_enabled_for_domain
+            from corehq.apps.case_search.models import (
+                case_search_enabled_for_domain,
+            )
             if case_search_enabled_for_domain(self.domain):
                 from corehq.apps.case_search.views import CaseSearchView
                 explore_data_views.append({
@@ -639,7 +642,9 @@ class ProjectDataTab(UITab):
             items.append([_("Explore Data"), explore_data_views])
 
         if self.can_use_lookup_tables:
-            from corehq.apps.fixtures.dispatcher import FixtureInterfaceDispatcher
+            from corehq.apps.fixtures.dispatcher import (
+                FixtureInterfaceDispatcher,
+            )
             items.extend(FixtureInterfaceDispatcher.navigation_sections(
                 request=self._request, domain=self.domain))
 
@@ -672,9 +677,9 @@ class ProjectDataTab(UITab):
         export_data_views = []
         if self.can_only_see_deid_exports:
             from corehq.apps.export.views.list import (
-                DeIdFormExportListView,
                 DeIdDailySavedExportListView,
                 DeIdDashboardFeedListView,
+                DeIdFormExportListView,
                 ODataFeedListView,
             )
             export_data_views.append({
@@ -700,41 +705,41 @@ class ProjectDataTab(UITab):
 
         elif self.can_export_data:
             from corehq.apps.export.views.download import (
-                DownloadNewFormExportView,
-                DownloadNewCaseExportView,
-                DownloadNewSmsExportView,
                 BulkDownloadNewFormExportView,
+                DownloadNewCaseExportView,
+                DownloadNewFormExportView,
+                DownloadNewSmsExportView,
             )
             from corehq.apps.export.views.edit import (
                 EditCaseDailySavedExportView,
                 EditCaseFeedView,
-                EditODataCaseFeedView,
-                EditODataFormFeedView,
                 EditFormDailySavedExportView,
                 EditFormFeedView,
                 EditNewCustomCaseExportView,
                 EditNewCustomFormExportView,
+                EditODataCaseFeedView,
+                EditODataFormFeedView,
             )
             from corehq.apps.export.views.list import (
-                FormExportListView,
                 CaseExportListView,
-                DashboardFeedListView,
                 DailySavedExportListView,
+                DashboardFeedListView,
+                FormExportListView,
                 ODataFeedListView,
             )
             from corehq.apps.export.views.new import (
-                CreateNewCustomFormExportView,
-                CreateNewCustomCaseExportView,
-                CreateNewDailySavedFormExport,
-                CreateNewDailySavedCaseExport,
-                CreateNewFormFeedView,
                 CreateNewCaseFeedView,
+                CreateNewCustomCaseExportView,
+                CreateNewCustomFormExportView,
+                CreateNewDailySavedCaseExport,
+                CreateNewDailySavedFormExport,
+                CreateNewFormFeedView,
                 CreateODataCaseFeedView,
                 CreateODataFormFeedView,
             )
             from corehq.apps.export.views.utils import (
+                DailySavedExportPaywall,
                 DashboardFeedPaywall,
-                DailySavedExportPaywall
             )
 
             if self.can_view_form_exports:
@@ -903,7 +908,9 @@ class ProjectDataTab(UITab):
                 })
 
             if toggles.SUPERSET_ANALYTICS.enabled(self.domain):
-                from corehq.apps.export.views.list import CommCareAnalyticsListView
+                from corehq.apps.export.views.list import (
+                    CommCareAnalyticsListView,
+                )
                 export_data_views.append({
                     'title': CommCareAnalyticsListView.page_title,
                     'url': reverse(CommCareAnalyticsListView.urlname, args=(self.domain,)),
@@ -933,11 +940,10 @@ class ProjectDataTab(UITab):
         ):
             return []
 
-        from corehq.apps.export.views.download import (
-            DownloadNewSmsExportView,
-        )
+        from corehq.apps.export.views.download import DownloadNewSmsExportView
         from corehq.apps.export.views.list import (
-            FormExportListView, CaseExportListView
+            CaseExportListView,
+            FormExportListView,
         )
 
         items = []
@@ -1213,7 +1219,10 @@ class MessagingTab(UITab):
             )
 
         if self.couch_user.can_edit_messaging():
-            from corehq.apps.data_interfaces.views import CaseGroupListView, CaseGroupCaseManagementView
+            from corehq.apps.data_interfaces.views import (
+                CaseGroupCaseManagementView,
+                CaseGroupListView,
+            )
             contacts_urls.append({
                 'title': _(CaseGroupListView.page_title),
                 'url': reverse(CaseGroupListView.urlname, args=[self.domain]),
@@ -1234,7 +1243,8 @@ class MessagingTab(UITab):
 
         if self.can_use_outbound_sms and self.couch_user.is_domain_admin():
             from corehq.apps.sms.views import (
-                DomainSmsGatewayListView, AddDomainGatewayView,
+                AddDomainGatewayView,
+                DomainSmsGatewayListView,
                 EditDomainGatewayView,
             )
             settings_urls.append({
@@ -1266,9 +1276,11 @@ class MessagingTab(UITab):
     @memoized
     def whatsapp_urls(self):
         from corehq.apps.sms.models import SQLMobileBackend
-        from corehq.messaging.smsbackends.turn.models import SQLTurnWhatsAppBackend
-        from corehq.messaging.smsbackends.infobip.models import InfobipBackend
         from corehq.apps.sms.views import WhatsAppTemplatesView
+        from corehq.messaging.smsbackends.infobip.models import InfobipBackend
+        from corehq.messaging.smsbackends.turn.models import (
+            SQLTurnWhatsAppBackend,
+        )
 
         whatsapp_urls = []
 
@@ -1402,8 +1414,8 @@ class ProjectUsersTab(UITab):
                     return None
 
             from corehq.apps.users.views.mobile import (
-                EditCommCareUserView,
                 ConfirmBillingAccountForExtraUsersView,
+                EditCommCareUserView,
                 MobileWorkerListView,
             )
 
@@ -1479,11 +1491,13 @@ class ProjectUsersTab(UITab):
                     return None
 
             from corehq.apps.users.views import (
-                EnterpriseUsersView,
                 EditWebUserView,
+                EnterpriseUsersView,
                 ListWebUsersView,
             )
-            from corehq.apps.users.views.mobile.users import FilteredWebUserDownload
+            from corehq.apps.users.views.mobile.users import (
+                FilteredWebUserDownload,
+            )
 
             if toggles.ENTERPRISE_USER_MANAGEMENT.enabled_for_request(self._request):
                 menu.append({
@@ -1521,9 +1535,7 @@ class ProjectUsersTab(UITab):
 
         if ((self.couch_user.is_domain_admin() or self.couch_user.can_view_roles())
                 and self.has_project_access):
-            from corehq.apps.users.views import (
-                ListRolesView,
-            )
+            from corehq.apps.users.views import ListRolesView
             menu.append({
                 'title': _(ListRolesView.page_title),
                 'url': reverse(ListRolesView.urlname,
@@ -1555,13 +1567,13 @@ class ProjectUsersTab(UITab):
         if (self.couch_user.can_edit_locations()
                 or self.couch_user.can_view_locations()):
             from corehq.apps.locations.views import (
-                LocationsListView,
-                NewLocationView,
                 EditLocationView,
                 FilteredLocationDownload,
-                LocationImportView,
-                LocationImportStatusView,
                 LocationFieldsView,
+                LocationImportStatusView,
+                LocationImportView,
+                LocationsListView,
+                NewLocationView,
             )
             is_view_only = (hasattr(self._request, 'is_view_only')
                             and self._request.is_view_only)
@@ -1598,7 +1610,9 @@ class ProjectUsersTab(UITab):
                 ]
             })
 
-        from corehq.apps.locations.permissions import user_can_edit_location_types
+        from corehq.apps.locations.permissions import (
+            user_can_edit_location_types,
+        )
         if (user_can_edit_location_types(self.couch_user, self.domain) and
                 self.couch_user.can_edit_locations()):
             from corehq.apps.locations.views import LocationTypesView
@@ -1673,8 +1687,8 @@ class EnterpriseSettingsTab(UITab):
         })
         if IdentityProvider.domain_has_editable_identity_provider(self.domain):
             from corehq.apps.sso.views.enterprise_admin import (
-                ManageSSOEnterpriseView,
                 EditIdentityProviderEnterpriseView,
+                ManageSSOEnterpriseView,
             )
             manage_sso = {
                 'title': _(ManageSSOEnterpriseView.page_title),
@@ -1784,7 +1798,10 @@ class ProjectSettingsTab(UITab):
         project_info = []
 
         if user_is_admin and has_project_access:
-            from corehq.apps.domain.views.settings import EditBasicProjectInfoView, EditPrivacySecurityView
+            from corehq.apps.domain.views.settings import (
+                EditBasicProjectInfoView,
+                EditPrivacySecurityView,
+            )
 
             project_info.extend([
                 {
@@ -1826,8 +1843,10 @@ class ProjectSettingsTab(UITab):
         if isinstance(self.couch_user, WebUser):
             if (user_is_billing_admin or self.couch_user.is_superuser) and not settings.ENTERPRISE_MODE:
                 from corehq.apps.domain.views.accounting import (
-                    DomainSubscriptionView, EditExistingBillingAccountView,
-                    DomainBillingStatementsView, ConfirmSubscriptionRenewalView,
+                    ConfirmSubscriptionRenewalView,
+                    DomainBillingStatementsView,
+                    DomainSubscriptionView,
+                    EditExistingBillingAccountView,
                     InternalSubscriptionManagementView,
                 )
                 current_subscription = Subscription.get_active_subscription_by_domain(self.domain)
@@ -1876,8 +1895,8 @@ class ProjectSettingsTab(UITab):
 
         if self.couch_user.is_superuser:
             from corehq.apps.domain.views.internal import (
-                EditInternalDomainInfoView,
                 EditInternalCalculationsView,
+                EditInternalDomainInfoView,
                 FlagsAndPrivilegesView,
             )
 
@@ -1911,8 +1930,8 @@ def _get_administration_section(domain):
     from corehq.apps.domain.views.internal import TransferDomainView
     from corehq.apps.domain.views.settings import (
         FeaturePreviewsView,
-        RecoveryMeasuresHistory,
         ManageDomainMobileWorkersView,
+        RecoveryMeasuresHistory,
     )
     from corehq.apps.ota.models import MobileRecoveryMeasure
 
@@ -2046,8 +2065,8 @@ def _get_integration_section(domain, couch_user):
         })
 
     if toggles.GENERIC_INBOUND_API.enabled(domain):
-        from corehq.motech.generic_inbound.views import ConfigurableAPIListView
         from corehq.motech.generic_inbound.reports import ApiRequestLogReport
+        from corehq.motech.generic_inbound.views import ConfigurableAPIListView
         integration.extend([{
             'title': ConfigurableAPIListView.page_title,
             'url': reverse(ConfigurableAPIListView.urlname, args=[domain])
@@ -2193,8 +2212,10 @@ class AccountingTab(UITab):
         )))
 
         from corehq.apps.accounting.views import (
-            TriggerInvoiceView, TriggerBookkeeperEmailView,
-            TestRenewalEmailView, TriggerCustomerInvoiceView
+            TestRenewalEmailView,
+            TriggerBookkeeperEmailView,
+            TriggerCustomerInvoiceView,
+            TriggerInvoiceView,
         )
         other_actions = [
             {
@@ -2239,8 +2260,11 @@ class SMSAdminTab(UITab):
     @property
     @memoized
     def sidebar_items(self):
-        from corehq.apps.sms.views import (GlobalSmsGatewayListView,
-            AddGlobalGatewayView, EditGlobalGatewayView)
+        from corehq.apps.sms.views import (
+            AddGlobalGatewayView,
+            EditGlobalGatewayView,
+            GlobalSmsGatewayListView,
+        )
         items = SMSAdminInterfaceDispatcher.navigation_sections(request=self._request, domain=self.domain)
         if has_privilege(self._request, privileges.GLOBAL_SMS_GATEWAY):
             items.append((_('SMS Connectivity'), [
@@ -2326,7 +2350,9 @@ class AdminTab(UITab):
         ]
 
         if self.couch_user and self.couch_user.is_staff:
-            from corehq.apps.hqadmin.views.operations import ReprocessMessagingCaseUpdatesView
+            from corehq.apps.hqadmin.views.operations import (
+                ReprocessMessagingCaseUpdatesView,
+            )
             from corehq.apps.notifications.views import ManageNotificationView
             data_operations = [
                 {'title': _('View raw documents'),

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -34,7 +34,12 @@ from corehq.apps.domain.views.internal import ProjectLimitsView
 from corehq.apps.domain.views.releases import ManageReleasesByLocation
 from corehq.apps.enterprise.dispatcher import EnterpriseReportDispatcher
 from corehq.apps.enterprise.views import ManageEnterpriseMobileWorkersView
-from corehq.apps.events.views import AttendeesListView, EventsView
+from corehq.apps.events.models import AttendeeModel
+from corehq.apps.events.views import (
+    AttendeeEditView,
+    AttendeesListView,
+    EventsView,
+)
 from corehq.apps.hqadmin.reports import (
     DeployHistoryReport,
     DeviceLogSoftAssertReport,
@@ -2463,17 +2468,33 @@ class AttendanceTrackingTab(UITab):
 
     @property
     def sidebar_items(self):
+
+        def _get_attendee_name(domain, attendee_id=None, **kwargs):
+            if attendee_id:
+                model = AttendeeModel.objects.get(
+                    case_id=attendee_id,
+                    domain=domain,
+                )
+                return model.name
+            return None
+
         items = [
             (_("Attendees"), [
                 {
                     'title': _("View All Attendees"),
                     'url': reverse(AttendeesListView.urlname, args=(self.domain,)),
+                    'description': _('Manage attendees for Attendance Tracking Events'),
+                    'subpages': [{
+                        'title': _get_attendee_name,
+                        'urlname': AttendeeEditView.urlname,
+                    }],
                 },
             ]),
             (_("Events"), [
                 {
                     'title': _("View All Events"),
                     'url': reverse(EventsView.urlname, args=(self.domain,)),
+                    'description': _('Manage Attendance Tracking Events'),
                 },
             ]),
         ]


### PR DESCRIPTION
## Technical Summary

This change allows an Attendance Coordinator to set the location of an attendee when creating them:

![image](https://user-images.githubusercontent.com/708421/232838073-8cafce0c-7d23-425d-8b40-8f68d2de9853.png)

It also shows the name of the attendee in the left panel when editing them:

![image](https://user-images.githubusercontent.com/708421/232839004-330fe129-72d2-4cae-b185-778ba849a8a5.png)

## Feature Flag

Attendance Tracking

## Safety Assurance

### Safety story

* Tested locally
* Inaccessible to users while the Attendance Tracking feature is under development

### Automated test coverage

This UI change is not covered by tests

### QA Plan

QA planned for feature, but not this specific change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
