### PR TITLE
Ancestor-exists() Case Query Function and Allow multiple terms case search field

### DIFF
--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -26,7 +26,6 @@ from corehq.apps.case_search.xpath_functions.comparison import property_comparis
 class SearchFilterContext:
     domain: str
     fuzzy: bool = False
-    multi_term: bool = False
 
 
 def print_ast(node):

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -115,7 +115,7 @@ def build_filter_from_ast(node, context):
     return visit(node)
 
 
-def build_filter_from_xpath(domain, xpath, fuzzy=False, multi_term=False):
+def build_filter_from_xpath(domain, xpath, fuzzy=False):
     """Given an xpath expression this function will generate an Elasticsearch
     filter"""
     error_message = _(
@@ -124,7 +124,7 @@ def build_filter_from_xpath(domain, xpath, fuzzy=False, multi_term=False):
         "The operators we accept are: {}"
     )
 
-    context = SearchFilterContext(domain, fuzzy, multi_term)
+    context = SearchFilterContext(domain, fuzzy)
     try:
         return build_filter_from_ast(parse_xpath(xpath), context)
     except TypeError as e:

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -26,6 +26,7 @@ from corehq.apps.case_search.xpath_functions.comparison import property_comparis
 class SearchFilterContext:
     domain: str
     fuzzy: bool = False
+    multi_term: bool = False
 
 
 def print_ast(node):
@@ -114,7 +115,7 @@ def build_filter_from_ast(node, context):
     return visit(node)
 
 
-def build_filter_from_xpath(domain, xpath, fuzzy=False):
+def build_filter_from_xpath(domain, xpath, fuzzy=False, multi_term=False):
     """Given an xpath expression this function will generate an Elasticsearch
     filter"""
     error_message = _(
@@ -123,7 +124,7 @@ def build_filter_from_xpath(domain, xpath, fuzzy=False):
         "The operators we accept are: {}"
     )
 
-    context = SearchFilterContext(domain, fuzzy)
+    context = SearchFilterContext(domain, fuzzy, multi_term)
     try:
         return build_filter_from_ast(parse_xpath(xpath), context)
     except TypeError as e:

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -118,13 +118,6 @@ class SearchCriteria:
                 self.key
             )
 
-        if self.is_ancestor_query:
-            non_missing = self.clone_without_blanks()
-            if non_missing.has_multiple_terms:
-                raise CaseFilterError(
-                    _("Multiple values are only supported for simple text and range searches"),
-                    self.key
-                )
 
     def _validate_daterange(self):
         if not self.is_daterange:

--- a/corehq/apps/case_search/tests/test_ancestor_functions.py
+++ b/corehq/apps/case_search/tests/test_ancestor_functions.py
@@ -4,6 +4,9 @@ from testil import eq
 
 from corehq.apps.case_search.xpath_functions.ancestor_functions import is_ancestor_comparison, \
     _is_ancestor_path_expression
+from corehq.apps.case_search.tests.utils import get_case_search_query
+from corehq.apps.es.tests.test_case_search_es import BaseCaseSearchTest
+from corehq.apps.es.tests.utils import es_test
 from corehq.util.test_utils import generate_cases
 
 
@@ -33,3 +36,89 @@ class TestIsAncestorPath(SimpleTestCase):
     def test_is_ancestor_path_expression(self, expression, expected):
         node = parse_xpath(expression)
         eq(_is_ancestor_path_expression(node), expected)
+
+
+@es_test
+class TestAncestorExists(BaseCaseSearchTest):
+    def setUp(self):
+        super(TestAncestorExists, self).setUp()
+        self._create_case_search_config()
+        # Note that cases must be defined before other cases can reference them
+        # a1>p1(LA)>g1(CA)
+        # a1>p1(LA):>h3(USA)
+        # a2:>h1>(BOS):>h2(MA)
+        # a2:>h1>(BOS)>g2(USA)
+        # c1>a3
+        cases = [
+            {'_id': 'h3', 'country': 'USA', 'case_type': 'h'},
+            {'_id': 'g2', 'country': 'USA', 'case_type': 'g'},
+            {'_id': 'g1', 'state': 'CA', 'case_type': 'g'},
+            {'_id': 'p1', 'city': 'LA', 'case_type': 'p', 'index': {
+                'parent': ('g', 'g1'),
+                'host': ('h', 'h3', 'extension'),
+            }},
+            {'_id': 'h2', 'state': 'MA', 'case_type': 'g'},
+            {'_id': 'h1', 'city': 'BOS', 'case_type': 'h', 'index': {
+                'host': ('h', 'h2', 'extension'),
+                'parent': ('g', 'g2'),
+            }},
+            {'_id': 'a1', 'case_type': 'a', 'index': {
+                'parent': ('p', 'p1'),
+            }},
+            {'_id': 'a3', 'case_type': 'a'},
+            {'_id': 'a2', 'case_type': 'a', 'index': {
+                'host': ('h', 'h1', 'extension'),
+            }},
+            {'_id': 'c1', 'city': 'SF', 'case_type': 'c', 'index': {
+                'parent': ('a', 'a3'),
+            }},
+        ]
+        self._bootstrap_cases_in_es_for_domain(self.domain, cases)
+
+    def testparent(self):
+        query1 = get_case_search_query(
+            self.domain,
+            ['a'],
+            {'_xpath_query': "ancestor-exists(parent, city='LA')"},
+        )
+        self.assertItemsEqual(query1.get_ids(), ['a1'])
+
+    def testparentparent(self):
+        query1 = get_case_search_query(
+            self.domain,
+            ['a'],
+            {'_xpath_query': "ancestor-exists(parent/parent, state='CA')"},
+        )
+        self.assertItemsEqual(query1.get_ids(), ['a1'])
+
+    def testhost(self):
+        query1 = get_case_search_query(
+            self.domain,
+            ['a'],
+            {'_xpath_query': "ancestor-exists(host, city='BOS')"},
+        )
+        self.assertItemsEqual(query1.get_ids(), ['a2'])
+
+    def testhosthost(self):
+        query1 = get_case_search_query(
+            self.domain,
+            ['a'],
+            {'_xpath_query': "ancestor-exists(host/host, state='MA')"},
+        )
+        self.assertItemsEqual(query1.get_ids(), ['a2'])
+
+    def testhostparent(self):
+        query1 = get_case_search_query(
+            self.domain,
+            ['a'],
+            {'_xpath_query': "ancestor-exists(host/parent, country='USA')"},
+        )
+        self.assertItemsEqual(query1.get_ids(), ['a2'])
+
+    def testparenthost(self):
+        query1 = get_case_search_query(
+            self.domain,
+            ['a'],
+            {'_xpath_query': "ancestor-exists(parent/host, country='USA')"},
+        )
+        self.assertItemsEqual(query1.get_ids(), ['a1'])

--- a/corehq/apps/case_search/tests/test_ancestor_functions.py
+++ b/corehq/apps/case_search/tests/test_ancestor_functions.py
@@ -91,6 +91,21 @@ class TestAncestorQueries(BaseCaseSearchTest):
         )
         self.assertItemsEqual(query1.get_ids(), ['a1', 'a3'])
 
+    def test_case_id_shortcut(self):
+        query1 = get_case_search_query(
+            self.domain,
+            ['h'],
+            {'parent/@case_id': 'g2'},
+        )
+        self.assertItemsEqual(query1.get_ids(), ['h1'])
+
+        query2 = get_case_search_query(
+            self.domain,
+            ['h'],
+            {'_xpath_query': "ancestor-exists(parent,@case_id='g2')"},
+        )
+        self.assertItemsEqual(query2.get_ids(), ['h1'])
+
     def test_parent(self):
         query1 = get_case_search_query(
             self.domain,

--- a/corehq/apps/case_search/tests/test_ancestor_functions.py
+++ b/corehq/apps/case_search/tests/test_ancestor_functions.py
@@ -165,8 +165,8 @@ class TestAncestorQueries(BaseCaseSearchTest):
         self.assertItemsEqual(query1.get_ids(), ['a1'])
 
     @generate_cases([
-        ("ancestor_exists(status='active' and subcase-exists('parent', city = 'LA'))",),
-        ("ancestor_exists(status='active' and subcase-count('parent', city = 'LA')) > 3",),
+        ("ancestor-exists(status='active' and subcase-exists('parent', city = 'LA'))",),
+        ("ancestor-exists(status='active' and subcase-count('parent', city = 'LA')) > 3",),
     ])
     def test_search_criteria_validate(self, xpath):
         with assert_raises(CaseFilterError):

--- a/corehq/apps/case_search/tests/test_ancestor_functions.py
+++ b/corehq/apps/case_search/tests/test_ancestor_functions.py
@@ -39,16 +39,16 @@ class TestIsAncestorPath(SimpleTestCase):
 
 
 @es_test
-class TestAncestorExists(BaseCaseSearchTest):
+class TestAncestorQueries(BaseCaseSearchTest):
     def setUp(self):
-        super(TestAncestorExists, self).setUp()
+        super(TestAncestorQueries, self).setUp()
         self._create_case_search_config()
         # Note that cases must be defined before other cases can reference them
         # a1>p1(LA)>g1(CA)
         # a1>p1(LA):>h3(USA)
         # a2:>h1>(BOS):>h2(MA)
         # a2:>h1>(BOS)>g2(USA)
-        # c1>a3
+        # a3>c1(SF)
         cases = [
             {'_id': 'h3', 'country': 'USA', 'case_type': 'h'},
             {'_id': 'g2', 'country': 'USA', 'case_type': 'g'},
@@ -83,7 +83,7 @@ class TestAncestorExists(BaseCaseSearchTest):
         )
         self.assertItemsEqual(query1.get_ids(), ['a1'])
 
-    def testparentparent(self):
+    def test_parentparent(self):
         query1 = get_case_search_query(
             self.domain,
             ['a'],
@@ -91,7 +91,7 @@ class TestAncestorExists(BaseCaseSearchTest):
         )
         self.assertItemsEqual(query1.get_ids(), ['a1'])
 
-    def testhost(self):
+    def test_host(self):
         query1 = get_case_search_query(
             self.domain,
             ['a'],
@@ -99,7 +99,7 @@ class TestAncestorExists(BaseCaseSearchTest):
         )
         self.assertItemsEqual(query1.get_ids(), ['a2'])
 
-    def testhosthost(self):
+    def test_hosthost(self):
         query1 = get_case_search_query(
             self.domain,
             ['a'],
@@ -107,7 +107,7 @@ class TestAncestorExists(BaseCaseSearchTest):
         )
         self.assertItemsEqual(query1.get_ids(), ['a2'])
 
-    def testhostparent(self):
+    def test_hostparent(self):
         query1 = get_case_search_query(
             self.domain,
             ['a'],

--- a/corehq/apps/case_search/tests/test_models.py
+++ b/corehq/apps/case_search/tests/test_models.py
@@ -95,7 +95,6 @@ def _make_request_dict(params):
     ("owner_id", ["a", "b"]),
     ("date", ["a", "__range__2022-01-01__2022-02-01"]),
     ("date", "__range__2022-01-01__2022"),
-    ("parent/foo", ["a", "b"])
 ])
 def test_search_criteria_validate(self, key, value):
     with assert_raises(CaseFilterError):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -1,5 +1,6 @@
 import re
 from collections import defaultdict
+import json
 
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
@@ -235,6 +236,8 @@ class CaseSearchQueryBuilder:
         fuzzy = criteria.key in self._fuzzy_properties
         if criteria.is_ancestor_query:
             query = f'{criteria.key} = "{value}"'
+            if isinstance(value, list):
+                query = f"""{criteria.key} = unwrap-list('{json.dumps(value)}')"""
             return build_filter_from_xpath(self.query_domains, query,
                                         fuzzy=fuzzy, multi_term=criteria.has_multiple_terms)
         elif criteria.is_index_query:

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -238,8 +238,7 @@ class CaseSearchQueryBuilder:
             query = f'{criteria.key} = "{value}"'
             if isinstance(value, list):
                 query = f"""{criteria.key} = unwrap-list('{json.dumps(value)}')"""
-            return build_filter_from_xpath(self.query_domains, query,
-                                        fuzzy=fuzzy, multi_term=criteria.has_multiple_terms)
+            return build_filter_from_xpath(self.query_domains, query, fuzzy=fuzzy)
         elif criteria.is_index_query:
             return reverse_index_case_query(value, criteria.index_query_identifier)
         else:

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -189,8 +189,7 @@ class CaseSearchQueryBuilder:
             if not criteria.is_empty:
                 if criteria.has_multiple_terms:
                     for value in criteria.value:
-                        search_es = search_es.filter(build_filter_from_xpath(self.query_domains, value,
-                                                                            multi_term=True))
+                        search_es = search_es.filter(build_filter_from_xpath(self.query_domains, value))
                     return search_es
                 else:
                     return search_es.filter(build_filter_from_xpath(self.query_domains, criteria.value))

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -234,6 +234,11 @@ class CaseSearchQueryBuilder:
 
         value = self._remove_ignored_patterns(criteria.key, criteria.value)
         fuzzy = criteria.key in self._fuzzy_properties
+        if fuzzy and criteria.has_multiple_terms:
+            raise CaseFilterError(
+                _("Fuzzy search is not supported with multiple values"),
+                criteria.key
+            )
         if criteria.is_ancestor_query:
             query = f'{criteria.key} = "{value}"'
             if isinstance(value, list):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -189,7 +189,8 @@ class CaseSearchQueryBuilder:
             if not criteria.is_empty:
                 if criteria.has_multiple_terms:
                     for value in criteria.value:
-                        search_es = search_es.filter(build_filter_from_xpath(self.query_domains, value))
+                        search_es = search_es.filter(build_filter_from_xpath(self.query_domains, value,
+                                                                            multi_term=True))
                     return search_es
                 else:
                     return search_es.filter(build_filter_from_xpath(self.query_domains, criteria.value))
@@ -235,7 +236,8 @@ class CaseSearchQueryBuilder:
         fuzzy = criteria.key in self._fuzzy_properties
         if criteria.is_ancestor_query:
             query = f'{criteria.key} = "{value}"'
-            return build_filter_from_xpath(self.query_domains, query, fuzzy=fuzzy)
+            return build_filter_from_xpath(self.query_domains, query,
+                                        fuzzy=fuzzy, multi_term=criteria.has_multiple_terms)
         elif criteria.is_index_query:
             return reverse_index_case_query(value, criteria.index_query_identifier)
         else:

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -8,6 +8,7 @@ from .query_functions import (
     starts_with
 )
 from .subcase_functions import subcase
+from .ancestor_functions import ancestor_exists
 from .value_functions import date, date_add, today
 
 # functions that transform or produce a value
@@ -29,4 +30,5 @@ XPATH_QUERY_FUNCTIONS = {
     'fuzzy-match': fuzzy_match,
     'phonetic-match': phonetic_match,
     'starts-with': starts_with,
+    'ancestor-exists': ancestor_exists,
 }

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -9,13 +9,14 @@ from .query_functions import (
 )
 from .subcase_functions import subcase
 from .ancestor_functions import ancestor_exists
-from .value_functions import date, date_add, today
+from .value_functions import date, date_add, today, unwrap_list
 
 # functions that transform or produce a value
 XPATH_VALUE_FUNCTIONS = {
     'date': date,
     'date-add': date_add,
     'today': today,
+    'unwrap-list': unwrap_list,
 }
 
 

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -138,10 +138,7 @@ def _get_case_ids_from_ast_filter(context, filter_node):
     and serialize(filter_node.left) == "@case_id" and filter_node.op == EQ):
         # case id is provided in query i.e @case_id="b9eaf791-e427-482d-add4-2a60acf0362e"
         case_ids = unwrap_value(filter_node.right, context)
-        if isinstance(case_ids, str):
-            return (case_id for case_id in [case_ids])
-        else:
-            return (case_id for case_id in case_ids)
+        return [case_ids] if isinstance(case_ids, str) else case_ids
     else:
         from corehq.apps.case_search.filter_dsl import build_filter_from_ast
         es_filter = build_filter_from_ast(filter_node, context)

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -4,7 +4,7 @@ from eulxml.xpath import parse as parse_xpath
 from eulxml.xpath.ast import BinaryExpression, FunctionCall, Step
 import itertools
 
-from corehq.apps.case_search.const import OPERATOR_MAPPING, EQ, NEQ
+from corehq.apps.case_search.const import OPERATOR_MAPPING, EQ
 from corehq.apps.case_search.exceptions import CaseFilterError, TooManyRelatedCasesError
 from corehq.apps.case_search.xpath_functions.utils import confirm_args_count
 from corehq.apps.case_search.const import MAX_RELATED_CASES
@@ -137,7 +137,7 @@ def _validate_ancestor_exists_filter(node):
 def _get_case_ids_from_ast_filter(context, filter_node):
     from corehq.apps.case_search.dsl_utils import unwrap_value
     if (isinstance(filter_node, BinaryExpression)
-    and serialize(filter_node.left) == "@case_id" and filter_node.op in (EQ, NEQ)):
+    and serialize(filter_node.left) == "@case_id" and filter_node.op == EQ):
         # case id is provided in query i.e @case_id="b9eaf791-e427-482d-add4-2a60acf0362e"
         case_ids = unwrap_value(filter_node.right, context)
         if isinstance(case_ids, str):

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -28,14 +28,16 @@ def ancestor_comparison_query(context, node):
     :param node: a node returned from eulxml.xpath.parse of the form `parent/grandparent/property = 'value'`
     """
 
-    case_property = serialize(node.left.right)
-    value = node.right
     # extract ancestor path:
     # `parent/grandparent/property = 'value'` --> `parent/grandparent`
     ancestor_path = serialize(node.left.left)
+    parsed_ancestor_path = parse_xpath(ancestor_path)
 
-    xpath = f'ancestor-exists({ancestor_path},{case_property}{node.op}"{value}")'
-    return ancestor_exists(parse_xpath(xpath), context)
+    case_property = serialize(node.left.right)
+    value = serialize(node.right)
+    parsed_ancestor_filter = parse_xpath(f'{case_property}{node.op}{value}')
+
+    return process_ancestor_exists(parsed_ancestor_path, parsed_ancestor_filter, context)
 
 
 def walk_ancestor_hierarchy(context, ancestor_path_node, case_ids):
@@ -109,6 +111,10 @@ def ancestor_exists(node, context):
     """
     confirm_args_count(node, 2)
     ancestor_path_node, ancestor_case_filter_node = node.args
+    return process_ancestor_exists(ancestor_path_node, ancestor_case_filter_node, context)
+
+
+def process_ancestor_exists(ancestor_path_node, ancestor_case_filter_node, context):
     _validate_ancestor_exists_filter(ancestor_case_filter_node)
     base_case_ids = _get_case_ids_from_ast_filter(context, ancestor_case_filter_node)
 

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -33,7 +33,7 @@ def ancestor_comparison_query(context, node):
     # `parent/grandparent/property = 'value'` --> `parent/grandparent`
     ancestor_path = serialize(node.left.left)
 
-    xpath = f'ancestor-exists({ancestor_path},{case_property}="{value}")'
+    xpath = f'ancestor-exists({ancestor_path},{case_property}{node.op}"{value}")'
     ancestor_case_filter_node = parse_xpath(xpath)
 
     from corehq.apps.case_search.filter_dsl import build_filter_from_ast

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -1,8 +1,6 @@
 from django.utils.translation import gettext
 from eulxml.xpath import serialize
-from eulxml.xpath import parse as parse_xpath
 from eulxml.xpath.ast import BinaryExpression, FunctionCall, Step
-import itertools
 
 from corehq.apps.case_search.const import OPERATOR_MAPPING, EQ
 from corehq.apps.case_search.exceptions import CaseFilterError, TooManyRelatedCasesError

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -2,6 +2,7 @@ from django.utils.translation import gettext
 from eulxml.xpath import serialize
 from eulxml.xpath import parse as parse_xpath
 from eulxml.xpath.ast import BinaryExpression, FunctionCall, Step
+import itertools
 
 from corehq.apps.case_search.const import OPERATOR_MAPPING, EQ, NEQ
 from corehq.apps.case_search.exceptions import CaseFilterError, TooManyRelatedCasesError
@@ -140,9 +141,9 @@ def _get_case_ids_from_ast_filter(context, filter_node):
         # case id is provided in query i.e @case_id="b9eaf791-e427-482d-add4-2a60acf0362e"
         case_ids = filter_node.right
         if isinstance(filter_node.right, str):
-            yield [case_ids]
+            return itertools([case_ids])
         else:
-            yield case_ids
+            return itertools(case_ids)
     else:
         from corehq.apps.case_search.filter_dsl import build_filter_from_ast
         es_filter = build_filter_from_ast(filter_node, context)

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -130,9 +130,8 @@ def _validate_ancestor_exists_filter(node):
 
     if hasattr(node, 'op') and node.op in OPERATOR_MAPPING:
         # This node is a leaf
-        return OPERATOR_MAPPING[node.op](_validate_ancestor_exists_filter(node.left),
-                                        _validate_ancestor_exists_filter(node.right))
-    return
+        _validate_ancestor_exists_filter(node.left)
+        _validate_ancestor_exists_filter(node.right)
 
 
 def _get_case_ids_from_ast_filter(context, filter_node):

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -35,10 +35,7 @@ def ancestor_comparison_query(context, node):
     ancestor_path = serialize(node.left.left)
 
     xpath = f'ancestor-exists({ancestor_path},{case_property}{node.op}"{value}")'
-    ancestor_case_filter_node = parse_xpath(xpath)
-
-    from corehq.apps.case_search.filter_dsl import build_filter_from_ast
-    return build_filter_from_ast(ancestor_case_filter_node, context)
+    return ancestor_exists(parse_xpath(xpath), context)
 
 
 def walk_ancestor_hierarchy(context, ancestor_path_node, case_ids):

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -139,14 +139,15 @@ def _validate_ancestor_exists_filter(node):
 
 
 def _get_case_ids_from_ast_filter(context, filter_node):
+    from corehq.apps.case_search.dsl_utils import unwrap_value
     if (isinstance(filter_node, BinaryExpression)
     and serialize(filter_node.left) == "@case_id" and filter_node.op in (EQ, NEQ)):
         # case id is provided in query i.e @case_id="b9eaf791-e427-482d-add4-2a60acf0362e"
-        case_ids = filter_node.right
-        if isinstance(filter_node.right, str):
-            return itertools([case_ids])
+        case_ids = unwrap_value(filter_node.right, context)
+        if isinstance(case_ids, str):
+            return (case_id for case_id in [case_ids])
         else:
-            return itertools(case_ids)
+            return (case_id for case_id in case_ids)
     else:
         from corehq.apps.case_search.filter_dsl import build_filter_from_ast
         es_filter = build_filter_from_ast(filter_node, context)

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -30,14 +30,11 @@ def ancestor_comparison_query(context, node):
 
     # extract ancestor path:
     # `parent/grandparent/property = 'value'` --> `parent/grandparent`
-    ancestor_path = serialize(node.left.left)
-    parsed_ancestor_path = parse_xpath(ancestor_path)
-
-    case_property = serialize(node.left.right)
-    value = serialize(node.right)
-    parsed_ancestor_filter = parse_xpath(f'{case_property}{node.op}{value}')
-
-    return process_ancestor_exists(parsed_ancestor_path, parsed_ancestor_filter, context)
+    ancestor_path_node = node.left.left
+    case_property = node.left.right
+    value = node.right
+    ancestor_filter_node = BinaryExpression(case_property, node.op, value)
+    return process_ancestor_exists(ancestor_path_node, ancestor_filter_node, context)
 
 
 def walk_ancestor_hierarchy(context, ancestor_path_node, case_ids):

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -111,3 +111,7 @@ def _child_case_lookup(context, case_ids, identifier):
     """returns a list of all case_ids who have parents `case_id` with the relationship `identifier`
     """
     return CaseSearchES().domain(context.domain).get_child_cases(case_ids, identifier).scroll_ids()
+
+
+def ancestor_exists(node, context):
+    pass

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -20,11 +20,6 @@ def property_comparison_query(context, case_property_name_raw, op, value_raw, no
     case_property_name = serialize(case_property_name_raw)
     value = unwrap_value(value_raw, context)
 
-    # In initial xpath parsing, multiple terms are converted to string
-    # i.e "['val1','val2']". This converts it back to a list for ES to filter by
-    if context.multi_term:
-        value = _parse_multiple_terms_list_str(value)
-
     if op in [EQ, NEQ]:
         query = case_property_query(case_property_name, value, fuzzy=context.fuzzy)
         if op == NEQ:
@@ -39,9 +34,3 @@ def property_comparison_query(context, case_property_name_raw, op, value_raw, no
                   "Dates must be surrounded in quotation marks"),
                 serialize(node),
             )
-
-
-def _parse_multiple_terms_list_str(value):
-    # Given a string representation of a list of strings, returns a list.
-    value = value.replace("'", '"')  # '["abc123", "def456"]'
-    return json.loads(value)

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -1,7 +1,6 @@
 from django.utils.translation import gettext
 from eulxml.xpath import serialize
 from eulxml.xpath.ast import Step
-import json
 
 from corehq.apps.case_search.dsl_utils import unwrap_value
 from corehq.apps.case_search.exceptions import CaseFilterError

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -22,7 +22,7 @@ def property_comparison_query(context, case_property_name_raw, op, value_raw, no
 
     # In initial xpath parsing, multiple terms are converted to string
     # i.e "['val1','val2']". This converts it back to a list for ES to filter by
-    if value.startswith('[') and value.endswith(']'):
+    if context.multi_term:
         value = _parse_multiple_terms_list_str(value)
 
     if op in [EQ, NEQ]:

--- a/corehq/apps/case_search/xpath_functions/value_functions.py
+++ b/corehq/apps/case_search/xpath_functions/value_functions.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 from django.utils.dateparse import parse_date
 from django.utils.translation import gettext as _
@@ -109,3 +110,11 @@ def date_add(node, context):
         raise XPathFunctionException(str(e), serialize(node))
 
     return result.strftime(ISO_DATE_FORMAT)
+
+
+def unwrap_list(node, context):
+    assert node.name == 'unwrap-list'
+    confirm_args_count(node, 1)
+
+    value = node.args[0]
+    return json.loads(value)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This changes adds two functionalities: 
1. We can configure a case search that checks the parent case for a search field with multiple choices

https://github.com/dimagi/commcare-hq/assets/88759246/9029614f-cb3d-47b9-b0c1-4881a8111c31


2. An ancestor-exists() case search query  

https://github.com/dimagi/commcare-hq/assets/88759246/2ea70194-3ca3-4567-8c5b-246199638ed7


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi-dev.atlassian.net/browse/USH-3221
Spec: https://docs.google.com/document/d/1WbcogXJYVOV8v34NEf6ojUxHcxPtCBlFmXIKCEwFRcc/edit#heading=h.d7s2sycdfk92

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case Search

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Adds testing that ancestor-exists returns expected cases. 
Will add additional testing

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA: https://dimagi-dev.atlassian.net/browse/QA-5125?search_id=d2f58eb3-a110-4b00-8b1c-65f7ec12a54f

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
