### PR TITLE
Remove click to sync from data dictionary

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -272,13 +272,6 @@
         {% endif %}
       </div>
       {% if not request.is_view_only %}
-        <p class="help-block">
-          {% url 'generate_data_dictionary' domain as refresh_url %}
-          {% blocktrans %}
-          Missing properties or case types? <a href="{{ refresh_url }}" target="_blank">Click to sync</a>
-          (opens in a new tab, may be slow...)
-          {% endblocktrans %}
-        </p>
         <div data-bind="hidden: $root.caseTypes().length > 0">
           <button class="btn btn-primary" data-bind="openModal: 'create-case-type'">
             <i class="fa fa-plus"></i>

--- a/corehq/apps/data_dictionary/urls.py
+++ b/corehq/apps/data_dictionary/urls.py
@@ -5,7 +5,6 @@ from corehq.apps.data_dictionary.views import (
     ExportDataDictionaryView,
     UploadDataDictionaryView,
     data_dictionary_json,
-    generate_data_dictionary,
     update_case_property,
     update_case_property_description,
     create_case_type
@@ -13,7 +12,6 @@ from corehq.apps.data_dictionary.views import (
 from corehq.apps.hqwebapp.decorators import waf_allow
 
 urlpatterns = [
-    url(r"^generate/$", generate_data_dictionary, name='generate_data_dictionary'),
     url(r"^json/$", data_dictionary_json, name='data_dictionary_json'),
     url(r"^json/?(?P<case_type_name>\w+)/?$", data_dictionary_json, name='case_type_dictionary_json'),
     url(r"^create_case_type/$", create_case_type, name='create_case_type'),

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -51,18 +51,6 @@ from corehq.util.workbook_reading.datamodels import Cell
 FHIR_RESOURCE_TYPE_MAPPING_SHEET = "fhir_mapping"
 ALLOWED_VALUES_SHEET_SUFFIX = "-vl"
 
-data_dictionary_rebuild_rate_limiter = RateLimiter(
-    feature_key='data_dictionary_rebuilds_per_user',
-    get_rate_limits=lambda scope: get_dynamic_rate_definition(
-        'data_dictionary_rebuilds_per_user',
-        default=RateDefinition(
-            per_hour=3,
-            per_minute=2,
-            per_second=1,
-        )
-    ).get_rate_limits(scope),
-)
-
 
 @login_and_domain_required
 @toggles.DATA_DICTIONARY.required_decorator()

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -66,26 +66,6 @@ data_dictionary_rebuild_rate_limiter = RateLimiter(
 
 @login_and_domain_required
 @toggles.DATA_DICTIONARY.required_decorator()
-@require_permission(HqPermissions.edit_data_dict)
-def generate_data_dictionary(request, domain):
-    if data_dictionary_rebuild_rate_limiter.allow_usage(domain):
-        data_dictionary_rebuild_rate_limiter.report_usage(domain)
-        try:
-            util.generate_data_dictionary(domain)
-        except util.OldExportsEnabledException:
-            return JsonResponse({
-                "failed": "Data Dictionary requires access to new exports"
-            }, status=400)
-
-        return JsonResponse({"status": "success"})
-    else:
-        return JsonResponse({
-            "failed": "Rate limit exceeded. Please try again later."
-        }, status=429)
-
-
-@login_and_domain_required
-@toggles.DATA_DICTIONARY.required_decorator()
 def data_dictionary_json(request, domain, case_type_name=None):
     props = []
     fhir_resource_type_name_by_case_type = {}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The click to sync link at the bottom of a case type for the data dictionary is removed.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2813).

Small change to remove the associated view, url, and template tag for the click to sync link on the data dictionary.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DATA_DICTIONARY

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Small change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
