### PR TITLE
Add support for purging _id in source in ES docs

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -395,6 +395,10 @@ class ElasticManageAdapter(BaseAdapter):
         :param dest: ``str`` name of the destination index
         :param wait_for_completion: ``bool`` would block the request until reindex is complete
         :param refresh: ``bool`` refreshes index
+        :param batch_size: ``int`` The size of the scroll batch used by the reindex process. larger
+                           batches may process more quickly but risk errors if the documents are too
+                           large. 1000 is the recommended maximum and elasticsearch default,
+                           and can be reduced if you encounter scroll timeouts.
 
         :returns: None if wait_for_completion is True else would return task_id of reindex task
         """

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -387,7 +387,8 @@ class ElasticManageAdapter(BaseAdapter):
         elif "*" in index:
             raise ValueError(f"refusing to operate with index wildcards: {index}")
 
-    def reindex(self, source, dest, wait_for_completion=False, refresh=False, batch_size=1000):
+    def reindex(self, source, dest, wait_for_completion=False,
+                refresh=False, batch_size=1000, purge_ids=False):
         """
         Starts the reindex process in elastic search cluster
 
@@ -399,6 +400,10 @@ class ElasticManageAdapter(BaseAdapter):
                            batches may process more quickly but risk errors if the documents are too
                            large. 1000 is the recommended maximum and elasticsearch default,
                            and can be reduced if you encounter scroll timeouts.
+        :param purge_ids: ``bool`` adds an inline script to remove the _id field from documents source.
+                          these cause errors on reindexing the doc, but the script slows down the reindex
+                          substantially, so it is only recommended to enable this if you have run into
+                          the specific error it is designed to resolve.
 
         :returns: None if wait_for_completion is True else would return task_id of reindex task
         """
@@ -418,6 +423,9 @@ class ElasticManageAdapter(BaseAdapter):
             },
             "conflicts": "proceed"
         }
+        if purge_ids:
+            reindex_body["script"] = {"inline": "if (ctx._source._id) {ctx._source.remove('_id')}"}
+
         reindex_info = self._es.reindex(
             reindex_body,
             wait_for_completion=wait_for_completion,

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -80,7 +80,7 @@ class ESSyncUtil:
         logger.info("You can use commcare-cloud to extract reindex logs from cluster")
         print("\n\t"
             + f"cchq {settings.SERVER_ENVIRONMENT} run-shell-command elasticsearch "
-            + f"\"grep '{task_id}.*ReindexResponse' opt/data/elasticsearch*/logs/*es.log\""
+            + f"\"grep '{task_id}.*ReindexResponse' /opt/data/elasticsearch*/logs/*es.log\""
             + "\n\n")
 
     def _get_source_destination_indexes(self, adapter):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SAAS-12152

A redo of https://github.com/dimagi/commcare-hq/pull/32588 as it was not merged around that time. Now we need it to reindex cases and forms on India env.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This has been tested before while reindexing forms on production. But this was not merged.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
