### PR TITLE
Align behavior of "childextension" cases

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -5,6 +5,9 @@ Example case graphs with outcomes:
    a   <--ext-- d(owned) >> a b d
        <--ext-- b
 
+   a(owned)    <--chi-- e >> a
+               <--ext-- e
+
    e(owned)    --ext--> a(closed) >> a b e
                --ext--> b
 
@@ -26,7 +29,10 @@ from collections import defaultdict
 from functools import partial, wraps
 from itertools import chain, islice
 
-from casexml.apps.case.const import CASE_INDEX_EXTENSION as EXTENSION
+from casexml.apps.case.const import (
+    CASE_INDEX_CHILD as CHILD,
+    CASE_INDEX_EXTENSION as EXTENSION,
+)
 from casexml.apps.phone.const import ASYNC_RETRY_AFTER
 from casexml.apps.phone.tasks import ASYNC_RESTORE_SENT
 
@@ -213,7 +219,9 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
             # hosts_by_extension since both are live and therefore this index
             # will not need to be traversed in other liveness calculations.
         elif relationship == EXTENSION:
-            if sub_id in open_ids:
+            if sub_id in open_ids and sub_id not in children_by_parent[ref_id]:
+                # A case that is both a child and an extension is not an
+                # extension.
                 if ref_id in live_ids:
                     # sub is open and is the extension of a live case
                     enliven(sub_id)
@@ -224,7 +232,7 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
                     extensions_by_host[ref_id].add(sub_id)
                     hosts_by_extension[sub_id].add(ref_id)
             else:
-                return IGNORE  # closed extension
+                return IGNORE  # closed extension or extension is child
         elif sub_id in owned_ids:
             # sub is owned and available (open and not an extension case)
             enliven(sub_id)
@@ -274,6 +282,11 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
     def filter_deleted_indices(related):
         return [index for index in related if index.referenced_id]
 
+    def populate_children_by_parent(related):
+        for index in related:
+            if index.relationship == CHILD:
+                children_by_parent[index.referenced_id].add(index.case_id)
+
     IGNORE = object()
     debug = logging.getLogger(__name__).debug
 
@@ -283,6 +296,7 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
     extensions_by_host = defaultdict(set)  # host_id -> (open) extension_ids
     hosts_by_extension = defaultdict(set)  # (open) extension_id -> host_ids
     parents_by_child = defaultdict(set)    # child_id -> parent_ids
+    children_by_parent = defaultdict(set)  # parent_id -> (open) child_id
     indices = defaultdict(list)  # case_id -> list of CommCareCaseIndex-like, used as a cache for later
     seen_ix = defaultdict(set)   # case_id -> set of '<index.case_id> <index.identifier>'
 
@@ -299,6 +313,7 @@ def get_live_case_ids_and_indices(domain, owned_ids, timing_context):
 
             populate_indices(related)
             related_not_deleted = filter_deleted_indices(related)
+            populate_children_by_parent(related_not_deleted)
             update_open_and_deleted_ids(related_not_deleted)
             next_ids = {classify(index, next_ids)
                         for index in related_not_deleted

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -945,7 +945,7 @@ class SimplifiedSyncLog(AbstractSyncLog):
                 made_changes = True
 
             for update in non_live_updates_by_case_id[case_id]:
-                if update.has_extension_indices_to_add():
+                if update.extension_indices_to_add:
                     # non-live cases with extension indices should be added and processed
                     self.case_ids_on_phone.add(update.case_id)
                     for index in update.indices_to_add:
@@ -995,11 +995,24 @@ class CaseUpdate:
 
     @property
     def extension_indices_to_add(self):
-        return [index for index in self.indices_to_add
-                if index.relationship == const.CASE_INDEX_EXTENSION]
-
-    def has_extension_indices_to_add(self):
-        return len(self.extension_indices_to_add) > 0
+        # According to commcare-core, and
+        # casexml/apps/phone/data_providers/case/livequery.py::
+        #
+        #     def is_extension(case_id):
+        #         # A case that is both a child and an extension is not
+        #         # an extension.
+        #
+        # More info: https://dimagi-dev.atlassian.net/browse/SC-1725
+        parent_ids = {
+            index.referenced_id for index in self.indices_to_add
+            if index.relationship == const.CASE_INDEX_CHILD
+        }
+        return [
+            index for index in self.indices_to_add if (
+                index.relationship == const.CASE_INDEX_EXTENSION
+                and index.referenced_id not in parent_ids
+            )
+        ]
 
     @property
     def is_live(self):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/data/case_relationship_tests.json
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/data/case_relationship_tests.json
@@ -964,6 +964,21 @@
         "outcome": [
             "L", "B", "C", "D", "E"
         ]
+    },
+    {
+        "name": "extension_and_child_relationship",
+        "owned": [
+            "parent"
+        ],
+        "subcases": [
+            ["child_and_extension", "parent"]
+        ],
+        "extensions": [
+            ["child_and_extension", "parent"]
+        ],
+        "outcome": [
+            "parent"
+        ]
     }
 
 ]

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -852,6 +852,7 @@ class ExtensionCasesSyncTokenUpdates(BaseSyncTest):
         """
         case_type = 'case'
         host = CaseStructure(case_id='host', attrs={'create': True})
+        parent = CaseStructure(case_id='parent', attrs={'create': True})
         extension = CaseStructure(
             case_id='extension',
             attrs={'create': True, 'owner_id': '-'},
@@ -861,7 +862,7 @@ class ExtensionCasesSyncTokenUpdates(BaseSyncTest):
                 relationship='extension',
                 related_type=case_type,
             ), CaseIndex(
-                CaseStructure(case_id=host.case_id, attrs={'create': False}),
+                parent,
                 identifier='child',
                 relationship='child',
                 related_type=case_type,
@@ -870,7 +871,7 @@ class ExtensionCasesSyncTokenUpdates(BaseSyncTest):
         self.device.post_changes(extension)
         sync_log = self.device.last_sync.get_log()
         self.assertDictEqual(sync_log.index_tree.indices,
-                             {extension.case_id: {'child': host.case_id}})
+                             {extension.case_id: {'child': parent.case_id}})
         self.assertDictEqual(sync_log.extension_index_tree.indices,
                              {extension.case_id: {'host': host.case_id}})
 

--- a/corehq/sql_accessors/migrations/0067_livequery_sql_include_child_indices.py
+++ b/corehq/sql_accessors/migrations/0067_livequery_sql_include_child_indices.py
@@ -8,7 +8,9 @@ migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {})
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('sql_accessors', '0067_livequery_sql'),
+        ('sql_accessors', '0067_livequery_sql_include_deleted_indices'),
     ]
 
-    operations = []
+    operations = [
+        migrator.get_migration('get_related_indices.sql'),
+    ]

--- a/corehq/sql_accessors/sql_templates/get_related_indices.sql
+++ b/corehq/sql_accessors/sql_templates/get_related_indices.sql
@@ -23,14 +23,13 @@ BEGIN
 
     UNION
 
-    -- open extension cases
+    -- open extension and child cases
     SELECT DISTINCT form_processor_commcarecaseindexsql.*
     FROM form_processor_commcarecaseindexsql
     JOIN form_processor_commcarecasesql USING (domain, case_id)
     JOIN case_ids ON cid = referenced_id -- referenced_id points to host
     WHERE domain = domain_name
         AND case_id || ' ' || identifier  NOT IN (SELECT xid FROM exclude_indices)
-        AND relationship_id = 2 -- is extension case
         AND NOT closed
         AND NOT deleted;
 END;

--- a/migrations.lock
+++ b/migrations.lock
@@ -957,6 +957,7 @@ sql_accessors
  0066_drop_unused_function
  0067_livequery_sql
  0067_livequery_sql_include_deleted_indices
+ 0067_livequery_sql_include_child_indices
 sql_proxy_accessors
  0001_initial
  0002_add_sync_functions


### PR DESCRIPTION
## Technical Summary

This PR is made up of the tests and behavior changes from #32999, and builds on the refactors in #33130.

Context: [SC-1725](https://dimagi-dev.atlassian.net/browse/SC-1725)

If an extension case is also a child case of the same parent/host, then commcare-core does not treat it as an extension case. A docstring in `livequery` confirms that this is the expected behavior in HQ as well, but currently it's not.

This change is to resolve that, and align HQ behavior with commcare-core. The first commit updates a unit test from commcare-core, and subsequent commits make that test pass.

Marking risk as high because of the location of this change.

## Feature Flag

N/A

## Safety Assurance

### Safety story

This area of the codebase is covered by a lot of tests, so changes that introduce regressions will be picked up.

I think performance hits are probably a bigger risk, but I believe that @snopoke's suggestion to change `get_related_indices.sql` has avoided that.

### Automated test coverage

Includes test coverage of change.

### QA Plan

No QA planned


### Migrations

- [x] The migrations in this code can be safely applied first independently of the code

This migration can be done safely before or after the code change is deployed. The migration returns (additional) child cases of the cases being processed by `livequery`.

The current code skips/ignores child cases, so the additional child cases will have no effect.

The new code checks whether extension cases are among the additional child cases. So if the new code is deployed before the migration, matches will not be found and current behavior will continue.

### Rollback instructions

- [ ] This PR can be reverted after deploy with no further considerations

Rolling back the code will revert the behavior change. The migration does not need to be reverted to revert the behavior.

To restore the `get_related_indices` query to its previous definition, the migration will need to be reverted manually:

1. Deploy the reverted code in a limited release if it has not already been deployed normally.
2. **FAKE** revert the migration:
   ```
   $ ./manage.py migrate --fake sql_accessors 0066
   ```
3. Re-apply the migration to set the query to its previous definition:
   ```
   $ ./manage.py migrate sql_accessors
   ```


### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-1725]: https://dimagi-dev.atlassian.net/browse/SC-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ