### PR TITLE
Removed case tiles ID mapping validation

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -81,7 +81,6 @@ class CaseTileHelper(object):
 
         # Add case search action if needed
         if module_offers_search(self.module) and not module_uses_inline_search(self.module):
-            from corehq.apps.app_manager.suite_xml.sections.details import DetailContributor
             # don't add search again action in split screen
             if not toggles.SPLIT_SCREEN_CASE_SEARCH.enabled(self.app.domain):
                 detail.actions.append(

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -137,13 +137,6 @@ class CaseTileHelper(object):
             ),
             "format": column.format
         }
-        if column.enum and column.format != "enum" and column.format != "conditional-enum":
-            raise SuiteError(
-                'Expected case tile field "{}" to be an id mapping with keys {}.'.format(
-                    column.case_tile_field,
-                    ", ".join(['"{}"'.format(i.key) for i in column.enum])
-                )
-            )
 
         context['variables'] = ''
         if column.format == "enum" or column.format == 'conditional-enum':


### PR DESCRIPTION
## Product Description
This validation causes case tiles to error if you set up a display property as an ID mapping and later change it to a different format, since the enum keys & values aren't cleared when the format is changed (which is convenient, because you can change it back without re-adding them).

## Feature Flag
REC case tiles

## Safety Assurance

### Safety story
Pretty minor. Removes a bit of app validation on a feature flag that isn't widely used.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
