### PR TITLE
Module to check privileges in JS

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/privileges.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/privileges.js
@@ -1,0 +1,23 @@
+hqDefine('hqwebapp/js/privileges', [
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+], function (
+    _,
+    initialPageData
+) {
+    var privilegePresent = function (allPrivileges, privilegeName) {
+        var value = allPrivileges.includes(privilegeName);
+        if (value === false) {
+            throw new Error(
+                'Privilege ' + privilegeName + ' not recognized. Must be one of: \n\n' +
+                allPrivileges.sort()
+            );
+        }
+        return value;
+    };
+    return {
+        hasPrivilege: function (privilegeName) {
+            return privilegePresent(initialPageData.get('privileges'), privilegeName);
+        },
+    };
+});

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -234,6 +234,7 @@
     {% initial_page_data 'secure_cookies' secure_cookies %}
     {% initial_page_data 'minimumZxcvbnScore' MINIMUM_ZXCVBN_SCORE %}
     {% initial_page_data 'minimumPasswordLength' MINIMUM_PASSWORD_LENGTH %}
+    {% initial_page_data 'privileges' privileges %}
 
 
     {# for get demo and get trial forms #}
@@ -294,6 +295,7 @@
         <script src="{% static 'hqwebapp/js/hq-bug-report.js' %}"></script>
         <script src="{% static 'hqwebapp/js/layout.js' %}"></script>
         <script src="{% static 'hqwebapp/js/toggles.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/privileges.js' %}"></script>
         <script src="{% static 'hqwebapp/js/alert_user.js' %}"></script>
         <script src="{% static 'hqwebapp/js/main.js' %}"></script>
         <script src="{% static 'hqwebapp/js/mobile_experience_warning.js' %}"></script>

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -139,9 +139,6 @@ def js_toggles(request):
 
 
 def js_privileges(request):
-    if not getattr(request, 'couch_user', None):
-        return {}
-
     domain = None
     if getattr(request, 'project', None):
         domain = request.project.name

--- a/docs/js-guide/integration-patterns.rst
+++ b/docs/js-guide/integration-patterns.rst
@@ -229,6 +229,39 @@ to include
    <script src="{% static 'hqwebapp/js/toggles.js' %}"></script>
    <script src="{% static 'style/js/bootstrap3/main.js' %}"></script>
 
+Domain Privileges
+----------------------------
+
+In python you generally have the ability to check at any point whether a
+domain has a particular privilege.
+
+In JavaScript, all privileges for the current domain are available and
+easy to check. For example, you can check whether the domain has the ``export_ownership``
+privilege by including the `privileges` JS module
+
+.. code:: javascript
+
+   hqDefine('your/js/module', [
+      ...
+      'hqwebapp/js/privileges'
+   ], function (
+      ...
+      privileges
+   ) {...};
+
+and then checking for the privilege using
+
+.. code:: javascript
+
+   var hasPrivilege = privileges.hasPrivilege('export_ownership')
+
+On a page that doesn’t inherit from our main templates, you’ll also have
+to include
+
+.. code:: html
+
+   <script src="{% static 'hqwebapp/js/privileges.js' %}"></script>
+
 Remote Method Invocation
 ------------------------
 

--- a/settings.py
+++ b/settings.py
@@ -1238,6 +1238,7 @@ TEMPLATES = [
                 'corehq.util.context_processors.status_page',
                 'corehq.util.context_processors.sentry',
                 'corehq.util.context_processors.bootstrap5',
+                'corehq.util.context_processors.js_privileges',
             ],
             'debug': DEBUG,
             'loaders': [


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2610)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Added a `privileges` module that we can use to check privileges in JS scripts, similar to how we check toggles like [here](https://github.com/dimagi/commcare-hq/blob/336a78662d4992edb4ccd796d7c464b07925ab3a/corehq/apps/data_interfaces/static/data_interfaces/js/case_property_input.js#L55). Going forward, this will hopefully make it easier to check domain privileges in JS. Currently, knowlege about a domain having a _specific_ privilege is passed to JS using a specific flag for that privilege. Each privilege requires a separate flag being passed from the view to JS. This is not ideal.

The change in this PR automatically passes in all privileges to JS, so we don't have to worry about the JS side having knowlegde about a specific privilege. We can just use the privilege module in JS to figure out what privileges there are.
## Safety Assurance
Impact on page load times is not certain. For the Dimagi Enterprise plan, there are about 53 privileges being passed to the FE, so 53 additional fields.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA plan

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

### Example usage in JS
![Screenshot from 2023-05-11 09-40-35](https://github.com/dimagi/commcare-hq/assets/64970009/b018c955-da2a-458b-959c-50aafddad770)

