### PR TITLE
Initialize caseTileTemplate to null if falsy

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -61,7 +61,7 @@ hqDefine("app_manager/js/details/screen", function () {
         self.caseTileTemplateOptions = self.caseTileTemplateOptions.map(function (templateOption) {
             return {templateValue: templateOption[0], templateName: templateOption[1]};
         });
-        self.caseTileTemplate = ko.observable(detail.case_tile_template);
+        self.caseTileTemplate = ko.observable(detail.case_tile_template || null);
         self.caseTileTemplateConfigs = options.caseTileTemplateConfigs;
         self.caseTileFieldsForTemplate = ko.computed(function () {
             return (self.caseTileTemplateConfigs[self.caseTileTemplate()] || {}).fields;


### PR DESCRIPTION
## Product Description
Bugfix for a "Changes you made may not be saved" alert that can occur when there are case tile properties set but no case tile template selected.

## Technical Summary
A quick fix option for [QA-5309](https://dimagi-dev.atlassian.net/browse/QA-5309). When no case tile template is selected the value of `caseTileTemplate` is being read as `undefined`. The first choice in the list of `caseTileTemplateOptions` is `null`, which is immediately seen by knockout as a change (`undefined` => `null`) triggering the unsaved state.

The quick fix is to either use `undefined` as the first in the list of choices, or initialize the value to `null` -- I opted for the latter, feeling that it expresses _"nothing" is selected_, rather than _there is no selection_.

## Feature Flag
case_list_tile

## Safety Assurance

### Safety story
Small javascript bugfix. This change affects how knockout interprets a falsy value of `caseTileTemplate` but doesn't change how that value is saved.

### Automated test coverage

### QA Plan
Will put on staging for QA to confirm that bug is resolved.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[QA-5309]: https://dimagi-dev.atlassian.net/browse/QA-5309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ