### PR TITLE
Disbursement algorithm grouping

### DIFF
--- a/corehq/apps/geospatial/models.py
+++ b/corehq/apps/geospatial/models.py
@@ -149,11 +149,11 @@ class ObjectiveAllocator:
             # One of the constraints might be null, so we need to do the appropriate constraints check based
             # on which constraints are non-null
             if self.max_distance and self.max_assignable:
-                constraints_met = distance <= self.max_distance and len(current_bin) <= self.max_assignable
+                constraints_met = distance <= self.max_distance and len(current_bin) < self.max_assignable
             elif self.max_distance:
                 constraints_met = distance <= self.max_distance
             else:
-                constraints_met = len(current_bin) <= self.max_assignable
+                constraints_met = len(current_bin) < self.max_assignable
 
             if constraints_met:
                 current_bin.append(current_objective.id)


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2887).

This adds in a new `group_objectives()` function to the straight-line disbursement algorithm. The use case for this function is to be able to group the closest x objectives together without having them soft-assigned to a mobile worker.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Automated tests.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests have been created to ensure correct functionality of `group_objectives()`.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
