### PR TITLE
[Tableau user syncing] Standard username case for comparison in sync task

### DIFF
--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -640,7 +640,7 @@ def tableau_username_to_hq(tableau_username):
         return tableau_username[3:]
 
 
-# Attaches to the parse_web_users method
+# Attaches to the parse_web_users method, used for user export
 def add_on_tableau_details(domain, web_user_dicts):
 
     session = TableauAPISession.create_session_for_domain(domain)

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -599,13 +599,13 @@ def sync_tableau_users_on_domain(domain):
                 remote_HQ_group_users = []
             return remote_HQ_group_users
 
-        all_remote_users = session.get_users_on_site()
+        all_remote_users = {username.lower(): value for username, value in session.get_users_on_site().items()}
         local_users = TableauUser.objects.filter(server=session.tableau_connected_app.server)
         remote_HQ_group_users = _get_HQ_group_users(session)
 
         # Add/delete/update remote users to match with local reality
         for local_user in local_users:
-            local_tableau_username = tableau_username(local_user.username)
+            local_tableau_username = tableau_username(local_user.username).lower()
             if local_tableau_username not in all_remote_users:
                 _add_tableau_user_remote(session, local_user, local_user.role)
             elif local_user.tableau_user_id != all_remote_users[local_tableau_username]['id']:
@@ -619,9 +619,9 @@ def sync_tableau_users_on_domain(domain):
                 )
 
         # Remove any remote users that don't exist locally
-        local_users_usernames = [tableau_username(user.username) for user in local_users]
+        local_users_usernames = [tableau_username(user.username).lower() for user in local_users]
         for remote_user in remote_HQ_group_users:
-            if remote_user['name'] not in local_users_usernames:
+            if remote_user['name'].lower() not in local_users_usernames:
                 _delete_user_remote(session, remote_user['id'])
 
     session = TableauAPISession.create_session_for_domain(domain)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR addresses number 1 of [this Jira ticket](https://dimagi-dev.atlassian.net/browse/USH-3119?atlOrigin=eyJpIjoiYTc3MDE5YjBiZTQ3NDhiMTkwZjIxMDZlOTcyMjg4YTMiLCJwIjoiaiJ9).

There is a bug when syncing Tableau users for one of our projects, and this PR fixes that issue. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I mentioned this issue in the coworking block today. For one user, every time the sync task adds the user to Tableau, e.g. "jeremy@gmail.com", Tableau converts it to a username that had a letter of a different case, e.g. "Jeremy@gmail.com".

This happened because there was a Tableau user on _a different site_ with the same username "Jeremy@gmail.com".

This PR makes both the local usernames and remote usernames lowercase for comparison between the two user lists to address this bug and any other username case sensitivity issues that might arise with the sync task. Tableau doesn't care about case sensitive, so we don't have to.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

TABLEAU_USER_SYNCING

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested manually.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None exist.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None, since this is a very specific bug for a feature with not a lot of QA infrastructure set up.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
