### PR TITLE
Disable account access for unverified accouts

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -554,6 +554,19 @@ def login_required(view_func):
     return _inner
 
 
+def active_domains_required(view_func):
+    from corehq.apps.registration.views import registration_default
+
+    @wraps(view_func)
+    def _inner(request, *args, **kwargs):
+        if not Domain.active_for_user(request.user):
+            return registration_default(request)
+
+        return view_func(request, *args, **kwargs)
+
+    return _inner
+
+
 def check_lockout(fn):
     @wraps(fn)
     def _inner(request, *args, **kwargs):

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -265,6 +265,7 @@ def _two_factor_needed(domain_name, request):
             and not request.user.is_verified()
         )
 
+
 @login_required()
 def password_change(req):
     user_to_edit = User.objects.get(id=req.user.id)

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -36,6 +36,7 @@ from dimagi.utils.web import json_response
 
 from corehq import toggles
 from corehq.apps.domain.decorators import (
+    active_domains_required,
     login_and_domain_required,
     login_required,
     require_superuser,
@@ -110,6 +111,7 @@ def project_id_mapping(request, domain):
 class BaseMyAccountView(BaseSectionPageView):
     section_name = gettext_lazy("My Account")
 
+    @method_decorator(active_domains_required)
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
         # this is only here to add the login_required decorator

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -111,7 +111,6 @@ def project_id_mapping(request, domain):
 class BaseMyAccountView(BaseSectionPageView):
     section_name = gettext_lazy("My Account")
 
-    @method_decorator(active_domains_required)
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
         # this is only here to add the login_required decorator
@@ -374,6 +373,7 @@ class TwoFactorProfileView(BaseMyAccountView, ProfileView):
     template_name = 'two_factor/profile/profile.html'
     page_title = gettext_lazy("Two Factor Authentication")
 
+    @method_decorator(active_domains_required)
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
         # this is only here to add the login_required decorator
@@ -414,6 +414,7 @@ class TwoFactorSetupView(BaseMyAccountView, SetupView):
         ('validation', HQDeviceValidationForm),
     )
 
+    @method_decorator(active_domains_required)
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
         # this is only here to add the login_required decorator

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -30,6 +30,7 @@ from corehq.apps.app_manager.dbaccessors import (
 )
 from corehq.apps.app_manager.util import is_remote_app
 from corehq.apps.builds.views import EditMenuView
+from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.internal import ProjectLimitsView
 from corehq.apps.domain.views.releases import ManageReleasesByLocation
 from corehq.apps.enterprise.dispatcher import EnterpriseReportDispatcher
@@ -2169,20 +2170,19 @@ class MySettingsTab(UITab):
                 'url': reverse(MyProjectsList.urlname),
             })
 
-        menu_items.extend([
-            {
-                'title': _(ChangeMyPasswordView.page_title),
-                'url': reverse(ChangeMyPasswordView.urlname),
-            },
-            {
+        menu_items.append({
+            'title': _(ChangeMyPasswordView.page_title),
+            'url': reverse(ChangeMyPasswordView.urlname),
+        })
+        if Domain.active_for_couch_user(self.couch_user):
+            menu_items.append({
                 'title': _(TwoFactorProfileView.page_title),
                 'url': reverse(TwoFactorProfileView.urlname),
-            },
-            {
-                'title': _(ApiKeyView.page_title),
-                'url': reverse(ApiKeyView.urlname),
-            },
-        ])
+            })
+        menu_items.append({
+            'title': _(ApiKeyView.page_title),
+            'url': reverse(ApiKeyView.urlname),
+        })
 
         if EnableMobilePrivilegesView.is_user_authorized(self.couch_user):
             menu_items.append({


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Disable access to ~"My Account"~ "Two Factor" setup section for a user if they don't have any active domains.
This is related to a security concern flagged during an audit, which blocks a user from creating an account using their email address, in case there is already an account created with their email address and has 2 factor auth setup.

Steps:
1. Someone creates an account on HQ using another user's email address, say barackobama@gov.in
2. they setup 2 factor auth on this account
3. they can't verify the account so they can't really use it
4. the original user, Barack, wants to sign up on HQ but sees a message "Username already linked with another account". Even if he would reset the password through forgot password, he would still not be able to access the account due to 2 factor auth.
Thus, Barack is totally blocked on having an account on HQ using their own email address.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
When a new user confirms their account, their [project space is marked as active](https://github.com/dimagi/commcare-hq/blob/caa619713ae566d4baab1debfea9f764d34410a2/corehq/apps/registration/views.py#L516).
For a user invited, from a domain, user is added to the domain they were invited from when they accept invite sent on their email.
So, it seems that the way to know if a user is verified, is by checking if they have active domains.
I added a decorator to the base view for account section so it disables access to all it's children views for an unverified user.
Domain specific views are protected by `login_and_domain_required` decorator, though non-domain specific views would need additional check, for example, [quick_find](https://github.com/dimagi/commcare-hq/blob/c8313096ea0d9b69ae3a2a4e1541047f4868ca4f/corehq/apps/hqwebapp/views.py#L1204) currently just needs user to be logged in and then would rely on the following view to handle checks for access, which is okay though a check on quick_find itself would be better.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
