### PR TITLE
[es] Swap indexes even if multiplexer is turned off

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -1319,17 +1319,17 @@ def create_document_adapter(cls, index_name, type_, *, secondary=None):
     provided.
 
     One thing to note here is that the behaviour of the function can be altered with django settings.
-    If ES_<app_name>_INDEX_SWAPPED is set to True, then primary index will act as secondary index and vice versa.
-    ES_<app_name>_INDEX_SWAPPED will be ignored if ES_<app_name>_INDEX_MULTIPLEXED is set to False
 
-    The function would return multiplexed adapter only in one case
+    The function would return multiplexed adapter only if
     - ES_<app name>_INDEX_MULTIPLEXED is True
     - Secondary index is provided.
 
-    And the indexes would only be swapped if
-    - ES_<app_name>_INDEX_MULTIPLEXED is set to True
+    The indexes would only be swapped only if
     - ES_<app_name>_INDEX_SWAPPED is set to True
     - secondary index is provided
+
+    If both ES_<app name>_INDEX_MULTIPLEXED and ES_<app_name>_INDEX_SWAPPED are set to True
+    then primary index will act as secondary index and vice versa.
 
     :param cls: an ``ElasticDocumentAdapter`` subclass
     :param index_name: the name of the index that the adapter interacts with
@@ -1339,7 +1339,7 @@ def create_document_adapter(cls, index_name, type_, *, secondary=None):
         If an index name is provided and ES_<app name>_INDEX_MULTIPLEXED is set to True,
         then returned adapter will be an instance of ``ElasticMultiplexAdapter``.
         If ``None`` (the default), the returned adapter will be an instance of ``cls``.
-        ES_<app name>_INDEX_MULTIPLEXED will be ignored in this case.
+        ES_<app name>_INDEX_MULTIPLEXED will be ignored if secondary is None.
     :returns: a document adapter instance.
     """
     def runtime_name(name):
@@ -1356,12 +1356,17 @@ def create_document_adapter(cls, index_name, type_, *, secondary=None):
 
     doc_adapter = cls(runtime_name(index_name), type_)
 
-    if secondary is not None and index_multiplexed(cls):
-        secondary_adapter = cls(runtime_name(secondary), type_)
-        if index_swapped(cls):
-            doc_adapter = ElasticMultiplexAdapter(secondary_adapter, doc_adapter)
-        else:
-            doc_adapter = ElasticMultiplexAdapter(doc_adapter, secondary_adapter)
+    if secondary is None:
+        return doc_adapter
+
+    secondary_adapter = cls(runtime_name(secondary), type_)
+
+    if index_multiplexed(cls) and index_swapped(cls):
+        doc_adapter = ElasticMultiplexAdapter(secondary_adapter, doc_adapter)
+    elif index_multiplexed(cls):
+        doc_adapter = ElasticMultiplexAdapter(doc_adapter, secondary_adapter)
+    elif index_swapped(cls):
+        doc_adapter = secondary_adapter
 
     return doc_adapter
 

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -1324,7 +1324,7 @@ def create_document_adapter(cls, index_name, type_, *, secondary=None):
     - ES_<app name>_INDEX_MULTIPLEXED is True
     - Secondary index is provided.
 
-    The indexes would only be swapped only if
+    The indexes would be swapped only if
     - ES_<app_name>_INDEX_SWAPPED is set to True
     - secondary index is provided
 

--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -2038,6 +2038,7 @@ class TestCreateDocumentAdapter(SimpleTestCase):
             secondary="some-secondary",
         )
         self.assertEqual(type(test_adapter), TestDocumentAdapter)
+        self.assertEqual(test_adapter.index_name, 'test_some-primary')
 
     @override_settings(ES_FOR_TEST_INDEX_MULTIPLEXED=True)
     def test_returns_multiplexer_adapter_with_multiplexed_setting(self):
@@ -2048,6 +2049,8 @@ class TestCreateDocumentAdapter(SimpleTestCase):
             secondary="some-secondary",
         )
         self.assertEqual(type(test_adapter), ElasticMultiplexAdapter)
+        self.assertEqual(test_adapter.index_name, 'test_some-primary')
+        self.assertEqual(test_adapter.secondary.index_name, 'test_some-secondary')
 
     @override_settings(ES_FOR_TEST_INDEX_MULTIPLEXED=True)
     @override_settings(ES_FOR_TEST_INDEX_SWAPPED=True)
@@ -2061,6 +2064,18 @@ class TestCreateDocumentAdapter(SimpleTestCase):
         self.assertEqual(type(test_adapter), ElasticMultiplexAdapter)
         self.assertEqual(test_adapter.primary.index_name, "test_some-secondary")
         self.assertEqual(test_adapter.secondary.index_name, "test_some-primary")
+
+    @override_settings(ES_FOR_TEST_INDEX_MULTIPLEXED=False)
+    @override_settings(ES_FOR_TEST_INDEX_SWAPPED=True)
+    def test_returns_doc_adapater_with_secondary_index(self):
+        test_adapter = create_document_adapter(
+            TestDocumentAdapter,
+            "some-primary",
+            "test_doc",
+            secondary="some-secondary",
+        )
+        self.assertEqual(type(test_adapter), TestDocumentAdapter)
+        self.assertEqual(test_adapter.index_name, "test_some-secondary")
 
     @override_settings(ES_FOR_TEST_INDEX_MULTIPLEXED=True)
     @override_settings(ES_FOR_TEST_INDEX_SWAPPED=True)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When we built configurable multiplexer https://github.com/dimagi/commcare-hq/pull/33021, we designed it a way that only multiplexed indexes can be swapped. But after thinking more about it, I realised that swapping non-multiplexed indexes would give us freedom to upgrade index wise and we would have the flexibility to get on to the newer indexes and stop writing the older indexes.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14612
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Changes are safe and are covered by tests.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Changes covered by test
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
