### PR TITLE
Repeat records view responses change

### DIFF
--- a/corehq/motech/repeaters/static/repeaters/js/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/repeat_record_report.js
@@ -12,6 +12,42 @@ hqDefine('repeaters/js/repeat_record_report', function () {
             $(this).nextAll('.record-attempt').toggle();
             e.preventDefault();
         });
+        $('#report-content').on('click', '.view-attempts-btn', function (e) {
+            const recordId = $(this).data().recordId;
+
+            // Clear out previous error message banner, if it exists
+            $(`#${recordId}.attempt-error`).remove();
+
+            let $attemptTable = $(`#${recordId}.attempt-row`);
+            if ($attemptTable.length) {
+                // There should only be one table per record
+                $($attemptTable[0]).toggle();
+                return;
+            }
+
+            const $row = $(this).closest('tr');
+            $.get({
+                url: initialPageData.reverse("repeat_record"),
+                data: { record_id: recordId },
+                success: function (data) {
+                    // User might have clicked to fetch attempts while previous fetch is busy,
+                    // so skip if one already exists
+                    $attemptTable = $(`#${recordId}.attempt-row`);
+                    if(!$attemptTable.length) {
+                        $row.after(data.attempts);
+                    }
+                },
+                error: function (data) {
+                    const defaultText = gettext('Failed to fetch attempts')
+                    const errorMessage = data.responseJSON ? data.responseJSON.error : null;
+                    $row.after(
+                        `<tr id="${recordId}" class="attempt-error"><td colspan="10">
+                            <div class="alert alert-danger">${errorMessage || defaultText}</div>
+                        </td></tr>`
+                    );
+                }
+            });
+        });
         var editor = null;
         $('#view-record-payload-modal').on('shown.bs.modal', function (event) {
             var recordData = $(event.relatedTarget).data(),

--- a/corehq/motech/repeaters/static/repeaters/js/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/repeat_record_report.js
@@ -12,7 +12,7 @@ hqDefine('repeaters/js/repeat_record_report', function () {
             $(this).nextAll('.record-attempt').toggle();
             e.preventDefault();
         });
-        $('#report-content').on('click', '.view-attempts-btn', function (e) {
+        $('#report-content').on('click', '.view-attempts-btn', function () {
             const recordId = $(this).data().recordId;
 
             // Clear out previous error message banner, if it exists
@@ -33,19 +33,19 @@ hqDefine('repeaters/js/repeat_record_report', function () {
                     // User might have clicked to fetch attempts while previous fetch is busy,
                     // so skip if one already exists
                     $attemptTable = $(`#${recordId}.attempt-row`);
-                    if(!$attemptTable.length) {
+                    if (!$attemptTable.length) {
                         $row.after(data.attempts);
                     }
                 },
                 error: function (data) {
-                    const defaultText = gettext('Failed to fetch attempts')
+                    const defaultText = gettext('Failed to fetch attempts');
                     const errorMessage = data.responseJSON ? data.responseJSON.error : null;
                     $row.after(
                         `<tr id="${recordId}" class="attempt-error"><td colspan="10">
                             <div class="alert alert-danger">${errorMessage || defaultText}</div>
                         </td></tr>`
                     );
-                }
+                },
             });
         });
         var editor = null;

--- a/corehq/motech/repeaters/templates/repeaters/partials/attempt_history.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/attempt_history.html
@@ -1,26 +1,65 @@
 {% load i18n %}
 
-<ul class="list-unstyled">
-{% for attempt_number, attempt in record.get_numbered_attempts %}
-    <li><strong>Attempt #{{ attempt_number }}</strong>
-    {% if attempt.state == 'SUCCESS' %}
-        <br/><i class="fa fa-check"></i> {% trans "Success" %}
-    {% elif attempt.state == 'EMPTY' %}
-        <br/><i class="fa fa-check"></i> {% trans "Empty" %}
-    {% elif attempt.state == 'FAIL' or attempt.state == 'CANCELLED' %}
-        <br/><i class="fa fa-exclamation-triangle"></i> {% trans "Failed" %}
-    {% elif attempt.state == 'PENDING' %}
-        <br/><i class="fa fa-spinner"></i> {% trans "Unsent" %}
-    {% endif %}
-    {% if attempt.message %}
-        <a href="#" class="toggle-next-attempt">…</a>
-        <div class="well record-attempt" style="display: none; font-family: monospace;">
-            {{ attempt.message }}
-        </div>
-    {% endif %}
-    {% if attempt.state == 'CANCELLED' %}
-        <br/><i class="fa fa-remove"></i> {% trans "Cancelled" %}
-    {% endif %}
-    </li>
-{% endfor %}
-</ul>
+<tr class='attempt-row' id="{{ record_id }}">
+    <td colspan="10">
+        <table style="width:100%;">
+            {% if not has_attempts %}
+                <tr>
+                    <td>
+                        <div>
+                            {% trans 'No attempts exist for this record.' %}
+                        </div>
+                    </td>
+                </tr>
+            {% endif %}
+            {% for attempt_number, attempt in record.get_numbered_attempts %}
+                <tr>
+                    <td>
+                        <div>
+                            <strong>Attempt #{{ attempt_number }}</strong> -
+                            {% if attempt.state == 'SUCCESS' %}
+                                <i class="fa fa-check"></i> {% trans "Success" %}
+                            {% elif attempt.state == 'EMPTY' %}
+                                <i class="fa fa-check"></i> {% trans "Empty" %}
+                            {% elif attempt.state == 'CANCELLED' %}
+                                <i class="fa fa-remove"></i> {% trans "Cancelled" %}
+                            {% elif attempt.state == 'FAIL' or attempt.state == 'CANCELLED' %}
+                                <i class="fa fa-exclamation-triangle"></i> {% trans "Failed" %}
+                            {% elif attempt.state == 'PENDING' %}
+                                <i class="fa fa-spinner"></i> {% trans "Unsent" %}
+                            {% endif %}
+                            {% if attempt.message %}
+                                <div class="well record-attempt" style="font-family: monospace;">
+                                    {{ attempt.message }}
+                                </div>
+                            {% endif %}
+                        </div>
+                    </td>
+                </tr>
+            {% endfor %}
+
+            <!-- Visual separation between attempts and DHIS2 errors -->
+            {% if has_dhis2_errors %}
+                <tr>
+                    <td>
+                        <hr/>
+                    </td>
+                </tr>
+            {% endif %}
+
+            <!-- DHIS2 specific errors -->
+            {% for error in dhis2_errors %}
+                <tr>
+                    <td>
+                        <div>
+                            <strong>DHIS2 Error #{{ forloop.counter }}</strong>
+                            <div class="well" style="font-family: monospace;">
+                                {{ error }}
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    </td>
+</tr>

--- a/corehq/motech/repeaters/tests/test_display.py
+++ b/corehq/motech/repeaters/tests/test_display.py
@@ -58,9 +58,3 @@ class RepeaterTestCase(TestCase):
         self.assertEqual(display.next_attempt_at, self.next_check_str)
         self.assertEqual(display.url, self.url)
         self.assertEqual(display.state, '<span class="label label-success">Success</span>')
-        self.assertHTMLEqual(display.attempts, """
-            <ul class="list-unstyled">
-                <li><strong>Attempt #1</strong>
-                    <br/><i class="fa fa-check"></i> Success
-                </li>
-            </ul>""")

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -41,10 +41,6 @@ class RepeatRecordDisplay:
     def state(self):
         return format_html('<span class="label label-{}">{}</span>', *_get_state_tuple(self.record))
 
-    @property
-    def attempts(self):
-        return render_to_string('repeaters/partials/attempt_history.html', {'record': self.record})
-
     def _format_date(self, date):
         if not date:
             return '---'

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -321,7 +321,7 @@ class RepeatRecordView(View):
             payload = pformat_json(payload)
 
         dhis2_errors = []
-        if isinstance(record.repeater, Dhis2EntityRepeater):
+        if toggles.DHIS2_INTEGRATION.enabled(domain) and isinstance(record.repeater, Dhis2EntityRepeater):
             logs = RequestLog.objects.filter(domain=domain, payload_id=record.payload_id)
             for log in logs:
                 resp_body = json.loads(log.response_body)

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -94,6 +94,16 @@ class BaseRepeatRecordReport(GenericTabularReport):
         </a>
         ''', record_id)
 
+    def _make_view_attempts_button(self, record_id):
+        return format_html('''
+        <button
+            class="btn btn-default view-attempts-btn"
+            data-record-id={}>
+            <i class="fa fa-search"></i>
+            Responses
+        </button>
+        ''', record_id)
+
     def _make_resend_payload_button(self, record_id):
         return format_html('''
         <button
@@ -176,7 +186,7 @@ class BaseRepeatRecordReport(GenericTabularReport):
             display.url,
             display.last_checked,
             display.next_attempt_at,
-            display.attempts,
+            self._make_view_attempts_button(record.record_id),
             self._make_view_payload_button(record.record_id),
             self._make_resend_payload_button(record.record_id),
         ]
@@ -209,7 +219,7 @@ class BaseRepeatRecordReport(GenericTabularReport):
             DataTablesColumn(_('URL')),
             DataTablesColumn(_('Last sent date')),
             DataTablesColumn(_('Retry Date')),
-            DataTablesColumn(_('Delivery Attempts')),
+            DataTablesColumn(_('View Responses')),
             DataTablesColumn(_('View payload')),
             DataTablesColumn(_('Resend')),
             DataTablesColumn(_('Cancel or Requeue payload'))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This PR changes how repeat record attempts are viewed by replacing the ellipsis with a "Responses" button that  fetches and displays each attempt in a separate row beneath the repeat record row:
![Screenshot from 2023-05-17 13-09-52](https://github.com/dimagi/commcare-hq/assets/122617251/73d3eb02-a4a1-4a04-97ae-65b161a9ce0a)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2740).

Previously, repeat records attempts were sent when repeat records were fetched. They were then viewed by clicking on the ellipsis. This PR changes the behaviour by replacing the ellipsis with a button that asynchronously fetches the repeat record attempts and displays them in a nicer format, with each attempt having its own row. Furthermore, if there are DHIS2 errors, these are fetched and presented to the user as well.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Displaying DHIS2 errors are specific to DHIS2_INTEGRATION feature flag.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Have done local testing.
- UI only change, data not affected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests do exist for repeat records.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
