### PR TITLE
Change the position of the case list map to sticky

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -3,6 +3,7 @@
 hqDefine("cloudcare/js/formplayer/menus/views", function () {
     const kissmetrics = hqImport("analytix/js/kissmetrix"),
         constants = hqImport("cloudcare/js/formplayer/constants"),
+        ko = hqImport("knockout"),
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
         initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         toggles = hqImport("hqwebapp/js/toggles"),
@@ -615,6 +616,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 selectedCaseIds: this.selectedCaseIds,
                 isMultiSelect: false,
                 showMap: this.showMap,
+                useTilesKo: ko.observable(this.useTiles),
                 columnStyle: this.columnStyle(),
                 sidebarEnabled: this.options.sidebarEnabled,
                 triggerEmptyCaseList: this.options.triggerEmptyCaseList,
@@ -737,6 +739,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         templateContext: function () {
             const dict = CaseTileListView.__super__.templateContext.apply(this, arguments);
             dict.useTiles = true;
+            dict.useTilesKo(true);
             dict.isMultiSelect = this.options.isMultiSelect;
             return dict;
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -3,7 +3,6 @@
 hqDefine("cloudcare/js/formplayer/menus/views", function () {
     const kissmetrics = hqImport("analytix/js/kissmetrix"),
         constants = hqImport("cloudcare/js/formplayer/constants"),
-        ko = hqImport("knockout"),
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
         initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         toggles = hqImport("hqwebapp/js/toggles"),
@@ -616,7 +615,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 selectedCaseIds: this.selectedCaseIds,
                 isMultiSelect: false,
                 showMap: this.showMap,
-                useTilesKo: ko.observable(this.useTiles),
                 columnStyle: this.columnStyle(),
                 sidebarEnabled: this.options.sidebarEnabled,
                 triggerEmptyCaseList: this.options.triggerEmptyCaseList,
@@ -739,7 +737,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         templateContext: function () {
             const dict = CaseTileListView.__super__.templateContext.apply(this, arguments);
             dict.useTiles = true;
-            dict.useTilesKo(true);
             dict.isMultiSelect = this.options.isMultiSelect;
             return dict;
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -565,6 +565,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                                             // -50 Stay clear of the breadcrumbs
                                             scrollTop: $(`#${rowId}`).offset().top - 50
                                         }, 500);
+
+                                        addressMap.panTo(latLng);
                                     });
                                 latLons.push(latLng);
                             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -565,8 +565,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                                             // -50 Stay clear of the breadcrumbs
                                             scrollTop: $(`#${rowId}`).offset().top - 50
                                         }, 500);
-
-                                        addressMap.panTo(latLng);
                                     });
                                 latLons.push(latLng);
                             }

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -59,7 +59,7 @@
         <% } %>
       </div>
       <% if (showMap) { %>
-        <div id="module-case-list-map" class="map" data-bind="css: { 'white-border': showMapKo() }"></div>
+        <div id="module-case-list-map" class="map <% if (useTiles) { %> white-border<% } %>"></div>
       <% } %>
     </div>
     <% if (actions || isMultiSelect) { %>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -59,7 +59,7 @@
         <% } %>
       </div>
       <% if (showMap) { %>
-        <div id="module-case-list-map" class="map"></div>
+        <div id="module-case-list-map" class="map" data-bind="css: { 'white-border': showMapKo() }"></div>
       <% } %>
     </div>
     <% if (actions || isMultiSelect) { %>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -8,11 +8,14 @@
   .box-shadow(0 0 10px 2px rgba(0,0,0,.1));
   margin-bottom: 2rem;
 
+  .white-border {
+    border: 1px solid white;
+  }
+
   #module-case-list-map {
     height: calc(~"100vh - 65px");
     position: sticky !important; // Has to be important so the leaflet code does not set it to relative
     top: 50px; // based on the height of the crumbs bar
-    border: 1px solid white;
 
     .marker-pin {
       text-align: center;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -9,7 +9,10 @@
   margin-bottom: 2rem;
 
   #module-case-list-map {
-    height: 100%;
+    height: calc(~"100vh - 65px");
+    position: sticky !important; // Has to be important so the leaflet code does not set it to relative
+    top: 50px; // based on the height of the crumbs bar
+    border: 1px solid white;
 
     .marker-pin {
       text-align: center;


### PR DESCRIPTION
## Product Description

* Change map to roughly the height of the view port (window) minus the bread crumbs bar.
* Make the map sticky to the window so it does not scroll behind the bread crumbs bar 

https://github.com/dimagi/commcare-hq/assets/1946138/0724d391-295a-4b46-9add-db23265e4a94

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3340

## Feature Flag

None

## Safety Assurance

### Safety story

Tested locally and on staging

### Automated test coverage

None

### QA Plan

* Case list with map loads properly.
* Scrolling down will keeps the map visible

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
