### PR TITLE
Obfuscate URL on Case List and Case List Explorer pages (version 2)

### DIFF
--- a/corehq/apps/reports/static/reports/js/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/hq_report.js
@@ -70,8 +70,8 @@ hqDefine("reports/js/hq_report", [
                                     data: getReportParams(undefined),
                                     type: "POST",
                                     success: function () {
-                                        alertUser.alert_user(gettext("Your requested Excel report will be sent to the email " +
-                                            "address defined in your account settings."), "success");
+                                        alertUser.alert_user(gettext("Your requested Excel report will be sent " +
+                                            "to the email address defined in your account settings."), "success");
                                     },
                                 });
                             } else {
@@ -188,15 +188,29 @@ hqDefine("reports/js/hq_report", [
 
         function getReportParams(additionalParams) {
             var params = window.location.search.substr(1);
+            if (params.includes('query_id=')) {
+                // getting the proper params for reports with obfuscated urls (Case List Explorer)
+                $.ajax({
+                    url: getReportBaseUrl('get_or_create_hash'),
+                    type: 'POST',
+                    dataType: 'json',
+                    async: false,
+                    data: {
+                        'query_id': params.replace('query_id=', ''),
+                        'params': '',
+                    },
+                    success: function (data) {
+                        params = data.query_string
+                    },
+                });
+            }
             if (params.length <= 1) {
                 if (self.loadDatespanFromCookie()) {
-                    params = "startdate=" + self.datespan.startdate +
-                        "&enddate=" + self.datespan.enddate;
+                    params = "startdate=" + self.datespan.startdate + "&enddate=" + self.datespan.enddate;
                 }
             }
             params += (additionalParams ? "&" + additionalParams : "");
             return params;
-
         }
 
         function getReportBaseUrl(renderType) {

--- a/corehq/apps/reports/static/reports/js/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/hq_report.js
@@ -200,7 +200,7 @@ hqDefine("reports/js/hq_report", [
                         'params': '',
                     },
                     success: function (data) {
-                        params = data.query_string
+                        params = data.query_string;
                     },
                 });
             }

--- a/corehq/apps/reports/static/reports/js/reports.async.js
+++ b/corehq/apps/reports/static/reports/js/reports.async.js
@@ -229,9 +229,14 @@ hqDefine("reports/js/reports.async", function () {
             });
         };
 
-        self.loadingIssueModal.on('click', '.try-again', function () {
+        $(document).on('click', '.try-again', function () {
             self.loadingIssueModal.find('.btn-primary').button('loading');
-            self.updateReport(true, window.location.search.substr(1));
+            if (self.isCaseListRelated(window.location.pathname)) {
+                self.getQueryId(window.location.search.substr(1), true, true, window.location.pathname);
+            }
+            else {
+                self.updateReport(true, window.location.search.substr(1));
+            }
         });
 
         self.loadingIssueModal.on('hide hide.bs.modal', function () {

--- a/corehq/apps/reports/static/reports/js/reports.async.js
+++ b/corehq/apps/reports/static/reports/js/reports.async.js
@@ -10,7 +10,9 @@ hqDefine("reports/js/reports.async", function () {
         self.standardReport = o.standardReport;
         self.filterRequest = null;
         self.reportRequest = null;
+        self.queryIdRequest = null;
         self.loaderClass = '.report-loading';
+        self.maxInputLimit = 5000;
 
         self.humanReadableErrors = {
             400: gettext("Please check your Internet connection!"),
@@ -26,6 +28,7 @@ hqDefine("reports/js/reports.async", function () {
             503: gettext("CommCare HQ is experiencing server difficulties. We're working quickly to resolve it." +
                 " Thank you for your patience. We are extremely sorry."),
             504: gettext("Gateway Timeout. Please contact CommCare HQ Support."),
+            'maxInputError': gettext("Your search term was too long. Please provide a shorter search filter"),
         };
 
         var loadFilters = function (data) {
@@ -42,8 +45,13 @@ hqDefine("reports/js/reports.async", function () {
 
         self.init = function () {
             self.reportContent.attr('style', 'position: relative;');
-
-            self.updateReport(true, window.location.search.substr(1), self.standardReport.filterSet);
+            var initParams = window.location.search.substr(1);
+            var pathName = window.location.pathname;
+            if (initParams && self.isCaseListRelated(pathName)) {
+                self.getQueryId(initParams, true, self.standardReport.filterSet, pathName);
+            } else {
+                self.updateReport(true, initParams, self.standardReport.filterSet);
+            }
 
             // only update the report if there are actually filters set
             if (!self.standardReport.needsFilters) {
@@ -51,10 +59,60 @@ hqDefine("reports/js/reports.async", function () {
             }
             self.filterForm.submit(function () {
                 var params = hqImport('reports/js/reports.util').urlSerialize(this);
-                history.pushState(null,window.location.title, window.location.pathname + '?' + params);
-                self.updateFilters(params);
-                self.updateReport(false, params, true);
+                if (self.isCaseListRelated(pathName)) {
+                    var userInput = this.search_xpath ? this.search_xpath.value :
+                        this.search_query ? this.search_query.value : '';
+                    if (userInput.length > self.maxInputLimit) {
+                        self.loadingIssueModal.find('.report-error-status').html(self.humanReadableErrors['maxInputError']);
+                        if (self.issueAttempts > 0) {
+                            self.loadingIssueModal.find('.btn-primary').button('fail');
+                        }
+                        self.issueAttempts += 1;
+                        self.loadingIssueModal.modal('show');
+                    } else {
+                        self.getQueryId(params, false, true, pathName);
+                    }
+                } else {
+                    self.updateFilters(params);
+                    self.updateReport(false, params, true);
+                    history.pushState(null,window.location.title, window.location.pathname + '?' + params);
+                }
                 return false;
+            });
+        };
+
+        self.isCaseListRelated = function (pathName) {
+            return pathName.includes('case_list');
+        };
+
+        self.getQueryId = function (params, initialLoad, setFilters, pathName) {
+            // This only applies to Case List and Case List Explorer filter queries
+            var queryId;
+            if (params.includes('query_id=')) {
+                queryId = params.replace('query_id=', '');
+                params = '';
+            } else {
+                queryId = '';
+            }
+            self.queryIdRequest = $.ajax({
+                url: pathName.replace(self.standardReport.urlRoot, self.standardReport.urlRoot + 'get_or_create_hash/'),
+                type: 'POST',
+                dataType: 'json',
+                data: {
+                    'query_id': queryId,
+                    'params': params,
+                },
+                success: function (data) {
+                    self.queryIdRequest = null;
+                    if (data.not_found) {
+                        // no corresponding filter config found - redirect to the landing page
+                        window.location.href = window.location.href.split('?')[0];
+                    } else {
+                        if (!initialLoad) { self.updateFilters(data.query_string); }
+                        self.updateReport(initialLoad, data.query_string, setFilters);
+                        history.pushState(null, window.location.title, pathName + '?query_id=' + data.query_id);
+                    }
+                },
             });
         };
 
@@ -68,9 +126,9 @@ hqDefine("reports/js/reports.async", function () {
             });
         };
 
-        self.updateReport = function (initial_load, params, setFilters) {
+        self.updateReport = function (initialLoad, params, setFilters) {
             var process_filters = "";
-            if (initial_load) {
+            if (initialLoad) {
                 process_filters = "hq_filters=true&";
                 if (self.standardReport.loadDatespanFromCookie()) {
                     process_filters = process_filters +
@@ -117,7 +175,7 @@ hqDefine("reports/js/reports.async", function () {
                     $('.loading-backdrop').fadeOut();
                     self.hqLoading.fadeOut();
 
-                    if (!initial_load || !self.standardReport.needsFilters) {
+                    if (!initialLoad || !self.standardReport.needsFilters) {
                         self.standardReport.filterSubmitButton
                             .button('reset');
                         setTimeout(function () {

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -51,6 +51,7 @@ from .views import (
     edit_form,
     email_report,
     export_report,
+    get_or_create_filter_hash,
     project_health_user_details,
     reports_home,
     resave_form_view,
@@ -163,6 +164,8 @@ urlpatterns = [
     ProjectReportDispatcher.url_pattern(),
     url(r'^user_management/', include(user_management_urls)),
     url(r'^release_management/', include(release_management_urls)),
+
+    url(r'^get_or_create_hash/', get_or_create_filter_hash, name='get_or_create_filter_hash'),
 ]
 
 # Exporting Case List Explorer reports with the word " on*" at the end of the search query

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -87,6 +87,7 @@ from corehq.apps.reports.formdetails.readable import (
     get_data_cleaning_data,
     get_readable_data_for_submission,
 )
+from corehq.apps.reports.models import QueryStringHash
 from corehq.apps.saved_reports.models import ReportConfig, ReportNotification
 from corehq.apps.saved_reports.tasks import (
     send_delayed_report,
@@ -1937,3 +1938,36 @@ class TableauVisualizationDetailView(BaseProjectReportSectionView, ModelFormMixi
     def form_valid(self, form):
         form.save()
         return super().form_valid(form)
+
+
+@login_and_domain_required
+@location_safe
+@require_POST
+def get_or_create_filter_hash(request, domain):
+    query_id = request.POST.get('query_id')
+    query_string = request.POST.get('params')
+    not_found = False
+
+    if query_string:
+        query, created = QueryStringHash.objects.get_or_create(query_string=query_string, domain=domain)
+        query_id = query.query_id.hex
+        query.save()  # Updates the 'last_accessed' field
+    elif query_id:
+        try:
+            query = QueryStringHash.objects.filter(query_id=query_id, domain=domain)
+        except ValidationError:
+            query = None
+        if not query:
+            not_found = True
+        else:
+            query = query[0]
+            query_string = query.query_string
+            query.save()  # Updates the 'last_accessed' field
+    else:
+        not_found = True
+
+    return JsonResponse({
+        'query_string': query_string,
+        'query_id': query_id,
+        'not_found': not_found,
+    })


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This is a revert of a PR that was recently reverted due to it causing a P2 bug. This PR adds a fix for the bug on top of reverting that revert. 

(Copied from the [original PR](https://github.com/dimagi/commcare-hq/pull/32836))
Both the Case List and Case List Explorer pages have user input textbox for more specific report filtering. Both of these pages also have those specific user inputs reflected in it's entirety in the URL, which is concerning in scenarios where users might want to share the url (and its specific filter configurations) with someone else and posts it somewhere public, with it containing sensitive information like names or ssn.

This PR replaces the potentially sensitive information containing portion of the url with a hashed value derived from that string. The hashed url will remain valid for a year, where it'll correspond to a specific filter configuration in that domain. This PR also adds a check to limit the textbox input to 5000 characters.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[P2 ticket](https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/issue/SUPPORT-16587)

(Copied from original PR)
[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-14444)

This change only applies to CLE and CL pages.
The hash and query string values are stored together in a new QueryStringHash object for up to a year before a background celery task that runs every week deletes it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[Case List Explorer](https://staging.commcarehq.org/hq/flags/edit/case_list_explorer/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging. QA is ongoing to make sure the original bug has been addressed. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-5007)

### Migrations
Related migration PR https://github.com/dimagi/commcare-hq/pull/32837

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
