### PR TITLE
Export drawn polygons as GeoJson file

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -16,6 +16,7 @@ hqDefine("geospatial/js/geospatial_map", [
             'use strict';
 
             var self = {};
+            let clickedMarker;
             mapboxgl.accessToken = initialPageData.get('mapbox_access_token');
 
             if (!centerCoordinates) {
@@ -42,10 +43,6 @@ hqDefine("geospatial/js/geospatial_map", [
             });
 
             map.addControl(draw);
-
-            function getCoordinates(event) {
-                return event.lngLat;
-            };
 
             map.on("draw.update", function(e) {
                 var selectedFeatures = e.features;
@@ -77,6 +74,10 @@ hqDefine("geospatial/js/geospatial_map", [
                 }
             });
 
+            function getCoordinates(event) {
+                return event.lngLat;
+            };
+
             function changeCaseMarkerColor(selectedCase, newColor) {
                 let marker = selectedCase.marker;
                 let element = marker.getElement();
@@ -101,7 +102,22 @@ hqDefine("geospatial/js/geospatial_map", [
             }
 
             // We should consider refactoring and splitting the below out to a new JS file
-            let clickedMarker;
+            function moveMarkerToClickedCoordinate(coordinates) {
+                if (clickedMarker != null) {
+                    clickedMarker.remove();
+                }
+                if (draw.getMode() === 'draw_polygon') {
+                    // It's weird moving the marker around with the ploygon
+                    return;
+                }
+                clickedMarker = new mapboxgl.Marker({color: "FF0000", draggable: true});
+                clickedMarker.setLngLat(coordinates);
+                clickedMarker.addTo(map);
+            }
+
+            self.getMapboxDrawInstance = function() {
+                return draw;
+            }
 
             self.getMapboxInstance = function() {
                 return map;
@@ -140,19 +156,6 @@ hqDefine("geospatial/js/geospatial_map", [
 
                 currCase.marker = marker;
             };
-
-            function moveMarkerToClickedCoordinate(coordinates) {
-                if (clickedMarker != null) {
-                    clickedMarker.remove();
-                }
-                if (draw.getMode() === 'draw_polygon') {
-                    // It's weird moving the marker around with the ploygon
-                    return;
-                }
-                clickedMarker = new mapboxgl.Marker({color: "FF0000", draggable: true});
-                clickedMarker.setLngLat(coordinates);
-                clickedMarker.addTo(map);
-            }
 
             // Handle click events here
             map.on('click', (event) => {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -1,9 +1,11 @@
 hqDefine("geospatial/js/geospatial_map", [
     "jquery",
     "hqwebapp/js/initial_page_data",
+    "knockout",
 ], function (
     $,
     initialPageData,
+    ko
 ) {
     $(function () {
         const defaultMarkerColor = "#808080"; // Gray
@@ -64,6 +66,8 @@ hqDefine("geospatial/js/geospatial_map", [
                 if (!selectedFeatures.length) {
                     return;
                 }
+                // mapControls().btnExportDisabled(draw.getSelected().features.length);
+
                 // Check if any features are selected
                 var selectedFeature = selectedFeatures[0];
                 // Update this logic if we need to support case filtering by selecting multiple polygons
@@ -179,17 +183,25 @@ hqDefine("geospatial/js/geospatial_map", [
             }
         };
 
+        var mapControlsModel = function () {
+            'use strict';
+            var self = {};
+
+            self.btnExportDisabled = ko.observable(true);
+            return self;
+        }
+
         $(document).ajaxComplete(function () {
             // This fires everytime an ajax request is completed
             var mapDiv = $('#geospatial-map');
             var $data = $(".map-data");
-            var exportButton = $("#btnExport");
+            var $exportButton = $("#btnExport");
 
             if (mapDiv.length && !map) {
                 map = loadMapBox();
             }
 
-            exportButton.click(function(e) {
+            $exportButton.click(function(e) {
                 if (map) {
                     exportGeoJson(map.getMapboxDrawInstance());
                 }
@@ -200,6 +212,10 @@ hqDefine("geospatial/js/geospatial_map", [
                 map.clearMap();
                 cases = caseData.cases
                 map.addCaseMarkersToMap();
+            }
+
+            if ($exportButton.length) {
+                $exportButton.koApplyBindings(mapControlsModel());
             }
         });
     });

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -164,15 +164,36 @@ hqDefine("geospatial/js/geospatial_map", [
             return self;
         };
 
+        var exportGeoJson = function(drawInstance) {
+            // Credit to https://gist.github.com/danswick/36796153bd86ce982a59043cbe0ac8f7
+            var exportButton = $("#btnExport");
+            var data = drawInstance.getAll();
+
+            if (data.features.length) {
+                // Stringify the GeoJson
+                var convertedData = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(data));
+
+                // Create export
+                exportButton.attr('href', 'data:' + convertedData);
+                exportButton.attr('download','data.geojson');
+            }
+        };
 
         $(document).ajaxComplete(function () {
             // This fires everytime an ajax request is completed
             var mapDiv = $('#geospatial-map');
             var $data = $(".map-data");
+            var exportButton = $("#btnExport");
 
             if (mapDiv.length && !map) {
                 map = loadMapBox();
             }
+
+            exportButton.click(function(e) {
+                if (map) {
+                    exportGeoJson(map.getMapboxDrawInstance());
+                }
+            });
 
             if ($data.length && map) {
                 var caseData = $data.data("context");

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -66,7 +66,6 @@ hqDefine("geospatial/js/geospatial_map", [
                 if (!selectedFeatures.length) {
                     return;
                 }
-                // mapControls().btnExportDisabled(draw.getSelected().features.length);
 
                 // Check if any features are selected
                 var selectedFeature = selectedFeatures[0];
@@ -186,8 +185,37 @@ hqDefine("geospatial/js/geospatial_map", [
         var mapControlsModel = function () {
             'use strict';
             var self = {};
-
+            var mapboxinstance = map.getMapboxInstance();
+            var polygons = [];
             self.btnExportDisabled = ko.observable(true);
+
+            var mapHasPolygons = function() {
+                return polygons.length;
+            };
+
+            function removeId(id) {
+                var index = polygons.indexOf(id); // Find the index of the specified ID
+                polygons.splice(index, 1); // Remove the ID from the array
+              }
+
+            mapboxinstance.on('draw.delete', function(e) {
+                e.features.forEach((feature) => {
+                    if (feature.geometry.type == "Polygon") {
+                        removeId(feature.id);
+                    }
+                });
+                self.btnExportDisabled(!mapHasPolygons());
+            });
+
+            mapboxinstance.on('draw.create', function(e) {
+                e.features.forEach((feature) => {
+                    if (feature.geometry.type == "Polygon") {
+                        polygons.push(feature.id)
+                    }
+                });
+                self.btnExportDisabled(!mapHasPolygons());
+            });
+
             return self;
         }
 

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -186,33 +186,23 @@ hqDefine("geospatial/js/geospatial_map", [
             'use strict';
             var self = {};
             var mapboxinstance = map.getMapboxInstance();
-            var polygons = [];
             self.btnExportDisabled = ko.observable(true);
 
             var mapHasPolygons = function() {
-                return polygons.length;
+                var drawnFeatures = map.getMapboxDrawInstance().getAll().features;
+                if (!drawnFeatures.length) {
+                    return false;
+                }
+                return drawnFeatures.some(function(feature) {
+                    return feature.geometry.type === "Polygon";
+                })
             };
 
-            function removeId(id) {
-                var index = polygons.indexOf(id); // Find the index of the specified ID
-                polygons.splice(index, 1); // Remove the ID from the array
-              }
-
             mapboxinstance.on('draw.delete', function(e) {
-                e.features.forEach((feature) => {
-                    if (feature.geometry.type == "Polygon") {
-                        removeId(feature.id);
-                    }
-                });
                 self.btnExportDisabled(!mapHasPolygons());
             });
 
             mapboxinstance.on('draw.create', function(e) {
-                e.features.forEach((feature) => {
-                    if (feature.geometry.type == "Polygon") {
-                        polygons.push(feature.id)
-                    }
-                });
                 self.btnExportDisabled(!mapHasPolygons());
             });
 

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -169,6 +169,8 @@ hqDefine("geospatial/js/geospatial_map", [
 
         var exportGeoJson = function(drawInstance) {
             // Credit to https://gist.github.com/danswick/36796153bd86ce982a59043cbe0ac8f7
+            // I could not get this to work using knockout.js. It did set the attributes, but a download wasn't
+            // triggered
             var exportButton = $("#btnExport");
             var data = drawInstance.getAll();
 

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -4,10 +4,10 @@
 
 {% block reportcontent %}
 <!-- This is used to get the data from report_context -->
-<div class="row well">
-    <a id="btnExport" class="btn btn-default" style="margin: 1em">{% trans 'Export Polygon as GeoJson' %}</a>
+<div class="panel panel-default">
+    <a id="btnExport" class="btn btn-default" style="margin: 1em" data-bind="disabled: btnExportDisabled">
+        {% trans 'Export Polygon as GeoJson' %}
+    </a>
 </div>
-<div class="row">
-    <div class="map-data" data-context="{% html_attr context %}"></div>
-</div>
+<div class="map-data" data-context="{% html_attr context %}"></div>
 {% endblock %}

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -1,7 +1,13 @@
 {% extends "reports/tabular.html" %}
 {% load hq_shared_tags %}
+{% load i18n %}
 
 {% block reportcontent %}
 <!-- This is used to get the data from report_context -->
-<div class="map-data" data-context="{% html_attr context %}"></div>
+<div class="row well">
+    <a id="btnExport" class="btn btn-default" style="margin: 1em">{% trans 'Export Polygon as GeoJson' %}</a>
+</div>
+<div class="row">
+    <div class="map-data" data-context="{% html_attr context %}"></div>
+</div>
 {% endblock %}

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -5,8 +5,8 @@
 {% block reportcontent %}
 <!-- This is used to get the data from report_context -->
 <div class="panel panel-default">
-    <a id="btnExport" class="btn btn-default" style="margin: 1em" data-bind="disabled: btnExportDisabled">
-        {% trans 'Export Polygon as GeoJson' %}
+    <a id="btnExport" class="btn btn-default" style="margin: 1em" data-bind="attr: { disabled: btnExportDisabled }">
+        {% trans 'Export Polygons as GeoJson' %}
     </a>
 </div>
 <div class="map-data" data-context="{% html_attr context %}"></div>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Users can now export and download the polygons they drew on the map as a Geojson file. A button has been added above the case management map to allow users to do this.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Added a "controls" pane / row above the case management map with an export button.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
GIS / Geospatial

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Screenshots
### The polygon I drew on CommCareHQ
![Screenshot from 2023-06-06 09-24-44](https://github.com/dimagi/commcare-hq/assets/64970009/a267092d-9900-4f75-a25c-59a34a873197)

## Imported in another app
![Screenshot from 2023-06-06 09-25-22](https://github.com/dimagi/commcare-hq/assets/64970009/68dbf4af-d4f8-4041-b294-7c60c6e67714)


