### PR TITLE
Ensure TermsAggregation size is never 0

### DIFF
--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -215,7 +215,7 @@ class TermsAggregation(Aggregation):
     def __init__(self, name, field, size=None, missing=None):
         assert re.match(r'\w+$', name), \
             "Names must be valid python variable names, was {}".format(name)
-        assert size != 0, "Aggregation size must be greater than 0"
+        assert size is None or size > 0, "Aggregation size must be greater than 0"
         self.name = name
         self.body = {
             "field": field,
@@ -238,7 +238,7 @@ class TermsAggregation(Aggregation):
         return query
 
     def size(self, size):
-        assert size != 0, "Aggregation size must be greater than 0"
+        assert size is None or size > 0, "Aggregation size must be greater than 0"
         query = deepcopy(self)
         query.body['size'] = size
         return query

--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -215,6 +215,7 @@ class TermsAggregation(Aggregation):
     def __init__(self, name, field, size=None, missing=None):
         assert re.match(r'\w+$', name), \
             "Names must be valid python variable names, was {}".format(name)
+        assert size != 0, "Aggregation size must be greater than 0"
         self.name = name
         self.body = {
             "field": field,
@@ -237,6 +238,7 @@ class TermsAggregation(Aggregation):
         return query
 
     def size(self, size):
+        assert size != 0, "Aggregation size must be greater than 0"
         query = deepcopy(self)
         query.body['size'] = size
         return query

--- a/corehq/apps/es/tests/test_aggregations.py
+++ b/corehq/apps/es/tests/test_aggregations.py
@@ -461,6 +461,17 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
         )
         self.checkQuery(query, json_output)
 
+    def test_terms_aggregation_does_not_accept_zero_size(self):
+        error_message = "Aggregation size must be greater than 0"
+        with self.assertRaisesMessage(AssertionError, error_message):
+            HQESQuery('cases').aggregation(
+                TermsAggregation('name', 'name').order('sort_field').size(0)
+            )
+        with self.assertRaisesMessage(AssertionError, error_message):
+            HQESQuery('cases').aggregation(
+                TermsAggregation('name', 'name', 0).order('sort_field')
+            )
+
 
 @es_test(requires=[form_adapter], setup_class=True)
 class TestDateHistogram(SimpleTestCase):

--- a/corehq/apps/es/tests/test_aggregations.py
+++ b/corehq/apps/es/tests/test_aggregations.py
@@ -80,8 +80,8 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                 FilterAggregation('closed', filters.term('closed', True))
             ),
             FiltersAggregation('total_by_status')
-                .add_filter('closed', filters.term('closed', True))
-                .add_filter('open', filters.term('closed', False))
+            .add_filter('closed', filters.term('closed', True))
+            .add_filter('open', filters.term('closed', False))
         ])
         self.checkQuery(query, json_output)
 
@@ -383,8 +383,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                     "buckets": [{
                         "key": 1454284800000,
                         "doc_count": 8
-                    },
-                    {
+                    }, {
                         "key": 1464284800000,
                         "doc_count": 3
                     }]

--- a/corehq/apps/users/views/utils.py
+++ b/corehq/apps/users/views/utils.py
@@ -144,7 +144,8 @@ def _get_location_case_counts(domain, location_ids):
         CaseES()
         .domain(domain)
         .owner(location_ids)
-        .aggregation(TermsAggregation('by_location', 'owner_id').size(0))
+        .aggregation(TermsAggregation('by_location', 'owner_id'))
+        .size(0)
     ).run()
     counts = query.aggregations.by_location.counts_by_bucket()
 

--- a/corehq/apps/users/views/utils.py
+++ b/corehq/apps/users/views/utils.py
@@ -145,7 +145,6 @@ def _get_location_case_counts(domain, location_ids):
         .domain(domain)
         .owner(location_ids)
         .aggregation(TermsAggregation('by_location', 'owner_id'))
-        .size(0)
     ).run()
     counts = query.aggregations.by_location.counts_by_bucket()
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Starting from ES 5, the terms aggregation cannot have a size 0. This is not being used in HQ, except at 1 place where it was added by mistake. The PR ensures that we never set 0 in aggregation size.

For more context on why size 0 was removed - https://github.com/elastic/elasticsearch/issues/18838


## Safety Assurance
Pretty safe, no actual usage on HQ, just an additional check with tests
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests are there

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
