### PR TITLE
Add secondary index names in adapters

### DIFF
--- a/corehq/apps/es/apps.py
+++ b/corehq/apps/es/apps.py
@@ -54,6 +54,7 @@ app_adapter = create_document_adapter(
     ElasticApp,
     "hqapps_2020-02-26",
     "app",
+    secondary='apps-20230524',
 )
 
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -183,6 +183,7 @@ case_search_adapter = create_document_adapter(
     ElasticCaseSearch,
     getattr(settings, "ES_CASE_SEARCH_INDEX_NAME", "case_search_2018-05-29"),
     case_adapter.type,
+    secondary='case-search-20230524',
 )
 
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -23,7 +23,6 @@ from corehq.apps.case_search.const import (
     IDENTIFIER,
     INDEXED_ON,
     INDICES_PATH,
-    IS_RELATED_CASE,
     REFERENCED_ID,
     RELEVANCE_SCORE,
     SPECIAL_CASE_PROPERTIES_MAP,

--- a/corehq/apps/es/cases.py
+++ b/corehq/apps/es/cases.py
@@ -90,6 +90,7 @@ case_adapter = create_document_adapter(
     ElasticCase,
     "hqcases_2016-03-04",
     "case",
+    secondary='cases-20230524',
 )
 
 

--- a/corehq/apps/es/domains.py
+++ b/corehq/apps/es/domains.py
@@ -88,6 +88,7 @@ domain_adapter = create_document_adapter(
     ElasticDomain,
     "hqdomains_2021-03-08",
     "hqdomain",
+    secondary='domains-20230524',
 )
 
 

--- a/corehq/apps/es/forms.py
+++ b/corehq/apps/es/forms.py
@@ -165,6 +165,7 @@ form_adapter = create_document_adapter(
     ElasticForm,
     getattr(settings, "ES_XFORM_INDEX_NAME", "xforms_2016-07-07"),
     "xform",
+    secondary='forms-20230524',
 )
 
 

--- a/corehq/apps/es/groups.py
+++ b/corehq/apps/es/groups.py
@@ -56,6 +56,7 @@ group_adapter = create_document_adapter(
     ElasticGroup,
     "hqgroups_2017-05-29",
     "group",
+    secondary='groups-20230524',
 )
 
 

--- a/corehq/apps/es/sms.py
+++ b/corehq/apps/es/sms.py
@@ -53,6 +53,7 @@ sms_adapter = create_document_adapter(
     ElasticSMS,
     "smslogs_2020-01-28",
     "sms",
+    secondary='sms-20230524',
 )
 
 

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -115,6 +115,7 @@ user_adapter = create_document_adapter(
     ElasticUser,
     "hqusers_2017-09-07",
     "user",
+    secondary='users-20230524',
 )
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds secondary index to all the indexes. This is required for the new reindex process. This will not turn on the multiplexer, the multiplexer will only be started when the `ES_<app>_INDEX_MULTIPLEXED` is set to `True` which is `False` by default. This is required to prepare the indexes for reindex.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12152

## Safety Assurance
This has been tested on staging.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Will be a no op. Pretty Safe
### Automated test coverage
NA
<!-- Identify the related test coverage and the tests it would catch -->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
