### PR TITLE
Drop Q6, only flag Q6a

### DIFF
--- a/custom/abt/reports/flagspecs_v2019.yml
+++ b/custom/abt/reports/flagspecs_v2019.yml
@@ -787,17 +787,6 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning_fr: "Problème signalé: fiches de stocks manquantes : bouteilles/sachets vides et stocks de déchets "
     warning_por: "Problema reportado: Deficiente arquivo de registo de estoque: garrfas vazias e estoque de lixo."
     responsible_follow_up: "District Coordinator"
-  - question: [separate_cards_batch]
-    comment: [separate_cards_batch_comments]
-    base_path: [stock_audit_grp, Q6]
-    flag_name: "6. If there are insecticides that expire during spray, are there separate stock cards for each batch of insecticide?"
-    flag_name_fr: "6. S'il y a des insecticides qui expirent pendant la pulvérisation, existe-t-il des fiches de stock distinctes pour chaque lot d'insecticide?"
-    flag_name_por: "6. Se ha insecticidas que expiram durante a pulverização, existem cartões de estoque separados para cada lote de insecticidas?"
-    answer: "no"
-    warning: "Problem reported: No separate stock cards for expiring insecticide."
-    warning_fr: "Problème signalé: pas de fiches de sotck séparés pour les insecticides périmés "
-    warning_por: "Problema reportado: Nao ha separacao de cartoes de estoque de insecticida expirado."
-    responsible_follow_up: "District Coordinator"
   - question: [expired_insecticides_separate]
     comment: [expired_insecticides_separate_comments]
     base_path: [stock_audit_grp, Q6a]

--- a/custom/abt/reports/flagspecs_v2020.yml
+++ b/custom/abt/reports/flagspecs_v2020.yml
@@ -919,17 +919,6 @@ http://openrosa.org/formdesigner/FC8DCFC3-F595-40E2-955B-90721FCD246F:
     warning_fr: "Problème signalé: fiches de stocks manquantes : bouteilles/sachets vides et stocks de déchets "
     warning_por: "Problema reportado: Deficiente arquivo de registo de estoque: garrfas vazias e estoque de lixo."
     responsible_follow_up: "District Coordinator"
-  - question: [separate_cards_batch]
-    base_path: [stock_audit_grp, Q6]
-    comment: [separate_cards_batch_comments]
-    flag_name: "6. If there are insecticides that expire prior to next year’s campaign, have they been physically separated from the other insecticides and clearly marked in the store room?"
-    flag_name_fr: "6. S'il y a des insecticides qui expirent avant la campagne de pulvérisation de l'année prochaine, ont-ils été physiquement séparés des autres insecticides et clairement marqués dans le magasin?"
-    flag_name_por: "6. "
-    answer: "no"
-    warning: "Problem reported: Expiring insecticides not physically seperated in the store"
-    warning_fr: "Problème signalé: Insecticides expirant durant campagne suivante non séparés dans le magasin"
-    warning_por: "Problema reportado: "
-    responsible_follow_up: "ECO"
   - question: [expired_insecticides_separate]
     comment: [expired_insecticides_separate_comments]
     base_path: [stock_audit_grp, Q6a]


### PR DESCRIPTION
## Technical Summary

The partner has requested that only answers to Question 6a that require follow-up be flagged in this custom report, not answers to Question 6.

## Safety Assurance

### Safety story

* Config for a custom report, not a code change
* Only applicable to specific domains

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
