### PR TITLE
fix type for version in License Agreement

### DIFF
--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -534,7 +534,7 @@ def confirm_domain(request, guid=''):
 def eula_agreement(request):
     if request.method == 'POST':
         current_user = CouchUser.from_django_user(request.user)
-        new_agreement = LicenseAgreement(type="End User License Agreement", version=EulaMixin.CURRENT_VERSION)
+        new_agreement = LicenseAgreement(type="End User License Agreement", version=str(EulaMixin.CURRENT_VERSION))
         new_agreement.signed = True
         new_agreement.date = datetime.utcnow()
         new_agreement.user_ip = get_ip(request)


### PR DESCRIPTION

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Bug fix for https://github.com/dimagi/commcare-hq/pull/32954
when testing on production an is returned because the version in License Agreement is of type `jsonobject.properties.StringProperty` when it needs to be of type `str`
Sentry error: https://dimagi.sentry.io/issues/4189001232/?project=136860&query=is%3Aunresolved+&referrer=issue-stream&statsPeriod=14d&stream_index=10


<img width="878" alt="Screen Shot 2023-05-17 at 11 54 48 AM" src="https://github.com/dimagi/commcare-hq/assets/42388648/70142feb-c9c0-4e80-9d1f-fa2667fe1eb5">

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
ANNUAL_TERMS_OF_SERVICE

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
