### PR TITLE
add bootstrap_version arg to 'build_requirejs'

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -43,6 +43,11 @@ class Command(ResourceStaticCommand):
                             help="Specify bootstrap3 or bootstrap5 (bootstrap3 is default)")
 
     def handle(self, **options):
+        bootstrap_version = options.get('bootstrap_version')
+        if bootstrap_version != "bootstrap3":
+            print("Only supports bootstrap3 for now.")
+            return
+
         logger.setLevel('DEBUG')
 
         local = options['local']

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -38,6 +38,9 @@ class Command(ResourceStaticCommand):
                  'Does not allow you to mimic CDN.')
         parser.add_argument('--no_optimize', action='store_true',
             help='Don\'t minify files. Runs much faster. Useful when running on a local environment.')
+        parser.add_argument('--bootstrap_version',
+                            default="bootstrap3",
+                            help="Specify bootstrap3 or bootstrap5 (bootstrap3 is default)")
 
     def handle(self, **options):
         logger.setLevel('DEBUG')


### PR DESCRIPTION
Reverting the latest boostrap5 changes (https://github.com/dimagi/commcare-hq/pull/33015) also broke deploy because of this commcare-cloud change (https://github.com/dimagi/commcare-cloud/pull/5949/files).

This change avoids having to rollback the commcare-cloud change and makes the `build_requirejs` command a noop for non-bootstrap3 arguments.

## Safety Assurance

### Safety story
Additive change with no-op outcome.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

Rolling this back will require rolling back https://github.com/dimagi/commcare-cloud/pull/5949/files as well.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
