### PR TITLE
Strip email part from attendance takers' usernames

### DIFF
--- a/corehq/apps/events/forms.py
+++ b/corehq/apps/events/forms.py
@@ -21,6 +21,7 @@ from corehq.apps.users.dbaccessors import (
     get_mobile_users_by_filters,
 )
 from corehq.apps.users.forms import PrimaryLocationWidget
+from corehq.apps.users.util import raw_username
 
 from .models import EVENT_IN_PROGRESS, EVENT_NOT_STARTED, AttendeeModel
 
@@ -249,7 +250,7 @@ class EventForm(forms.Form):
             )
         else:
             users = get_all_commcare_users_by_domain(self.domain)
-        return [(u.user_id, u.username) for u in users]
+        return [(u.user_id, raw_username(u.username)) for u in users]
 
 
 class NewAttendeeForm(forms.Form):


### PR DESCRIPTION
## Product Description
Currently the attendance takers' usernames are listed on the Event page with the email suffix as part of the username, i.e. `<username>@commcarehq.org`. This PR removes the email part and only displays the username, similar to how the mobile workers' usernames are listed on the Mobile Workers page.

## Technical Summary
Invoke a function, `raw_username`, on each username when populating the field.

## Feature Flag
Attendance Tracking Events

## Safety Assurance

### Safety story
Tested locally

### QA Plan
No QA necessary

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
