### PR TITLE
Add support for case search to case tiles

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -235,7 +235,11 @@ class DetailContributor(SectionContributor):
 
                 if module_offers_search(module) and not module_uses_inline_search(module):
                     in_search = module_loads_registry_case(module) or "search" in id
-                    d.actions.append(self._get_case_search_action(module, in_search=in_search))
+                    d.actions.append(
+                        DetailContributor.get_case_search_action(module,
+                                                                 self.build_profile_id,
+                                                                 in_search=in_search)
+                    )
 
             try:
                 if not self.app.enable_multi_sort:
@@ -361,21 +365,22 @@ class DetailContributor(SectionContributor):
         action.stack.add_frame(frame)
         return action
 
-    def _get_case_search_action(self, module, in_search=False):
+    @staticmethod
+    def get_case_search_action(module, build_profile_id, in_search=False):
         action_kwargs = DetailContributor._get_action_kwargs(module, in_search)
         if in_search:
             search_label = module.search_config.search_again_label
         else:
             search_label = module.search_config.search_label
 
-        if self.app.enable_localized_menu_media:
+        if module.get_app().enable_localized_menu_media:
             action = LocalizedAction(
                 menu_locale_id=(
                     id_strings.case_search_again_locale(module) if in_search
                     else id_strings.case_search_locale(module)
                 ),
-                media_image=search_label.uses_image(build_profile_id=self.build_profile_id),
-                media_audio=search_label.uses_audio(build_profile_id=self.build_profile_id),
+                media_image=search_label.uses_image(build_profile_id=build_profile_id),
+                media_audio=search_label.uses_audio(build_profile_id=build_profile_id),
                 image_locale_id=(
                     id_strings.case_search_again_icon_locale(module) if in_search
                     else id_strings.case_search_icon_locale(module)

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -682,7 +682,18 @@ class CaseTileHelper(object):
 
         # Populate the template
         detail_as_string = self._case_tile_template_string.format(**context)
-        return load_xmlobject_from_string(detail_as_string, xmlclass=Detail)
+        detail = load_xmlobject_from_string(detail_as_string, xmlclass=Detail)
+
+        # Add case search action if needed
+        if module_offers_search(self.module) and not module_uses_inline_search(self.module):
+            in_search = module_loads_registry_case(self.module)
+            detail.actions.append(
+                DetailContributor.get_case_search_action(self.module,
+                                                         self.build_profile_id,
+                                                         in_search=in_search)
+            )
+
+        return detail
 
     def _get_matched_detail_column(self, case_tile_field):
         """


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-3187

## Technical Summary
This makes case tile templates automatically insert an action for case search, if relevant, rather than making the template writer include it. This makes templates more reusable across modules, rather than tying them to a specific case search config.

## Feature Flag
REC case tiles

## Safety Assurance

### Safety story
Feature flag with few real users. Changes are to making new app version.

### Automated test coverage

Tests in PR.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
