### PR TITLE
Support deleting individual forms

### DIFF
--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -231,6 +231,19 @@
             </button>
           </form>
         {% endif %}
+        {% if is_archived %}
+          <div style="display: inline-block;">
+            <span class="hq-help-template"
+                  data-title="{% trans "Deleting Forms" %}"
+                  data-content="{% trans "This is a permanent action that cannot be undone." %}"
+                  data-placement="left"
+            ></span>
+            <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#delete-form-modal">
+              <i class="fa fa-trash"></i>
+              {% trans 'Delete this form' %}
+            </button>
+          </div>
+        {% endif %}
 
       {% endif %}
     </div>
@@ -348,3 +361,33 @@
     {% include 'reports/partials/data_corrections_modal.html' %}
   {% endif %}
 {% endif %}
+
+<div class="modal fade" id="delete-form-modal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">{% trans 'Permanently Delete Form' %}</h4>
+      </div>
+      <div class="modal-body">
+        <form action="{% url "delete_form" domain instance.form_id %}" method="POST">{% csrf_token %}
+          <p class="alert alert-warning">
+            <i class="fa fa-exclamation-triangle"></i>
+            {% blocktrans %}
+              It is important you read the entire message below thoroughly before completing this action.
+            {% endblocktrans %}
+          </p>
+          <p>Once deleted, you will not be able to recover this form. Are you sure you want to delete this form?</p>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">
+              {% trans "Cancel" %}
+            </button>
+            <button type="submit" class="btn btn-danger" id="delete-form-btn">
+              {% trans "Delete" %}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -232,7 +232,7 @@
           </form>
         {% endif %}
         {% if is_archived %}
-          <div style="display: inline-block;">
+          <form>
             <span class="hq-help-template"
                   data-title="{% trans "Deleting Forms" %}"
                   data-content="{% trans "This is a permanent action that cannot be undone." %}"
@@ -242,7 +242,7 @@
               <i class="fa fa-trash"></i>
               {% trans 'Delete this form' %}
             </button>
-          </div>
+          </form>
         {% endif %}
 
       {% endif %}

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -379,10 +379,10 @@
           </p>
           <p>Once deleted, you will not be able to recover this form. Are you sure you want to delete this form?</p>
           <div class="modal-footer">
-            <button type="button" class="btn btn-default" data-dismiss="modal">
+            <button type="button" class="btn btn-default disable-on-submit-no-spinner" data-dismiss="modal">
               {% trans "Cancel" %}
             </button>
-            <button type="submit" class="btn btn-danger" id="delete-form-btn">
+            <button type="submit" class="btn btn-danger disable-on-submit" id="delete-form-btn">
               {% trans "Delete" %}
             </button>
           </div>

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -377,7 +377,11 @@
               It is important you read the entire message below thoroughly before completing this action.
             {% endblocktrans %}
           </p>
-          <p>Once deleted, you will not be able to recover this form. Are you sure you want to delete this form?</p>
+          <p>
+            {% blocktrans %}
+              Once deleted, you will not be able to recover this form. Are you sure you want to delete this form?
+            {% endblocktrans %}
+          </p>
           <div class="modal-footer">
             <button type="button" class="btn btn-default disable-on-submit-no-spinner" data-dismiss="modal">
               {% trans "Cancel" %}

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -46,6 +46,7 @@ from .views import (
     archive_form,
     case_form_data,
     delete_config,
+    delete_form,
     delete_scheduled_report,
     download_form,
     edit_form,
@@ -119,6 +120,7 @@ urlpatterns = [
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/correct_data/$', edit_form, name='edit_form'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/archive/$', archive_form, name='archive_form'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/unarchive/$', unarchive_form, name='unarchive_form'),
+    url(r'^form_data/(?P<instance_id>[\w\-:]+)/delete/$', delete_form, name='delete_form'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/rebuild/$', resave_form_view, name='resave_form'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/attachment/(?P<attachment_id>.*)$', view_form_attachment),
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1578,6 +1578,14 @@ def archive_form(request, domain, instance_id):
     return HttpResponseRedirect(redirect)
 
 
+@require_form_view_permission
+@require_permission(HqPermissions.edit_data)
+@require_POST
+@location_safe
+def delete_form(request, domain, instance_id):
+    pass
+
+
 def _get_cases_with_forms_message(domain, cases_with_other_forms, case_id_from_request):
     def _get_all_case_links():
         all_case_links = []

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1583,7 +1583,17 @@ def archive_form(request, domain, instance_id):
 @require_POST
 @location_safe
 def delete_form(request, domain, instance_id):
-    pass
+    form = safely_get_form(request, domain, instance_id)
+    assert form.domain == domain
+    if form.is_archived:
+        form.soft_delete()
+        form.save()
+        return HttpResponseRedirect(reverse('project_report_dispatcher',
+                                            args=(domain, 'submit_history')))
+    else:
+        return HttpResponseForbidden(
+            _(f"Cannot delete form {instance_id} because it is not archived.")
+        )
 
 
 def _get_cases_with_forms_message(domain, cases_with_other_forms, case_id_from_request):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Before archiving (no user impact):
<img width="1197" alt="UI before archiving" src="https://github.com/dimagi/commcare-hq/assets/15785053/d6656983-2a64-4eb5-bd41-0254b2fb0bb7">

After archiving:
<img width="1200" alt="UI after archiving" src="https://github.com/dimagi/commcare-hq/assets/15785053/9369fa4f-5400-4362-a84d-ff23f31e418e">

Confirmation dialog:
<img width="599" alt="Delete form confirmation dialog" src="https://github.com/dimagi/commcare-hq/assets/15785053/6ec395b0-5fe3-4809-b467-79d7ef2ef9be">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14515

Adds support for users to delete forms _after_ they have been archived.

In addition to the UI changes to enforce only allowing deletion after archiving, the `delete_form` endpoint [enforces this](https://github.com/dimagi/commcare-hq/commit/90a8b03afb618011caa0fdc3107225d4ff71f5c4#diff-3ee284c76d901bb74bc51d844c455d014f9a2675460fa35fb4fde2febe057942R1588-R1596) as well.

### Comments/Concerns

#### redirect url
I set the redirect url to the submit history report, since once the form is deleted, it isn't really clear where we should redirect the user to.

#### spinner on delete button [resolved; see comments below]
I'm not sure how fast/slow the soft delete operation will be, and had issues when attempting to add a spinner to the `delete` button in the modal. I basically followed the same format as other buttons in the same `single_form.html` file:
```
<button type="submit" class="btn btn-danger" id="delete-form-btn">
  {% trans "Delete" %}
  <i class="fa fa-refresh fa-spin" id="delete-spinner" style="display:none"></i>
</button>
```
I imagine it has something to do with the button being located with the modal?

#### language used
I need to run this by Corlia.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This operation is inherently risky given it in theory is a permanent deletion of a form. However right now we don't have a mechanism to hard delete soft deleted items (it is in the works), meaning despite language used in this PR, this action is not yet permanent. That being said, it should still be treated as such given the mechanism to do periodic hard deletes will be deployed in the near future.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-5173

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
