### PR TITLE
Strips tags in group data

### DIFF
--- a/corehq/apps/groups/views.py
+++ b/corehq/apps/groups/views.py
@@ -3,6 +3,7 @@ import json
 from django.contrib import messages
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.urls import reverse
+from django.utils.html import strip_tags
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
@@ -136,7 +137,11 @@ def update_group_data(request, domain, group_id):
                 "Unable to update group data. Please check the key-value mappings and try to update again."
             ))
             return HttpResponseRedirect(request.META['HTTP_REFERER'])
-        group.metadata = updated_data
+        sanitized_updated_data = {
+            strip_tags(data_key): strip_tags(data_value)
+            for data_key, data_value in updated_data.items()
+        }
+        group.metadata = sanitized_updated_data
 
         _ensure_case_sharing_privilege(request, group)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When entering data for user groups, HQ will sanitize the values entered from security perspective by removing any tags (anything starting with a '<' and ending with '>') in the text entered for both key and value

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
HQ documentation on [security](https://github.com/dimagi/commcare-hq/blob/master/STANDARDS.rst#security) does not specify any recommendations on how to handle user inputs.
As for the HQ page in question, user groups, we use [DOMPurify](https://github.com/cure53/DOMPurify) in javascript [here](https://github.com/dimagi/commcare-hq/blob/70cb58bc34c25aedf238cb5f7229db92dcdb3ddd/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-input-map.js#L86-L87) that protects user from script tags when displaying but lets user enter html tags. Even though in DB, we save everything that comes.
Changing this now to strip tags for both key and value of group data.

Post changes in PR
1. `<h1>Test</h1>` will become `Test`
2. `Script<script>alert('hello');</script>` will become `Script`

I have setup an example [here](https://www.commcarehq.org/a/firsttestproject-1/settings/users/groups/034a33910026e791bcc3c32bf28d9fe7/#groupdata-tab) where,
1. when `Script<script>alert('hello');</script>` is entered, 
- on production, the save fails. I believe that is because of AWS WAF which prevents script tag to being used at all.
- locally, it is saved successfully. The value stored in DB is still `Script<script>alert('hello');</script>` but in view it shows just "Script" in the summary view, I believe due to DOMPurify.
4. When `<h1>Data</h1>` is used, it gets saved successfully and is rendered as a heading

Local:
![Screenshot from 2023-04-26 14-03-04](https://user-images.githubusercontent.com/3864163/234518882-614e219a-a223-4a44-a132-33d3b65cfc9a.png)

Production: (same as local except the script tag example removed to be able to save)
![Screenshot from 2023-04-26 14-09-07](https://user-images.githubusercontent.com/3864163/234519799-04055476-44d3-4946-975d-b6c415c67d2e.png)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
Tested locally that all works okay in the UI

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change will not effect any data that is already present and will come into action only when user saves group's data in the UI.
Even though the stripping of tags is happening at the server, so user won't see the final state till they reload or revisit the page, this should be okay considering tags aren't expected to be used here anyway.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
