### PR TITLE
Make module settings "advanced" section display properly

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -27,14 +27,12 @@
           <i class="fa fa-check"></i>{% trans "Multimedia" %}
         </a>
       </li>
-      {% if not module.is_surveys %}
-        {% if add_ons.register_from_case_list or add_ons.case_list_menu_item or module.doc_type == "AdvancedModule" %}
-          <li>
-            <a href="#" data-slug="advanced" data-collapse="1">
-              <i class="fa fa-check"></i>{% trans "Advanced" %}
-            </a>
-          </li>
-        {% endif %}
+      {% if show_advanced_settings %}
+        <li>
+          <a href="#" data-slug="advanced" data-collapse="1">
+            <i class="fa fa-check"></i>{% trans "Advanced" %}
+          </a>
+        </li>
       {% endif %}
     </ul>
   </div>
@@ -215,7 +213,7 @@
         </div>
       </div>
 
-      {% if not module.is_surveys or show_advanced_settings %}
+      {% if show_advanced_settings %}
         <div class="panel panel-appmanager" data-slug="advanced">
           <div class="panel-heading">
             <h4 class="panel-title panel-title-nolink">{% trans "Advanced" %}</h4>

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -169,7 +169,7 @@ def get_module_view_context(request, app, module, lang=None):
         'unique_id': module.unique_id,
     }
     case_property_builder = _setup_case_property_builder(app)
-    show_advanced_settings = False
+    show_advanced_settings = not module.is_surveys
     if toggles.MOBILE_UCR.enabled(app.domain):
         show_advanced_settings = True
         module_brief.update({

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -195,6 +195,7 @@ def get_module_view_context(request, app, module, lang=None):
         show_advanced_settings
         or add_ons.show("register_from_case_list", request, app, module)
         or add_ons.show("case_list_menu_item", request, app, module) and not isinstance(module, ShadowModule)
+        or toggles.CUSTOM_ASSERTIONS.enabled(app.domain)
     )
     context.update({
         'show_advanced_settings': show_advanced_settings,

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -169,7 +169,12 @@ def get_module_view_context(request, app, module, lang=None):
         'unique_id': module.unique_id,
     }
     case_property_builder = _setup_case_property_builder(app)
-    show_advanced_settings = not module.is_surveys
+    show_advanced_settings = (
+        not module.is_surveys
+        or add_ons.show("register_from_case_list", request, app, module)
+        or add_ons.show("case_list_menu_item", request, app, module) and not isinstance(module, ShadowModule)
+        or toggles.CUSTOM_ASSERTIONS.enabled(app.domain)
+    )
     if toggles.MOBILE_UCR.enabled(app.domain):
         show_advanced_settings = True
         module_brief.update({
@@ -191,17 +196,8 @@ def get_module_view_context(request, app, module, lang=None):
     if isinstance(module, ShadowModule):
         context.update(_get_shadow_module_view_context(app, module, lang))
 
-    show_advanced_settings = (
-        show_advanced_settings
-        or add_ons.show("register_from_case_list", request, app, module)
-        or add_ons.show("case_list_menu_item", request, app, module) and not isinstance(module, ShadowModule)
-        or toggles.CUSTOM_ASSERTIONS.enabled(app.domain)
-    )
-    context.update({
-        'show_advanced_settings': show_advanced_settings,
-    })
-
-    context.update({'module_brief': module_brief})
+    context['show_advanced_settings'] = show_advanced_settings
+    context['module_brief'] = module_brief
     return context
 
 


### PR DESCRIPTION
## Product Description
The "Advanced" section in module settings appears if any one of a number of conditions is met.  I previously added a new element to the section without adding an appropriate check to the display conditions.  This PR makes it so the advanced section will always appear if the Custom Assertions feature flag is enabled

![image](https://user-images.githubusercontent.com/2367539/234366472-561d58d9-0a12-488d-b24c-ba2ce26dbc8b.png)

## Technical Summary
Thanks @Robert-Costello for finding this - I'd missed that condition in this PR:
https://github.com/dimagi/commcare-hq/pull/32793

## Feature Flag
Custom assertions

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
