### PR TITLE
Modify fix_unwrappable_apps domain to run on all domains

### DIFF
--- a/corehq/apps/app_manager/management/commands/fix_unwrappable_apps.py
+++ b/corehq/apps/app_manager/management/commands/fix_unwrappable_apps.py
@@ -4,6 +4,7 @@ from corehq.apps.app_manager.management.commands.helpers import (
 )
 from corehq.toggles import SYNC_SEARCH_CASE_CLAIM
 
+
 class Command(AppMigrationCommandBase):
     help = """
     Short-lived command from 2023-03-02 to fix unwrappable apps caused by
@@ -13,7 +14,7 @@ class Command(AppMigrationCommandBase):
     https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/125/SUPPORT-16128
     https://dimagi-dev.atlassian.net/browse/SUPPORT-16045
     """
-    chunk_size = 5
+    chunk_size = 1
     DOMAIN_LIST_FILENAME = 'fix_unwrappable_apps-domains.txt'
     DOMAIN_PROGRESS_NUMBER_FILENAME = 'fix_unwrappable_apps-progress.txt'
     include_builds = True

--- a/corehq/apps/app_manager/management/commands/fix_unwrappable_apps.py
+++ b/corehq/apps/app_manager/management/commands/fix_unwrappable_apps.py
@@ -2,7 +2,7 @@ from corehq.apps.app_manager.dbaccessors import wrap_app
 from corehq.apps.app_manager.management.commands.helpers import (
     AppMigrationCommandBase,
 )
-
+from corehq.toggles import SYNC_SEARCH_CASE_CLAIM
 
 class Command(AppMigrationCommandBase):
     help = """
@@ -16,6 +16,8 @@ class Command(AppMigrationCommandBase):
     chunk_size = 5
     DOMAIN_LIST_FILENAME = 'fix_unwrappable_apps-domains.txt'
     DOMAIN_PROGRESS_NUMBER_FILENAME = 'fix_unwrappable_apps-progress.txt'
+    include_builds = True
+    include_linked_apps = True
 
     def migrate_app(self, app_doc):
         changed = False
@@ -39,3 +41,6 @@ class Command(AppMigrationCommandBase):
 
         if changed:
             return app_doc
+
+    def get_domains(self):
+        return SYNC_SEARCH_CASE_CLAIM.get_enabled_domains()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Modifies the `fix_unwrappable_apps` command to make it comprehensive. The plan is to run it on all servers to stop several interrupt issues that have been popping up due to corrupted data.

I just wanted to get a review before running this widely, I'm not sure we even need to merge this PR.

Jira: [link](https://dimagi-dev.atlassian.net/browse/USH-3296?atlOrigin=eyJpIjoiZGRkZDAxMjlmYjJiNDk3MDg4OTBkN2I1YmM3MTRjZDkiLCJwIjoiaiJ9).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Pretty simple, it changes a couple of settings and limits the command to case search domains (the problem is with case search in couch apps).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

SYNC_SEARCH_CASE_CLAIM

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

This command has been run on many heavily used domains before and hasn't broken anything.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
