### PR TITLE
lbounds in mapbox response can be undefined

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1084,9 +1084,9 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             var query = $(form).find('.query').val();
             self.geocoder.query(query, function (err, data) {
                 if (err === null) {
-                    if (data.lbounds !== null) {
+                    if (data.lbounds) {
                         self.map.fitBounds(data.lbounds);
-                    } else if (data.latlng !== null) {
+                    } else if (data.latlng) {
                         self.map.setView([data.latlng[0], data.latlng[1]], self.DEFAULT.zoom);
                     }
                 }


### PR DESCRIPTION
## Product Description
The search box for GPS fields does not work.

Mapbox' `geocoder.query` passes undefined for `lbounds` not `null`. So the if statement evaluates to True causing the next line to throw an exception.

![image](https://github.com/dimagi/commcare-hq/assets/1946138/51aa9fec-de85-4b89-b8e4-2944f63920f1)

## Technical Summary
Found while checking out where else we use maps.

## Feature Flag
None

## Safety Assurance

### Safety story
Tested the search locally and on Staging. Since it depends on a third party response it would be tricky to automatically test in a unit test

### Automated test coverage

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
