### PR TITLE
Delivery Attempts column shows timestamps

### DIFF
--- a/corehq/motech/repeaters/templates/repeaters/partials/attempt_history.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/attempt_history.html
@@ -4,13 +4,17 @@
 {% for attempt_number, attempt in record.get_numbered_attempts %}
     <li><strong>Attempt #{{ attempt_number }}</strong>
     {% if attempt.state == 'SUCCESS' %}
-        <br/><i class="fa fa-check"></i> {% trans "Success" %}
+        <br/><i class="fa fa-check"></i>
     {% elif attempt.state == 'EMPTY' %}
-        <br/><i class="fa fa-check"></i> {% trans "Empty" %}
+        <br/><i class="fa fa-check"></i>
     {% elif attempt.state == 'FAIL' or attempt.state == 'CANCELLED' %}
-        <br/><i class="fa fa-exclamation-triangle"></i> {% trans "Failed" %}
+        <br/><i class="fa fa-exclamation-triangle"></i>
     {% elif attempt.state == 'PENDING' %}
-        <br/><i class="fa fa-spinner"></i> {% trans "Unsent" %}
+        <br/><i class="fa fa-spinner"></i>
+    {% endif %}
+    {% if attempt.state == 'PENDING' %}
+    {% elif attempt.state == 'EMPTY' %}({{ attempt.created_at }})
+    {% else %}{{ attempt.created_at }}
     {% endif %}
     {% if attempt.message %}
         <a href="#" class="toggle-next-attempt">…</a>


### PR DESCRIPTION
## Technical Summary

Context: [SC-2739](https://dimagi-dev.atlassian.net/browse/SC-2739)

Builds on changes made in https://github.com/dimagi/commcare-hq/pull/32952

Adds timestamps of delivery attempts to the "Delivery Attempts" column of the Repeat Records report. If the payload is empty (and therefore not sent) the timestamp appears in brackets. If the payload is still pending, a timestamp is not given.

**NOTE:** base branch is/was not "master" at the time this PR was opened.

![image](https://github.com/dimagi/commcare-hq/assets/708421/be2afa13-c381-48c7-a5cb-b8554ece74ca)

## Feature Flag
N/A

## Safety Assurance

### Safety story

* Small change
* Cosmetic
* Tested locally

### Automated test coverage

Not covered by tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2739]: https://dimagi-dev.atlassian.net/browse/SC-2739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ