### PR TITLE
Create new GIS page + Feature Flag

### DIFF
--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -1,0 +1,10 @@
+{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% load i18n %}
+{% load hq_shared_tags %}
+
+{% block page_title %}
+  {{ current_page.title }}
+{% endblock %}
+
+{% block page_content %}
+{% endblock %}

--- a/corehq/apps/geospatial/urls.py
+++ b/corehq/apps/geospatial/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import re_path as url
+
+from .views import MapView
+
+urlpatterns = [
+    url(r'^map/$', MapView.as_view(), name=MapView.urlname),
+]

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -1,1 +1,34 @@
-# Create your views here.
+from django.http import Http404
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from corehq.apps.domain.views.base import BaseDomainView
+from corehq import toggles
+
+
+class BaseGeospatialView(BaseDomainView):
+    urlname = 'maps_page'
+    section_name = _("Geospatial")
+
+    def dispatch(self, *args, **kwargs):
+        if not toggles.GEOSPATIAL.enabled(self.domain):
+            raise Http404
+        return super(BaseGeospatialView, self).dispatch(*args, **kwargs)
+
+    @property
+    def section_url(self):
+        return reverse(BaseGeospatialView.urlname, args=(self.domain,))
+
+
+class MapView(BaseGeospatialView):
+    urlname = 'maps_page'
+    template_name = 'map_visualization.html'
+    page_title = _("Map Visualization")
+
+    @property
+    def page_name(self):
+        return _("Map Visualization")
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=[self.domain])

--- a/corehq/tabs/config.py
+++ b/corehq/tabs/config.py
@@ -16,6 +16,7 @@ from corehq.tabs.tabclasses import (
     SMSAdminTab,
     TranslationsTab,
     AttendanceTrackingTab,
+    GeospatialTab,
 )
 
 MENU_TABS = (
@@ -33,6 +34,7 @@ MENU_TABS = (
     EnterpriseSettingsTab,
     MySettingsTab,
     TranslationsTab,
+    GeospatialTab,
     # Admin
     AdminTab,
     SMSAdminTab,

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -40,6 +40,7 @@ from corehq.apps.events.views import (
     AttendeesListView,
     EventsView,
 )
+from corehq.apps.geospatial.views import MapView
 from corehq.apps.hqadmin.reports import (
     DeployHistoryReport,
     DeviceLogSoftAssertReport,
@@ -2504,6 +2505,29 @@ class AttendanceTrackingTab(UITab):
     def _is_viewable(self):
         # The FF check is temporary until the full feature is released
         return toggles.ATTENDANCE_TRACKING.enabled(self.domain) and self.couch_user.can_manage_events(self.domain)
+
+
+class GeospatialTab(UITab):
+    title = gettext_noop("Geospatial")
+    view = MapView.urlname
+    _is_viewable = False
+
+    url_prefix_formats = (
+        '/a/{domain}/settings/geospatial',
+    )
+
+    @property
+    def sidebar_items(self):
+        items = [
+            (_("Map Visualization"), [
+                {
+                    'title': _("View Map"),
+                    'url': reverse(MapView.urlname, args=(self.domain,)),
+                    'description': _('Visually view and manage cases on a map')
+                }
+            ])
+        ]
+        return items
 
 
 def _get_repeat_record_report(domain):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2363,6 +2363,16 @@ ATTENDANCE_TRACKING = StaticToggle(
     save_fn=_handle_attendance_tracking_role,
 )
 
+GEOSPATIAL = StaticToggle(
+    'geospatial',
+    'Allows access to GIS functionality',
+    TAG_SOLUTIONS_LIMITED,
+    namespaces=[NAMESPACE_DOMAIN],
+    description='Additional views will be added allowing for visually viewing '
+                'and assigning cases on a map.'
+
+)
+
 class FrozenPrivilegeToggle(StaticToggle):
     """
     A special toggle to represent a legacy toggle that should't be


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This change adds an empty page for map visualization:
![Screenshot from 2023-05-10 12-34-36](https://github.com/dimagi/commcare-hq/assets/122617251/5cfe3b6d-7456-4afd-be69-6afade93378e)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2710).

A new `Geospatial` feature flag has been created. Along with this, a boilerplate map visualization page is created which sits behind the newly created feature flag.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
New feature flag: Geospatial

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Unused feature flag

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations
The [following](https://github.com/dimagi/commcare-hq/pull/32939) PR requires the changes from this, and so if this PR needs to be reverted then the linked PR should also be reverted.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
