### PR TITLE
Get length of generator results

### DIFF
--- a/custom/abt/reports/fixture_utils.py
+++ b/custom/abt/reports/fixture_utils.py
@@ -95,7 +95,7 @@ def get_sorted_levels(domain, filters) -> Tuple[list, dict, dict, dict]:
     l3_data_items = get_fixture_items_for_data_type(
         domain, data_types_by_tag["level_3_eco"],
     )
-    country_has_level_3 = l3_data_items.count() > 1
+    country_has_level_3 = len(list(l3_data_items)) > 1
     if country_has_level_3:
         l3s_by_l2 = get_fixture_dicts_by_key(
             domain,
@@ -110,7 +110,7 @@ def get_sorted_levels(domain, filters) -> Tuple[list, dict, dict, dict]:
         l4_data_items = get_fixture_items_for_data_type(
             domain, data_types_by_tag["level_4_eco"],
         )
-        country_has_level_4 = l4_data_items.count() > 1
+        country_has_level_4 = len(list(l4_data_items)) > 1
         if country_has_level_4:
             l4s_by_l3 = get_fixture_dicts_by_key(
                 domain,


### PR DESCRIPTION
Related to [this PR](https://github.com/dimagi/commcare-hq/pull/32923) to master.

## Product Description
Fix an issue with custom reports not being accessible.

## Technical Summary
An invalid operation was done on a generator object. This PR simply employs a fix for that. 

## Feature Flag
None

## Safety Assurance

### Safety story
Tested through shell on production (no current tests exist for this, also not on staging).

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
