### PR TITLE
Add Content-Length header in export response

### DIFF
--- a/corehq/ex-submodules/couchexport/shortcuts.py
+++ b/corehq/ex-submodules/couchexport/shortcuts.py
@@ -1,4 +1,5 @@
 import io
+import os
 from wsgiref.util import FileWrapper
 
 from couchexport.files import TempBase
@@ -30,6 +31,7 @@ def export_response(file, format, filename, checkpoint=None):
     if format.download:
         from corehq.util.files import safe_filename_header
         response['Content-Disposition'] = safe_filename_header(filename, format.extension)
+        response['Content-Length'] = os.fstat(file.fileno()).st_size
 
     if checkpoint:
         response['X-CommCareHQ-Export-Token'] = checkpoint.get_id


### PR DESCRIPTION
## Product Description

Adds file size info the http response headers when downloading files served through `export_response`

## Technical Summary


## Feature Flag
NA

## Safety Assurance


### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
It's a one-line change that just adds a header

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Tested locally


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
