### PR TITLE
FHIR endpoint decorators for requiring JSON content headers 

### DIFF
--- a/corehq/motech/fhir/const.py
+++ b/corehq/motech/fhir/const.py
@@ -42,3 +42,5 @@ FHIR_DATA_TYPE_LIST_OF_STRING = 'fhir_list_of_string'
 FHIR_DATA_TYPES = (
     FHIR_DATA_TYPE_LIST_OF_STRING,
 )
+
+HQ_ACCEPTABLE_FHIR_MIME_TYPES = ['application/json', 'application/fhir+json']

--- a/corehq/motech/fhir/tests/test_utils.py
+++ b/corehq/motech/fhir/tests/test_utils.py
@@ -1,4 +1,5 @@
-from django.test import SimpleTestCase, TestCase
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase, TestCase
 
 from nose.tools import assert_equal
 
@@ -8,6 +9,8 @@ from corehq.motech.fhir.utils import (
     load_fhir_resource_types,
     resource_url,
     update_fhir_resource_property,
+    require_fhir_json_accept_headers,
+    require_fhir_json_content_type_headers
 )
 
 DOMAIN = "test-domain"
@@ -153,3 +156,45 @@ def test_resource_url():
     url = resource_url(DOMAIN, 'R4', 'Patient', 'abc123')
     drop_hostname = url.split('/', maxsplit=3)[3]
     assert_equal(drop_hostname, f'a/{DOMAIN}/fhir/R4/Patient/abc123/')
+
+
+class TestHeaderDecorators(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _do_get_request(self, view, headers={}):
+        request = self.factory.get('/foo', **headers)
+        return view(request)
+
+    def test_require_fhir_json_accept_headers(self):
+        @require_fhir_json_accept_headers
+        def test_view(request):
+            return HttpResponse()
+        response = self._do_get_request(test_view)
+        self.assertEqual(response.status_code, 200)
+        response = self._do_get_request(test_view, headers={'HTTP_ACCEPT': 'application/json'})
+        self.assertEqual(response.status_code, 200)
+        response = self._do_get_request(test_view, headers={'HTTP_ACCEPT': 'application/xml'})
+        self.assertEqual(response.status_code, 406)
+        self.assertEqual(
+            response.content.decode("utf-8"),
+            '{"message": "Not Acceptable"}'
+        )
+
+    def _do_post_request(self, view, content_type=None):
+        request = self.factory.post('/foo', content_type=content_type)
+        return view(request)
+
+    def test_require_fhir_json_content_type_headers(self):
+        @require_fhir_json_content_type_headers
+        def test_view(request):
+            return HttpResponse()
+        response = self._do_post_request(test_view, content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        response = self._do_post_request(test_view, content_type='application/xml')
+        self.assertEqual(response.status_code, 415)
+        self.assertEqual(
+            response.content.decode("utf-8"),
+            '{"message": "Unsupported Media Type"}'
+        )

--- a/corehq/motech/fhir/utils.py
+++ b/corehq/motech/fhir/utils.py
@@ -1,14 +1,16 @@
 import os
-
+from functools import wraps
 from memoized import memoized
 
-from corehq.motech.fhir.const import FHIR_VERSION_4_0_1
+from corehq.motech.fhir.const import FHIR_VERSION_4_0_1, HQ_ACCEPTABLE_FHIR_MIME_TYPES
 from corehq.motech.fhir.models import (
     FHIRResourceProperty,
     FHIRResourceType,
     get_schema_dir,
 )
 from corehq.util.view_utils import absolute_reverse
+
+from django.http import JsonResponse
 
 
 def resource_url(domain, fhir_version_name, resource_type, case_id):
@@ -75,3 +77,24 @@ def load_fhir_resource_types(fhir_version=FHIR_VERSION_4_0_1, exclude_resource_t
             resource_types.remove(schema)
     resource_types.sort()
     return resource_types
+
+
+def require_fhir_json_accept_headers(view_func):
+    @wraps(view_func)
+    def _inner(request, *args, **kwargs):
+        accept_header = request.META.get('HTTP_ACCEPT')
+        if accept_header and accept_header not in HQ_ACCEPTABLE_FHIR_MIME_TYPES + ['*/*']:
+            return JsonResponse(status=406, data={'message': "Not Acceptable"})
+        return view_func(request, *args, **kwargs)
+
+    return _inner
+
+
+def require_fhir_json_content_type_headers(view_func):
+    @wraps(view_func)
+    def _inner(request, *args, **kwargs):
+        if request.content_type not in HQ_ACCEPTABLE_FHIR_MIME_TYPES:
+            return JsonResponse(status=415, data={'message': "Unsupported Media Type"})
+        return view_func(request, *args, **kwargs)
+
+    return _inner

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -11,6 +11,7 @@ from corehq.apps.domain.decorators import (
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase
 from corehq.motech.exceptions import ConfigurationError
+from corehq.motech.fhir.utils import require_fhir_json_accept_headers
 from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
 from corehq.util.view_utils import get_case_or_404
 
@@ -51,6 +52,7 @@ class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
 @login_or_api_key
 @require_superuser
 @toggles.FHIR_INTEGRATION.required_decorator()
+@require_fhir_json_accept_headers
 def get_view(request, domain, fhir_version_name, resource_type, resource_id):
     fhir_version = _get_fhir_version(fhir_version_name)
     if not fhir_version:
@@ -77,6 +79,7 @@ def get_view(request, domain, fhir_version_name, resource_type, resource_id):
 @login_or_api_key
 @require_superuser
 @toggles.FHIR_INTEGRATION.required_decorator()
+@require_fhir_json_accept_headers
 def search_view(request, domain, fhir_version_name, resource_type):
     fhir_version = _get_fhir_version(fhir_version_name)
     if not fhir_version:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Implements [USH-3083](https://dimagi-dev.atlassian.net/browse/USH-3083?atlOrigin=eyJpIjoiYmIwMzRkNjFkMWFjNGYzZGIzZTEzYWNkOWY5MzVmNjUiLCJwIjoiaiJ9), which is part of the roadmap to enhance HQ's FHIR interoperability.

Continues the [draft PR](https://github.com/dimagi/commcare-hq/pull/32859).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

This PR adds two view decorators that set requirements for the "Accept" and "Content-Type" headers on HTTP requests to the two existing FHIR endpoints. 

The first decorator rejects requests that have an Accept header that is not equal to 'application/fhir+json' or 'application/json'. Note that requests with _no_ Accept header are also allowed.

The second decorator rejects requests that do not have a Content-Type header equal to the same values.

Since the endpoints are GET only, we only need to use the first decorator for now.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

FHIR_INTEGRATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested manually locally and added automated tests. Changes only affect the two FHIR-related endpoints the decorator is added to.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

I don't think it's necessary for now.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3083]: https://dimagi-dev.atlassian.net/browse/USH-3083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ