### PR TITLE
Show correct message in geocoder widget when no results returned

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -129,7 +129,7 @@ hqDefine("cloudcare/js/form_entry/utils", function () {
         // This populates the "region" html node with the first option, so that it is read by
         // screen readers on focus.
         geocoder.on('results', (items) => {
-            if (items && items.features) {
+            if (items && !_.isEmpty(items.features)) {
                 liveRegionEl.html("<p>" + items.features[0].place_name + "</p>");
             }
         });


### PR DESCRIPTION
## Product Description
Displays the correct "no results found" error message in geocoder widget when Mapbox returns no results, rather than a mysterious "there was an error"
![image](https://github.com/dimagi/commcare-hq/assets/100609770/8685d0a2-a8e5-4342-9ed3-5950e4a77931) 
=> 
![image](https://github.com/dimagi/commcare-hq/assets/100609770/c25f99bc-fc3d-4810-bd02-0cc6cd619537)


## Technical Summary
[USH-3299](https://dimagi-dev.atlassian.net/browse/USH-3299) 
Checks if the array of "features" returned by mapbox is empty to avoid trying to load an item `features[0].place_name` that doesn't exist. The mapbox widget then applies its "no results found" message instead of erroring out.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Trivial change to a conditional that only loads a place name.

### Automated test coverage
n/a

### QA Plan
QA should not be required, but could be requested for a quick pass if reviewers think needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3299]: https://dimagi-dev.atlassian.net/browse/USH-3299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ