### PR TITLE
Show the name of the repeater / remote service

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -282,6 +282,9 @@ class Repeater(RepeaterSuperProxy):
 
     _has_config = False
 
+    def __str__(self):
+        return self.name or self.connection_settings.name
+
     def _get_connection_settings(self, id_):
         return ConnectionSettings.objects.get(id=id_, domain=self.domain)
 

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -11,6 +11,8 @@ from corehq.motech.repeaters.const import (
 )
 from corehq.util.timezones.conversions import ServerTime
 
+MISSING_VALUE = '---'
+
 
 class RepeatRecordDisplay:
     def __init__(self, record, timezone, date_format="%Y-%m-%d %H:%M"):
@@ -36,6 +38,12 @@ class RepeatRecordDisplay:
             return self.record.repeater.get_url(self.record)
         else:
             return _('Unable to generate url for record')
+
+    @property
+    def remote_service(self):
+        if self.record.repeater:
+            return str(self.record.repeater)
+        return MISSING_VALUE
 
     @property
     def state(self):

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -173,7 +173,7 @@ class BaseRepeatRecordReport(GenericTabularReport):
         row = [
             checkbox,
             display.state,
-            display.url,
+            display.remote_service,
             display.next_attempt_at,
             display.attempts,
             self._make_view_payload_button(record.record_id),


### PR DESCRIPTION
## Technical Summary

Context: [SC-2738](https://dimagi-dev.atlassian.net/browse/SC-2738)

Builds on https://github.com/dimagi/commcare-hq/pull/32952 to populate the "Remote Service" column.

**NOTE:** base branch is/was not "master" at the time this PR was opened.

![image](https://github.com/dimagi/commcare-hq/assets/708421/2a0f916d-cba0-44be-9489-89c87034252f)

## Feature Flag
N/A 

## Safety Assurance

### Safety story

* Small change
* Tested locally

### Automated test coverage

Not covered by tests

### QA Plan

No Q.A. planned for this change

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2738]: https://dimagi-dev.atlassian.net/browse/SC-2738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ