### PR TITLE
Add invisible field for adding to the map

### DIFF
--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_one_two.json
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_one_two.json
@@ -1,5 +1,5 @@
 {
     "slug": "one_one_two",
     "filename": "one_one_two.xml",
-    "fields": ["title", "top", "bottom_left", "bottom_right"]
+    "fields": ["title", "top", "bottom_left", "bottom_right", "map"]
 }

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_one_two.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_one_two.xml
@@ -107,4 +107,27 @@
             </text>
         </template>
     </field>
+    <field>
+        <style
+            horz-align="left"
+            vert-align="center"
+            font-size="medium">
+            <grid
+                grid-height="1"
+                grid-width="5"
+                grid-x="6"
+                grid-y="2"/>
+        </style>
+        <header>
+            <text>
+            </text>
+        </header>
+        <template form="address" width="0">
+            <text>
+                <xpath function="{map[xpath_function]}">
+                    {map[variables]}
+                </xpath>
+            </text>
+        </template>
+    </field>
 </detail>

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -22,7 +22,7 @@ TILE_DIR = Path(__file__).parent.parent / "case_tile_templates"
 
 class CaseTileTemplates(models.TextChoices):
     PERSON_SIMPLE = ("person_simple", _("Person Simple"))
-    ONE_ONE_TWO = ("one_one_two", _("One one two"))
+    ONE_ONE_TWO = ("one_one_two", _("Title row, subtitle row, third row with two cells, and map"))
 
 
 @dataclass


### PR DESCRIPTION
## Product Description

* Add invisible field for map coordinates to one one two case tile template
* Rename the template in the drop down 

## Technical Summary
Base on this [chat](https://dimagi.slack.com/archives/C057VEUA8HX/p1686579488616809).

## Feature Flag
None

## Safety Assurance

### Safety story
Tried it out locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

1. For exiting case lists using the template show new name in drop down
2. Require additional field on saving
3. Show pins according the new map field

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
