### PR TITLE
Fix sort param in case v0.6

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -535,10 +535,11 @@ class ESQuerySet(object):
 
     def __init__(self, raw, query):
         if 'error' in raw:
-            msg = textwrap.dedent(f"""ElasticSearch Error
+            msg = textwrap.dedent(f"""
+                ElasticSearch Error
                 {raw['error']}
                 Index: {query.index}
-                Query: {query.dumps(pretty=True)}""")
+                Query: {query.dumps(pretty=True)}""").lstrip()
 
             raise ESError(msg)
         self.raw = raw

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -534,12 +534,11 @@ class ESQuerySet(object):
 
     def __init__(self, raw, query):
         if 'error' in raw:
-            msg = ("ElasticSearch Error\n{error}\nIndex: {index}"
-                   "\nQuery: {query}").format(
-                       error=raw['error'],
-                       index=query.index,
-                       query=query.dumps(pretty=True),
-            )
+            msg = f"""ElasticSearch Error
+                {raw['error']}
+                Index: {query.index}"
+                Query: {query.dumps(pretty=True)}"""
+
             raise ESError(msg)
         self.raw = raw
         self.query = query

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -410,6 +410,7 @@ class ESQuery(object):
 
     def sort(self, field, desc=False, reset_sort=True):
         """Order the results by field."""
+        assert field != '_id', "Cannot sort on reserved _id field"
         sort_field = {
             field: {'order': 'desc' if desc else 'asc'}
         }

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -88,6 +88,7 @@ Language
 import json
 from collections import namedtuple
 from copy import deepcopy
+import textwrap
 
 from memoized import memoized
 
@@ -534,10 +535,10 @@ class ESQuerySet(object):
 
     def __init__(self, raw, query):
         if 'error' in raw:
-            msg = f"""ElasticSearch Error
+            msg = textwrap.dedent(f"""ElasticSearch Error
                 {raw['error']}
-                Index: {query.index}"
-                Query: {query.dumps(pretty=True)}"""
+                Index: {query.index}
+                Query: {query.dumps(pretty=True)}""")
 
             raise ESError(msg)
         self.raw = raw

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -539,7 +539,7 @@ class ESQuerySet(object):
                        error=raw['error'],
                        index=query.index,
                        query=query.dumps(pretty=True),
-                    )
+            )
             raise ESError(msg)
         self.raw = raw
         self.query = query

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -156,8 +156,8 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
             "size": SIZE_LIMIT
         }
         query = forms.FormES()\
-                .filter(filters.domain("zombocom"))\
-                .xmlns('banana')
+            .filter(filters.domain("zombocom"))\
+            .xmlns('banana')
         raw_query = query.raw_query
         self.checkQuery(raw_query, json_output, is_raw_query=True)
 
@@ -177,34 +177,36 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
     def test_values_list(self):
         example_response = {
             '_shards': {'failed': 0, 'successful': 5, 'total': 5},
-            'hits': {'hits': [{
-                '_id': '8063dff5-460b-46f2-b4d0-5871abfd97d4',
-                '_index': 'xforms_1cce1f049a1b4d864c9c25dc42648a45',
-                '_score': 1.0,
-                '_type': 'xform',
-                '_source': {
-                    'app_id': 'fe8481a39c3738749e6a4766fca99efd',
-                    'doc_type': 'xforminstance',
-                    'domain': 'mikesproject',
-                    'xmlns': 'http://openrosa.org/formdesigner/3a7cc07c-551c-4651-ab1a-d60be3017485'
-                    }
-                },
-                {
-                    '_id': 'dc1376cd-0869-4c13-a267-365dfc2fa754',
-                    '_index': 'xforms_1cce1f049a1b4d864c9c25dc42648a45',
-                    '_score': 1.0,
-                    '_type': 'xform',
-                    '_source': {
-                        'app_id': '3d622620ca00d7709625220751a7b1f9',
-                        'doc_type': 'xforminstance',
-                        'domain': 'jacksproject',
-                        'xmlns': 'http://openrosa.org/formdesigner/54db1962-b938-4e2b-b00e-08414163ead4'
+            'hits': {
+                'hits': [
+                    {
+                        '_id': '8063dff5-460b-46f2-b4d0-5871abfd97d4',
+                        '_index': 'xforms_1cce1f049a1b4d864c9c25dc42648a45',
+                        '_score': 1.0,
+                        '_type': 'xform',
+                        '_source': {
+                            'app_id': 'fe8481a39c3738749e6a4766fca99efd',
+                            'doc_type': 'xforminstance',
+                            'domain': 'mikesproject',
+                            'xmlns': 'http://openrosa.org/formdesigner/3a7cc07c-551c-4651-ab1a-d60be3017485'
+                        }
+                    },
+                    {
+                        '_id': 'dc1376cd-0869-4c13-a267-365dfc2fa754',
+                        '_index': 'xforms_1cce1f049a1b4d864c9c25dc42648a45',
+                        '_score': 1.0,
+                        '_type': 'xform',
+                        '_source': {
+                            'app_id': '3d622620ca00d7709625220751a7b1f9',
+                            'doc_type': 'xforminstance',
+                            'domain': 'jacksproject',
+                            'xmlns': 'http://openrosa.org/formdesigner/54db1962-b938-4e2b-b00e-08414163ead4'
                         }
                     }
                 ],
                 'max_score': 1.0,
                 'total': 5247
-                },
+            },
             'timed_out': False,
             'took': 4
         }

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -261,6 +261,10 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
         ]
         self.checkQuery(query.sort('timeStart', reset_sort=False), json_output)
 
+    def test_sort_raises_on__id_field(self):
+        with self.assertRaisesMessage(AssertionError, "Cannot sort on reserved _id field"):
+            HQESQuery('forms').sort('_id')
+
     def test_exclude_source(self):
         json_output = {
             "query": {

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -126,7 +126,7 @@ def _get_query(domain, params):
              .domain(domain)
              .size(page_size)
              .sort("@indexed_on")
-             .sort("_id", reset_sort=False))
+             .sort("_uid", reset_sort=False))
     for key, val in params.lists():
         if len(val) == 1:
             query = query.filter(_get_filter(domain, key, val[0]))

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -1,7 +1,6 @@
 from base64 import b64decode, b64encode
 
 from django.http import QueryDict
-from django.utils.http import urlencode
 
 from corehq.apps.api.util import make_date_filter
 from corehq.apps.case_search.filter_dsl import (


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
@zandre-eng pointed out that case api v0.6 is throwing error in get on staging [error trace](https://dimagi.sentry.io/issues/4290875905/?environment=staging&project=136860&query=is%3Aunresolved&referrer=issue-stream&sort=date&statsPeriod=1h&stream_index=0). On looking we figured that it is not allowed to sort on `_id` since ES 2 itself (https://www.elastic.co/guide/en/elasticsearch/reference/2.4/mapping-id-field.html#mapping-id-field)

> The value of the _id field is accessible in certain queries (term, terms, match, query_string, simple_query_string), but not in aggregations, scripts or when sorting, where the [_uid](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/mapping-uid-field.html) field should be used instead:

I believe only reason for passing in `_id` in sort to get consistent query results, so the fix that we attempted here is changing `_id` with `_uid` as suggested in the doc.

I have tested these changes locally and things were working fine. Would be adding it to staging as well.

I have also added a test to ensure that we don't accidentally add this reserved keyword in sort after that. 


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
case_api_v0_6
## Safety Assurance
Tested locally and would be putting on staging as well. 
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests are added
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
