### PR TITLE
[multi-major] Update chardet to latest version

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -58,7 +58,7 @@ cffi==1.14.3
     #   cryptography
     #   csiphash
     #   pynacl
-chardet==3.0.4
+chardet==5.1.0
     # via ghdiff
 charset-normalizer==3.1.0
     # via requests

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -50,7 +50,7 @@ cffi==1.14.3
     #   cryptography
     #   csiphash
     #   pynacl
-chardet==3.0.4
+chardet==5.1.0
     # via ghdiff
 charset-normalizer==3.1.0
     # via requests

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -52,7 +52,7 @@ cffi==1.14.3
     #   cryptography
     #   csiphash
     #   pynacl
-chardet==3.0.4
+chardet==5.1.0
     # via ghdiff
 charset-normalizer==3.1.0
     # via requests

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -46,7 +46,7 @@ cffi==1.14.3
     #   cryptography
     #   csiphash
     #   pynacl
-chardet==3.0.4
+chardet==5.1.0
     # via ghdiff
 charset-normalizer==3.1.0
     # via requests

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -50,7 +50,7 @@ cffi==1.14.3
     #   cryptography
     #   csiphash
     #   pynacl
-chardet==3.0.4
+chardet==5.1.0
     # via ghdiff
 charset-normalizer==3.1.0
     # via requests


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
`chardet` is used by `ghdiff` to  detect character encoding of the files provided. But we are not using that in HQ. And I have updated `chardet` in `ghdiff` and ran tests in it and they work fine. So this should be a pretty safe change. 


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14578
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Described above
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
