### PR TITLE
Case tile template selection UI

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -83,7 +83,6 @@ from corehq.apps.app_manager.dbaccessors import (
     get_latest_released_app_doc,
     wrap_app,
 )
-from corehq.apps.app_manager.detail_screen import PropertyXpathGenerator
 from corehq.apps.app_manager.exceptions import (
     AppEditingError,
     FormNotFoundException,
@@ -114,7 +113,7 @@ from corehq.apps.app_manager.helpers.validators import (
     ShadowModuleValidator,
 )
 from corehq.apps.app_manager.suite_xml import xml_models as suite_models
-from corehq.apps.app_manager.suite_xml.const import CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+from corehq.apps.app_manager.suite_xml.features.case_tiles import CaseTileTemplates
 from corehq.apps.app_manager.suite_xml.generator import (
     MediaSuiteGenerator,
     SuiteGenerator,
@@ -2040,7 +2039,7 @@ class Detail(IndexedSchema, CaseListLookupMixin):
     def wrap(cls, data):
         if 'use_case_tiles' in data:
             if data.get('use_case_tiles'):
-                data['case_tile_template'] = CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+                data['case_tile_template'] = CaseTileTemplates.PERSON_SIMPLE.value
             del data['use_case_tiles']
         return super(Detail, cls).wrap(data)
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -55,10 +55,14 @@ hqDefine("app_manager/js/details/screen", function () {
         self.containsSearchConfiguration = options.containsSearchConfiguration;
         self.containsCustomXMLConfiguration = options.containsCustomXMLConfiguration;
         self.allowsTabs = options.allowsTabs;
+        self.caseTileTemplateOptions = options.caseTileTemplateOptions;
+        self.caseTileTemplate = ko.observable(spec[self.columnKey].case_tile_template);
         self.caseTileFields = options.caseTileFields;
-        self.caseTileTemplate = ko.observable(spec[self.columnKey].case_tile_template ? "yes" : "no");
+        self.caseTileFieldsForTemplate = ko.computed(function () {
+            return self.caseTileFields[self.caseTileTemplate()];
+        });
         self.showCaseTileColumn = ko.computed(function () {
-            return self.caseTileTemplate() === "yes" && hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_TILE');
+            return self.caseTileTemplate() !== "None" && hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_TILE');
         });
         self.persistCaseContext = ko.observable(spec[self.columnKey].persist_case_context || false);
         self.persistentCaseContextXML = ko.observable(spec[self.columnKey].persistent_case_context_xml || 'case_name');
@@ -333,7 +337,7 @@ hqDefine("app_manager/js/details/screen", function () {
                 }
             ));
 
-            data.caseTileTemplate = self.caseTileTemplate() === "yes" ? "person_simple" : null;
+            data.caseTileTemplate = self.caseTileTemplate() === "None" ? null : self.caseTileTemplate();
             data.persistCaseContext = self.persistCaseContext();
             data.persistentCaseContextXML = self.persistentCaseContextXML();
             data.persistTileOnForms = self.persistTileOnForms();

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -55,14 +55,17 @@ hqDefine("app_manager/js/details/screen", function () {
         self.containsSearchConfiguration = options.containsSearchConfiguration;
         self.containsCustomXMLConfiguration = options.containsCustomXMLConfiguration;
         self.allowsTabs = options.allowsTabs;
-        self.caseTileTemplateOptions = options.caseTileTemplateOptions;
+        self.caseTileTemplateOptions = [[null, "Don't Use Case Tiles"]].concat(options.caseTileTemplateOptions);
+        self.caseTileTemplateOptions = self.caseTileTemplateOptions.map(function (templateOption) {
+            return {templateValue: templateOption[0], templateName: templateOption[1]};
+        });
         self.caseTileTemplate = ko.observable(spec[self.columnKey].case_tile_template);
         self.caseTileFields = options.caseTileFields;
         self.caseTileFieldsForTemplate = ko.computed(function () {
             return self.caseTileFields[self.caseTileTemplate()];
         });
         self.showCaseTileColumn = ko.computed(function () {
-            return self.caseTileTemplate() !== "None" && hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_TILE');
+            return self.caseTileTemplate() && hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_TILE');
         });
         self.persistCaseContext = ko.observable(spec[self.columnKey].persist_case_context || false);
         self.persistentCaseContextXML = ko.observable(spec[self.columnKey].persistent_case_context_xml || 'case_name');
@@ -337,7 +340,7 @@ hqDefine("app_manager/js/details/screen", function () {
                 }
             ));
 
-            data.caseTileTemplate = self.caseTileTemplate() === "None" ? null : self.caseTileTemplate();
+            data.caseTileTemplate = self.caseTileTemplate();
             data.persistCaseContext = self.persistCaseContext();
             data.persistentCaseContextXML = self.persistentCaseContextXML();
             data.persistTileOnForms = self.persistTileOnForms();

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -55,7 +55,7 @@ hqDefine("app_manager/js/details/screen", function () {
         self.containsSearchConfiguration = options.containsSearchConfiguration;
         self.containsCustomXMLConfiguration = options.containsCustomXMLConfiguration;
         self.allowsTabs = options.allowsTabs;
-        self.caseTileTemplateOptions = [[null, "Don't Use Case Tiles"]].concat(options.caseTileTemplateOptions);
+        self.caseTileTemplateOptions = [[null, gettext("Don't Use Case Tiles")]].concat(options.caseTileTemplateOptions);
         self.caseTileTemplateOptions = self.caseTileTemplateOptions.map(function (templateOption) {
             return {templateValue: templateOption[0], templateName: templateOption[1]};
         });

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -66,7 +66,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                     containsCustomXMLConfiguration: columnType === "short",
                     allowsTabs: columnType === 'long',
                     allowsEmptyColumns: columnType === 'long',
-                    caseTileTemplateOptions: ["None"].concat(spec.caseTileTemplateOptions),
+                    caseTileTemplateOptions: spec.caseTileTemplateOptions,
                     caseTileFields: spec.caseTileFields,
                 }
             );

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -66,7 +66,8 @@ hqDefine('app_manager/js/details/screen_config', function () {
                     containsCustomXMLConfiguration: columnType === "short",
                     allowsTabs: columnType === 'long',
                     allowsEmptyColumns: columnType === 'long',
-                    caseTileFields: [""].concat(spec.caseTileFields),
+                    caseTileTemplateOptions: ["None"].concat(spec.caseTileTemplateOptions),
+                    caseTileFields: spec.caseTileFields,
                 }
             );
             self.screens.push(screen);

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -31,6 +31,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     saveUrl: hqImport('hqwebapp/js/initial_page_data').reverse('edit_module_detail_screens'),
                     parentModules: initial_page_data('parent_case_modules'),
                     allCaseModules: initial_page_data('all_case_modules'),
+                    caseTileTemplateOptions: options.case_tile_template_options,
                     caseTileFields: options.case_tile_fields,
                     childCaseTypes: detail.subcase_types,
                     fixture_columns_by_type: options.fixture_columns_by_type || {},

--- a/corehq/apps/app_manager/suite_xml/const.py
+++ b/corehq/apps/app_manager/suite_xml/const.py
@@ -5,4 +5,5 @@ FIELD_TYPE_PROPERTY = 'property'
 FIELD_TYPE_LEDGER = 'ledger'
 FIELD_TYPE_SCHEDULE = 'schedule'
 
+ALL_CASE_TILE_TEMPLATES = ['person_simple']
 CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE = 'person_simple'

--- a/corehq/apps/app_manager/suite_xml/const.py
+++ b/corehq/apps/app_manager/suite_xml/const.py
@@ -4,6 +4,3 @@ FIELD_TYPE_LOCATION = 'location'
 FIELD_TYPE_PROPERTY = 'property'
 FIELD_TYPE_LEDGER = 'ledger'
 FIELD_TYPE_SCHEDULE = 'schedule'
-
-ALL_CASE_TILE_TEMPLATES = ['person_simple']
-CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE = 'person_simple'

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -1,5 +1,7 @@
 import json
 from dataclasses import dataclass
+from django.db import models
+from django.utils.translation import gettext_lazy as _
 from eulxml.xmlmap.core import load_xmlobject_from_string
 from memoized import memoized
 from pathlib import Path
@@ -17,6 +19,10 @@ from corehq.apps.app_manager.util import (
 
 
 TILE_DIR = Path(__file__).parent.parent / "case_tile_templates"
+
+
+class CaseTileTemplates(models.TextChoices):
+    PERSON_SIMPLE = ("person_simple", _("Person Simple"))
 
 
 @dataclass

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -42,15 +42,15 @@
       {% if request|toggle_enabled:'CASE_LIST_TILE' %}
         <div class="row">
           <div class="col-sm-6">
-            <select data-bind="value: caseTileTemplate" class="form-control">
-              <option value="no">{% trans "Don't Use Case Tiles" %}</option>
-              <option value="yes">{% trans "Use Case Tiles" %}</option>
-            </select>
+            <label>
+              {% trans "Case Tile Template" %}
+            </label>
+            <select data-bind="options:caseTileTemplateOptions, value:caseTileTemplate" class="form-control"></select>
           </div>
         </div>
       {% endif %}
       {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
-        <div data-bind="visible: caseTileTemplate() == 'no'">
+        <div data-bind="visible: caseTileTemplate() === 'None'">
           <div class="checkbox">
             <label>
               <input type="checkbox" data-bind="checked: persistCaseContext">
@@ -65,7 +65,7 @@
           </div>
         </div>
       {% endif %}
-      <div data-bind="visible: caseTileTemplate() == 'yes' || hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML')">
+      <div data-bind="visible: caseTileTemplate() !== 'None' || hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML')">
         <div class="checkbox">
           <label>
             <input type="checkbox" data-bind="checked: persistTileOnForms">
@@ -98,7 +98,7 @@
         {% endwith %}
       {% endif %}
 
-      <div data-bind="visible: caseTileTemplate() == 'yes' || persistentCaseTileFromModule() || hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML')">
+      <div data-bind="visible: caseTileTemplate() !== 'None' || persistentCaseTileFromModule() || hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML')">
         <div class="checkbox" data-bind="visible: persistTileOnForms() || persistentCaseTileFromModule">
           <label>
             <input type="checkbox" data-bind="checked: enableTilePullDown">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -45,12 +45,12 @@
             <label>
               {% trans "Case Tile Template" %}
             </label>
-            <select data-bind="options:caseTileTemplateOptions, value:caseTileTemplate" class="form-control"></select>
+            <select data-bind="options:caseTileTemplateOptions, optionsText: 'templateName', optionsValue: 'templateValue', value:caseTileTemplate" class="form-control"></select>
           </div>
         </div>
       {% endif %}
       {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
-        <div data-bind="visible: caseTileTemplate() === 'None'">
+        <div data-bind="visible: !caseTileTemplate()">
           <div class="checkbox">
             <label>
               <input type="checkbox" data-bind="checked: persistCaseContext">
@@ -65,7 +65,7 @@
           </div>
         </div>
       {% endif %}
-      <div data-bind="visible: caseTileTemplate() !== 'None' || hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML')">
+      <div data-bind="visible: caseTileTemplate() || hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML')">
         <div class="checkbox">
           <label>
             <input type="checkbox" data-bind="checked: persistTileOnForms">
@@ -98,7 +98,7 @@
         {% endwith %}
       {% endif %}
 
-      <div data-bind="visible: caseTileTemplate() !== 'None' || persistentCaseTileFromModule() || hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML')">
+      <div data-bind="visible: caseTileTemplate() || persistentCaseTileFromModule() || hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML')">
         <div class="checkbox" data-bind="visible: persistTileOnForms() || persistentCaseTileFromModule">
           <label>
             <input type="checkbox" data-bind="checked: enableTilePullDown">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
@@ -82,9 +82,9 @@
       <td class="col-sm-3 form-group" data-bind="css: {'has-error': showWarning}"></td>
       <!--/ko-->
       <!--/ko-->
-      <!-- ko if: $parent.showCaseTileColumn() -->
+      <!-- ko if: $parent.showCaseTileColumn() && $parent.caseTileFieldsForTemplate() -->
       <td class="col-sm-2">
-        <select class="form-control" data-bind="value: case_tile_field, options: $parent.caseTileFields"></select>
+        <select class="form-control" data-bind="value: case_tile_field, options: $parent.caseTileFieldsForTemplate"></select>
       </td>
       <!-- /ko -->
       <td class="col-sm-1 text-center">

--- a/corehq/apps/app_manager/tests/test_suite_case_tiles.py
+++ b/corehq/apps/app_manager/tests/test_suite_case_tiles.py
@@ -9,7 +9,7 @@ from corehq.apps.app_manager.models import (
     MappingItem,
     Module,
 )
-from corehq.apps.app_manager.suite_xml.const import CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+from corehq.apps.app_manager.suite_xml.features.case_tiles import CaseTileTemplates
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -97,7 +97,7 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
 
         module = app.add_module(Module.new_module('Untitled Module', None))
         module.case_type = 'patient'
-        module.case_details.short.case_tile_template = CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+        module.case_details.short.case_tile_template = CaseTileTemplates.PERSON_SIMPLE.value
         module.case_details.short.persist_tile_on_forms = True
         module.case_details.short.pull_down_tile = True
         self._add_columns_for_case_details(module)
@@ -116,7 +116,7 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
         factory = AppFactory()
         module0, form0 = factory.new_advanced_module("m0", "person")
         factory.form_requires_case(form0, "person")
-        module0.case_details.short.case_tile_template = CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+        module0.case_details.short.case_tile_template = CaseTileTemplates.PERSON_SIMPLE.value
         self._add_columns_for_case_details(module0)
 
         module1, form1 = factory.new_advanced_module("m1", "person")
@@ -135,7 +135,7 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
         module0.case_details.short.custom_xml = '<detail id="m0_case_short"></detail>'
         self.ensure_module_session_datum_xml(factory, '', 'detail-persistent="m0_case_short"')
         module0.case_details.short.custom_xml = ''
-        module0.case_details.short.case_tile_template = CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+        module0.case_details.short.case_tile_template = CaseTileTemplates.PERSON_SIMPLE.value
 
         # configured to use pull down tile from the other module
         module1.case_details.short.pull_down_tile = True
@@ -144,7 +144,7 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
 
         # set to use persistent case tile of its own as well but it would still
         # persists case tiles and detail inline from another module
-        module1.case_details.short.case_tile_template = CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+        module1.case_details.short.case_tile_template = CaseTileTemplates.PERSON_SIMPLE.value
         module1.case_details.short.persist_tile_on_forms = True
         self._add_columns_for_case_details(module1)
         self.ensure_module_session_datum_xml(factory, 'detail-inline="m0_case_long"',
@@ -166,7 +166,7 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
         factory = AppFactory()
         module0, form0 = factory.new_advanced_module("m0", "person")
         factory.form_requires_case(form0, "person")
-        module0.case_details.short.case_tile_template = CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+        module0.case_details.short.case_tile_template = CaseTileTemplates.PERSON_SIMPLE.value
         self._add_columns_for_case_details(module0)
 
         module1, form1 = factory.new_advanced_module("m1", "person")
@@ -185,11 +185,11 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
         module0.case_details.short.custom_xml = '<detail id="m0_case_short"></detail>'
         self.ensure_module_session_datum_xml(factory, '', 'detail-persistent="m0_case_short"')
         module0.case_details.short.custom_xml = ''
-        module0.case_details.short.case_tile_template = CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+        module0.case_details.short.case_tile_template = CaseTileTemplates.PERSON_SIMPLE.value
 
         # set to use persistent case tile of its own as well but it would still
         # persists case tiles from another module
-        module1.case_details.short.case_tile_template = CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+        module1.case_details.short.case_tile_template = CaseTileTemplates.PERSON_SIMPLE.value
         module1.case_details.short.persist_tile_on_forms = True
         self._add_columns_for_case_details(module1)
         self.ensure_module_session_datum_xml(factory, '', 'detail-persistent="m0_case_short"')
@@ -335,7 +335,7 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
         module, form = factory.new_advanced_module("my_module", "person")
         factory.form_requires_case(form, "person")
         module.case_details.short.custom_xml = '<detail id="m0_case_short"></detail>'
-        module.case_details.short.case_tile_template = CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+        module.case_details.short.case_tile_template = CaseTileTemplates.PERSON_SIMPLE.value
         module.case_details.short.persist_tile_on_forms = True
         module.case_details.short.persist_case_context = True
         suite = factory.app.create_suite()
@@ -372,7 +372,7 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
 
         module = app.add_module(Module.new_module('Untitled Module', None))
         module.case_type = 'patient'
-        module.case_details.short.case_tile_template = CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+        module.case_details.short.case_tile_template = CaseTileTemplates.PERSON_SIMPLE.value
         self._add_columns_for_case_details(module)
 
         module.search_config = CaseSearch(

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -56,8 +56,6 @@ from corehq.apps.app_manager.models import (
     AdvancedModule,
     CaseListForm,
     CaseSearch,
-    CaseSearchAgainLabel,
-    CaseSearchLabel,
     CaseSearchProperty,
     DefaultCaseSearchProperty,
     DeleteModuleRecord,

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -76,7 +76,7 @@ from corehq.apps.app_manager.models import (
     get_all_mobile_filter_configs,
     get_auto_filter_configurations, ConditionalCaseUpdate,
 )
-from corehq.apps.app_manager.suite_xml.const import CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE
+from corehq.apps.app_manager.suite_xml.const import ALL_CASE_TILE_TEMPLATES
 from corehq.apps.app_manager.suite_xml.features.case_tiles import case_tile_template_config
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     get_uuids_by_instance_id,
@@ -233,7 +233,9 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             'has_lookup_tables': bool([i for i in item_lists if i['fixture_type'] == LOOKUP_TABLE_FIXTURE]),
             'has_mobile_ucr': bool([i for i in item_lists if i['fixture_type'] == REPORT_FIXTURE]),
             'default_value_expression_enabled': app.enable_default_value_expression,
-            'case_tile_fields': case_tile_template_config(CASE_TILE_TEMPLATE_NAME_PERSON_SIMPLE).fields,
+            'case_tile_template_options': ALL_CASE_TILE_TEMPLATES,
+            'case_tile_fields': {template: case_tile_template_config(template).fields
+                                 for template in ALL_CASE_TILE_TEMPLATES},
             'search_config': {
                 'search_properties':
                     module.search_config.properties if module_offers_search(module) else [],

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -76,8 +76,7 @@ from corehq.apps.app_manager.models import (
     get_all_mobile_filter_configs,
     get_auto_filter_configurations, ConditionalCaseUpdate,
 )
-from corehq.apps.app_manager.suite_xml.const import ALL_CASE_TILE_TEMPLATES
-from corehq.apps.app_manager.suite_xml.features.case_tiles import case_tile_template_config
+from corehq.apps.app_manager.suite_xml.features.case_tiles import case_tile_template_config, CaseTileTemplates
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     get_uuids_by_instance_id,
 )
@@ -233,9 +232,9 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             'has_lookup_tables': bool([i for i in item_lists if i['fixture_type'] == LOOKUP_TABLE_FIXTURE]),
             'has_mobile_ucr': bool([i for i in item_lists if i['fixture_type'] == REPORT_FIXTURE]),
             'default_value_expression_enabled': app.enable_default_value_expression,
-            'case_tile_template_options': ALL_CASE_TILE_TEMPLATES,
-            'case_tile_fields': {template: case_tile_template_config(template).fields
-                                 for template in ALL_CASE_TILE_TEMPLATES},
+            'case_tile_template_options': CaseTileTemplates.choices,
+            'case_tile_fields': {template[0]: case_tile_template_config(template[0]).fields
+                                 for template in CaseTileTemplates.choices},
             'search_config': {
                 'search_properties':
                     module.search_config.properties if module_offers_search(module) else [],


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

In JIRA: [link](https://dimagi-dev.atlassian.net/browse/USH-3161?atlOrigin=eyJpIjoiZWU2MGVjMDA0YzM5NDQxMWIzZDAzMDE3NDVkMzRhMjQiLCJwIjoiaiJ9).

This UI PR is the much-anticipated UI for the case tile template selection work, and a follow-up to #33018 and #33002. It makes a modification to the "Display Properties" section of the Case List configuration in app manager (where the case tile settings live), that allows the user to select a template that they'd like to use for case tiles.

When no template is selected, the case tile field columns are hidden:

![Screenshot 2023-06-01 at 12 15 39 PM](https://github.com/dimagi/commcare-hq/assets/6729291/9019e861-7a68-4269-9599-37e48973a0f7)

When a template _is_ selected, the case tile mapping column allows you to select values from the template:

![Screenshot 2023-06-01 at 12 18 23 PM](https://github.com/dimagi/commcare-hq/assets/6729291/d1837979-16fe-4266-9ee1-179a0b45feda)

It may not look super different on the surface since we only have the one template, but the key is that we can now add whatever templates we like and the UI will adapt accordingly, whereas before it was not possible to use templates.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I think the code is mostly straightforward. Let me know what questions you have!

I looked into adding a case tile preview using an HTML snippet as suggested in the spec, but had some trouble seeing an easy enough path to do this inside the scope of this PR.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

CASE_LIST_TILE

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None exist for this part of the app manager UI as far as I can tell.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Curious whether you all think this should go through QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
