### PR TITLE
Update case export select logic

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -861,6 +861,9 @@ class ExportInstance(BlobMixin, Document):
     def selected_tables(self):
         return [t for t in self.tables if t.selected]
 
+    def get_default_selected_table_count(self):
+        return len([t for t in self.tables if self.defaults.default_is_table_selected(t.path)])
+
     def get_table(self, path):
         for table in self.tables:
             if table.path == path:

--- a/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
@@ -7,7 +7,7 @@
     <legend data-bind="visible: table.isVisible(),
                        visible: table.label() !== 'Case History'">
       <span>
-        <input type="checkbox"
+        <input {% if disable_table_checkbox %}disabled="disabled"{% endif %} type="checkbox"
                data-bind="checked: table.selected" />
       </span>
       <span>

--- a/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
@@ -7,7 +7,7 @@
     <legend data-bind="visible: table.isVisible(),
                        visible: table.label() !== 'Case History'">
       <span>
-        <input type="checkbox"
+        <input {% if selected_table_count < 2 %}disabled="disabled"{% endif %} type="checkbox"
                data-bind="checked: table.selected" />
       </span>
       <span>

--- a/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
@@ -7,7 +7,7 @@
     <legend data-bind="visible: table.isVisible(),
                        visible: table.label() !== 'Case History'">
       <span>
-        <input {% if selected_table_count < 2 %}disabled="disabled"{% endif %} type="checkbox"
+        <input type="checkbox"
                data-bind="checked: table.selected" />
       </span>
       <span>

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -120,6 +120,7 @@ class BaseExportView(BaseProjectDataView):
             isinstance(self.export_instance, CaseExportInstance)
             and self.export_instance.case_type == ALL_CASE_TYPE_EXPORT
         )
+        selected_table_count = 0
         if not is_all_case_types_export:
             schema = self.get_export_schema(
                 self.domain,
@@ -127,6 +128,7 @@ class BaseExportView(BaseProjectDataView):
                 self.export_instance.identifier,
             )
             number_of_apps_to_process = schema.get_number_of_apps_to_process()
+            selected_table_count = len(self.export_instance.selected_tables)
 
         if self.export_instance.owner_id or not self.export_instance._id:
             sharing_options = SharingOption.CHOICES
@@ -149,7 +151,8 @@ class BaseExportView(BaseProjectDataView):
             'number_of_apps_to_process': number_of_apps_to_process,
             'sharing_options': sharing_options,
             'terminology': self.terminology,
-            'is_all_case_types_export': is_all_case_types_export
+            'is_all_case_types_export': is_all_case_types_export,
+            'selected_table_count': selected_table_count
         }
 
     @property

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -136,7 +136,6 @@ class BaseExportView(BaseProjectDataView):
             sharing_options = [SharingOption.EDIT_AND_EXPORT]
 
         allow_deid = has_privilege(self.request, privileges.DEIDENTIFIED_DATA)
-        table_count = self.export_instance.get_default_selected_table_count()
         return {
             'export_instance': self.export_instance,
             'export_home_url': self.export_home_url,

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -134,7 +134,7 @@ class BaseExportView(BaseProjectDataView):
             sharing_options = [SharingOption.EDIT_AND_EXPORT]
 
         allow_deid = has_privilege(self.request, privileges.DEIDENTIFIED_DATA)
-
+        table_count = self.export_instance.get_default_selected_table_count()
         return {
             'export_instance': self.export_instance,
             'export_home_url': self.export_home_url,
@@ -149,7 +149,8 @@ class BaseExportView(BaseProjectDataView):
             'number_of_apps_to_process': number_of_apps_to_process,
             'sharing_options': sharing_options,
             'terminology': self.terminology,
-            'is_all_case_types_export': is_all_case_types_export
+            'is_all_case_types_export': is_all_case_types_export,
+            'disable_table_checkbox': (table_count < 2)
         }
 
     @property

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -120,7 +120,9 @@ class BaseExportView(BaseProjectDataView):
             isinstance(self.export_instance, CaseExportInstance)
             and self.export_instance.case_type == ALL_CASE_TYPE_EXPORT
         )
+        table_count = 0
         if not is_all_case_types_export:
+            table_count = self.export_instance.get_default_selected_table_count()
             schema = self.get_export_schema(
                 self.domain,
                 self.request.GET.get('app_id') or getattr(self.export_instance, 'app_id'),

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -120,7 +120,6 @@ class BaseExportView(BaseProjectDataView):
             isinstance(self.export_instance, CaseExportInstance)
             and self.export_instance.case_type == ALL_CASE_TYPE_EXPORT
         )
-        selected_table_count = 0
         if not is_all_case_types_export:
             schema = self.get_export_schema(
                 self.domain,
@@ -128,7 +127,6 @@ class BaseExportView(BaseProjectDataView):
                 self.export_instance.identifier,
             )
             number_of_apps_to_process = schema.get_number_of_apps_to_process()
-            selected_table_count = len(self.export_instance.selected_tables)
 
         if self.export_instance.owner_id or not self.export_instance._id:
             sharing_options = SharingOption.CHOICES
@@ -151,8 +149,7 @@ class BaseExportView(BaseProjectDataView):
             'number_of_apps_to_process': number_of_apps_to_process,
             'sharing_options': sharing_options,
             'terminology': self.terminology,
-            'is_all_case_types_export': is_all_case_types_export,
-            'selected_table_count': selected_table_count
+            'is_all_case_types_export': is_all_case_types_export
         }
 
     @property


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This change disables the ability to deselect an export table if it is the only table available.
![Screenshot from 2023-04-19 17-00-41](https://user-images.githubusercontent.com/122617251/233122047-0cad0614-be19-44af-bba8-7ea17ec177f2.png)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2666).

This change looks at the count of default selected tables in an export config. If this is less than two, then the checkbox to deselect a table is disabled. This is only if the export is not a bulk case export, in which case the table count will default to 0. This logic extends to all export types, such as form exports.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Small UI change, and have done local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
