### PR TITLE
Fixed "search again" workflow for case tiles

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -71,11 +71,8 @@ class CaseTileHelper(object):
         # Add case search action if needed
         if module_offers_search(self.module) and not module_uses_inline_search(self.module):
             from corehq.apps.app_manager.suite_xml.sections.details import DetailContributor
-            in_search = module_loads_registry_case(self.module) or "search" in self.detail_id
             detail.actions.append(
-                DetailContributor.get_case_search_action(self.module,
-                                                         self.build_profile_id,
-                                                         in_search=in_search)
+                DetailContributor.get_case_search_action(self.module, self.build_profile_id, self.detail_id)
             )
 
         return detail

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -41,10 +41,11 @@ def case_tile_template_config(template):
 
 
 class CaseTileHelper(object):
-    def __init__(self, app, module, detail, detail_type, build_profile_id):
+    def __init__(self, app, module, detail, detail_id, detail_type, build_profile_id):
         self.app = app
         self.module = module
         self.detail = detail
+        self.detail_id = detail_id
         self.detail_type = detail_type
         self.cols_by_tile_field = {col.case_tile_field: col for col in self.detail.columns}
         self.build_profile_id = build_profile_id
@@ -70,7 +71,7 @@ class CaseTileHelper(object):
         # Add case search action if needed
         if module_offers_search(self.module) and not module_uses_inline_search(self.module):
             from corehq.apps.app_manager.suite_xml.sections.details import DetailContributor
-            in_search = module_loads_registry_case(self.module)
+            in_search = module_loads_registry_case(self.module) or "search" in self.detail_id
             detail.actions.append(
                 DetailContributor.get_case_search_action(self.module,
                                                          self.build_profile_id,

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -108,9 +108,10 @@ class DetailContributor(SectionContributor):
                             include_sort=detail_type.endswith('short'),
                         )  # list of DetailColumnInfo named tuples
                     if detail_column_infos:
+                        detail_id = id_strings.detail(module, detail_type)
                         if detail.case_tile_template:
                             helper = CaseTileHelper(self.app, module, detail,
-                                                    detail_type, self.build_profile_id)
+                                                    detail_id, detail_type, self.build_profile_id)
                             elements.append(helper.build_case_tile_detail())
                         else:
                             print_template_path = None
@@ -124,7 +125,7 @@ class DetailContributor(SectionContributor):
                                 detail,
                                 detail_column_infos,
                                 tabs=list(detail.get_tabs()),
-                                id=id_strings.detail(module, detail_type),
+                                id=detail_id,
                                 title=title,
                                 print_template=print_template_path,
                             )

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -234,11 +234,8 @@ class DetailContributor(SectionContributor):
                         d.actions.append(self._get_case_list_form_action(module))
 
                 if module_offers_search(module) and not module_uses_inline_search(module):
-                    in_search = module_loads_registry_case(module) or "search" in id
                     d.actions.append(
-                        DetailContributor.get_case_search_action(module,
-                                                                 self.build_profile_id,
-                                                                 in_search=in_search)
+                        DetailContributor.get_case_search_action(module, self.build_profile_id, id)
                     )
 
             try:
@@ -366,7 +363,8 @@ class DetailContributor(SectionContributor):
         return action
 
     @staticmethod
-    def get_case_search_action(module, build_profile_id, in_search=False):
+    def get_case_search_action(module, build_profile_id, detail_id):
+        in_search = module_loads_registry_case(module) or "search" in detail_id
         action_kwargs = DetailContributor._get_action_kwargs(module, in_search)
         if in_search:
             search_label = module.search_config.search_again_label

--- a/corehq/apps/app_manager/tests/test_suite_case_tiles.py
+++ b/corehq/apps/app_manager/tests/test_suite_case_tiles.py
@@ -406,6 +406,7 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
         form.xmlns = 'http://id_m0-f0'
         form.requires = 'case'
 
+        # case list detail
         self.assertXmlPartialEqual(
             """
             <partial>
@@ -428,4 +429,28 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
             app.create_suite(),
             # action[1] is the reg from case list action hard-coded into the default template
             "detail[@id='m0_case_short']/action[2]",
+        )
+
+        # case search detail
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+              <action redo_last="true" auto_launch="false()">
+                <display>
+                  <text>
+                    <locale id="case_search.m0.again"/>
+                  </text>
+                </display>
+                <stack>
+                  <push>
+                    <mark/>
+                    <command value="'search_command.m0'"/>
+                  </push>
+                </stack>
+              </action>
+            </partial>
+            """,
+            app.create_suite(),
+            # action[1] is the reg from case list action hard-coded into the default template
+            "detail[@id='m0_search_short']/action[2]",
         )


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-3247

Followup for https://github.com/dimagi/commcare-hq/pull/32974, which did not properly handle (or, coincidentally, test) the search again workflow.

## Feature Flag
Case search & claim + REC case tiles

## Safety Assurance

### Safety story
Small change, with tests, to a rarely-used combination of feature flags.

### Automated test coverage

In PR.

### QA Plan

This was reported by QA, so I'll ask them to verify, but I'm not going to block merge on QA, as the change is low risk and the workflow is already quite broken.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
