### PR TITLE
Upgrade Dependencies to fix issues with Apple Silicon

### DIFF
--- a/DEV_SETUP_MAC.md
+++ b/DEV_SETUP_MAC.md
@@ -5,8 +5,6 @@
 
 - You will need `brew` aka [Homebrew](https://brew.sh) for package management.
 
-  **Big Sur:** see notes on running `brew` with Rosetta, aka `ibrew` below.
-
 
 - It is highly recommended that you install a python environment manager. Two options are:
 
@@ -89,29 +87,6 @@
           ```
 
   [oracle_jdk8]: https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html
-
-### Prerequisites: Notes for MacOs 11.x (Big Sur)
-
-- It is recommended that you install Rosetta:
-    ```sh
-    softwareupdate --install-rosetta
-    ```
-    This allows you to install and run Brew services in x86 fashion.
-    "Rosetta 2 is an emulator designed to bridge the transition between Intel and Apple processors. In short, it translates apps built for Intel so they will run on Apple Silicon." [Link](https://www.computerworld.com/article/3597949/everything-you-need-to-know-about-rosetta-2-on-apple-silicon-macs.html).
-    While reading through this document, be careful to watch out for specific recommendations regarding your architecture.
-
-
-- If `brew` cannot successfully build packages on your system, you can run `brew` with Rosetta under the alias `ibrew` using the method below.
-    However, please try installing the latest version of `brew` first, as this might also be fixed for MacOS 11.x
-    ```sh
-    arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-    ```
-    And let's call this Rosetta-enabled Homebrew `ibrew` for short by adding this to `~/.zshrc`:
-    ```
-    alias ibrew="arch -x86_64 /usr/local/bin/brew"
-    ```
-
-    Note: 12.x Monterey seems to be handling `brew` just fine when following the [official install guide](https://brew.sh).
 
 
 ## Issues Installing `requirements/requirements.txt`
@@ -202,20 +177,6 @@ Now that you have Elasticsearch running you will need to install the necessary p
     analysis-phonetic 2.4.6
     ```
 
-## Fixing ImportError with `libmagic`
-
-If you are sure that the following `brew install libmagic` ran successfully, but you are still seeing the error below, then this section is for you!
-```sh
-ImportError: failed to find libmagic.  Check your installation
-```
-
-As of Mac OS 12.x, `brew` now installs itself in `/opt/homebrew/`, and it looks like our version of the python package that requires `libmagic` has not caught up.
-
-To fix:
-```sh
-cd /usr/local/lib/
-ln -s /opt/homebrew/Cellar/libmagic/5.41/lib/libmagic.dylib libmagic.dylib
-```
 
 ## Refreshing data in `elasticsearch` manually (alternative to `run_ptop`)
 

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -77,7 +77,7 @@ Pillow
 polib
 prometheus-client
 psycogreen
-psycopg2>=2.8.4  # Python 3.8 support
+psycopg2
 py-KISSmetrics
 pycryptodome>=3.6.6  # security update
 PyGithub

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -527,7 +527,7 @@ python-dateutil==2.8.2
     #   pandas
 python-imap==1.0.0
     # via -r base-requirements.in
-python-magic==0.4.22
+python-magic==0.4.27
     # via -r base-requirements.in
 python-mimeparse==1.6.0
     # via django-tastypie

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -263,7 +263,7 @@ ghdiff==0.4
     # via -r base-requirements.in
 git-build-branch==0.1.14
     # via -r dev-requirements.in
-gnureadline==8.0.0
+gnureadline==8.1.2
     # via -r dev-requirements.in
 google-api-core==2.5.0
     # via google-api-python-client

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -462,7 +462,7 @@ psutil==5.8.0
     # via -r dev-requirements.in
 psycogreen==1.0.2
     # via -r base-requirements.in
-psycopg2==2.8.6
+psycopg2==2.9.6
     # via
     #   -r base-requirements.in
     #   sqlalchemy-postgres-copy

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -377,7 +377,7 @@ protobuf==3.18.3
     #   googleapis-common-protos
 psycogreen==1.0.2
     # via -r base-requirements.in
-psycopg2==2.8.6
+psycopg2==2.9.6
     # via -r base-requirements.in
 py-kissmetrics==1.1.0
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -426,7 +426,7 @@ python-dateutil==2.8.2
     #   pandas
 python-imap==1.0.0
     # via -r base-requirements.in
-python-magic==0.4.22
+python-magic==0.4.27
     # via -r base-requirements.in
 python-mimeparse==1.6.0
     # via django-tastypie

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -387,7 +387,7 @@ protobuf==3.18.3
     #   googleapis-common-protos
 psycogreen==1.0.2
     # via -r base-requirements.in
-psycopg2==2.8.6
+psycopg2==2.9.6
     # via -r base-requirements.in
 ptyprocess==0.7.0
     # via pexpect

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -447,7 +447,7 @@ python-dateutil==2.8.2
     #   pandas
 python-imap==1.0.0
     # via -r base-requirements.in
-python-magic==0.4.22
+python-magic==0.4.27
     # via -r base-requirements.in
 python-mimeparse==1.6.0
     # via django-tastypie

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -402,7 +402,7 @@ python-dateutil==2.8.2
     #   pandas
 python-imap==1.0.0
     # via -r base-requirements.in
-python-magic==0.4.22
+python-magic==0.4.27
     # via -r base-requirements.in
 python-mimeparse==1.6.0
     # via django-tastypie

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -353,7 +353,7 @@ protobuf==3.18.3
     #   googleapis-common-protos
 psycogreen==1.0.2
     # via -r base-requirements.in
-psycopg2==2.8.6
+psycopg2==2.9.6
     # via -r base-requirements.in
 py-kissmetrics==1.1.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -388,7 +388,7 @@ protobuf==3.18.3
     #   googleapis-common-protos
 psycogreen==1.0.2
     # via -r base-requirements.in
-psycopg2==2.8.6
+psycopg2==2.9.6
     # via
     #   -r base-requirements.in
     #   sqlalchemy-postgres-copy

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -441,7 +441,7 @@ python-dateutil==2.8.2
     #   pandas
 python-imap==1.0.0
     # via -r base-requirements.in
-python-magic==0.4.22
+python-magic==0.4.27
     # via -r base-requirements.in
 python-mimeparse==1.6.0
     # via django-tastypie


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
While setting up my new system which uses a M2 based chip, I struggled a bit with setting up HQ on my local system and on little bit digging I found that some of the packages that were causing the issues have started supporting apple silicon in the newer versions. 
This PR updates - 
- gunreadline
- psycopg2
- python-magic

I have looked through the changelog and they seemed to be pretty safe. I have also linked the changelogs in the commit description too. 
I will put it on staging to test psycopg2  majorly, python-magic is used at one place to figure out mime-types of incoming request and gnureadline is dev only dependency. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Changelog looks safe enough
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
