### PR TITLE
Convert connection settings queryset to list before using

### DIFF
--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -57,7 +57,7 @@ class ConnectionQuerySet(models.QuerySet):
 
     def delete(self):
         from .repeaters.models import Repeater
-        repeaters = Repeater.all_objects.filter(connection_settings_id__in=self.values("id"))
+        repeaters = Repeater.all_objects.filter(connection_settings_id__in=list(self.values("id")))
         if repeaters.exists():
             raise models.ProtectedError(
                 "Cannot delete ConnectionSettings with related Repeater(s)",

--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -57,7 +57,7 @@ class ConnectionQuerySet(models.QuerySet):
 
     def delete(self):
         from .repeaters.models import Repeater
-        repeaters = Repeater.all_objects.filter(connection_settings_id__in=list(self.values("id")))
+        repeaters = Repeater.all_objects.filter(connection_settings_id__in=self.values_list("id", flat=True))
         if repeaters.exists():
             raise models.ProtectedError(
                 "Cannot delete ConnectionSettings with related Repeater(s)",


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I'm attempting to delete a domain on staging that doesn't have any connection setting objects, but as part of the delete method for `ConnectionQuerySet`, we check repeaters associated with connection settings to ensure those are cleaned up too.

In this case, when attempting to invoke any method on the queryset returned from `Repeater.all_objects.filter(connection_settings_id__in=self.values("id"))`, the following error is thrown:

```
UndefinedTable: relation "motech_connectionsettings" does not exist
LINE 1: ...."connection_settings_id" IN (SELECT U0."id" FROM "motech_co...
```

however if I just convert `self.values("id")` to a list before using it in the queryset filter, an empty queryset is returned as expected. I double checked that no repeaters exist for this domain, so this is just a code bug in deletion code.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
