### PR TITLE
Rc/force annual tos

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -29,6 +29,7 @@ class UserResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMix
     default_phone_number = fields.CharField(attribute='default_phone_number', null=True)
     email = fields.CharField(attribute='email')
     phone_numbers = fields.ListField(attribute='phone_numbers')
+    eulas = fields.CharField(attribute='eulas', null=True)
 
     def obj_get(self, bundle, **kwargs):
         domain = kwargs['domain']

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -91,6 +91,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(api_users[0], {
             'default_phone_number': None,
             'email': '',
+            'eulas': '[]',
             'first_name': '',
             'groups': [],
             'id': backend_id,
@@ -116,6 +117,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(api_user, {
             'default_phone_number': None,
             'email': '',
+            'eulas': '[]',
             'first_name': '',
             'groups': [],
             'id': backend_id,

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -54,7 +54,7 @@ from corehq.apps.registration.utils import (
     send_mobile_experience_reminder,
     send_new_request_update_email,
 )
-from corehq.apps.users.models import CouchUser, WebUser, Invitation
+from corehq.apps.users.models import CouchUser, WebUser, Invitation, CURRENT_VERSION
 from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.util.context_processors import get_per_domain_context
 from corehq.util.jqueryrmi import JSONResponseMixin, allow_remote_invocation
@@ -532,7 +532,6 @@ def confirm_domain(request, guid=''):
 
 @retry_resource(3)
 def eula_agreement(request):
-    CURRENT_VERSION = '3.0'  # Should be kept in sync with EulaMixin. Should be a const?
     if request.method == 'POST':
         current_user = CouchUser.from_django_user(request.user)
         new_agreement = LicenseAgreement(type="End User License Agreement", version=CURRENT_VERSION)

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -54,7 +54,7 @@ from corehq.apps.registration.utils import (
     send_mobile_experience_reminder,
     send_new_request_update_email,
 )
-from corehq.apps.users.models import CouchUser, WebUser, Invitation, CURRENT_VERSION
+from corehq.apps.users.models import CouchUser, EulaMixin, WebUser, Invitation
 from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.util.context_processors import get_per_domain_context
 from corehq.util.jqueryrmi import JSONResponseMixin, allow_remote_invocation
@@ -534,7 +534,7 @@ def confirm_domain(request, guid=''):
 def eula_agreement(request):
     if request.method == 'POST':
         current_user = CouchUser.from_django_user(request.user)
-        new_agreement = LicenseAgreement(type="End User License Agreement", version=CURRENT_VERSION)
+        new_agreement = LicenseAgreement(type="End User License Agreement", version=EulaMixin.CURRENT_VERSION)
         new_agreement.signed = True
         new_agreement.date = datetime.utcnow()
         new_agreement.user_ip = get_ip(request)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -112,7 +112,6 @@ COMMCARE_USER = 'commcare'
 MAX_WEB_USER_LOGIN_ATTEMPTS = 5
 MAX_COMMCARE_USER_LOGIN_ATTEMPTS = 500
 
-CURRENT_VERSION = '3.0'  # Set this to the most up to date version of the eula
 
 
 def _add_to_list(list, obj, default):
@@ -712,7 +711,7 @@ class DjangoUserMixin(DocumentSchema):
 
 
 class EulaMixin(DocumentSchema):
-    CURRENT_VERSION = CURRENT_VERSION
+    CURRENT_VERSION = '3.0'  # Set this to the most up to date version of the eula
     eulas = SchemaListProperty(LicenseAgreement)
 
     @classmethod

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -741,6 +741,13 @@ class EulaMixin(DocumentSchema):
                     current_eula = eula
         return current_eula
 
+    def get_eulas(self):
+        eulas = self.eulas
+        eulas_json = []
+        for eula in eulas:
+            eulas_json.append(eula.to_json())
+        return eulas_json
+
     @property
     def eula(self, version=CURRENT_VERSION):
         current_eula = self.get_eula(version)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -112,6 +112,8 @@ COMMCARE_USER = 'commcare'
 MAX_WEB_USER_LOGIN_ATTEMPTS = 5
 MAX_COMMCARE_USER_LOGIN_ATTEMPTS = 500
 
+CURRENT_VERSION = '3.0'  # Set this to the most up to date version of the eula
+
 
 def _add_to_list(list, obj, default):
     if obj in list:
@@ -710,7 +712,6 @@ class DjangoUserMixin(DocumentSchema):
 
 
 class EulaMixin(DocumentSchema):
-    CURRENT_VERSION = '3.0'  # Set this to the most up to date version of the eula
     eulas = SchemaListProperty(LicenseAgreement)
 
     @classmethod

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -728,7 +728,9 @@ class EulaMixin(DocumentSchema):
         current_eula = self.eula
         if current_eula.version == version:
             if toggles.FORCE_ANNUAL_TOS.enabled(current_domain):
-                elapsed = datetime.now() - current_eula.date if current_eula.date else 365
+                if not current_eula.date:
+                    return False
+                elapsed = datetime.now() - current_eula.date
                 return current_eula.signed and elapsed.days < 365
             return current_eula.signed
         return False

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -724,16 +724,22 @@ class EulaMixin(DocumentSchema):
     def is_eula_signed(self, version=CURRENT_VERSION):
         if self.is_superuser:
             return True
-        for eula in self.eulas:
-            if eula.version == version:
-                return eula.signed
+        current_domain = getattr(self, 'current_domain', None)
+        current_eula = self.eula
+        if current_eula.version == version:
+            if toggles.FORCE_ANNUAL_TOS.enabled(current_domain):
+                elapsed = datetime.now() - current_eula.date if current_eula.date else 365
+                return current_eula.signed and elapsed.days < 365
+            return current_eula.signed
         return False
 
     def get_eula(self, version):
+        current_eula = None
         for eula in self.eulas:
             if eula.version == version:
-                return eula
-        return None
+                if not current_eula or eula.date > current_eula.date:
+                    current_eula = eula
+        return current_eula
 
     @property
     def eula(self, version=CURRENT_VERSION):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -712,6 +712,7 @@ class DjangoUserMixin(DocumentSchema):
 
 
 class EulaMixin(DocumentSchema):
+    CURRENT_VERSION = CURRENT_VERSION
     eulas = SchemaListProperty(LicenseAgreement)
 
     @classmethod

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -837,7 +837,7 @@ def _format_enterprise_user(domain, user):
 def paginate_web_users(request, domain):
     web_users, pagination = _get_web_users(request, [domain])
     web_users_fmt = [{
-        'eulas': u.eulas,
+        'eulas': u.get_eulas(),
         'email': u.get_email(),
         'domain': domain,
         'name': u.full_name,

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -837,6 +837,7 @@ def _format_enterprise_user(domain, user):
 def paginate_web_users(request, domain):
     web_users, pagination = _get_web_users(request, [domain])
     web_users_fmt = [{
+        'eulas': u.eulas,
         'email': u.get_email(),
         'domain': domain,
         'name': u.full_name,

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -959,6 +959,7 @@ class UserRepeaterTest(TestCase, DomainSubscriptionMixin):
                 'groups': [],
                 'phone_numbers': [],
                 'email': '',
+                'eulas': '[]',
                 'resource_uri': '/a/user-repeater/api/v0.5/user/{}/'.format(user._id),
             }
         )

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2519,3 +2519,10 @@ EXPORT_OWNERSHIP = FrozenPrivilegeToggle(
     namespaces=[NAMESPACE_DOMAIN],
     description='Allow exports to have ownership',
 )
+
+FORCE_ANNUAL_TOS = StaticToggle(
+    'annual_terms_of_service',
+    "USH Specific toggle that forces users to agree to terms of service annually.",
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This forces users to agree to terms of service on an annual basis on domains where FF is turned on.

<img width="907" alt="Screen Shot 2023-05-11 at 3 01 24 PM" src="https://github.com/dimagi/commcare-hq/assets/42388648/d7e94536-f630-4511-9b81-70efba781f29">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira ticket: https://dimagi-dev.atlassian.net/browse/USH-3087
Spec doc: https://docs.google.com/document/d/1WvbrQ7K8IonWxfGR9PSKau67NUBpLxmDj_6jPxtFTMY/edit#

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->


ANNUAL_TERMS_OF_SERVICE

## Safety Assurance
Behind FF. Tested locally. Will also be tested on staging with multiple devs.

testing steps outline here https://dimagi-dev.atlassian.net/browse/USH-3168?focusedCommentId=265296

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA. This change doesn't lend itself to formal QA testing.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
