### PR TITLE
FHIR - Support '_id' and '_type' params on search endpoint

### DIFF
--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -111,13 +111,13 @@ class TestFHIRGetView(BaseFHIRViewTest):
 
 class TestFHIRSearchView(BaseFHIRViewTest):
     def test_flag_not_enabled(self):
-        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?patient_id={PERSON_CASE_ID}"
+        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?_id={PERSON_CASE_ID}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
     @flag_enabled('FHIR_INTEGRATION')
     def test_unsupported_fhir_version(self):
-        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?patient_id={PERSON_CASE_ID}"
+        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?_id={PERSON_CASE_ID}"
         url = url.replace(FHIR_VERSION, 'A4')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
@@ -133,33 +133,33 @@ class TestFHIRSearchView(BaseFHIRViewTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
-            {'message': "Please pass patient_id"}
+            {'message': "Please pass resource ID."}
         )
 
     @flag_enabled('FHIR_INTEGRATION')
     def test_deleted_case(self):
-        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?patient_id={DELETED_CASE_ID}"
+        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?_id={DELETED_CASE_ID}"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 410)
         self.assertEqual(
             response.json(),
-            {'message': f"Patient with ID {DELETED_CASE_ID} was removed"}
+            {'message': "Gone"}
         )
 
     @flag_enabled('FHIR_INTEGRATION')
     def test_missing_case_id(self):
-        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + "?patient_id=just-a-case-id"
+        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + "?_id=just-a-case-id"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 404)
         self.assertEqual(
             response.json(),
-            {'message': "Could not find patient with ID just-a-case-id"}
+            {'message': "Not Found"}
         )
 
     @flag_enabled('FHIR_INTEGRATION')
     def test_no_case_types_for_resource_type(self):
         url = reverse("fhir_search",
-                      args=[DOMAIN, FHIR_VERSION, "DiagnosticReport"]) + f"?patient_id={PERSON_CASE_ID}"
+                      args=[DOMAIN, FHIR_VERSION, "DiagnosticReport"]) + f"?_id={PERSON_CASE_ID}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -169,7 +169,7 @@ class TestFHIRSearchView(BaseFHIRViewTest):
 
     @flag_enabled('FHIR_INTEGRATION')
     def test_search(self):
-        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?patient_id={PERSON_CASE_ID}"
+        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Observation"]) + f"?_id={PERSON_CASE_ID}"
         response = self.client.get(url)
         self.assertEqual(
             response.json(),
@@ -189,7 +189,7 @@ class TestFHIRSearchView(BaseFHIRViewTest):
 
     @flag_enabled('FHIR_INTEGRATION')
     def test_search_patient(self):
-        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Patient"]) + f"?patient_id={PERSON_CASE_ID}"
+        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Patient"]) + f"?_id={PERSON_CASE_ID}"
         response = self.client.get(url)
         self.assertEqual(
             response.json(),

--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -188,8 +188,8 @@ class TestFHIRSearchView(BaseFHIRViewTest):
         )
 
     @flag_enabled('FHIR_INTEGRATION')
-    def test_search_patient(self):
-        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Patient"]) + f"?_id={PERSON_CASE_ID}"
+    def test_search_patient_using_patient_id(self):
+        url = reverse("fhir_search", args=[DOMAIN, FHIR_VERSION, "Patient"]) + f"?patient_id={PERSON_CASE_ID}"
         response = self.client.get(url)
         self.assertEqual(
             response.json(),

--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -164,7 +164,7 @@ class TestFHIRSearchView(BaseFHIRViewTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
-            {'message': f"Resource type DiagnosticReport not available on {DOMAIN}"}
+            {'message': f"Resource type(s) DiagnosticReport not available on {DOMAIN}"}
         )
 
     @flag_enabled('FHIR_INTEGRATION')
@@ -205,6 +205,16 @@ class TestFHIRSearchView(BaseFHIRViewTest):
                     }
                 ]
             }
+        )
+
+    @flag_enabled('FHIR_INTEGRATION')
+    def test_no_resource_provided(self):
+        url = reverse("fhir_search_mulitple_types", args=[DOMAIN, FHIR_VERSION]) + f"?_id={PERSON_CASE_ID}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'message': "No resource type specified for search."}
         )
 
 

--- a/corehq/motech/fhir/urls.py
+++ b/corehq/motech/fhir/urls.py
@@ -7,6 +7,8 @@ from corehq.motech.fhir.views import (
 
 urlpatterns = [
     url(r'^fhir/(?P<fhir_version_name>\w+)/(?P<resource_type>\w+)/$', search_view, name="fhir_search"),
+    url(r'^fhir/(?P<fhir_version_name>\w+)/$', search_view,
+        name="fhir_search_mulitple_types"),
     url(r'^fhir/(?P<fhir_version_name>\w+)/(?P<resource_type>\w+)/(?P<resource_id>[\w\-]+)/$', get_view,
         name="fhir_get_view"),
 ]

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -85,7 +85,7 @@ def search_view(request, domain, fhir_version_name, resource_type=None):
     fhir_version = _get_fhir_version(fhir_version_name)
     if not fhir_version:
         return JsonResponse(status=400, data={'message': "Unsupported FHIR version"})
-    resource_id = request.GET.get('_id', request.GET.get('patient_id'))
+    resource_id = request.GET.get('_id', None) or request.GET.get('patient_id')
     if not resource_id:
         return JsonResponse(status=400, data={'message': "Please pass resource ID."})
     try:

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -84,7 +84,7 @@ def search_view(request, domain, fhir_version_name, resource_type):
     fhir_version = _get_fhir_version(fhir_version_name)
     if not fhir_version:
         return JsonResponse(status=400, data={'message': "Unsupported FHIR version"})
-    resource_id = request.GET.get('_id')
+    resource_id = request.GET.get('_id', request.GET.get('patient_id'))
     if not resource_id:
         return JsonResponse(status=400, data={'message': "Please pass resource ID."})
     try:

--- a/corehq/motech/fhir/views.py
+++ b/corehq/motech/fhir/views.py
@@ -95,13 +95,12 @@ def search_view(request, domain, fhir_version_name, resource_type=None):
     except CaseNotFound:
         return JsonResponse(status=404, data={'message': "Not Found"})
 
-    def _get_resource_types(resource_type, request):
-        if resource_type:
-            return [resource_type]
-        else:
-            type_param = request.GET.get('_type')
-            return [resource_type.strip() for resource_type in type_param.split(',')] if type_param else None
-    resource_types = _get_resource_types(resource_type, request)
+    resource_types = None
+    if resource_type:
+        resource_types = [resource_type]
+    else:
+        type_param = request.GET.get('_type')
+        resource_types = [resource_type.strip() for resource_type in type_param.split(',')] if type_param else None
 
     if not resource_types:
         return JsonResponse(status=400,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Per [USH-3086](https://dimagi-dev.atlassian.net/browse/USH-3086?atlOrigin=eyJpIjoiY2ZjYjcxODg5ZmYyNDBkNmJlYjgzZmRiMDQ1NDQ2NzQiLCJwIjoiaiJ9), this PR adds support for the ['_id'](https://www.hl7.org/fhir/search.html#_id) and ['_type' ](https://www.hl7.org/fhir/search.html#_type) FHIR parameters on the search endpoint.


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

_id basically replaces the current usage of patient_id, but backwards compatibility for patient_id is maintained. 

_type was a little tricky to implement, since the current code only supports searching by a single token, not by case property/resource attribute, or another parameter that searcjes across multiple case/resource types. So for now, this code just attempts to allow the user to specify the _type parameter and adds only partial support for searching across multiple types.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

FHIR_INTEGRATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Existing automated tests test this well, and backwards compatibility will be maintained for the patient_id parameter.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

djtest corehq.motech.fhir.tests.test_fhir_views:TestFHIRSearchView


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [X] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3086]: https://dimagi-dev.atlassian.net/browse/USH-3086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ