### PR TITLE
Fix Exports Timezone Issue

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -302,7 +302,9 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     name = StringProperty()
     is_active = BooleanProperty()
-    date_created = DateTimeProperty()  # expected to be a naive datetime specified in UTC
+    # date_created is expected to be a naive datetime specified in UTC
+    # Defaulting to a lambda rather than utcnow directly to make freezegun function. Not ideal
+    date_created = DateTimeProperty(default=lambda: datetime.utcnow())
     default_timezone = StringProperty(default=getattr(settings, "TIME_ZONE", "UTC"))
     default_geocoder_location = DictProperty()
     case_sharing = BooleanProperty(default=False)

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -302,7 +302,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     name = StringProperty()
     is_active = BooleanProperty()
-    date_created = DateTimeProperty()
+    date_created = DateTimeProperty()  # expected to be a naive datetime specified in UTC
     default_timezone = StringProperty(default=getattr(settings, "TIME_ZONE", "UTC"))
     default_geocoder_location = DictProperty()
     case_sharing = BooleanProperty(default=False)

--- a/corehq/apps/domain/tests/test_models.py
+++ b/corehq/apps/domain/tests/test_models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from freezegun import freeze_time
 from django.test import SimpleTestCase, override_settings
 from corehq.apps.domain.models import Domain
 
@@ -11,3 +13,12 @@ class DomainTests(SimpleTestCase):
     def test_odata_feed_limit_when_unset_uses_default(self):
         domain = Domain()
         self.assertEqual(domain.get_odata_feed_limit(), 10)
+
+    @freeze_time('2023-06-05')
+    def test_date_created_defaults_to_utcnow_when_not_specified(self):
+        domain = Domain()
+        self.assertEqual(domain.date_created, datetime(year=2023, month=6, day=5))
+
+    def test_date_created_can_be_overridden_by_constructor(self):
+        domain = Domain(date_created=datetime(year=2023, day=1, month=1))
+        self.assertEqual(domain.date_created, datetime(year=2023, month=1, day=1))

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -16,19 +16,19 @@ hqDefine("hqwebapp/js/daterangepicker.config", [
         return ' to ';
     };
     $.fn.createDateRangePicker = function (
-        range_labels, separator, startdate, enddate
+        rangeLabels, separator, startdate, enddate
     ) {
         var ranges = {};
-        ranges[range_labels.last_7_days] = [
+        ranges[rangeLabels.last_7_days] = [
             moment().subtract('7', 'days').startOf('days'),
         ];
 
-        ranges[range_labels.last_month] = [
+        ranges[rangeLabels.last_month] = [
             moment().subtract('1', 'months').startOf('month'),
             moment().subtract('1', 'months').endOf('month'),
         ];
 
-        ranges[range_labels.last_30_days] = [
+        ranges[rangeLabels.last_30_days] = [
             moment().subtract('30', 'days').startOf('days'),
         ];
         var config = {
@@ -60,12 +60,12 @@ hqDefine("hqwebapp/js/daterangepicker.config", [
                 $el.val(gettext("Show All Dates")).change();
 
                 // Clear startdate and enddate filters
-                var filter_id = $(this)[0].getAttribute("name");
-                var filter_id_start = filter_id + "-start";
-                var filter_id_end = filter_id + "-end";
-                if (document.getElementById(filter_id_start) && document.getElementById(filter_id_end)) {
-                    document.getElementById(filter_id_start).setAttribute("value", "");
-                    document.getElementById(filter_id_end).setAttribute("value", "");
+                var filterId = $(this)[0].getAttribute("name");
+                var filterIdStart = filterId + "-start";
+                var filterIdEnd = filterId + "-end";
+                if (document.getElementById(filterIdStart) && document.getElementById(filterIdEnd)) {
+                    document.getElementById(filterIdStart).setAttribute("value", "");
+                    document.getElementById(filterIdEnd).setAttribute("value", "");
                 }
             });
         }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -12,16 +12,6 @@ hqDefine("hqwebapp/js/daterangepicker.config", [
 ) {
     'use strict';
 
-    var getLocalDate = function (date) {
-        /**
-         * This fixes an issue with daterangepicker where a date is passed in
-         * then converted to the browser's local timezone. So if you are in
-         * EST that means the date shows up as the day before.
-         */
-        var _date = new Date(date);
-        _date.setMinutes(_date.getMinutes() + _date.getTimezoneOffset());
-        return _date;
-    };
     $.fn.getDateRangeSeparator = function () {
         return ' to ';
     };
@@ -52,8 +42,8 @@ hqDefine("hqwebapp/js/daterangepicker.config", [
         };
         var hasStartAndEndDate = !_.isEmpty(startdate) && !_.isEmpty(enddate);
         if (hasStartAndEndDate) {
-            config.startDate = getLocalDate(startdate);
-            config.endDate = getLocalDate(enddate);
+            config.startDate = new Date(startdate);
+            config.endDate = new Date(enddate);
         }
 
         $(this).daterangepicker(config);

--- a/corehq/apps/reports/tests/test_util.py
+++ b/corehq/apps/reports/tests/test_util.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import patch, Mock
 from datetime import datetime
 import pytz
@@ -14,7 +13,7 @@ from corehq.apps.reports.util import get_user_id_from_form, datespan_from_beginn
 from corehq.form_processor.exceptions import XFormNotFound
 from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.utils import TestFormMetadata
-from corehq.util.test_utils import TestFileMixin, get_form_ready_to_save
+from corehq.util.test_utils import get_form_ready_to_save
 from corehq.apps.reports.standard.cases.utils import get_user_type
 from corehq.apps.data_interfaces.deduplication import DEDUPE_XMLNS
 from corehq.apps.domain.models import Domain

--- a/corehq/apps/reports/tests/test_util.py
+++ b/corehq/apps/reports/tests/test_util.py
@@ -1,22 +1,48 @@
 import os
 from unittest.mock import patch, Mock
+from datetime import datetime
+import pytz
 
 from django.core.cache import cache
 from django.test import SimpleTestCase
 
 from testil import eq
+from freezegun import freeze_time
 
 from corehq.apps.reports.tasks import summarize_user_counts
-from corehq.apps.reports.util import get_user_id_from_form
+from corehq.apps.reports.util import get_user_id_from_form, datespan_from_beginning
 from corehq.form_processor.exceptions import XFormNotFound
 from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.util.test_utils import TestFileMixin, get_form_ready_to_save
 from corehq.apps.reports.standard.cases.utils import get_user_type
 from corehq.apps.data_interfaces.deduplication import DEDUPE_XMLNS
+from corehq.apps.domain.models import Domain
 
 DOMAIN = 'test_domain'
 USER_ID = "5bc1315c-da6f-466d-a7c4-4580bc84a7b9"
+
+
+@freeze_time("2023-02-10")
+class TestDateSpanFromBeginning(SimpleTestCase):
+    def test_start_and_end_date_dont_change_in_utc(self):
+        start_time = datetime(year=2020, month=4, day=5)
+
+        domain = Domain(date_created=start_time)
+        datespan = datespan_from_beginning(domain, pytz.utc)
+
+        self.assertEqual(datespan.startdate, datetime(year=2020, month=4, day=5))
+        self.assertEqual(datespan.enddate, datetime(year=2023, month=2, day=10))
+
+    def test_start_and_end_date_can_change_if_behind_utc(self):
+        start_time = datetime(year=2020, month=4, day=5)
+
+        domain = Domain(date_created=start_time)
+        # for some reason, pytz represents GMT+1 as 1 hour BEHIND GMT.
+        datespan = datespan_from_beginning(domain, pytz.timezone('Etc/GMT+1'))
+
+        self.assertEqual(datespan.startdate, datetime(year=2020, month=4, day=4))
+        self.assertEqual(datespan.enddate, datetime(year=2023, month=2, day=9))
 
 
 class TestSummarizeUserCounts(SimpleTestCase):

--- a/corehq/apps/reports/tests/test_util.py
+++ b/corehq/apps/reports/tests/test_util.py
@@ -37,7 +37,7 @@ class TestDateSpanFromBeginning(SimpleTestCase):
         start_time = datetime(year=2020, month=4, day=5)
 
         domain = Domain(date_created=start_time)
-        # for some reason, pytz represents GMT+1 as 1 hour BEHIND GMT.
+        # POSIX timezones represent GMT+1 as 1 hour BEHIND GMT.
         datespan = datespan_from_beginning(domain, pytz.timezone('Etc/GMT+1'))
 
         self.assertEqual(datespan.startdate, datetime(year=2020, month=4, day=4))

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -54,7 +54,7 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
                             user_filter=None, simplified=False, CommCareUser=None, include_inactive=False):
     """
         WHEN THERE ARE A LOT OF USERS, THIS IS AN EXPENSIVE OPERATION.
-        Returns a list of CommCare Users based on domain, group, and user 
+        Returns a list of CommCare Users based on domain, group, and user
         filter (demo_user, admin, registered, unknown)
     """
     def _create_temp_user(user_id):
@@ -79,9 +79,9 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
             users = []
             for id in user_ids:
                 user = CommCareUser.get_by_user_id(id)
-                if not user and (user_filter[HQUserType.ADMIN].show or
-                      user_filter[HQUserType.DEMO_USER].show or
-                      user_filter[HQUserType.UNKNOWN].show):
+                if not user and (user_filter[HQUserType.ADMIN].show
+                      or user_filter[HQUserType.DEMO_USER].show
+                      or user_filter[HQUserType.UNKNOWN].show):
                     user = _create_temp_user(id)
                 if user:
                     users.append(user)
@@ -103,10 +103,10 @@ def get_all_users_by_domain(domain=None, group=None, user_ids=None,
             if user_id in registered_users_by_id and user_filter[HQUserType.ACTIVE].show:
                 user = registered_users_by_id[user_id]
                 users.append(user)
-            elif (user_id not in registered_users_by_id and
-                 (user_filter[HQUserType.ADMIN].show or
-                  user_filter[HQUserType.DEMO_USER].show or
-                  user_filter[HQUserType.UNKNOWN].show)):
+            elif (user_id not in registered_users_by_id
+                 and (user_filter[HQUserType.ADMIN].show
+                 or user_filter[HQUserType.DEMO_USER].show
+                 or user_filter[HQUserType.UNKNOWN].show)):
                 user = _create_temp_user(user_id)
                 if user:
                     users.append(user)
@@ -261,8 +261,8 @@ def get_possible_reports(domain_name):
     from corehq.apps.reports.dispatcher import (ProjectReportDispatcher, CustomProjectReportDispatcher)
 
     # todo: exports should be its own permission at some point?
-    report_map = (ProjectReportDispatcher().get_reports(domain_name) +
-                  CustomProjectReportDispatcher().get_reports(domain_name))
+    report_map = (ProjectReportDispatcher().get_reports(domain_name)
+                  + CustomProjectReportDispatcher().get_reports(domain_name))
     reports = []
     domain_obj = Domain.get_by_name(domain_name)
     for heading, models in report_map:

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -344,9 +344,15 @@ def numcell(text, value=None, convert='int', raw=None):
 
 
 def datespan_from_beginning(domain_object, timezone):
-    startdate = domain_object.date_created
-    now = datetime.utcnow()
-    datespan = DateSpan(startdate, now, timezone=timezone)
+    # Start and end dates must be naive (no timezone) to work with DateSpan
+    startdate = domain_object.date_created  # full time in UTC
+    localized_start = startdate.astimezone(timezone)
+    localized_start = datetime(year=localized_start.year, month=localized_start.month, day=localized_start.day)
+
+    now = datetime.now(tz=timezone)
+    localized_end = datetime(year=now.year, month=now.month, day=now.day)
+
+    datespan = DateSpan(localized_start, localized_end, timezone=timezone)
     datespan.is_default = True
     return datespan
 

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -4,6 +4,7 @@ import math
 import warnings
 from collections import defaultdict, namedtuple
 from datetime import datetime
+import pytz
 
 from django.conf import settings
 from django.core.cache import cache
@@ -345,7 +346,8 @@ def numcell(text, value=None, convert='int', raw=None):
 
 def datespan_from_beginning(domain_object, timezone):
     # Start and end dates must be naive (no timezone) to work with DateSpan
-    startdate = domain_object.date_created  # full time in UTC
+    # domain creation time is expected to be a naive date in UTC
+    startdate = pytz.utc.localize(domain_object.date_created)
     localized_start = startdate.astimezone(timezone)
     localized_start = datetime(year=localized_start.year, month=localized_start.month, day=localized_start.day)
 

--- a/corehq/ex-submodules/dimagi/utils/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/dates.py
@@ -108,10 +108,19 @@ class DateSpan(object):
     """
     A useful class for representing a date span
     """
+    # Both startdate and enddate are intended to be provided as naive datetimes (without timezones).
+    # They will be interpreted as being in the timezone provided
     startdate = None
     enddate = None
     format = None
     inclusive = True
+    # is_default signifies whether or not this date span is the default for a given field
+    # TODO: Handle this in a different way. This is not directly used by this class, and the idea of a 'default'
+    #  for a datespan makes no sense in the context of the scope of this class.
+    # It's the consumers of the class that care about whether or not a given datespan is default information
+    #  and they can track that separately.
+    # Finally, it's error-prone -- the initial dates are either default or not, but you can freely change
+    #  those dates without changing this property.
     is_default = False
     _max_days = None
 


### PR DESCRIPTION
## Technical Summary
Associated Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-14546

Dates east of UTC were displaying yesterday's date for the default datespan rather than today. The logic was reversed and providing the wrong data at multiple stages of the process. The ticket links to a google document that breaks this down.

## Safety Assurance

### Safety story
Because the error was mostly contained in generic code, I was concerned that changing that generic code could have unwanted side effects to things that weren't exports. I listed those in the associated ticket, and followed the code paths to gain confidence that the other code paths that use the datespan widget either do not rely on having default spans, or would be glad to have the fix.

I've also done local testing to verify that the correct dates are displayed, and that these dates do not change regardless of my browser's timezone.

### Automated test coverage

The new test suite `TestDateSpanFromBeginning` was created to verify the server side behavior.

### QA Plan

No QA required.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
