### PR TITLE
add user type names for system case auto updates

### DIFF
--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -12,12 +12,13 @@ from soil import DownloadBase
 from corehq.apps.casegroups.models import CommCareCaseGroup
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
-from corehq.apps.hqcase.utils import get_case_by_identifier
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.motech.repeaters.const import RECORD_CANCELLED_STATE
 
 
 def add_cases_to_case_group(domain, case_group_id, uploaded_data, progress_tracker):
+    from corehq.apps.hqcase.utils import get_case_by_identifier
+
     response = {
         'errors': [],
         'success': [],

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -15,6 +15,8 @@ from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.exceptions import CaseNotFound, MissingFormXml
 from corehq.form_processor.models import CommCareCase
+from corehq.apps.data_interfaces.deduplication import DEDUPE_XMLNS
+from corehq.motech.dhis2.const import XMLNS_DHIS2
 
 CASEBLOCK_CHUNKSIZE = 100
 SYSTEM_FORM_XMLNS = 'http://commcarehq.org/case'
@@ -25,6 +27,8 @@ SYSTEM_FORM_XMLNS_MAP = {
     SYSTEM_FORM_XMLNS: gettext_lazy('System Form'),
     EDIT_FORM_XMLNS: gettext_lazy('Data Cleaning Form'),
     AUTO_UPDATE_XMLNS: gettext_lazy('Automatic Case Update Rule'),
+    DEDUPE_XMLNS: gettext_lazy('Deduplication Rule'),
+    XMLNS_DHIS2: gettext_lazy('DHIS2 Integration')
 }
 
 ALLOWED_CASE_IDENTIFIER_TYPES = [

--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -334,7 +334,7 @@ def form_to_json(domain, form, timezone):
             "username": form.metadata.username if form.metadata else '',
         },
         'readable_name': form_name,
-        'user_type': get_user_type(form.metadata, domain) if form.metadata else 'Unknown',
+        'user_type': get_user_type(form, domain),
     }
 
 

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -14,6 +14,7 @@ from corehq.apps.reports.models import HQUserType
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS_MAP
 from corehq.apps.data_interfaces.deduplication import DEDUPE_XMLNS
+from corehq.motech.dhis2.const import XMLNS_DHIS2
 from django.utils.translation import gettext_lazy
 
 
@@ -185,6 +186,7 @@ def query_location_restricted_forms(query, domain, couch_user):
 def _get_system_form_types():
     form_types = SYSTEM_FORM_XMLNS_MAP.copy()
     form_types[DEDUPE_XMLNS] = gettext_lazy('Deduplication Rule')
+    form_types[XMLNS_DHIS2] = gettext_lazy('DHIS2 Integration')
     return form_types
 
 

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -13,9 +13,6 @@ from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
 from corehq.apps.reports.models import HQUserType
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS_MAP
-from corehq.apps.data_interfaces.deduplication import DEDUPE_XMLNS
-from corehq.motech.dhis2.const import XMLNS_DHIS2
-from django.utils.translation import gettext_lazy
 
 
 def _get_special_owner_ids(domain, admin, unknown, web, demo, commtrack):
@@ -183,19 +180,11 @@ def query_location_restricted_forms(query, domain, couch_user):
     return query.filter(form_es.user_id(accessible_ids))
 
 
-def _get_system_form_types():
-    form_types = SYSTEM_FORM_XMLNS_MAP.copy()
-    form_types[DEDUPE_XMLNS] = gettext_lazy('Deduplication Rule')
-    form_types[XMLNS_DHIS2] = gettext_lazy('DHIS2 Integration')
-    return form_types
-
-
 def get_user_type(form, domain=None):
     user_type = 'Unknown'
     if getattr(form.metadata, 'username', None) == 'system':
-        form_types = _get_system_form_types()
-        if form.xmlns in form_types:
-            user_type = form_types[form.xmlns]
+        if form.xmlns in SYSTEM_FORM_XMLNS_MAP:
+            user_type = SYSTEM_FORM_XMLNS_MAP[form.xmlns]
         else:
             user_type = 'System'
     elif getattr(form.metadata, 'userID', None):

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -183,7 +183,7 @@ def query_location_restricted_forms(query, domain, couch_user):
 
 
 def _get_system_form_types():
-    form_types = SYSTEM_FORM_XMLNS_MAP
+    form_types = SYSTEM_FORM_XMLNS_MAP.copy()
     form_types[DEDUPE_XMLNS] = gettext_lazy('Deduplication Rule')
     return form_types
 

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -198,7 +198,7 @@ def get_user_type(form, domain=None):
             user_type = 'System'
     elif getattr(form.metadata, 'userID', None):
         doc_info = get_doc_info_by_id(domain, form.metadata.userID)
-        if doc_info:
+        if doc_info.type_display:
             user_type = doc_info.type_display
 
     return user_type

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -12,6 +12,9 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
 from corehq.apps.reports.models import HQUserType
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
+from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS_MAP
+from corehq.apps.data_interfaces.deduplication import DEDUPE_XMLNS
+from django.utils.translation import gettext_lazy
 
 
 def _get_special_owner_ids(domain, admin, unknown, web, demo, commtrack):
@@ -179,13 +182,23 @@ def query_location_restricted_forms(query, domain, couch_user):
     return query.filter(form_es.user_id(accessible_ids))
 
 
-def get_user_type(form_metadata, domain=None):
+def _get_system_form_types():
+    form_types = SYSTEM_FORM_XMLNS_MAP
+    form_types[DEDUPE_XMLNS] = gettext_lazy('Deduplication Rule')
+    return form_types
+
+
+def get_user_type(form, domain=None):
     user_type = 'Unknown'
-    if getattr(form_metadata, 'userID', None):
-        doc_info = get_doc_info_by_id(domain, form_metadata.userID)
+    if getattr(form.metadata, 'username', None) == 'system':
+        form_types = _get_system_form_types()
+        if form.xmlns in form_types:
+            user_type = form_types[form.xmlns]
+        else:
+            user_type = 'System'
+    elif getattr(form.metadata, 'userID', None):
+        doc_info = get_doc_info_by_id(domain, form.metadata.userID)
         if doc_info:
             user_type = doc_info.type_display
-    elif form_metadata.username == 'system':
-        user_type = 'System'
 
     return user_type

--- a/corehq/apps/reports/tests/test_util.py
+++ b/corehq/apps/reports/tests/test_util.py
@@ -13,6 +13,7 @@ from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.util.test_utils import TestFileMixin, get_form_ready_to_save
 from corehq.apps.reports.standard.cases.utils import get_user_type
+from corehq.apps.data_interfaces.deduplication import DEDUPE_XMLNS
 
 DOMAIN = 'test_domain'
 USER_ID = "5bc1315c-da6f-466d-a7c4-4580bc84a7b9"
@@ -44,22 +45,33 @@ class TestSummarizeUserCounts(SimpleTestCase):
 
 class TestGetUserType(SimpleTestCase):
     def setUp(self):
-        self.form_metadata = Mock(userID=None, username='foobar')
+        self.form = Mock(
+            xmlns='my-xmlns',
+            metadata=Mock(
+                userID=None,
+                username='foobar'
+            )
+        )
 
     def test_unknown_user(self):
-        self.assertEqual(get_user_type(self.form_metadata), 'Unknown')
+        self.assertEqual(get_user_type(self.form), 'Unknown')
 
     def test_system_user(self):
-        self.form_metadata.username = 'system'
-        self.assertEqual(get_user_type(self.form_metadata), 'System')
+        self.form.metadata.username = 'system'
+        self.assertEqual(get_user_type(self.form), 'System')
+
+    def test_system_update(self):
+        self.form.metadata.username = 'system'
+        self.form.xmlns = DEDUPE_XMLNS
+        self.assertEqual(get_user_type(self.form), 'Deduplication Rule')
 
     @patch(
         'corehq.apps.reports.standard.cases.utils.get_doc_info_by_id',
         return_value=Mock(type_display='Foobar')
     )
     def test_display_user(self, _):
-        self.form_metadata.userID = '1234'
-        self.assertEqual(get_user_type(self.form_metadata), 'Foobar')
+        self.form.metadata.userID = '1234'
+        self.assertEqual(get_user_type(self.form), 'Foobar')
 
 
 def test_get_user_id():

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -194,9 +194,7 @@ def get_case_history(case):
             'Form Name': name,
             'Form Received On': form.received_on,
             'Form Submitted By': form.metadata.username,
-            'Form User Type': (
-                get_user_type(form.metadata, case.domain) if form.metadata else 'Unknown'
-            ),
+            'Form User Type': get_user_type(form, case.domain),
         }
         case_blocks = extract_case_blocks(form)
         for block in case_blocks:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Below is an example of the old representation of system updates in the case history table:
![Screenshot from 2023-04-24 10-07-52](https://user-images.githubusercontent.com/122617251/233937072-c0fd427c-70da-40bb-ae93-cd79451d9a33.png)

This has been updated with a more specific representation of system updates as follows:
![Screenshot from 2023-04-24 10-00-04](https://user-images.githubusercontent.com/122617251/233937095-a643313b-88ea-444b-adc4-e8ad4553b586.png)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2697)

Currently, all system case updates are labelled as "System" in the "User Type" column in the case history table. This change adds more specific names for system updates, such as the automatic case update and deduplication rules.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Small UI update, have done local testing. Unit tests also exist for related code.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests exist for `get_user_type()`.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
