### PR TITLE
Bump sh from 1.14.2 to 2.0.3

### DIFF
--- a/corehq/apps/export/management/commands/process_skipped_pages.py
+++ b/corehq/apps/export/management/commands/process_skipped_pages.py
@@ -161,7 +161,7 @@ class Command(BaseCommand):
             else:
                 raise CommandError('Unexpected page filename: {}'.format(page_filename))
 
-            doc_count = int(sh.wc('-l', page_path).split(' ')[0])
+            doc_count = int(sh.wc('-l', page_path).strip().split(' ')[0])
             total_docs += doc_count
             unprocessed_pages.append((page_path, page_number, doc_count))
 

--- a/corehq/apps/hqadmin/views/system.py
+++ b/corehq/apps/hqadmin/views/system.py
@@ -238,10 +238,7 @@ def _get_branches_merged_into_autostaging(cwd=None):
         return _get_branches_merged_into_autostaging(cwd=cwd)
 
     # sh returning string from command git.log(...)
-    branches = pipe.split("\n")
-    if branches[-1] == '':
-        # artifact of git.log(...) output ending with newline
-        branches.pop()
+    branches = pipe.strip().split("\n")
     CommitBranchPair = namedtuple('CommitBranchPair', ['commit', 'branch'])
     return sorted(
         (CommitBranchPair(
@@ -262,10 +259,7 @@ def _get_submodules():
     """
     import sh
     git = sh.git.bake(_tty_out=False)
-    submodules = git.submodule().split("\n")
-    if submodules[-1] == '':
-        # artifact of git.submodule() ending with newline
-        submodules.pop()
+    submodules = git.submodule().strip().split("\n")
     return [
         line.strip()[1:].split()[1]
         for line in submodules

--- a/corehq/apps/hqadmin/views/system.py
+++ b/corehq/apps/hqadmin/views/system.py
@@ -236,6 +236,12 @@ def _get_branches_merged_into_autostaging(cwd=None):
         #   unknown revision or path not in the working tree.
         git.fetch()
         return _get_branches_merged_into_autostaging(cwd=cwd)
+
+    # sh returning string from command git.log(...)
+    branches = pipe.split("\n")
+    if branches[-1] == '':
+        # artifact of git.log(...) output ending with newline
+        branches.pop()
     CommitBranchPair = namedtuple('CommitBranchPair', ['commit', 'branch'])
     return sorted(
         (CommitBranchPair(
@@ -244,7 +250,7 @@ def _get_branches_merged_into_autostaging(cwd=None):
             .replace("Merge branch '", '')
             .replace("' into autostaging", '')
             .split(' ')[1:]
-        ) for line in pipe),
+        ) for line in branches),
         key=lambda pair: pair.branch
     )
 
@@ -256,9 +262,13 @@ def _get_submodules():
     """
     import sh
     git = sh.git.bake(_tty_out=False)
+    submodules = git.submodule().split("\n")
+    if submodules[-1] == '':
+        # artifact of git.submodule() ending with newline
+        submodules.pop()
     return [
         line.strip()[1:].split()[1]
-        for line in git.submodule()
+        for line in submodules
     ]
 
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -570,7 +570,7 @@ schema==0.7.5
     # via -r base-requirements.in
 sentry-sdk==1.19.1
     # via -r base-requirements.in
-sh==1.14.2
+sh==2.0.3
     # via
     #   -r base-requirements.in
     #   git-build-branch

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -459,7 +459,7 @@ schema==0.7.5
     # via -r base-requirements.in
 sentry-sdk==1.19.1
     # via -r base-requirements.in
-sh==1.14.2
+sh==2.0.3
     # via -r base-requirements.in
 simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -479,7 +479,7 @@ sentry-sdk==1.19.1
     # via -r base-requirements.in
 setproctitle==1.2.2
     # via -r prod-requirements.in
-sh==1.14.2
+sh==2.0.3
     # via -r base-requirements.in
 simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -431,7 +431,7 @@ schema==0.7.5
     # via -r base-requirements.in
 sentry-sdk==1.19.1
     # via -r base-requirements.in
-sh==1.14.2
+sh==2.0.3
     # via -r base-requirements.in
 simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -476,7 +476,7 @@ schema==0.7.5
     # via -r base-requirements.in
 sentry-sdk==1.19.1
     # via -r base-requirements.in
-sh==1.14.2
+sh==2.0.3
     # via -r base-requirements.in
 simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
     # via -r base-requirements.in

--- a/scripts/vellum-to-hq
+++ b/scripts/vellum-to-hq
@@ -121,7 +121,7 @@ def build_vellum(path, branch, test=True):
     stderr = byte_stream(sys.stderr)
     sh.make(_cwd=path, _out=stdout, _err=stderr, *make_args)
 
-    return str(git("rev-parse", "HEAD"))
+    return git("rev-parse", "HEAD").strip()
 
 
 def get_old_vellum_rev(path):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Changelog: https://github.com/amoffat/sh/blob/develop/CHANGELOG.md

I'm preparing to add a dependency that requires `sh>=2.0.0` so upgrading now. We only use `sh` to help determine branches included in autostaging branch, and in `process_skipped_pages` management command. I plan to test these use cases on staging.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Will test on staging.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
