### PR TITLE
Use forceManualSearch for requests from split screen case search

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -448,6 +448,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     break;
                 }
             }
+
+            // force manual search in split screen case search for workflow compatibility
+            this.forceManualSearch = this.options.sidebarEnabled;
         },
 
         templateContext: function () {
@@ -528,7 +531,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             e.preventDefault();
 
             self.validateAllFields().done(function () {
-                FormplayerFrontend.trigger("menu:query", self.getAnswers(), self.selectValuesByKeys);
+                FormplayerFrontend.trigger(
+                    "menu:query",
+                    self.getAnswers(),
+                    self.selectValuesByKeys,
+                    self.forceManualSearch);
             });
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -448,9 +448,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     break;
                 }
             }
-
-            // force manual search in split screen case search for workflow compatibility
-            this.forceManualSearch = this.options.sidebarEnabled;
         },
 
         templateContext: function () {
@@ -535,7 +532,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     "menu:query",
                     self.getAnswers(),
                     self.selectValuesByKeys,
-                    self.forceManualSearch);
+                    self.options.sidebarEnabled
+                );
             });
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -199,7 +199,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         API.listMenus();
     });
 
-    FormplayerFrontend.on("menu:query", function (queryDict, selectValuesByKeys = false, forceManualSearch) {
+    FormplayerFrontend.on("menu:query", function (queryDict, selectValuesByKeys = false, sidebarEnabled) {
         var urlObject = utils.currentUrlToObject();
         var queryObject = _.extend(
             {
@@ -207,7 +207,8 @@ hqDefine("cloudcare/js/formplayer/router", function () {
                 execute: true,
                 selectValuesByKeys,
             },
-            forceManualSearch ? { forceManualSearch: true } : {}
+            // force manual search in split screen case search for workflow compatibility
+            sidebarEnabled ? { forceManualSearch: true } : {}
         );
         urlObject.setQueryData(queryObject);
         utils.setUrlToObject(urlObject);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -199,14 +199,17 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         API.listMenus();
     });
 
-    FormplayerFrontend.on("menu:query", function (queryDict, selectValuesByKeys = false, forceManualSearch = false) {
+    FormplayerFrontend.on("menu:query", function (queryDict, selectValuesByKeys = false, forceManualSearch) {
         var urlObject = utils.currentUrlToObject();
-        urlObject.setQueryData({
-            inputs: queryDict,
-            execute: true,
-            selectValuesByKeys: selectValuesByKeys,
-            forceManualSearch: forceManualSearch,
-        });
+        var queryObject = _.extend(
+            {
+                inputs: queryDict,
+                execute: true,
+                selectValuesByKeys,
+            },
+            forceManualSearch ? { forceManualSearch: true } : {}
+        );
+        urlObject.setQueryData(queryObject);
         utils.setUrlToObject(urlObject);
         API.listMenus();
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -199,12 +199,13 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         API.listMenus();
     });
 
-    FormplayerFrontend.on("menu:query", function (queryDict, selectValuesByKeys = false) {
+    FormplayerFrontend.on("menu:query", function (queryDict, selectValuesByKeys = false, forceManualSearch = false) {
         var urlObject = utils.currentUrlToObject();
         urlObject.setQueryData({
             inputs: queryDict,
             execute: true,
             selectValuesByKeys: selectValuesByKeys,
+            forceManualSearch: forceManualSearch,
         });
         utils.setUrlToObject(urlObject);
         API.listMenus();


### PR DESCRIPTION
## Product Description
Relatively urgent bugfix for skip to default workflow in split screen case search.

## Technical Summary
[USH-3387](https://dimagi-dev.atlassian.net/browse/USH-3387?focusedCommentId=274482)
Always uses `forceManualSearch` for case search requests to formplayer when split screen case search is enabled. 

## Feature Flag
split_screen_case_search

## Safety Assurance

### Safety story
Only has an effect if split screen case search is enabled. Tested locally with all case search workflows and will put on staging to verify.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3387]: https://dimagi-dev.atlassian.net/browse/USH-3387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ