### PR TITLE
Application error report GA

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -131,7 +131,8 @@ advanced_v0 = pro_v1 + [
     privileges.APP_USER_PROFILES,
     privileges.VIEW_APP_DIFF,
     privileges.LOCATION_SAFE_CASE_IMPORTS,
-    privileges.FILTERED_BULK_USER_DOWNLOAD
+    privileges.FILTERED_BULK_USER_DOWNLOAD,
+    privileges.APPLICATION_ERROR_REPORT,
 ]
 
 enterprise_v0 = advanced_v0 + [

--- a/corehq/apps/accounting/migrations/0075_application_error_report_priv.py
+++ b/corehq/apps/accounting/migrations/0075_application_error_report_priv.py
@@ -1,0 +1,39 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.privileges import APPLICATION_ERROR_REPORT
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _grandfather_application_error_report_priv(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+
+    # APPLICATION_ERROR_REPORT are Advanced Plan and higher
+    skip_editions = ','.join((
+        SoftwarePlanEdition.PAUSED,
+        SoftwarePlanEdition.COMMUNITY,
+        SoftwarePlanEdition.STANDARD,
+        SoftwarePlanEdition.PRO
+    ))
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        APPLICATION_ERROR_REPORT,
+        skip_edition=skip_editions,
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0074_filtered_bulk_user_download_priv'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _grandfather_application_error_report_priv,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -174,7 +174,7 @@
           <span data-bind="text: menu_item_label()"></span>
           <!--/ko-->
           <span data-bind="if: !built_with.signed()">{% trans "Unsigned Jar" %}</span>
-          {% if request|request_has_privilege:"APPLICATION_ERROR_REPORT" or user.is_superuser or user.is_dimagi %}
+          {% if has_application_error_report_access %}
             | <a class="release-error-report-link" data-bind="text: numErrorsText,
                               attr: {href: $root.app_error_url('{{ app.id }}', version())}"></a>
           {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -174,7 +174,7 @@
           <span data-bind="text: menu_item_label()"></span>
           <!--/ko-->
           <span data-bind="if: !built_with.signed()">{% trans "Unsigned Jar" %}</span>
-          {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
+          {% if request|request_has_privilege:"APPLICATION_ERROR_REPORT" or user.is_superuser or user.is_dimagi %}
             | <a class="release-error-report-link" data-bind="text: numErrorsText,
                               attr: {href: $root.app_error_url('{{ app.id }}', version())}"></a>
           {% endif %}

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -174,7 +174,12 @@ def paginate_releases(request, domain, app_id):
             for app in apps
         ]
 
-    if toggles.APPLICATION_ERROR_REPORT.enabled(request.couch_user.username):
+    application_error_report_access = (
+        domain_has_privilege(domain, privileges.APPLICATION_ERROR_REPORT)
+        or request.couch_user.is_superuser
+        or request.couch_user.is_dimagi
+    )
+    if application_error_report_access:
         versions = [app['version'] for app in saved_apps]
         num_errors_dict = _get_error_counts(domain, app_id, versions)
         for app in saved_apps:

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -175,7 +175,7 @@ def paginate_releases(request, domain, app_id):
             for app in apps
         ]
 
-    if ApplicationErrorReport.show_in_navigation(domain, None, request.couch_user):
+    if ApplicationErrorReport.has_access(domain, request.couch_user):
         versions = [app['version'] for app in saved_apps]
         num_errors_dict = _get_error_counts(domain, app_id, versions)
         for app in saved_apps:
@@ -219,7 +219,7 @@ def get_releases_context(request, domain, app_id):
         'can_edit_apps': request.couch_user.can_edit_apps(),
         'can_view_app_diff': (domain_has_privilege(domain, privileges.VIEW_APP_DIFF)
                               or request.user.is_superuser),
-        'has_application_error_report_access': ApplicationErrorReport.show_in_navigation(domain, None, request.couch_user)
+        'has_application_error_report_access': ApplicationErrorReport.has_access(domain, request.couch_user)
     }
     if not app.is_remote_app():
         context.update({

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -215,7 +215,10 @@ class Command(BaseCommand):
         Role(slug=privileges.FILTERED_BULK_USER_DOWNLOAD,
              name='Bulk user management features',
              description='For mobile users, enables bulk deletion page and bulk lookup page. '
-                         'For web users, enables filtered download page.')
+                         'For web users, enables filtered download page.'),
+        Role(slug=privileges.APPLICATION_ERROR_REPORT,
+             name='Application error report',
+             description='Show Application Error Report'),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -555,6 +555,10 @@ class ApplicationErrorReport(GenericTabularReport, ProjectReport):
 
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):
+        return cls.has_access(domain, user)
+
+    @classmethod
+    def has_access(cls, domain=None, user=None):
         domain_access = (
             domain_has_privilege(domain, privileges.APPLICATION_ERROR_REPORT)
             if domain else False

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -17,7 +17,8 @@ from dimagi.utils.dates import safe_strftime
 from dimagi.utils.parsing import string_to_utc_datetime
 from phonelog.models import UserErrorEntry
 
-from corehq import toggles
+from corehq import toggles, privileges
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
     get_brief_apps_in_domain,
@@ -554,7 +555,15 @@ class ApplicationErrorReport(GenericTabularReport, ProjectReport):
 
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):
-        return user and toggles.APPLICATION_ERROR_REPORT.enabled(user.username)
+        domain_access = (
+            domain_has_privilege(domain, privileges.APPLICATION_ERROR_REPORT)
+            if domain else False
+        )
+        user_access = (
+            user.is_superuser or user.is_dimagi
+            if user else False
+        )
+        return user and (domain_access or user_access)
 
     @property
     def shared_pagination_GET_params(self):

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -109,6 +109,8 @@ EXPORT_OWNERSHIP = 'export_ownership'
 
 FILTERED_BULK_USER_DOWNLOAD = 'filtered_bulk_user_download'
 
+APPLICATION_ERROR_REPORT = 'application_error_report'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -166,7 +168,8 @@ MAX_PRIVILEGES = [
     FORM_CASE_IDS_CASE_IMPORTER,
     EXPORT_MULTISORT,
     EXPORT_OWNERSHIP,
-    FILTERED_BULK_USER_DOWNLOAD
+    FILTERED_BULK_USER_DOWNLOAD,
+    APPLICATION_ERROR_REPORT,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -239,5 +242,6 @@ class Titles(object):
             FORM_CASE_IDS_CASE_IMPORTER: _("Download buttons for Form- and Case IDs on Case Importer"),
             EXPORT_MULTISORT: _("Sort multiple rows in exports simultaneously"),
             EXPORT_OWNERSHIP: _("Allow exports to have ownership"),
-            FILTERED_BULK_USER_DOWNLOAD: _("Bulk user management features")
+            FILTERED_BULK_USER_DOWNLOAD: _("Bulk user management features"),
+            APPLICATION_ERROR_REPORT: _("Application error report"),
         }.get(privilege, privilege)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1285,14 +1285,6 @@ CUSTOM_ASSERTIONS = StaticToggle(
     help_link="https://confluence.dimagi.com/display/saas/User+defined+assert+blocks",
 )
 
-APPLICATION_ERROR_REPORT = StaticToggle(
-    'application_error_report',
-    'Show Application Error Report',
-    TAG_SOLUTIONS_OPEN,
-    help_link='https://confluence.dimagi.com/display/saas/Show+Application+Error+Report+Feature+Flag',
-    namespaces=[NAMESPACE_USER],
-)
-
 OPENMRS_INTEGRATION = StaticToggle(
     'openmrs_integration',
     'Enable OpenMRS integration',
@@ -2518,4 +2510,15 @@ FILTERED_BULK_USER_DOWNLOAD = FrozenPrivilegeToggle(
     """,
     # TODO: Move to public wiki
     help_link='https://confluence.dimagi.com/display/saas/Bulk+User+Management'
+)
+
+APPLICATION_ERROR_REPORT = FrozenPrivilegeToggle(
+    privileges.APPLICATION_ERROR_REPORT,
+    'application_error_report',
+    label='Show Application Error Report',
+    tag=TAG_SOLUTIONS_OPEN,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="Show Application Error Report.",
+    # TODO: Move to public wiki
+    help_link='https://confluence.dimagi.com/display/saas/Show+Application+Error+Report+Feature+Flag'
 )

--- a/migrations.lock
+++ b/migrations.lock
@@ -94,6 +94,7 @@ accounting
  0072_export_multisort_priv
  0073_export_ownership_priv
  0074_filtered_bulk_user_download_priv
+ 0075_application_error_report_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2821).

This change moves the `APPLICATION_ERROR_REPORT` feature flag to general availability for the Advanced Plan and higher. One thing to note is that this feature flag has been moved from being enabled on a per-user to a per-domain basis. Since this feature flag was mostly used by Dimagi staff, to retain the original functionality, there are extra conditional checks to enable this feature if the domain has privilege OR if the user is a superuser/dimagi staff member.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`APPLICATION_ERROR_REPORT` which has been changed to a privilege.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

No, as the migration requires the created privilege to exist in the code to be able to bootstrap correctly.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

The following will need to be manually reverted when doing a rollback:
- The newly created Role (select * from django_prbac_role rle where rle.slug = 'application_error_report' )
- The grant records created for this (select * from django_prbac_grant where to_role_id = {{ django_prbac_role id }})

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
