### PR TITLE
Remove Instance URI from case search config

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -18,6 +18,7 @@ from corehq.apps.app_manager.const import (
     AUTO_SELECT_RAW,
     AUTO_SELECT_USER,
     CALCULATED_SORT_FIELD_RX,
+    MOBILE_UCR_VERSION_1,
     WORKFLOW_FORM,
     WORKFLOW_MODULE,
     WORKFLOW_PARENT_MODULE,
@@ -43,11 +44,11 @@ from corehq.apps.app_manager.util import (
     app_callout_templates,
     module_case_hierarchy_has_circular_reference,
     module_loads_registry_case,
+    module_uses_inline_search,
     module_uses_smart_links,
     split_path,
     xpath_references_case,
     xpath_references_usercase,
-    module_uses_inline_search,
 )
 from corehq.apps.app_manager.xform import parse_xml as _parse_xml
 from corehq.apps.app_manager.xpath import LocationXpath, interpolate_xpath
@@ -281,6 +282,7 @@ class ApplicationValidator(ApplicationBaseValidator):
 class ModuleBaseValidator(object):
     def __init__(self, module):
         self.module = module
+        self.app = module.get_app()
 
     def get_module_info(self):
         return {
@@ -336,8 +338,10 @@ class ModuleBaseValidator(object):
 
         errors.extend(self.validate_smart_links())
 
+        errors.extend(self.validate_search_config())
+
         if self.module.root_module_id:
-            root_module = self.module.get_app().get_module_by_unique_id(self.module.root_module_id)
+            root_module = self.app.get_module_by_unique_id(self.module.root_module_id)
             if root_module and module_uses_inline_search(root_module):
                 errors.append({
                     'type': 'inline search as parent module',
@@ -354,18 +358,17 @@ class ModuleBaseValidator(object):
             return []
 
         errors = []
-        app = self.module.get_app()
         try:
-            form = app.get_form(self.module.case_list_form.form_id)
+            form = self.app.get_form(self.module.case_list_form.form_id)
         except FormNotFoundException:
             errors.append({
                 'type': 'case list form missing',
                 'module': self.get_module_info()
             })
         else:
-            if toggles.FOLLOWUP_FORMS_AS_CASE_LIST_FORM.enabled(app.domain):
+            if toggles.FOLLOWUP_FORMS_AS_CASE_LIST_FORM.enabled(self.app.domain):
                 from corehq.apps.app_manager.views.modules import get_parent_select_followup_forms
-                valid_forms = [f.unique_id for f in get_parent_select_followup_forms(app, self.module)]
+                valid_forms = [f.unique_id for f in get_parent_select_followup_forms(self.app, self.module)]
                 if form.unique_id not in valid_forms and not form.is_registration_form(self.module.case_type):
                     errors.append({
                         'type': 'invalid case list followup form',
@@ -400,15 +403,14 @@ class ModuleBaseValidator(object):
         if not hasattr(self.module, 'parent_select') or not self.module.parent_select.active:
             return []
 
-        app = self.module.get_app()
         errors = []
 
         if self.module.parent_select.relationship == 'parent':
             from corehq.apps.app_manager.views.modules import get_modules_with_parent_case_type
-            valid_modules = get_modules_with_parent_case_type(app, self.module)
+            valid_modules = get_modules_with_parent_case_type(self.app, self.module)
         else:
             from corehq.apps.app_manager.views.modules import get_all_case_modules
-            valid_modules = get_all_case_modules(app, self.module)
+            valid_modules = get_all_case_modules(self.app, self.module)
         valid_module_ids = [info['unique_id'] for info in valid_modules]
         if self.module.parent_select.module_id not in valid_module_ids:
             errors.append({
@@ -508,6 +510,29 @@ class ModuleBaseValidator(object):
                         'module': self.get_module_info(),
                         'column': column,
                     }
+
+    def validate_search_config(self):
+        search_config = getattr(self.module, 'search_config', None)
+        if search_config:
+            for prop in search_config.properties:
+                if prop.itemset.instance_id:
+                    scheme = prop.itemset.instance_id.split(':', 1)[0]
+                    is_mobile_ucr = scheme == 'commcare-reports'
+                    is_lookup_table = scheme == 'item-list'
+                    if not (is_mobile_ucr or is_lookup_table):
+                        yield {
+                            'type': 'case search nodeset invalid',
+                            'module': self.get_module_info(),
+                            'property': prop.name,
+                            'message': _('It must reference a lookup table or mobile report.'),
+                        }
+                    if is_mobile_ucr and self.app.mobile_ucr_restore_version == MOBILE_UCR_VERSION_1:
+                        yield {
+                            'type': 'case search nodeset invalid',
+                            'module': self.get_module_info(),
+                            'property': prop.name,
+                            'message': _('This feature is compatible with only version 2 of Mobile UCR'),
+                        }
 
 
 class ModuleDetailValidatorMixin(object):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2056,10 +2056,7 @@ class CaseList(IndexedSchema, NavMenuItemMediaMixin):
 
 class Itemset(DocumentSchema):
     instance_id = StringProperty(exclude_if_none=True)
-    instance_uri = StringProperty(exclude_if_none=True)
-
     nodeset = StringProperty(exclude_if_none=True)
-
     label = StringProperty(exclude_if_none=True)
     value = StringProperty(exclude_if_none=True)
     sort = StringProperty(exclude_if_none=True)

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -301,8 +301,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
         // init with blank string to avoid triggering save button
         var appearance = searchProperty.appearance || "";
         if (searchProperty.input_ === "select1" || searchProperty.input_ === "select") {
-            var uri = searchProperty.itemset.instance_uri;
-            if (uri !== null && uri.includes("commcare-reports")) {
+            var instance_id = searchProperty.itemset.instance_id;
+            if (instance_id !== null && instance_id.includes("commcare-reports")) {
                 appearance = "report_fixture";
             } else {
                 appearance = "lookup_table_fixture";

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -22,7 +22,6 @@ hqDefine("app_manager/js/details/case_claim", function () {
     var itemsetModel = function (options, saveButton) {
         options = _.defaults(options, {
             'instance_id': '',
-            'instance_uri': '',
             'nodeset': null,
             'label': '',
             'value': '',
@@ -41,7 +40,6 @@ hqDefine("app_manager/js/details/case_claim", function () {
                         return item.id === value;
                     });
                     if (itemList && itemList.length === 1) {
-                        self.instance_uri(itemList[0]['uri']);
                         self.nodeset(itemsetValue(itemList[0]));
                     }
                     else {
@@ -73,7 +71,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             return false;
         });
         subscribeToSave(self,
-            ['nodeset', 'label', 'value', 'sort', 'instance_uri'], saveButton);
+            ['nodeset', 'label', 'value', 'sort'], saveButton);
 
         return self;
     };

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -126,7 +126,6 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     'optionsLabel': gettext("Mobile UCR Options"),
                     'tableLabel': gettext("Mobile UCR Report"),
                     'selectLabel': gettext("Select a Report..."),
-                    'advancedLabel': gettext("Advanced Mobile UCR Options"),
                 };
             }
             else {
@@ -136,7 +135,6 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     'optionsLabel': gettext("Lookup Table Options"),
                     'tableLabel': gettext("Lookup Table"),
                     'selectLabel': gettext("Select a Lookup Table..."),
-                    'advancedLabel': gettext("Advanced Lookup Table Options"),
                 };
             }
         });

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -191,12 +191,6 @@ class EntryInstances(PostProcessor):
                 Instance(id=instance.instance_id, src=instance.instance_path)
                 for instance in form.custom_instances
             )
-        if entry.queries:
-            custom_instances.extend([
-                Instance(id=prop.itemset.instance_id, src=prop.itemset.instance_uri)
-                for prop in module.search_config.properties
-                if prop.itemset.instance_id
-            ])
 
         # sorted list to prevent intermittent test failures
         custom_instances = set(sorted(custom_instances, key=lambda i: i.id))
@@ -206,7 +200,7 @@ class EntryInstances(PostProcessor):
             if existing:
                 if existing.src != instance.src:
                     raise DuplicateInstanceIdError(
-                        _("Conflicting instance declarations in {entry_id} for {instance_id}:"
+                        _("Conflicting instance declarations in {entry_id} for {instance_id}: "
                           "{src_1} != {src_2}").format(
                               entry_id=entry.command.id,
                               instance_id=instance.id,

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -52,11 +52,7 @@ Other instances use a namespaced convention: "type:sub-type". For example:
 
 Custom instances
 ----------------
-There are two places in app builder where users can define custom instances:
-
-* in a form using the 'CUSTOM_INSTANCES' plugin
-* in 'Lookup Table Selection' case search properties under 'Advanced Lookup Table Options'
-
+App builders can define custom instances in a form using the 'CUSTOM_INSTANCES' plugin
 """
 import html
 import re

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -499,6 +499,11 @@
               {% if not not_actual_build %}The shadow form is {% include "app_manager/partials/form_error_message.html" %}{% endif %}
             {% case "password_format" %}
               {# Do nothing; the full message is contained in error.message #}
+            {% case "case search nodeset invalid" %}
+              {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
+                <a href="{{ module_url }}">{{ module_name }}</a> has a case search property
+                <code>{{ property }}</code> that references an invalid instance.
+              {% endblocktrans %}
             {% case "error" %}
               Details: {{ error.message }}
             {% else %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -148,6 +148,17 @@
                     <input class="form-control" type="text" data-bind="value: itemset.sort, attr:{placeholder:dropdownLabels().labelPlaceholder}"/>
                   </div>
                 </div>
+                <div class="form-group">
+                  <label class="control-label col-xs-12 col-sm-3">
+                    {% trans "Instance Nodeset" %}
+                  </label>
+                  <div class="col-xs-12 col-sm-9">
+                    <input class="form-control" type="text" data-bind="value: itemset.nodeset"/>
+                    <p class="alert alert-warning" data-bind="visible: !itemset.nodesetValid()">
+                      {% trans "This refers to data other than selected report/lookup-table." %}
+                    </p>
+                  </div>
+                </div>
                 </fieldset>
                 {% if js_options.has_geocoder_privs or js_options.ush_case_claim_2_53 %}
                     <fieldset>
@@ -218,20 +229,6 @@
                       {% endif %}
                     </fieldset>
                 {% endif %}
-                <fieldset data-bind="visible: appearanceFinal() == 'fixture' || appearanceFinal() == 'checkbox'">
-                  <legend  data-bind="text: dropdownLabels().advancedLabel"></legend>
-                  <div class="form-group">
-                    <label class="control-label col-xs-12 col-sm-3">
-                      {% trans "Instance Nodeset" %}
-                    </label>
-                    <div class="col-xs-12 col-sm-9">
-                      <input class="form-control" type="text" data-bind="value: itemset.nodeset"/>
-                      <p class="alert alert-warning" data-bind="visible: !itemset.nodesetValid()">
-                        {% trans "This refers to data other than selected report/lookup-table." %}
-                      </p>
-                    </div>
-                  </div>
-                </fieldset>
               {% endif %}
             </div>
           </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -222,14 +222,6 @@
                   <legend  data-bind="text: dropdownLabels().advancedLabel"></legend>
                   <div class="form-group">
                     <label class="control-label col-xs-12 col-sm-3">
-                      {% trans "Instance URI" %}
-                    </label>
-                    <div class="col-xs-12 col-sm-9">
-                      <input class="form-control" type="text" data-bind="value: itemset.instance_uri"/>
-                    </div>
-                  </div>
-                  <div class="form-group">
-                    <label class="control-label col-xs-12 col-sm-3">
                       {% trans "Instance Nodeset" %}
                     </label>
                     <div class="col-xs-12 col-sm-9">

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -320,7 +320,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         instance_id = "commcare-reports:123abc"
         self.module.search_config.properties[0].itemset = Itemset(
             instance_id=instance_id,
-            instance_uri="jr://fixture/commcare-reports:abcdef",
             nodeset=f"instance('{instance_id}')/rows/row",
             label='name',
             value='id',

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -317,7 +317,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
     @flag_enabled('MOBILE_UCR')
     def test_prompt_itemset_mobile_report(self):
         self.module.search_config.properties[0].input_ = 'select1'
-        instance_id = "123abc"
+        instance_id = "commcare-reports:123abc"
         self.module.search_config.properties[0].itemset = Itemset(
             instance_id=instance_id,
             instance_uri="jr://fixture/commcare-reports:abcdef",
@@ -347,7 +347,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
 
         expected_instance = f"""
             <partial>
-              <instance id="{instance_id}" src="jr://fixture/commcare-reports:abcdef"/>
+              <instance id="{instance_id}" src="jr://fixture/commcare-reports:123abc"/>
             </partial>
             """
         self.assertXmlPartialEqual(

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -16,7 +16,7 @@ from corehq.apps.app_manager.models import (
     ShadowModule,
 )
 from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
-    RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE,
+    RESULTS_INSTANCE_INLINE,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -210,12 +210,13 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
         self._test_search_prompt_itemset_instance(shadow_module)
 
     def _test_search_prompt_itemset_instance(self, module):
-        instance_id = "123"
+        instance_id = "item-list:123"
         module.search_config = CaseSearch(
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}, input_="select1", itemset=Itemset(
                     instance_id=instance_id,
-                    instance_uri="jr://fixture/custom_fixture",
+                    # This will be generated automatically
+                    # instance_uri="jr://fixture/custom_fixture",
                     nodeset=f"instance('{instance_id}')/rows/row",
                     label='name',
                     value='id',
@@ -228,7 +229,7 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
 
         expected_instance = f"""
                 <partial>
-                  <instance id="{instance_id}" src="jr://fixture/custom_fixture"/>
+                  <instance id="{instance_id}" src="jr://fixture/item-list:123"/>
                 </partial>
                 """
         self.assertXmlPartialEqual(

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -215,8 +215,6 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}, input_="select1", itemset=Itemset(
                     instance_id=instance_id,
-                    # This will be generated automatically
-                    # instance_uri="jr://fixture/custom_fixture",
                     nodeset=f"instance('{instance_id}')/rows/row",
                     label='name',
                     value='id',

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -11,7 +11,9 @@ from corehq.apps.app_manager.models import (
     Itemset,
     ShadowModule,
 )
-from corehq.apps.app_manager.suite_xml.post_process.instances import get_instance_names
+from corehq.apps.app_manager.suite_xml.post_process.instances import (
+    get_instance_names,
+)
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -113,13 +115,16 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
                                        self.factory.app.create_suite(), "entry/instance")
 
             configuration_mock_obj.sync_hierarchical_fixture = False
-            self.assertXmlPartialEqual(flat_fixture_format_xml, self.factory.app.create_suite(), "entry/instance")
+            self.assertXmlPartialEqual(flat_fixture_format_xml,
+                                       self.factory.app.create_suite(), "entry/instance")
 
             configuration_mock_obj.sync_flat_fixture = False
-            self.assertXmlPartialEqual(hierarchical_fixture_format_xml, self.factory.app.create_suite(), "entry/instance")
+            self.assertXmlPartialEqual(hierarchical_fixture_format_xml,
+                                       self.factory.app.create_suite(), "entry/instance")
 
             configuration_mock_obj.sync_hierarchical_fixture = True
-            self.assertXmlPartialEqual(hierarchical_fixture_format_xml, self.factory.app.create_suite(), "entry/instance")
+            self.assertXmlPartialEqual(hierarchical_fixture_format_xml,
+                                       self.factory.app.create_suite(), "entry/instance")
 
         # To ensure for new domains or domains adding locations now come on flat fixture
         configuration_mock_obj.sync_hierarchical_fixture = True  # default value

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -65,7 +65,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
                 CaseSearchProperty(name='favorite_color', label={'en': 'Favorite Color'}, itemset=Itemset(
-                    instance_id='item-list:colors', instance_uri='jr://fixture/item-list:colors',
+                    instance_id='item-list:colors',
                     nodeset="instance('item-list:colors')/colors_list/colors",
                     label='name', sort='name', value='value'),
                 )
@@ -296,8 +296,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         instance_id = "commcare-reports:123abc"
         self.module.search_config.properties[0].itemset = Itemset(
             instance_id=instance_id,
-            # This will be generated automatically
-            # instance_uri="jr://fixture/commcare-reports:abcdef",
             nodeset=f"instance('{instance_id}')/rows/row",
             label='name',
             value='id',
@@ -363,7 +361,7 @@ class RegistrySuiteShadowModuleTest(SimpleTestCase, SuiteMixin):
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
                 CaseSearchProperty(name='favorite_color', label={'en': 'Favorite Color'}, itemset=Itemset(
-                    instance_id='item-list:colors', instance_uri='jr://fixture/item-list:colors',
+                    instance_id='item-list:colors',
                     nodeset="instance('item-list:colors')/colors_list/colors",
                     label='name', sort='name', value='value'),
                 )
@@ -389,7 +387,7 @@ class RegistrySuiteShadowModuleTest(SimpleTestCase, SuiteMixin):
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
                 CaseSearchProperty(name='favorite_color', label={'en': 'Texture'}, itemset=Itemset(
-                    instance_id='item-list:textures', instance_uri='jr://fixture/item-list:textures',
+                    instance_id='item-list:textures',
                     nodeset="instance('item-list:textures')/textures_list/textures",
                     label='name', sort='name', value='value'),
                 )

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -293,10 +293,11 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
     @flag_enabled('MOBILE_UCR')
     def test_prompt_itemset_mobile_report(self):
         self.module.search_config.properties[0].input_ = 'select1'
-        instance_id = "123abc"
+        instance_id = "commcare-reports:123abc"
         self.module.search_config.properties[0].itemset = Itemset(
             instance_id=instance_id,
-            instance_uri="jr://fixture/commcare-reports:abcdef",
+            # This will be generated automatically
+            # instance_uri="jr://fixture/commcare-reports:abcdef",
             nodeset=f"instance('{instance_id}')/rows/row",
             label='name',
             value='id',
@@ -323,7 +324,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
         expected_instance = f"""
                 <partial>
-                  <instance id="{instance_id}" src="jr://fixture/commcare-reports:abcdef"/>
+                  <instance id="{instance_id}" src="jr://fixture/commcare-reports:123abc"/>
                 </partial>
                 """
         self.assertXmlPartialEqual(

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -21,8 +21,10 @@ from corehq.apps.app_manager.models import (
     ParentSelect,
     ShadowModule,
 )
-from corehq.apps.app_manager.suite_xml.post_process.remote_requests import RESULTS_INSTANCE, \
-    RESULTS_INSTANCE_INLINE
+from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
+    RESULTS_INSTANCE,
+    RESULTS_INSTANCE_INLINE,
+)
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -129,7 +131,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                 </itemset>
               </prompt>
             </query>
-            <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
+            <datum id="case_id"
+                nodeset="instance('results')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                 value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             <query url="http://localhost:8000/a/test_domain/phone/case_fixture/123/"
                 storage-instance="registry" template="case" default_search="true">
@@ -139,7 +142,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
               <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
             </query>
           </session>
-        </partial>"""
+        </partial>"""  # noqa: E501
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[1]/session")
 
         # assert that session instance is added to the entry

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -654,7 +654,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.module.search_config.properties[0].input_ = 'select1'
         self.module.search_config.properties[0].itemset = Itemset(
             instance_id='states',
-            instance_uri="jr://fixture/item-list:states",
             nodeset="instance('item-list:states')/state_list/state[@state_name = 'Uttar Pradesh']",
             label='name',
             value='id',
@@ -683,7 +682,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.module.search_config.properties[0].input_ = 'select1'
         self.module.search_config.properties[0].itemset = Itemset(
             instance_id='states',
-            instance_uri="jr://fixture/item-list:states",
             nodeset="instance('item-list:states')/state_list/state[@state_name = 'Uttar Pradesh']",
             label='name',
             value='id',
@@ -740,8 +738,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.module.search_config.properties[0].input_ = 'select1'
         self.module.search_config.properties[0].itemset = Itemset(
             instance_id=instance_id,
-            # This will be generated automatically
-            # instance_uri="jr://fixture/commcare-reports:abcdef",
             nodeset=f"instance('{instance_id}')/rows/row",
             label='name',
             value='id',

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -191,7 +191,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         # reset to newly wrapped module
         self.module = self.app.modules[0]
 
-    def test_search_config_relevant(self, *args):
+    def test_search_config_relevant(self):
         config = CaseSearch()
 
         self.assertEqual(
@@ -203,7 +203,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             config.get_relevant(config.case_session_var),
             "(count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/search_case_id]) = 0) and (double(now()) mod 2 = 0)")  # noqa: E501
 
-    def test_search_config_relevant_multi_select(self, *args):
+    def test_search_config_relevant_multi_select(self):
         config = CaseSearch()
 
         self.assertEqual(config.get_relevant(config.case_session_var, multi_select=True), "$case_id != ''")
@@ -214,7 +214,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
     @flag_enabled("USH_CASE_CLAIM_UPDATES")
     @flag_enabled('USH_SEARCH_FILTER')
-    def test_remote_request(self, *args):
+    def test_remote_request(self):
         """
         Suite should include remote-request if searching is configured
         """
@@ -227,7 +227,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
     @flag_enabled("USH_CASE_CLAIM_UPDATES")
     @flag_enabled('USH_SEARCH_FILTER')
-    def test_remote_request_custom_detail(self, *args):
+    def test_remote_request_custom_detail(self):
         """Remote requests for modules with custom details point to the custom detail
         """
         self.module.case_details.short.custom_xml = '<detail id="m0_case_short"></detail>'
@@ -236,8 +236,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     @flag_enabled('USH_SEARCH_FILTER')
-    @patch('corehq.apps.app_manager.suite_xml.post_process.resources.ResourceOverrideHelper.update_suite')
-    def test_duplicate_remote_request(self, *args):
+    @patch('corehq.apps.app_manager.suite_xml.post_process.resources.ResourceOverrideHelper.update_suite', lambda _: None)
+    def test_duplicate_remote_request(self):
         """
         Adding a second search config should not affect the initial one.
         """
@@ -255,7 +255,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             "./remote-request[2]"
         )
 
-    def test_case_search_action(self, *args):
+    def test_case_search_action(self):
         """
         Case search action should be added to case list and a new search detail should be created
         """
@@ -292,7 +292,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     @flag_enabled('USH_SEARCH_FILTER')
-    def test_case_search_filter(self, *args):
+    def test_case_search_filter(self):
         search_filter = "rating > 3"
         self.module.search_config.search_filter = search_filter
         suite = self.app.create_suite()
@@ -311,7 +311,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     @flag_enabled('USH_SEARCH_FILTER')
-    def test_additional_types(self, *args):
+    def test_additional_types(self):
         another_case_type = "another_case_type"
         self.module.search_config.additional_case_types = [another_case_type]
         suite_xml = self.app.create_suite()
@@ -340,7 +340,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         )
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
-    def test_additional_types__shadow_module(self, *args):
+    def test_additional_types__shadow_module(self):
         shadow_module = self.app.add_module(ShadowModule.new_module("shadow", "en"))
         shadow_module.source_module_id = self.module.get_or_create_unique_id()
         shadow_module.search_config = CaseSearch(
@@ -380,14 +380,14 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             "./remote-request[2]/session/query/data[@key='case_type']"
         )
 
-    def test_case_search_action_relevant_condition(self, *args):
+    def test_case_search_action_relevant_condition(self):
         condition = "'foo' = 'bar'"
         self.module.search_config.search_button_display_condition = condition
         suite = self.app.create_suite()
         suite = parse_normalize(suite, to_string=False)
         self.assertEqual(condition, suite.xpath('./detail[1]/action/@relevant')[0])
 
-    def test_case_search_auto_launch_off(self, *args):
+    def test_case_search_auto_launch_off(self):
         self.module.search_config.auto_launch = True
         suite = self.app.create_suite()
         expected = """
@@ -410,7 +410,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.assertXmlPartialEqual(expected, suite, "./detail[1]/action")
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
-    def test_case_search_auto_launch(self, *args):
+    def test_case_search_auto_launch(self):
         self.module.search_config.auto_launch = True
         suite = self.app.create_suite()
         expected = f"""
@@ -432,7 +432,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./detail[1]/action")
 
-    def test_only_default_properties(self, *args):
+    def test_only_default_properties(self):
         self.module.search_config = CaseSearch(
             default_properties=[
                 DefaultCaseSearchProperty(
@@ -454,7 +454,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_config_default_only'), suite, "./remote-request[1]")
 
-    def test_custom_related_case_property(self, *args):
+    def test_custom_related_case_property(self):
         self.module.search_config.custom_related_case_property = "potential_duplicate_id"
         suite = self.app.create_suite()
 
@@ -466,7 +466,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         xpath = "./remote-request[1]/session/query/data[@key='x_commcare_custom_related_case_property']"
         self.assertXmlPartialEqual(expected, suite, xpath)
 
-    def test_blacklisted_owner_ids(self, *args):
+    def test_blacklisted_owner_ids(self):
         self.module.search_config = CaseSearch(
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
@@ -479,7 +479,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_config_blacklisted_owners'), suite, "./remote-request[1]")
 
-    def test_prompt_hint(self, *args):
+    def test_prompt_hint(self):
         self.module.search_config.properties[0].hint = {'en': 'Search against name'}
         suite = self.app.create_suite()
         expected = """
@@ -500,7 +500,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
-    def test_default_search(self, *args):
+    def test_default_search(self):
         suite = self.app.create_suite()
         suite = parse_normalize(suite, to_string=False)
         self.assertEqual("false", suite.xpath("./remote-request[1]/session/query/@default_search")[0])
@@ -510,7 +510,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         suite = parse_normalize(suite, to_string=False)
         self.assertEqual("true", suite.xpath("./remote-request[1]/session/query/@default_search")[0])
 
-    def test_prompt_appearance(self, *args):
+    def test_prompt_appearance(self):
         """Setting the appearance to "barcode"
         """
         self.module.search_config.properties[0].appearance = 'barcode_scan'
@@ -544,7 +544,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
-    def test_prompt_daterange(self, *args):
+    def test_prompt_daterange(self):
         """Setting the appearance to "daterange"
         """
         # Shouldn't be included for versions before 2.50
@@ -578,7 +578,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
-    def test_prompt_address(self, *args):
+    def test_prompt_address(self):
         """Setting the appearance to "address"
         """
         self.module.search_config.properties[0].appearance = 'address'
@@ -611,7 +611,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
-    def test_prompt_address_receiver(self, *args):
+    def test_prompt_address_receiver(self):
         """Setting the appearance to "address"
         """
         self.module.search_config.properties[0].receiver_expression = 'home-street'
@@ -629,7 +629,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
-    def test_prompt_hidden(self, *args):
+    def test_prompt_hidden(self):
         """Setting the appearance to "address"
         """
         self.module.search_config.properties[0].hidden = True
@@ -647,7 +647,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
-    def test_prompt_address_receiver_itemset(self, *args):
+    def test_prompt_address_receiver_itemset(self):
         """Setting the appearance to "address"
         """
         self.module.search_config.properties[0].receiver_expression = 'home-street'
@@ -774,7 +774,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         )
 
     @flag_enabled("USH_CASE_CLAIM_UPDATES")
-    def test_prompt_default_value(self, *args):
+    def test_prompt_default_value(self):
         """Setting the default to "default_value"
         """
         self.module.search_config.properties[0].default_value = 'foo'
@@ -824,7 +824,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
-    def test_allow_blank_value(self, *args):
+    def test_allow_blank_value(self):
         self.module.search_config.properties[0].allow_blank_value = True
         suite = self.app.create_suite()
         expected = """
@@ -840,7 +840,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
-    def test_exclude_from_search(self, *args):
+    def test_exclude_from_search(self):
         self.module.search_config.properties[0].exclude = True
         suite = self.app.create_suite()
         expected = """
@@ -856,7 +856,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
-    def test_case_search_title_translation(self, *args):
+    def test_case_search_title_translation(self):
         self.app.build_spec = BuildSpec(version='2.53.0', build_number=1)
         suite = self.app.create_suite()
         expected_query_title = """
@@ -890,7 +890,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.assertXmlPartialEqual(expected_search_detail, suite, "./detail[@id='m0_search_short']/title")
         self.assertXmlPartialEqual(expected_case_detail, suite, "./detail[@id='m0_case_short']/title")
 
-    def test_required(self, *args):
+    def test_required(self):
         self.module.search_config.properties[0].required = Assertion(
             test="#session/user/data/is_supervisor = 'n'",
         )
@@ -913,7 +913,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt[@key='name']")
 
-    def test_case_search_validation_conditions(self, *args):
+    def test_case_search_validation_conditions(self):
         self.module.search_config.properties = [
             CaseSearchProperty(name='name', label={'en': 'Name'}, validations=[
                 Assertion(test='2 + 2 = 5', text={"en": ""})

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -1,6 +1,7 @@
-from django.test import SimpleTestCase
 from unittest.mock import patch
 from uuid import uuid4
+
+from django.test import SimpleTestCase
 
 from corehq.apps.app_manager.const import REGISTRY_WORKFLOW_SMART_LINK
 from corehq.apps.app_manager.exceptions import UnknownInstanceError
@@ -13,23 +14,26 @@ from corehq.apps.app_manager.models import (
     CaseSearchLabel,
     CaseSearchProperty,
     DefaultCaseSearchProperty,
+    DetailColumn,
     Itemset,
-    Module, DetailColumn, ShadowModule,
+    Module,
+    ShadowModule,
 )
-from corehq.apps.app_manager.suite_xml.sections.details import (
-    AUTO_LAUNCH_EXPRESSIONS,
-    DetailContributor
-)
-from corehq.apps.app_manager.suite_xml.sections.entries import EntriesContributor
 from corehq.apps.app_manager.suite_xml.generator import SuiteGenerator
 from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
     RESULTS_INSTANCE,
     RemoteRequestFactory,
 )
+from corehq.apps.app_manager.suite_xml.sections.details import (
+    AUTO_LAUNCH_EXPRESSIONS,
+    DetailContributor,
+)
+from corehq.apps.app_manager.suite_xml.sections.entries import (
+    EntriesContributor,
+)
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
-    TestXmlMixin,
     parse_normalize,
     patch_get_xform_resource_overrides,
 )
@@ -730,7 +734,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             sort='id',
         )
         with self.assertRaises(UnknownInstanceError):
-            suite = self.app.create_suite()
+            self.app.create_suite()
 
     @flag_enabled('MOBILE_UCR')
     def test_prompt_itemset_mobile_report(self):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -485,8 +485,9 @@ def _case_list_form_options(app, module, lang=None):
         'post_form_workflow': f.post_form_workflow,
         'is_registration_form': True,
     } for f in reg_forms})
-    if (hasattr(module, 'parent_select')   # AdvancedModule doesn't have parent_select
-            and toggles.FOLLOWUP_FORMS_AS_CASE_LIST_FORM and module.parent_select.active):
+    if (hasattr(module, 'parent_select')  # AdvancedModule doesn't have parent_select
+            and toggles.FOLLOWUP_FORMS_AS_CASE_LIST_FORM
+            and module.parent_select.active):
         followup_forms = get_parent_select_followup_forms(app, module)
         if followup_forms:
             options.update({f.unique_id: {

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1050,7 +1050,7 @@ def _update_search_properties(module, search_properties, lang='en'):
 
     def _get_itemset(prop):
         fixture_props = json.loads(prop['fixture'])
-        keys = {'instance_uri', 'instance_id', 'nodeset', 'label', 'value', 'sort'}
+        keys = {'instance_id', 'nodeset', 'label', 'value', 'sort'}
         missing = [key for key in keys if not fixture_props.get(key)]
         if missing:
             raise CaseSearchConfigError(_("""


### PR DESCRIPTION
## Product Description
Remove the Instance URI field from case search property config for "Mobile UCR Selection" and "Lookup Table Selection" type questions:

![image](https://github.com/dimagi/commcare-hq/assets/2367539/da5a2d58-2082-4d9d-af9b-e5b2e9b4c4fb)

The "Instance Nodeset" field remains, though I've moved it up to the other related fields:

![image](https://github.com/dimagi/commcare-hq/assets/2367539/2cfdb354-a7e3-412f-8050-284bd10febd3)

This field was autopopulated anyways, and there wasn't much of a use-case for overriding it.  Having it stored there meant that when apps were copied, mobile UCR references were stale, which blocked apps from being built.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3335, though there's more context in https://dimagi-dev.atlassian.net/browse/QA-5216
I did an in-depth writeup of my rationale in [this comment](https://dimagi-dev.atlassian.net/browse/QA-5216?focusedCommentId=272531), though I'll summarize here:

The impetus for this work was that QA reported being blocked by build failures when copying a case search test app.  I traced this down to an error being raised during suite generation - we declared multiple instances with the same ID, but different instance URIs.

What happened is that in the original app, case search properties that use "Mobile UCR Selection" would have a default autogenerated instance URI pointing to the ID of the mobile report instance (which is associated with the app).  When the app was copied, those IDs change, breaking those references.  However, we do add the original IDs as an alias (`report_slug`) for the report, which is intended to prevent breakages like this, by letting `instance('...')` type references continue using the old ID.  In this case though, we also hardcoded the URI, which _does_ need to change.  This error would've passed silently, as in non-app-aware restores, mobile UCR fixtures from all apps on the project space are included.  In fact, QA reported that they'd long needed to manually update these references when copying to another project space, but not when using the same space.

The strange thing was that we generated the instance declaration for this use-case _twice_, and with the copied apps, they disagreed.  We generated a "custom instance declaration" based on the stored instance URI, even though this is never actually overridden by users.  This was incorrect when the app was copied.  We also autodetect the instance declaration based on the stored nodeset (something like `instance('commcare-reports:83d1d7a6efeb4a3db14066d97c130c98')/rows/row`), and this _did_ correctly resolve to the copied app's report config instance ID.

To address this, I removed the instance URI field from the back-end and from the UI, forcing this feature to rely solely on autodetecting instances (which we do all over the place anyways).

This does make a few assumptions:

Users don't actually need to custom-define fixtures here.  I checked with QA and delivery and this seems a reasonable assumption.  They can use mobile UCR and lookup table fixtures - looks like anything else would break anyways, based on how the rest of the config is done (we regularly assume that the instance is one of those two)

We don't need to worry about mobile UCR v1 in this workflow.  Mobile UCR v1 instance IDs are naked UUIDs, without a namespace, so you need context to know that's what they refer to.  Many of the tests we have used gibberish IDs which relied on hardcoded fixtures to get something resolvable.  By updating all these to have either an `item-list` or `commcare-report` namespace, the auto detection was able to function.  I checked prod and staging and found no apps with an instance_uri reference that didn't contain either of the strings `item-list` or `commcare-reports`.  There _were_ a handful of old test apps that had `instance_id` values that didn't have either namespace.  In some of them, the domain wouldn't load in the UI at all, and in others, it did load, but the case property config page had errors because the `instance_id`s were unrecognized.

Besides the inspection of actual usage, I feel confident about these assumptions because we already assume that the instance matches one of the two (here, among other places:
https://github.com/dimagi/commcare-hq/blob/4a17c65b3c744ed814feec5e59049c2f28cc3c25/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js#L305-L309
The value stored for instance ID is expected to be in the `item_list` variable defined here, which includes the namespace.
https://github.com/dimagi/commcare-hq/blob/387a2f423acbb833fbe2346b563ac6c1fded1f17/corehq/apps/app_manager/views/modules.py#L233-L235

In fact, we'd migrated these instances explicitly, back in https://github.com/dimagi/commcare-hq/pull/31727

I tried to make these expectations a bit more explicit, and I added a validation error if someone attempts to use Mobile UCR v1 with this feature.

## Feature Flag

Case search, mobile UCR, USH case search extensions, you name it

## Safety Assurance
See the above technical description and the linked Jira comment

### Safety story

### Automated test coverage

yes

### QA Plan

QA raised this issue, so I'll send it back to them to validate 

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change