### PR TITLE
Fix incorrect sort query

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -421,6 +421,7 @@ class ESQuery(object):
         sort_field = {
             '{}.{}'.format(path, field_name): {
                 'order': 'desc' if desc else 'asc',
+                'nested_path': path,
                 'nested_filter': nested_filter,
             }
         }

--- a/corehq/apps/es/tests/test_sorting.py
+++ b/corehq/apps/es/tests/test_sorting.py
@@ -25,6 +25,7 @@ class TestESSort(SimpleTestCase):
         expected = [{
             "case_properties.value": {
                 "order": "asc",
+                "nested_path": path,
                 "nested_filter": sort_filter
             }
         }]


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2774).

This is a small change to the CaseSearchES sorting query that gets created when trying to sort by `case_property` in the Case List Explorer. The query was missing the `nested_path` property which was resulting in no sorting being applied to case properties.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case List Explorer

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Small one-line change.
- Have done local testing.
- Unit tests exist.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests exist to check that the query structure is as expected.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
