### PR TITLE
Just use `venv`

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -52,9 +52,47 @@ NOTE: Developers on Mac OS have additional prerequisites. See the [Supplementary
   - **Linux**:
 
     In Ubuntu you will also need to install the modules for `python-dev`, `pip`, and `venv` explicitly.
-    ```sh
-    sudo apt install python3.9-dev python3-pip python3-venv
-    ```
+
+    The [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa)
+    allows you to use multiple versions of Python on your own machine as we do
+    in production environments. The deadsnakes PPA supports Ubuntu LTS
+    releases, but you can use their Python versions on interim Ubuntu releases
+    as follows:
+
+    1. Find the name of your Ubuntu release if you don't already know it:
+       ```shell
+       $ cat /etc/lsb-release
+       DISTRIB_ID=Ubuntu
+       DISTRIB_RELEASE=23.04
+       DISTRIB_CODENAME=lunar  # <-- This is the name you want
+       DISTRIB_DESCRIPTION="Ubuntu 23.04"
+       ```
+
+    2. Pin your release's package priority to 1001 so that deadsnakes packages
+       can't replace official packages, even if they are newer:
+       ```shell
+       $ cat << EOF | sudo tee /etc/apt/preferences.d/99lunar
+       Package: *
+       Pin: release lunar
+       Pin-Priority: 1001
+       EOF
+       ```
+       but change "lunar" to the name of the release you are using.
+
+    3. Add the deadsnakes PPA, and install the Python version that CommCare HQ
+       requires:
+       ```shell
+       $ sudo add-apt-repository ppa:deadsnakes/ppa
+       ```
+       This will create a file in `/etc/apt/sources.list.d/` with the name of your
+       release. Change the filename, and the name inside the file, to the latest
+       LTS release instead (e.g. "jammy").
+
+    4. Install the version of Python that CommCare HQ requires.
+       ```shell
+       $ sudo apt update
+       $ sudo apt install python3.9 python3.9-dev python3-pip python3.9-venv
+       ```
 
   - **Mac**:
 

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -273,6 +273,29 @@ please see [`xmlsec`'s install notes](https://pypi.org/project/xmlsec/).
     python3 -m pip install --upgrade pip
     ```
 
+#### Option C: With standard Python venv
+
+Virtual environments were introduced as a standard in Python 3.3 [with PEP 405](https://peps.python.org/pep-0405/).
+
+By convention, virtual environments use a ".venv" or "venv" directory in the
+root of the codebase. Once you have cloned the CommCare HQ repo in "Step 2"
+below, create a Python 3.9 virtual environment in the root of the codebase
+with:
+```shell
+$ python3.9 -m venv .venv
+```
+
+For convenience, you can create an alias to activate virtual environments in
+".venv" and "venv" directories. To do that, add the following to your
+`.bashrc` or `.zshrc` file:
+```shell
+alias venv='if [[ -d .venv ]] ; then source .venv/bin/activate ; elif [[ -d venv ]] ; then source venv/bin/activate ; fi'
+```
+Then you can activate virtual environments with
+```shell
+$ venv
+```
+
 
 ### Step 2: Clone this repo and install requirements
 


### PR DESCRIPTION
## Technical Summary

Updates DEV_SETUP.md with how to use the deadsnakes PPA with non-LTS Ubuntu releases, and how to use standard Python venv (which, imho, is much simpler than the alternatives).

## Safety Assurance

### Safety story

Documentation only.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
