### PR TITLE
Switch back to original release of flower

### DIFF
--- a/requirements/prod-requirements.in
+++ b/requirements/prod-requirements.in
@@ -2,8 +2,7 @@
 
 pip
 
-# Switch back to normal package as soon as flower release a version > 1.2.0
-flower @ git+https://github.com/mher/flower@a4fc7c97d897a3172d1058d5269115eb88d811de
+flower
 setproctitle
 uWSGI
 ipython  # for nicer django shell experience

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -208,7 +208,7 @@ fiona==1.9.3
     # via geopandas
 firebase-admin==6.1.0
     # via -r base-requirements.in
-flower @ git+https://github.com/mher/flower@a4fc7c97d897a3172d1058d5269115eb88d811de
+flower==2.0.0
     # via -r prod-requirements.in
 future==0.18.3
     # via pyjwkest


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Finally flower released 2.0, so our changes are finally in and we no longer need to pull from a specific commit 🎉 
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-13911 (Has been open since an year)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
There is no changelog for Flower but went though the commits https://github.com/mher/flower/compare/v1.2.0...v2.0.0 and nothing jumps out to be breaking.

It is relatively safe as it does not affect any core service. Nevertheless I will put it on staging to see if everything is good.  

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
