### PR TITLE
Render line breaks properly in Web Apps markdown

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -1,8 +1,9 @@
 /* global DOMPurify, mdAnchorRender */
 hqDefine("cloudcare/js/form_entry/form_ui", function () {
-    var constants = hqImport("cloudcare/js/form_entry/const"),
+    var cloudcareUtils = hqImport("cloudcare/js/utils");
+        constants = hqImport("cloudcare/js/form_entry/const"),
         entries = hqImport("cloudcare/js/form_entry/entries"),
-        utils = hqImport("cloudcare/js/form_entry/utils");
+        formEntryUtils = hqImport("cloudcare/js/form_entry/utils");
     var md = window.markdownit();
     var groupNum = 0;
 
@@ -39,7 +40,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         ko.bindingHandlers.renderMarkdown = {
             update: function (element, valueAccessor) {
                 var value = ko.unwrap(valueAccessor());
-                value = md.render(value || '');
+                value = cloudcareUtils.renderMarkdown(value || '');
                 $(element).html(value);
             },
         };
@@ -203,7 +204,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
                     if (options.target.pendingAnswer &&
                             options.target.pendingAnswer() !== constants.NO_PENDING_ANSWER) {
                         // There is a request in progress
-                        if (options.target.entry.templateType === "file" || utils.answersEqual(options.data.answer, options.target.pendingAnswer())) {
+                        if (options.target.entry.templateType === "file" || formEntryUtils.answersEqual(options.data.answer, options.target.pendingAnswer())) {
                             // We can now mark it as not dirty
                             options.data.answer = _.clone(options.target.pendingAnswer());
                             options.target.pendingAnswer(constants.NO_PENDING_ANSWER);
@@ -583,7 +584,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.fromJS(json);
         self.parent = parent;
         // Grab the containing pubsub so questions can interact with other questions on the same form.
-        const container = utils.getBroadcastContainer(self);
+        const container = formEntryUtils.getBroadcastContainer(self);
         self.broadcastPubSub = (container) ? container.pubsub : new ko.subscribable();
         self.error = ko.observable(null);
         self.serverError = ko.observable(null);
@@ -651,8 +652,8 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.onchange = self.triggerAnswer;
 
         self.mediaSrc = function (resourceType) {
-            if (!resourceType || !_.isFunction(utils.resourceMap)) { return ''; }
-            return utils.resourceMap(resourceType);
+            if (!resourceType || !_.isFunction(formEntryUtils.resourceMap)) { return ''; }
+            return formEntryUtils.resourceMap(resourceType);
         };
 
         self.navigateTo = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -1,7 +1,8 @@
-/*global Backbone, DOMPurify */
+/*global Backbone */
 
 hqDefine("cloudcare/js/formplayer/menus/controller", function () {
     var constants = hqImport("cloudcare/js/formplayer/constants"),
+        cloudcareUtils = hqImport("cloudcare/js/utils"),
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
         formplayerUtils = hqImport("cloudcare/js/formplayer/utils/utils"),
         menusUtils = hqImport("cloudcare/js/formplayer/menus/utils"),
@@ -226,7 +227,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             obj.style = styles[i];
             obj.id = i;
             if (obj.style.displayFormat === 'Markdown') {
-                obj.html = DOMPurify.sanitize(md.render(details[i]));
+                obj.html = cloudcareUtils.renderMarkdown(details[i]);
             }
             detailModel.push(obj);
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -274,8 +274,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         templateContext: function () {
-            const appId = formplayerUtils.currentUrlToObject().appId,
-                  md = window.markdownit();
+            const appId = formplayerUtils.currentUrlToObject().appId;
             return {
                 data: this.options.model.get('data'),
                 styles: this.options.styles,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -6,7 +6,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
         initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         toggles = hqImport("hqwebapp/js/toggles"),
-        utils = hqImport("cloudcare/js/formplayer/utils/utils");
+        formplayerUtils = hqImport("cloudcare/js/formplayer/utils/utils"),
+        cloudcareUtils = hqImport("cloudcare/js/utils");
 
 
 
@@ -91,7 +92,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             const imageUri = this.options.model.get('imageUri');
             const audioUri = this.options.model.get('audioUri');
             const navState = this.options.model.get('navigationState');
-            const appId = utils.currentUrlToObject().appId;
+            const appId = formplayerUtils.currentUrlToObject().appId;
             return {
                 navState: navState,
                 imageUrl: imageUri ? FormplayerFrontend.getChannel().request('resourceMap', imageUri, appId) : "",
@@ -273,14 +274,14 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         templateContext: function () {
-            const appId = utils.currentUrlToObject().appId,
+            const appId = formplayerUtils.currentUrlToObject().appId,
                   md = window.markdownit();
             return {
                 data: this.options.model.get('data'),
                 styles: this.options.styles,
                 isMultiSelect: this.options.isMultiSelect,
                 renderMarkdown: function (datum) {
-                    return md.render(DOMPurify.sanitize(datum || "")).replaceAll("\n", "<br>");
+                    return cloudcareUtils.renderMarkdown(datum);
                 },
                 resolveUri: function (uri) {
                     return FormplayerFrontend.getChannel().request('resourceMap', uri, appId);
@@ -420,7 +421,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         paginationGoAction: function (e) {
             e.preventDefault();
             const goText = Number(this.ui.paginationGoText.val());
-            const pageNo = utils.paginationGoPageNumber(goText, this.options.pageCount);
+            const pageNo = formplayerUtils.paginationGoPageNumber(goText, this.options.pageCount);
             FormplayerFrontend.trigger("menu:paginate", pageNo - 1, this.selectedCaseIds);
             kissmetrics.track.event("Accessibility Tracking - Pagination Go To Page Interaction");
         },
@@ -592,7 +593,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         templateContext: function () {
-            const paginateItems = utils.paginateOptions(this.options.currentPage, this.options.pageCount);
+            const paginateItems = formplayerUtils.paginateOptions(this.options.currentPage, this.options.pageCount);
             const casesPerPage = parseInt($.cookie("cases-per-page-limit")) || 10;
             return {
                 startPage: paginateItems.startPage,
@@ -877,7 +878,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         className: "",
         template: _.template($("#detail-view-item-template").html() || ""),
         templateContext: function () {
-            const appId = utils.currentUrlToObject().appId;
+            const appId = formplayerUtils.currentUrlToObject().appId;
             return {
                 resolveUri: function (uri) {
                     return FormplayerFrontend.getChannel().request('resourceMap', uri, appId);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -274,13 +274,13 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         templateContext: function () {
             const appId = utils.currentUrlToObject().appId,
-                md = window.markdownit();
+                  md = window.markdownit();
             return {
                 data: this.options.model.get('data'),
                 styles: this.options.styles,
                 isMultiSelect: this.options.isMultiSelect,
                 renderMarkdown: function (datum) {
-                    return md.render(DOMPurify.sanitize(datum || ""));
+                    return md.render(DOMPurify.sanitize(datum || "")).replaceAll("\n", "<br>");
                 },
                 resolveUri: function (uri) {
                     return FormplayerFrontend.getChannel().request('resourceMap', uri, appId);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -452,7 +452,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
         templateContext: function () {
             var description = this.options.collection.description === undefined ?
-                "" : md.render(this.options.collection.description.trim());
+                "" : cloudcareUtils.renderMarkdown(this.options.collection.description.trim());
             return {
                 title: this.options.title.trim(),
                 description: DOMPurify.sanitize(description),

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -1,4 +1,4 @@
-/* global moment, NProgress */
+/* global DOMPurify, moment, NProgress */
 hqDefine('cloudcare/js/utils', [
     'jquery',
     'hqwebapp/js/initial_page_data',
@@ -232,6 +232,11 @@ hqDefine('cloudcare/js/utils', [
         });
     };
 
+    function renderMarkdown(text) {
+        const md = window.markdownit();
+        return md.render(DOMPurify.sanitize(text || "")).replaceAll("\n", "<br>");
+    };
+
     function chainedRenderer(matcher, transform, target) {
         return function (tokens, idx, options, env, self) {
             var hIndex = tokens[idx].attrIndex('href');
@@ -438,6 +443,7 @@ hqDefine('cloudcare/js/utils', [
         initTimePicker: initTimePicker,
         getFormUrl: getFormUrl,
         getSubmitUrl: getSubmitUrl,
+        renderMarkdown: renderMarkdown,
         showError: showError,
         showWarning: showWarning,
         showHTMLError: showHTMLError,


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-3346

## Technical Summary

`&#10;` entities in display property calculations weren't being rendered as line breaks in case tiles. Our [markdown library](https://github.com/markdown-it/markdown-it) was changing them into `\n` characters - correctly, since part of the CommonMark spec is to translate decimal numeric characters and HTML entities into their unicode equivalents ([reference](https://spec.commonmark.org/0.28/#decimal-numeric-character)). Initially I added [a plugin](https://github.com/Manvel/markdown-it-html-entities) to get around this, which did keep the `&#10;` in the string. However, it still didn't appear in the HTML, and I'm not certain why - something about underscore template rendering? So I ended up just letting the unicode replacement happen and then replacing `\n` with a line break tag. Ew, although we do something similar in form entry [here](https://github.com/dimagi/commcare-hq/blob/70d8c4bb5ecae1609b3c3c4ecc9130bc3ade2aac/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js#L182).

## Safety Assurance

### Safety story
This should get some more testing, just in case. The logic change is minor, this is just moderate risk because it's the web apps UI.

I'm open to reverting the naming changes and releasing those in July if anyone is feeling paranoid.

### Automated test coverage

No

### QA Plan

https://dimagi-dev.atlassian.net/browse/QA-5305

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
