### PR TITLE
Check for both case_id and owner_id in Case API

### DIFF
--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -317,16 +317,11 @@ def _get_owner_ids(domain, data, case_db):
 
         for index in data_item.indices.values():
             index_case_id = index.get_id(case_db)
-            valid_case_id = False
             if index_case_id in case_db.real_case_ids:
                 case_ids.append(index_case_id)
-                valid_case_id = True
-            try:
+            else:
                 case_owner_id = case_db.get_owner_id(index_case_id)
                 owner_ids.append(case_owner_id)
-            except UserError as e:
-                if not valid_case_id:
-                    raise e
 
     case_owner_ids = (
         CaseSearchES()

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -5,7 +5,6 @@ from django.core.exceptions import PermissionDenied
 
 import jsonobject
 from jsonobject.exceptions import BadValueError
-from memoized import memoized
 
 from casexml.apps.case.mock import CaseBlock, IndexAttrs
 

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -307,13 +307,9 @@ def _get_owner_ids(domain, data, case_db):
     for data_item in data:
         if data_item.owner_id:
             owner_ids.append(data_item.owner_id)
-        try:
+        if not data_item.is_new_case:
             case_id = data_item.get_case_id(case_db)
             case_ids.append(case_id)
-        except UserError as e:
-            # If we don't have an owner_id, we have to have a valid case_id
-            if not data_item.owner_id:
-                raise e
 
         for index in data_item.indices.values():
             index_case_id = index.get_id(case_db)

--- a/corehq/apps/hqcase/tests/test_case_api_permissions.py
+++ b/corehq/apps/hqcase/tests/test_case_api_permissions.py
@@ -253,6 +253,22 @@ class TestCaseAPIPermissions(TestCase):
             json = response.json()
             self.assertEqual(json['case']['properties'], self.test_case_property)
 
+    def test_case_api_update_new_owner_no_permission(self):
+        with get_web_user(
+            self.domain,
+            self.user_location,
+            self.location_restricted_permissions,
+            self.client,
+        ):
+            case_update = {
+                'case_id': self.case_mapping['user_case'],
+                'owner_id': self.restricted_location.location_id,
+                'properties': self.test_case_property
+            }
+            url = reverse('case_api', args=(self.domain,))
+            response = self.client.put(url, case_update, content_type='application/json')
+            self.assertEqual(response.status_code, 403)
+
     def test_case_api_create_successful(self):
         with get_web_user(
             self.domain,


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

This change is motivated by [this](https://github.com/dimagi/commcare-hq/pull/32890#discussion_r1240165674) comment thread. Small change to the Case API to check for both `case_id` and `owner_id` for cases and indices. Previously, used only one of the two based on whether it was a case create or update. It was realized that this might not always be enough for permission checking when a user is trying to change the `owner_id` of a case.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Automated tests exist.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests do exist to validate permission checking works as expected.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
