### PR TITLE
Update es mappings for ES5

### DIFF
--- a/corehq/pillows/mappings/app_mapping.py
+++ b/corehq/pillows/mappings/app_mapping.py
@@ -25,26 +25,25 @@ APP_MAPPING = {
             "type": "date"
         },
         "admin_password": {
-            "type": "string"
+            "type": "text"
         },
         "admin_password_charset": {
-            "type": "string"
+            "type": "text"
         },
         "application_version": {
-            "type": "string"
+            "type": "text"
         },
         "attribution_notes": {
-            "type": "string"
+            "type": "text"
         },
         "build_broken": {
             "type": "boolean"
         },
         "build_comment": {
-            "type": "string"
+            "type": "text"
         },
         "build_langs": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "build_signed": {
             "type": "boolean"
@@ -57,14 +56,13 @@ APP_MAPPING = {
                     "type": "long"
                 },
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "latest": {
                     "type": "boolean"
                 },
                 "version": {
-                    "type": "string"
+                    "type": "text"
                 }
             }
         },
@@ -84,8 +82,7 @@ APP_MAPPING = {
                     "type": "date"
                 },
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "latest": {
                     "type": "boolean"
@@ -94,7 +91,7 @@ APP_MAPPING = {
                     "type": "boolean"
                 },
                 "version": {
-                    "type": "string"
+                    "type": "text"
                 }
             }
         },
@@ -109,20 +106,19 @@ APP_MAPPING = {
             "type": "boolean"
         },
         "comment_from": {
-            "type": "string"
+            "type": "text"
         },
         "copy_history": {
-            "type": "string"
+            "type": "text"
         },
         "copy_of": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "cp_is_active": {
             "type": "boolean"
         },
         "created_from_template": {
-            "type": "string"
+            "type": "text"
         },
         "date_created": {
             "format": DATE_FORMATS_STRING,
@@ -133,23 +129,21 @@ APP_MAPPING = {
             "type": "date"
         },
         "description": {
-            "type": "string"
+            "type": "text"
         },
         "doc_type": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "domain": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
-            "type": "string"
+            "type": "text"
         },
         "family_id": {
-            "type": "string"
+            "type": "text"
         },
         "force_http": {
             "type": "boolean"
@@ -158,8 +152,7 @@ APP_MAPPING = {
             "type": "boolean"
         },
         "langs": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "modules": {
             "dynamic": False,
@@ -170,8 +163,7 @@ APP_MAPPING = {
                     "type": "object",
                     "properties": {
                         "doc_type": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "label": {
                             "dynamic": False,
@@ -185,11 +177,10 @@ APP_MAPPING = {
                 "case_type": {
                     "fields": {
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     },
-                    "type": "string"
+                    "type": "text"
                 },
                 "details": {
                     "dynamic": False,
@@ -200,22 +191,20 @@ APP_MAPPING = {
                             "type": "object",
                             "properties": {
                                 "advanced": {
-                                    "type": "string"
+                                    "type": "text"
                                 },
                                 "doc_type": {
-                                    "index": "not_analyzed",
-                                    "type": "string"
+                                    "type": "keyword"
                                 },
                                 "enum": {
                                     "dynamic": False,
                                     "type": "object",
                                     "properties": {
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         },
                                         "key": {
-                                            "type": "string"
+                                            "type": "text"
                                         },
                                         "value": {
                                             "dynamic": False,
@@ -224,13 +213,13 @@ APP_MAPPING = {
                                     }
                                 },
                                 "field": {
-                                    "type": "string"
+                                    "type": "text"
                                 },
                                 "filter_xpath": {
-                                    "type": "string"
+                                    "type": "text"
                                 },
                                 "format": {
-                                    "type": "string"
+                                    "type": "text"
                                 },
                                 "header": {
                                     "dynamic": False,
@@ -240,7 +229,7 @@ APP_MAPPING = {
                                     "type": "long"
                                 },
                                 "model": {
-                                    "type": "string"
+                                    "type": "text"
                                 },
                                 "time_ago_interval": {
                                     "type": "float"
@@ -248,39 +237,36 @@ APP_MAPPING = {
                             }
                         },
                         "doc_type": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "filter": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "sort_elements": {
                             "dynamic": False,
                             "type": "object",
                             "properties": {
                                 "direction": {
-                                    "type": "string"
+                                    "type": "text"
                                 },
                                 "doc_type": {
-                                    "index": "not_analyzed",
-                                    "type": "string"
+                                    "type": "keyword"
                                 },
                                 "field": {
-                                    "type": "string"
+                                    "type": "text"
                                 },
                                 "type": {
-                                    "type": "string"
+                                    "type": "text"
                                 }
                             }
                         },
                         "type": {
-                            "type": "string"
+                            "type": "text"
                         }
                     }
                 },
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "forms": {
                     "dynamic": False,
@@ -299,23 +285,21 @@ APP_MAPPING = {
                                             "type": "object",
                                             "properties": {
                                                 "answer": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "doc_type": {
-                                                    "index": "not_analyzed",
-                                                    "type": "string"
+                                                    "type": "keyword"
                                                 },
                                                 "question": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "type": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 }
                                             }
                                         },
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         },
                                         "preload": {
                                             "dynamic": False,
@@ -332,23 +316,21 @@ APP_MAPPING = {
                                             "type": "object",
                                             "properties": {
                                                 "answer": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "doc_type": {
-                                                    "index": "not_analyzed",
-                                                    "type": "string"
+                                                    "type": "keyword"
                                                 },
                                                 "question": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "type": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 }
                                             }
                                         },
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         }
                                     }
                                 },
@@ -361,29 +343,26 @@ APP_MAPPING = {
                                             "type": "object",
                                             "properties": {
                                                 "answer": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "doc_type": {
-                                                    "index": "not_analyzed",
-                                                    "type": "string"
+                                                    "type": "keyword"
                                                 },
                                                 "question": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "type": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 }
                                             }
                                         },
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         }
                                     }
                                 },
                                 "doc_type": {
-                                    "index": "not_analyzed",
-                                    "type": "string"
+                                    "type": "keyword"
                                 },
                                 "load_from_form": {
                                     "dynamic": False,
@@ -394,23 +373,21 @@ APP_MAPPING = {
                                             "type": "object",
                                             "properties": {
                                                 "answer": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "doc_type": {
-                                                    "index": "not_analyzed",
-                                                    "type": "string"
+                                                    "type": "keyword"
                                                 },
                                                 "question": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "type": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 }
                                             }
                                         },
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         },
                                         "preload": {
                                             "dynamic": False,
@@ -427,29 +404,27 @@ APP_MAPPING = {
                                             "type": "object",
                                             "properties": {
                                                 "answer": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "doc_type": {
-                                                    "index": "not_analyzed",
-                                                    "type": "string"
+                                                    "type": "keyword"
                                                 },
                                                 "question": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "type": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 }
                                             }
                                         },
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         },
                                         "external_id": {
-                                            "type": "string"
+                                            "type": "text"
                                         },
                                         "name_path": {
-                                            "type": "string"
+                                            "type": "text"
                                         }
                                     }
                                 },
@@ -462,29 +437,27 @@ APP_MAPPING = {
                                             "type": "object",
                                             "properties": {
                                                 "answer": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "doc_type": {
-                                                    "index": "not_analyzed",
-                                                    "type": "string"
+                                                    "type": "keyword"
                                                 },
                                                 "question": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "type": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 }
                                             }
                                         },
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         },
                                         "followup_date": {
-                                            "type": "string"
+                                            "type": "text"
                                         },
                                         "name_path": {
-                                            "type": "string"
+                                            "type": "text"
                                         }
                                     }
                                 },
@@ -497,23 +470,21 @@ APP_MAPPING = {
                                             "type": "object",
                                             "properties": {
                                                 "answer": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "doc_type": {
-                                                    "index": "not_analyzed",
-                                                    "type": "string"
+                                                    "type": "keyword"
                                                 },
                                                 "question": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "type": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 }
                                             }
                                         },
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         },
                                         "preload": {
                                             "dynamic": False,
@@ -526,43 +497,41 @@ APP_MAPPING = {
                                     "type": "nested",
                                     "properties": {
                                         "case_name": {
-                                            "type": "string"
+                                            "type": "text"
                                         },
                                         "case_properties": {
                                             "dynamic": False,
                                             "type": "object"
                                         },
                                         "case_type": {
-                                            "type": "string"
+                                            "type": "text"
                                         },
                                         "condition": {
                                             "dynamic": False,
                                             "type": "object",
                                             "properties": {
                                                 "answer": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "doc_type": {
-                                                    "index": "not_analyzed",
-                                                    "type": "string"
+                                                    "type": "keyword"
                                                 },
                                                 "question": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "type": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 }
                                             }
                                         },
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         },
                                         "reference_id": {
-                                            "type": "string"
+                                            "type": "text"
                                         },
                                         "repeat_context": {
-                                            "type": "string"
+                                            "type": "text"
                                         }
                                     }
                                 },
@@ -575,23 +544,21 @@ APP_MAPPING = {
                                             "type": "object",
                                             "properties": {
                                                 "answer": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "doc_type": {
-                                                    "index": "not_analyzed",
-                                                    "type": "string"
+                                                    "type": "keyword"
                                                 },
                                                 "question": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "type": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 }
                                             }
                                         },
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         },
                                         "update": {
                                             "dynamic": False,
@@ -608,61 +575,56 @@ APP_MAPPING = {
                                             "type": "object",
                                             "properties": {
                                                 "answer": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "doc_type": {
-                                                    "index": "not_analyzed",
-                                                    "type": "string"
+                                                    "type": "keyword"
                                                 },
                                                 "question": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 },
                                                 "type": {
-                                                    "type": "string"
+                                                    "type": "text"
                                                 }
                                             }
                                         },
                                         "doc_type": {
-                                            "index": "not_analyzed",
-                                            "type": "string"
+                                            "type": "keyword"
                                         },
                                         "followup_date": {
-                                            "type": "string"
+                                            "type": "text"
                                         }
                                     }
                                 }
                             }
                         },
                         "doc_type": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "form_filter": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "form_type": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "name": {
                             "dynamic": False,
                             "type": "object"
                         },
                         "requires": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "show_count": {
                             "type": "boolean"
                         },
                         "unique_id": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "version": {
                             "type": "long"
                         },
                         "xmlns": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     }
                 },
@@ -678,14 +640,13 @@ APP_MAPPING = {
                             "type": "boolean"
                         },
                         "doc_type": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "module_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "relationship": {
-                            "type": "string"
+                            "type": "text"
                         }
                     }
                 },
@@ -697,8 +658,7 @@ APP_MAPPING = {
                     "type": "object",
                     "properties": {
                         "doc_type": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "label": {
                             "dynamic": False,
@@ -710,16 +670,14 @@ APP_MAPPING = {
                     }
                 },
                 "root_module_id": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "task_list": {
                     "dynamic": False,
                     "type": "object",
                     "properties": {
                         "doc_type": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "label": {
                             "dynamic": False,
@@ -731,7 +689,7 @@ APP_MAPPING = {
                     }
                 },
                 "unique_id": {
-                    "type": "string"
+                    "type": "text"
                 }
             }
         },
@@ -740,17 +698,16 @@ APP_MAPPING = {
             "type": "object",
             "properties": {
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "media_type": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "multimedia_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "unique_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "version": {
                     "type": "long"
@@ -760,56 +717,52 @@ APP_MAPPING = {
         "name": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
-            "type": "string"
+            "type": "text"
         },
         "phone_model": {
-            "type": "string"
+            "type": "text"
         },
         "platform": {
-            "type": "string"
+            "type": "text"
         },
         "profile": {
             "dynamic": True,
             "type": "object"
         },
         "recipients": {
-            "type": "string"
+            "type": "text"
         },
         "secure_submissions": {
             "type": "boolean"
         },
         "short_odk_media_url": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "short_odk_url": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "short_url": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "success_message": {
             "dynamic": False,
             "type": "object"
         },
         "text_input": {
-            "type": "string"
+            "type": "text"
         },
         "translation_strategy": {
-            "type": "string"
+            "type": "text"
         },
         "translations": {
             "dynamic": False,
             "type": "object"
         },
         "upstream_app_id": {
-            "type": "string"
+            "type": "text"
         },
         "upstream_version": {
             "type": "long"
@@ -818,7 +771,7 @@ APP_MAPPING = {
             "type": "boolean"
         },
         "user_type": {
-            "type": "string"
+            "type": "text"
         },
         "vellum_case_management": {
             "type": "boolean"

--- a/corehq/pillows/mappings/case_mapping.py
+++ b/corehq/pillows/mappings/case_mapping.py
@@ -101,14 +101,11 @@ CASE_MAPPING = {
         },
         "domain": {
             "fields": {
-                "domain": {
-                    "type": "text"
-                },
                 "exact": {
                     "type": "keyword"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "export_tag": {
             "type": "text"
@@ -117,12 +114,9 @@ CASE_MAPPING = {
             "fields": {
                 "exact": {
                     "type": "keyword"
-                },
-                "external_id": {
-                    "type": "text"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "indices": {
             "dynamic": False,
@@ -160,12 +154,9 @@ CASE_MAPPING = {
             "fields": {
                 "exact": {
                     "type": "keyword"
-                },
-                "name": {
-                    "type": "text"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "opened_by": {
             "type": "keyword"
@@ -193,12 +184,9 @@ CASE_MAPPING = {
             "fields": {
                 "exact": {
                     "type": "keyword"
-                },
-                "type": {
-                    "type": "text"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "user_id": {
             "type": "text"

--- a/corehq/pillows/mappings/case_mapping.py
+++ b/corehq/pillows/mappings/case_mapping.py
@@ -24,32 +24,30 @@ CASE_MAPPING = {
             "type": "nested",
             "properties": {
                 "action_type": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "date": {
                     "format": DATE_FORMATS_STRING,
                     "type": "date"
                 },
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "indices": {
                     "dynamic": False,
                     "type": "object",
                     "properties": {
                         "doc_type": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "identifier": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "referenced_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "referenced_type": {
-                            "type": "string"
+                            "type": "text"
                         }
                     }
                 },
@@ -58,32 +56,30 @@ CASE_MAPPING = {
                     "type": "date"
                 },
                 "sync_log_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "user_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "xform_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "xform_name": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "xform_xmlns": {
-                    "type": "string"
+                    "type": "text"
                 }
             }
         },
         "backend_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "closed": {
             "type": "boolean"
         },
         "closed_by": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "closed_on": {
             "format": DATE_FORMATS_STRING,
@@ -98,38 +94,32 @@ CASE_MAPPING = {
             "type": "date"
         },
         "contact_phone_number": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "doc_type": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "domain": {
             "fields": {
                 "domain": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 },
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
             "type": "multi_field"
         },
         "export_tag": {
-            "type": "string"
+            "type": "text"
         },
         "external_id": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "external_id": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 }
             },
             "type": "multi_field"
@@ -139,17 +129,16 @@ CASE_MAPPING = {
             "type": "object",
             "properties": {
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "identifier": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "referenced_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "referenced_type": {
-                    "type": "string"
+                    "type": "text"
                 }
             }
         },
@@ -161,7 +150,7 @@ CASE_MAPPING = {
             "type": "date"
         },
         "location_id": {
-            "type": "string"
+            "type": "text"
         },
         "modified_on": {
             "format": DATE_FORMATS_STRING,
@@ -170,32 +159,27 @@ CASE_MAPPING = {
         "name": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "name": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 }
             },
             "type": "multi_field"
         },
         "opened_by": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "opened_on": {
             "format": DATE_FORMATS_STRING,
             "type": "date"
         },
         "owner_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "owner_type": {
-            "index": "not_analyzed",
             "null_value": NULL_VALUE,
-            "type": "string"
+            "type": "keyword"
         },
         "referrals": {
             "enabled": False,
@@ -208,25 +192,22 @@ CASE_MAPPING = {
         "type": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "type": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 }
             },
             "type": "multi_field"
         },
         "user_id": {
-            "type": "string"
+            "type": "text"
         },
         "version": {
-            "type": "string"
+            "type": "text"
         },
         "xform_ids": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         Tombstone.PROPERTY_NAME: {
             "type": "boolean"

--- a/corehq/pillows/mappings/case_search_mapping.py
+++ b/corehq/pillows/mappings/case_search_mapping.py
@@ -87,7 +87,7 @@ CASE_SEARCH_MAPPING = {
                     "type": "keyword"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "external_id": {
             "type": "keyword"
@@ -147,11 +147,8 @@ CASE_SEARCH_MAPPING = {
                 "exact": {
                     "type": "keyword"
                 },
-                "type": {
-                    "type": "text"
-                }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "user_id": {
             "type": "keyword"

--- a/corehq/pillows/mappings/case_search_mapping.py
+++ b/corehq/pillows/mappings/case_search_mapping.py
@@ -34,11 +34,10 @@ CASE_SEARCH_MAPPING = {
                 "key": {
                     "fields": {
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     },
-                    "type": "string"
+                    "type": "text"
                 },
                 "value": {
                     "fields": {
@@ -49,9 +48,8 @@ CASE_SEARCH_MAPPING = {
                         },
                         "exact": {
                             "ignore_above": 8191,
-                            "index": "not_analyzed",
                             "null_value": "",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "numeric": {
                             "ignore_malformed": True,
@@ -59,11 +57,11 @@ CASE_SEARCH_MAPPING = {
                         },
                         "phonetic": {
                             "analyzer": "phonetic",
-                            "type": "string"
+                            "type": "text"
                         }
                     },
                     "null_value": "",
-                    "type": "string"
+                    "type": "text"
                 },
                 "geopoint_value": {
                     "type": "geo_point"
@@ -74,59 +72,49 @@ CASE_SEARCH_MAPPING = {
             "type": "boolean"
         },
         "closed_by": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "closed_on": {
             "format": DATE_FORMATS_STRING,
             "type": "date"
         },
         "doc_type": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "domain": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
             "type": "multi_field"
         },
         "external_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "indices": {
             "dynamic": False,
             "type": "nested",
             "properties": {
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "identifier": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "referenced_id": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "referenced_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "relationship": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             }
         },
         "location_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "modified_on": {
             "format": DATE_FORMATS_STRING,
@@ -135,23 +123,20 @@ CASE_SEARCH_MAPPING = {
         "name": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
-            "type": "string"
+            "type": "text"
         },
         "opened_by": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "opened_on": {
             "format": DATE_FORMATS_STRING,
             "type": "date"
         },
         "owner_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "server_modified_on": {
             "format": DATE_FORMATS_STRING,
@@ -160,19 +145,16 @@ CASE_SEARCH_MAPPING = {
         "type": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "type": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 }
             },
             "type": "multi_field"
         },
         "user_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         Tombstone.PROPERTY_NAME: {
             "type": "boolean"

--- a/corehq/pillows/mappings/case_search_mapping.py
+++ b/corehq/pillows/mappings/case_search_mapping.py
@@ -60,7 +60,6 @@ CASE_SEARCH_MAPPING = {
                             "type": "text"
                         }
                     },
-                    "null_value": "",
                     "type": "text"
                 },
                 "geopoint_value": {

--- a/corehq/pillows/mappings/domain_mapping.py
+++ b/corehq/pillows/mappings/domain_mapping.py
@@ -31,14 +31,11 @@ DOMAIN_MAPPING = {
         },
         "author": {
             "fields": {
-                "author": {
-                    "type": "text"
-                },
                 "exact": {
                     "type": "keyword"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "cached_properties": {
             "dynamic": False,
@@ -256,25 +253,19 @@ DOMAIN_MAPPING = {
             "properties": {
                 "city": {
                     "fields": {
-                        "city": {
-                            "type": "text"
-                        },
                         "exact": {
                             "type": "keyword"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 },
                 "countries": {
                     "fields": {
-                        "countries": {
-                            "type": "keyword"
-                        },
                         "exact": {
                             "type": "keyword"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 },
                 "description": {
                     "fields": {
@@ -285,7 +276,7 @@ DOMAIN_MAPPING = {
                             "type": "keyword"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 },
                 "doc_type": {
                     "type": "keyword"
@@ -297,12 +288,9 @@ DOMAIN_MAPPING = {
                     "fields": {
                         "exact": {
                             "type": "keyword"
-                        },
-                        "region": {
-                            "type": "text"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 }
             }
         },
@@ -330,14 +318,11 @@ DOMAIN_MAPPING = {
             "properties": {
                 "area": {
                     "fields": {
-                        "area": {
-                            "type": "text"
-                        },
                         "exact": {
                             "type": "keyword"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 },
                 "can_use_data": {
                     "type": "boolean"
@@ -367,12 +352,9 @@ DOMAIN_MAPPING = {
                     "fields": {
                         "exact": {
                             "type": "keyword"
-                        },
-                        "initiative": {
-                            "type": "text"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 },
                 "notes": {
                     "type": "text"
@@ -381,23 +363,17 @@ DOMAIN_MAPPING = {
                     "fields": {
                         "exact": {
                             "type": "keyword"
-                        },
-                        "organization_name": {
-                            "type": "text"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 },
                 "phone_model": {
                     "fields": {
                         "exact": {
                             "type": "keyword"
-                        },
-                        "phone_model": {
-                            "type": "text"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 },
                 "platform": {
                     "type": "text"
@@ -421,12 +397,9 @@ DOMAIN_MAPPING = {
                     "fields": {
                         "exact": {
                             "type": "keyword"
-                        },
-                        "sub_area": {
-                            "type": "text"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 },
                 "using_adm": {
                     "type": "boolean"
@@ -438,12 +411,9 @@ DOMAIN_MAPPING = {
                     "fields": {
                         "exact": {
                             "type": "keyword"
-                        },
-                        "workshop_region": {
-                            "type": "text"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 }
             }
         },
@@ -494,12 +464,9 @@ DOMAIN_MAPPING = {
             "fields": {
                 "exact": {
                     "type": "keyword"
-                },
-                "name": {
-                    "type": "text"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "organization": {
             "type": "text"
@@ -527,12 +494,9 @@ DOMAIN_MAPPING = {
             "fields": {
                 "exact": {
                     "type": "keyword"
-                },
-                "short_description": {
-                    "type": "text"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "sms_case_registration_enabled": {
             "type": "boolean"
@@ -572,12 +536,9 @@ DOMAIN_MAPPING = {
             "fields": {
                 "exact": {
                     "type": "keyword"
-                },
-                "title": {
-                    "type": "text"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "use_sql_backend": {
             "type": "boolean"

--- a/corehq/pillows/mappings/domain_mapping.py
+++ b/corehq/pillows/mappings/domain_mapping.py
@@ -24,15 +24,15 @@ DOMAIN_MAPPING = {
             "type": "boolean"
         },
         "area": {
-            "type": "string"
+            "type": "text"
         },
         "attribution_notes": {
-            "type": "string"
+            "type": "text"
         },
         "author": {
             "fields": {
                 "author": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "exact": {
                     "type": "keyword"
@@ -49,10 +49,10 @@ DOMAIN_MAPPING = {
             "type": "object",
             "properties": {
                 "case_owner_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "case_type": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "doc_type": {
                     "type": "keyword"
@@ -103,13 +103,13 @@ DOMAIN_MAPPING = {
                     "type": "keyword"
                 },
                 "user_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "user_ip": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "version": {
-                    "type": "string"
+                    "type": "text"
                 }
             }
         },
@@ -117,7 +117,7 @@ DOMAIN_MAPPING = {
             "type": "boolean"
         },
         "copy_history": {
-            "type": "string"
+            "type": "text"
         },
         "cp_300th_form_submission": {
             "format": DATE_FORMATS_STRING,
@@ -241,14 +241,14 @@ DOMAIN_MAPPING = {
             "type": "boolean"
         },
         "creating_user": {
-            "type": "string"
+            "type": "text"
         },
         "date_created": {
             "format": DATE_FORMATS_STRING,
             "type": "date"
         },
         "default_timezone": {
-            "type": "string"
+            "type": "text"
         },
         "deployment": {
             "dynamic": False,
@@ -257,7 +257,7 @@ DOMAIN_MAPPING = {
                 "city": {
                     "fields": {
                         "city": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "exact": {
                             "type": "keyword"
@@ -279,7 +279,7 @@ DOMAIN_MAPPING = {
                 "description": {
                     "fields": {
                         "description": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "exact": {
                             "type": "keyword"
@@ -299,7 +299,7 @@ DOMAIN_MAPPING = {
                             "type": "keyword"
                         },
                         "region": {
-                            "type": "string"
+                            "type": "text"
                         }
                     },
                     "type": "multi_field"
@@ -307,7 +307,7 @@ DOMAIN_MAPPING = {
             }
         },
         "description": {
-            "type": "string"
+            "type": "text"
         },
         "doc_type": {
             "type": "keyword"
@@ -322,7 +322,7 @@ DOMAIN_MAPPING = {
             "type": "boolean"
         },
         "hr_name": {
-            "type": "string"
+            "type": "text"
         },
         "internal": {
             "dynamic": False,
@@ -331,7 +331,7 @@ DOMAIN_MAPPING = {
                 "area": {
                     "fields": {
                         "area": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "exact": {
                             "type": "keyword"
@@ -343,7 +343,7 @@ DOMAIN_MAPPING = {
                     "type": "boolean"
                 },
                 "commcare_edition": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "commconnect_domain": {
                     "type": "boolean"
@@ -369,13 +369,13 @@ DOMAIN_MAPPING = {
                             "type": "keyword"
                         },
                         "initiative": {
-                            "type": "string"
+                            "type": "text"
                         }
                     },
                     "type": "multi_field"
                 },
                 "notes": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "organization_name": {
                     "fields": {
@@ -383,7 +383,7 @@ DOMAIN_MAPPING = {
                             "type": "keyword"
                         },
                         "organization_name": {
-                            "type": "string"
+                            "type": "text"
                         }
                     },
                     "type": "multi_field"
@@ -394,28 +394,28 @@ DOMAIN_MAPPING = {
                             "type": "keyword"
                         },
                         "phone_model": {
-                            "type": "string"
+                            "type": "text"
                         }
                     },
                     "type": "multi_field"
                 },
                 "platform": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "project_manager": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "project_state": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "self_started": {
                     "type": "boolean"
                 },
                 "sf_account_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "sf_contract_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "sub_area": {
                     "fields": {
@@ -423,7 +423,7 @@ DOMAIN_MAPPING = {
                             "type": "keyword"
                         },
                         "sub_area": {
-                            "type": "string"
+                            "type": "text"
                         }
                     },
                     "type": "multi_field"
@@ -440,7 +440,7 @@ DOMAIN_MAPPING = {
                             "type": "keyword"
                         },
                         "workshop_region": {
-                            "type": "string"
+                            "type": "text"
                         }
                     },
                     "type": "multi_field"
@@ -466,14 +466,14 @@ DOMAIN_MAPPING = {
             "type": "boolean"
         },
         "is_test": {
-            "type": "string"
+            "type": "text"
         },
         "last_modified": {
             "format": DATE_FORMATS_STRING,
             "type": "date"
         },
         "license": {
-            "type": "string"
+            "type": "text"
         },
         "migrations": {
             "dynamic": False,
@@ -496,26 +496,26 @@ DOMAIN_MAPPING = {
                     "type": "keyword"
                 },
                 "name": {
-                    "type": "string"
+                    "type": "text"
                 }
             },
             "type": "multi_field"
         },
         "organization": {
-            "type": "string"
+            "type": "text"
         },
         "phone_model": {
-            "type": "string"
+            "type": "text"
         },
         "project_type": {
             "analyzer": "comma",
-            "type": "string"
+            "type": "text"
         },
         "published": {
             "type": "boolean"
         },
         "publisher": {
-            "type": "string"
+            "type": "text"
         },
         "restrict_superusers": {
             "type": "boolean"
@@ -529,7 +529,7 @@ DOMAIN_MAPPING = {
                     "type": "keyword"
                 },
                 "short_description": {
-                    "type": "string"
+                    "type": "text"
                 }
             },
             "type": "multi_field"
@@ -538,13 +538,13 @@ DOMAIN_MAPPING = {
             "type": "boolean"
         },
         "sms_case_registration_owner_id": {
-            "type": "string"
+            "type": "text"
         },
         "sms_case_registration_type": {
-            "type": "string"
+            "type": "text"
         },
         "sms_case_registration_user_id": {
-            "type": "string"
+            "type": "text"
         },
         "sms_mobile_worker_registration_enabled": {
             "type": "boolean"
@@ -557,16 +557,16 @@ DOMAIN_MAPPING = {
             "type": "date"
         },
         "sub_area": {
-            "type": "string"
+            "type": "text"
         },
         "subscription": {
-            "type": "string"
+            "type": "text"
         },
         "survey_management_enabled": {
             "type": "boolean"
         },
         "tags": {
-            "type": "string"
+            "type": "text"
         },
         "title": {
             "fields": {
@@ -574,7 +574,7 @@ DOMAIN_MAPPING = {
                     "type": "keyword"
                 },
                 "title": {
-                    "type": "string"
+                    "type": "text"
                 }
             },
             "type": "multi_field"
@@ -583,7 +583,7 @@ DOMAIN_MAPPING = {
             "type": "boolean"
         },
         "yt_id": {
-            "type": "string"
+            "type": "text"
         },
         Tombstone.PROPERTY_NAME: {
             "type": "boolean"

--- a/corehq/pillows/mappings/domain_mapping.py
+++ b/corehq/pillows/mappings/domain_mapping.py
@@ -32,12 +32,10 @@ DOMAIN_MAPPING = {
         "author": {
             "fields": {
                 "author": {
-                    "index": "analyzed",
                     "type": "string"
                 },
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
             "type": "multi_field"
@@ -57,8 +55,7 @@ DOMAIN_MAPPING = {
                     "type": "string"
                 },
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "enabled": {
                     "type": "boolean"
@@ -77,8 +74,7 @@ DOMAIN_MAPPING = {
                     "type": "object"
                 },
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "form_details": {
                     "dynamic": False,
@@ -98,15 +94,13 @@ DOMAIN_MAPPING = {
                     "type": "date"
                 },
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "signed": {
                     "type": "boolean"
                 },
                 "type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "user_id": {
                     "type": "string"
@@ -263,12 +257,10 @@ DOMAIN_MAPPING = {
                 "city": {
                     "fields": {
                         "city": {
-                            "index": "analyzed",
                             "type": "string"
                         },
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     },
                     "type": "multi_field"
@@ -276,12 +268,10 @@ DOMAIN_MAPPING = {
                 "countries": {
                     "fields": {
                         "countries": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     },
                     "type": "multi_field"
@@ -289,19 +279,16 @@ DOMAIN_MAPPING = {
                 "description": {
                     "fields": {
                         "description": {
-                            "index": "analyzed",
                             "type": "string"
                         },
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     },
                     "type": "multi_field"
                 },
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "public": {
                     "type": "boolean"
@@ -309,11 +296,9 @@ DOMAIN_MAPPING = {
                 "region": {
                     "fields": {
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "region": {
-                            "index": "analyzed",
                             "type": "string"
                         }
                     },
@@ -325,8 +310,7 @@ DOMAIN_MAPPING = {
             "type": "string"
         },
         "doc_type": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "downloads": {
             "type": "long"
@@ -347,12 +331,10 @@ DOMAIN_MAPPING = {
                 "area": {
                     "fields": {
                         "area": {
-                            "index": "analyzed",
                             "type": "string"
                         },
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     },
                     "type": "multi_field"
@@ -373,8 +355,7 @@ DOMAIN_MAPPING = {
                     "type": "boolean"
                 },
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "goal_followup_rate": {
                     "type": "double"
@@ -385,11 +366,9 @@ DOMAIN_MAPPING = {
                 "initiative": {
                     "fields": {
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "initiative": {
-                            "index": "analyzed",
                             "type": "string"
                         }
                     },
@@ -401,11 +380,9 @@ DOMAIN_MAPPING = {
                 "organization_name": {
                     "fields": {
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "organization_name": {
-                            "index": "analyzed",
                             "type": "string"
                         }
                     },
@@ -414,11 +391,9 @@ DOMAIN_MAPPING = {
                 "phone_model": {
                     "fields": {
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "phone_model": {
-                            "index": "analyzed",
                             "type": "string"
                         }
                     },
@@ -445,11 +420,9 @@ DOMAIN_MAPPING = {
                 "sub_area": {
                     "fields": {
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "sub_area": {
-                            "index": "analyzed",
                             "type": "string"
                         }
                     },
@@ -464,11 +437,9 @@ DOMAIN_MAPPING = {
                 "workshop_region": {
                     "fields": {
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "workshop_region": {
-                            "index": "analyzed",
                             "type": "string"
                         }
                     },
@@ -509,8 +480,7 @@ DOMAIN_MAPPING = {
             "type": "object",
             "properties": {
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "has_migrated_permissions": {
                     "type": "boolean"
@@ -523,11 +493,9 @@ DOMAIN_MAPPING = {
         "name": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "name": {
-                    "index": "analyzed",
                     "type": "string"
                 }
             },
@@ -558,11 +526,9 @@ DOMAIN_MAPPING = {
         "short_description": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "short_description": {
-                    "index": "analyzed",
                     "type": "string"
                 }
             },
@@ -605,11 +571,9 @@ DOMAIN_MAPPING = {
         "title": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "title": {
-                    "index": "analyzed",
                     "type": "string"
                 }
             },

--- a/corehq/pillows/mappings/group_mapping.py
+++ b/corehq/pillows/mappings/group_mapping.py
@@ -24,25 +24,19 @@ GROUP_MAPPING = {
         },
         "domain": {
             "fields": {
-                "domain": {
-                    "type": "text"
-                },
                 "exact": {
                     "type": "keyword"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "name": {
             "fields": {
                 "exact": {
                     "type": "keyword"
-                },
-                "name": {
-                    "type": "text"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "path": {
             "type": "text"

--- a/corehq/pillows/mappings/group_mapping.py
+++ b/corehq/pillows/mappings/group_mapping.py
@@ -20,18 +20,15 @@ GROUP_MAPPING = {
             "type": "boolean"
         },
         "doc_type": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "domain": {
             "fields": {
                 "domain": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 },
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
             "type": "multi_field"
@@ -39,27 +36,25 @@ GROUP_MAPPING = {
         "name": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "name": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 }
             },
             "type": "multi_field"
         },
         "path": {
-            "type": "string"
+            "type": "text"
         },
         "removed_users": {
-            "type": "string"
+            "type": "text"
         },
         "reporting": {
             "type": "boolean"
         },
         "users": {
-            "type": "string"
+            "type": "text"
         },
         Tombstone.PROPERTY_NAME: {
             "type": "boolean"

--- a/corehq/pillows/mappings/sms_mapping.py
+++ b/corehq/pillows/mappings/sms_mapping.py
@@ -22,65 +22,61 @@ SMS_MAPPING = {
     "dynamic": False,
     "properties": {
         "backend_api": {
-            "type": "string"
+            "type": "text"
         },
         "backend_id": {
-            "type": "string"
+            "type": "text"
         },
         "base_doc": {
-            "type": "string"
+            "type": "text"
         },
         "billed": {
             "type": "boolean"
         },
         "couch_recipient": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "couch_recipient_doc_type": {
-            "type": "string"
+            "type": "text"
         },
         "date": {
             "format": DATE_FORMATS_STRING,
             "type": "date"
         },
         "direction": {
-            "type": "string"
+            "type": "text"
         },
         "doc_type": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "domain": {
             "fields": {
                 "domain": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 },
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
             "type": "multi_field"
         },
         "phone_number": {
-            "type": "string"
+            "type": "text"
         },
         "processed": {
             "type": "boolean"
         },
         "reminder_id": {
-            "type": "string"
+            "type": "text"
         },
         "text": {
-            "type": "string"
+            "type": "text"
         },
         "workflow": {
-            "type": "string"
+            "type": "text"
         },
         "xforms_session_couch_id": {
-            "type": "string"
+            "type": "text"
         },
         Tombstone.PROPERTY_NAME: {
             "type": "boolean"

--- a/corehq/pillows/mappings/sms_mapping.py
+++ b/corehq/pillows/mappings/sms_mapping.py
@@ -51,14 +51,11 @@ SMS_MAPPING = {
         },
         "domain": {
             "fields": {
-                "domain": {
-                    "type": "text"
-                },
                 "exact": {
                     "type": "keyword"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "phone_number": {
             "type": "text"

--- a/corehq/pillows/mappings/user_mapping.py
+++ b/corehq/pillows/mappings/user_mapping.py
@@ -20,20 +20,18 @@ USER_MAPPING = {
     "dynamic": False,
     "properties": {
         "CURRENT_VERSION": {
-            "type": "string"
+            "type": "text"
         },
         "__group_ids": {
-            "type": "string"
+            "type": "text"
         },
         "__group_names": {
             "fields": {
                 "__group_names": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 },
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
             "type": "multi_field"
@@ -42,20 +40,18 @@ USER_MAPPING = {
             "type": "boolean"
         },
         "assigned_location_ids": {
-            "type": "string"
+            "type": "text"
         },
         "base_doc": {
-            "type": "string"
+            "type": "text"
         },
         "base_username": {
             "fields": {
                 "base_username": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 },
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
             "type": "multi_field"
@@ -77,12 +73,10 @@ USER_MAPPING = {
                     "type": "nested",
                     "properties": {
                         "app_id": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "build_id": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "build_version": {
                             "type": "integer"
@@ -112,11 +106,10 @@ USER_MAPPING = {
                     }
                 },
                 "commcare_version": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "device_id": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "last_used": {
                     "format": DATE_FORMATS_STRING,
@@ -125,18 +118,15 @@ USER_MAPPING = {
             }
         },
         "doc_type": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "domain": {
             "fields": {
                 "domain": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 },
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
             "type": "multi_field"
@@ -146,18 +136,15 @@ USER_MAPPING = {
             "type": "object",
             "properties": {
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "domain": {
                     "fields": {
                         "domain": {
-                            "index": "analyzed",
-                            "type": "string"
+                            "type": "text"
                         },
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     },
                     "type": "multi_field"
@@ -166,20 +153,19 @@ USER_MAPPING = {
                     "type": "boolean"
                 },
                 "location_id": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "override_global_tz": {
                     "type": "boolean"
                 },
                 "role_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "timezone": {
-                    "type": "string"
+                    "type": "text"
                 },
                 'assigned_location_ids': {
-                    'type': 'string'
+                    'type': 'text'
                 },
             }
         },
@@ -188,18 +174,15 @@ USER_MAPPING = {
             "type": "object",
             "properties": {
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "domain": {
                     "fields": {
                         "domain": {
-                            "index": "analyzed",
-                            "type": "string"
+                            "type": "text"
                         },
                         "exact": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     },
                     "type": "multi_field"
@@ -208,20 +191,19 @@ USER_MAPPING = {
                     "type": "boolean"
                 },
                 "location_id": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "override_global_tz": {
                     "type": "boolean"
                 },
                 "role_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "timezone": {
-                    "type": "string"
+                    "type": "text"
                 },
                 'assigned_location_ids': {
-                    'type': 'string'
+                    'type': 'text'
                 },
             }
         },
@@ -234,28 +216,27 @@ USER_MAPPING = {
                     "type": "date"
                 },
                 "doc_type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "signed": {
                     "type": "boolean"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "user_id": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "user_ip": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "version": {
-                    "type": "string"
+                    "type": "text"
                 }
             }
         },
         "first_name": {
-            "type": "string"
+            "type": "text"
         },
         "is_active": {
             "type": "boolean"
@@ -270,7 +251,7 @@ USER_MAPPING = {
             "type": "boolean"
         },
         "language": {
-            "type": "string"
+            "type": "text"
         },
         "last_device": {
             "dynamic": False,
@@ -281,12 +262,10 @@ USER_MAPPING = {
                     "type": "object",
                     "properties": {
                         "app_id": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "build_id": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "build_version": {
                             "type": "integer"
@@ -316,11 +295,10 @@ USER_MAPPING = {
                     }
                 },
                 "commcare_version": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "device_id": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "last_used": {
                     "format": DATE_FORMATS_STRING,
@@ -333,20 +311,19 @@ USER_MAPPING = {
             "type": "date"
         },
         "last_name": {
-            "type": "string"
+            "type": "text"
         },
         "location_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "password": {
-            "type": "string"
+            "type": "text"
         },
         "phone_numbers": {
-            "type": "string"
+            "type": "text"
         },
         "registering_device_id": {
-            "type": "string"
+            "type": "text"
         },
         "reporting_metadata": {
             "dynamic": False,
@@ -357,7 +334,7 @@ USER_MAPPING = {
                     "type": "object",
                     "properties": {
                         "app_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "build_version": {
                             "type": "integer"
@@ -373,7 +350,7 @@ USER_MAPPING = {
                     "type": "nested",
                     "properties": {
                         "app_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "build_version": {
                             "type": "integer"
@@ -389,19 +366,19 @@ USER_MAPPING = {
                     "type": "object",
                     "properties": {
                         "app_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "build_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "build_version": {
                             "type": "integer"
                         },
                         "commcare_version": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "device_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "submission_date": {
                             "format": DATE_FORMATS_STRING,
@@ -414,19 +391,19 @@ USER_MAPPING = {
                     "type": "nested",
                     "properties": {
                         "app_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "build_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "build_version": {
                             "type": "integer"
                         },
                         "commcare_version": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "device_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "submission_date": {
                             "format": DATE_FORMATS_STRING,
@@ -439,7 +416,7 @@ USER_MAPPING = {
                     "type": "object",
                     "properties": {
                         "app_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "build_version": {
                             "type": "integer"
@@ -455,7 +432,7 @@ USER_MAPPING = {
                     "type": "nested",
                     "properties": {
                         "app_id": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "build_version": {
                             "type": "integer"
@@ -469,7 +446,7 @@ USER_MAPPING = {
             }
         },
         "status": {
-            "type": "string"
+            "type": "text"
         },
         "user_data": {
             "enabled": False,
@@ -480,30 +457,25 @@ USER_MAPPING = {
             "type": "nested",
             "properties": {
                 "key": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "value": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 }
             }
         },
         "user_location_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "username": {
             "fields": {
                 "exact": {
                     "include_in_all": False,
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "username": {
                     "analyzer": "standard",
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 }
             },
             "type": "multi_field"

--- a/corehq/pillows/mappings/user_mapping.py
+++ b/corehq/pillows/mappings/user_mapping.py
@@ -27,14 +27,11 @@ USER_MAPPING = {
         },
         "__group_names": {
             "fields": {
-                "__group_names": {
-                    "type": "text"
-                },
                 "exact": {
                     "type": "keyword"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "analytics_enabled": {
             "type": "boolean"
@@ -47,14 +44,11 @@ USER_MAPPING = {
         },
         "base_username": {
             "fields": {
-                "base_username": {
-                    "type": "text"
-                },
                 "exact": {
                     "type": "keyword"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "created_on": {
             "format": DATE_FORMATS_STRING,
@@ -122,14 +116,11 @@ USER_MAPPING = {
         },
         "domain": {
             "fields": {
-                "domain": {
-                    "type": "text"
-                },
                 "exact": {
                     "type": "keyword"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "domain_membership": {
             "dynamic": False,
@@ -140,14 +131,11 @@ USER_MAPPING = {
                 },
                 "domain": {
                     "fields": {
-                        "domain": {
-                            "type": "text"
-                        },
                         "exact": {
                             "type": "keyword"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 },
                 "is_admin": {
                     "type": "boolean"
@@ -178,14 +166,11 @@ USER_MAPPING = {
                 },
                 "domain": {
                     "fields": {
-                        "domain": {
-                            "type": "text"
-                        },
                         "exact": {
                             "type": "keyword"
                         }
                     },
-                    "type": "multi_field"
+                    "type": "text"
                 },
                 "is_admin": {
                     "type": "boolean"
@@ -472,13 +457,10 @@ USER_MAPPING = {
                 "exact": {
                     "include_in_all": False,
                     "type": "keyword"
-                },
-                "username": {
-                    "analyzer": "standard",
-                    "type": "text"
                 }
             },
-            "type": "multi_field"
+            "analyzer": "standard",
+            "type": "text"
         },
         Tombstone.PROPERTY_NAME: {
             "type": "boolean"

--- a/corehq/pillows/mappings/xform_mapping.py
+++ b/corehq/pillows/mappings/xform_mapping.py
@@ -19,50 +19,43 @@ XFORM_MAPPING = {
     "dynamic": False,
     "properties": {
         "#export_tag": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "@uiVersion": {
-            "type": "string"
+            "type": "text"
         },
         "@version": {
-            "type": "string"
+            "type": "text"
         },
         "__retrieved_case_ids": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "_attachments": {
             "dynamic": False,
             "type": "object"
         },
         "app_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "backend_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "build_id": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "doc_type": {
-            "type": "string"
+            "type": "text"
         },
         "domain": {
             "fields": {
                 "domain": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 },
                 "exact": {
                     # exact is full text string match - hyphens get parsed in standard
                     # analyzer
                     # in queries you can access by domain.exact
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 }
             },
             "type": "multi_field"
@@ -75,12 +68,10 @@ XFORM_MAPPING = {
             "dynamic": False,
             "properties": {
                 "#type": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "@name": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "case": {
                     "dynamic": False,
@@ -91,36 +82,30 @@ XFORM_MAPPING = {
                         # template needs to be added along with fundamentally
                         # altering case queries
                         "@case_id": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "@date_modified": {
                             "format": DATE_FORMATS_STRING,
                             "type": "date"
                         },
                         "@user_id": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "@xmlns": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "case_id": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "date_modified": {
                             "format": DATE_FORMATS_STRING,
                             "type": "date"
                         },
                         "user_id": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "xmlns": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     }
                 },
@@ -128,20 +113,16 @@ XFORM_MAPPING = {
                     "dynamic": False,
                     "properties": {
                         "appVersion": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "app_build_version": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "commcare_version": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "deviceID": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "geo_point": {
                             "geohash": True,
@@ -151,8 +132,7 @@ XFORM_MAPPING = {
                             "type": "geo_point"
                         },
                         "instanceID": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "timeEnd": {
                             "format": DATE_FORMATS_STRING,
@@ -163,13 +143,11 @@ XFORM_MAPPING = {
                             "type": "date"
                         },
                         "userID": {
-                            "index": "not_analyzed",
                             "null_value": NULL_VALUE,
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "username": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "type": "keyword"
                         }
                     }
                 }
@@ -186,8 +164,7 @@ XFORM_MAPPING = {
             "type": "boolean"
         },
         "path": {
-            "index": "not_analyzed",
-            "type": "string"
+            "type": "keyword"
         },
         "received_on": {
             "format": DATE_FORMATS_STRING,
@@ -201,19 +178,16 @@ XFORM_MAPPING = {
             "type": "ip"
         },
         "user_type": {
-            "index": "not_analyzed",
             "null_value": NULL_VALUE,
-            "type": "string"
+            "type": "keyword"
         },
         "xmlns": {
             "fields": {
                 "exact": {
-                    "index": "not_analyzed",
-                    "type": "string"
+                    "type": "keyword"
                 },
                 "xmlns": {
-                    "index": "analyzed",
-                    "type": "string"
+                    "type": "text"
                 }
             },
             "type": "multi_field"

--- a/corehq/pillows/mappings/xform_mapping.py
+++ b/corehq/pillows/mappings/xform_mapping.py
@@ -125,10 +125,6 @@ XFORM_MAPPING = {
                             "type": "keyword"
                         },
                         "geo_point": {
-                            "geohash": True,
-                            "geohash_precision": "10m",
-                            "geohash_prefix": True,
-                            "lat_lon": True,
                             "type": "geo_point"
                         },
                         "instanceID": {

--- a/corehq/pillows/mappings/xform_mapping.py
+++ b/corehq/pillows/mappings/xform_mapping.py
@@ -48,9 +48,6 @@ XFORM_MAPPING = {
         },
         "domain": {
             "fields": {
-                "domain": {
-                    "type": "text"
-                },
                 "exact": {
                     # exact is full text string match - hyphens get parsed in standard
                     # analyzer
@@ -58,7 +55,7 @@ XFORM_MAPPING = {
                     "type": "keyword"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         "external_blobs": {
             "dynamic": False,
@@ -181,12 +178,9 @@ XFORM_MAPPING = {
             "fields": {
                 "exact": {
                     "type": "keyword"
-                },
-                "xmlns": {
-                    "type": "text"
                 }
             },
-            "type": "multi_field"
+            "type": "text"
         },
         Tombstone.PROPERTY_NAME: {
             "type": "boolean"


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Creating this pull request for future references. These mappings are for ES5 cluster but we can't use them to create a new index in ES2 cluster. The `text` keyword is not supported as a valid `type` in ES2 and will throw the following error on index creation.

```
elasticsearch2.exceptions.RequestError: TransportError(400, 'mapper_parsing_exception', 'No handler for type [text] declared on field [@uiVersion]
```

But these mapping can be used as it is when we move to ES5.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
