### PR TITLE
Dynamically filter event attendance list

### DIFF
--- a/corehq/apps/events/forms.py
+++ b/corehq/apps/events/forms.py
@@ -243,13 +243,10 @@ class EventForm(forms.Form):
         return [(m.case_id, m.name) for m in models]
 
     def _get_possible_attendance_takers_ids(self):
+        attendance_takers_filters = {'user_active_status': True}
         if self.event and self.event.location_id:
-            users = get_mobile_users_by_filters(
-                self.domain,
-                {'location_id': self.event.location_id},
-            )
-        else:
-            users = get_all_commcare_users_by_domain(self.domain)
+            attendance_takers_filters['location_id'] = self.event.location_id
+        users = get_mobile_users_by_filters(self.domain, attendance_takers_filters)
         return [(u.user_id, u.raw_username) for u in users]
 
 

--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -77,6 +77,37 @@ hqDefine("events/js/new_event", [
                 return false;
             });
 
+            self.locationId.subscribe(function (newLocation) {
+                function rebuildList (elementId, data) {
+                    const $expectedList = $(`#${elementId}`);
+                    $expectedList.empty();
+                    for (const item of data) {
+                        $expectedList.append(
+                            `<option value="${item.id}">${item.name}</option>`
+                        );
+                    }
+                };
+
+                $.ajax({
+                    url: initialPageData.reverse('get_attendees_and_attendance_takers'),
+                    method: 'GET',
+                    data: {
+                        'location_id': newLocation,
+                    },
+                    success: function (data) {
+                        $("#attendance-list-error").addClass("hidden");
+
+                        rebuildList("id_expected_attendees", data.attendees);
+                        rebuildList("id_attendance_takers", data.attendance_takers);
+                        multiselectUtils.rebuildMultiselect('id_expected_attendees', ATTENDEE_PROPS);
+                        multiselectUtils.rebuildMultiselect('id_attendance_takers', ATTENDANCE_TAKER_PROPS);
+                    },
+                    error: function (error) {
+                        $("#attendance-list-error").removeClass("hidden");
+                    },
+                });
+            });
+
             return self;
         }
 

--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -14,6 +14,17 @@ hqDefine("events/js/new_event", [
     locationsWidgets
 ) {
     $(function () {
+        const ATTENDEE_PROPS = {
+            selectableHeaderTitle: gettext('Possible Attendees'),
+            selectedHeaderTitle: gettext('Expected Attendees'),
+            searchItemTitle: gettext('Search Attendees'),
+        };
+        const ATTENDANCE_TAKER_PROPS = {
+            selectableHeaderTitle: gettext('Possible Attendance Takers'),
+            selectedHeaderTitle: gettext('Selected Attendance Takers'),
+            searchItemTitle: gettext('Search Attendance Takers'),
+        };
+
         $("#id_start_date").datepicker({
             dateFormat: "yy-mm-dd",
             minDate: 0,
@@ -24,17 +35,9 @@ hqDefine("events/js/new_event", [
             minDate: 0,
         });
 
-        multiselectUtils.createFullMultiselectWidget('id_expected_attendees', {
-            selectableHeaderTitle: gettext('Possible Attendees'),
-            selectedHeaderTitle: gettext('Expected Attendees'),
-            searchItemTitle: gettext('Search Attendees'),
-        });
+        multiselectUtils.createFullMultiselectWidget('id_expected_attendees', ATTENDEE_PROPS);
 
-        multiselectUtils.createFullMultiselectWidget('id_attendance_takers', {
-            selectableHeaderTitle: gettext('Possible Attendance Takers'),
-            selectedHeaderTitle: gettext('Selected Attendance Takers'),
-            searchItemTitle: gettext('Search Attendance Takers'),
-        });
+        multiselectUtils.createFullMultiselectWidget('id_attendance_takers', ATTENDANCE_TAKER_PROPS);
 
         function eventViewModel(initialData) {
             'use strict';

--- a/corehq/apps/events/templates/new_event.html
+++ b/corehq/apps/events/templates/new_event.html
@@ -7,7 +7,15 @@
 
 {% block page_content %}
   {% initial_page_data 'current_values' form.current_values %}
+  {% registerurl "get_attendees_and_attendance_takers" domain %}
 
+  <div id="attendance-list-error" class="alert alert-danger hidden">
+    <p>
+      {% blocktrans %}
+      There was a problem fetching the list of attendees and attendance takers. Please try again.
+      {% endblocktrans %}
+    </p>
+  </div>
   <form id="tracking-event-form" class="form-horizontal disable-on-submit" method="post">
     {% crispy form %}
   </form>

--- a/corehq/apps/events/tests/test_views.py
+++ b/corehq/apps/events/tests/test_views.py
@@ -14,8 +14,19 @@ from corehq.apps.users.role_utils import UserRolePresets
 from corehq.form_processor.models import CommCareCase
 from corehq.util.test_utils import flag_enabled
 from corehq.apps.events.models import AttendanceTrackingConfig
+from corehq.apps.locations.models import LocationType, SQLLocation
+from corehq.apps.es.tests.utils import es_test
+from corehq.apps.es.case_search import case_search_adapter
+from corehq.form_processor.tests.utils import create_case
+from corehq.apps.es.users import user_adapter
 
-from ..models import Event, get_attendee_case_type, AttendeeModel
+
+from ..models import (
+    Event,
+    get_attendee_case_type,
+    AttendeeModel,
+    LOCATION_IDS_CASE_PROPERTY,
+)
 from ..views import (
     EventCreateView,
     EventsView,
@@ -433,3 +444,92 @@ class TestAttendeesDeleteView(BaseEventViewTestClass):
                 response.content.decode('utf-8'),
                 '{"failed": "Cannot delete an attendee that has been tracked in one or more events."}'
             )
+
+
+@es_test(requires=[user_adapter, case_search_adapter], setup_class=True)
+class TestGetAttendeesAndAttendanceTakersView(BaseEventViewTestClass):
+
+    urlname = 'get_attendees_and_attendance_takers'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        location_type = LocationType.objects.create(
+            domain=cls.domain,
+            name='Place'
+        )
+        cls.locations = [
+            SQLLocation.objects.create(
+                domain=cls.domain,
+                name='Mordor',
+                location_id=str(uuid.uuid4().hex),
+                location_type=location_type
+            ),
+            SQLLocation.objects.create(
+                domain=cls.domain,
+                name='Shire',
+                location_id=str(uuid.uuid4().hex),
+                location_type=location_type
+            )
+        ]
+
+        cls.attendance_takers = [
+            CommCareUser.create(
+                cls.domain, "Sauron", "123", None, None, email="sauron@email.com", location=cls.locations[0]
+            ),
+            CommCareUser.create(
+                cls.domain, "Frodo", "123", None, None, email="frodo@email.com", location=cls.locations[1]
+            )
+        ]
+        user_adapter.bulk_index(cls.attendance_takers, refresh=True)
+
+        attendee_case_type = get_attendee_case_type(cls.domain)
+        cls.attendees = [
+            create_case(
+                cls.domain,
+                case_id=uuid.uuid4().hex,
+                case_type=attendee_case_type,
+                name='Gandalf',
+                case_json={
+                    LOCATION_IDS_CASE_PROPERTY: cls.locations[0].location_id
+                },
+                save=True
+            ),
+            create_case(
+                cls.domain,
+                case_id=uuid.uuid4().hex,
+                case_type=attendee_case_type,
+                name='Mary',
+                case_json={
+                    LOCATION_IDS_CASE_PROPERTY: cls.locations[1].location_id
+                },
+                save=True
+            )
+        ]
+        case_search_adapter.bulk_index(cls.attendees, refresh=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        for mobile_worker in cls.attendance_takers:
+            mobile_worker.delete(cls.domain, None)
+        CommCareCase.objects.hard_delete_cases(cls.domain, [attendee.case_id for attendee in cls.attendees])
+        SQLLocation.bulk_delete(cls.locations, None)
+        super().tearDownClass()
+
+    def test_no_location_filter(self):
+        self.log_user_in(self.admin_webuser)
+        response = self.client.get(self.endpoint)
+        json = response.json()
+        self.assertEqual(len(json['attendees']), 2)
+        self.assertEqual(len(json['attendance_takers']), 3)
+
+    def test_with_location_filter(self):
+        self.log_user_in(self.admin_webuser)
+        response = self.client.get(self.endpoint, {'location_id': self.locations[0].location_id})
+        json = response.json()
+        self.assertEqual(json['attendees'], [{'id': self.attendees[0].case_id, 'name': self.attendees[0].name}])
+        self.assertEqual(
+            json['attendance_takers'],
+            [{'id': self.attendance_takers[0].user_id, 'name': self.attendance_takers[0].username}]
+        )

--- a/corehq/apps/events/tests/test_views.py
+++ b/corehq/apps/events/tests/test_views.py
@@ -37,6 +37,8 @@ from ..views import (
 )
 from corehq.apps.users.models import CommCareUser
 
+
+@es_test(requires=[user_adapter], setup_class=True)
 class BaseEventViewTestClass(TestCase):
 
     domain = 'test-domain'
@@ -80,6 +82,8 @@ class BaseEventViewTestClass(TestCase):
         cls.mobile_worker = CommCareUser.create(
             cls.domain, "UserX", "123", None, None, email="user_x@email.com"
         )
+        user_adapter.index(cls.mobile_worker, refresh=True)
+
         role = cls.attendance_coordinator_role()
         cls.role_webuser.set_role(cls.domain, role.get_qualified_id())
         cls.role_webuser.save()
@@ -446,7 +450,7 @@ class TestAttendeesDeleteView(BaseEventViewTestClass):
             )
 
 
-@es_test(requires=[user_adapter, case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter], setup_class=True)
 class TestGetAttendeesAndAttendanceTakersView(BaseEventViewTestClass):
 
     urlname = 'get_attendees_and_attendance_takers'

--- a/corehq/apps/events/urls.py
+++ b/corehq/apps/events/urls.py
@@ -12,6 +12,7 @@ from .views import (
     ConvertMobileWorkerAttendeesView,
     MobileWorkerAttendeeSatusView,
     poll_mobile_worker_attendee_progress,
+    get_attendees_and_attendance_takers
 )
 
 urlpatterns = [
@@ -35,4 +36,6 @@ urlpatterns = [
     url(r'^attendees/convert_users/status/poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
         poll_mobile_worker_attendee_progress,
         name='poll_mobile_worker_attendee_progress'),
+    url(r'^attendees/get_attendees_and_attendance_takers/$', get_attendees_and_attendance_takers,
+        name='get_attendees_and_attendance_takers'),
 ]

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -14,6 +14,10 @@ from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
 from corehq.apps.users.views import BaseUserSettingsView
 from corehq.util.jqueryrmi import JSONResponseMixin, allow_remote_invocation
+from corehq.apps.users.dbaccessors import (
+    get_all_commcare_users_by_domain,
+    get_mobile_users_by_filters
+)
 from .exceptions import AttendeeTrackedException
 from soil.util import expose_cached_download, get_download_context
 from soil.exceptions import TaskFailedError
@@ -525,4 +529,34 @@ def paginated_attendees(request, domain):
     return JsonResponse({
         'attendees': [{'case_id': c.case_id, 'name': c.name} for c in cases],
         'total': total,
+    })
+
+
+@require_GET
+@login_and_domain_required
+@require_permission(HqPermissions.manage_attendance_tracking)
+def get_attendees_and_attendance_takers(request, domain):
+    location_id = request.GET.get('location_id', None)
+    if location_id:
+        attendees = AttendeeModel.objects.by_location_id(domain=domain, location_id=location_id)
+        attendance_takers = get_mobile_users_by_filters(
+            domain,
+            {'location_id': location_id}
+        )
+    else:
+        attendees = AttendeeModel.objects.by_domain(domain=domain)
+        attendance_takers = get_all_commcare_users_by_domain(domain)
+
+    attendees_list = [
+        {'id': attendee.case_id, 'name': attendee.name}
+        for attendee in attendees
+    ]
+    attendance_takers_list = [
+        {'id': attendance_taker.user_id, 'name': attendance_taker.raw_username}
+        for attendance_taker in attendance_takers
+    ]
+
+    return JsonResponse({
+        'attendees': attendees_list,
+        'attendance_takers': attendance_takers_list
     })

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -537,16 +537,14 @@ def paginated_attendees(request, domain):
 @require_permission(HqPermissions.manage_attendance_tracking)
 def get_attendees_and_attendance_takers(request, domain):
     location_id = request.GET.get('location_id', None)
+    attendance_takers_filters = {'user_active_status': True}
     if location_id:
         attendees = AttendeeModel.objects.by_location_id(domain=domain, location_id=location_id)
-        attendance_takers = get_mobile_users_by_filters(
-            domain,
-            {'location_id': location_id}
-        )
+        attendance_takers_filters['location_id'] = location_id
     else:
         attendees = AttendeeModel.objects.by_domain(domain=domain)
-        attendance_takers = get_all_commcare_users_by_domain(domain)
 
+    attendance_takers = get_mobile_users_by_filters(domain, attendance_takers_filters)
     attendees_list = [
         {'id': attendee.case_id, 'name': attendee.name}
         for attendee in attendees


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Attendees and attendance takers are dynamically filtered based on selected location:
![Screenshot from 2023-06-05 09-45-48](https://github.com/dimagi/commcare-hq/assets/122617251/567cb49d-bacf-4a81-8ca8-ee2a8be16d92)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2829).

This allows for the attendees and attendance takers lists on the create/edit event page to be dynamically filtered when the user changes the event's location. After changing the location, any selected attendees and attendance takers will be unselected as the new filtered options are given.

The above is achieved through subscribing to changes on the location field. The new `location_id` is then sent to a back-end view which returns a JSON containing attendees and attendance takers filtered on the given `location_id`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ATTENDANCE_TRACKING`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Unit tests.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests created to ensure `get_attendees_and_attendance_takers` view returns the correct results when using/not using a location filter.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
