### PR TITLE
Display notification when data source rebuild failed

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -5,11 +5,9 @@ import re
 from ast import literal_eval
 from collections import namedtuple
 from copy import copy, deepcopy
-from corehq import toggles
 from datetime import datetime, timedelta
 from uuid import UUID
 
-from celery.states import FAILURE
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.serializers.json import DjangoJSONEncoder
@@ -19,11 +17,11 @@ from django.utils.translation import gettext as _
 
 import requests
 import yaml
+from celery.states import FAILURE
 from couchdbkit.exceptions import BadValueError
 from django_bulk_update.helper import bulk_update as bulk_update_helper
 from jsonpath_ng.ext import parser
 from memoized import memoized
-from corehq.apps.domain.models import AllowedUCRExpressionSettings
 
 from dimagi.ext.couchdbkit import (
     BooleanProperty,
@@ -47,10 +45,12 @@ from dimagi.utils.couch.undo import is_deleted
 from dimagi.utils.dates import DateSpan
 from dimagi.utils.modules import to_function
 
+from corehq import toggles
 from corehq.apps.cachehq.mixins import (
     CachedCouchDocumentMixin,
     QuickCachedDocumentMixin,
 )
+from corehq.apps.domain.models import AllowedUCRExpressionSettings
 from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.userreports.app_manager.data_source_meta import (
     REPORT_BUILDER_DATA_SOURCE_TYPE_VALUES,
@@ -949,7 +949,9 @@ class ReportConfiguration(QuickCachedDocumentMixin, Document):
     @property
     @memoized
     def cached_data_source(self):
-        from corehq.apps.userreports.reports.data_source import ConfigurableReportDataSource
+        from corehq.apps.userreports.reports.data_source import (
+            ConfigurableReportDataSource,
+        )
         return ConfigurableReportDataSource.from_spec(self).data_source
 
     @property
@@ -1006,7 +1008,9 @@ class ReportConfiguration(QuickCachedDocumentMixin, Document):
         return langs
 
     def validate(self, required=True):
-        from corehq.apps.userreports.reports.data_source import ConfigurableReportDataSource
+        from corehq.apps.userreports.reports.data_source import (
+            ConfigurableReportDataSource,
+        )
 
         def _check_for_duplicates(supposedly_unique_list, error_msg):
             # http://stackoverflow.com/questions/9835762/find-and-list-duplicates-in-python-list

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -2,10 +2,11 @@ import glob
 import json
 import os
 import re
+from ast import literal_eval
 from collections import namedtuple
 from copy import copy, deepcopy
 from corehq import toggles
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import UUID
 
 from django.conf import settings
@@ -15,6 +16,7 @@ from django.db import models
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
+import requests
 import yaml
 from couchdbkit.exceptions import BadValueError
 from django_bulk_update.helper import bulk_update as bulk_update_helper
@@ -188,10 +190,8 @@ class DataSourceBuildInformation(DocumentSchema):
     def is_rebuilding(self):
         return (
             self.initiated
-            and (
-                not self.finished
-                and not self.rebuilt_asynchronously
-            )
+            and not self.finished
+            and not self.rebuilt_asynchronously
         )
 
     @property
@@ -204,6 +204,73 @@ class DataSourceBuildInformation(DocumentSchema):
     @property
     def is_rebuild_in_progress(self):
         return self.is_rebuilding or self.is_rebuilding_in_place
+
+    def rebuild_failed(self, data_source_config_id):
+        """
+        Returns ``True`` if the rebuild failed, ``False`` if it succeeded
+        or has not yet failed, or ``None`` if Flower is not available.
+        """
+        flower_url = getattr(settings, 'CELERY_FLOWER_URL')
+
+        def none_max(a, b):
+            if a is None:
+                return b
+            if b is None:
+                return a
+            return max(a, b)
+
+        def format_datetime(dt):
+            return dt.strftime('%Y-%m-%d %H:%M')
+
+        def is_this_data_source(rebuild_task):
+            args = literal_eval(rebuild_task['args'])  # a tuple
+            return args[0] == data_source_config_id
+
+        def iter_tasks():
+            task_names = (
+                'corehq.apps.userreports.tasks.rebuild_indicators',
+                'corehq.apps.userreports.tasks.rebuild_indicators_in_place',
+                'corehq.apps.userreports.tasks.resume_building_indicators',
+            )
+            initiated_at = none_max(self.initiated, self.initiated_in_place)
+            start = format_datetime(initiated_at - timedelta(seconds=60))
+            for task_name in task_names:
+                tasks = requests.get(
+                    flower_url + '/api/tasks',
+                    params={
+                        'taskname': task_name,
+                        'received_start': start,
+                    },
+                    timeout=3,
+                ).json()
+                for task_uuid, task in tasks.items():
+                    if is_this_data_source(task):
+                        yield task
+
+        if not self.initiated and not self.initiated_in_place:
+            # The rebuild task hasn't started.
+            return False
+
+        if (
+            (self.initiated and self.finished)
+            or (self.initiated_in_place and self.finished_in_place)
+        ):
+            # The rebuild task completed.
+            return False
+
+        if not flower_url:
+            # We are unable to find out about the rebuild task.
+            return None
+
+        rebuild_tasks = sorted(iter_tasks(), key=lambda t: t['started'])
+        if rebuild_tasks:
+            # Return True if the last task failed, otherwise return False.
+            # See https://docs.celeryq.dev/en/stable/reference/celery.result.html#celery.result.AsyncResult.state
+            return rebuild_tasks[-1]['state'] == 'FAILURE'
+
+        # The rebuild is not finished and the task is not found. It must
+        # have died.
+        return True
 
 
 class DataSourceMeta(DocumentSchema):
@@ -676,6 +743,13 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
                 raise BadSpecError("Primary key columns must have is_primary_key set to true", self.data_source_id)
             columns = self.sql_settings.primary_key
         return columns
+
+    @cached_property
+    def rebuild_failed(self):
+        # `has_died()` returns `None` if we can't use the Flower API,
+        # and so we don't know. Treating `None` as falsy allows calling
+        # code to give `rebuild_has_died` the benefit of the doubt.
+        return self.meta.build.rebuild_failed(self._id)
 
 
 class RegistryDataSourceConfiguration(DataSourceConfiguration):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -9,6 +9,7 @@ from corehq import toggles
 from datetime import datetime, timedelta
 from uuid import UUID
 
+from celery.states import FAILURE
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.serializers.json import DjangoJSONEncoder
@@ -265,8 +266,7 @@ class DataSourceBuildInformation(DocumentSchema):
         rebuild_tasks = sorted(iter_tasks(), key=lambda t: t['started'])
         if rebuild_tasks:
             # Return True if the last task failed, otherwise return False.
-            # See https://docs.celeryq.dev/en/stable/reference/celery.result.html#celery.result.AsyncResult.state
-            return rebuild_tasks[-1]['state'] == 'FAILURE'
+            return rebuild_tasks[-1]['state'] == FAILURE
 
         # The rebuild is not finished and the task is not found. It must
         # have died.

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -7,10 +7,11 @@
   {% if data_source.meta.build.is_rebuild_in_progress %}
         <div id="built-warning" class="alert alert-warning">
           <h4><i class="fa fa-exclamation-triangle"></i>
-          {% if data_source.meta.build.is_rebuilding %}
+          {% if data_source.rebuild_failed %}
+            {% trans "Populating your report did not complete successfully." %}
+          {% elif data_source.meta.build.is_rebuilding %}
             {% trans "Please note that this datasource is being rebuilt." %}
-          {% endif %}
-          {% if data_source.meta.build.is_rebuilding_in_place %}
+          {% elif data_source.meta.build.is_rebuilding_in_place %}
             {% trans "Please note that this datasource is being rebuilt in place." %}
           {% endif %}
           </h4>

--- a/corehq/apps/userreports/templates/userreports/partials/build_in_progress_warning.html
+++ b/corehq/apps/userreports/templates/userreports/partials/build_in_progress_warning.html
@@ -1,9 +1,19 @@
 {% load i18n %}
-{% if not data_source_config.is_static and data_source_config.meta.build.is_rebuild_in_progress  %}
+{% if not data_source_config.is_static %}
+  {% if data_source_config.rebuild_failed %}
+      <div id="built-warning" class="alert alert-warning">
+        <h4>
+          <i class="fa fa-exclamation-triangle"></i>
+          {% trans "Populating your report did not complete successfully." %}
+        </h4>
+        {% trans 'You can try clicking "Advanced" and choosing "Resume Build".' %}
+      </div>
+  {% elif data_source_config.meta.build.is_rebuild_in_progress %}
       <div id="built-warning" class="alert alert-warning">
         <h4><i class="fa fa-exclamation-triangle"></i> {% trans "Your report is still being populated." %}</h4>
         {% blocktrans %}
           What you are seeing now is just a preview, and contains some or none of your data.
         {% endblocktrans %}
       </div>
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
## Technical Summary

Prompted by [this forum post](https://forum.dimagi.com/t/ucr-building-getting-stuck-after-reaching-a-certain-number/9849/10).

When checking the status of a UCR data source, this adds a check to see whether the rebuild has failed.

If the Flower API is available, it fetches the tasks for the rebuild and checks whether the most recent task has failed. If the user kicks off multiple rebuilds within a minute, the API will return multiple tasks. Only the last one is checked for failure.

If the Flower API is not available, the UI assumes the task completed successfully.

## Feature Flag
N/A

## Safety Assurance

### Safety story

Tested on Staging.

### Automated test coverage

Not included.

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
