### PR TITLE
Force users to select at least one attendance taker

### DIFF
--- a/corehq/apps/events/forms.py
+++ b/corehq/apps/events/forms.py
@@ -73,7 +73,8 @@ class EventForm(forms.Form):
     )
     attendance_takers = forms.MultipleChoiceField(
         label=_("Attendance Takers"),
-        required=False,
+        required=True,
+        help_text="Please choose at least one Attendance Taker"
     )
 
     def __init__(self, *args, **kwargs):

--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -40,6 +40,17 @@ hqDefine("events/js/new_event", [
             'use strict';
             var self = {};
 
+            // Disable the submit button unless attendance takers are present
+            var submitBtn = $('input[type="submit"]');
+            var attendanceTakers = $(id_attendance_takers);
+
+            var initialAttendanceTakers = initialData.attendance_takers;
+            submitBtn.prop('disabled', !initialAttendanceTakers || initialAttendanceTakers.length == 0);
+            attendanceTakers.on('change', function() {
+                var attendanceTakersLength = attendanceTakers.val().length
+                submitBtn.prop('disabled', attendanceTakersLength === 0);
+            });
+
             self.name = ko.observable(initialData.name);
             self.startDate = ko.observable(initialData.start_date);
             self.endDate = ko.observable(initialData.end_date);

--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -41,7 +41,7 @@ hqDefine("events/js/new_event", [
             var self = {};
 
             // Disable the submit button unless attendance takers are present
-            var submitBtn = $('input[type="submit"]');
+            var submitBtn = $('input[id="submit-id-submit_btn"]');
             var attendanceTakers = $(id_attendance_takers);
 
             var initialAttendanceTakers = initialData.attendance_takers;

--- a/corehq/apps/events/tests/test_views.py
+++ b/corehq/apps/events/tests/test_views.py
@@ -24,7 +24,7 @@ from ..views import (
     AttendeeDeleteView,
     EventEditView
 )
-
+from corehq.apps.users.models import CommCareUser
 
 class BaseEventViewTestClass(TestCase):
 
@@ -65,6 +65,9 @@ class BaseEventViewTestClass(TestCase):
             None,
             None,
             is_admin=False,
+        )
+        cls.mobile_worker = CommCareUser.create(
+            cls.domain.name, "UserX", "123", None, None, email="user_x@email.com"
         )
         role = cls.attendance_coordinator_role()
         cls.role_webuser.set_role(cls.domain, role.get_qualified_id())
@@ -274,7 +277,6 @@ class TestEventsCreateView(BaseEventViewTestClass):
 
     def _event_data(self):
         timestamp = datetime.utcnow().date()
-
         return {
             'name': 'test-event',
             'start_date': timestamp,
@@ -282,6 +284,7 @@ class TestEventsCreateView(BaseEventViewTestClass):
             'attendance_target': 10,
             'sameday_reg': True,
             'track_each_day': False,
+            'attendance_takers': [self.mobile_worker.user_id],
         }
 
 

--- a/corehq/apps/events/tests/test_views.py
+++ b/corehq/apps/events/tests/test_views.py
@@ -67,7 +67,7 @@ class BaseEventViewTestClass(TestCase):
             is_admin=False,
         )
         cls.mobile_worker = CommCareUser.create(
-            cls.domain.name, "UserX", "123", None, None, email="user_x@email.com"
+            cls.domain, "UserX", "123", None, None, email="user_x@email.com"
         )
         role = cls.attendance_coordinator_role()
         cls.role_webuser.set_role(cls.domain, role.get_qualified_id())


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2806)
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
We now disbale the submit button on the Create/Edit Events page in Attendance Tracking unless the user specified at least one attendance taker.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
We now disbale the submit button on the Create/Edit Events page in Attendance Tracking unless the user specified at least one attendance taker. Reason for this decision:
- Marking the attendance takers field in the form as required do prevent the user from submitting a form when no attendance takers are specified, but the error message associated with the "required" requirement doesn't show. Nothing basically happens. I tried specifying the error message explicitly, adding a MinLengthValidator, but it didn't work. I suspect it's because we're using a custom widget?
- Manually validating this field in the `clean` method works, but when editing the form, some of the fields are being thrown aways when this validation fails. I tried manually injecting them again, but was not successful. Anycase, that solution would have not been very clean in my opinion. I think this one is best. But, other opinions are welcome.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Attendance Tracking

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA plan

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

### Screenshot
![Screenshot from 2023-06-01 09-41-15](https://github.com/dimagi/commcare-hq/assets/64970009/c0d7e986-65fb-43e7-aa74-daa749676580)
