### PR TITLE
Persist export filter toggles

### DIFF
--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -551,9 +551,9 @@ hqDefine('export/js/models', [
         const urlParams = new URLSearchParams(window.location.search);
         // Whether or not to show advanced columns in the UI
         self.showAdvanced = ko.observable(false);
-        self.showDeleted = ko.observable(urlParams.get('delete_filter_enabled') == 'True');
+        self.showDeleted = ko.observable(urlParams.get('delete_filter_enabled') === 'True');
 
-        self.showDeprecated = ko.observable(urlParams.get('load_deprecated') == 'True');
+        self.showDeprecated = ko.observable(urlParams.get('load_deprecated') === 'True');
         ko.mapping.fromJS(tableJSON, TableConfiguration.mapping, self);
     };
 

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -548,10 +548,12 @@ hqDefine('export/js/models', [
      */
     var TableConfiguration = function (tableJSON) {
         var self = this;
+        const urlParams = new URLSearchParams(window.location.search);
         // Whether or not to show advanced columns in the UI
         self.showAdvanced = ko.observable(false);
-        self.showDeleted = ko.observable(false);
-        self.showDeprecated = ko.observable(false);
+        self.showDeleted = ko.observable(urlParams.get('delete_filter_enabled') == 'True');
+
+        self.showDeprecated = ko.observable(urlParams.get('load_deprecated') == 'True');
         ko.mapping.fromJS(tableJSON, TableConfiguration.mapping, self);
     };
 

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -221,7 +221,10 @@ hqDefine('export/js/models', [
 
         // We've already built the schema and now the user is clicking the button to refresh the page
         if (this.buildSchemaProgress() === 100) {
-            window.location.reload(false);
+            // This param will let us know to automatically enable the filter after the page refreshes
+            let pageUrl = new URL(window.location.href);
+            pageUrl.searchParams.append('delete_filter_enabled', 'True');
+            window.location.href = pageUrl;
             return;
         }
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The "Show Deleted Properties" and/or "Show Deprecated Properties" will automatically be selected if relevant URL parameters are present:
![Screenshot from 2023-05-30 15-23-09](https://github.com/dimagi/commcare-hq/assets/122617251/a48d3f2d-ba01-496c-9c52-4914adcaaf20)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2597).

The first time a user clicks to show deleted/deprecated properties for a case or form export config, a popup will ask the user to load them in after which a page refresh will happen. This change makes it so that the clicked filter persists as enabled after the page refresh has happened. This is done by looking for a "load_deprecated=True" or "delete_filter_enabled=True" param in the URL. The former is an already implemented param that also signals to load in deprecated properties, whilst the latter is a new param that has been added in this PR and is purely to keep track on whether to automatically enable the deleted properties filter.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Have done local testing for both case and form export configs.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
