### PR TITLE
Improve bulk case import workflow

### DIFF
--- a/corehq/apps/case_importer/static/case_importer/js/main.js
+++ b/corehq/apps/case_importer/static/case_importer/js/main.js
@@ -41,6 +41,22 @@ hqDefine("case_importer/js/main", [
         }
     };
 
+    var behaviorForOptionsPage = function () {
+        var $caseType = $('#case_type');
+        if (!$caseType.length) {
+            // We're not on the Case Options page
+            return;
+        }
+
+        $('#field_form').submit(function () {
+            $('[disabled]').each(function () {
+                $(this).prop('disabled', false);
+            });
+
+            return true;
+        });
+    }
+
     var behaviorForExcelMappingPage = function () {
         var excelFields = initialPageData.get('excel_fields');
         var caseFieldSpecs = initialPageData.get('case_field_specs');
@@ -95,6 +111,7 @@ hqDefine("case_importer/js/main", [
         });
 
         behaviorForUploadPage();
+        behaviorForOptionsPage();
         behaviorForExcelMappingPage();
     });
 });

--- a/corehq/apps/case_importer/static/case_importer/js/main.js
+++ b/corehq/apps/case_importer/static/case_importer/js/main.js
@@ -49,6 +49,18 @@ hqDefine("case_importer/js/main", [
             return;
         }
 
+        $('#field_form').submit(function () {
+            $('[disabled]').each(function () {
+                $(this).prop('disabled', false);
+            });
+
+            return true;
+        });
+
+        if (initialPageData.get('is_bulk_import')) {
+            return;
+        }
+
         var excelFieldRows = excelFieldsModule.excelFieldRowsModel(excelFields, caseFieldSpecs);
         $('#excel-field-rows').koApplyBindings(excelFieldRows);
 
@@ -63,14 +75,6 @@ hqDefine("case_importer/js/main", [
             if (value !== originalValue) {
                 $(this).val(value);
             }
-        });
-
-        $('#field_form').submit(function () {
-            $('[disabled]').each(function () {
-                $(this).prop('disabled', false);
-            });
-
-            return true;
         });
 
         $('#autofill').click(function () {

--- a/corehq/apps/case_importer/static/case_importer/js/main.js
+++ b/corehq/apps/case_importer/static/case_importer/js/main.js
@@ -55,7 +55,7 @@ hqDefine("case_importer/js/main", [
 
             return true;
         });
-    }
+    };
 
     var behaviorForExcelMappingPage = function () {
         var excelFields = initialPageData.get('excel_fields');

--- a/corehq/apps/case_importer/templates/case_importer/excel_config.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_config.html
@@ -13,15 +13,17 @@
       {% blocktrans %}
       <p>
         <i class="fa fa-warning"></i>
-        A bulk case import for multiple case types has been detected. For bulk case imports:
+        A bulk case import for multiple case types has been detected. This is because every sheet name in
+        the Excel file matches a case type in the project. If this is incorrect, then please rename at least
+        one Excel sheet so that not all sheet names match case types in the project.
       </p>
-      <ul>
-        <li>Excel mapping is disabled.</li>
-        <li>New cases for new case types cannot be created.</li>
-      </ul>
       <p>
-        If this is incorrect, then please rename the Excel sheets so that they do not share the same
-        name as the case types in the project.
+        Documentation for bulk case imports can be found on our
+        <a
+          href="https://confluence.dimagi.com/display/commcarepublic/Updating+Cases+-+Update+multiple+case+types+in+a+single+Excel+import"
+          target="_blank">
+          help page for this feature.
+        </a>
       </p>
       {% endblocktrans %}
     </div>
@@ -29,7 +31,8 @@
 
   <form class="form-horizontal form-report"
         action="{% url "excel_fields" domain %}"
-        method="post">
+        method="post"
+        id="field_form">
     {% csrf_token %}
     <input type="hidden" name="is_bulk_import" value="{{is_bulk_import}}" />
 
@@ -40,20 +43,16 @@
           {% trans "Case type" %}
         </label>
         <div class="col-sm-6">
-          <select class="form-control hqwebapp-select2" name="case_type" id="case_type">
-            {% if is_bulk_import %}
-              <option value="{{ bulk_import_case_type }}">{{ bulk_import_case_type }}</option>
-            {% else %}
-              <option disabled>{% trans "Used in existing applications:" %}</option>
-              {% for case_type in case_types_from_apps %}
-                <option value="{{case_type|escape}}">{{case_type|escape}}</option>
-              {% endfor %}
+          <select class="form-control hqwebapp-select2" name="case_type" id="case_type" {% if is_bulk_import %}disabled="disabled"{% endif %}>
+            <option disabled>{% trans "Used in existing applications:" %}</option>
+            {% for case_type in case_types_from_apps %}
+              <option value="{{case_type|escape}}">{{case_type|escape}}</option>
+            {% endfor %}
 
-              <option disabled>{% trans "From unknown or deleted applications:" %}</option>
-              {% for case_type in unrecognized_case_types %}
-                <option value="{{case_type|escape}}">{{case_type|escape}}</option>
-              {% endfor %}
-            {% endif %}
+            <option disabled>{% trans "From unknown or deleted applications:" %}</option>
+            {% for case_type in unrecognized_case_types %}
+              <option value="{{case_type|escape}}">{{case_type|escape}}</option>
+            {% endfor %}
           </select>
         </div>
       </div>
@@ -66,7 +65,7 @@
           {% trans "Excel column" %}
         </label>
         <div class="col-sm-6">
-          <select class="form-control hqwebapp-select2" name="search_column" id="search_column">
+          <select class="form-control hqwebapp-select2" name="search_column" id="search_column" {% if is_bulk_import %}disabled="disabled"{% endif %}>
             {% for column in columns %}
               <option value="{{column|escape}}">
                 {{column|escape}}
@@ -108,6 +107,16 @@
         </div>
       </div>
     </fieldset>
+
+    {% if is_bulk_import %}
+      <div class="alert alert-warning">
+        <p>
+          {% blocktrans %}
+            Selecting a case type, excel column, or corresponding case field is disabled when doing a bulk case import.
+          {% endblocktrans %}
+        </p>
+      </div>
+    {% endif %}
 
     <div class="form-actions">
       <div class="col-sm-offset-3">

--- a/corehq/apps/case_importer/templates/case_importer/excel_fields.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_fields.html
@@ -30,6 +30,7 @@
 
   {% initial_page_data 'excel_fields' excel_fields %}
   {% initial_page_data 'case_field_specs' case_field_specs %}
+  {% initial_page_data 'is_bulk_import' is_bulk_import %}
 
   <form action="{% url "excel_commit" domain %}"
         method="post"

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -219,12 +219,11 @@ def _process_file_and_get_upload(uploaded_file_handle, request, domain, max_colu
 
     context = {
         'columns': columns,
-        'unrecognized_case_types': unrecognized_case_types,
-        'case_types_from_apps': case_types_from_apps,
+        'unrecognized_case_types': [] if is_bulk_import else unrecognized_case_types,
+        'case_types_from_apps': [ALL_CASE_TYPE_IMPORT] if is_bulk_import else case_types_from_apps,
         'domain': domain,
         'slug': base.ImportCases.slug,
-        'is_bulk_import': is_bulk_import,
-        'bulk_import_case_type': ALL_CASE_TYPE_IMPORT
+        'is_bulk_import': is_bulk_import
     }
     return case_upload, context
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This changes the config options page of the case import workflow when doing a bulk case import:
![Screenshot from 2023-05-16 09-09-52](https://github.com/dimagi/commcare-hq/assets/122617251/55f17a31-5fc4-47eb-8900-ad8199ecdf4d)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2735).

Small set of UI changes. Firstly, the warning banner for a bulk case import has been improved to better notify the user why a bulk import has been detected, along with a link to relevant documentation. Secondly, all dropdown fields that only have one selectable option for a bulk case import have now been disabled to better reflect to the user that this cannot be changed. A banner has been added to notify the user of these disabled fields.

There was also a minor knockout js error that occured due to the excel fields not being available for a bulk import. This has also been resolved in this PR.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Small UI change.
- Have done local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
