### PR TITLE
Filter cases based on drawn polygon

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -60,7 +60,6 @@ hqDefine("geospatial/js/geospatial_map", [
             }
 
             self.removeAllMarkers = function() {
-                console.log("Markers before: ", markers);
                 markers.forEach(marker => {
                     marker.remove();
                 })
@@ -68,11 +67,9 @@ hqDefine("geospatial/js/geospatial_map", [
             }
 
             self.addCaseMarkersToMap = function (cases) {
-                console.log("Current state of markeers: ", markers);
                 const markerColor = "#00FF00";
                 cases.forEach(element => {
                     let coordinates = element.coordinates;
-                    console.log("element: ", element);
                     if (coordinates && coordinates.lat && coordinates.lng) {
                         self.addMarker(coordinates, markerColor);
                     }

--- a/corehq/apps/geospatial/tests/test_report.py
+++ b/corehq/apps/geospatial/tests/test_report.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from corehq.apps.geospatial.reports import _get_geo_location
+
+
+class CaseManagementMapTestCase(TestCase):
+    def setUp(self):
+        pass
+
+    def test_get_geo_location_returns_lat_lon(self):
+        """_get_geo_location expects an es_case which is just a dictionary"""
+
+        es_case = {'case_json': {'commcare_gps_point': '42.78 -91.82 0.0 0.0'}}
+        self.assertEqual(_get_geo_location(es_case), {'lat': 42.78, 'lng': -91.82})


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2777)

This is the first of two PR's I will make for this ticket. The second one will include the ability to save the drawn shape as a GeoJson file.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The user is now able to select cases by drawing a polygon on the map. Currently the user cannot do anything with the selected cases though

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR does the following:
- Moved the `_get_geo_location` out of the `CaseManagementMap` class. Not strictly need to be in there and makes testing easier.
- Filter cases on the CaseManagementMap according to the drawn polygon on the map. Both the `draw.update` and `draw.selectionChange` events triggers this filtering. The `draw.update` was added to allow the user to filter cases when the polygon is dragged to a new place, or when the polygon is changed (i.e made bigger).
- The filtered cases are available in JS in the `userFilteredCases` variable.
- Marker colours are also updated to make it easier to see which cases are currently selected. These cases are the cases inside the `userFilteredCases`.
- Added a `caseMarkers` variable that is a mapping of case ids to its corresponding Marker object. This makes it easier to update markers.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Geospatial / GIS functionality

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing only
- Added a unit test

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA plan

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

### Some Screenshots
## No cases selected
![Screenshot from 2023-06-05 10-12-54](https://github.com/dimagi/commcare-hq/assets/64970009/5901f75d-8706-4c96-a6fc-d2054614864a)

## One case selected / filtered by the drawn polygon
![Screenshot from 2023-06-05 10-13-08](https://github.com/dimagi/commcare-hq/assets/64970009/ea1e77fa-a063-4704-a45a-72e0d604deb0)

## Multiple cases selected / filtered by the drawn polygon
![Screenshot from 2023-06-05 10-13-12](https://github.com/dimagi/commcare-hq/assets/64970009/4a619af7-43f5-4edd-a709-d27368a4119b)