### PR TITLE
ABHA Validation on HQ for Creation flow

### DIFF
--- a/custom/abdm/milestone_one/views/abha_creation_views.py
+++ b/custom/abdm/milestone_one/views/abha_creation_views.py
@@ -9,6 +9,7 @@ from custom.abdm.auth import ABDMUserAuthentication
 from custom.abdm.milestone_one.utils import abha_creation_util as abdm_util
 from custom.abdm.milestone_one.utils.decorators import required_request_params
 from custom.abdm.milestone_one.utils.response_util import parse_response
+from custom.abdm.utils import check_for_existing_abha_number
 
 
 @api_view(["POST"])
@@ -56,4 +57,6 @@ def verify_mobile_otp(request):
         resp = abdm_util.create_health_id(txn_id, health_id)
         resp["user_token"] = resp.pop("token")
         resp.pop("refreshToken")
+        resp["exists_on_abdm"] = not resp.pop("new")
+        resp["exists_on_hq"] = check_for_existing_abha_number(request.user.domain, health_id)
     return parse_response(resp)

--- a/custom/abdm/milestone_one/views/abha_verification_views.py
+++ b/custom/abdm/milestone_one/views/abha_verification_views.py
@@ -97,6 +97,9 @@ def get_health_card_png(request):
 @required_request_params(["health_id"])
 def get_existence_by_health_id(request):
     health_id = request.data.get("health_id")
+    if check_for_existing_abha_number(request.user.domain, health_id):
+        return generate_invalid_req_response(ERROR_MESSAGES[ABHA_IN_USE_ERROR_CODE],
+                                             error_code=ABHA_IN_USE_ERROR_CODE)
     resp = abdm_util.exists_by_health_id(health_id)
     if "status" in resp:
         resp = {"health_id": health_id, "exists": resp.get("status")}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR adds below two things to ABHA creation flow in ABDM app:
- In the screen which shows option for `Check ABHA ID`, we have added a check for ABHA in HQ and returns appropriate error if exists.
- After the sucessfull creation of ABHA , it adds two keus in response `exists_on_abdm` and `exists_on_hq` which denotes whether ABHA already exists on ABDM and HQ respectively.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
