### PR TITLE
Updated case tiles to always treat templates as markdown in web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1,4 +1,4 @@
-/*global Marionette */
+/*globals DomPurify, Marionette */
 
 hqDefine("cloudcare/js/formplayer/menus/views", function () {
     var kissmetrics = hqImport("analytix/js/kissmetrix"),
@@ -301,8 +301,12 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
     var CaseTileView = CaseView.extend({
         template: _.template($("#case-tile-view-item-template").html() || ""),
         templateContext: function () {
-            var dict = CaseTileView.__super__.templateContext.apply(this, arguments);
+            var dict = CaseTileView.__super__.templateContext.apply(this, arguments),
+                md = window.markdownit();
             dict['prefix'] = this.options.prefix;
+            dict['renderMarkdown'] = function (datum) {
+                return md.render(DOMPurify.sanitize(datum || ""));
+            };
             return dict;
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1,4 +1,4 @@
-/*globals DomPurify, Marionette */
+/*globals DOMPurify, Marionette */
 
 hqDefine("cloudcare/js/formplayer/menus/views", function () {
     var kissmetrics = hqImport("analytix/js/kissmetrix"),

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -110,7 +110,7 @@
       <% } else if(styles[index].widthHint === 0) { %>
       <div style="display:none;"><%- datum %></div>
       <% } else { %>
-      <div><%- datum %></div>
+      <div><%= renderMarkdown(datum) %></div>
       <% } %>
     </div>
     <% }); %>


### PR DESCRIPTION
## Technical Summary
Case tiles in web apps currently display HTML markup:
![Screen Shot 2023-05-02 at 4 20 37 PM](https://user-images.githubusercontent.com/1486591/235777098-8127afc3-ad38-4630-91fe-117f2400be15.png)

This changes Web Apps to assume that templates are instead using markdown. It HTML sanitizes the tile content coming from formplayer and then renders it as markdown. Implications:
* This makes it intentional that Web Apps doesn't support HTML in tile templates, so templates that (presumably) work on mobile, notably the one template HQ supports, [tdh.txt](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/suite_xml/case_tile_templates/tdh.txt), will be forever incompatible with Web Apps. I have heard that mobile might already support markdown templates (and `tdh.txt` could be easily converted to markdown) but have not yet been able to verify this.
* All data displayed on a tile in web apps will be interpreted in markdown. So a case property like `i_like_*stars*` would be rendered with italics. I think this is more of a pro than a con, as it lets app builders add markdown via calculated display properties, without needing the template edited. I suspect markdown characters are rare in case properties, but it is possible to escape them with backslashes.

An alternative would be for formplayer to HTML sanitize case properties / calculations before injecting them into the template. I don't like that as much because I'd prefer Web Apps to do its own escaping, rather than having to trust data it receives from formplayer.


## Feature Flag
CASE_LIST_TILE

## Safety Assurance

### Safety story
Small change, all code is in flagged areas, and based on that first screenshot, I'm fairly certain no real projects are using case tiles in web apps.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
