### PR TITLE
Use smaller fields and tighter spacing in split screen case search

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -57,7 +57,7 @@
     </div>
   </<%- contentTag %>>
   <<%- contentTag %>
-    class="<% if (contentTag === 'td') { %>col-sm-6 <% } %>query-input-group
+    class="<% if (contentTag === 'td') { %>col-sm-6 <% } else { %>input-group-sm <% } %>query-input-group
            <% if (errorMessage) { %> has-error<% } %>">
 
     <% if (input == "select1") { %>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -17,17 +17,23 @@
   }
   .query-input-group {
     margin-right: 8px;
-    margin-bottom: 8px;
+    margin-bottom: 4px;
     margin-left: 8px;
   }
   .query-caption {
-    margin-top: 8px;
+    margin-top: 4px;
     margin-right: 8px;
     margin-left: 8px;
   }
   .mapboxgl-ctrl-geocoder {
     min-width: 100%;
     font-size: 1em;
+    > .mapboxgl-ctrl-geocoder--input {
+      height: inherit;
+    }
+  }
+  .select2-container .select2-selection--multiple {
+    min-height: inherit;
   }
 }
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
<img width="320" alt="image" src="https://github.com/dimagi/commcare-hq/assets/100609770/13a2ddc6-edb7-4579-928f-873a4837a78c"> => <img width="320" alt="image" src="https://github.com/dimagi/commcare-hq/assets/100609770/d0f22862-39fd-4151-a302-58eba2834db6">


## Technical Summary
Raised by QA that more fields should fit vertically. [QA-5231 ](https://dimagi-dev.atlassian.net/browse/QA-5231)
Uses bootstrap class for smaller search fields when using split screen case search. Adjusts top/bottom spacing and tweaks geocoder and multiple-select `select2` elements to follow this same sizing when in the split screen sidebar.
 
## Feature Flag
split_screen_case_search

## Safety Assurance

### Safety story
UI changes only.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
