### PR TITLE
Disable errors so build doesn't fail

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,6 +25,7 @@ jobs:
         uses: super-linter/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
+          DISABLE_ERRORS: true
           VALIDATE_JAVASCRIPT_ES: true
           VALIDATE_PYTHON_FLAKE8: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Disable errors on Super-Linter, meaning the build won't fail when errors have been detected. The errors are still output in the GH action terminal, but one would have to manually go there to check. 