### PR TITLE
Lint `suite_xml/sections/entries.py`

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -286,7 +286,7 @@ class EntriesHelper(object):
                 self.app.commtrack_enabled and
                 session_var('supply_point_id') in getattr(form, 'source', "")
             ):
-                from corehq.apps.app_manager.models import AUTO_SELECT_LOCATION
+                from corehq.apps.app_manager.const import AUTO_SELECT_LOCATION
                 datum, assertions = EntriesHelper.get_userdata_autoselect(
                     'commtrack-supply-point',
                     'supply_point_id',
@@ -677,7 +677,7 @@ class EntriesHelper(object):
 
     @staticmethod
     def get_auto_select_datums_and_assertions(action, auto_select, form):
-        from corehq.apps.app_manager.models import AUTO_SELECT_USER, AUTO_SELECT_CASE, \
+        from corehq.apps.app_manager.const import AUTO_SELECT_USER, AUTO_SELECT_CASE, \
             AUTO_SELECT_FIXTURE, AUTO_SELECT_RAW, AUTO_SELECT_USERCASE
         if auto_select.mode == AUTO_SELECT_USER:
             return EntriesHelper.get_userdata_autoselect(

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -13,8 +13,8 @@ modules.  See ``update_refs`` and ``rename_other_id``, both inner functions in `
 `this comment`_ on matching parent and child datums.
 
 
-.. _this comment: https://github.com/dimagi/commcare-hq/blob/c9fa01d1ccbb73d8f07fefbe56a0bbe1dbe231f8/corehq/apps/app_manager/suite_xml/sections/entries.py#L966-L971  # noqa
-"""
+.. _this comment: https://github.com/dimagi/commcare-hq/blob/c9fa01d1ccbb73d8f07fefbe56a0bbe1dbe231f8/corehq/apps/app_manager/suite_xml/sections/entries.py#L966-L971
+"""  # noqa
 from collections import defaultdict
 
 from django.utils.translation import gettext as _


### PR DESCRIPTION
## Technical Summary

I figured I'd try my hand at being a knight. This PR is related to https://github.com/dimagi/commcare-hq/pull/33198 where @esoergel lints `app_manager/models.py`, but things escalate a bit when his fourth commit touches `suite_xml/sections/entries.py`. This PR carries on with that file.

The first commit cherrypicks from Ethan's last, for `suite_xml/sections/entries.py` only, in the hope that I can avoid a merge conflict. :crossed_fingers: 

## Feature Flag

N/A

## Safety Assurance

### Safety story

Lint only

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
