### PR TITLE
Applied line break fix to mapping popup

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -586,7 +586,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                             let markerCoordinates = addressCoordinates.split(" ").slice(0,2);
                             if (markerCoordinates.length > 1) {
                                 const rowId = `row-${model.id}`;
-                                const popupText = md.render(DOMPurify.sanitize(model.attributes.data[popupIndex]));
+                                const popupText = cloudcareUtils.renderMarkdown(model.attributes.data[popupIndex]);
                                 let marker = L.marker(markerCoordinates, {icon: locationIcon});
                                 markers.push(marker);
                                 marker = marker.addTo(addressMap)


### PR DESCRIPTION
## Technical Summary
Make https://github.com/dimagi/commcare-hq/pull/33149/ and https://github.com/dimagi/commcare-hq/pull/33155 play nicely together so that `&#10;` renders as a line break in the map popup.

## Feature Flag
REC case tiles

## Safety Assurance

### Safety story
Main risk is of a js error. Tested on staging to mitigate that.

### Automated test coverage

nope

### QA Plan

no, tested manually on staging


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
