### PR TITLE
Ze/user filters for location restricted users

### DIFF
--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -158,6 +158,7 @@ class EmwfOptionsController(object):
             ]
         else:
             return [
+                (self.get_static_options_size, self.get_static_options),
                 (self.get_locations_size, self.get_locations),
                 (self.get_all_users_size, self.get_all_users),
             ]

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -353,6 +353,10 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         user_type_filters = []
         has_user_ids = bool(user_ids)
 
+        can_access_all_locations = request_user.has_permission(domain, 'access_all_locations')
+        if has_user_ids and not can_access_all_locations:
+            cls._verify_users_are_accessible(domain, request_user, user_ids)
+
         if has_user_ids:
             # if userid are passed then remove default active filter
             # and move it with mobile worker filter
@@ -377,26 +381,27 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         if HQUserType.DEMO_USER in user_types:
             user_type_filters.append(user_es.demo_users())
 
-        if not request_user.has_permission(domain, 'access_all_locations'):
-            cls._verify_users_are_accessible(domain, request_user, user_ids)
-            return q.OR(
-                filters.term("_id", user_ids),
-                user_es.location(list(SQLLocation.active_objects
-                                      .get_locations_and_children(location_ids)
-                                      .accessible_to_user(domain, request_user)
-                                      .location_ids())),
-            )
-
         if HQUserType.ACTIVE in user_types or HQUserType.DEACTIVATED in user_types:
             if has_user_ids:
                 return q.OR(*user_type_filters, filters.OR(filters.term("_id", user_ids)))
             else:
-                return q.OR(*user_type_filters, user_es.mobile_users())
+                query = user_es.mobile_users()
+                if not can_access_all_locations:
+                    query = filters.AND(
+                        query,
+                        user_es.location(list(
+                            SQLLocation.objects
+                            .accessible_to_user(domain, request_user)
+                            .location_ids()
+                        ))
+                    )
+                return q.OR(*user_type_filters, query)
 
         # return matching user types and exact matches
-        location_ids = list(SQLLocation.active_objects
-                            .get_locations_and_children(location_ids)
-                            .location_ids())
+        location_query = SQLLocation.active_objects.get_locations_and_children(location_ids)
+        if not can_access_all_locations:
+            location_query = location_query.accessible_to_user(domain, request_user)
+        location_ids = list(location_query.location_ids())
 
         group_id_filter = filters.term("__group_ids", group_ids)
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -357,7 +357,6 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
             # if userid are passed then remove default active filter
             # and move it with mobile worker filter
             q = q.remove_default_filter('active')
-            has_user_ids = True
             if HQUserType.DEACTIVATED in user_types:
                 deactivated_mbwf = filters.AND(user_es.is_active(False), user_es.mobile_users())
                 user_type_filters.append(deactivated_mbwf)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This change adds user filters to location-restricted users:
![Screenshot from 2023-05-08 12-31-58](https://github.com/dimagi/commcare-hq/assets/122617251/e97f5af4-3961-467b-b0d8-1cb5106b0ede)

These filters have been added for reports on the "Monitor Workers" pages:
![Screenshot from 2023-05-08 12-41-32](https://github.com/dimagi/commcare-hq/assets/122617251/cf88344d-1749-466b-8d0c-90b457bb06f6)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2352).

Currently, non location-restricted users have access to static user filters, such as "Deactivated Mobile Workers", which are not available for location-restricted users. This change makes these filters available to location-restricted users as well, while also refinining the query function so that location-restricted users still only get data that they have access to.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Unit test

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
A unit test has been added to check that location-restricted users only get appropriate restricted data.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
