### PR TITLE
Small fix

### DIFF
--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -452,7 +452,7 @@ def _process_bulk_upload(bulk_file, domain):
                         continue
                     if row_len < 3:
                         # if missing value or description, fill in "blank"
-                        row += [Cell(value='') for _ in range(3 - row_len)]
+                        row += [Cell(value='') for __ in range(3 - row_len)]
                     row = [cell.value if cell.value is not None else '' for cell in row]
                     prop_name, allowed_value, description = [str(val) for val in row[0:3]]
                     if allowed_value and not prop_name:

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -8,7 +8,7 @@ from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.db.models.query import Prefetch
 from django.db.transaction import atomic
-from django.http import HttpResponse, JsonResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -20,31 +20,27 @@ from couchexport.writers import Excel2007ExportWriter
 
 from corehq import toggles
 from corehq.apps.case_importer.tracking.filestorage import make_temp_file
-from corehq.apps.data_dictionary import util
 from corehq.apps.data_dictionary.models import (
     CaseProperty,
     CasePropertyAllowedValue,
     CasePropertyGroup,
     CaseType,
 )
-from corehq.apps.data_dictionary.util import save_case_property, save_case_property_group
+from corehq.apps.data_dictionary.util import (
+    save_case_property,
+    save_case_property_group,
+)
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.settings.views import BaseProjectDataView
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
-
 from corehq.motech.fhir.utils import (
     load_fhir_resource_mappings,
+    load_fhir_resource_types,
     remove_fhir_resource_type,
     update_fhir_resource_type,
-    load_fhir_resource_types,
-)
-from corehq.project_limits.rate_limiter import (
-    RateDefinition,
-    RateLimiter,
-    get_dynamic_rate_definition,
 )
 from corehq.util.files import file_extention_from_filename
 from corehq.util.workbook_reading import open_any_workbook


### PR DESCRIPTION
## Technical Summary

Fixes a variable assignment that overwrites `gettext_lazy()`. Drops unused imports.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Small change. The broken code was only used to translate error messages related to data dictionary bulk upload, which is seldom used, and why it was probably not encountered.

### Automated test coverage

Not covered by tests.

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
