### PR TITLE
[USH-3134] form link child module manual linking fix

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -418,7 +418,7 @@ class EndOfFormNavigationWorkflow(object):
 
         if target_module.root_module_id:
             root_module = self.helper.app.get_module_by_unique_id(target_module.root_module_id)
-            frame_children = prepend_parent_frame_children(self.helper, frame_children, root_module)
+            frame_children = prepend_parent_frame_children(self.helper, frame_children, root_module, link.datums, form)
 
         return StackFrameMeta(link.xpath, list(frame_children), current_session=source_form_datums)
 
@@ -433,10 +433,15 @@ class EndOfFormNavigationWorkflow(object):
                 )
 
 
-def prepend_parent_frame_children(helper, frame_children, parent_module):
+def prepend_parent_frame_children(helper, frame_children, parent_module, manual_values=None, form=None):
     # Note: this fn is roughly equivalent to just passing include_root_module
     # to get_frame_children in the first place, but that gives the wrong order
     parent_frame_children = helper.get_frame_children(parent_module)
+    if manual_values:
+        parent_frame_children = list(
+            _get_datums_matched_to_manual_values(parent_frame_children, manual_values, form)
+        )
+
     parent_ids = {parent.id for parent in parent_frame_children}
     return parent_frame_children + [
         child for child in frame_children

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -609,6 +609,64 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         """
         self.assertXmlPartialEqual(expected, suite_xml, "./entry[4]/stack")
 
+    def test_form_links_other_child_module_manual_linking(self):
+        factory = AppFactory(build_version='2.9.0')
+        m0, m0f0 = factory.new_basic_module('parent', 'mother')
+        factory.form_requires_case(m0f0)
+        m1, m1f0 = factory.new_basic_module('child', 'baby', parent_module=m0)
+        factory.form_requires_case(m1f0)
+
+        m2, m2f0 = factory.new_basic_module('other_module', 'baby')
+        factory.form_opens_case(m2f0, 'baby')
+        m2f0.post_form_workflow = WORKFLOW_FORM
+        m2f0.form_links = [FormLink(
+            xpath='true()', form_id=m1f0.unique_id, form_module_id=m1.unique_id,
+        )]
+        suite_xml = factory.app.create_suite()
+        print(suite_xml.decode())
+
+        # m2f0 links to m1f0 (child of m0-f0) - automatic linking
+        expected = """
+        <partial>
+          <stack>
+            <create if="true()">
+              <command value="'m0'"/>
+              <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
+              <command value="'m1'"/>
+              <datum id="case_id_baby" value="instance('commcaresession')/session/data/case_id_new_baby_0"/>
+              <command value="'m1-f0'"/>
+            </create>
+          </stack>
+        </partial>
+        """
+        self.assertXmlPartialEqual(expected, suite_xml, "./entry[3]/stack")
+
+        # set manual links
+        m2f0.form_links = [FormLink(
+            xpath='true()', form_id=m1f0.unique_id, form_module_id=m1.unique_id,
+            datums=[
+                FormDatum(name="case_id", xpath="xpath1"),
+                FormDatum(name="case_id_baby", xpath="xpath2"),
+            ]
+        )]
+
+        suite_xml = factory.app.create_suite()
+
+        expected = """
+        <partial>
+          <stack>
+            <create if="true()">
+              <command value="'m0'"/>
+              <datum id="case_id" value="xpath1"/>
+              <command value="'m1'"/>
+              <datum id="case_id_baby" value="xpath2"/>
+              <command value="'m1-f0'"/>
+            </create>
+          </stack>
+        </partial>
+        """
+        self.assertXmlPartialEqual(expected, suite_xml, "./entry[3]/stack")
+
     def _build_workflow_app(self, mode):
         factory = AppFactory(build_version='2.9.0')
         m0, m0f0 = factory.new_basic_module('m0', '')

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -623,7 +623,6 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
             xpath='true()', form_id=m1f0.unique_id, form_module_id=m1.unique_id,
         )]
         suite_xml = factory.app.create_suite()
-        print(suite_xml.decode())
 
         # m2f0 links to m1f0 (child of m0-f0) - automatic linking
         expected = """
@@ -651,7 +650,6 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         )]
 
         suite_xml = factory.app.create_suite()
-
         expected = """
         <partial>
           <stack>

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -562,8 +562,6 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         self.assertXmlPartialEqual(expected, suite_xml, "./entry[1]/stack")
 
     def test_form_links_other_child_module(self):
-        # This test demonstrates current behavior that I believe to be flawed
-
         factory = AppFactory(build_version='2.9.0')
         m0, m0f0 = factory.new_basic_module('parent', 'mother')
         factory.form_opens_case(m0f0)


### PR DESCRIPTION
## Technical Summary
When configuring end of form navigation with manual link datums, the user provided datums are matched to those from the suite file in order to produce the correct ordering.

When linking to a form in a child module we need to apply the same matching to any user provided datums.

## Safety Assurance

### Safety story
This is an additive fix that should not affect existing apps. It will also only impact app builds.

### Automated test coverage
Good coverage + new test added

### QA Plan
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
