### PR TITLE
Get length of generator results

### DIFF
--- a/custom/abt/reports/fixture_utils.py
+++ b/custom/abt/reports/fixture_utils.py
@@ -95,7 +95,7 @@ def get_sorted_levels(domain, filters) -> Tuple[list, dict, dict, dict]:
     l3_data_items = get_fixture_items_for_data_type(
         domain, data_types_by_tag["level_3_eco"],
     )
-    country_has_level_3 = l3_data_items.count() > 1
+    country_has_level_3 = len(list(l3_data_items)) > 1
     if country_has_level_3:
         l3s_by_l2 = get_fixture_dicts_by_key(
             domain,
@@ -110,7 +110,7 @@ def get_sorted_levels(domain, filters) -> Tuple[list, dict, dict, dict]:
         l4_data_items = get_fixture_items_for_data_type(
             domain, data_types_by_tag["level_4_eco"],
         )
-        country_has_level_4 = l4_data_items.count() > 1
+        country_has_level_4 = len(list(l4_data_items)) > 1
         if country_has_level_4:
             l4s_by_l3 = get_fixture_dicts_by_key(
                 domain,


### PR DESCRIPTION
## Product Description
Currently there's an issue with the `late_pmt_2020` custom report on the `vectorlink-uganda` domain.

![image](https://user-images.githubusercontent.com/44245062/236404018-b16e18ba-1f8d-4425-9e20-e051eb16ec25.png)

This PR fixes the error.

## Technical Summary
[Ticket](https://www.commcarehq.org/a/vectorlink-uganda/reports/custom/late_pmt_2020/?startdate=2023-04-28&enddate=2023-05-04&level_1=&level_2=&level_3=&level_4=)

[This](https://dimagi.sentry.io/issues/3684867215/?environment=production&query=is%3Aunresolved+domain%3Avectorlink-uganda&referrer=issue-stream&statsPeriod=14d&stream_index=0) is the error.

An attempt to run `.count()` on a generator was made, hence the error. This PR is simply calls `len(list(<generator>))` in order to circumvent this error. 

## Feature Flag
?

## Safety Assurance

### Safety story
No automated test for this change...

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
