### PR TITLE
Diagnose DHIS2 errors

### DIFF
--- a/corehq/motech/dhis2/const.py
+++ b/corehq/motech/dhis2/const.py
@@ -77,3 +77,25 @@ COMPLETE_DATE_CHOICES = [
     (COMPLETE_DATE_ON_PERIOD_END, _('Use last day of period')),
     (COMPLETE_DATE_ON_SEND, _('Use date that dataValues are sent')),
 ]
+
+ERROR_DIAGNOSIS = {
+    '504 Gateway Time-out': _(
+        "It could be that CommCare HQ is sending data faster than DHIS2 can "
+        "handle. If possible, try increasing the resources on your DHIS2 instance. "
+        "The ability to send data from CommCare HQ slower is coming soon."
+    ),
+    'Event.programStage does not point to a valid programStage: null': _(
+        "This Event’s Program has multiple stages. You will need to update the configuration "
+        "to specify which program stage the Event’s data belongs to. "
+        "(See the “programStage” property in the data forwarder’s configuration.)"
+    ),
+    'Program stage is not repeatable and an event already exists': _(
+        "An event for this program stage has already been submitted. It could be that the new "
+        "event is for a different program stage. You will need to update the configuration to "
+        "specify the correct program stage for this submission. (See the “programStage” property "
+        "in the data forwarder’s configuration.)"
+    ),
+    '502 Bad Gateway': _(
+        "The DHIS2 server is currently not accepting connections."
+    )
+}

--- a/corehq/motech/dhis2/parse_response.py
+++ b/corehq/motech/dhis2/parse_response.py
@@ -56,7 +56,11 @@ def get_events_errors(response: dict) -> dict:
 
 
 def get_diagnosis_message(error: str) -> str:
-    for error_msg in ERROR_DIAGNOSIS.keys():
-        if error_msg.lower() in error.lower():
-            return ERROR_DIAGNOSIS[error_msg]
-    return _('No diagnosis available for this error.')
+    diagnosis_message = [
+        v for k, v in ERROR_DIAGNOSIS.items() if k.lower() in error.lower()
+    ]
+    return (
+        diagnosis_message[0]
+        if diagnosis_message
+        else _('No diagnosis available for this error.')
+    )

--- a/corehq/motech/dhis2/parse_response.py
+++ b/corehq/motech/dhis2/parse_response.py
@@ -55,7 +55,7 @@ def get_events_errors(response: dict) -> dict:
     return {str(match.full_path): match.value for match in matches}
 
 
-def diagnose_error(error: str) -> str:
+def get_diagnosis_message(error: str) -> str:
     for error_msg in ERROR_DIAGNOSIS.keys():
         if error_msg.lower() in error.lower():
             return ERROR_DIAGNOSIS[error_msg]

--- a/corehq/motech/dhis2/parse_response.py
+++ b/corehq/motech/dhis2/parse_response.py
@@ -1,8 +1,10 @@
 from operator import eq
 
 from jsonpath_ng import Child, Fields, Slice, Where, Root
+from django.utils.translation import gettext_lazy as _
 
 from corehq.motech.openmrs.jsonpath import Cmp
+from .const import ERROR_DIAGNOSIS
 
 
 def get_errors(response: dict) -> dict:
@@ -51,3 +53,10 @@ def get_events_errors(response: dict) -> dict:
     ), Fields("description"))
     matches = jsonpath_expr.find(response)
     return {str(match.full_path): match.value for match in matches}
+
+
+def diagnose_error(error: str) -> str:
+    for error_msg in ERROR_DIAGNOSIS.keys():
+        if error_msg.lower() in error.lower():
+            return ERROR_DIAGNOSIS[error_msg]
+    return _('No diagnosis available for this error.')

--- a/corehq/motech/dhis2/parse_response.py
+++ b/corehq/motech/dhis2/parse_response.py
@@ -56,11 +56,8 @@ def get_events_errors(response: dict) -> dict:
 
 
 def get_diagnosis_message(error: str) -> str:
-    diagnosis_message = [
-        v for k, v in ERROR_DIAGNOSIS.items() if k.lower() in error.lower()
-    ]
-    return (
-        diagnosis_message[0]
-        if diagnosis_message
-        else _('No diagnosis available for this error.')
-    )
+    error_lower = error.lower()
+    try:
+        return next(v for k, v in ERROR_DIAGNOSIS.items() if k.lower() in error_lower)
+    except StopIteration:
+        return _('No diagnosis available for this error')

--- a/corehq/motech/repeaters/templates/repeaters/partials/attempt_history.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/attempt_history.html
@@ -48,13 +48,15 @@
             {% endif %}
 
             <!-- DHIS2 specific errors -->
-            {% for error in dhis2_errors %}
+            {% for error, diagnosis in dhis2_errors %}
                 <tr>
                     <td>
                         <div>
                             <strong>DHIS2 Error #{{ forloop.counter }}</strong>
                             <div class="well" style="font-family: monospace;">
-                                {{ error }}
+                                {{ error }}<br/><br/>
+                                <strong>{% trans 'Diagnosis:' %}</strong>
+                                {{ diagnosis }}
                             </div>
                         </div>
                     </td>

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -37,7 +37,7 @@ from corehq.form_processor.exceptions import XFormNotFound
 from corehq.motech.utils import pformat_json
 from corehq.util.xml_utils import indent_xml
 from corehq.motech.dhis2.repeaters import Dhis2EntityRepeater
-from corehq.motech.dhis2.parse_response import get_errors, diagnose_error
+from corehq.motech.dhis2.parse_response import get_errors, get_diagnosis_message
 from corehq.motech.models import RequestLog
 
 from ..const import RECORD_CANCELLED_STATE
@@ -326,14 +326,14 @@ class RepeatRecordView(View):
                 try:
                     resp_body = json.loads(log.response_body)
                     log_errors = [
-                        (error, diagnose_error(error)) for error in get_errors(resp_body).values()
+                        (error, get_diagnosis_message(error)) for error in get_errors(resp_body).values()
                     ]
                     dhis2_errors += log_errors
                 except json.JSONDecodeError:
                     # If it's not JSON, then we might be dealing with an HTML string, so remove HTML tags
                     tag_remove_regex = re.compile('<.*?>')
                     cleaned_log = re.sub(tag_remove_regex, '', log.response_body)
-                    dhis2_errors.append((cleaned_log, diagnose_error(cleaned_log)))
+                    dhis2_errors.append((cleaned_log, get_diagnosis_message(cleaned_log)))
 
         attempt_html = render_to_string(
             'repeaters/partials/attempt_history.html',

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -37,7 +37,7 @@ from corehq.form_processor.exceptions import XFormNotFound
 from corehq.motech.utils import pformat_json
 from corehq.util.xml_utils import indent_xml
 from corehq.motech.dhis2.repeaters import Dhis2EntityRepeater
-from corehq.motech.dhis2.parse_response import get_errors
+from corehq.motech.dhis2.parse_response import get_errors, diagnose_error
 from corehq.motech.models import RequestLog
 
 from ..const import RECORD_CANCELLED_STATE
@@ -325,13 +325,15 @@ class RepeatRecordView(View):
             for log in logs:
                 try:
                     resp_body = json.loads(log.response_body)
-                    log_errors = [error for error in get_errors(resp_body).values()]
+                    log_errors = [
+                        (error, diagnose_error(error)) for error in get_errors(resp_body).values()
+                    ]
                     dhis2_errors += log_errors
                 except json.JSONDecodeError:
                     # If it's not JSON, then we might be dealing with an HTML string, so remove HTML tags
                     tag_remove_regex = re.compile('<.*?>')
                     cleaned_log = re.sub(tag_remove_regex, '', log.response_body)
-                    dhis2_errors.append(cleaned_log)
+                    dhis2_errors.append((cleaned_log, diagnose_error(cleaned_log)))
 
         attempt_html = render_to_string(
             'repeaters/partials/attempt_history.html',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A diagnosis will be given for recognized DHIS2 errors:
![Screenshot from 2023-06-01 10-12-48](https://github.com/dimagi/commcare-hq/assets/122617251/ef80669a-838d-4b5a-8a8a-e5cb19ec938d)

If it is an unrecognized diagnosis, then a generic response will be given:
![Screenshot from 2023-06-01 10-14-10](https://github.com/dimagi/commcare-hq/assets/122617251/408fb9a7-3bad-4e68-ae95-404af9751a02)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2776).

This change aims to make it easier for users to diagnose DHIS2 error messages by providing a diagnosis message alongside the error message. These help messages were taken from [this](https://docs.google.com/document/d/1MHJ21Ywr_8lZHDufyQfhjC_iBQzjfXyOMz5l-eeFHr4/edit?usp=sharing) document, which was compiled using common error messages currently happening on production. 

This list of diagnosis messages will need to be maintained and updated with any new common DHIS2 errors.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`DHIS2_INTEGRATION`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Small UI change.
- Have done local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
