### PR TITLE
Add a management command to verify ES Reindex from logs

### DIFF
--- a/corehq/apps/es/management/commands/verify_reindex.py
+++ b/corehq/apps/es/management/commands/verify_reindex.py
@@ -7,20 +7,21 @@ from django.core.management.base import BaseCommand
 
 class Command(BaseCommand):
     help = dedent("""\
-    Verify if a reindex process is completed in a ElasticSearch 2 cluster. The command parses the logs for reindex and provides detailed information of the process.
+    Verify if a reindex process is completed in a ElasticSearch 2 cluster.
+    The command parses the logs for reindex and provides detailed information of the process.
 
     The log should be extracted from elasticsearch logs. It can be done using commcare cloud.
-    
     ```
     cchq <env> run-shell-command elasticsearch "cat /opt/data/elasticsearch*/logs/*es.log | grep <task_id>"
     ```
 
-    If the above command fail to yeild any output then the reindex log should be manually searched in elasticsearch logs.
+    If the above command fail to yeild any output then
+    the reindex log should be manually searched in elasticsearch logs.
 
     So running this command should look something like
 
     ./manage.py verify_reindex --eslog '[2023-05-23 08:59:37,648][INFO] [tasks] 29216 finished with response ReindexResponse[took=1.8s,updated=0,created=1111,batches=2,versionConflicts=0,noops=0,retries=0,throttledUntil=0s,indexing_failures=[],search_failures=[]]'
-    """)
+    """) # noqa E501
 
     def create_parser(self, prog_name, subcommand, **kwargs):
         parser = super().create_parser(prog_name, subcommand, **kwargs)
@@ -37,12 +38,11 @@ class Command(BaseCommand):
         if response['indexing_failures']:
             print(f"Reindex Failed because of Indexing Failures - {response['indexing_failures']}")
         elif response['search_failures']:
-            print(f"Reindex Failed because of Search Failures" - {response['search_failures']})
+            print(f"Reindex Failed because of Search Failures - {response['search_failures']}")
         elif response.get('canceled'):
             print(f"Reindex cancelled becuase - {response['canceled']}")
         else:
             print("Reindex Successful -")
-
 
     def _assert_valid_log_string(self, log_string):
         invalid_string = False
@@ -51,13 +51,13 @@ class Command(BaseCommand):
             int(task_id)
         except ValueError:
             invalid_string = True
-        if not "ReindexResponse[" in log_string:
-            invalid_string= True
+        if "ReindexResponse[" not in log_string:
+            invalid_string = True
         if invalid_string:
             raise ValueError("""Invalid log string provided. The log string should be of format - \
                 '[2023-05-23 08:59:37,648][INFO] [tasks] 29216 finished with response ReindexResponse[took=1.8s,updated=0,created=1111,batches=2,versionConflicts=0,noops=0,retries=0,throttledUntil=0s,indexing_failures=[],search_failures=[]]'
-            """)
-        
+            """) # noqa E501
+
     def _parse_task_id(self, log_string):
         task_id_start = log_string.find("tasks] ") + len("tasks] ")
         task_id_end = log_string.find(" finished")
@@ -72,8 +72,8 @@ class Command(BaseCommand):
         response_dict = {}
         if response_data:
             # Find all tokens of format a=b, or a=[b,c],
-            items =  re.findall(r'(\w+)=(\[.*?\]|[^,\]]+)', response_data)
-            
+            items = re.findall(r'(\w+)=(\[.*?\]|[^,\]]+)', response_data)
+
             for tokens in items:
                 key = tokens[0].strip()
                 value_str = tokens[1].strip()
@@ -86,5 +86,3 @@ class Command(BaseCommand):
                     value = value_str
                 response_dict[key] = value
         return response_dict
-
-

--- a/corehq/apps/es/management/commands/verify_reindex.py
+++ b/corehq/apps/es/management/commands/verify_reindex.py
@@ -1,0 +1,90 @@
+import argparse
+import re
+from textwrap import dedent
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = dedent("""\
+    Verify if a reindex process is completed in a ElasticSearch 2 cluster. The command parses the logs for reindex and provides detailed information of the process.
+
+    The log should be extracted from elasticsearch logs. It can be done using commcare cloud.
+    
+    ```
+    cchq <env> run-shell-command elasticsearch "cat /opt/data/elasticsearch*/logs/*es.log | grep <task_id>"
+    ```
+
+    If the above command fail to yeild any output then the reindex log should be manually searched in elasticsearch logs.
+
+    So running this command should look something like
+
+    ./manage.py verify_reindex --eslog '[2023-05-23 08:59:37,648][INFO] [tasks] 29216 finished with response ReindexResponse[took=1.8s,updated=0,created=1111,batches=2,versionConflicts=0,noops=0,retries=0,throttledUntil=0s,indexing_failures=[],search_failures=[]]'
+    """)
+
+    def create_parser(self, prog_name, subcommand, **kwargs):
+        parser = super().create_parser(prog_name, subcommand, **kwargs)
+        parser.formatter_class = argparse.RawDescriptionHelpFormatter
+        return parser
+
+    def add_arguments(self, parser):
+        parser.add_argument("-l", "--eslog", required=True, help="Reindex log string from es logs")
+
+    def handle(self, eslog, **options):
+        self._assert_valid_log_string(eslog)
+
+        response = self._parse_reindex_response(eslog)
+        if response['indexing_failures']:
+            print(f"Reindex Failed because of Indexing Failures - {response['indexing_failures']}")
+        elif response['search_failures']:
+            print(f"Reindex Failed because of Search Failures" - {response['search_failures']})
+        elif response.get('canceled'):
+            print(f"Reindex cancelled becuase - {response['canceled']}")
+        else:
+            print("Reindex Successful -")
+
+
+    def _assert_valid_log_string(self, log_string):
+        invalid_string = False
+        task_id = self._parse_task_id(log_string)
+        try:
+            int(task_id)
+        except ValueError:
+            invalid_string = True
+        if not "ReindexResponse[" in log_string:
+            invalid_string= True
+        if invalid_string:
+            raise ValueError("""Invalid log string provided. The log string should be of format - \
+                '[2023-05-23 08:59:37,648][INFO] [tasks] 29216 finished with response ReindexResponse[took=1.8s,updated=0,created=1111,batches=2,versionConflicts=0,noops=0,retries=0,throttledUntil=0s,indexing_failures=[],search_failures=[]]'
+            """)
+        
+    def _parse_task_id(self, log_string):
+        task_id_start = log_string.find("tasks] ") + len("tasks] ")
+        task_id_end = log_string.find(" finished")
+        task_id = log_string[task_id_start:task_id_end]
+        return task_id
+
+    def _parse_reindex_response(self, log_string):
+        response_start = log_string.find("ReindexResponse[") + len("ReindexResponse[")
+        response_end = log_string.rfind("]")
+        response_data = log_string[response_start:response_end]
+        # Parsing response details
+        response_dict = {}
+        if response_data:
+            # Find all tokens of format a=b, or a=[b,c],
+            items =  re.findall(r'(\w+)=(\[.*?\]|[^,\]]+)', response_data)
+            
+            for tokens in items:
+                key = tokens[0].strip()
+                value_str = tokens[1].strip()
+                # Process array fields
+                if value_str.startswith('[') and value_str.endswith(']'):
+                    value_str = value_str[1:-1]
+                    value_arr = value_str.split(',') if value_str else []
+                    value = [val.strip() for val in value_arr]
+                else:
+                    value = value_str
+                response_dict[key] = value
+        return response_dict
+
+

--- a/corehq/apps/es/tests/test_verify_reindex.py
+++ b/corehq/apps/es/tests/test_verify_reindex.py
@@ -4,28 +4,29 @@ from django.test import SimpleTestCase
 from corehq.apps.es.management.commands.verify_reindex import Command as reindex_verify
 from django.core.management import call_command
 
+
 class TestVerifyReindex(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.error_log = "[2023-05-23 08:05:48,875][INFO][tasks] 25286904 finished with response ReindexResponse[took=1m,updated=0,created=0,batches=1,versionConflicts=0,noops=0,retries=0,throttledUntil=0s,indexing_failures=[org.elasticsearch.action.bulk.BulkItemResponse$Failure@13ad032b, org.elasticsearch.action.bulk.BulkItemResponse$Failure@48125afb, org.elasticsearch.action.bulk.BulkItemResponse$Failure@6bf4625c],search_failures=[]]"
+        cls.error_log = "[2023-05-23 08:05:48,875][INFO][tasks] 25286904 finished with response ReindexResponse[took=1m,updated=0,created=0,batches=1,versionConflicts=0,noops=0,retries=0,throttledUntil=0s,indexing_failures=[org.elasticsearch.action.bulk.BulkItemResponse$Failure@13ad032b, org.elasticsearch.action.bulk.BulkItemResponse$Failure@48125afb, org.elasticsearch.action.bulk.BulkItemResponse$Failure@6bf4625c],search_failures=[]]" # noqa E501
 
-        cls.cancelled_log = "[2023-05-23 07:59:15,469][INFO ][tasks] 25286746 finished with response ReindexResponse[took=1m,updated=0,created=0,batches=1,versionConflicts=0,noops=0,retries=0,canceled=by user request,throttledUntil=0s,indexing_failures=[],search_failures=[]]"
+        cls.cancelled_log = "[2023-05-23 07:59:15,469][INFO ][tasks] 25286746 finished with response ReindexResponse[took=1m,updated=0,created=0,batches=1,versionConflicts=0,noops=0,retries=0,canceled=by user request,throttledUntil=0s,indexing_failures=[],search_failures=[]]" # noqa E501
 
-        cls.success_log = "[2023-05-23 08:59:37,648][INFO ][tasks] 29216 finished with response ReindexResponse[took=1.8s,updated=0,created=1111,batches=2,versionConflicts=0,noops=0,retries=0,throttledUntil=0s,indexing_failures=[],search_failures=[]]"
+        cls.success_log = "[2023-05-23 08:59:37,648][INFO ][tasks] 29216 finished with response ReindexResponse[took=1.8s,updated=0,created=1111,batches=2,versionConflicts=0,noops=0,retries=0,throttledUntil=0s,indexing_failures=[],search_failures=[]]" # noqa E501
 
         return super().setUpClass()
-    
+
     def test__parse_reindex_response_with_success_log(self):
         output = reindex_verify()._parse_reindex_response(self.success_log)
-        expected_output = {'took': '1.8s', 'updated': '0', 'created': '1111', 'batches': '2', 'versionConflicts': '0', 'noops': '0', 'retries': '0', 'throttledUntil': '0s', 'indexing_failures': [], 'search_failures': []}
+        expected_output = {'took': '1.8s', 'updated': '0', 'created': '1111', 'batches': '2', 'versionConflicts': '0', 'noops': '0', 'retries': '0', 'throttledUntil': '0s', 'indexing_failures': [], 'search_failures': []} # noqa E501
 
         self.assertEqual(output, expected_output)
-    
+
     def test__parse_reindex_response_with_error_logs(self):
         output = reindex_verify()._parse_reindex_response(self.error_log)
 
-        expected_output = {'took': '1m', 'updated': '0', 'created': '0', 'batches': '1', 'versionConflicts': '0', 'noops': '0', 'retries': '0', 'throttledUntil': '0s', 'indexing_failures': ['org.elasticsearch.action.bulk.BulkItemResponse$Failure@13ad032b', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@48125afb', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@6bf4625c'], 'search_failures': []}
+        expected_output = {'took': '1m', 'updated': '0', 'created': '0', 'batches': '1', 'versionConflicts': '0', 'noops': '0', 'retries': '0', 'throttledUntil': '0s', 'indexing_failures': ['org.elasticsearch.action.bulk.BulkItemResponse$Failure@13ad032b', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@48125afb', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@6bf4625c'], 'search_failures': []} # noqa E501
 
         self.assertEqual(output, expected_output)
 
@@ -33,8 +34,8 @@ class TestVerifyReindex(SimpleTestCase):
         output = StringIO()
         with mock.patch('sys.stdout', output):
             call_command('verify_reindex', '--eslog', self.error_log, stdout=output)
-        
-        expected_log = "Reindex Failed because of Indexing Failures - ['org.elasticsearch.action.bulk.BulkItemResponse$Failure@13ad032b', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@48125afb', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@6bf4625c']\n"
+
+        expected_log = "Reindex Failed because of Indexing Failures - ['org.elasticsearch.action.bulk.BulkItemResponse$Failure@13ad032b', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@48125afb', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@6bf4625c']\n" # noqa E501
 
         self.assertEqual(output.getvalue(), expected_log)
 
@@ -43,14 +44,14 @@ class TestVerifyReindex(SimpleTestCase):
         with mock.patch('sys.stdout', output):
             call_command('verify_reindex', '--eslog', self.success_log, stdout=output)
         self.assertEqual(output.getvalue(), "Reindex Successful -\n")
-    
+
     def test_verify_reindex_command_with_cancelled_log(self):
         output = StringIO()
         with mock.patch('sys.stdout', output):
             call_command('verify_reindex', '--eslog', self.cancelled_log, stdout=output)
-        
+
         self.assertEqual(output.getvalue(), "Reindex cancelled becuase - by user request\n")
-    
+
     def test_verify_reindex_command_with_invalid_log(self):
         log = "Some weird log entry"
         with self.assertRaises(ValueError):

--- a/corehq/apps/es/tests/test_verify_reindex.py
+++ b/corehq/apps/es/tests/test_verify_reindex.py
@@ -1,0 +1,57 @@
+from io import StringIO
+from unittest import mock
+from django.test import SimpleTestCase
+from corehq.apps.es.management.commands.verify_reindex import Command as reindex_verify
+from django.core.management import call_command
+
+class TestVerifyReindex(SimpleTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.error_log = "[2023-05-23 08:05:48,875][INFO][tasks] 25286904 finished with response ReindexResponse[took=1m,updated=0,created=0,batches=1,versionConflicts=0,noops=0,retries=0,throttledUntil=0s,indexing_failures=[org.elasticsearch.action.bulk.BulkItemResponse$Failure@13ad032b, org.elasticsearch.action.bulk.BulkItemResponse$Failure@48125afb, org.elasticsearch.action.bulk.BulkItemResponse$Failure@6bf4625c],search_failures=[]]"
+
+        cls.cancelled_log = "[2023-05-23 07:59:15,469][INFO ][tasks] 25286746 finished with response ReindexResponse[took=1m,updated=0,created=0,batches=1,versionConflicts=0,noops=0,retries=0,canceled=by user request,throttledUntil=0s,indexing_failures=[],search_failures=[]]"
+
+        cls.success_log = "[2023-05-23 08:59:37,648][INFO ][tasks] 29216 finished with response ReindexResponse[took=1.8s,updated=0,created=1111,batches=2,versionConflicts=0,noops=0,retries=0,throttledUntil=0s,indexing_failures=[],search_failures=[]]"
+
+        return super().setUpClass()
+    
+    def test__parse_reindex_response_with_success_log(self):
+        output = reindex_verify()._parse_reindex_response(self.success_log)
+        expected_output = {'took': '1.8s', 'updated': '0', 'created': '1111', 'batches': '2', 'versionConflicts': '0', 'noops': '0', 'retries': '0', 'throttledUntil': '0s', 'indexing_failures': [], 'search_failures': []}
+
+        self.assertEqual(output, expected_output)
+    
+    def test__parse_reindex_response_with_error_logs(self):
+        output = reindex_verify()._parse_reindex_response(self.error_log)
+
+        expected_output = {'took': '1m', 'updated': '0', 'created': '0', 'batches': '1', 'versionConflicts': '0', 'noops': '0', 'retries': '0', 'throttledUntil': '0s', 'indexing_failures': ['org.elasticsearch.action.bulk.BulkItemResponse$Failure@13ad032b', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@48125afb', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@6bf4625c'], 'search_failures': []}
+
+        self.assertEqual(output, expected_output)
+
+    def test_verify_reindex_command_with_error_log(self):
+        output = StringIO()
+        with mock.patch('sys.stdout', output):
+            call_command('verify_reindex', '--eslog', self.error_log, stdout=output)
+        
+        expected_log = "Reindex Failed because of Indexing Failures - ['org.elasticsearch.action.bulk.BulkItemResponse$Failure@13ad032b', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@48125afb', 'org.elasticsearch.action.bulk.BulkItemResponse$Failure@6bf4625c']\n"
+
+        self.assertEqual(output.getvalue(), expected_log)
+
+    def test_verify_reindex_command_with_success_log(self):
+        output = StringIO()
+        with mock.patch('sys.stdout', output):
+            call_command('verify_reindex', '--eslog', self.success_log, stdout=output)
+        self.assertEqual(output.getvalue(), "Reindex Successful -\n")
+    
+    def test_verify_reindex_command_with_cancelled_log(self):
+        output = StringIO()
+        with mock.patch('sys.stdout', output):
+            call_command('verify_reindex', '--eslog', self.cancelled_log, stdout=output)
+        
+        self.assertEqual(output.getvalue(), "Reindex cancelled becuase - by user request\n")
+    
+    def test_verify_reindex_command_with_invalid_log(self):
+        log = "Some weird log entry"
+        with self.assertRaises(ValueError):
+            call_command('verify_reindex', '--eslog', log)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SAAS-14455
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The PR adds a management command to parse the ES reindex logs to verify if the reindex process is complete or not. This is required because the reindex in ES are done as a tasks and the task information expires as soon as task is finished/killed/cancelled. And we don't have a way the state of task when the reindex stopped. This can only be done by looking into logs. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Pretty safe, very limited to ES and a management command that does not affect any part of HQ.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Changes are  covered by tests. 
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
