### PR TITLE
Restrict logo file size

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -340,7 +340,9 @@ class DomainGlobalSettingsForm(forms.Form):
         required=False,
         help_text=gettext_lazy("Upload a custom image to display instead of the "
                     "CommCare HQ logo.  It will be automatically resized to "
-                    "a height of 32 pixels.")
+                    "a height of 32 pixels. Upload size limit is {size_limit} MB.").format(
+            size_limit=f"{settings.MAX_UPLOAD_SIZE_ATTACHMENT/(1024*1024):,.0f}"
+        )
     )
     delete_logo = BooleanField(
         label=gettext_lazy("Delete Logo"),
@@ -527,6 +529,17 @@ class DomainGlobalSettingsForm(forms.Form):
         if isinstance(data, dict):
             return data
         return json.loads(data or '{}')
+
+    def clean_logo(self):
+        logo = self.cleaned_data['logo']
+        if self.can_use_custom_logo and logo:
+            if logo.size > settings.MAX_UPLOAD_SIZE_ATTACHMENT:
+                raise ValidationError(
+                    _("Logo exceeds {}MB size limit").format(
+                        f"{settings.MAX_UPLOAD_SIZE_ATTACHMENT/(1024*1024):,.0f}"
+                    )
+                )
+        return logo
 
     def clean_confirmation_link_expiry(self):
         data = self.cleaned_data['confirmation_link_expiry']

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -338,11 +338,11 @@ class DomainGlobalSettingsForm(forms.Form):
     logo = ImageField(
         label=gettext_lazy("Custom Logo"),
         required=False,
-        help_text=gettext_lazy("Upload a custom image to display instead of the "
-                    "CommCare HQ logo.  It will be automatically resized to "
-                    "a height of 32 pixels. Upload size limit is {size_limit} MB.").format(
-            size_limit=f"{settings.MAX_UPLOAD_SIZE_ATTACHMENT/(1024*1024):,.0f}"
-        )
+        help_text=gettext_lazy(
+            "Upload a custom image to display instead of the "
+            "CommCare HQ logo.  It will be automatically resized to "
+            "a height of 32 pixels. Upload size limit is {size_limit} MB."
+        ).format(size_limit=f"{settings.MAX_UPLOAD_SIZE_ATTACHMENT/(1024*1024):,.0f}")
     )
     delete_logo = BooleanField(
         label=gettext_lazy("Delete Logo"),
@@ -535,7 +535,7 @@ class DomainGlobalSettingsForm(forms.Form):
         if self.can_use_custom_logo and logo:
             if logo.size > settings.MAX_UPLOAD_SIZE_ATTACHMENT:
                 raise ValidationError(
-                    _("Logo exceeds {}MB size limit").format(
+                    _("Logo exceeds {} MB size limit").format(
                         f"{settings.MAX_UPLOAD_SIZE_ATTACHMENT/(1024*1024):,.0f}"
                     )
                 )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
In an audit of HQ, it has been highlighted that there is no restriction of file uploaded as a logo under Project Settings.
Even though the file is majorly compressed when it is converted into a [thumbnail](https://github.com/dimagi/commcare-hq/blob/7a6f6466aa98cac71901ddf99a54aeaa183561c2/corehq/apps/domain/forms.py#L588), the issue is with the picture being originally uploaded. Having an unrestricted size file upload is considered a [vulnerability](https://cwe.mitre.org/data/definitions/434.html).

This change adds a restriction on uploaded file to be less than 15MB, which is a high enough number and was picked because this is the size restriction we have for attachments sent with form submissions as well.

For UI changes,
Extended the message under the "Browse" button to mention the size limit in the end
![Screenshot from 2023-04-27 16-36-25](https://user-images.githubusercontent.com/3864163/234845382-86beabc5-cdbd-4650-8585-284c6a2be5ce.png)

Here is how the error message looks (the restriction was updated to be 1 MB only for demo purposes)

![Screenshot from 2023-04-27 16-53-25](https://user-images.githubusercontent.com/3864163/234847962-e08e4e11-1b87-4b1e-a8fc-ebdc33e0ccc7.png)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
This won't change any of the existing logos. I tested the change locally. Unless someone is uploading a very high quality image of their logo, this limit should be enough for almost all uploads. And in case there is a high quality image to be uploaded, user could always upload a lighter version of it.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Same as above under "Safety Assurance"

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
