### PR TITLE
don't make a details request if there is no details view configured

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -102,6 +102,8 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
                     length: response.entities.length,
                     multiSelect: response.multiSelect,
                 }));
+                // backwards compatibility - remove after FP deploy of #1374
+                _.defaults(response, {"hasDetails": true});
                 _.extend(this, _.pick(response, this.entityProperties));
                 return response.entities;
             } else if (response.type === "query") {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -53,6 +53,7 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
             'widthHints',
             'multiSelect',
             'maxSelectValue',
+            'hasDetails',
         ],
 
         commandProperties: [
@@ -128,4 +129,3 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
         return new MenuSelect(response, options);
     };
 });
-

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -260,7 +260,17 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         rowClick: function (e) {
             if (!(e.target.classList.contains('module-case-list-column-checkbox') || e.target.classList.contains("select-row-checkbox"))) {
                 e.preventDefault();
-                FormplayerFrontend.trigger("menu:show:detail", this.model.get('id'), 0, this.isMultiSelect);
+                let model_id = this.model.get('id');
+                if (!this.model.collection.hasDetails) {
+                    if (this.isMultiSelect) {
+                        let action = this.isChecked() ? constants.MULTI_SELECT_ADD : constants.MULTI_SELECT_REMOVE;
+                        FormplayerFrontend.trigger("multiSelect:updateCases", action, [model_id]);
+                    } else {
+                        FormplayerFrontend.trigger("menu:select", model_id);
+                    }
+                    return;
+                }
+                FormplayerFrontend.trigger("menu:show:detail", model_id, 0, this.isMultiSelect);
             }
         },
 


### PR DESCRIPTION
## Technical Summary
Skip the details request altogether if there is no detail configured for the view.

This happens when using case tiles which do not have a `detail-confirm` configured.

See FP changes: https://github.com/dimagi/formplayer/pull/1374

## Safety Assurance

### Safety story
This should be safe. If there is no details then it will select the case which is what was happening before when processing the details response: https://github.com/dimagi/commcare-hq/blob/23ac6b9171766982336ce34c0f83b66aee60863c/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js#L140-L147

This PR includes a default value to maintain backwards compatibility to allow seamless rollout / rollback of the FP change.

### Automated test coverage
None

### QA Plan
Tested locally with and without the FP change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
