### PR TITLE
Escape HTML tags for key value strings

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-input-map.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-input-map.js
@@ -1,9 +1,11 @@
 hqDefine('hqwebapp/js/ui_elements/ui-element-input-map', [
     'jquery',
+    'underscore',
     'hqwebapp/js/main',
     'DOMPurify/dist/purify.min',
 ], function (
     $,
+    _,
     hqMain,
     DOMPurify
 ) {
@@ -83,8 +85,8 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-input-map', [
                     });
 
                 }
-                mapKey = DOMPurify.sanitize(mapKey);
-                mapVal = DOMPurify.sanitize(mapVal);
+                mapKey = _.escape(DOMPurify.sanitize(mapKey));
+                mapVal = _.escape(DOMPurify.sanitize(mapVal));
                 if (mapKey && !mapKey.trim()) {
                     mapKey = `"<span style="white-space: pre;">${mapKey}</span>"`;
                 }


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No user visible changes

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/INDIV-109
Follow up to https://github.com/dimagi/commcare-hq/pull/32887 to sanitize during display instead of stripping of tags.

**BEFORE**

![Screenshot from 2023-05-05 22-17-36](https://user-images.githubusercontent.com/3864163/236518823-9fe85f04-c756-467e-aed1-fa95c314e34d.png)

**AFTER**
![Screenshot from 2023-05-05 22-16-51](https://user-images.githubusercontent.com/3864163/236518849-f5d8f50b-9e9c-4b44-a677-a49d0e0e715a.png)

Data flow that leads to the Javascript changed in this PR, shared [here](https://github.com/dimagi/commcare-hq/pull/32887#issuecomment-1536450811)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally that all works okay in the UI.
Data was still saved with tags intact.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-5139

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
