### PR TITLE
Split Screen Case Search: field validation fix

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -9,6 +9,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         views = hqImport("cloudcare/js/formplayer/menus/views"),
         toggles = hqImport("hqwebapp/js/toggles"),
         QueryListView = hqImport("cloudcare/js/formplayer/menus/views/query"),
+        Collection = hqImport("cloudcare/js/formplayer/menus/collections"),
         md = window.markdownit();
     var selectMenu = function (options) {
 
@@ -126,7 +127,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         }
         var queryResponse = menuResponse.queryResponse;
         if (sidebarEnabled && !appPreview && menuResponse.type === "entities" && queryResponse != null)  {
-            var queryCollection = new Backbone.Collection(queryResponse.displays);
+            var queryCollection = new Collection(queryResponse.displays);
             FormplayerFrontend.regions.getRegion('sidebar').show(QueryListView({collection: queryCollection, title: menuResponse.title, description: menuResponse.description,  sidebarEnabled: true}).render());
         } else if (sidebarEnabled && !appPreview && menuResponse.type === "query") {
             FormplayerFrontend.regions.getRegion('sidebar').show(QueryListView({collection: menuResponse, title: menuResponse.title, description: menuResponse.description, sidebarEnabled: true}).render());

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -600,13 +600,23 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             var fetchingPrompts = FormplayerFrontend.getChannel().request("app:select:menus", urlObject);
             $.when(fetchingPrompts).done(function (response) {
                 // Update models based on response
-                _.each(response.models, function (responseModel, i) {
-                    self.collection.models[i].set({
-                        error: responseModel.get('error'),
-                        required: responseModel.get('required'),
-                        required_msg: responseModel.get('required_msg'),
-                    });
+                if (response.queryResponse != null) {
+                    _.each(response.queryResponse.displays, function (responseModel, i) {
+                        self.collection.models[i].set({
+                            error: responseModel.error,
+                            required: responseModel.required,
+                            required_msg: responseModel.required_msg,
+                        });
                 });
+                } else {
+                    _.each(response.models, function (responseModel, i) {
+                        self.collection.models[i].set({
+                            error: responseModel.get('error'),
+                            required: responseModel.get('required'),
+                            required_msg: responseModel.get('required_msg'),
+                        });
+                    });
+                }
                 promise.resolve(response);
 
             });


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Bug reported by delivery on the test domain: [here](https://dimagi-dev.atlassian.net/browse/USH-3371)

Field validation only worked the second time the user pressed submit, but now it works the same as it does without SSCS enabled. 
With SSCS: 
![Untitled design](https://github.com/dimagi/commcare-hq/assets/36681924/65954ca7-07a7-4030-bfad-72215f62a64d)

Without SSCS:
![Untitled design](https://github.com/dimagi/commcare-hq/assets/36681924/7ea278dc-6628-4a7a-a354-a52e98c2666e)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
There were quite a few red herrings with this bug, but ultimately the root was in `_updateModelsForValidation` which is called at the time of Submit and for any field change for a query screen. The models were not actually being updated because of how the response is formatted since for SSCS, it is not a query response for some instances, but rather a entities response with the `queryReponse` attached. 
The response was only properly handled when then QueryListView screen was re-rendered which is why it worked the second time but not the first time and seemed "delayed" from the user's perspective. 


Note: the `Backbon.Collection` -> `Collections` change is unrelated to the bug, but is just a generally good thing to have and what I've been doing all the testing with so I figured I'd leave it in rather than re-do the testing and separate into another PR. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
SPLIT_SCREEN_CASE_SEARCH

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This check for `queryResponse` which is flagged on the formplayer end and otherwise make no changes outside of that FF

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
We have JS tests now for SSCS! Not this exact change, but that ensures the basic workflow is still functional

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I'm not requesting QA for this change prior to deploy, but will flag as part of the greater SSCS QA epic

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
