### PR TITLE
Ze/change icons in repeat record report

### DIFF
--- a/corehq/motech/repeaters/templates/repeaters/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/repeat_record_report.html
@@ -20,14 +20,26 @@
       {% if total > 0 %}
         <div id="form_options" class="well form-inline">
           <div>
-            <button id="resend-all-button" class="btn btn-default" data-target="#are-you-sure">
-                {% blocktrans %}Resend selected{% endblocktrans %}
+            <button id="resend-all-button"
+                    class="btn btn-default"
+                    data-target="#are-you-sure"
+                    title="{% trans 'Resend selected records' %}">
+              <i class="fa fa-play"></i>
+              {% trans 'Resend' %}
             </button>
-            <button id="cancel-all-button" class="btn btn-default" data-target="#are-you-sure">
-                {% blocktrans %}Cancel selected{% endblocktrans %}
+            <button id="cancel-all-button"
+                    class="btn btn-default"
+                    data-target="#are-you-sure"
+                    title="{% trans 'Cancel selected records' %}">
+              <i class="fa fa-times"></i>
+              {% trans 'Cancel' %}
             </button>
-            <button id="requeue-all-button" class="btn btn-default" data-target="#are-you-sure">
-                {% blocktrans %}Requeue selected{% endblocktrans %}
+            <button id="requeue-all-button"
+                    class="btn btn-default"
+                    data-target="#are-you-sure"
+                    title="{% trans 'Requeue selected records' %}">
+              <i class="fa fa-recycle"></i>
+              {% trans 'Requeue' %}
             </button>
             <label class="checkbox" >
               <input type="checkbox" id="select-all" data-id="{{ form_query_string|urlencode }}">

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -89,7 +89,8 @@ class BaseRepeatRecordReport(GenericTabularReport):
             data-record-id={}
             data-toggle="modal"
             data-target="#view-record-payload-modal">
-            View Payload
+            <i class="fa fa-search"></i>
+            Payload
         </a>
         ''', record_id)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Icons have been added to the bulk action buttons, along with shortened text:
![Screenshot from 2023-05-09 12-56-11](https://github.com/dimagi/commcare-hq/assets/122617251/0523715e-4fc8-492a-96a5-5f803e60beae)

An icon has also been added to the "View Payload" button:
![Screenshot from 2023-05-09 12-56-59](https://github.com/dimagi/commcare-hq/assets/122617251/a55363cf-337a-470f-ac35-7035d321ddd5)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2741).

Very small UI change to add icons to some of the buttons on the Repeat Records page, along with shortening text as needed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Small UI change.
- Have done local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
