### PR TITLE
Revert PR #32389

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -29,7 +29,6 @@ from corehq.form_processor.signals import sql_case_post_save
 from corehq.tests.locks import reentrant_redis_locks
 from corehq.toggles import NAMESPACE_DOMAIN, RUN_AUTO_CASE_UPDATES_ON_SAVE
 from corehq.util.context_managers import drop_connected_signals
-from corehq.util.test_utils import flag_enabled
 from corehq.util.test_utils import set_parent_case as set_actual_parent_case
 
 
@@ -746,29 +745,6 @@ class CaseRuleActionsTest(BaseCaseRuleTest):
         """
         Updating case property "external_id" updates ``case.external_id``
         """
-        rule = _create_empty_rule(self.domain)
-        _, definition = rule.add_action(UpdateCaseDefinition, close_case=False)
-        definition.set_properties_to_update([
-            UpdateCaseDefinition.PropertyDefinition(
-                name='external_id',
-                value_type=UpdateCaseDefinition.VALUE_TYPE_EXACT,
-                value='Bella Ramsay',
-            ),
-        ])
-        definition.save()
-
-        with _with_case(self.domain, 'person', datetime.utcnow()) as case:
-            self.assertActionResult(rule, 0)
-
-            result = rule.run_actions_when_case_matches(case)
-            case = CommCareCase.objects.get_case(case.case_id, self.domain)
-
-            self.assertActionResult(rule, 1, result, CaseRuleActionResult(num_updates=1))
-            self.assertNotIn('external_id', case.case_json)
-            self.assertEqual(case.external_id, 'Bella Ramsay')
-
-    @flag_enabled('USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY')
-    def test_equivalent_to_feature_flag(self):
         rule = _create_empty_rule(self.domain)
         _, definition = rule.add_action(UpdateCaseDefinition, close_case=False)
         definition.set_properties_to_update([

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -142,7 +142,6 @@ def _get_update_or_close_case_block(
     case_properties=None,
     close=False,
     owner_id=None,
-    domain=None,
 ):
     kwargs = {
         'create': False,
@@ -157,8 +156,6 @@ def _get_update_or_close_case_block(
         kwargs['update'] = case_properties
     if owner_id:
         kwargs['owner_id'] = owner_id
-    if domain:
-        kwargs['domain'] = domain
 
     return CaseBlock.deprecated_init(case_id, **kwargs)
 
@@ -188,7 +185,7 @@ def update_case(
                the project is over its submission rate limit.
                See the docstring for submit_form_locally for meaning of values
     """
-    caseblock = _get_update_or_close_case_block(case_id, case_properties, close, owner_id, domain=domain)
+    caseblock = _get_update_or_close_case_block(case_id, case_properties, close, owner_id)
     return submit_case_blocks(
         ElementTree.tostring(caseblock.as_xml(), encoding='utf-8').decode('utf-8'),
         domain,

--- a/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock/case_block.py
@@ -8,7 +8,6 @@ from dimagi.utils.parsing import json_format_datetime, string_to_datetime
 from collections import namedtuple
 from functools import partial
 import six
-from corehq.toggles import USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY
 
 # relationship = "child" for index to a parent case (default)
 # relationship = "extension" for index to a host case
@@ -39,7 +38,6 @@ class CaseBlock(object):
         index=None,
         strict=True,
         date_opened_deprecated_behavior=False,
-        domain=None,
     ):
         """
         When `date_opened_deprecated_behavior`, a date_opened YYYY-MM-DD value is inserted on new cases.
@@ -71,7 +69,6 @@ class CaseBlock(object):
             self._check_for_duplicate_properties()
         self.index = {key: self._make_index_attrs(value)
                       for key, value in index.items()} if index else {}
-        self.domain = domain
 
     @classmethod
     def deprecated_init(cls, *args, **kwargs):
@@ -114,13 +111,8 @@ class CaseBlock(object):
             'update': self.update,
         }
 
-        external_id = self.external_id
-        # This is probably not the best way, but is needed currently.
-        if self.domain and USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY.enabled(self.domain):
-            external_id = self.update.get('external_id', external_id)
-
         result['update'].update({
-            'external_id': external_id,
+            'external_id': self.external_id,
             'date_opened': self.date_opened,
         })
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_case_block.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_case_block.py
@@ -1,6 +1,5 @@
 from django.test import SimpleTestCase
 from casexml.apps.case.mock import CaseBlock
-from corehq.util.test_utils import flag_disabled, flag_enabled
 
 
 class TestCaseBlock(SimpleTestCase):
@@ -9,17 +8,3 @@ class TestCaseBlock(SimpleTestCase):
         xml = CaseBlock("arbitrary_id", update={'float': float(1.2), 'int': 5}).as_xml()
         self.assertEqual(xml.findtext('update/float'), "1.2")
         self.assertEqual(xml.findtext('update/int'), "5")
-
-    @flag_disabled('USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY')
-    def test_custom_external_id_property_not_used(self):
-        domain = "test-domain"
-        xml = CaseBlock("arbitrary_id", update={'external_id': "01234"}, external_id="43210", domain=domain)\
-            .as_xml()
-        self.assertEqual(xml.findtext('update/external_id'), "43210")
-
-    @flag_enabled('USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY')
-    def test_custom_external_id_property_used(self):
-        domain = "test-domain"
-        xml = CaseBlock("arbitrary_id", update={'external_id': "01234"}, external_id="43210", domain=domain)\
-            .as_xml()
-        self.assertEqual(xml.findtext('update/external_id'), "01234")

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -654,13 +654,6 @@ LAZY_LOAD_MULTIMEDIA = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY = StaticToggle(
-    'custom-external_id-case-property',
-    'eCHIS: Use the user defined external_id case property when running auto case update rules.',
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN],
-)
-
 APP_BUILDER_ADVANCED = StaticToggle(
     'advanced-app-builder',
     'Advanced Module in App-Builder',


### PR DESCRIPTION
## Technical Summary

Follows on from PR #32856 "Allow `AutomaticUpdateRule` to update `case.external_id`"

Drops the `USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY` feature flag, added in PR #32389. Users no longer need the feature flag in order to update the `external_id` case property using an auto update rule.

:fish: 

## Feature Flag

Drops `USE_CUSTOM_EXTERNAL_ID_CASE_PROPERTY`

## Safety Assurance

### Safety story

* A unit test added in the previous PR (and removed in this one) verifies that that change reproduced the behavior of the feature flag.
* The feature flag is only used by one project.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
