### PR TITLE
Change super-linter action

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v5
+        uses: super-linter/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master


### PR DESCRIPTION
This change is to use the [official](https://github.com/super-linter/super-linter) super-linter action. Turns out `github/super-linter@v5` is an old one.