### PR TITLE
Cs/update support nested input to command

### DIFF
--- a/corehq/apps/es/management/commands/make_elastic_migration.py
+++ b/corehq/apps/es/management/commands/make_elastic_migration.py
@@ -197,6 +197,16 @@ class Command(makemigrations.Command):
 
     @staticmethod
     def get_nested_value(keys_list, data_dict):
+        """
+        :param keys_list: A list of keys specifying the nested path of the value
+        :param data_dict: The dictionary containing the nested value
+
+        :returns: a nested dictionary corresponding to the keys_list
+
+        Example usage:
+            >>> get_nested_value(['person', 'name'], {'person': {'name': 'Sonny', 'surname': 'Corleone'}})
+            {'person': {'name': 'Sonny'}}
+        """
         # Get the nested value
         value = data_dict
         for key in keys_list:

--- a/corehq/apps/es/tests/test_command_make_elastic_migration.py
+++ b/corehq/apps/es/tests/test_command_make_elastic_migration.py
@@ -194,6 +194,13 @@ class TestMakeElasticMigrationCommand(TestCase):
         self.assertIs(adapter, groups.group_adapter)
         self.assertEqual(["domain", "name"], sorted(properties))
 
+    def test_adapter_and_properties_type_with_nested_structure(self):
+        adapter, properties = Command().adapter_and_properties_type("groups:domain.fields.domain,name")
+        self.assertIs(adapter, groups.group_adapter)
+        self.assertEqual(["domain", "name"], sorted(properties))
+        self.assertEqual(list(properties['domain'].keys()), ['fields'])
+        self.assertEqual(list(properties['domain']['fields'].keys()), ['domain'])
+
     def test_adapter_and_properties_type_returns_all_properties_if_none_specified(self):
         adapter, properties = Command().adapter_and_properties_type("groups")
         self.assertIs(adapter, groups.group_adapter)


### PR DESCRIPTION
Add support for nested input to the `make_elastic_migration` management command.

This change will ensure the following is a valid command:
`./manage.py make_elastic_migration --name add_assigned_location_ids -u users:domain_memberships.properties.assigned_location_ids`