### PR TITLE
Remove redundant `navigate_menu` request from case search

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -517,8 +517,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             var self = this;
             var promise = $.Deferred();
             var invalidFields = [];
+            var updatingModels = self.updateModelsForValidation || self._updateModelsForValidation();
 
-            self._updateModelsForValidation().done(function (response) {
+            $.when(updatingModels).done(function (response) {
                 // Gather error messages
                 self.children.each(function (childView) {
                     if (!childView.isValid()) {
@@ -548,11 +549,12 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
         _updateModelsForValidation: function () {
             var self = this;
+            var promise = $.Deferred();
+            self.updateModelsForValidation = promise;
 
             var urlObject = formplayerUtils.currentUrlToObject();
             urlObject.setQueryData(self.getAnswers(), false);
-            var promise = $.Deferred(),
-                fetchingPrompts = FormplayerFrontend.getChannel().request("app:select:menus", urlObject);
+            var fetchingPrompts = FormplayerFrontend.getChannel().request("app:select:menus", urlObject);
             $.when(fetchingPrompts).done(function (response) {
                 // Update models based on response
                 _.each(response.models, function (responseModel, i) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -496,18 +496,13 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         validateFieldChange: function (changedChildView) {
             var self = this;
             var promise = $.Deferred();
-            var invalidFields = [];
 
             self._updateModelsForValidation().done(function (response) {
                 //Gather error messages
                 self.children.each(function (childView) {
-                    //Filter out empty required fields that user has not updated yet
-                    if ((!childView.hasRequiredError() || childView === changedChildView)
-                         && !childView.isValid()) {
-                        invalidFields.push(childView.model.get('text'));
-                    }
+                    //Filter out empty required fields and check for validity
+                    if (!childView.hasRequiredError() || childView === changedChildView) { childView.isValid(); }
                 });
-
                 promise.resolve(response);
             });
 


### PR DESCRIPTION
## Product Description
No direct impact to users. Possible minor performance improvement.

## Technical Summary
[USH-2746](https://dimagi-dev.atlassian.net/browse/USH-2746?atlOrigin=eyJpIjoiZDI4ZDkzZWY1NDcwNDUxOThhY2EyMGNiOWFhNWMzZmIiLCJwIjoiaiJ9)

Previous behavior:

https://user-images.githubusercontent.com/100609770/236019882-386c0eb5-7301-4f4a-90a3-7d7a39681956.mov


Updated behavior:

https://user-images.githubusercontent.com/100609770/236021037-6b05e8d6-1949-4d66-a2e7-5980d3036fa2.mov


Makes the promise from `_updateModelsForValidation` accessible on the `QueryListView` to be checked by `validateAllFields`. If the promise does not exist (because no case search fields have changed yet), defaults to running `_updateModelsForValidation`; otherwise, waits for the promise to resolve before checking fields for validity and displaying errors. 

Also removes an `invalidFields` array that was unused in `validateFieldChange`.

## Feature Flag
search_claim

## Safety Assurance
Pretty minor change, checking the promise of a function that already runs, and defaulting to the existing behavior of just running the function.

### Safety story
Tested locally using variations of fields that should pass/fail required conditions (checked in javascript) and validation conditions (checked by Formplayer) -- making sure the request is correctly rejected or passed through, and if rejected, that errors are displayed properly in the notification banner.

### Automated test coverage


### QA Plan
[QA-5071](https://dimagi-dev.atlassian.net/browse/QA-5071)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-2746]: https://dimagi-dev.atlassian.net/browse/USH-2746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[QA-5071]: https://dimagi-dev.atlassian.net/browse/QA-5071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ