### PR TITLE
Move menu instance declarations to menu node in suite file

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -223,3 +223,7 @@ class CommCareFeatureSupportMixin(object):
             toggles.CUSTOM_ASSERTIONS.enabled(self.domain)
             and self._require_minimum_version('2.54')
         )
+
+    @property
+    def supports_menu_instances(self):
+        return self._require_minimum_version('2.54')

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -217,13 +217,13 @@ class CommCareFeatureSupportMixin(object):
         )
 
     @property
+    def supports_menu_instances(self):
+        return self._require_minimum_version('2.54')
+
+    @property
     def supports_module_assertions(self):
         # form-level assertions have been supported longer
         return (
             toggles.CUSTOM_ASSERTIONS.enabled(self.domain)
             and self._require_minimum_version('2.54')
         )
-
-    @property
-    def supports_menu_instances(self):
-        return self._require_minimum_version('2.54')

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -13,7 +13,7 @@ from corehq.apps.app_manager.suite_xml.post_process.endpoints import (
     EndpointsHelper,
 )
 from corehq.apps.app_manager.suite_xml.post_process.instances import (
-    EntryInstances,
+    InstancesHelper,
 )
 from corehq.apps.app_manager.suite_xml.post_process.menu import (
     GridMenuHelper,
@@ -113,7 +113,7 @@ class SuiteGenerator(object):
         if self.app.custom_assertions:
             RootMenuAssertionsHelper(self.suite, self.app, self.modules).update_suite()
 
-        EntryInstances(self.suite, self.app, self.modules).update_suite()
+        InstancesHelper(self.suite, self.app, self.modules).update_suite()
         ResourceOverrideHelper(self.suite, self.app, self.modules).update_suite()
         return self.suite.serializeDocument(pretty=True)
 

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -2,19 +2,23 @@
 InstancesHelper
 --------------
 
-Every instance referenced in an xpath expression needs to be added to the relevant entry,
-so that CommCare knows what data to load when.  This includes case list calculations,
-form display conditions, etc.
+Every instance referenced in an xpath expression needs to be added to the
+relevant entry or menu node, so that CommCare knows what data to load when.
+This includes case list calculations, form/menu display conditions, assertions,
+etc.
 
 HQ knows about a particular set of instances (locations, reports, etc.).
-There's factory-based code dealing with these "known" instances
-When a new feature involves any kind of XPath calculation, it needs to be scanned for instances.
+There's factory-based code dealing with these "known" instances. When a new
+feature involves any kind of XPath calculation, it needs to be scanned for
+instances.
 
-Instances are used to reference data beyond the scope of the current XML document.
-Examples are the commcare session, casedb, lookup tables, mobile reports, case search data etc.
+Instances are used to reference data beyond the scope of the current XML
+document. Examples are the commcare session, casedb, lookup tables, mobile
+reports, case search data etc.
 
-Instances are added into the suite file in ``<entry>`` elements and directly in the form XML. This is
-done in post processing of the suite file in ``corehq.apps.app_manager.suite_xml.post_process.instances``.
+Instances are added into the suite file in ``<entry>`` or ``<menu>`` elements
+and directly in the form XML. This is done in post processing of the suite file
+in ``corehq.apps.app_manager.suite_xml.post_process.instances``.
 
 How instances work
 ------------------

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -1,5 +1,5 @@
 """
-EntryInstances
+InstancesHelper
 --------------
 
 Every instance referenced in an xpath expression needs to be added to the relevant entry,
@@ -82,7 +82,7 @@ from corehq.apps.app_manager.util import (
 from corehq.util.timer import time_method
 
 
-class EntryInstances(PostProcessor):
+class InstancesHelper(PostProcessor):
     IGNORED_INSTANCES = {
         'jr://instance/remote',
         'jr://instance/search-input',
@@ -248,9 +248,9 @@ class EntryInstances(PostProcessor):
     @staticmethod
     def require_instances(entry, instances, unknown_instance_ids):
         used = {(instance.id, instance.src) for instance in entry.instances}
-        instance_order_updated = EntryInstances.update_instance_order(entry)
+        instance_order_updated = InstancesHelper.update_instance_order(entry)
         for instance in instances:
-            if instance.src in EntryInstances.IGNORED_INSTANCES:  # ignore legacy instances
+            if instance.src in InstancesHelper.IGNORED_INSTANCES:  # ignore legacy instances
                 continue
             if (instance.id, instance.src) not in used:
                 entry.instances.append(
@@ -259,7 +259,7 @@ class EntryInstances(PostProcessor):
                     Instance(id=instance.id, src=instance.src)
                 )
                 if not instance_order_updated:
-                    instance_order_updated = EntryInstances.update_instance_order(entry)
+                    instance_order_updated = InstancesHelper.update_instance_order(entry)
         covered_ids = {instance_id for instance_id, _ in used}
         assert_no_unknown_instances(unknown_instance_ids - covered_ids)
 

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -110,7 +110,6 @@ class EntryInstances(PostProcessor):
         self.require_instances(entry, instances=all_instances, instance_ids=unknown_instance_ids)
 
     def _get_all_xpaths_for_entry(self, entry):
-        xpaths_by_menu, menu_by_command = self._get_menu_xpaths()
         details_by_id = self._get_detail_mapping()
         detail_ids = set()
         xpaths = set()
@@ -143,11 +142,7 @@ class EntryInstances(PostProcessor):
 
         details = [details_by_id[detail_id] for detail_id in detail_ids if detail_id]
 
-        entry_id = entry.command.id
-        if entry_id in menu_by_command:
-            menu_id = menu_by_command[entry_id]
-            menu_xpaths = xpaths_by_menu[menu_id]
-            xpaths.update(menu_xpaths)
+        xpaths.update(self._get_menu_xpaths(entry.command.id))
 
         for detail in details:
             xpaths.update(detail.get_all_xpaths())
@@ -163,8 +158,15 @@ class EntryInstances(PostProcessor):
     def _get_detail_mapping(self):
         return {detail.id: detail for detail in self.suite.details}
 
+    def _get_menu_xpaths(self, entry_id):
+        xpaths_by_menu, menu_by_command = self._get_xpaths_by_menu()
+        if entry_id in menu_by_command:
+            menu_id = menu_by_command[entry_id]
+            return xpaths_by_menu[menu_id]
+        return {}
+
     @memoized
-    def _get_menu_xpaths(self):
+    def _get_xpaths_by_menu(self):
         xpaths_by_menu = defaultdict(list)
         menu_by_command = {}
         for menu in self.suite.menus:

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -82,10 +82,6 @@ from corehq.util.timer import time_method
 
 
 class EntryInstances(PostProcessor):
-    """Adds instance declarations to the suite file
-
-    See docs/apps/instances.rst"""
-
     IGNORED_INSTANCES = {
         'jr://instance/remote',
         'jr://instance/search-input',

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -1,6 +1,6 @@
 """
 InstancesHelper
---------------
+---------------
 
 Every instance referenced in an xpath expression needs to be added to the
 relevant entry or menu node, so that CommCare knows what data to load when.

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -287,10 +287,9 @@ class EntryInstances(PostProcessor):
             xpaths.add(menu.relevant)
 
         known_instances, unknown_instance_ids = get_all_instances_referenced_in_xpaths(self.app, xpaths)
+        assert_no_unknown_instances(unknown_instance_ids)
         for instance in known_instances:
             menu.instances.append(instance)
-
-        # TODO deal with unknown_instance_ids
 
 _factory_map = {}
 

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -620,6 +620,7 @@ class MenuMixin(XmlObject):
     style = StringField('@style')
     commands = NodeListField('command', Command)
     assertions = NodeListField('assertions/assert', Assertion)
+    instances = NodeListField('instance', Instance)
 
 
 class Menu(MenuMixin, DisplayNode, IdNode):

--- a/corehq/apps/app_manager/tests/test_suite_assertions.py
+++ b/corehq/apps/app_manager/tests/test_suite_assertions.py
@@ -100,7 +100,7 @@ class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
         self.assertXmlPartialEqual(
             self._instance_declaration, suite, "menu[@id='root']/instance")
 
-    def test_custom_app_assertions(self, *args):
+    def test_unknown_instance_reference(self, *args):
         factory = AppFactory(build_version='2.54.0')
         module, form = factory.new_basic_module('m0', 'case1')
         xpath = "instance('unknown')/thing/val = 1"

--- a/corehq/apps/app_manager/tests/test_suite_assertions.py
+++ b/corehq/apps/app_manager/tests/test_suite_assertions.py
@@ -24,6 +24,8 @@ class DefaultSuiteAssertionsTest(SimpleTestCase, SuiteMixin):
 
 @patch_get_xform_resource_overrides()
 class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
+    _instance_declaration = """<partial><instance id="casedb" src="jr://instance/casedb"/></partial>"""
+
     def setUp(self):
         self._assertion_0 = "foo = 'bar' and baz = 'buzz'"
         self._assertion_1 = "count(instance('casedb')/casedb/case[@case_type='friend']) > 0"
@@ -70,7 +72,7 @@ class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
         self._assert_translations(factory.app, 'm0.f0')
 
     def test_custom_module_assertions(self, *args):
-        factory = AppFactory()
+        factory = AppFactory(build_version='2.54.0')
         module, form = factory.new_basic_module('m0', 'case1')
         module.custom_assertions = self._custom_assertions
         suite = factory.app.create_suite()
@@ -81,18 +83,18 @@ class CustomSuiteAssertionsTest(SimpleTestCase, TestXmlMixin):
         )
         self._assert_translations(factory.app, 'm0')
         self.assertXmlPartialEqual(
-            """<partial><instance id="casedb" src="jr://instance/casedb"/></partial>""",
-            suite,
-            "entry/instance"
-        )
+            self._instance_declaration, suite, "menu[@id='m0']/instance")
 
     def test_custom_app_assertions(self, *args):
-        factory = AppFactory()
+        factory = AppFactory(build_version='2.54.0')
         module, form = factory.new_basic_module('m0', 'case1')
         factory.app.custom_assertions = self._custom_assertions
+        suite = factory.app.create_suite()
         self.assertXmlPartialEqual(
             self._get_expected_xml('root'),
-            factory.app.create_suite(),
+            suite,
             "menu[@id='root']/assertions"
         )
         self._assert_translations(factory.app, 'root')
+        self.assertXmlPartialEqual(
+            self._instance_declaration, suite, "menu[@id='root']/instance")

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -73,21 +73,17 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
     def test_location_instances(self):
         self.form.form_filter = "instance('locations')/locations/"
         self.factory.new_form(self.module)
-        # I'm temporarily modifying this test just for this PR
-        # Instances associated with form filters appear in the corresponding
-        # <entry> elements for all forms in the module. So adding another form
-        # to this module results in another instance declaration that I'm
-        # pretty sure is redundant
+        suite = self.factory.app.create_suite()
         self.assertXmlPartialEqual(
             """
             <partial>
                 <instance id='locations' src='jr://fixture/locations' />
-                <instance id='locations' src='jr://fixture/locations' />
             </partial>
             """,
-            self.factory.app.create_suite(),
-            "entry/instance"
+            suite,
+            "entry[1]/instance"
         )
+        self.assertXmlPartialEqual("<partial />", suite, "entry[2]/instance")
 
     @mock.patch.object(LocationFixtureConfiguration, 'for_domain')
     def test_location_instance_during_migration(self, sync_patch):

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -72,9 +72,16 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
 
     def test_location_instances(self):
         self.form.form_filter = "instance('locations')/locations/"
+        self.factory.new_form(self.module)
+        # I'm temporarily modifying this test just for this PR
+        # Instances associated with form filters appear in the corresponding
+        # <entry> elements for all forms in the module. So adding another form
+        # to this module results in another instance declaration that I'm
+        # pretty sure is redundant
         self.assertXmlPartialEqual(
             """
             <partial>
+                <instance id='locations' src='jr://fixture/locations' />
                 <instance id='locations' src='jr://fixture/locations' />
             </partial>
             """,

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -2,7 +2,10 @@ from unittest import mock
 
 from django.test import SimpleTestCase
 
-from corehq.apps.app_manager.exceptions import DuplicateInstanceIdError
+from corehq.apps.app_manager.exceptions import (
+    DuplicateInstanceIdError,
+    UnknownInstanceError,
+)
 from corehq.apps.app_manager.models import (
     CaseSearch,
     CaseSearchProperty,
@@ -11,7 +14,9 @@ from corehq.apps.app_manager.models import (
     Itemset,
     ShadowModule,
 )
-from corehq.apps.app_manager.suite_xml.post_process.instances import get_instance_names
+from corehq.apps.app_manager.suite_xml.post_process.instances import (
+    get_instance_names,
+)
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -43,6 +48,13 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
             self.factory.app.create_suite(),
             "entry/instance"
         )
+
+    def test_unknown_instances(self):
+        xpath = "instance('unknown')/thing/val = 1"
+        self.form.form_filter = xpath
+        with self.assertRaises(UnknownInstanceError) as e:
+            self.factory.app.create_suite()
+        self.assertIn(xpath, str(e.exception))
 
     def test_duplicate_custom_instances(self):
         self.factory.form_requires_case(self.form)

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -30,7 +30,7 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
         self.factory = AppFactory(include_xmlns=True)
         self.module, self.form = self.factory.new_basic_module('m0', 'case1')
 
-    def test_custom_instances(self, *args):
+    def test_custom_instances(self):
         instance_id = "foo"
         instance_path = "jr://foo/bar"
         self.form.custom_instances = [CustomInstance(instance_id=instance_id, instance_path=instance_path)]
@@ -44,7 +44,7 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
             "entry/instance"
         )
 
-    def test_duplicate_custom_instances(self, *args):
+    def test_duplicate_custom_instances(self):
         self.factory.form_requires_case(self.form)
         instance_id = "casedb"
         instance_path = "jr://casedb/bar"
@@ -54,7 +54,7 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
         with self.assertRaises(DuplicateInstanceIdError):
             self.factory.app.create_suite()
 
-    def test_duplicate_regular_instances(self, *args):
+    def test_duplicate_regular_instances(self):
         """Make sure instances aren't getting added multiple times if they are referenced multiple times
         """
         self.factory.form_requires_case(self.form)
@@ -70,7 +70,7 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
             "entry/instance"
         )
 
-    def test_location_instances(self, *args):
+    def test_location_instances(self):
         self.form.form_filter = "instance('locations')/locations/"
         self.assertXmlPartialEqual(
             """
@@ -131,7 +131,7 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
         configuration_mock_obj.sync_hierarchical_fixture = False
         self.assertXmlPartialEqual(flat_fixture_format_xml, self.factory.app.create_suite(), "entry/instance")
 
-    def test_unicode_lookup_table_instance(self, *args):
+    def test_unicode_lookup_table_instance(self):
         self.form.form_filter = "instance('item-list:província')/província/"
         self.assertXmlPartialEqual(
             """
@@ -143,7 +143,7 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
             "entry/instance"
         )
 
-    def test_search_input_instance(self, *args):
+    def test_search_input_instance(self):
         # instance is not added and no errors
         self.form.form_filter = "instance('search-input:results')/values/"
         self.assertXmlPartialEqual(
@@ -156,7 +156,7 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
             "entry/instance"
         )
 
-    def test_search_input_instance_remote_request(self, *args):
+    def test_search_input_instance_remote_request(self):
         self.form.requires = 'case'
         self.module.case_type = 'case'
 
@@ -235,6 +235,24 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
             expected_instance,
             suite,
             f"./remote-request[1]/instance[@id='{instance_id}']",
+        )
+
+    def test_module_filter_instances_on_all_forms(self):
+        # instances from module filters result in instance declarations in all forms in the module
+        factory = AppFactory(build_version='2.20.0')  # enable_module_filtering
+        self.module, self.form = factory.new_basic_module('m0', 'case1')
+        self.module.module_filter = "instance('locations')/locations/"
+        factory.new_form(self.module)
+        # two forms, two entries, two instances
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+                <instance id='locations' src='jr://fixture/locations' />
+                <instance id='locations' src='jr://fixture/locations' />
+            </partial>
+            """,
+            factory.app.create_suite(),
+            "entry/instance"
         )
 
 

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -646,6 +646,10 @@ def validate_custom_assertions(custom_assertions_string, existing_assertions, la
     assertions = json.loads(custom_assertions_string)
     try:  # validate that custom assertions can be added into the XML
         for assertion in assertions:
+            if (len(assertion['test']) == 0):
+                raise AppMisconfigurationError(_("Custom assertions must not be blank."))
+            if (len(assertion['text']) == 0):
+                raise AppMisconfigurationError(_("Please add a message for assertion."))
             etree.fromstring(
                 '<assertion test="{test}"><text><locale id="abc.def"/>{text}</text></assertion>'.format(
                     **assertion


### PR DESCRIPTION
## Product Description
This adds support for instance declarations in modules without children, enabling the use of instance references in app-level custom assertions.

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3162

> Detect instance references in menu-level xpaths (relevency conditions and custom assertions) and put the associated instance declarations in the menu node.  For 2.53 and below these should still go on entries

Should not be merged until https://dimagi-dev.atlassian.net/browse/USH-3225 is live

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I'll put this on staging and it'll be part of the custom assertions QA

### Automated test coverage

included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
