### PR TITLE
Require Content-type and Accept headers for requests to FHIR endpoints

### DIFF
--- a/corehq/motech/fhir/const.py
+++ b/corehq/motech/fhir/const.py
@@ -42,3 +42,5 @@ FHIR_DATA_TYPE_LIST_OF_STRING = 'fhir_list_of_string'
 FHIR_DATA_TYPES = (
     FHIR_DATA_TYPE_LIST_OF_STRING,
 )
+
+HQ_ACCEPTABLE_FHIR_MIME_TYPES = ['application/json', 'application/fhir+json']

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -11,6 +11,7 @@ from corehq.apps.domain.decorators import (
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase
 from corehq.motech.exceptions import ConfigurationError
+from corehq.motech.fhir.utils import require_fhir_json_headers
 from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
 from corehq.util.view_utils import get_case_or_404
 
@@ -51,6 +52,7 @@ class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
 @login_or_api_key
 @require_superuser
 @toggles.FHIR_INTEGRATION.required_decorator()
+@require_fhir_json_headers
 def get_view(request, domain, fhir_version_name, resource_type, resource_id):
     fhir_version = _get_fhir_version(fhir_version_name)
     if not fhir_version:
@@ -77,6 +79,7 @@ def get_view(request, domain, fhir_version_name, resource_type, resource_id):
 @login_or_api_key
 @require_superuser
 @toggles.FHIR_INTEGRATION.required_decorator()
+@require_fhir_json_headers
 def search_view(request, domain, fhir_version_name, resource_type):
     fhir_version = _get_fhir_version(fhir_version_name)
     if not fhir_version:


### PR DESCRIPTION
@snopoke this is the code I've written today for the FHIR headers. I think per the DHIR documentation we need to reject both invalid Content-Type and Accept headers? Let me know what you think! 

So far I've tested that this works locally via Postman. I'll add tests after the main ideas here are confirmed.
