### PR TITLE
Update case export select logic (fixed)

### DIFF
--- a/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
@@ -8,7 +8,7 @@
                        visible: table.label() !== 'Case History'">
       <span>
         <input type="checkbox"
-               data-bind="checked: table.selected" />
+               data-bind="checked: table.selected, attr: { disabled: {{ disable_table_checkbox|JSON }} }" />
       </span>
       <span>
         <span data-bind="text: table.label()" />

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -120,7 +120,10 @@ class BaseExportView(BaseProjectDataView):
             isinstance(self.export_instance, CaseExportInstance)
             and self.export_instance.case_type == ALL_CASE_TYPE_EXPORT
         )
+        table_count = 0
         if not is_all_case_types_export:
+            # Case History table is not a selectable table, so exclude it from count
+            table_count = len([t for t in self.export_instance.tables if t.label != 'Case History'])
             schema = self.get_export_schema(
                 self.domain,
                 self.request.GET.get('app_id') or getattr(self.export_instance, 'app_id'),
@@ -149,7 +152,8 @@ class BaseExportView(BaseProjectDataView):
             'number_of_apps_to_process': number_of_apps_to_process,
             'sharing_options': sharing_options,
             'terminology': self.terminology,
-            'is_all_case_types_export': is_all_case_types_export
+            'is_all_case_types_export': is_all_case_types_export,
+            'disable_table_checkbox': (table_count < 2)
         }
 
     @property


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2666).

This change is a rewrite of [this](https://github.com/dimagi/commcare-hq/pull/32851) PR which has since been reverted due to causing a P2 issue on production. Specifically, the issue was that repeat groups were not selectable when doing a form export as the code evaluated that there was only 1 default selected table available.

This PR implements the same change as the above-mentioned PR, but the checks have been refined to count all tables (not only default selected ones). The "Case History" table is excluded from the count, as it is not a selectable/exportable table.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Have done local testing to ensure that form tables are selectable when repeat groups are included. This change only disables the table checkbox if there is one selectable table available.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
