### PR TITLE
Use docker compose v2 syntax

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Docker info
       run: |
         docker version
-        docker-compose version
+        docker compose version
     - name: Docker login
       env:
         TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,12 @@ env:
     # CODECOV_TOKEN
     - secure: "ae0iiAahjQMG+0qt+UMk3aKDIsKf7kdGoa7NACl/lhToH90AalF5206fpj7++pakWhO5prHLRgD/KQxplWRm6SVCHsZLSVq/vz//Ooc+ne6dzFSey0vystEpOlBwEpxPiWJV01Ows8t56SlOwm6zVOxKsxTLt9pfzeNsiw4Vdk0="
 before_install:
-  # get newer version of docker-compose for variable substitution in compose files
-  - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv -v docker-compose /usr/local/bin/
+  - sudo apt install docker-compose-plugin
 install:
   - mkdir -p $TRAVIS_BUILD_DIR/docker-volumes
 before_script:
   - docker version
-  - docker-compose version
+  - docker compose version
 script:
   - if [[ "$DOCKER_USERNAME" && "$DOCKER_PASSWORD" ]]; then echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; fi
   - scripts/docker test --noinput --stop --verbosity=2 --divide-depth=1 --with-timing --with-flaky --threshold=10 --max-test-time=29

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -399,10 +399,11 @@ needs of most developers.
     source $WORKON_HOME/hq/bin/activate
     ```
 
-3. Install the `docker-compose` python library
-
+3. Install `docker compose`
+  - **Mac**: comes with Docker Desktop
+  - **Linux**:
     ```sh
-    pip install docker-compose
+    sudo apt install docker-compose-plugin
     ```
 
 4. Ensure the elasticsearch config files are world-readable (their containers

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -9,10 +9,9 @@ Linux
 
 1. Install `Docker`_. You should `manage Docker as a non-root user`_.
 
-2. Install `Docker Compose`_. (You can install it in a virtualenv with
-   ``$ pip install docker-compose``.)
+2. Install `Docker Compose`_: ``sudo apt install docker-compose-plugin``
 
-OS X
+MacOS
 ~~~~
 
 Install `Docker Desktop`_. It is available for Mac with Intel, and Mac

--- a/scripts/docker
+++ b/scripts/docker
@@ -94,7 +94,7 @@ function usage() {
             echo "  teardown    Remove all containers, images and volumes"
             echo "  test        Run tests"
             echo ""
-            echo "All other commands are passed directly to docker-compose."
+            echo "All other commands are passed directly to docker compose."
             echo ""
             echo "Examples:"
             echo ""
@@ -140,7 +140,7 @@ else
             echo "Defaulting to most recently known M1 setup: $os_suffix"
             echo ""
             echo "To remove this message in the future, create a new 'base OS'"
-            echo "(or copy an existing, working) docker-compose configuration"
+            echo "(or copy an existing, working) docker compose configuration"
             echo "for your OS. For example:"
             echo ""
             macos_version=$(sw_vers -productVersion | cut -d. -f1)
@@ -299,12 +299,12 @@ if [ "$CMD" == "test" ]; then
     # Disabled due to: https://github.com/github/feedback/discussions/8848
     # [ -n "$GITHUB_ACTIONS" ] && echo "::group::Docker setup"  # ends in docker/run.sh
     echo "Pulling docker containers..."
-    docker-compose pull --quiet
+    docker compose pull --quiet
 
     # Print service versions
-    docker-compose run --no-deps --rm minio minio --version
-    docker-compose run --no-deps --rm postgres postgres --version
-    docker-compose run --no-deps --rm redis redis-server --version
+    docker compose run --no-deps --rm minio minio --version
+    docker compose run --no-deps --rm postgres postgres --version
+    docker compose run --no-deps --rm redis redis-server --version
     # Cannot get Couch version easily before it is running.
     #
     # The major version of elasticsearch is hard-coded in the container name
@@ -316,11 +316,11 @@ if [ "$CMD" == "test" ]; then
     # Some version information is encoded in docker image names
     docker images
 
-    docker-compose run --rm web run_tests "${TEST:-python}" "$@"
+    docker compose run --rm web run_tests "${TEST:-python}" "$@"
 elif [ "$CMD" == "shell" ]; then
-    docker-compose run --rm web ./manage.py $CMD "$@"
+    docker compose run --rm web ./manage.py $CMD "$@"
 elif [ "$CMD" == "bootstrap" ]; then
-    docker-compose run --rm web bootstrap
+    docker compose run --rm web bootstrap
 elif [ "$CMD" == "bash" ]; then
     SERVICE_NAME="${1:-web}"
     shift
@@ -328,19 +328,19 @@ elif [ "$CMD" == "bash" ]; then
     if [ "$(docker inspect -f {{.State.Running}} $CONTAINER 2> /dev/null)" == "true" ]; then
         docker exec -it $CONTAINER $CMD "$@"
     else
-        docker-compose run --rm $SERVICE_NAME $CMD "$@"
+        docker compose run --rm $SERVICE_NAME $CMD "$@"
     fi
 elif [ "$CMD" == "rebuild" ]; then
     if [ -z "$1" ]; then
-        docker-compose down --rmi local
-        docker-compose build
+        docker compose down --rmi local
+        docker compose build
     else
-        docker-compose stop "$@"
-        docker-compose rm "$@"
-        docker-compose build "$@"
+        docker compose stop "$@"
+        docker compose rm "$@"
+        docker compose build "$@"
     fi
 else
-    docker-compose $CMD "$@"
+    docker compose $CMD "$@"
     if [ "$TEARDOWN" == "yes" ]; then
         if [ "$COMPOSE_PROJECT_NAME" == "hqservice" ]; then
             echo "THIS WILL DELETE ALL SERVICE DATA"


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14537

Based on https://docs.docker.com/compose/migrate/, it does not appear that we have any usages impacted by the upgrade (apart from the change of syntax from `docker-compose` to `docker compose`)

docker compose v2 comes with docker desktop on macOS, so this was really straightforward to test. I'm able to run `./scripts/docker up -d` and other commands just as before, and can see the slightly nicer interface docker compose v2 offers.

My understanding is that podman v4.1 and greater are compatible with docker compose v2, so linux users using podman will need to ensure they are upgraded once this PR is merged.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Impacts developers only.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
