### PR TITLE
Fix dependency-metrics github action

### DIFF
--- a/.github/workflows/dependency-metrics.yml
+++ b/.github/workflows/dependency-metrics.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+      - name: install libxml
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libxmlsec1-dev
       - name: install dev-requirements
         run: pip install -r requirements/dev-requirements.txt
       - name: run metrics for pip


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14266

The dependency-metrics github action [failed](https://github.com/dimagi/commcare-hq/actions/runs/5063174563/jobs/9089483485) with the following error:
`ERROR: Could not build wheels for xmlsec, which is required to install pyproject.toml-based projects` 

I think this is another reason for supporting a requirements file as input rather than pip installing dependencies for the targeted repo, but as a short term fix installing libxmlsec1-dev will do the trick (tested by running the github action with this change and it was successful).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Internal tool
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- Reverting this PR will break the commcare-hq dependency-metrics daily github action

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
