### PR TITLE
Updated logic for search again button

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -78,9 +78,8 @@ class CaseTileHelper(object):
         # Add case search action if needed
         if module_offers_search(self.module) and not module_uses_inline_search(self.module):
             from corehq.apps.app_manager.suite_xml.sections.details import DetailContributor
-            in_search = module_loads_registry_case(self.module)
             # don't add search again action in split screen
-            if not (toggles.SPLIT_SCREEN_CASE_SEARCH.enabled(self.app.domain) and in_search):
+            if not toggles.SPLIT_SCREEN_CASE_SEARCH.enabled(self.app.domain):
                 detail.actions.append(
                     DetailContributor.get_case_search_action(self.module, self.build_profile_id, self.detail_id)
                 )


### PR DESCRIPTION
## Technical Summary
Marked invisible because this is a PR into https://github.com/dimagi/commcare-hq/pull/33060

Fixing a compatibility issue between https://github.com/dimagi/commcare-hq/pull/32972 , which updated some logic that referenced `in_search`, and https://github.com/dimagi/commcare-hq/pull/33064/ , which moved the `in_search` into `get_case_search_action`. This is [breaking](https://dimagi.sentry.io/issues/4236896049/?environment=staging&project=136860&query=is%3Aunresolved&referrer=issue-stream&stream_index=2) app builds on staging for apps that use case tiles.

I'm not positive this logic is correct, that we don't want to add any search-related action in split screen, I don't totally recall how the various case search workflows are all supposed to work with split screen. [This conversation](https://github.com/dimagi/commcare-hq/pull/33060/commits/1c0353a5eae1f900b3472e6936b0155009759f33#r1218440974) might also be relevant.

## Feature Flag
REC case tile

## Safety Assurance

### Safety story, etc.
N/A, this isn't being merged into master