### PR TITLE
Management command to migrate user email domains

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -610,19 +610,6 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
                                         wrapper=cls.wrap, **kwargs)
         return result
 
-    @classmethod
-    def by_owner(cls, owner_id, stale=True, **kwargs):
-        if stale:
-            kwargs['stale'] = settings.COUCH_STALE_QUERY
-
-        key = [owner_id]
-        db = cls.get_db()
-        result = cache_core.cached_view(db, "reportconfig/user_notifications", reduce=False,
-                                        include_docs=True, startkey=key, endkey=key + [{}],
-                                        wrapper=cls.wrap, **kwargs)
-
-        return result
-
     @property
     @memoized
     def all_recipient_emails(self):

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -610,6 +610,19 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
                                         wrapper=cls.wrap, **kwargs)
         return result
 
+    @classmethod
+    def by_owner(cls, owner_id, stale=True, **kwargs):
+        if stale:
+            kwargs['stale'] = settings.COUCH_STALE_QUERY
+
+        key = [owner_id]
+        db = cls.get_db()
+        result = cache_core.cached_view(db, "reportconfig/user_notifications", reduce=False,
+                                        include_docs=True, startkey=key, endkey=key + [{}],
+                                        wrapper=cls.wrap, **kwargs)
+
+        return result
+
     @property
     @memoized
     def all_recipient_emails(self):

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -24,7 +24,15 @@ NEW_USERNAME = 'new_username'
 
 
 class Command(BaseCommand):
-    help = "Create a new web user with the same data as the old user"
+    help = """
+    Creates new web users with the same data as existing web users
+    - Input is a CSV file with old_username and new_username columns
+    - The new user is created, data is copied/transferred over, and the old user is deactivated which will log
+    users out on their next request
+    - Sends an email to the new user's preferred email and old user's preferred email informing them of the change
+    If a user wants to reactivate their old account, they can request this via support who has the ability to make
+    this change in hq admin  under User Administration -> Lookup user by email -> Disable/Enable User Account
+    """
 
     def add_arguments(self, parser):
         parser.add_argument('file', help='')

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -38,19 +38,9 @@ class Command(BaseCommand):
 
     def iterate_usernames_to_update(self, file):
         with open(file, newline='') as csvfile:
-            reader = csv.reader(csvfile, delimiter=' ', quotechar='|')
-            header = next(reader)
-            header_values = header[0].split(',')
-            try:
-                old_user_index = header_values.index(OLD_USERNAME)
-                new_user_index = header_values.index(NEW_USERNAME)
-            except ValueError:
-                logger.error(f'The provided csv file should contain both a {OLD_USERNAME} and {NEW_USERNAME} '
-                             'header column')
-                return
+            reader = csv.DictReader(csvfile)
             for row in reader:
-                row_values = row[0].split(',')
-                yield row_values[old_user_index], row_values[new_user_index]
+                yield row[OLD_USERNAME], row[NEW_USERNAME]
 
 
 def clone_user(old_username, new_username):

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
 
     def handle(self, command, file, **options):
         logger.setLevel(logging.INFO if options["verbose"] else logging.WARNING)
-        dry_run = options['dry-run']
+        dry_run = options['dry_run']
 
         if command == NOTIFY:
             command_to_run = notify_users_command

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -114,14 +114,14 @@ def transfer_exports(from_user, to_user):
 
 def transfer_scheduled_reports(from_user, to_user_id):
     for domain in from_user.domains:
-        for scheduled_report in ReportNotification.by_domain_and_owner(domain, from_user._id):
+        for scheduled_report in ReportNotification.by_domain_and_owner(domain, from_user._id, stale=False):
             scheduled_report.owner_id = to_user_id
             scheduled_report.save()
 
 
 def transfer_saved_reports(from_user, to_user):
     for domain in from_user.domains:
-        for saved_report in ReportConfig.by_domain_and_owner(domain, from_user.get_id):
+        for saved_report in ReportConfig.by_domain_and_owner(domain, from_user.get_id, stale=False):
             saved_report.owner_id = to_user.get_id
             saved_report.save()
 

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -149,7 +149,7 @@ def clone_user(old_username, new_username, dry_run=False):
     transfer_exports(old_user, new_user, dry_run=dry_run)
     transfer_scheduled_reports(old_user, new_user, dry_run=dry_run)
     transfer_saved_reports(old_user, new_user, dry_run=dry_run)
-    transfer_feature_flags(old_user, new_user, dry_run=dry_run)
+    transfer_feature_flags(old_user.username, new_user.username, dry_run=dry_run)
 
     return old_user, new_user
 

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -79,6 +79,7 @@ def iterate_usernames_to_update(file):
 
 def clone_user(old_username, new_username):
     new_username = new_username.lower()
+    old_username = old_username.lower()
     old_user = WebUser.get_by_username(old_username)
     if not old_user:
         raise OldUserNotFound

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -194,15 +194,14 @@ def send_deprecation_email(old_user, new_user):
     email_html = render_to_string('users/email/deprecated_user.html', context)
     email_plaintext = render_to_string('users/email/deprecated_user.txt', context)
 
-    logger.info(
-        f'Sending email with deprecated notice to old email {old_user.email} and new email {new_user.email}.'
-    )
+    logger.info(f'Sending email with deprecated notice to old email {old_user.get_email()} and '
+                f'new email {new_user.get_email()}.')
     send_html_email_async.delay(
         _("Deprecated User"),
-        old_user.email,
+        old_user.get_email(),
         email_html,
         text_content=email_plaintext,
         email_from=settings.DEFAULT_FROM_EMAIL,
         file_attachments=[],
-        cc=[new_user.email]
+        cc=[new_user.get_email()]
     )

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -136,7 +136,7 @@ def transfer_feature_flags(from_user, to_user):
         logger.info(f'Updating toggle {toggle} from {from_user.username} to {to_user.username}')
         set_toggle(toggle, from_user.username, False)
         set_toggle(toggle, to_user.username, True)
-        logger.info(f'Transferred access to {toggle.slug}.')
+        logger.info(f'Transferred access to {toggle}.')
 
     toggles_enabled_for_user.clear(from_user.username)
     toggles_enabled_for_user.clear(to_user.username)

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -98,15 +98,25 @@ def iterate_usernames_to_update(file):
             yield row[OLD_USERNAME], row[NEW_USERNAME]
 
 
-def clone_user(old_username, new_username, dry_run=False):
-    new_username = new_username.lower()
+def validate_usernames(old_username, new_username):
+    """
+    Ensures the old_username has an existing user, and the new_username does not
+    :return: the old user that was fetched from the DB if all went well
+    """
     old_username = old_username.lower()
     old_user = WebUser.get_by_username(old_username)
     if not old_user:
         raise OldUserNotFound
 
+    new_username = new_username.lower()
     if WebUser.get_by_username(new_username):
         raise NewUserAlreadyExists
+
+    return old_user
+
+
+def clone_user(old_username, new_username, dry_run=False):
+    old_user = validate_usernames(old_username, new_username)
 
     new_user = None
     if not dry_run:

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -147,7 +147,7 @@ def clone_user(old_username, new_username, dry_run=False):
     copy_domain_memberships(old_user, new_user, dry_run=dry_run)
     # Transfer methods do impact the existing user
     transfer_exports(old_user, new_user, dry_run=dry_run)
-    transfer_scheduled_reports(old_user, new_user.get_id, dry_run=dry_run)
+    transfer_scheduled_reports(old_user, new_user, dry_run=dry_run)
     transfer_saved_reports(old_user, new_user, dry_run=dry_run)
     transfer_feature_flags(old_user, new_user, dry_run=dry_run)
 
@@ -208,12 +208,12 @@ def transfer_exports(from_user, to_user, dry_run=False):
                 logger.info(f'{dry_run_tag}Transferred ownership of export {export._id}.')
 
 
-def transfer_scheduled_reports(from_user, to_user_id, dry_run=False):
+def transfer_scheduled_reports(from_user, to_user, dry_run=False):
     dry_run_tag = "[DRY_RUN]" if dry_run else ""
     for domain in from_user.domains:
         for scheduled_report in ReportNotification.by_domain_and_owner(domain, from_user._id, stale=False):
             if not dry_run:
-                scheduled_report.owner_id = to_user_id
+                scheduled_report.owner_id = to_user._id
                 scheduled_report.save()
             logger.info(f'{dry_run_tag}Transferred ownership of scheduled report {scheduled_report._id}.')
 

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -1,0 +1,182 @@
+import csv
+import logging
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+from django.template.loader import render_to_string
+from django.utils.translation import ugettext_lazy as _
+
+import settings
+from corehq.apps.export.dbaccessors import _get_export_instance
+from corehq.apps.export.models import ExportInstance
+from corehq.apps.hqwebapp.tasks import send_html_email_async
+from corehq.apps.saved_reports.models import ReportConfig, ReportNotification
+from corehq.apps.users.models import DomainMembership, WebUser
+from corehq.const import USER_CHANGE_VIA_CLONE
+
+logger = logging.getLogger(__name__)
+
+OLD_USERNAME = 'old_username'
+NEW_USERNAME = 'new_username'
+
+
+class Command(BaseCommand):
+    help = "Create a new web user with the same data as the old user"
+
+    def add_arguments(self, parser):
+        parser.add_argument('file', help='')
+        parser.add_argument('--verbose', action="store_true")
+
+    def handle(self, file, **options):
+        logger.setLevel(logging.INFO if options["verbose"] else logging.WARNING)
+        for old_username, new_username in self.iterate_usernames_to_update(file):
+            old_user, new_user = clone_user(old_username, new_username)
+            logger.info(f'Created new user {new_user.username}.')
+            # TODO: create entry in postgres to ensure the old user is deleted when the new user logs in
+            # send notice email to both the old and new user
+            send_deprecation_email(old_user, new_user)
+
+    def iterate_usernames_to_update(self, file):
+        with open(file, newline='') as csvfile:
+            reader = csv.reader(csvfile, delimiter=' ', quotechar='|')
+            header = next(reader)
+            header_values = header[0].split(',')
+            try:
+                old_user_index = header_values.index(OLD_USERNAME)
+                new_user_index = header_values.index(NEW_USERNAME)
+            except ValueError:
+                logger.error(f'The provided csv file should contain both a {OLD_USERNAME} and {NEW_USERNAME} '
+                             'header column')
+                return
+            for row in reader:
+                row_values = row[0].split(',')
+                yield row_values[old_user_index], row_values[new_user_index]
+
+
+def clone_user(old_username, new_username):
+    new_username = new_username.lower()
+    old_user = WebUser.get_by_username(old_username)
+    new_user = create_new_user_from_old_user(old_user, new_username)
+
+    # Copy methods do not impact the existing user
+    copy_domain_memberships(old_user, new_user)
+    # Transfer methods do impact the existing user
+    transfer_exports(old_user, new_user)
+    transfer_scheduled_reports(old_user.get_id, new_user.get_id)
+    transfer_saved_reports(old_user, new_user)
+
+    return old_user, new_user
+
+
+def create_new_user_from_old_user(old_user, new_username):
+    new_user = WebUser.create(
+        None,
+        new_username,
+        User.objects.make_random_password(),
+        None,
+        USER_CHANGE_VIA_CLONE,
+        email=new_username,
+        by_domain_required_for_log=False,
+    )
+
+    new_user = copy_user_fields(old_user, new_user)
+    new_user.save()
+
+    return WebUser.get_by_username(new_user.username, strict=True)
+
+
+def copy_domain_memberships(from_user, to_user):
+    for domain_membership in from_user.domain_memberships:
+        # intentionally leave out last_accessed
+        copied_membership = DomainMembership(
+            domain=domain_membership.domain,
+            timezone=domain_membership.timezone,
+            override_global_tz=domain_membership.override_global_tz,
+            role_id=domain_membership.role_id,
+            location_id=domain_membership.location_id,
+            assigned_location_ids=domain_membership.assigned_location_ids,
+            program_id=domain_membership.program_id
+        )
+        to_user.domain_memberships.append(copied_membership)
+        to_user.domains.append(copied_membership.domain)
+
+    to_user.save()
+
+
+def transfer_exports(from_user, to_user):
+    for domain in from_user.domains:
+        key = [domain]
+        for export in _get_export_instance(ExportInstance, key):
+            if export.owner_id == from_user.get_id:
+                export.owner_id = to_user.get_id
+                export.save()
+
+
+def transfer_scheduled_reports(from_user_id, to_user_id):
+    for scheduled_report in ReportNotification.by_owner(from_user_id):
+        scheduled_report.owner_id = to_user_id
+        scheduled_report.save()
+
+
+def transfer_saved_reports(from_user, to_user):
+    for domain in from_user.domains:
+        for saved_report in ReportConfig.by_domain_and_owner(domain, from_user.get_id):
+            saved_report.owner_id = to_user.get_id
+            saved_report.save()
+
+
+def copy_user_fields(from_user, to_user):
+    # DjangoUserMixin fields
+    # username, email and password have already been set
+    # do not copy last_login and date_joined
+    to_user.first_name = from_user.first_name
+    to_user.last_name = from_user.last_name
+    to_user.is_staff = from_user.is_staff
+    to_user.is_active = from_user.is_active
+    to_user.is_superuser = from_user.is_superuser
+
+    # CouchUser fields
+    # ignoring device_ids, last_device, created_on, last_modified
+    to_user.devices = from_user.devices
+    to_user.phone_numbers = from_user.phone_numbers
+    to_user.status = from_user.status
+    to_user.language = from_user.language
+    to_user.subscribed_to_commcare_users = from_user.subscribed_to_commcare_users
+    to_user.announcements_seen = from_user.announcements_seen
+    to_user.user_data = from_user.user_data
+    to_user.update_metadata(from_user.metadata)
+    to_user.set_location(from_user.location_id)
+    to_user.assigned_location_ids = from_user.assigned_location_ids
+    to_user.has_built_app = from_user.has_built_app
+    to_user.analytics_enabled = from_user.analytics_enabled
+
+    # Web User fields
+    to_user.program_id = from_user.program_id
+    to_user.fcm_device_token = from_user.fcm_device_token
+    to_user.atypical_user = from_user.atypical_user
+
+    # EulaMixin field
+    to_user.eulas = from_user.eulas
+
+    return to_user
+
+
+def send_deprecation_email(old_user, new_user):
+    context = {
+        'greeting': _("Dear %s,") % new_user.first_name if new_user.first_name else _("Hello,"),
+        'old_username': old_user.username,
+        'new_username': new_user.username,
+    }
+
+    email_html = render_to_string('users/deprecated_user.html', context)
+    email_plaintext = render_to_string('users/deprecated_user.txt', context)
+
+    send_html_email_async.delay(
+        _("Deprecated User"),
+        old_user.email,
+        email_html,
+        text_content=email_plaintext,
+        email_from=settings.DEFAULT_FROM_EMAIL,
+        file_attachments=[],
+        cc=[new_user.email]
+    )

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -157,7 +157,8 @@ def copy_user_fields(from_user, to_user):
     to_user.announcements_seen = from_user.announcements_seen
     to_user.user_data = from_user.user_data
     to_user.update_metadata(from_user.metadata)
-    to_user.set_location(from_user.location_id)
+    # I know it isn't recommended to set location_id directly, but this seems like a good exception
+    to_user.location_id = from_user.location_id
     to_user.assigned_location_ids = from_user.assigned_location_ids
     to_user.has_built_app = from_user.has_built_app
     to_user.analytics_enabled = from_user.analytics_enabled

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -62,7 +62,7 @@ def clone_user(old_username, new_username):
     copy_domain_memberships(old_user, new_user)
     # Transfer methods do impact the existing user
     transfer_exports(old_user, new_user)
-    transfer_scheduled_reports(old_user.get_id, new_user.get_id)
+    transfer_scheduled_reports(old_user, new_user.get_id)
     transfer_saved_reports(old_user, new_user)
 
     return old_user, new_user
@@ -112,15 +112,16 @@ def transfer_exports(from_user, to_user):
                 export.save()
 
 
-def transfer_scheduled_reports(from_user_id, to_user_id):
-    for scheduled_report in ReportNotification.by_owner(from_user_id):
-        scheduled_report.owner_id = to_user_id
-        scheduled_report.save()
+def transfer_scheduled_reports(from_user, to_user_id):
+    for domain in from_user.domains:
+        for scheduled_report in ReportNotification.by_domain_and_owner(domain, from_user._id, stale=False):
+            scheduled_report.owner_id = to_user_id
+            scheduled_report.save()
 
 
 def transfer_saved_reports(from_user, to_user):
     for domain in from_user.domains:
-        for saved_report in ReportConfig.by_domain_and_owner(domain, from_user.get_id):
+        for saved_report in ReportConfig.by_domain_and_owner(domain, from_user.get_id, stale=False):
             saved_report.owner_id = to_user.get_id
             saved_report.save()
 

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -93,7 +93,8 @@ def copy_domain_memberships(from_user, to_user):
             role_id=domain_membership.role_id,
             location_id=domain_membership.location_id,
             assigned_location_ids=domain_membership.assigned_location_ids,
-            program_id=domain_membership.program_id
+            program_id=domain_membership.program_id,
+            is_admin=domain_membership.is_admin,
         )
         to_user.domain_memberships.append(copied_membership)
         to_user.domains.append(copied_membership.domain)

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -149,7 +149,7 @@ def clone_user(old_username, new_username, dry_run=False):
     transfer_exports(old_user, new_user, dry_run=dry_run)
     transfer_scheduled_reports(old_user, new_user, dry_run=dry_run)
     transfer_saved_reports(old_user, new_user, dry_run=dry_run)
-    transfer_feature_flags(old_user.username, new_user.username, dry_run=dry_run)
+    transfer_feature_flags(old_user, new_user, dry_run=dry_run)
 
     return old_user, new_user
 
@@ -228,20 +228,20 @@ def transfer_saved_reports(from_user, to_user, dry_run=False):
             logger.info(f'{dry_run_tag}Transferred ownership of saved report {saved_report._id}.')
 
 
-def transfer_feature_flags(from_username, to_username, dry_run=False):
+def transfer_feature_flags(from_user, to_user, dry_run=False):
     dry_run_tag = "[DRY_RUN]" if dry_run else ""
-    enabled_toggles = toggles_enabled_for_user(from_username)
+    enabled_toggles = toggles_enabled_for_user(from_user.username)
     by_name = all_toggles_by_name()
     for toggle_name in enabled_toggles:
         if not dry_run:
             toggle_slug = by_name[toggle_name].slug
-            set_toggle(toggle_slug, from_username, False)
-            set_toggle(toggle_slug, to_username, True)
-        logger.info(f'{dry_run_tag}Updated toggle name {toggle_name} from {from_username} to {to_username}')
+            set_toggle(toggle_slug, from_user.username, False)
+            set_toggle(toggle_slug, to_user.username, True)
+        logger.info(f'{dry_run_tag}Transferred feature flag {toggle_name}.')
 
     if not dry_run:
-        toggles_enabled_for_user.clear(from_username)
-        toggles_enabled_for_user.clear(to_username)
+        toggles_enabled_for_user.clear(from_user.username)
+        toggles_enabled_for_user.clear(to_user.username)
 
 
 def copy_user_fields(from_user, to_user):

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -114,14 +114,14 @@ def transfer_exports(from_user, to_user):
 
 def transfer_scheduled_reports(from_user, to_user_id):
     for domain in from_user.domains:
-        for scheduled_report in ReportNotification.by_domain_and_owner(domain, from_user._id, stale=False):
+        for scheduled_report in ReportNotification.by_domain_and_owner(domain, from_user._id):
             scheduled_report.owner_id = to_user_id
             scheduled_report.save()
 
 
 def transfer_saved_reports(from_user, to_user):
     for domain in from_user.domains:
-        for saved_report in ReportConfig.by_domain_and_owner(domain, from_user.get_id, stale=False):
+        for saved_report in ReportConfig.by_domain_and_owner(domain, from_user.get_id):
             saved_report.owner_id = to_user.get_id
             saved_report.save()
 

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -49,6 +49,7 @@ def clone_user(old_username, new_username):
     new_username = new_username.lower()
     old_user = WebUser.get_by_username(old_username)
     new_user = create_new_user_from_old_user(old_user, new_username)
+    new_user.save()
 
     # Copy methods do not impact the existing user
     copy_domain_memberships(old_user, new_user)
@@ -73,10 +74,7 @@ def create_new_user_from_old_user(old_user, new_username):
         by_domain_required_for_log=False,
     )
 
-    new_user = copy_user_fields(old_user, new_user)
-    new_user.save()
-
-    return WebUser.get_by_username(new_user.username, strict=True)
+    return copy_user_fields(old_user, new_user)
 
 
 def deactivate_django_user(django_user):

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -29,6 +29,10 @@ class OldUserNotFound(Exception):
     pass
 
 
+class NewUserAlreadyExists(Exception):
+    pass
+
+
 class Command(BaseCommand):
     help = """
     Creates new web users with the same data as existing web users
@@ -62,7 +66,7 @@ class Command(BaseCommand):
             except OldUserNotFound:
                 non_existent_old_users.append((old_username, new_username))
                 continue
-            except CouchUser.Inconsistent:
+            except (CouchUser.Inconsistent, NewUserAlreadyExists):
                 already_existing_users.append((old_username, new_username))
                 continue
 
@@ -87,6 +91,9 @@ def clone_user(old_username, new_username, dry_run=False):
     old_user = WebUser.get_by_username(old_username)
     if not old_user:
         raise OldUserNotFound
+
+    if WebUser.get_by_username(new_username):
+        raise NewUserAlreadyExists
 
     new_user = None
     if not dry_run:

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -154,7 +154,7 @@ def copy_user_fields(from_user, to_user):
 
 def send_deprecation_email(old_user, new_user):
     context = {
-        'greeting': _("Dear %s,") % new_user.first_name if new_user.first_name else _("Hello,"),
+        'greeting': _("Dear {name},").format(name=new_user.first_name) if new_user.first_name else _("Hello,"),
         'old_username': old_user.username,
         'new_username': new_user.username,
     }

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -181,8 +181,8 @@ def send_deprecation_email(old_user, new_user):
         'new_username': new_user.username,
     }
 
-    email_html = render_to_string('users/deprecated_user.html', context)
-    email_plaintext = render_to_string('users/deprecated_user.txt', context)
+    email_html = render_to_string('users/email/deprecated_user.html', context)
+    email_plaintext = render_to_string('users/email/deprecated_user.txt', context)
 
     send_html_email_async.delay(
         _("Deprecated User"),

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -9,8 +9,6 @@ from django.core.management.base import BaseCommand, CommandError
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
-from toggle.shortcuts import set_toggle
-
 import settings
 from corehq.apps.export.dbaccessors import _get_export_instance
 from corehq.apps.export.models import ExportInstance
@@ -18,7 +16,7 @@ from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.saved_reports.models import ReportConfig, ReportNotification
 from corehq.apps.users.models import CouchUser, DomainMembership, WebUser
 from corehq.const import USER_CHANGE_VIA_CLONE
-from corehq.toggles import all_toggles_by_name, toggles_enabled_for_user
+from corehq.toggles import all_toggles_by_name, toggles_enabled_for_user, set_toggle
 from corehq.util.bounced_email_manager import EMAIL_REGEX_VALIDATION
 
 logger = logging.getLogger(__name__)

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         logger.setLevel(logging.INFO if options["verbose"] else logging.WARNING)
         for old_username, new_username in iterate_usernames_to_update(file):
             old_user, new_user = clone_user(old_username, new_username)
-            deactivate_user(old_user)
+            deactivate_django_user(old_user.get_django_user())
             send_deprecation_email(old_user, new_user)
 
 
@@ -79,10 +79,10 @@ def create_new_user_from_old_user(old_user, new_username):
     return WebUser.get_by_username(new_user.username, strict=True)
 
 
-def deactivate_user(user):
-    user.is_active = False
-    user.save()
-    logger.info(f'Deactivated user {user.username}.')
+def deactivate_django_user(django_user):
+    django_user.is_active = False
+    django_user.save()
+    logger.info(f'Deactivated user {django_user.username}.')
 
 
 def copy_domain_memberships(from_user, to_user):

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
 
 
 def iterate_usernames_to_update(file):
-    with open(file, newline='') as csvfile:
+    with open(file) as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             yield row[OLD_USERNAME], row[NEW_USERNAME]

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -16,7 +16,7 @@ from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.saved_reports.models import ReportConfig, ReportNotification
 from corehq.apps.users.models import CouchUser, DomainMembership, WebUser
 from corehq.const import USER_CHANGE_VIA_CLONE
-from corehq.toggles import toggles_enabled_for_user
+from corehq.toggles import all_toggles_by_name, toggles_enabled_for_user
 from corehq.util.bounced_email_manager import EMAIL_REGEX_VALIDATION
 
 logger = logging.getLogger(__name__)
@@ -165,11 +165,13 @@ def transfer_saved_reports(from_user, to_user):
 
 def transfer_feature_flags(from_user, to_user):
     enabled_toggles = toggles_enabled_for_user(from_user.username)
-    for toggle in enabled_toggles:
-        logger.info(f'Updating toggle {toggle} from {from_user.username} to {to_user.username}')
-        set_toggle(toggle, from_user.username, False)
-        set_toggle(toggle, to_user.username, True)
-        logger.info(f'Transferred access to {toggle}.')
+    by_name = all_toggles_by_name()
+    for toggle_name in enabled_toggles:
+        logger.info(f'Updating toggle name {toggle_name} from {from_user.username} to {to_user.username}')
+        toggle_slug = by_name[toggle_name].slug
+        set_toggle(toggle_slug, from_user.username, False)
+        set_toggle(toggle_slug, to_user.username, True)
+        logger.info(f'Transferred access to toggle slug {toggle_slug}.')
 
     toggles_enabled_for_user.clear(from_user.username)
     toggles_enabled_for_user.clear(to_user.username)

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -104,9 +104,12 @@ def notify_users_command(old_username, new_username, dry_run):
     old_user = validate_usernames(old_username, new_username)
 
     scheduled_date = date.today() + timedelta(days=7)
+    scheduled_date = scheduled_date.strftime("%B %d, %Y")
+
     dry_run_tag = "[DRY_RUN]" if dry_run else ""
     logger.info(f'{dry_run_tag}Sending email notifying {old_user.get_email()} a migration is scheduled for '
                 f'{scheduled_date}.')
+
     if not dry_run:
         send_scheduled_migration_email(old_user, new_username, scheduled_date)
 
@@ -308,7 +311,7 @@ def send_scheduled_migration_email(old_user, new_username, scheduled_date):
         'greeting': _("Dear {name},").format(name=old_user.first_name) if old_user.first_name else _("Hello,"),
         'old_username': old_user.username,
         'new_username': new_username,
-        'date': scheduled_date
+        'scheduled_date': scheduled_date
     }
 
     email_html = render_to_string('users/email/notify_scheduled_user_migration.html', context)

--- a/corehq/apps/users/management/commands/clone_web_users.py
+++ b/corehq/apps/users/management/commands/clone_web_users.py
@@ -104,7 +104,6 @@ def create_new_user_from_old_user(old_user, new_username):
         User.objects.make_random_password(),
         None,
         USER_CHANGE_VIA_CLONE,
-        email=new_username,
         by_domain_required_for_log=False,
     )
     new_user = copy_user_fields(old_user, new_user)
@@ -185,6 +184,7 @@ def copy_user_fields(from_user, to_user):
     to_user.is_staff = from_user.is_staff
     to_user.is_active = from_user.is_active
     to_user.is_superuser = from_user.is_superuser
+    to_user.email = from_user.email or from_user.username
 
     # CouchUser fields
     # ignoring device_ids, last_device, created_on, last_modified

--- a/corehq/apps/users/templates/users/email/deprecated_user.html
+++ b/corehq/apps/users/templates/users/email/deprecated_user.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+
+<p>{{ greeting }}</p>
+
+{% blocktrans %}
+  <p>
+    The user associated with the username {{ old_username }} has been deprecated in favor of a new user with the username {{ new_username }}.
+    To complete this process, log in with the new username. Taking this action will confirm the deletion of the old user,
+    and will result in the old user being inaccessible.
+  </p>
+
+  <p>
+    Thanks,<br />
+    CommCareHQ
+  </p>
+{% endblocktrans %}

--- a/corehq/apps/users/templates/users/email/deprecated_user.html
+++ b/corehq/apps/users/templates/users/email/deprecated_user.html
@@ -8,16 +8,22 @@
     {{ new_username }}.
 
     The following data was copied to your new user:
-     - general user data (name, phone number, email, etc)
-     - project space memberships (including roles and locations)
-     - saved/scheduled report ownership
+    <ul>
+      <li>General user data (name, phone number, email, etc.)</li>
+      <li>Project space memberships (including roles and locations)</li>
+      <li>Saved reports</li>
+      <li>Scheduled reports</li>
+    </ul>
 
     The following data was not copied to your new user:
-     - API keys
-     - pending CommCare invitations
+    <ul>
+      <li>API keys</li>
+      <li>Pending CommCare invitations</li>
+    </ul>
 
     The {{ old_username }} user is no longer active. You can log into your new user with the username
-    {{ new_username }}. If you are exempt from SSO, you can follow the Forgot Password workflow to successfully login.
+    {{ new_username }}. If you are exempt from SSO, you can follow the <i>Forgot Password</i> workflow to successfully
+    login.
   </p>
 
   <p>

--- a/corehq/apps/users/templates/users/email/deprecated_user.html
+++ b/corehq/apps/users/templates/users/email/deprecated_user.html
@@ -4,7 +4,7 @@
 
 {% blocktrans %}
   <p>
-    As mentioned a week ago, your CommCare user {{ old_username }} has now been migrated to the new user:
+    Your CommCare user {{ old_username }} has now been migrated to the new user:
     {{ new_username }}.
 
     The following data was copied to your new user:

--- a/corehq/apps/users/templates/users/email/deprecated_user.html
+++ b/corehq/apps/users/templates/users/email/deprecated_user.html
@@ -4,15 +4,20 @@
 
 {% blocktrans %}
   <p>
-    As your organization has already communicated to you, your current CommCare user: {{ old_username }} is being
-    migrated over to a new user: {{ new_username }}. You can now log in with the new user using SSO.
+    As mentioned a week ago, your CommCare user {{ old_username }} has now been migrated to the new user:
+    {{ new_username }}.
 
-    This new user will have access to the same project spaces as the deprecated user, and saved exports, saved reports,
-    and scheduled reports created by your deprecated user have been transferred to the new user.
+    The following data was copied to your new user:
+     - general user data (name, phone number, email, etc)
+     - project space memberships (including roles and locations)
+     - saved/scheduled report ownership
 
-    The deprecated user is no longer active. If for any reason you need to gain access to the old account, please
-    contact support informing them your account associated with {{ old_username }} has been deactivated as a result of
-    the MSI user migration.
+    The following data was not copied to your new user:
+     - API keys
+     - pending CommCare invitations
+
+    The {{ old_username }} user is no longer active. You can log into your new user with the username
+    {{ new_username }}. If you are exempt from SSO, you can follow the Forgot Password workflow to successfully login.
   </p>
 
   <p>

--- a/corehq/apps/users/templates/users/email/deprecated_user.html
+++ b/corehq/apps/users/templates/users/email/deprecated_user.html
@@ -4,9 +4,14 @@
 
 {% blocktrans %}
   <p>
-    The user associated with the username {{ old_username }} has been deprecated in favor of a new user with the username {{ new_username }}.
-    To complete this process, log in with the new username. Taking this action will confirm the deletion of the old user,
-    and will result in the old user being inaccessible.
+    As your organization has already communicated to you, your current CommCare user {{ old_username }} is being
+    migrated over to a new user {{ new_username }}. You can now log in with the new user using SSO.
+
+    This new user will have access to the same project spaces as the deprecated user, and saved exports, saved reports,
+    and scheduled reports created by your deprecated user have been transferred to the new user.
+
+    The deprecated user is no longer active. If for any reason you need to gain access to the old account, please
+    contact support.
   </p>
 
   <p>

--- a/corehq/apps/users/templates/users/email/deprecated_user.html
+++ b/corehq/apps/users/templates/users/email/deprecated_user.html
@@ -4,14 +4,15 @@
 
 {% blocktrans %}
   <p>
-    As your organization has already communicated to you, your current CommCare user {{ old_username }} is being
-    migrated over to a new user {{ new_username }}. You can now log in with the new user using SSO.
+    As your organization has already communicated to you, your current CommCare user: {{ old_username }} is being
+    migrated over to a new user: {{ new_username }}. You can now log in with the new user using SSO.
 
     This new user will have access to the same project spaces as the deprecated user, and saved exports, saved reports,
     and scheduled reports created by your deprecated user have been transferred to the new user.
 
     The deprecated user is no longer active. If for any reason you need to gain access to the old account, please
-    contact support.
+    contact support informing them your account associated with {{ old_username }} has been deactivated as a result of
+    the MSI user migration.
   </p>
 
   <p>

--- a/corehq/apps/users/templates/users/email/deprecated_user.txt
+++ b/corehq/apps/users/templates/users/email/deprecated_user.txt
@@ -7,13 +7,14 @@ As mentioned a week ago, your CommCare user {{ old_username }} has now been migr
 {{ new_username }}.
 
 The following data was copied to your new user:
- - general user data (name, phone number, email, etc)
- - project space memberships (including roles and locations)
- - saved/scheduled report ownership
+ - General user data (name, phone number, email, etc.)
+ - Project space memberships (including roles and locations)
+ - Saved reports
+ - Scheduled reports
 
 The following data was not copied to your new user:
  - API keys
- - pending CommCare invitations
+ - Pending CommCare invitations
 
 The {{ old_username }} user is no longer active. You can log into your new user with the username
 {{ new_username }}. If you are exempt from SSO, you can follow the Forgot Password workflow to successfully login.

--- a/corehq/apps/users/templates/users/email/deprecated_user.txt
+++ b/corehq/apps/users/templates/users/email/deprecated_user.txt
@@ -1,0 +1,12 @@
+{% load i18n %}
+
+{{ greeting }}
+
+{% blocktrans %}
+The user associated with the username {{ old_username }} has been deprecated in favor of a new user with the username {{ new_username }}.
+To complete this process, log in with the new username. Taking this action will confirm the deletion of the old user,
+and will result in the old user being inaccessible.
+
+Thanks,
+CommCareHQ
+{% endblocktrans %}

--- a/corehq/apps/users/templates/users/email/deprecated_user.txt
+++ b/corehq/apps/users/templates/users/email/deprecated_user.txt
@@ -3,15 +3,20 @@
 {{ greeting }}
 
 {% blocktrans %}
-As your organization has already communicated to you, your current CommCare user: {{ old_username }} is being
-migrated over to a new user: {{ new_username }}. You can now log in with the new user using SSO.
+As mentioned a week ago, your CommCare user {{ old_username }} has now been migrated to the new user:
+{{ new_username }}.
 
-This new user will have access to the same project spaces as the deprecated user, and saved exports, saved reports,
-and scheduled reports created by your deprecated user have been transferred to the new user.
+The following data was copied to your new user:
+ - general user data (name, phone number, email, etc)
+ - project space memberships (including roles and locations)
+ - saved/scheduled report ownership
 
-The deprecated user is no longer active. If for any reason you need to gain access to the old account, please
-contact support informing them your account associated with {{ old_username }} has been deactivated as a result of
-the MSI user migration.
+The following data was not copied to your new user:
+ - API keys
+ - pending CommCare invitations
+
+The {{ old_username }} user is no longer active. You can log into your new user with the username
+{{ new_username }}. If you are exempt from SSO, you can follow the Forgot Password workflow to successfully login.
 
 Thanks,
 CommCareHQ

--- a/corehq/apps/users/templates/users/email/deprecated_user.txt
+++ b/corehq/apps/users/templates/users/email/deprecated_user.txt
@@ -3,14 +3,15 @@
 {{ greeting }}
 
 {% blocktrans %}
-As your organization has already communicated to you, your current CommCare user {{ old_username }} is being
-migrated over to a new user {{ new_username }}. You can now log in with the new user using SSO.
+As your organization has already communicated to you, your current CommCare user: {{ old_username }} is being
+migrated over to a new user: {{ new_username }}. You can now log in with the new user using SSO.
 
 This new user will have access to the same project spaces as the deprecated user, and saved exports, saved reports,
 and scheduled reports created by your deprecated user have been transferred to the new user.
 
 The deprecated user is no longer active. If for any reason you need to gain access to the old account, please
-contact support.
+contact support informing them your account associated with {{ old_username }} has been deactivated as a result of
+the MSI user migration.
 
 Thanks,
 CommCareHQ

--- a/corehq/apps/users/templates/users/email/deprecated_user.txt
+++ b/corehq/apps/users/templates/users/email/deprecated_user.txt
@@ -3,7 +3,7 @@
 {{ greeting }}
 
 {% blocktrans %}
-As mentioned a week ago, your CommCare user {{ old_username }} has now been migrated to the new user:
+Your CommCare user {{ old_username }} has now been migrated to the new user:
 {{ new_username }}.
 
 The following data was copied to your new user:

--- a/corehq/apps/users/templates/users/email/deprecated_user.txt
+++ b/corehq/apps/users/templates/users/email/deprecated_user.txt
@@ -3,9 +3,14 @@
 {{ greeting }}
 
 {% blocktrans %}
-The user associated with the username {{ old_username }} has been deprecated in favor of a new user with the username {{ new_username }}.
-To complete this process, log in with the new username. Taking this action will confirm the deletion of the old user,
-and will result in the old user being inaccessible.
+As your organization has already communicated to you, your current CommCare user {{ old_username }} is being
+migrated over to a new user {{ new_username }}. You can now log in with the new user using SSO.
+
+This new user will have access to the same project spaces as the deprecated user, and saved exports, saved reports,
+and scheduled reports created by your deprecated user have been transferred to the new user.
+
+The deprecated user is no longer active. If for any reason you need to gain access to the old account, please
+contact support.
 
 Thanks,
 CommCareHQ

--- a/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.html
+++ b/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.html
@@ -4,7 +4,7 @@
 
 {% blocktrans %}
   <p>
-    We have scheduled a migration to be run on {{ date }} that will impact your CommCare user. Your
+    We have scheduled a migration to be run on {{ scheduled_date }} that will impact your CommCare user. Your
     organization has requested that your user, {{ old_username }}, be migrated to a new user with the username
     {{ new_username }}.
 

--- a/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.html
+++ b/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.html
@@ -4,31 +4,30 @@
 
 {% blocktrans %}
   <p>
-    We have scheduled a migration to be run on {{ scheduled_date }} that will impact your CommCare user. Your
-    organization has requested that your user, {{ old_username }}, be migrated to a new user with the username
-    {{ new_username }}.
-
-    The following data will be copied to your new user:
-    <ul>
-      <li>General user data (name, phone number, email, etc.)</li>
-      <li>Project space memberships (including roles and locations)</li>
-      <li>Saved reports</li>
-      <li>Scheduled reports</li>
-    </ul>
-
-    The following data will not be copied to your new user:
-    <ul>
-      <li>API keys</li>
-      <li>Pending CommCare invitations</li>
-    </ul>
-
-    Additionally, your password will be reset for your new user, and 2FA will be disabled by default. If you are exempt
-    from SSO, you will be able to follow the <i>Forgot Password</i> workflow to log in.
-
-    Once the migration is complete, you will not have access to the user associated with the username
-    {{ old_username }}. Please take the following week to prepare for this transition.
+    We have scheduled a migration to be run on {{ scheduled_date }} that will impact your CommCare user. Your organization has requested that your user, {{ old_username }}, be migrated to a new user with the username {{ new_username }}.
   </p>
-
+  <p>
+    The following data will be copied to your new user:
+  </p>
+  <ul>
+    <li>General user data (name, phone number, email, etc.)</li>
+    <li>Project space memberships (including roles and locations)</li>
+    <li>Saved reports</li>
+    <li>Scheduled reports</li>
+  </ul>
+  <p>
+    The following data will not be copied to your new user:
+  </p>
+  <ul>
+    <li>API keys</li>
+    <li>Pending CommCare invitations</li>
+  </ul>
+  <p>
+    Additionally, your password will be reset for your new user, and two factor authentication (2FA) will be disabled by default.
+  </p>
+  <p>
+    Once the migration is complete, you will not have access to the user associated with the username {{ old_username }}. Please take the following week to prepare for this transition, and reach out to us if you have any questions.
+  </p>
   <p>
     Thanks,<br />
     CommCareHQ

--- a/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.html
+++ b/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+
+<p>{{ greeting }}</p>
+
+{% blocktrans %}
+  <p>
+    We have scheduled a migration to be run on {{ date }} that will impact your CommCare user. Your
+    organization has requested that your user, {{ old_username }}, be migrated to a new user with the username
+    {{ new_username }}.
+
+    The following data will be copied to your new user:
+     - general user data (name, phone number, email, etc)
+     - project space memberships (including roles and locations)
+     - saved/scheduled report ownership
+
+    The following data will not be copied to your new user:
+     - API keys
+     - pending CommCare invitations
+
+    Additionally, your password will be reset for your new user, and 2FA will be disabled by default. If you are exempt
+    from SSO, you will be able to follow the Forgot Password workflow to log in.
+
+    Once the migration is complete, you will not have access to the user associated with the username {{ old_username }}.
+    Please take the following week to prepare for this transition.
+  </p>
+
+  <p>
+    Thanks,<br />
+    CommCareHQ
+  </p>
+{% endblocktrans %}

--- a/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.html
+++ b/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.html
@@ -9,16 +9,21 @@
     {{ new_username }}.
 
     The following data will be copied to your new user:
-     - general user data (name, phone number, email, etc)
-     - project space memberships (including roles and locations)
-     - saved/scheduled report ownership
+    <ul>
+      <li>General user data (name, phone number, email, etc.)</li>
+      <li>Project space memberships (including roles and locations)</li>
+      <li>Saved reports</li>
+      <li>Scheduled reports</li>
+    </ul>
 
     The following data will not be copied to your new user:
-     - API keys
-     - pending CommCare invitations
+    <ul>
+      <li>API keys</li>
+      <li>Pending CommCare invitations</li>
+    </ul>
 
     Additionally, your password will be reset for your new user, and 2FA will be disabled by default. If you are exempt
-    from SSO, you will be able to follow the Forgot Password workflow to log in.
+    from SSO, you will be able to follow the <i>Forgot Password</i> workflow to log in.
 
     Once the migration is complete, you will not have access to the user associated with the username
     {{ old_username }}. Please take the following week to prepare for this transition.

--- a/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.html
+++ b/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.html
@@ -20,8 +20,8 @@
     Additionally, your password will be reset for your new user, and 2FA will be disabled by default. If you are exempt
     from SSO, you will be able to follow the Forgot Password workflow to log in.
 
-    Once the migration is complete, you will not have access to the user associated with the username {{ old_username }}.
-    Please take the following week to prepare for this transition.
+    Once the migration is complete, you will not have access to the user associated with the username
+    {{ old_username }}. Please take the following week to prepare for this transition.
   </p>
 
   <p>

--- a/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.txt
+++ b/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.txt
@@ -8,13 +8,14 @@ organization has requested that your user, {{ old_username }}, be migrated to a 
 {{ new_username }}.
 
 The following data will be copied to your new user:
- - general user data (name, phone number, email, etc)
- - project space memberships (including roles and locations)
- - saved/scheduled report ownership
+ - General user data (name, phone number, email, etc.)
+ - Project space memberships (including roles and locations)
+ - Saved reports
+ - Scheduled reports
 
 The following data will not be copied to your new user:
  - API keys
- - pending CommCare invitations
+ - Pending CommCare invitations
 
 Additionally, your password will be reset for your new user, and 2FA will be disabled by default. If you are exempt
 from SSO, you will be able to follow the Forgot Password workflow to log in.

--- a/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.txt
+++ b/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.txt
@@ -1,0 +1,28 @@
+{% load i18n %}
+
+{{ greeting }}
+
+{% blocktrans %}
+We have scheduled a migration to be run on {{ date }} that will impact your CommCare user. Your
+organization has requested that your user, {{ old_username }}, be migrated to a new user with the username
+{{ new_username }}.
+
+The following data will be copied to your new user:
+ - general user data (name, phone number, email, etc)
+ - project space memberships (including roles and locations)
+ - saved/scheduled report ownership
+
+The following data will not be copied to your new user:
+ - API keys
+ - pending CommCare invitations
+
+Additionally, your password will be reset for your new user, and 2FA will be disabled by default. If you are exempt
+from SSO, you will be able to follow the Forgot Password workflow to log in.
+
+Once the migration is complete, you will not have access to the user associated with the username {{ old_username }}.
+Please take the following week to prepare for this transition.
+
+
+Thanks,
+CommCareHQ
+{% endblocktrans %}

--- a/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.txt
+++ b/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.txt
@@ -3,9 +3,7 @@
 {{ greeting }}
 
 {% blocktrans %}
-We have scheduled a migration to be run on {{ scheduled_date }} that will impact your CommCare user. Your
-organization has requested that your user, {{ old_username }}, be migrated to a new user with the username
-{{ new_username }}.
+We have scheduled a migration to be run on {{ scheduled_date }} that will impact your CommCare user. Your organization has requested that your user, {{ old_username }}, be migrated to a new user with the username {{ new_username }}.
 
 The following data will be copied to your new user:
  - General user data (name, phone number, email, etc.)
@@ -17,11 +15,9 @@ The following data will not be copied to your new user:
  - API keys
  - Pending CommCare invitations
 
-Additionally, your password will be reset for your new user, and 2FA will be disabled by default. If you are exempt
-from SSO, you will be able to follow the Forgot Password workflow to log in.
+Additionally, your password will be reset for your new user, and two factor authentication (2FA) will be disabled by default.
 
-Once the migration is complete, you will not have access to the user associated with the username
-{{ old_username }}. Please take the following week to prepare for this transition.
+Once the migration is complete, you will not have access to the user associated with the username {{ old_username }}. Please take the following week to prepare for this transition, and reach out to us if you have any questions.
 
 
 Thanks,

--- a/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.txt
+++ b/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.txt
@@ -3,7 +3,7 @@
 {{ greeting }}
 
 {% blocktrans %}
-We have scheduled a migration to be run on {{ date }} that will impact your CommCare user. Your
+We have scheduled a migration to be run on {{ scheduled_date }} that will impact your CommCare user. Your
 organization has requested that your user, {{ old_username }}, be migrated to a new user with the username
 {{ new_username }}.
 

--- a/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.txt
+++ b/corehq/apps/users/templates/users/email/notify_scheduled_user_migration.txt
@@ -19,8 +19,8 @@ The following data will not be copied to your new user:
 Additionally, your password will be reset for your new user, and 2FA will be disabled by default. If you are exempt
 from SSO, you will be able to follow the Forgot Password workflow to log in.
 
-Once the migration is complete, you will not have access to the user associated with the username {{ old_username }}.
-Please take the following week to prepare for this transition.
+Once the migration is complete, you will not have access to the user associated with the username
+{{ old_username }}. Please take the following week to prepare for this transition.
 
 
 Thanks,

--- a/corehq/apps/users/tests/test_clone_web_users.py
+++ b/corehq/apps/users/tests/test_clone_web_users.py
@@ -3,9 +3,6 @@ from unittest.mock import patch
 from django.contrib.auth.models import User
 from django.test import TestCase
 
-from toggle.models import Toggle
-from toggle.shortcuts import toggle_enabled
-
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.export.dbaccessors import _get_export_instance
 from corehq.apps.export.models import ExportInstance, FormExportInstance
@@ -19,7 +16,7 @@ from corehq.apps.users.management.commands.clone_web_users import (
 )
 from corehq.apps.users.models import WebUser
 from corehq.const import USER_CHANGE_VIA_CLONE
-from corehq.toggles import NAMESPACE_USER, TAG_INTERNAL, StaticToggle
+from corehq.toggles import NAMESPACE_USER, TAG_INTERNAL, StaticToggle, toggle_enabled, Toggle
 
 TEST_TOGGLE = StaticToggle(
     'test_toggle',

--- a/corehq/apps/users/tests/test_clone_web_users.py
+++ b/corehq/apps/users/tests/test_clone_web_users.py
@@ -12,17 +12,6 @@ from corehq.apps.users.management.commands.clone_web_users import (
     transfer_scheduled_reports,
 )
 from corehq.apps.users.models import WebUser
-# class TestCloneUser(TestCase):
-#
-#     def setUp(self):
-#         self.existing_user = WebUser.create(
-#             domain=None,
-#             username='existing-user@dimagi.com',
-#             email='existing-user@dimagi.com',
-#             password=User.objects.make_random_password(),
-#             created_by='gherceg@dimagi.com',
-#             created_via=''
-#         )
 from corehq.const import USER_CHANGE_VIA_CLONE
 
 

--- a/corehq/apps/users/tests/test_clone_web_users.py
+++ b/corehq/apps/users/tests/test_clone_web_users.py
@@ -138,7 +138,7 @@ class TestCloneWebUsers(TestCase):
         expected_report_id = scheduled_report._id
         self.addCleanup(scheduled_report.delete)
 
-        transfer_scheduled_reports(self.old_user, self.new_user._id)
+        transfer_scheduled_reports(self.old_user, self.new_user)
 
         scheduled_report = ReportNotification.by_domain_and_owner(self.domain, self.new_user._id, stale=False)[0]
         self.assertEqual(expected_report_id, scheduled_report._id)
@@ -150,7 +150,7 @@ class TestCloneWebUsers(TestCase):
         expected_report_id = scheduled_report._id
         self.addCleanup(scheduled_report.delete)
 
-        transfer_scheduled_reports(self.old_user, self.new_user._id, dry_run=True)
+        transfer_scheduled_reports(self.old_user, self.new_user, dry_run=True)
 
         scheduled_report = ReportNotification.by_domain_and_owner(self.domain, self.old_user._id, stale=False)[0]
         self.assertEqual(expected_report_id, scheduled_report._id)

--- a/corehq/apps/users/tests/test_clone_web_users.py
+++ b/corehq/apps/users/tests/test_clone_web_users.py
@@ -1,0 +1,138 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.export.dbaccessors import _get_export_instance
+from corehq.apps.export.models import ExportInstance, FormExportInstance
+from corehq.apps.saved_reports.models import ReportConfig, ReportNotification
+from corehq.apps.users.management.commands.clone_web_users import (
+    copy_domain_memberships,
+    transfer_exports,
+    transfer_saved_reports,
+    transfer_scheduled_reports,
+)
+from corehq.apps.users.models import WebUser
+# class TestCloneUser(TestCase):
+#
+#     def setUp(self):
+#         self.existing_user = WebUser.create(
+#             domain=None,
+#             username='existing-user@dimagi.com',
+#             email='existing-user@dimagi.com',
+#             password=User.objects.make_random_password(),
+#             created_by='gherceg@dimagi.com',
+#             created_via=''
+#         )
+from corehq.const import USER_CHANGE_VIA_CLONE
+
+
+class TestCloneWebUsers(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestCloneWebUsers, cls).setUpClass()
+        cls.domain = 'initial-domain'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.admin_user = WebUser.create(
+            None,
+            'gherceg@dimagi.com',
+            User.objects.make_random_password(),
+            None,
+            'api',
+            by_domain_required_for_log=False,
+            email='gherceg@dimagi.com',
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.admin_user.delete(cls.domain, deleted_by=None)
+        cls.domain_obj.delete()
+        super(TestCloneWebUsers, cls).tearDownClass()
+
+    def setUp(self):
+        super(TestCloneWebUsers, self).setUp()
+        self.old_user = WebUser.create(
+            self.domain,
+            'old-user@dimagi.com',
+            User.objects.make_random_password(),
+            self.admin_user,
+            'api',
+            email='old-user@dimagi.com',
+        )
+
+        self.new_user = WebUser.create(
+            None,
+            'new-user@dimagi.com',
+            User.objects.make_random_password(),
+            None,
+            USER_CHANGE_VIA_CLONE,
+            by_domain_required_for_log=False,
+            email='new-user@dimagi.com',
+        )
+
+    def tearDown(self):
+        self.old_user.delete(self.domain, deleted_by=None)
+        self.new_user.delete(self.domain, deleted_by=None)
+        super(TestCloneWebUsers, self).tearDown()
+
+    def test_copy_domain_memberships(self):
+        self.assertEqual(1, len(self.old_user.domain_memberships))
+        self.assertEqual([], self.new_user.domain_memberships)
+
+        copy_domain_memberships(self.old_user, self.new_user)
+
+        self.assertEqual(len(self.old_user.domain_memberships), len(self.new_user.domain_memberships))
+
+    def test_copy_domain_memberships_copies_roles(self):
+        old_domain_membership = self.old_user.domain_memberships[0]
+        old_domain_membership.role_id = 'abc123'
+
+        copy_domain_memberships(self.old_user, self.new_user)
+
+        new_domain_membership = self.new_user.domain_memberships[0]
+        self.assertEqual('abc123', new_domain_membership.role_id)
+
+    def test_copy_domain_memberships_copies_locations(self):
+        old_domain_membership = self.old_user.domain_memberships[0]
+        old_domain_membership.location_id = 'abc123'
+
+        copy_domain_memberships(self.old_user, self.new_user)
+
+        new_domain_membership = self.new_user.domain_memberships[0]
+        self.assertEqual('abc123', new_domain_membership.location_id)
+
+    def test_transfer_exports(self):
+        export = FormExportInstance(owner_id=self.old_user._id, domain=self.domain)
+        export.save()
+        self.addCleanup(export.delete)
+
+        transfer_exports(self.old_user, self.new_user)
+
+        export = _get_export_instance(ExportInstance, [self.domain])[0]
+        self.assertEqual(export.owner_id, self.new_user._id)
+
+    def test_transfer_scheduled_reports(self):
+        scheduled_report = ReportNotification(owner_id=self.old_user._id, config_ids=['test'])
+        scheduled_report.save()
+        self.addCleanup(scheduled_report.delete)
+        self.assertEqual(scheduled_report.owner_id, self.old_user._id)
+        self.assertEqual(1, len(ReportNotification.by_owner(self.old_user._id)))
+        self.assertEqual([], ReportNotification.by_owner(self.new_user._id))
+
+        transfer_scheduled_reports(self.old_user._id, self.new_user._id)
+
+        self.assertEqual(1, len(ReportNotification.by_owner(self.new_user._id)))
+
+    def test_transfer_saved_reports(self):
+        saved_report = ReportConfig(
+            name='test',
+            owner_id=self.old_user._id,
+            report_slug='worker_activity',
+            report_type='project_report',
+            domain=self.domain)
+        saved_report.save()
+        self.addCleanup(saved_report.delete)
+        self.assertEqual(1, len(ReportConfig.by_domain_and_owner(self.domain, self.old_user._id)))
+        transfer_saved_reports(self.old_user, self.new_user)
+
+        self.assertEqual(1, len(ReportConfig.by_domain_and_owner(self.domain, self.new_user._id)))

--- a/corehq/apps/users/tests/test_clone_web_users.py
+++ b/corehq/apps/users/tests/test_clone_web_users.py
@@ -200,7 +200,7 @@ class TestCloneWebUsers(TestCase):
         with patch('corehq.toggles.all_toggles_by_name', return_value=mock_togglesbyname),\
              patch('corehq.apps.users.management.commands.clone_web_users.all_toggles_by_name',
                    return_value=mock_togglesbyname):
-            transfer_feature_flags(self.old_user.username, self.new_user.username)
+            transfer_feature_flags(self.old_user, self.new_user)
 
         self.assertFalse(toggle_enabled('test_toggle', self.old_user.username))
         self.assertTrue(toggle_enabled('test_toggle', self.new_user.username))
@@ -217,7 +217,7 @@ class TestCloneWebUsers(TestCase):
         with patch('corehq.toggles.all_toggles_by_name', return_value=mock_togglesbyname),\
              patch('corehq.apps.users.management.commands.clone_web_users.all_toggles_by_name',
                    return_value=mock_togglesbyname):
-            transfer_feature_flags(self.old_user.username, self.new_user.username, dry_run=True)
+            transfer_feature_flags(self.old_user, self.new_user, dry_run=True)
 
         self.assertTrue(toggle_enabled('test_toggle', self.old_user.username))
         self.assertFalse(toggle_enabled('test_toggle', self.new_user.username))

--- a/corehq/apps/users/tests/test_clone_web_users.py
+++ b/corehq/apps/users/tests/test_clone_web_users.py
@@ -200,7 +200,7 @@ class TestCloneWebUsers(TestCase):
         with patch('corehq.toggles.all_toggles_by_name', return_value=mock_togglesbyname),\
              patch('corehq.apps.users.management.commands.clone_web_users.all_toggles_by_name',
                    return_value=mock_togglesbyname):
-            transfer_feature_flags(self.old_user, self.new_user)
+            transfer_feature_flags(self.old_user.username, self.new_user.username)
 
         self.assertFalse(toggle_enabled('test_toggle', self.old_user.username))
         self.assertTrue(toggle_enabled('test_toggle', self.new_user.username))
@@ -217,7 +217,7 @@ class TestCloneWebUsers(TestCase):
         with patch('corehq.toggles.all_toggles_by_name', return_value=mock_togglesbyname),\
              patch('corehq.apps.users.management.commands.clone_web_users.all_toggles_by_name',
                    return_value=mock_togglesbyname):
-            transfer_feature_flags(self.old_user, self.new_user, dry_run=True)
+            transfer_feature_flags(self.old_user.username, self.new_user.username, dry_run=True)
 
         self.assertTrue(toggle_enabled('test_toggle', self.old_user.username))
         self.assertFalse(toggle_enabled('test_toggle', self.new_user.username))

--- a/corehq/const.py
+++ b/corehq/const.py
@@ -36,5 +36,6 @@ USER_CHANGE_VIA_INVITATION = "invitation"
 USER_CHANGE_VIA_SSO_NEW_USER = "sso_new"
 USER_CHANGE_VIA_SSO_INVITE = "sso_invitation"
 USER_CHANGE_VIA_AUTO_DEACTIVATE = "auto_deactivate"
+USER_CHANGE_VIA_CLONE = "clone_user"
 
 LOADTEST_HARD_LIMIT = 500_000  # max cases a loadtest user can sync


### PR DESCRIPTION
## Technical Summary
from @gherceg's original PR https://github.com/dimagi/commcare-hq/pull/30655
with some updates to reflect small changes in the codebase and make this command more re-usable.

It seems we might need to do this more than once based on a new partner request outlined here
https://dimagi-dev.atlassian.net/browse/SAAS-14702

so let's actually merge this command in and create some documentation around this workflow so that it's almost instantaneous next time. :)

## Safety Assurance

### Safety story
only management command

### Automated test coverage
n/a

### QA Plan
QA was already done on the previous iteration

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
