### PR TITLE
Removes Null users from Login/Logout API Response

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1064,7 +1064,7 @@ class NavigationEventAuditResource(HqBaseResource, Resource):
     local_date = fields.DateField(attribute='local_date', readonly=True)
     UTC_start_time = fields.DateTimeField(attribute='UTC_start_time', readonly=True)
     UTC_end_time = fields.DateTimeField(attribute='UTC_end_time', readonly=True)
-    user = fields.CharField(attribute='user', readonly=True, null=True)
+    user = fields.CharField(attribute='user', readonly=True)
 
     class Meta:
         authentication = RequirePermissionAuthentication(HqPermissions.view_web_users)

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1195,6 +1195,7 @@ class NavigationEventAuditResource(HqBaseResource, Resource):
         local_date_filter = cls._get_compound_filter('local_date', params)
 
         results = (queryset
+                .exclude(user__isnull=True)
                 .annotate(local_date=TruncDate('event_date', tzinfo=local_timezone))
                 .filter(local_date_filter)
                 .values('local_date', 'user'))

--- a/corehq/apps/api/tests/audit_resources.py
+++ b/corehq/apps/api/tests/audit_resources.py
@@ -63,6 +63,7 @@ class TestNavigationEventAuditResource(APIResourceTest):
         for single_datetime in cls._daterange(datetime(2023, 5, 2, 0), datetime(2023, 5, 2, 23)):
             cls.domain1_audits.create_event(cls.username1, single_datetime)
             cls.domain1_audits.create_event(cls.username2, single_datetime)
+            cls.domain1_audits.create_event(None, single_datetime)
 
         for single_datetime in cls._daterange(datetime(2023, 6, 1, 0), datetime(2023, 6, 1, 23)):
             cls.domain2_audits.create_event(cls.username3, single_datetime)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Excludes "null" users from response.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Bug found from https://dimagi-dev.atlassian.net/browse/QA-5209 and related to https://github.com/dimagi/commcare-hq/pull/32922

Response objects are sorted first by local date, then by user in ascending order. When sorted by user,  `null` users are ordered to be on the bottom. For example, the response order would be user1: [sam@dimagi.com](mailto:sam@dimagi.com), user2: null. But when using the cursor, we filter for users > cursor_user to get objects after the current cursor. But in this comparison, null seems to be treated as a string so if the cursor is at [sam@dimagi.com](mailto:sam@dimagi.com), it would skip user2: null since “s” comes after “n”.

Users are logged as `null` when action is taken on a login page since no user is associated with the action. This data point is not relevant so can be removed. This will also improve performance since the exclusion occurs before annotation and aggregation.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
 The change is limited to users who have ACTION_TIMES_API flag which will be very few as of this moment.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Adds null user to existing unit tests to ensure it is handled.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Continuation of https://dimagi-dev.atlassian.net/browse/QA-5106

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [X] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
