### PR TITLE
Generate token for Update Translations workflow

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+      - uses: tibdex/github-app-token@36464acb844fc53b9b8b2401da68844f6b05ebb0
+          id: generate-token
+          with:
+            app_id: ${{ secrets.APP_ID }}
+            private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Install Python requirements
         run: |
           pip install --upgrade pip
@@ -45,6 +50,7 @@ jobs:
         # Pinned to the commit of https://github.com/peter-evans/create-pull-request/releases/tag/v4.1.2
         uses: peter-evans/create-pull-request@171dd555b9ab6b18fa02519fdfacbb8bf671e1b4
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           base: master
           branch: create-pull-request/update-translations
           branch-suffix: short-commit-hash


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-14528)

As [recommended](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens) by creator of the create-pull-request repo (which we use to create our weekly automated Update Translations PRs), we can use a github app to generate tokens to use with our create PR workflow to further trigger workflows. This way, the current genie won't have to manually start the tests and wait from them finish before being able to deploy. 


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
