### PR TITLE
Remove two-factor backup token from user pages

### DIFF
--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -37,7 +37,7 @@
     {% if commtrack_enabled or uses_locations %}
       <li><a href="#commtrack-data" data-toggle="tab">{% trans "Locations" %}</a></li>
     {% endif %}
-    {% if not request.is_view_only or token %}
+    {% if not request.is_view_only %}
       <li><a href="#user-password" data-toggle="tab">{% trans "Security" %}</a></li>
     {% endif %}
     {% if not is_currently_logged_in_user and not request.is_view_only %}
@@ -77,22 +77,6 @@
               {% crispy reset_password_form %}
             </div>
           </form>
-          <div class="spacer"></div>
-        {% endif %}
-        {% if token %}
-          <fieldset>
-            <legend>{% trans 'Two Factor Authentication' %}</legend>
-            <div class="form form-horizontal">
-              <div class="form-group">
-                <label class="control-label col-sm-3 col-md-2">
-                  {% trans "Backup Token" %}
-                </label>
-                <div class="controls col-sm-9 col-md-8 col-lg-6">
-                  <input type="text" class="form-control" disabled value="{{ token }}" />
-                </div>
-              </div>
-            </div>
-          </fieldset>
         {% endif %}
       </div>
     </div>

--- a/corehq/apps/users/templates/users/edit_web_user.html
+++ b/corehq/apps/users/templates/users/edit_web_user.html
@@ -56,10 +56,6 @@
             </ul>
           </dd>
         {% endif %}
-        {% if token %}
-          <dt>{% trans 'Backup Token' %}</dt>
-          <dd>{{ token }}</dd>
-        {% endif %}
       </dl>
     </fieldset>
   </div>

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -33,14 +33,12 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _, ngettext, gettext_lazy, gettext_noop
 
 from corehq.apps.users.analytics import get_role_user_count
-from dimagi.utils.couch import CriticalSection
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_GET, require_POST
 from django_digest.decorators import httpdigest
-from django_otp.plugins.otp_static.models import StaticToken
 from django_prbac.utils import has_privilege
 from memoized import memoized
 
@@ -61,7 +59,6 @@ from corehq.apps.domain.decorators import (
     require_superuser,
 )
 from corehq.apps.domain.forms import clean_password
-from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.enterprise.models import EnterprisePermissions
 from corehq.apps.es import UserES, queries
@@ -306,20 +303,6 @@ class BaseEditUserView(BaseUserSettingsView):
         return context
 
     @property
-    def backup_token(self):
-        if Domain.get_by_name(self.request.domain).two_factor_auth:
-            with CriticalSection([f"backup-token-{self.editable_user._id}"]):
-                device = (self.editable_user.get_django_user()
-                          .staticdevice_set
-                          .get_or_create(name='backup')[0])
-                token = device.token_set.first()
-                if token:
-                    return device.token_set.first().token
-                else:
-                    return device.token_set.create(token=StaticToken.random_token()).token
-        return None
-
-    @property
     @memoized
     def commtrack_form(self):
         if self.request.method == "POST" and self.request.POST['form_type'] == "commtrack":
@@ -454,8 +437,6 @@ class EditWebUserView(BaseEditUserView):
             ctx.update({'tableau_form': self.tableau_form})
         if self.can_grant_superuser_access:
             ctx.update({'update_permissions': True})
-
-        ctx.update({'token': self.backup_token})
 
         idp = IdentityProvider.get_active_identity_provider_by_username(
             self.editable_user.username

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -211,7 +211,6 @@ class EditCommCareUserView(BaseEditUserView):
             'edit_user_form_title': self.edit_user_form_title,
             'strong_mobile_passwords': self.request.project.strong_mobile_passwords,
             'has_any_sync_logs': self.has_any_sync_logs,
-            'token': self.backup_token,
         })
         return context
 


### PR DESCRIPTION
## Product Description
Remove two-factor backup token from user pages.  See discussion in [ticket](https://dimagi-dev.atlassian.net/browse/USH-616) for context.  Only applies to domains with two-factor enabled.

| | mobile | web |
| ----- | ------ | ---- |
| **Before** | ![image](https://github.com/dimagi/commcare-hq/assets/2367539/31be4e2d-5436-4a14-9994-6e9676729484) | ![image](https://github.com/dimagi/commcare-hq/assets/2367539/2a441e44-e8d4-451d-adb3-5ea33e80e18b) | 
| **After** | ![image](https://github.com/dimagi/commcare-hq/assets/2367539/94c6151b-9cb2-4bae-8abe-629916adb767) | ![image](https://github.com/dimagi/commcare-hq/assets/2367539/13b6b90c-61d7-481f-8ddd-55fbacdab84a) |

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-616

I initially kept it in mobile worker pages, since the ownership model of those is different, even going so far as to make it display only with an auditable view, before thinking YAGNI and abandoning that approach. Preserved for posterity in https://github.com/dimagi/commcare-hq/pull/32950

My rationale being that backup tokens for mobile workers only applies to projects that have two factor auth, and which have mobile worker roles that can log on to HQ.  Given that this negatively impacts security, it's better to not allow it unless we decide it's truly necessary.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

The code changes themselves are super straightforward.  I deemed local testing plus PR review sufficient

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
