### PR TITLE
Revert "Disable errors so build doesn't fail"

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,7 +25,6 @@ jobs:
         uses: super-linter/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
-          DISABLE_ERRORS: true
           VALIDATE_JAVASCRIPT_ES: true
           VALIDATE_PYTHON_FLAKE8: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts dimagi/commcare-hq#33152 because it didn't resolve the issue. The resolution was to temporary disable our linter action while we wait for upstream to fix the issues.