### PR TITLE
Attendance Tracking | Order events by descending start time

### DIFF
--- a/corehq/apps/events/models.py
+++ b/corehq/apps/events/models.py
@@ -120,9 +120,9 @@ def get_attendee_case_type(domain):
 
 class EventObjectManager(models.Manager):
 
-    def by_domain(self, domain, most_recent_first=False):
-        if most_recent_first:
-            return super().get_queryset().filter(domain=domain).order_by('start_date')
+    def by_domain(self, domain, not_started_first=False):
+        if not_started_first:
+            return super().get_queryset().filter(domain=domain).order_by('-start_date')
         return super().get_queryset().filter(domain=domain)
 
 

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -95,7 +95,7 @@ class EventsView(BaseEventView, CRUDPaginatedViewMixin):
 
     @property
     def domain_events(self):
-        return Event.objects.by_domain(self.domain, most_recent_first=True)
+        return Event.objects.by_domain(self.domain, not_started_first=True)
 
     @property
     def paginated_list(self):


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2691)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Events are now ordered in the events list to show those that have not started yet first.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
We now show "not yet started" events first. This is sorted by `start_date` in desc order rather than using the status. True sorting power will be unlocked once [this ticket](https://dimagi-dev.atlassian.net/browse/SC-2787) is done.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Attendance Tracking

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested Locally

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

### Example
![image](https://github.com/dimagi/commcare-hq/assets/64970009/f5f885a3-70b5-4433-81a0-3637f4923bec)
