### PR TITLE
Update Grapevine URL

### DIFF
--- a/corehq/messaging/smsbackends/grapevine/models.py
+++ b/corehq/messaging/smsbackends/grapevine/models.py
@@ -38,7 +38,7 @@ class GrapevineException(Exception):
 
 class SQLGrapevineBackend(SQLSMSBackend):
 
-    url = 'https://bulk.vine.co.za/httpInputhandler/ApplinkUpload'
+    url = 'https://bms27.vine.co.za/httpInputhandler/ApplinkUpload'
     show_inbound_api_key_during_edit = False
 
     class Meta(object):


### PR DESCRIPTION
## Product Description
No user-facing changes

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SUPPORT-16502

The current URL only supports TLS 1.0. This new URL supports TLS 2.0.

## Safety Assurance

### Safety story
I tested this change on staging with a gateway config I set up there, and I was able to receive an SMS I sent using it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
