### PR TITLE
Enforce restrict_domain_creation setting

### DIFF
--- a/corehq/apps/accounting/utils/account.py
+++ b/corehq/apps/accounting/utils/account.py
@@ -24,6 +24,8 @@ def is_user_restricted_from_domain_creation(couch_user):
     """
     domains = [dm.domain for dm in couch_user.domain_memberships]
     linked_accounts = list({BillingAccount.get_account_by_domain(d) for d in domains})
+    if any([couch_user.username in acc.enterprise_admin_emails for acc in linked_accounts]):
+        return True
     # if the user is part of any billing account that does not have this enabled
     # they can keep creating domains
     return all([acc.restrict_domain_creation for acc in linked_accounts])

--- a/corehq/apps/accounting/utils/account.py
+++ b/corehq/apps/accounting/utils/account.py
@@ -15,3 +15,15 @@ def get_account_or_404(domain):
 def request_has_permissions_for_enterprise_admin(request, account):
     return (account.has_enterprise_admin(request.couch_user.username)
             or has_privilege(request, privileges.ACCOUNTING_ADMIN))
+
+
+def is_user_restricted_from_domain_creation(couch_user):
+    """
+    :param couch_user: CouchUser
+    :return: boolean indicating if user is restricted (True) or not (False)
+    """
+    domains = [dm.domain for dm in couch_user.domain_memberships]
+    linked_accounts = list({BillingAccount.get_account_by_domain(d) for d in domains})
+    # if the user is part of any billing account that does not have this enabled
+    # they can keep creating domains
+    return all([acc.restrict_domain_creation for acc in linked_accounts])


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13528

This will limit domain creation for any user who is _only_ a member of domain(s) that restrict domain creation. 

If the user is a member of domains linked to different billing accounts, and only some of those billing accounts restrict domain creation, the user will still be able to create domains from the register domain view.

There are two key takeaways based on this:

1) users who are members of an enterprise billing account with this restriction enabled, but who were able to create a domain due to this bug previously will be able to continue creating new domains going forward.

2) there is still a workaround to this issue, which occurs when the user is first invited to join commcare by their enterprise. If they create their own account first, they will have a domain independent of the enterprise billing account. However if the `restrict_signup` setting is also enabled, this loophole shouldn't be possible.

Realistically, this setting should probably be enforced by checking the email domain of the user instead of the billing account(s) the user is linked to, but this is a quick fix for the current bug if we want it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Apart from causing errors, if this check were to fail in enforcing this setting, it still cannot do any worse than the existing behavior which doesn't check at all.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will request QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
