### PR TITLE
Fix ARIA property name

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -4,7 +4,7 @@
 <script type="text/template" id="case-view-list-template">
   <div class="module-case-list-container">
 
-    <div arialabel="<%- title %>" tabindex="0" class="page-header menu-header"><h1 class="page-title"><%- title %></h1></div>
+    <div aria-label="<%- title %>" tabindex="0" class="page-header menu-header"><h1 class="page-title"><%- title %></h1></div>
 
     <div class="module-search-container">
       <div class="input-group input-group-lg">


### PR DESCRIPTION
## Product Description
ARIA label is now set correctly and can be seen in ARIA dev tools

## Technical Summary
Just a typo in the property name

## Safety Assurance

### Safety story
Loaded the page locally, looks the same in the browser. Label is set correctly when viewing in aria dev tools

### Automated test coverage

### QA Plan

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
