### PR TITLE
[USH-3277] allow the geocoder widget to use the user's location

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -1,7 +1,8 @@
 /*global MapboxGeocoder*/
 hqDefine("cloudcare/js/form_entry/utils", function () {
     var errors = hqImport("cloudcare/js/form_entry/errors"),
-        formEntryConst = hqImport("cloudcare/js/form_entry/const");
+        formEntryConst = hqImport("cloudcare/js/form_entry/const"),
+        toggles = hqImport("hqwebapp/js/toggles");
 
     var module = {
         resourceMap: undefined,
@@ -87,6 +88,9 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         geolocateOnLoad = false,
         setProximity = false
     ) {
+        showGeolocationButton = showGeolocationButton || toggles.toggleEnabled('GEOCODER_MY_LOCATION_BUTTON');
+        geolocateOnLoad = geolocateOnLoad || toggles.toggleEnabled('GEOCODER_AUTOLOAD_USER_LOCATION');
+        setProximity = setProximity || toggles.toggleEnabled('GEOCODER_USER_PROXIMITY');
         var defaultGeocoderLocation = initialPageData.get('default_geocoder_location') || {};
         var geocoder = new MapboxGeocoder({
             accessToken: initialPageData.get("mapbox_access_token"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -101,7 +101,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         if (setProximity && geocoder.geolocation.isSupport()) {
             geocoder.geolocation.getCurrentPosition().then(function (position) {
                 geocoder.setProximity(position.coords);
-            });
+            }).catch(error => console.log("Unable to set geocoder proximity: ", error.message));
         } else if (defaultGeocoderLocation.coordinates) {
             geocoder.setProximity(defaultGeocoderLocation.coordinates);
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -73,15 +73,32 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
      * @param {function} clearCallBack - function to call back after clearing the input
      * @param {Object} initialPageData - initial_page_data object
      * @param {function|undefined} inputOnKeyDown - inputOnKeyDown function (optional)
+     * @param {boolean} showGeolocationButton - show geolocation button. Defaults to false. (optional)
+     * @param {boolean} geolocateOnLoad - geolocate the user's location on load. Defaults to false. (optional)
+     * @param {boolean} setProximity - set proximity to user's location. Defaults to false. (optional)
      */
-    module.renderMapboxInput = function (divId, itemCallback, clearCallBack, initialPageData, inputOnKeyDown) {
+    module.renderMapboxInput = function (
+        divId,
+        itemCallback,
+        clearCallBack,
+        initialPageData,
+        inputOnKeyDown,
+        showGeolocationButton= false,
+        geolocateOnLoad = false,
+        setProximity = false
+    ) {
         var defaultGeocoderLocation = initialPageData.get('default_geocoder_location') || {};
         var geocoder = new MapboxGeocoder({
             accessToken: initialPageData.get("mapbox_access_token"),
             types: 'address',
             enableEventLogging: false,
+            enableGeolocation: showGeolocationButton,
         });
-        if (defaultGeocoderLocation.coordinates) {
+        if (setProximity && geocoder.geolocation.isSupport()) {
+            geocoder.geolocation.getCurrentPosition().then(function (position) {
+                geocoder.setProximity(position.coords);
+            });
+        } else if (defaultGeocoderLocation.coordinates) {
             geocoder.setProximity(defaultGeocoderLocation.coordinates);
         }
         geocoder.on('clear', clearCallBack);
@@ -112,6 +129,10 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
                 liveRegionEl.html("<p>" + items.features[0].place_name + "</p>");
             }
         });
+        
+        if (geolocateOnLoad) {
+            geocoder._geolocateUser();
+        }
     };
 
     /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -69,8 +69,8 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
     /**
      * Sets a div to be a mapbox geocoder input
      * @param {(string|string[])} divId - Div ID for the Mapbox input
-     * @param {Object} itemCallback - function to call back after new search
-     * @param {Object} clearCallBack - function to call back after clearing the input
+     * @param {function} itemCallback - function to call back after new search
+     * @param {function} clearCallBack - function to call back after clearing the input
      * @param {Object} initialPageData - initial_page_data object
      * @param {function|undefined} inputOnKeyDown - inputOnKeyDown function (optional)
      */
@@ -80,12 +80,12 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
             accessToken: initialPageData.get("mapbox_access_token"),
             types: 'address',
             enableEventLogging: false,
-            getItemValue: itemCallback,
         });
         if (defaultGeocoderLocation.coordinates) {
             geocoder.setProximity(defaultGeocoderLocation.coordinates);
         }
         geocoder.on('clear', clearCallBack);
+        geocoder.on('result', (item) => itemCallback(item.result));
         geocoder.addTo('#' + divId);
         const divEl = $("#" + divId);
         const liveRegionEl = $("#" + divId + "-sr[role='region']");

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -954,6 +954,46 @@ USH_CASE_CLAIM_UPDATES = StaticToggle(
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
 )
 
+GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
+    "geocoder_my_location_button",
+    "USH: Add button to geocoder to populate search with the user's current location",
+    TAG_RELEASE,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    When enabled this will add a small button to the geocoder widget that, when pressed, and if
+    the user grants permission, will perform a reverse geocoding query based on the user's reported location.
+    The result will be used to populate the search field of the geocoder widget.
+    
+    This is intended as a temporary toggle and will likely get rolled into the "USH_CASE_CLAIM_UPDATES" toggle.
+    """,
+    parent_toggles=[USH_CASE_CLAIM_UPDATES],
+)
+
+GEOCODER_AUTOLOAD_USER_LOCATION = StaticToggle(
+    "geocoder_autoload_user_location",
+    "USH: Auto-load the geocoder widget with the user's current location",
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    When enabled, and if the user grants permissions, the geocoder widget will automatically do a reverse
+    geocoding query using the user's reported location The result will be used to populate the search field
+    of the geocoder widget.
+    """,
+    parent_toggles=[USH_CASE_CLAIM_UPDATES],
+)
+
+GEOCODER_USER_PROXIMITY = StaticToggle(
+    "geocoder_user_proximity",
+    "USH: Set the geocoder widget's proximity based on the user's location.",
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    This has the effect of getting search results that are closer to the user's location. This will override
+    the domains default proximity setting ("Default project location").
+    """,
+    parent_toggles=[USH_CASE_CLAIM_UPDATES],
+)
+
 USH_SEARCH_FILTER = StaticToggle(
     'case_search_filter',
     "USH Specific toggle to use Search Filter in case search options.",

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -963,7 +963,7 @@ GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
     When enabled this will add a small button to the geocoder widget that, when pressed, and if
     the user grants permission, will perform a reverse geocoding query based on the user's reported location.
     The result will be used to populate the search field of the geocoder widget.
-    
+
     This is intended as a temporary toggle and will likely get rolled into the "USH_CASE_CLAIM_UPDATES" toggle.
     """,
     parent_toggles=[USH_CASE_CLAIM_UPDATES],


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-3277

## Product Description
This adds 3 features to the geocoder widget. Each is controlled via a separate toggle (for now):

1. Add a button to the geocder widget that will populate the input with the user's current location (according to the browser).
    
    ![geolocation-on](https://github.com/dimagi/commcare-hq/assets/249606/6ffb5a3c-6542-4e19-939d-9b1318e35974)
    
    If the user does not give permission a message is shown:
    
    ![geolocation-denied](https://github.com/dimagi/commcare-hq/assets/249606/c54734a8-297e-454d-9bd7-ee0c3571dbec)

2. Auto-populate the geocoder widget with the user's location. 

    This is similar to the first point but does not require the user to press the button. When the widget is loaded it will auto-populate with the location of the user.

3. Set the search proximity based on the user's location

    The effect of this is that the search will sort matching locations based on their distance from the user's location.
    This will override the proximity configured for the domain (See "Default project location" setting).

#### Note
The use of feature flags implies that this cannot be configured per app / per app module. If that is desired in the future additional work will be required.

## Technical Summary
The changes are relatively small and use existing features of the geocoder widget. 

## Feature Flag
3 new flags
* `GEOCODER_MY_LOCATION_BUTTON`
  * It is likely that this will be rolled into the `USH_CASE_CLAIM_UPDATES` flag in the future.
* `GEOCODER_AUTOLOAD_USER_LOCATION`
* `GEOCODER_USER_PROXIMITY`

## Safety Assurance

### Safety story
The changes are limited to the geocoder widget in web apps (both case search and form entry).
Local testing was done to ensure the features do not break when enabled / disabled / user denies location access.

### Automated test coverage
None (I may look at this later but leaving it for now)

### QA Plan
None (though I may put this on staging for easier testing by internal team)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
