### PR TITLE
Update `flagspecs_v2020.yml`

### DIFF
--- a/custom/abt/reports/flagspecs_v2020.yml
+++ b/custom/abt/reports/flagspecs_v2020.yml
@@ -932,10 +932,10 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     responsible_follow_up: "ECO"
   - question: [expired_insecticides_separate]
     comment: [expired_insecticides_separate_comments]
-    base_path: [stock_audit_grp, Q7]
-    flag_name: "7. If there are insecticides that expire during spray, have they been physically separated from the other insecticides and clearly marked in the store room?"
-    flag_name_fr: "7. S'il y a des insecticides qui expirent pendant la saison de pulvérisation, ont-ils été physiquement séparés des autres insecticides dans le magasin?"
-    flag_name_por: "7. Os insecticidas que expiram durante a época de pulverização foram fisicamente separados dos outros que estão no armazém?"
+    base_path: [stock_audit_grp, Q6a]
+    flag_name: "6a. Have the insecticides that expire during the spray campaign or before next year's campaign been physically separated from the other insecticides and clearly marked in the store?"
+    flag_name_fr: "6a. Est-ce que les insecticides qui expirent pendant cette campagne de pulvérisation ou avant la campagne de l'année prochaine sont physiquement séparés des autres insecticides et clairement identifiés dans le magasin?"
+    flag_name_por: "6a. Os insecticidas que expiram durante a época de pulverização foram fisicamente separados dos outros que estão no armazém?"
     answer: "no"
     warning: "Problem reported: Expiring insecticide not physically separated from others."
     warning_fr: "Problème signalé: les insecticides périmés ne sont pas séparés physiquement des autres insecticides dans le magasin"


### PR DESCRIPTION
## Technical Summary

Jira: [SC-2670](https://dimagi-dev.atlassian.net/browse/SC-2670)

`supervisory_report_v2020` (confusingly titled (non-uniquely) as "Supervisory Report") needs to be updated the same way that `supervisory_report_v2019` ("Supervisory Report 2019") was in PR https://github.com/dimagi/commcare-hq/pull/32783

## Safety Assurance

### Safety story

* Only vivible to Vectorlink domains
* Non-code change, only affects a static UCR data source.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2670]: https://dimagi-dev.atlassian.net/browse/SC-2670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ