### PR TITLE
Fix save button for custom assertions

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
@@ -23,7 +23,14 @@ hqDefine('app_manager/js/custom_assertions', function () {
         };
 
         self.wrap = function (assertions) {
-            return ko.mapping.fromJS(assertions, self.mapping, self);
+            let ret = ko.mapping.fromJS(assertions, self.mapping, self);
+
+            // after initialization, fire change event so save button works
+            self.customAssertions.subscribe(function () {
+                $("#custom-assertions input[name='custom_assertions']").change();
+            });
+
+            return ret;
         };
 
         self.unwrap = function () {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary

@shubham1g5 pointed out that the save button doesn't trigger when you remove elements
https://github.com/dimagi/commcare-hq/pull/32842#issuecomment-1533451214
This happened in each of the three places this widget appears, and it also doesn't trigger when you add new events until you populate them.  This PR fires a change event for any modifications to the list of assertions after initialization.

## Feature Flag
Custom Assertions

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This feature is still in development

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
