### PR TITLE
Filtered bulk user download to GA

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -131,6 +131,7 @@ advanced_v0 = pro_v1 + [
     privileges.APP_USER_PROFILES,
     privileges.VIEW_APP_DIFF,
     privileges.LOCATION_SAFE_CASE_IMPORTS,
+    privileges.FILTERED_BULK_USER_DOWNLOAD
 ]
 
 enterprise_v0 = advanced_v0 + [

--- a/corehq/apps/accounting/migrations/0074_filtered_bulk_user_download_priv.py
+++ b/corehq/apps/accounting/migrations/0074_filtered_bulk_user_download_priv.py
@@ -15,6 +15,7 @@ def _grandfather_filtered_bulk_user_download_priv(apps, schema_editor):
         SoftwarePlanEdition.PAUSED,
         SoftwarePlanEdition.COMMUNITY,
         SoftwarePlanEdition.STANDARD,
+        SoftwarePlanEdition.PRO
     ))
     call_command(
         'cchq_prbac_grandfather_privs',

--- a/corehq/apps/accounting/migrations/0074_filtered_bulk_user_download_priv.py
+++ b/corehq/apps/accounting/migrations/0074_filtered_bulk_user_download_priv.py
@@ -1,0 +1,38 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.privileges import FILTERED_BULK_USER_DOWNLOAD
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _grandfather_filtered_bulk_user_download_priv(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+
+    # FILTERED_BULK_USER_DOWNLOAD are Advanced Plan and higher
+    skip_editions = ','.join((
+        SoftwarePlanEdition.PAUSED,
+        SoftwarePlanEdition.COMMUNITY,
+        SoftwarePlanEdition.STANDARD,
+    ))
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        FILTERED_BULK_USER_DOWNLOAD,
+        skip_edition=skip_editions,
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0073_export_ownership_priv'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _grandfather_filtered_bulk_user_download_priv,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -212,6 +212,10 @@ class Command(BaseCommand):
         Role(slug=privileges.EXPORT_OWNERSHIP,
              name='Allow exports to have ownership',
              description='Allow exports to have ownership'),
+        Role(slug=privileges.FILTERED_BULK_USER_DOWNLOAD,
+             name='Bulk user management features',
+             description='For mobile users, enables bulk deletion page and bulk lookup page. '
+                         'For web users, enables filtered download page.')
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/apps/users/decorators.py
+++ b/corehq/apps/users/decorators.py
@@ -5,6 +5,8 @@ from django.http import Http404, HttpResponse
 from django.utils.translation import gettext as _
 
 from corehq import toggles
+from corehq import privileges
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.decorators import (
     login_and_domain_required,
     redirect_for_login_or_domain,
@@ -182,7 +184,7 @@ def require_can_use_filtered_user_download(view_func):
 
 
 def can_use_filtered_user_download(domain):
-    if toggles.FILTERED_BULK_USER_DOWNLOAD.enabled(domain):
+    if domain_has_privilege(domain, privileges.FILTERED_BULK_USER_DOWNLOAD):
         return True
     if toggles.DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
         return True

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -60,7 +60,7 @@
             <a href="https://confluence.dimagi.com/display/commcarepublic/Create+and+Manage+CommCare+Mobile+Workers" target="_blank">Help Site</a>.
           {% endblocktrans %}
         </p>
-        {% if request|ui_notify_enabled:"MULTI_DOMAIN_DOWNLOAD_MOBILE_WORKERS" and request|toggle_enabled:"FILTERED_BULK_USER_DOWNLOAD" and request|toggle_enabled:"DOMAIN_PERMISSIONS_MIRROR" %}
+        {% if request|ui_notify_enabled:"MULTI_DOMAIN_DOWNLOAD_MOBILE_WORKERS" and request|request_has_privilege:"FILTERED_BULK_USER_DOWNLOAD" and request|toggle_enabled:"DOMAIN_PERMISSIONS_MIRROR" %}
           <div class="alert alert-ui-notify alert-dismissible helpbubble helpbubble-purple helpbubble-no-arrow fade in"
                data-slug="{{ 'MULTI_DOMAIN_DOWNLOAD_MOBILE_WORKERS'|ui_notify_slug }}"
                role="alert">
@@ -110,7 +110,7 @@
                 {% trans "Bulk Clear Data" %}
               </a>
             {% endif %}
-            {% if request|toggle_enabled:"FILTERED_BULK_USER_DOWNLOAD" %}
+            {% if request|request_has_privilege:"FILTERED_BULK_USER_DOWNLOAD" %}
               <a class="btn btn-danger" href="{% url "delete_commcare_users" domain %}">
                 <i class="fa fa-trash"></i>
                 {% trans "Bulk Delete Users" %}

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -31,8 +31,6 @@ from corehq.apps.users.models import (
 from corehq.apps.users.views import _delete_user_role, _update_role_from_view
 from corehq.apps.users.views.mobile.users import MobileWorkerListView
 from corehq.const import USER_CHANGE_VIA_WEB
-from corehq.toggles import FILTERED_BULK_USER_DOWNLOAD, NAMESPACE_DOMAIN
-from corehq.toggles.shortcuts import set_toggle
 from corehq.util.test_utils import (
     flag_enabled,
     generate_cases,
@@ -337,6 +335,7 @@ class TestDeletePhoneNumberView(TestCase):
 
 
 @es_test(requires=[user_adapter], setup_class=True)
+@patch('corehq.apps.users.decorators.can_use_filtered_user_download', return_value=True)
 class TestCountWebUsers(TestCase):
 
     view = 'count_web_users'
@@ -347,8 +346,6 @@ class TestCountWebUsers(TestCase):
 
         cls.domain = 'test'
         cls.domain_obj = create_domain(cls.domain)
-
-        set_toggle(FILTERED_BULK_USER_DOWNLOAD.slug, cls.domain, True, namespace=NAMESPACE_DOMAIN)
 
         location_type = LocationType(domain=cls.domain, name='phony')
         location_type.save()
@@ -395,7 +392,7 @@ class TestCountWebUsers(TestCase):
         cls.domain_obj.delete()
         super().tearDownClass()
 
-    def test_admin_user_sees_all_web_users(self):
+    def test_admin_user_sees_all_web_users(self, _):
         self.client.login(
             username=self.admin_user.username,
             password='badpassword',
@@ -403,7 +400,7 @@ class TestCountWebUsers(TestCase):
         result = self.client.get(reverse(self.view, kwargs={'domain': self.domain}))
         self.assertEqual(json.loads(result.content)['user_count'], 2)
 
-    def test_admin_location_user_sees_all_web_users(self):
+    def test_admin_location_user_sees_all_web_users(self, _):
         self.client.login(
             username=self.admin_user_with_location.username,
             password='badpassword',

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -107,6 +107,8 @@ EXPORT_MULTISORT = 'export_multisort'
 
 EXPORT_OWNERSHIP = 'export_ownership'
 
+FILTERED_BULK_USER_DOWNLOAD = 'filtered_bulk_user_download'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -163,7 +165,8 @@ MAX_PRIVILEGES = [
     LOCATION_SAFE_CASE_IMPORTS,
     FORM_CASE_IDS_CASE_IMPORTER,
     EXPORT_MULTISORT,
-    EXPORT_OWNERSHIP
+    EXPORT_OWNERSHIP,
+    FILTERED_BULK_USER_DOWNLOAD
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -236,4 +239,5 @@ class Titles(object):
             FORM_CASE_IDS_CASE_IMPORTER: _("Download buttons for Form- and Case IDs on Case Importer"),
             EXPORT_MULTISORT: _("Sort multiple rows in exports simultaneously"),
             EXPORT_OWNERSHIP: _("Allow exports to have ownership"),
+            FILTERED_BULK_USER_DOWNLOAD: _("Bulk user management features")
         }.get(privilege, privilege)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1590,18 +1590,6 @@ ENABLE_ALL_ADD_ONS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-FILTERED_BULK_USER_DOWNLOAD = StaticToggle(
-    'filtered_bulk_user_download',
-    "Bulk user management features",
-    TAG_SOLUTIONS_OPEN,
-    [NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/saas/Bulk+User+Management',
-    description="""
-        For mobile users, enables bulk deletion page and bulk lookup page.
-        For web users, enables filtered download page.
-    """
-)
-
 BULK_UPLOAD_DATE_OPENED = StaticToggle(
     'bulk_upload_date_opened',
     "Allow updating of the date_opened field with the bulk uploader",
@@ -2516,4 +2504,18 @@ FORCE_ANNUAL_TOS = StaticToggle(
     "USH Specific toggle that forces users to agree to terms of service annually.",
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
+)
+
+FILTERED_BULK_USER_DOWNLOAD = FrozenPrivilegeToggle(
+    privileges.FILTERED_BULK_USER_DOWNLOAD,
+    'filtered_bulk_user_download',
+    label='Bulk user management features',
+    tag=TAG_SOLUTIONS_OPEN,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+        For mobile users, enables bulk deletion page and bulk lookup page.
+        For web users, enables filtered download page.
+    """,
+    # TODO: Move to public wiki
+    help_link='https://confluence.dimagi.com/display/saas/Bulk+User+Management'
 )

--- a/migrations.lock
+++ b/migrations.lock
@@ -93,6 +93,7 @@ accounting
  0071_add_billingaccountwebuserhistory
  0072_export_multisort_priv
  0073_export_ownership_priv
+ 0074_filtered_bulk_user_download_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2819).

This change moves the `FILTERED_BULK_USER_DOWNLOAD` feature flag to general availability for the Advanced Plan and higher.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
FILTERED_BULK_USER_DOWNLOAD

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

No, as the migration requires the created privileges to exist in the code to be able to bootstrap correctly.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

The following will need to be manually reverted when doing a rollback:
- The newly created Role (select * from django_prbac_role rle where rle.slug = 'filtered_bulk_user_download' )
- The grant records created for this (select * from django_prbac_grant where to_role_id = {{ django_prbac_role id }})

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change