### PR TITLE
GA show_owner_location_property_in_report_builder feature flag

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -133,6 +133,7 @@ advanced_v0 = pro_v1 + [
     privileges.LOCATION_SAFE_CASE_IMPORTS,
     privileges.FILTERED_BULK_USER_DOWNLOAD,
     privileges.APPLICATION_ERROR_REPORT,
+    privileges.SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER,
 ]
 
 enterprise_v0 = advanced_v0 + [

--- a/corehq/apps/accounting/migrations/0076_location_owner_in_report_builder_priv.py
+++ b/corehq/apps/accounting/migrations/0076_location_owner_in_report_builder_priv.py
@@ -1,0 +1,38 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.privileges import SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _grandfather_location_owner_in_report_builder_priv(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+
+    skip_editions = ','.join((
+        SoftwarePlanEdition.PAUSED,
+        SoftwarePlanEdition.COMMUNITY,
+        SoftwarePlanEdition.STANDARD,
+        SoftwarePlanEdition.PRO,
+    ))
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER,
+        skip_edition=skip_editions,
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0075_application_error_report_priv'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _grandfather_location_owner_in_report_builder_priv,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -219,6 +219,9 @@ class Command(BaseCommand):
         Role(slug=privileges.APPLICATION_ERROR_REPORT,
              name='Application error report',
              description='Show Application Error Report'),
+        Role(slug=privileges.SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER,
+             name='Additional "Owner (Location)" property in report builder reports.',
+             description='Show an additional "Owner (Location)" property in report builder reports.'),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -104,14 +104,18 @@ class Command(BaseCommand):
         Role(slug=privileges.CUSTOM_REPORTS, name='Custom Reports', description=''),
         Role(slug=privileges.ROLE_BASED_ACCESS, name='Role-based Access', description=''),
         Role(slug=privileges.RESTRICT_ACCESS_BY_LOCATION, name='Restrict Access By Location', description=''),
-        Role(slug=privileges.OUTBOUND_SMS, name='Outbound SMS',
-             description='Use of any outbound messaging / SMS services.',
+        Role(
+            slug=privileges.OUTBOUND_SMS, name='Outbound SMS',
+            description='Use of any outbound messaging / SMS services.',
         ),
-        Role(slug=privileges.REMINDERS_FRAMEWORK, name='Rules Engine (Use of Reminders Framework)',
-             description='Use of reminders framework for spawning reminders/alerts based on certain criteria.',
+        Role(
+            slug=privileges.REMINDERS_FRAMEWORK, name='Rules Engine (Use of Reminders Framework)',
+            description='Use of reminders framework for spawning reminders/alerts based on certain criteria.',
         ),
-        Role(slug=privileges.CUSTOM_SMS_GATEWAY, name='Custom Telerivet (Android) SMS Gateway',
-             description='Ability to set up telerivet gateway on the "SMS Connectivity" page (inbound or outbound).',
+        Role(
+            slug=privileges.CUSTOM_SMS_GATEWAY, name='Custom Telerivet (Android) SMS Gateway',
+            description='Ability to set up telerivet gateway on the "SMS Connectivity" page '
+                        '(inbound or outbound).',
         ),
         Role(slug=privileges.INBOUND_SMS, name='Inbound SMS (where available)', description=''),
         Role(slug=privileges.BULK_CASE_MANAGEMENT, name='Bulk Case Management', description=''),

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -89,12 +89,13 @@ from corehq.apps.userreports.ui.fields import JsonField
 from corehq.apps.userreports.util import has_report_builder_access, get_ucr_datasource_config_by_id
 from corehq.toggles import (
     SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER,
-    SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER,
     OVERRIDE_EXPANDED_COLUMN_LIMIT_IN_REPORT_BUILDER,
     SHOW_IDS_IN_REPORT_BUILDER,
     DATA_REGISTRY_UCR
 )
+from corehq import privileges
 from dimagi.utils.couch.undo import undo_delete
+from corehq.apps.accounting.utils import domain_has_privilege
 
 STATIC_CASE_PROPS = [
     "closed",
@@ -792,7 +793,7 @@ class CaseDataSourceHelper(ManagedReportBuilderDataSourceHelper):
         if SHOW_IDS_IN_REPORT_BUILDER.enabled(self.domain):
             properties['case_id'] = self._get_case_id_pseudo_property()
 
-        if SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER.enabled(self.domain):
+        if domain_has_privilege(self.domain, privileges.SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER):
             properties[COMPUTED_OWNER_LOCATION_PROPERTY_ID] = self._get_owner_location_pseudo_property()
             properties[COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID] = \
                 self._get_owner_location_with_descendants_pseudo_property()

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -80,7 +80,12 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
             ApplicationCaseDataSourceHelper(self.domain, self.app, 'form', self.form.unique_id)
 
     def test_builder_for_forms(self):
-        builder = ApplicationFormDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_FORM, self.form.unique_id)
+        builder = ApplicationFormDataSourceHelper(
+            self.domain,
+            self.app,
+            DATA_SOURCE_TYPE_FORM,
+            self.form.unique_id
+        )
         self.assertEqual('XFormInstance', builder.source_doc_type)
         expected_filter = {
             "type": "and",
@@ -149,7 +154,9 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
 
         self.assertTrue(COMPUTED_OWNER_LOCATION_PROPERTY_ID in builder.data_source_properties)
         self.assertTrue(COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID in builder.data_source_properties)
-        self.assertTrue(COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID in builder.data_source_properties)
+        self.assertTrue(
+            COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID in builder.data_source_properties
+        )
 
         owner_location_prop = builder.data_source_properties[COMPUTED_OWNER_LOCATION_PROPERTY_ID]
         self.assertEqual(COMPUTED_OWNER_LOCATION_PROPERTY_ID, owner_location_prop.get_id())

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -38,8 +38,6 @@ from corehq.apps.userreports.reports.builder.forms import (
     RegistryCaseDataSourceHelper,
 )
 from corehq.apps.userreports.tests.utils import get_simple_xform, get_sample_registry_data_source
-from corehq.util.test_utils import privilege_enabled
-from corehq import privileges
 
 
 class ReportBuilderDBTest(TestCase):
@@ -148,8 +146,8 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
         self.assertEqual('first_name', first_name_prop.get_id())
         self.assertEqual('first name', first_name_prop.get_text())
 
-    @privilege_enabled(privileges.SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER)
-    def test_owner_as_location(self):
+    @patch('corehq.apps.userreports.reports.builder.forms.domain_has_privilege', return_value=True)
+    def test_owner_as_location(self, *args):
         builder = ApplicationCaseDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
 
         self.assertTrue(COMPUTED_OWNER_LOCATION_PROPERTY_ID in builder.data_source_properties)

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -38,7 +38,8 @@ from corehq.apps.userreports.reports.builder.forms import (
     RegistryCaseDataSourceHelper,
 )
 from corehq.apps.userreports.tests.utils import get_simple_xform, get_sample_registry_data_source
-from corehq.util.test_utils import flag_enabled
+from corehq.util.test_utils import privilege_enabled
+from corehq import privileges
 
 
 class ReportBuilderDBTest(TestCase):
@@ -142,7 +143,7 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
         self.assertEqual('first_name', first_name_prop.get_id())
         self.assertEqual('first name', first_name_prop.get_text())
 
-    @flag_enabled('SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER')
+    @privilege_enabled(privileges.SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER)
     def test_owner_as_location(self):
         builder = ApplicationCaseDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
 

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -111,6 +111,8 @@ FILTERED_BULK_USER_DOWNLOAD = 'filtered_bulk_user_download'
 
 APPLICATION_ERROR_REPORT = 'application_error_report'
 
+SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER = 'show_owner_location_property_in_report_builder'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -170,6 +172,7 @@ MAX_PRIVILEGES = [
     EXPORT_OWNERSHIP,
     FILTERED_BULK_USER_DOWNLOAD,
     APPLICATION_ERROR_REPORT,
+    SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -244,4 +247,7 @@ class Titles(object):
             EXPORT_OWNERSHIP: _("Allow exports to have ownership"),
             FILTERED_BULK_USER_DOWNLOAD: _("Bulk user management features"),
             APPLICATION_ERROR_REPORT: _("Application error report"),
+            SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER: _(
+                "Show an additional 'Owner (Location)' property in report builder reports."
+            ),
         }.get(privilege, privilege)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -68,7 +68,7 @@ TAG_SAAS_CONDITIONAL = Tag(
     name='SaaS - Conditional Use',
     css_class='primary',
     description="When enabled, “SaaS - Conditional Use” feature flags will be fully supported by the SaaS team. "
-                "Please confirm with the SaaS Product team before enabling “SaaS - Conditional Use” flags for an external "
+                "Please confirm with the SaaS Product team before enabling “SaaS - Conditional Use” flags for an external "  # noqa: E501
                 "customer."
 )
 TAG_SOLUTIONS = Tag(
@@ -81,15 +81,15 @@ TAG_SOLUTIONS_OPEN = Tag(
     name='Solutions - Open Use',
     css_class='info',
     description="These features are only available for our services projects. This may affect support and "
-                "pricing when the project is transitioned to a subscription. Open Use Solutions Feature Flags can be "
+                "pricing when the project is transitioned to a subscription. Open Use Solutions Feature Flags can be "  # noqa: E501
                 "enabled by GS."
 )
 TAG_SOLUTIONS_CONDITIONAL = Tag(
     name='Solutions - Conditional Use',
     css_class='info',
     description="These features are only available for our services projects. This may affect support and "
-                "pricing when the project is transitioned to a subscription. Conditional Use Solutions Feature Flags can be "
-                "complicated and should be enabled by GS only after ensuring your partners have the proper training materials."
+                "pricing when the project is transitioned to a subscription. Conditional Use Solutions Feature Flags can be "  # noqa: E501
+                "complicated and should be enabled by GS only after ensuring your partners have the proper training materials."  # noqa: E501
 )
 TAG_SOLUTIONS_LIMITED = Tag(
     name='Solutions - Limited Use',
@@ -111,11 +111,11 @@ TAG_INTERNAL = Tag(
 # Order roughly corresponds to how much we want you to use it
 ALL_TAG_GROUPS = [TAG_SOLUTIONS, TAG_PRODUCT, TAG_CUSTOM, TAG_INTERNAL, TAG_RELEASE, TAG_DEPRECATED]
 ALL_TAGS = [
-               TAG_SOLUTIONS_OPEN,
-               TAG_SOLUTIONS_CONDITIONAL,
-               TAG_SOLUTIONS_LIMITED,
-               TAG_SAAS_CONDITIONAL,
-           ] + ALL_TAG_GROUPS
+    TAG_SOLUTIONS_OPEN,
+    TAG_SOLUTIONS_CONDITIONAL,
+    TAG_SOLUTIONS_LIMITED,
+    TAG_SAAS_CONDITIONAL,
+] + ALL_TAG_GROUPS
 
 
 class StaticToggle(object):
@@ -194,7 +194,7 @@ class StaticToggle(object):
 
         domain_enabled_after = self.enabled_for_new_domains_after
         if (domain_enabled_after is not None and NAMESPACE_DOMAIN in self.namespaces
-            and was_domain_created_after(item, domain_enabled_after)):
+                and was_domain_created_after(item, domain_enabled_after)):
             return True
 
         user_enabled_after = self.enabled_for_new_users_after
@@ -206,21 +206,21 @@ class StaticToggle(object):
 
     def enabled_for_request(self, request):
         return (
-                   None in self.namespaces
-                   and hasattr(request, 'user')
-                   and self.enabled(request.user.username, namespace=None)
-               ) or (
-                   NAMESPACE_DOMAIN in self.namespaces
-                   and hasattr(request, 'domain')
-                   and self.enabled(request.domain, namespace=NAMESPACE_DOMAIN)
-               ) or (
-                   NAMESPACE_EMAIL_DOMAIN in self.namespaces
-                   and hasattr(request, 'user')
-                   and self.enabled(
-                   request.user.email or request.user.username,
-                   namespace=NAMESPACE_EMAIL_DOMAIN
-               )
-               )
+            None in self.namespaces
+            and hasattr(request, 'user')
+            and self.enabled(request.user.username, namespace=None)
+        ) or (
+            NAMESPACE_DOMAIN in self.namespaces
+            and hasattr(request, 'domain')
+            and self.enabled(request.domain, namespace=NAMESPACE_DOMAIN)
+        ) or (
+            NAMESPACE_EMAIL_DOMAIN in self.namespaces
+            and hasattr(request, 'user')
+            and self.enabled(
+                request.user.email or request.user.username,
+                namespace=NAMESPACE_EMAIL_DOMAIN
+            )
+        )
 
     def set(self, item, enabled, namespace=None):
         if namespace == NAMESPACE_USER:
@@ -292,9 +292,9 @@ def was_domain_created_after(domain, checkpoint):
     from corehq.apps.domain.models import Domain
     domain_obj = Domain.get_by_name(domain)
     return (
-        domain_obj is not None and
-        domain_obj.date_created is not None and
-        domain_obj.date_created > checkpoint
+        domain_obj is not None
+        and domain_obj.date_created is not None
+        and domain_obj.date_created > checkpoint
     )
 
 
@@ -308,9 +308,9 @@ def was_user_created_after(username, checkpoint):
     from corehq.apps.users.models import WebUser
     user = WebUser.get_by_username(username)
     return (
-        user is not None and
-        user.created_on is not None and
-        user.created_on > checkpoint
+        user is not None
+        and user.created_on is not None
+        and user.created_on > checkpoint
     )
 
 
@@ -448,6 +448,7 @@ class FeatureRelease(DynamicallyPredictablyRandomToggle):
     an 'owner' to indicate the member of the team responsible for releasing this feature.
     This will be displayed on the UI when editing the toggle.
     """
+
     def __init__(
         self,
         slug,
@@ -860,7 +861,7 @@ SYNC_ALL_LOCATIONS = StaticToggle(
     TAG_DEPRECATED,
     [NAMESPACE_DOMAIN],
     description="Do not turn this feature flag. It is only used for providing compatability for old projects. "
-                "We are actively trying to remove projects from this list. This functionality is now possible by using the "
+                "We are actively trying to remove projects from this list. This functionality is now possible by using the "  # noqa: E501
                 "Advanced Settings on the Organization Levels page and setting the Level to Expand From option.",
 )
 
@@ -933,7 +934,7 @@ USH_CASE_LIST_MULTI_SELECT = StaticToggle(
     'USH: Allow selecting multiple cases from the case list',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/saas/USH%3A+Allow+selecting+multiple+cases+from+the+case+list',
+    help_link='https://confluence.dimagi.com/display/saas/USH%3A+Allow+selecting+multiple+cases+from+the+case+list',  # noqa: E501
     description="""
     Allows user to select multiple cases and load them all into the form.
     """
@@ -1136,7 +1137,7 @@ SECURE_SESSION_TIMEOUT = StaticToggle(
     "USH: Allow domain to override default length of inactivity timeout",
     TAG_CUSTOM,
     [NAMESPACE_DOMAIN],
-    help_link="https://confluence.dimagi.com/display/saas/Allow+domain+to+override+default+length+of+inactivity+timeout",
+    help_link="https://confluence.dimagi.com/display/saas/Allow+domain+to+override+default+length+of+inactivity+timeout",  # noqa: E501
 )
 
 # not referenced in code directly but passed through to vellum
@@ -1914,7 +1915,7 @@ HMAC_CALLOUT = StaticToggle(
     'USH: Enable signed messaging url callouts in cloudcare',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
-    help_link="https://confluence.dimagi.com/display/saas/COVID%3A+Enable+signed+messaging+url+callouts+in+cloudcare",
+    help_link="https://confluence.dimagi.com/display/saas/COVID%3A+Enable+signed+messaging+url+callouts+in+cloudcare",  # noqa: E501
 )
 
 GAEN_OTP_SERVER = StaticToggle(
@@ -2134,7 +2135,7 @@ FOLLOWUP_FORMS_AS_CASE_LIST_FORM = StaticToggle(
     'child modules that use Parent Child Selection',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
-    help_link="https://confluence.dimagi.com/pages/viewpage.action?spaceKey=USH&title=Add+Form+to+Bottom+of++Case+List",
+    help_link="https://confluence.dimagi.com/pages/viewpage.action?spaceKey=USH&title=Add+Form+to+Bottom+of++Case+List",  # noqa: E501
 )
 
 
@@ -2169,7 +2170,7 @@ CASE_IMPORT_DATA_DICTIONARY_VALIDATION = StaticToggle(
     'USH: Validate data per data dictionary definitions during case import',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
-    help_link="https://confluence.dimagi.com/display/saas/Validate+data+per+data+dictionary+definitions+during+case+import",
+    help_link="https://confluence.dimagi.com/display/saas/Validate+data+per+data+dictionary+definitions+during+case+import",  # noqa: E501
 )
 
 DO_NOT_REPUBLISH_DOCS = StaticToggle(
@@ -2255,7 +2256,7 @@ SMS_USE_LATEST_DEV_APP = FeatureRelease(
 
 VIEW_FORM_ATTACHMENT = StaticToggle(
     'view_form_attachments',
-    'Allow users on the domain to view form attachments without having to have the report Submit History permission.',
+    'Allow users on the domain to view form attachments without having to have the report Submit History permission.',  # noqa: E501
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
 )
@@ -2325,6 +2326,7 @@ def _handle_attendance_tracking_role(domain, is_enabled):
     else:
         archive_attendance_coordinator_role_for_domain(domain)
 
+
 ATTENDANCE_TRACKING = StaticToggle(
     'attendance_tracking',
     'Allows access to the attendance tracking page',
@@ -2344,6 +2346,7 @@ GEOSPATIAL = StaticToggle(
                 'and assigning cases on a map.'
 
 )
+
 
 class FrozenPrivilegeToggle(StaticToggle):
     """
@@ -2527,6 +2530,6 @@ SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER = FrozenPrivilegeToggle(
     label='Show an additional "Owner (Location)" property in report builder reports.',
     tag=TAG_SOLUTIONS_OPEN,
     namespaces=[NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/saas/Enable+creation+of+report+builder+reports+that+are+location+safe',
+    help_link='https://confluence.dimagi.com/display/saas/Enable+creation+of+report+builder+reports+that+are+location+safe',  # noqa: E501
     description='This can be used to create report builder reports that are location-safe.'
 )

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1426,15 +1426,6 @@ UNLIMITED_REPORT_BUILDER_REPORTS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER = StaticToggle(
-    'show_owner_location_property_in_report_builder',
-    'Show an additional "Owner (Location)" property in report builder reports.',
-    TAG_SOLUTIONS_OPEN,
-    [NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/saas/Enable+creation+of+report+builder+reports+that+are+location+safe',
-    description='This can be used to create report builder reports that are location-safe.'
-)
-
 SHOW_IDS_IN_REPORT_BUILDER = StaticToggle(
     'show_ids_in_report_builder',
     'Allow adding Case IDs to report builder reports.',
@@ -2528,4 +2519,14 @@ APPLICATION_ERROR_REPORT = FrozenPrivilegeToggle(
     description="Show Application Error Report.",
     # TODO: Move to public wiki
     help_link='https://confluence.dimagi.com/display/saas/Show+Application+Error+Report+Feature+Flag'
+)
+
+SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER = FrozenPrivilegeToggle(
+    privileges.SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER,
+    'show_owner_location_property_in_report_builder',
+    label='Show an additional "Owner (Location)" property in report builder reports.',
+    tag=TAG_SOLUTIONS_OPEN,
+    namespaces=[NAMESPACE_DOMAIN],
+    help_link='https://confluence.dimagi.com/display/saas/Enable+creation+of+report+builder+reports+that+are+location+safe',
+    description='This can be used to create report builder reports that are location-safe.'
 )

--- a/migrations.lock
+++ b/migrations.lock
@@ -95,6 +95,7 @@ accounting
  0073_export_ownership_priv
  0074_filtered_bulk_user_download_priv
  0075_application_error_report_priv
+ 0076_location_owner_in_report_builder_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
Creating this PR so long, but there's something I need to sort out locally.

## Product Description
GA show_owner_location_property_in_report_builder feature flag to Advanced Plan and higher.

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2866)

## Feature Flag
None

## Safety Assurance

Tested locally

### Automated test coverage
Tests included

### QA Plan
No formal QA planned.


### Migrations
- [ ] The migrations in this code can be safely applied first independently of the code

The migration depends on the code.

### Rollback instructions
Once this migration is applied, there's no turning back.

- [ ] This PR can be reverted after deploy with no further considerations

If this PR is reverted, we'd have to removing the created privilege. 

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
