### PR TITLE
Use eval_lazy before getting object type on lazy objects

### DIFF
--- a/corehq/apps/userreports/expressions/evaluator/main.py
+++ b/corehq/apps/userreports/expressions/evaluator/main.py
@@ -5,6 +5,7 @@ import operator
 from datetime import date, datetime
 from decimal import Decimal
 
+from corehq.util import eval_lazy
 from simpleeval import (
     DEFAULT_OPERATORS,
     FeatureNotAvailable,
@@ -72,7 +73,7 @@ def eval_statements(statement, variable_context, execution_context=None):
         variable_context: a dict with variable names as key and assigned values as dict values
     """
     execution_context = execution_context or EvalExecutionContext.empty()
-    var_types = set(type(value) for value in variable_context.values())
+    var_types = set(type(eval_lazy(value)) for value in variable_context.values())
     if not var_types.issubset(SAFE_TYPES):
         raise InvalidExpression('Context contains disallowed types')
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-2864

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The eval_statements is returning None due to an exception being swallowed up from `InvalidExpression`



## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
There is good test coverage for eval_statements.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations
UCRs that use eval_statements will have to be rebuilt

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
