### PR TITLE
Fixed background colors for case tiles in Web Apps

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
@@ -124,12 +124,13 @@
   transition: background .6s;
 }
 
-.module-table-case-list tbody tr:nth-child(even) td {
+// Apply to all children to cover both regular case lists and case tiles
+.module-table-case-list tbody tr:nth-child(even) > * {
   background-color: @cc-bg;
 }
 
-.module-table-case-list tbody tr:hover td {
-  background-color: darken(@cc-bg, 5);;
+.module-table-case-list tbody tr:hover > * {
+  background-color: darken(@cc-bg, 5);
 }
 
 .module-search-container, .case-list-actions {


### PR DESCRIPTION
## Product Description
The every other row striping and the highlight on hover weren't supported for case tiles in web apps.

Before
![Screen Shot 2023-04-24 at 3 31 39 PM](https://user-images.githubusercontent.com/1486591/234097212-d71d1e67-019c-4208-bb89-d91e7bc43f3f.png)


After (top row is being hovered over)
![Screen Shot 2023-04-24 at 3 27 35 PM](https://user-images.githubusercontent.com/1486591/234096995-dff98568-5ba8-4b5a-a950-931e6a8f7fb5.png)


## Feature Flag
Case tiles

## Safety Assurance

Low risk, and I'm fairly certain no one is using case tiles in web apps in production. Tested locally with a case tiles case list and a normal case list.

### Safety story


### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
