### PR TITLE
404 for event not found

### DIFF
--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -226,10 +226,13 @@ class EventEditView(EventCreateView):
     @use_multiselect
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
-        self.event_obj = Event.objects.get(
-            domain=self.domain,
-            event_id=kwargs['event_id'],
-        )
+        try:
+            self.event_obj = Event.objects.get(
+                domain=self.domain,
+                event_id=kwargs['event_id'],
+            )
+        except Event.DoesNotExist:
+            raise Http404()
         return super().dispatch(request, *args, **kwargs)
 
     @property


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A 404 page is now shown instead of the 500 internal server error page when searching for an event that does not exist.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2688).

This is a small change that adds a try/except block when doing a get query for an event. If the event is not found, then a 404 is raised.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
ATTENDANCE_TRACKING

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Unit tests.
- Minor change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests have been added to test correct status codes for `EventEditView`.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
