### PR TITLE
fix flaky ES test

### DIFF
--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -589,8 +589,16 @@ class TestElasticManageAdapter(AdapterWithIndexTestCase):
         self.assertTrue(validation)
 
     def test_index_validate_query_returns_false_for_invalid_query(self):
+        type_ = "test_doc"
+        mapping = {
+            "properties": {
+                "value": {"type": "float"}
+            }
+        }
         self.adapter.index_create(self.index)
-        query = {"query": {"termmz": {"value": 'some val'}}}
+        self.adapter.index_put_mapping(self.index, type_, mapping)
+        # Value field expects a float but string is sent in term query
+        query = {"query": {"term": {"value": 'some_string'}}}
         validation = self.adapter.index_validate_query(index=self.index, query=query)
         self.assertFalse(validation)
 


### PR DESCRIPTION
Fixes a flaky test `corehq.apps.es.tests.test_client:TestElasticManageAdapter.test_index_validate_query_returns_false_for_invalid_query`

I think the flakiness was observed due to index taking in dynamic mappings and considering the random query sent as a valid query. So it was fixed by putting mappings in the index and then searching with invalid query.  
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
NA
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Test Fix
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Pretty safe
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
