### PR TITLE
FHIR decorator to validate '_format' parameter

### DIFF
--- a/corehq/motech/fhir/tests/test_utils.py
+++ b/corehq/motech/fhir/tests/test_utils.py
@@ -179,8 +179,10 @@ class TestHeaderDecorators(TestCase):
         self.assertEqual(response.status_code, 406)
         self.assertEqual(
             response.content.decode("utf-8"),
-            '{"message": "Requested format not acceptable."}'
+            '{"message": "Requested format in \'_format\' param not acceptable."}'
         )
+        response = test_view(self.factory.post('/foo', {'_format': 'application/xml'}))
+        self.assertEqual(response.status_code, 406)
 
     def test_validate_accept_header(self):
         @validate_accept_header_and_format_param

--- a/corehq/motech/fhir/tests/test_utils.py
+++ b/corehq/motech/fhir/tests/test_utils.py
@@ -9,7 +9,7 @@ from corehq.motech.fhir.utils import (
     load_fhir_resource_types,
     resource_url,
     update_fhir_resource_property,
-    require_fhir_json_accept_headers,
+    validate_accept_header_and_format_param,
     require_fhir_json_content_type_headers
 )
 
@@ -163,12 +163,27 @@ class TestHeaderDecorators(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
-    def _do_get_request(self, view, headers={}):
-        request = self.factory.get('/foo', **headers)
+    def _do_get_request(self, view, params=None, headers={}):
+        request = self.factory.get('/foo', params, **headers)
         return view(request)
 
-    def test_require_fhir_json_accept_headers(self):
-        @require_fhir_json_accept_headers
+    def test_validate_format_param(self):
+        @validate_accept_header_and_format_param
+        def test_view(request):
+            return HttpResponse()
+        response = self._do_get_request(test_view)
+        self.assertEqual(response.status_code, 200)
+        response = self._do_get_request(test_view, {'_format': 'application/json'})
+        self.assertEqual(response.status_code, 200)
+        response = self._do_get_request(test_view, {'_format': 'application/xml'})
+        self.assertEqual(response.status_code, 406)
+        self.assertEqual(
+            response.content.decode("utf-8"),
+            '{"message": "Requested format not acceptable."}'
+        )
+
+    def test_validate_accept_header(self):
+        @validate_accept_header_and_format_param
         def test_view(request):
             return HttpResponse()
         response = self._do_get_request(test_view)
@@ -181,6 +196,14 @@ class TestHeaderDecorators(TestCase):
             response.content.decode("utf-8"),
             '{"message": "Not Acceptable"}'
         )
+
+    def test_format_param_overwrites_accept_header(self):
+        @validate_accept_header_and_format_param
+        def test_view(request):
+            return HttpResponse()
+        response = self._do_get_request(test_view, {'_format': 'application/xml'},
+                                        headers={'HTTP_ACCEPT': 'application/json'})
+        self.assertEqual(response.status_code, 406)
 
     def _do_post_request(self, view, content_type=None):
         request = self.factory.post('/foo', content_type=content_type)

--- a/corehq/motech/fhir/utils.py
+++ b/corehq/motech/fhir/utils.py
@@ -79,12 +79,23 @@ def load_fhir_resource_types(fhir_version=FHIR_VERSION_4_0_1, exclude_resource_t
     return resource_types
 
 
-def require_fhir_json_accept_headers(view_func):
+def validate_accept_header_and_format_param(view_func):
     @wraps(view_func)
     def _inner(request, *args, **kwargs):
-        accept_header = request.META.get('HTTP_ACCEPT')
-        if accept_header and accept_header not in HQ_ACCEPTABLE_FHIR_MIME_TYPES + ['*/*']:
-            return JsonResponse(status=406, data={'message': "Not Acceptable"})
+        def _get_format_param(request):
+            if request.META.get('REQUEST_METHOD') == 'POST':
+                return request.POST.get('_format')
+            elif request.META.get('REQUEST_METHOD') == 'GET':
+                return request.GET.get('_format')
+            else:
+                return None
+        _format_param = _get_format_param(request)
+        if _format_param and _format_param not in HQ_ACCEPTABLE_FHIR_MIME_TYPES + ['json']:
+            return JsonResponse(status=406, data={'message': "Requested format not acceptable."})
+        else:
+            accept_header = request.META.get('HTTP_ACCEPT')
+            if accept_header and accept_header not in HQ_ACCEPTABLE_FHIR_MIME_TYPES + ['*/*']:
+                return JsonResponse(status=406, data={'message': "Not Acceptable"})
         return view_func(request, *args, **kwargs)
 
     return _inner

--- a/corehq/motech/fhir/utils.py
+++ b/corehq/motech/fhir/utils.py
@@ -91,7 +91,8 @@ def validate_accept_header_and_format_param(view_func):
                 return None
         _format_param = _get_format_param(request)
         if _format_param and _format_param not in HQ_ACCEPTABLE_FHIR_MIME_TYPES + ['json']:
-            return JsonResponse(status=406, data={'message': "Requested format not acceptable."})
+            return JsonResponse(status=406,
+                                data={'message': "Requested format in '_format' param not acceptable."})
         else:
             accept_header = request.META.get('HTTP_ACCEPT')
             if accept_header and accept_header not in HQ_ACCEPTABLE_FHIR_MIME_TYPES + ['*/*']:

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -11,7 +11,7 @@ from corehq.apps.domain.decorators import (
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase
 from corehq.motech.exceptions import ConfigurationError
-from corehq.motech.fhir.utils import require_fhir_json_accept_headers
+from corehq.motech.fhir.utils import validate_accept_header_and_format_param
 from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
 from corehq.util.view_utils import get_case_or_404
 
@@ -52,7 +52,7 @@ class EditFHIRRepeaterView(EditRepeaterView, AddFHIRRepeaterView):
 @login_or_api_key
 @require_superuser
 @toggles.FHIR_INTEGRATION.required_decorator()
-@require_fhir_json_accept_headers
+@validate_accept_header_and_format_param
 def get_view(request, domain, fhir_version_name, resource_type, resource_id):
     fhir_version = _get_fhir_version(fhir_version_name)
     if not fhir_version:
@@ -79,7 +79,7 @@ def get_view(request, domain, fhir_version_name, resource_type, resource_id):
 @login_or_api_key
 @require_superuser
 @toggles.FHIR_INTEGRATION.required_decorator()
-@require_fhir_json_accept_headers
+@validate_accept_header_and_format_param
 def search_view(request, domain, fhir_version_name, resource_type):
     fhir_version = _get_fhir_version(fhir_version_name)
     if not fhir_version:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR modifies an existing decorator to validate the '_format' parameter of a request to a FHIR endpoint.

In Jira it's [USH-3084](https://dimagi-dev.atlassian.net/browse/USH-3084?atlOrigin=eyJpIjoiNWQ0NzZiZjFiMWMxNDYwOWJiODY4OTUyNjUzMTFjZjUiLCJwIjoiaiJ9), and is somewhat an extension of [USH-3083](https://dimagi-dev.atlassian.net/browse/USH-3083?atlOrigin=eyJpIjoiNmM4YmM2MjdjOTFkNDZmYzk0NzQ4ZTFkNzVjYzc3MTQiLCJwIjoiaiJ9), which originally added the decorator.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

According to [FHIR documentation](https://www.hl7.org/fhir/http.html#parameters) on the subject, the '_format' parameter allows a client to specify what they'd like the response format to be. It should override the accept header when it is specified.

The main sort of caveat I've had with this code is that it may not work properly for HTTP methods other than GET and POST. It's difficult to parse parameters in Django request objects with other types of HTTP methods (see [this Stack Overflow discussion](https://stackoverflow.com/questions/4994789/django-where-are-the-params-stored-on-a-put-delete-request)). So I didn't want to implement this functionality until we were sure we needed it. I'm not sure whether we should expect this parameter to be specified when PUT or DELETE requests are made. I'm curious to hear your thoughts about this.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

FHIR_INTEGRATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

This change will only affect endpoints that are behind a FF. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added!

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None for now.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3084]: https://dimagi-dev.atlassian.net/browse/USH-3084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-3083]: https://dimagi-dev.atlassian.net/browse/USH-3083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ