### PR TITLE
Check extension case is not child case

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -266,11 +266,7 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
         open_ids.update(case_ids)
 
     def filter_deleted_indices(related):
-        live_related = []
-        for index in related:
-            if index.referenced_id:
-                live_related.append(index)
-        return live_related
+        return [index for index in related if index.referenced_id]
 
     IGNORE = object()
     debug = logging.getLogger(__name__).debug

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -268,8 +268,6 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
     def filter_deleted_indices(related):
         live_related = []
         for index in related:
-            # add all indices to `indices` so that they are included in the restore
-            indices[index.case_id].append(index)
             if index.referenced_id:
                 live_related.append(index)
         return live_related
@@ -296,6 +294,11 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
             related = get_related_indices(list(next_ids), exclude)
             if not related:
                 break
+
+            # add all indices to `indices` so that they are included in
+            # the restore
+            for index in related:
+                indices[index.case_id].append(index)
 
             related_not_deleted = filter_deleted_indices(related)
             update_open_and_deleted_ids(related_not_deleted)

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -273,6 +273,12 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
                 case_ids.remove(case_id)
         open_ids.update(case_ids)
 
+    def populate_indices(related):
+        # add all indices to `indices` so that they are included in the
+        # restore
+        for index in related:
+            indices[index.case_id].append(index)
+
     def filter_deleted_indices(related):
         return [index for index in related if index.referenced_id]
 
@@ -305,11 +311,7 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
             if not related:
                 break
 
-            # add all indices to `indices` so that they are included in
-            # the restore
-            for index in related:
-                indices[index.case_id].append(index)
-
+            populate_indices(related)
             related_not_deleted = filter_deleted_indices(related)
             populate_children_by_parent(related_not_deleted)
             update_open_and_deleted_ids(related_not_deleted)

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -294,10 +294,10 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
         exclude = set(chain.from_iterable(seen_ix[id] for id in next_ids))
         with timing_context("get_related_indices({} cases, {} seen)".format(len(next_ids), len(exclude))):
             related = get_related_indices(list(next_ids), exclude)
-            related_not_deleted = filter_deleted_indices(related)
             if not related:
                 break
 
+            related_not_deleted = filter_deleted_indices(related)
             update_open_and_deleted_ids(related_not_deleted)
             next_ids = {classify(index, next_ids)
                         for index in related_not_deleted

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -5,6 +5,9 @@ Example case graphs with outcomes:
    a   <--ext-- d(owned) >> a b d
        <--ext-- b
 
+   a(owned)    <--chi-- e >> a
+               <--ext-- e
+
    e(owned)    --ext--> a(closed) >> a b e
                --ext--> b
 
@@ -213,7 +216,9 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
             # hosts_by_extension since both are live and therefore this index
             # will not need to be traversed in other liveness calculations.
         elif relationship == EXTENSION:
-            if sub_id in open_ids:
+            if sub_id in open_ids and not extension_is_child(sub_id, ref_id):
+                # A case that is both a child and an extension is not an
+                # extension.
                 if ref_id in live_ids:
                     # sub is open and is the extension of a live case
                     enliven(sub_id)
@@ -224,7 +229,7 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
                     extensions_by_host[ref_id].add(sub_id)
                     hosts_by_extension[sub_id].add(ref_id)
             else:
-                return IGNORE  # closed extension
+                return IGNORE  # closed extension or extension is child
         elif sub_id in owned_ids:
             # sub is owned and available (open and not an extension case)
             enliven(sub_id)
@@ -268,6 +273,18 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
     def filter_deleted_indices(related):
         return [index for index in related if index.referenced_id]
 
+    def extension_is_child(extension_id, host_id):
+        if host_id in children_by_parent:
+            return extension_id in children_by_parent[host_id]
+
+        indices = get_reverse_indices(host_id)
+        child_ids = {
+            index.case_id for index in indices
+            if index.relationship_id == CommCareCaseIndex.CHILD
+        }
+        children_by_parent[host_id] = child_ids
+        return extension_id in child_ids
+
     IGNORE = object()
     debug = logging.getLogger(__name__).debug
 
@@ -277,6 +294,7 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
     extensions_by_host = defaultdict(set)  # host_id -> (open) extension_ids
     hosts_by_extension = defaultdict(set)  # (open) extension_id -> host_ids
     parents_by_child = defaultdict(set)    # child_id -> parent_ids
+    children_by_parent = {}
     indices = defaultdict(list)  # case_id -> list of CommCareCaseIndex-like, used as a cache for later
     seen_ix = defaultdict(set)   # case_id -> set of '<index.case_id> <index.identifier>'
 
@@ -284,6 +302,7 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
     owned_ids = set(owned_ids)  # owned, open case ids (may be extensions)
     open_ids = set(owned_ids)
     get_related_indices = partial(CommCareCaseIndex.objects.get_related_indices, domain)
+    get_reverse_indices = partial(CommCareCaseIndex.objects.get_reverse_indices, domain)
     while next_ids:
         exclude = set(chain.from_iterable(seen_ix[id] for id in next_ids))
         with timing_context("get_related_indices({} cases, {} seen)".format(len(next_ids), len(exclude))):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -1010,7 +1010,7 @@ class CaseUpdate:
         return [
             index for index in self.indices_to_add if (
                 index.relationship == const.CASE_INDEX_EXTENSION
-                and not index.referenced_id in parent_ids
+                and index.referenced_id not in parent_ids
             )
         ]
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -945,7 +945,7 @@ class SimplifiedSyncLog(AbstractSyncLog):
                 made_changes = True
 
             for update in non_live_updates_by_case_id[case_id]:
-                if update.has_extension_indices_to_add():
+                if update.extension_indices_to_add:
                     # non-live cases with extension indices should be added and processed
                     self.case_ids_on_phone.add(update.case_id)
                     for index in update.indices_to_add:
@@ -995,11 +995,24 @@ class CaseUpdate:
 
     @property
     def extension_indices_to_add(self):
-        return [index for index in self.indices_to_add
-                if index.relationship == const.CASE_INDEX_EXTENSION]
-
-    def has_extension_indices_to_add(self):
-        return len(self.extension_indices_to_add) > 0
+        # According to commcare-core, and
+        # casexml/apps/phone/data_providers/case/livequery.py::
+        #
+        #     def is_extension(case_id):
+        #         # A case that is both a child and an extension is not
+        #         # an extension.
+        #
+        # More info: https://dimagi-dev.atlassian.net/browse/SC-1725
+        parent_ids = {
+            index.referenced_id for index in self.indices_to_add
+            if index.relationship == const.CASE_INDEX_CHILD
+        }
+        return [
+            index for index in self.indices_to_add if (
+                index.relationship == const.CASE_INDEX_EXTENSION
+                and not index.referenced_id in parent_ids
+            )
+        ]
 
     @property
     def is_live(self):

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -313,7 +313,7 @@ class RestoreParams(object):
         return self.device_id and self.device_id.startswith("WebAppsLogin")
 
     def __repr__(self):
-        return "RestoreParams(sync_log_id='{}', version={}, app='{}', device_id='{}'".format(
+        return "RestoreParams(sync_log_id='{}', version={}, app='{}', device_id='{}')".format(
             self.sync_log_id,
             self.version,
             self.app,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/data/case_relationship_tests.json
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/data/case_relationship_tests.json
@@ -964,6 +964,21 @@
         "outcome": [
             "L", "B", "C", "D", "E"
         ]
+    },
+    {
+        "name": "extension_and_child_relationship",
+        "owned": [
+            "parent"
+        ],
+        "subcases": [
+            ["child_and_extension", "parent"]
+        ],
+        "extensions": [
+            ["child_and_extension", "parent"]
+        ],
+        "outcome": [
+            "parent"
+        ]
     }
 
 ]

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -852,6 +852,7 @@ class ExtensionCasesSyncTokenUpdates(BaseSyncTest):
         """
         case_type = 'case'
         host = CaseStructure(case_id='host', attrs={'create': True})
+        parent = CaseStructure(case_id='parent', attrs={'create': True})
         extension = CaseStructure(
             case_id='extension',
             attrs={'create': True, 'owner_id': '-'},
@@ -861,7 +862,7 @@ class ExtensionCasesSyncTokenUpdates(BaseSyncTest):
                 relationship='extension',
                 related_type=case_type,
             ), CaseIndex(
-                CaseStructure(case_id=host.case_id, attrs={'create': False}),
+                parent,
                 identifier='child',
                 relationship='child',
                 related_type=case_type,
@@ -870,7 +871,7 @@ class ExtensionCasesSyncTokenUpdates(BaseSyncTest):
         self.device.post_changes(extension)
         sync_log = self.device.last_sync.get_log()
         self.assertDictEqual(sync_log.index_tree.indices,
-                             {extension.case_id: {'child': host.case_id}})
+                             {extension.case_id: {'child': parent.case_id}})
         self.assertDictEqual(sync_log.extension_index_tree.indices,
                              {extension.case_id: {'host': host.case_id}})
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -326,9 +326,6 @@ class SyncTokenUpdateTest(BaseSyncTest):
                 )],
             )
         ])
-        index_ref = CommCareCaseIndex(identifier=index_id,
-                                      referenced_type=PARENT_TYPE,
-                                      referenced_id=parent_id)
 
         self._testUpdate(self.device.last_sync.log.get_id, {parent_id, child_id})
 
@@ -358,9 +355,6 @@ class SyncTokenUpdateTest(BaseSyncTest):
                 )],
             )
         ])
-        index_ref = CommCareCaseIndex(identifier=index_id,
-                                      referenced_type=PARENT_TYPE,
-                                      referenced_id=parent_id)
         # should be there
         self._testUpdate(self.device.last_sync.log.get_id, {parent_id, child_id})
 
@@ -719,15 +713,6 @@ class SyncTokenUpdateTest(BaseSyncTest):
             )],
             attrs={'create': True}
         )
-        parent_ref = CommCareCaseIndex(
-            identifier=PARENT_TYPE,
-            referenced_type=PARENT_TYPE,
-            referenced_id=parent.case_id)
-        grandparent_ref = CommCareCaseIndex(
-            identifier=PARENT_TYPE,
-            referenced_type=PARENT_TYPE,
-            referenced_id=grandparent.case_id)
-
         self.device.post_changes(child)
 
         self._testUpdate(
@@ -986,64 +971,70 @@ class ExtensionCasesSyncTokenUpdates(BaseSyncTest):
 
     def test_long_chain_with_children(self):
         """
-                  +----+
-                  | E1 |
-                  +--^-+
-                     |e
-        +---+     +--+-+
-        |O  +--c->| C  |
-        +---+     +--^-+
-       (owned)       |e
-                  +--+-+
-                  | E2 |
-                  +----+
+                       +------+
+                       | ext1 |
+                       +---^--+
+                           |e
+        +-------+      +---+---+
+        | owned +--c-->| child |
+        +-------+      +---^---+
+                           |e
+                       +---+--+
+                       | ext2 |
+                       +------+
         """
         case_type = 'case'
 
-        E1 = CaseStructure(
+        ext1 = CaseStructure(
             case_id='extension_1',
             attrs={'create': True, 'owner_id': '-'},
         )
 
-        C = CaseStructure(
+        child = CaseStructure(
             case_id='child',
             attrs={'create': True, 'owner_id': '-'},
             indices=[CaseIndex(
-                E1,
+                ext1,
                 identifier='extension_1',
                 relationship='extension',
                 related_type=case_type,
             )]
         )
 
-        O = CaseStructure(
+        owned = CaseStructure(
             case_id='owned',
             attrs={'create': True},
             indices=[CaseIndex(
-                C,
+                child,
                 identifier='child',
                 relationship='child',
                 related_type=case_type,
             )]
         )
-        E2 = CaseStructure(
+        ext2 = CaseStructure(
             case_id='extension_2',
             attrs={'create': True, 'owner_id': '-'},
             indices=[CaseIndex(
-                C,
+                child,
                 identifier='extension',
                 relationship='extension',
                 related_type=case_type,
             )]
         )
-        self.device.post_changes([O, E2])
+        self.device.post_changes([owned, ext2])
         sync_log = self.device.last_sync.get_log()
 
-        expected_dependent_ids = set([C.case_id, E1.case_id, E2.case_id])
-        self.assertEqual(sync_log.dependent_case_ids_on_phone, expected_dependent_ids)
+        expected_dependent_ids = {child.case_id, ext1.case_id, ext2.case_id}
+        self.assertEqual(
+            sync_log.dependent_case_ids_on_phone,
+            expected_dependent_ids,
+        )
 
-        all_ids = set([E1.case_id, E2.case_id, O.case_id, C.case_id])
-        self.assertEqual(sync_log.case_ids_on_phone, all_ids)
+        all_ids = {ext1.case_id, ext2.case_id, owned.case_id, child.case_id}
+        self.assertEqual(
+            sync_log.case_ids_on_phone,
+            all_ids,
+        )
 
 
 @sharded
@@ -1622,9 +1613,6 @@ class MultiUserSyncTest(BaseSyncTest):
                 )],
             )
         ])
-        index_ref = CommCareCaseIndex(identifier=PARENT_TYPE,
-                                      referenced_type=PARENT_TYPE,
-                                      referenced_id=parent_id)
 
         # sanity check that we are in the right state
         sync_log = self.guy.last_sync.get_log()

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -1158,7 +1158,7 @@ class CommCareCaseIndex(PartitionedModel, models.Model, SaveStateMixin):
             "identifier='{i.identifier}', "
             "referenced_type='{i.referenced_type}', "
             "referenced_id='{i.referenced_id}', "
-            "relationship='{i.relationship})"
+            "relationship='{i.relationship}')"
         ).format(i=self)
 
     class Meta(object):

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -1152,14 +1152,14 @@ class CommCareCaseIndex(PartitionedModel, models.Model, SaveStateMixin):
 
     def __str__(self):
         return (
-            "CaseIndex("
-            "case_id='{i.case_id}', "
-            "domain='{i.domain}', "
-            "identifier='{i.identifier}', "
-            "referenced_type='{i.referenced_type}', "
-            "referenced_id='{i.referenced_id}', "
-            "relationship='{i.relationship}')"
-        ).format(i=self)
+            'CaseIndex('
+            f'case_id={self.case_id!r}, '
+            f'domain={self.domain!r}, '
+            f'identifier={self.identifier!r}, '
+            f'referenced_type={self.referenced_type!r}, '
+            f'referenced_id={self.referenced_id!r}, '
+            f'relationship={self.relationship!r})'
+        )
 
     class Meta(object):
         index_together = [

--- a/corehq/sql_accessors/migrations/0067_livequery_sql_include_child_indices.py
+++ b/corehq/sql_accessors/migrations/0067_livequery_sql_include_child_indices.py
@@ -8,7 +8,9 @@ migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {})
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('sql_accessors', '0067_livequery_sql'),
+        ('sql_accessors', '0067_livequery_sql_include_deleted_indices'),
     ]
 
-    operations = []
+    operations = [
+        migrator.get_migration('get_related_indices.sql'),
+    ]

--- a/corehq/sql_accessors/sql_templates/get_related_indices.sql
+++ b/corehq/sql_accessors/sql_templates/get_related_indices.sql
@@ -23,14 +23,13 @@ BEGIN
 
     UNION
 
-    -- open extension cases
+    -- open extension and child cases
     SELECT DISTINCT form_processor_commcarecaseindexsql.*
     FROM form_processor_commcarecaseindexsql
     JOIN form_processor_commcarecasesql USING (domain, case_id)
     JOIN case_ids ON cid = referenced_id -- referenced_id points to host
     WHERE domain = domain_name
         AND case_id || ' ' || identifier  NOT IN (SELECT xid FROM exclude_indices)
-        AND relationship_id = 2 -- is extension case
         AND NOT closed
         AND NOT deleted;
 END;

--- a/migrations.lock
+++ b/migrations.lock
@@ -955,6 +955,7 @@ sql_accessors
  0066_drop_unused_function
  0067_livequery_sql
  0067_livequery_sql_include_deleted_indices
+ 0067_livequery_sql_include_child_indices
 sql_proxy_accessors
  0001_initial
  0002_add_sync_functions


### PR DESCRIPTION
## Technical Summary

Context: [SC-1725](https://dimagi-dev.atlassian.net/browse/SC-1725)

If an extension case is also a child case of the same parent/host, then commcare-core does not treat it as an extension case. A docstring in `livequery` confirms that this is the expected behavior in HQ as well, but currently it's not.

This change is to resolve that, and align HQ behavior with commcare-core. The first commit updates a unit test from commcare-core, and subsequent commits make that test pass.

**NOTE:** Commit [d41a9a7](https://github.com/dimagi/commcare-hq/pull/32999/commits/d41a9a7701a24928d0ba8e8a12411c694b210c51) adds a DB query for every host case. This code gets used a lot (although extension cases are not used as much). I'd like a second opinion that this additional query isn't going to introduce a noticeable performance hit.

Marking risk as high because of the volume that this code handles.

Note that the base branch is not `master`. This PR builds on refactor PR https://github.com/dimagi/commcare-hq/pull/33115

## Feature Flag
N/A

## Safety Assurance

### Safety story

Not a big change, but it is a change in a high-volume area of the codebase.

### Automated test coverage

Solid test coverage.

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-1725]: https://dimagi-dev.atlassian.net/browse/SC-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ