### PR TITLE
Replace HTML newline earlier on in logic

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -233,7 +233,7 @@ hqDefine('cloudcare/js/utils', [
     };
 
     function renderMarkdown(text) {
-        const md = window.markdownit();
+        const md = window.markdownit().set({ breaks: true });
         return md.render(DOMPurify.sanitize(text || "").replaceAll("&#10;", "\n"));
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -234,7 +234,7 @@ hqDefine('cloudcare/js/utils', [
 
     function renderMarkdown(text) {
         const md = window.markdownit();
-        return md.render(DOMPurify.sanitize(text || "")).replaceAll("\n", "<br>");
+        return md.render(DOMPurify.sanitize(text || "").replaceAll("&#10;", "\n"));
     };
 
     function chainedRenderer(matcher, transform, target) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -233,7 +233,7 @@ hqDefine('cloudcare/js/utils', [
     };
 
     function renderMarkdown(text) {
-        const md = window.markdownit().set({ breaks: true });
+        const md = window.markdownit({ breaks: true });
         return md.render(DOMPurify.sanitize(text || "").replaceAll("&#10;", "\n"));
     };
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Note: time-sensitive, we are trying to get this out with the ~~Sunday night~~ Wednesday deploy.

In response to [this ticket](https://dimagi-dev.atlassian.net/browse/USH-3373?atlOrigin=eyJpIjoiNTI0ZWI1YjMyMWQxNDczMDgxY2Q1NjVmODY1NzRiY2YiLCJwIjoiaiJ9).

Header and bullet markdown isn't working in case tiles. The small change in this PR makes both of these work.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The issue with header markdown stemmed from markdown-it's processing of the HTML newline character: `&#10;`. As described in the ticket, it doesn't do the header markdown processing properly for that character, but it does for `\n`. Notice how the header incorrectly continues on with `&#10;`, but not for `\n`:  

```
md.render("## Name ## &#10;Please call the contact...")
> '<h2><strong>Name</strong> ## \nPlease call the contact...</h2>\n'
md.render("## Name ## \nPlease call the contact...")
> '<h2><strong>Name</strong></h2>\n<p>Please call the contact...</p>\n'
```

I believe the issue with bullet markdown stemmed from this same issue as well. Bullet markdown seems to work properly under this change.

Per Jenny's description in #33155, the markdown library changes `&#10;`s to `\n`s anyways, so simply replacing the `\n`s in the HTML before it's rendered should be a safe way to get markdown-it to process the markdown as intended.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

The logic of this is quite sound, I believe (See the last paragraph in the section above). But I've tested locally so far, and am open to other ideas on how to make this feel safer.

We can also consider limiting this change to case tiles somehow, to limit the possible scope.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

No.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Unfortunately, I don't think there's time before Sunday night.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

^^ There's one non-technical caveat, which is that USH delivery should be informed beforehand, so that they know to expect that their display property calcs will be shown in the UI differently.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
