### PR TITLE
Data Dictionary: Minor Bug fixes

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -234,7 +234,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         };
 
         self.newCaseProperty = function () {
-            if (_.isString(self.newPropertyName())) {
+            if (_.isString(self.newPropertyName()) && self.newPropertyName().trim()) {
                 var prop = propertyListItem(self.newPropertyName(), self.newPropertyName(), false, '', self.activeCaseType(), '', '', {});
                 prop.dataType.subscribe(changeSaveButton);
                 prop.description.subscribe(changeSaveButton);
@@ -249,7 +249,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         };
 
         self.newGroup = function () {
-            if (_.isString(self.newGroupName())) {
+            if (_.isString(self.newGroupName()) && self.newGroupName().trim()) {
                 var group = propertyListItem(self.newGroupName(), '', true, '', self.activeCaseType());
                 self.casePropertyList.push(group);
                 self.newGroupName(undefined);

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -188,8 +188,7 @@ def save_case_property(name, case_type, domain=None, data_type=None,
     prop = CaseProperty.get_or_create(
         name=name, case_type=case_type, domain=domain
     )
-    if data_type:
-        prop.data_type = data_type
+    prop.data_type = data_type if data_type else ""
     if description is not None:
         prop.description = description
     if group is not None:

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -192,9 +192,13 @@ def save_case_property(name, case_type, domain=None, data_type=None,
         prop.data_type = data_type
     if description is not None:
         prop.description = description
-    if group:
+    if group is not None:
         prop.group = group
-        prop.group_obj, created = CasePropertyGroup.objects.get_or_create(name=group, case_type=prop.case_type)
+        # Allow properties to have no group
+        if group:
+            prop.group_obj, created = CasePropertyGroup.objects.get_or_create(name=group, case_type=prop.case_type)
+        else:
+            prop.group_obj = None
     if deprecated is not None:
         prop.deprecated = deprecated
     if label is not None:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
This PR fixes these bugs in the data dictionary page:
1. Properties cannot be assigned to the "No group" section.
2. User can create properties and groups with space only strings. (" ")
3. Property data types cannot be set to Select Data Type (No Data type)

<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
[DATA_DICTIONARY](https://staging.commcarehq.org/hq/flags/edit/data_dictionary/)
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Tested locally
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
