### PR TITLE
Allow case tile rows to grow in height in web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -206,7 +206,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         if (useUniformUnits) {
             heightPixels = widthPixels;
         } else {
-            heightPixels = widthPixels / 2;
+            heightPixels = "auto";
         }
 
         model = {


### PR DESCRIPTION
## Product Description
Let row height increase to prevent tile content from overlapping with cells above and below.

Keep column widths static so that users can still scan the tiles vertically.

## Feature Flag
case tiles

## Safety Assurance

### Safety story
Tiny. Tested locally on a case tiles case list and a regular case list.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
