### PR TITLE
Do not publish form/case changes on delete domain

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -188,7 +188,7 @@ def delete_all_cases(domain_name):
     logger.info('Deleting cases...')
     case_ids = iter_ids(CommCareCase, 'case_id', domain_name)
     for chunk in chunked(case_ids, 1000, list):
-        CommCareCase.objects.hard_delete_cases(domain_name, chunk)
+        CommCareCase.objects.hard_delete_cases(domain_name, chunk, publish_changes=False)
     logger.info('Deleting cases complete.')
 
 
@@ -196,7 +196,7 @@ def delete_all_forms(domain_name):
     logger.info('Deleting forms...')
     form_ids = iter_ids(XFormInstance, 'form_id', domain_name)
     for chunk in chunked(form_ids, 1000, list):
-        XFormInstance.objects.hard_delete_forms(domain_name, chunk)
+        XFormInstance.objects.hard_delete_forms(domain_name, chunk, publish_changes=False)
     logger.info('Deleting forms complete.')
 
 

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -13,6 +13,7 @@ from dimagi.utils.chunked import chunked
 from corehq.apps.accounting.models import Subscription
 from corehq.apps.accounting.utils import get_change_status
 from corehq.apps.domain.utils import silence_during_tests
+from corehq.apps.es import CaseES, CaseSearchES, FormES
 from corehq.apps.userreports.dbaccessors import (
     delete_all_ucr_tables_for_domain,
 )
@@ -189,6 +190,8 @@ def delete_all_cases(domain_name):
     case_ids = iter_ids(CommCareCase, 'case_id', domain_name)
     for chunk in chunked(case_ids, 1000, list):
         CommCareCase.objects.hard_delete_cases(domain_name, chunk, publish_changes=False)
+    _delete_es_docs(CaseES, domain_name)
+    _delete_es_docs(CaseSearchES, domain_name)
     logger.info('Deleting cases complete.')
 
 
@@ -197,6 +200,7 @@ def delete_all_forms(domain_name):
     form_ids = iter_ids(XFormInstance, 'form_id', domain_name)
     for chunk in chunked(form_ids, 1000, list):
         XFormInstance.objects.hard_delete_forms(domain_name, chunk, publish_changes=False)
+    _delete_es_docs(FormES, domain_name)
     logger.info('Deleting forms complete.')
 
 
@@ -217,6 +221,20 @@ def iter_ids(model_class, field, domain, chunk_size=1000):
             oneline="concise",
             stream=stream,
         )
+
+
+def _delete_es_docs(es_query, domain_name):
+    query = es_query().domain(domain_name)
+    with silence_during_tests() as stream:
+        doc_ids = with_progress_bar(
+            query.scroll_ids(),
+            query.count(),
+            prefix=es_query.__name__,
+            oneline="concise",
+            stream=stream,
+        )
+        for chunk in chunked(doc_ids, 1000, list):
+            query.adapter.bulk_delete(chunk)
 
 
 def _delete_data_files(domain_name):

--- a/corehq/apps/domain/tests/test_utils.py
+++ b/corehq/apps/domain/tests/test_utils.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from random import randint
 from unittest.mock import patch
 
+from django.conf import settings
 from django.test import SimpleTestCase, TestCase
 
 from corehq.apps.app_manager.models import Application
@@ -214,3 +215,39 @@ class IsDomainInUseTests(SimpleTestCase):
         self.get_by_name_patcher = patch('corehq.apps.domain.utils.Domain.get_by_name')
         self.mock_get_by_name = self.get_by_name_patcher.start()
         self.addCleanup(self.get_by_name_patcher.stop)
+
+
+delete_es_docs_patch = patch('corehq.apps.domain.deletion._delete_es_docs')
+
+
+def patch_domain_deletion():
+    """Do not delete docs in Elasticsearch when deleting a domain
+
+    Without this, every test that deletes a domain would need to be
+    decorated with `@es_test`.
+    """
+    assert settings.UNIT_TESTING
+    delete_es_docs_patch.start()
+
+
+@contextmanager
+def suspend(patch_obj):
+    """Contextmanager/decorator to suspend an active patch
+
+    Usage as decorator:
+
+        @suspend(delete_es_docs_patch)
+        def test_something():
+            ...  # do thing with ES docs deletion
+
+    Usage as context manager:
+
+        with suspend(delete_es_docs_patch):
+            ...  # do thing with ES docs deletion
+    """
+    assert settings.UNIT_TESTING
+    patch_obj.stop()
+    try:
+        yield
+    finally:
+        patch_obj.start()

--- a/corehq/apps/domain/tests/test_utils.py
+++ b/corehq/apps/domain/tests/test_utils.py
@@ -226,8 +226,9 @@ def patch_domain_deletion():
     Without this, every test that deletes a domain would need to be
     decorated with `@es_test`.
     """
+    # Use __enter__ and __exit__ to start/stop so patch.stopall() does not stop it.
     assert settings.UNIT_TESTING
-    delete_es_docs_patch.start()
+    delete_es_docs_patch.__enter__()
 
 
 @contextmanager
@@ -246,8 +247,8 @@ def suspend(patch_obj):
             ...  # do thing with ES docs deletion
     """
     assert settings.UNIT_TESTING
-    patch_obj.stop()
+    patch_obj.__exit__(None, None, None)
     try:
         yield
     finally:
-        patch_obj.start()
+        patch_obj.__enter__()

--- a/corehq/apps/users/tests/test_migration_add_data_dict_permission.py
+++ b/corehq/apps/users/tests/test_migration_add_data_dict_permission.py
@@ -38,7 +38,8 @@ class TestMigrationQuery(TestCase):
         self.role = UserRole(domain=self.domain, name="role1")
         self.role.save()
         self.addCleanup(self.role.delete)
-        self.addCleanup(patch.stopall)
+        self.addCleanup(patcher1.stop)
+        self.addCleanup(patcher2.stop)
 
     def test_role_has_edit_data_permission(self):
         self.role.rolepermission_set.set([

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -277,9 +277,11 @@ class CommCareCaseManager(RequireDBManager):
             publish_case_saved(case)
         return undeleted_count
 
-    def hard_delete_cases(self, domain, case_ids):
+    def hard_delete_cases(self, domain, case_ids, *, publish_changes=True):
         """Permanently delete cases in domain
 
+        :param publish_changes: Flag for change feed publication.
+            Documents in Elasticsearch will not be deleted if this is false.
         :returns: Number of deleted cases.
         """
         assert isinstance(case_ids, list), type(case_ids)
@@ -287,7 +289,8 @@ class CommCareCaseManager(RequireDBManager):
             cursor.execute('SELECT hard_delete_cases(%s, %s)', [domain, case_ids])
             deleted_count = sum(row[0] for row in cursor)
 
-        self.publish_deleted_cases(domain, case_ids)
+        if publish_changes:
+            self.publish_deleted_cases(domain, case_ids)
 
         return deleted_count
 

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -370,7 +370,12 @@ class XFormInstanceManager(RequireDBManager):
 
         return count
 
-    def hard_delete_forms(self, domain, form_ids, delete_attachments=True):
+    def hard_delete_forms(self, domain, form_ids, delete_attachments=True, *, publish_changes=True):
+        """Delete forms permanently
+
+        :param publish_changes: Flag for change feed publication.
+            Documents in Elasticsearch will not be deleted if this is false.
+        """
         assert isinstance(form_ids, list)
 
         deleted_count = 0
@@ -394,7 +399,8 @@ class XFormInstanceManager(RequireDBManager):
             metas = get_blob_db().metadb.get_for_parents(deleted_forms)
             get_blob_db().bulk_delete(metas=metas)
 
-        self.publish_deleted_forms(domain, form_ids)
+        if publish_changes:
+            self.publish_deleted_forms(domain, form_ids)
 
         return deleted_count
 

--- a/corehq/tests/noseplugins/patches.py
+++ b/corehq/tests/noseplugins/patches.py
@@ -1,5 +1,6 @@
 from nose.plugins import Plugin
 
+from corehq.apps.domain.tests.test_utils import patch_domain_deletion
 from corehq.form_processor.tests.utils import patch_testcase_databases
 from corehq.util.es.testing import patch_es_user_signals
 from corehq.util.test_utils import patch_foreign_value_caches
@@ -19,6 +20,7 @@ class PatchesPlugin(Plugin):
         extend_freezegun_ignore_list()
         patch_es_user_signals()
         patch_foreign_value_caches()
+        patch_domain_deletion()
 
 
 def patch_assertItemsEqual():

--- a/corehq/util/es/testing.py
+++ b/corehq/util/es/testing.py
@@ -7,8 +7,9 @@ _sync_user_to_es_patch = patch('corehq.apps.users.signals._update_user_in_es')
 
 
 def patch_es_user_signals():
+    # Use __enter__ and __exit__ to start/stop so patch.stopall() does not stop it.
     assert settings.UNIT_TESTING
-    _sync_user_to_es_patch.start()
+    _sync_user_to_es_patch.__enter__()
 
 
 @contextmanager
@@ -27,8 +28,8 @@ def sync_users_to_es():
             ...  # do thing with users in ES
     """
     assert settings.UNIT_TESTING
-    _sync_user_to_es_patch.stop()
+    _sync_user_to_es_patch.__exit__(None, None, None)
     try:
         yield
     finally:
-        _sync_user_to_es_patch.start()
+        _sync_user_to_es_patch.__enter__()


### PR DESCRIPTION
Domain deletions have been causing high load, resulting in pillow backlogs and general HQ performance degradation.

This PR moves Elasticsearch deletions to a synchronous function that deletes all documents for the domain in `form`, `case`, and `case_search` indexes instead of propagating them through the change feed. Form and case deletion events are not sent via repeaters, so that is not a concern.

One advantage of this new way of deleting documents in ES is that all documents for the domain in the form and case indexes are deleted each time `delete_domain` is run. So documents in ES will not need to be handled specially (with `delete_es_docs_for_domain`) if a command needs to be killed or dies for some other reason while deleting forms or cases. Simply run `delete_domain` again until it succeeds.

## Safety Assurance

### Safety story

Only affects domain deletions.

### Automated test coverage

Yes.

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations