### PR TITLE
Dhis2Repeater to skip system forms with data from DHIS2

### DIFF
--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -103,6 +103,14 @@ class Dhis2Repeater(FormRepeater, Dhis2Instance):
     def __hash__(self):
         return hash(self.id)
 
+    def allowed_to_forward(self, payload):
+        return (
+            super().allowed_to_forward(payload)
+            # If the payload is the system form for updating a case with
+            # its DHIS2 TEI ID then don't send it back.
+            and payload.xmlns != XMLNS_DHIS2
+        )
+
     @memoized
     def payload_doc(self, repeat_record):
         return XFormInstance.objects.get_form(repeat_record.payload_id, repeat_record.domain)

--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -32,6 +32,7 @@ def get_success_repeat_record_count(domain, repeater_id):
 
 
 def get_cancelled_repeat_record_count(domain, repeater_id):
+    # Does not include RECORD_EMPTY_STATE
     return get_repeat_record_count(domain, repeater_id, RECORD_CANCELLED_STATE)
 
 

--- a/corehq/motech/repeaters/tests/test_dbaccessors.py
+++ b/corehq/motech/repeaters/tests/test_dbaccessors.py
@@ -182,11 +182,11 @@ class TestRepeatRecordDBAccessors(TestCase):
     def test_get_repeat_records_by_payload_id(self):
         id_1_records = list(get_repeat_records_by_payload_id(self.domain, self.payload_id_1))
         self.assertEqual(len(id_1_records), 2)
-        self.assertItemsEqual([r._id for r in id_1_records], [r._id for r in self.records[0:2]])
+        self.assertItemsEqual([r._id for r in id_1_records], [r._id for r in self.records[:2]])
 
         id_2_records = list(get_repeat_records_by_payload_id(self.domain, self.payload_id_2))
         self.assertEqual(len(id_2_records), 6)
-        self.assertItemsEqual([r._id for r in id_2_records], [r._id for r in self.records[2:6]])
+        self.assertItemsEqual([r._id for r in id_2_records], [r._id for r in self.records[2:]])
 
 
 class TestOtherDBAccessors(TestCase):

--- a/corehq/motech/repeaters/tests/test_dbaccessors.py
+++ b/corehq/motech/repeaters/tests/test_dbaccessors.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 
 from corehq.motech.repeaters.const import RECORD_PENDING_STATE
 from corehq.motech.repeaters.dbaccessors import (
+    get_cancelled_repeat_record_count,
     get_domains_that_have_repeat_records,
     get_failure_repeat_record_count,
     get_overdue_repeat_record_count,
@@ -66,6 +67,22 @@ class TestRepeatRecordDBAccessors(TestCase):
             next_check=before - timedelta(minutes=10),
             payload_id=cls.payload_id_2,
         )
+        cancelled = RepeatRecord(
+            domain=cls.domain,
+            succeeded=False,
+            cancelled=True,
+            repeater_id=cls.repeater_id,
+            next_check=before,
+            payload_id=cls.payload_id_2,
+        )
+        empty = RepeatRecord(
+            domain=cls.domain,
+            succeeded=True,
+            cancelled=True,
+            repeater_id=cls.repeater_id,
+            next_check=before,
+            payload_id=cls.payload_id_2,
+        )
         other_id = RepeatRecord(
             domain=cls.domain,
             succeeded=False,
@@ -80,6 +97,8 @@ class TestRepeatRecordDBAccessors(TestCase):
             success,
             pending,
             overdue,
+            cancelled,
+            empty,
             other_id,
         ]
 
@@ -98,11 +117,15 @@ class TestRepeatRecordDBAccessors(TestCase):
 
     def test_get_success_repeat_record_count(self):
         count = get_success_repeat_record_count(self.domain, self.repeater_id)
-        self.assertEqual(count, 1)
+        self.assertEqual(count, 2)  # Empty records are included
 
     def test_get_failure_repeat_record_count(self):
         count = get_failure_repeat_record_count(self.domain, self.repeater_id)
         self.assertEqual(count, 2)
+
+    def test_get_cancelled_repeat_record_count(self):
+        count = get_cancelled_repeat_record_count(self.domain, self.repeater_id)
+        self.assertEqual(count, 1)  # Empty records are not included
 
     def test_get_repeat_record_count_with_state_and_no_repeater(self):
         count = get_repeat_record_count(self.domain, state=RECORD_PENDING_STATE)
@@ -150,7 +173,7 @@ class TestRepeatRecordDBAccessors(TestCase):
 
     def test_get_all_repeat_records_by_domain_with_repeater_id(self):
         records = list(iter_repeat_records_by_domain(self.domain, repeater_id=self.repeater_id))
-        self.assertEqual(len(records), 5)
+        self.assertEqual(len(records), 7)
 
     def test_get_all_repeat_records_by_domain(self):
         records = list(iter_repeat_records_by_domain(self.domain))
@@ -162,7 +185,7 @@ class TestRepeatRecordDBAccessors(TestCase):
         self.assertItemsEqual([r._id for r in id_1_records], [r._id for r in self.records[0:2]])
 
         id_2_records = list(get_repeat_records_by_payload_id(self.domain, self.payload_id_2))
-        self.assertEqual(len(id_2_records), 4)
+        self.assertEqual(len(id_2_records), 6)
         self.assertItemsEqual([r._id for r in id_2_records], [r._id for r in self.records[2:6]])
 
 


### PR DESCRIPTION
## Technical Summary

Jira: [SC-2770](https://dimagi-dev.atlassian.net/browse/SC-2770)

Dhis2Repeater forwards CommCare form data to DHIS2 as DHIS2 Events. This change allows Dhis2Repeater to skip system forms created when a _Dhis2EntityRepeater_ updated a CommCare case. (e.g. A Dhis2EntityRepeater saves a DHIS2 tracked entity ID to its corresponding CommCare case via a system form. We want Dhis2Repeater to skip that form without processing it.)

This change also adds a test to verify the behavior of `get_cancelled_repeat_record_count()`.

## Feature Flag

DHIS2 Integration

## Safety Assurance

### Safety story

* Small change
* Behavior verified by tests

### Automated test coverage

Included

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2770]: https://dimagi-dev.atlassian.net/browse/SC-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ