### PR TITLE
Add super-linter to github actions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 115
 # http://pep8.readthedocs.org/en/latest/intro.html#error-codes
-ignore = E128, E265, F403, W503, W1618
+ignore = E128, E265, F403, W503
 per-file-ignores =
     **/migrations/*.py: E501, E303

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,34 @@
+---
+name: Lint Code Base
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v5
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          VALIDATE_JAVASCRIPT_ES: true
+          JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.yml
+          VALIDATE_PYTHON_FLAKE8: true
+          PYTHON_FLAKE8_CONFIG_FILE: .flake8
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IGNORE_GITIGNORED_FILES: true


### PR DESCRIPTION
This PR adds Super-Linter to the repo as a replacement for StickerCI.

Super-Linter automatically determines the PR diff files and runs the specified linters on only those files. The output is being displayed in the github actions console. The rules can be configured in the configuration files specified by the respective `<linter>_CONFIG_FILE` settings. Currently it's using the same .flake8 and .eslintrc.yml files that I presume Stickler was using.

More details [here](https://docs.google.com/document/d/10_-FB6BqC0tqRR0VeoTmkQuKYjkmIpvykwXCuDUKfvU/edit#heading=h.z4yuw6ps0ygd).

For future readers, [this document](https://docs.google.com/document/d/10Fh6Ks1LxlyKPtedTo3TxTQAtv0o9xHHGc7TF9qzFDc/edit) specifies how to add super-linter to other repos and configure custom rules.