### PR TITLE
Add wrapper around case list tile select all and style like tile

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -25,8 +25,10 @@
           <% if (hasNoItems) { %>
             {% include 'formplayer/no_items_text.html' %}
           <% } else if (isMultiSelect) { %>
-            <input type="checkbox" id="select-all-tile-checkbox"/>
-            <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
+            <div id="select-all-tile-wrapper">
+              <input type="checkbox" id="select-all-tile-checkbox"/>
+              <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
+            </div>
           <% } %>
           <section  class="js-case-container clearfix list-cell-container-style"></section>
         <% } else { %>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
@@ -47,6 +47,11 @@ body {
   }
 }
 
+#select-all-tile-wrapper {
+  background-color: @cc-bg;
+  border: 1px solid white;
+}
+
 #select-all-tile-checkbox {
   margin-top: 10px;
   margin-bottom: 10px;


### PR DESCRIPTION
## Product Description
Style select all check box the same as tile to make map look lined up.

<img width="729" alt="image" src="https://github.com/dimagi/commcare-hq/assets/1946138/ba32e959-8504-466b-a3a4-71132137cd11">


## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3384

## Feature Flag
`case_list_tile` and `case_list_map`

## Safety Assurance

Tested locally. Just a cosmetic change

### Safety story

Tested locally

### Automated test coverage

None

### QA Plan

* Load case list with/without tile and with/without multi select one. All should look good.
* Select all check box should still work with styling added.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
