### PR TITLE
Allow `AutomaticUpdateRule` to update `case.external_id`

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
 from datetime import datetime
-from unittest import expectedFailure
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
@@ -743,7 +742,6 @@ class CaseRuleActionsTest(BaseCaseRuleTest):
             self.assertEqual(case.name, 'Ellie')
 
 
-    @expectedFailure  # TODO: Allow setting case.external_id
     def test_update_external_id(self):
         """
         Updating case property "external_id" updates ``case.external_id``

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -1,9 +1,8 @@
 from contextlib import contextmanager
 from datetime import datetime
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
-
-from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseFactory
 
@@ -18,17 +17,17 @@ from corehq.apps.data_interfaces.models import (
     CustomActionDefinition,
     CustomMatchDefinition,
     DomainCaseRuleRun,
+    LocationFilterDefinition,
     MatchPropertyDefinition,
     UCRFilterDefinition,
     UpdateCaseDefinition,
-    LocationFilterDefinition,
 )
 from corehq.apps.data_interfaces.tasks import run_case_update_rules_for_domain
 from corehq.apps.domain.models import Domain
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.signals import sql_case_post_save
-from corehq.toggles import NAMESPACE_DOMAIN, RUN_AUTO_CASE_UPDATES_ON_SAVE
 from corehq.tests.locks import reentrant_redis_locks
+from corehq.toggles import NAMESPACE_DOMAIN, RUN_AUTO_CASE_UPDATES_ON_SAVE
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.test_utils import set_parent_case as set_actual_parent_case
 
@@ -581,8 +580,8 @@ class CaseRuleCriteriaTest(BaseCaseRuleTest):
             self.assertTrue(rule.criteria_match(case, datetime.utcnow()))
 
     def test_location_filter_criteria_does_include_child_locations(self):
-        from corehq.apps.locations.models import SQLLocation, LocationType
         from corehq.apps.domain.shortcuts import create_domain
+        from corehq.apps.locations.models import LocationType, SQLLocation
 
         create_domain(self.domain)
 

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -150,6 +150,10 @@ def _get_update_or_close_case_block(
         'close': close,
     }
     if case_properties:
+        if 'external_id' in case_properties:
+            # `copy()` so as not to modify by reference
+            case_properties = case_properties.copy()
+            kwargs['external_id'] = case_properties.pop('external_id')
         kwargs['update'] = case_properties
     if owner_id:
         kwargs['owner_id'] = owner_id


### PR DESCRIPTION
## Technical Summary

This is a small change to allow `AutomaticUpdateRule` to update `case.external_id`.

It is intended as an alternative to [the `USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY` feature flag](https://github.com/dimagi/commcare-hq/pull/32389).

The feature flag affects the behavior of `CaseBlock`. This change only affects `AutomaticUpdateRule` where the rule is trying to update `case.external_id`.

It aligns the behavior of `AutomaticUpdateRule` with expectations---there is no reason why users should not be able to update `external_id`.

:blowfish: Easier to review by commit

## Feature Flag

N/A

## Safety Assurance

### Safety story

Behavior verified with unit tests.

### Automated test coverage

Test coverage included

### QA Plan

QA not planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
