### PR TITLE
Coerce QuerySet to list

### DIFF
--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -57,7 +57,7 @@ class ConnectionQuerySet(models.QuerySet):
 
     def delete(self):
         from .repeaters.models import Repeater
-        repeaters = Repeater.all_objects.filter(connection_settings_id__in=self.values_list("id", flat=True))
+        repeaters = Repeater.all_objects.filter(connection_settings_id__in=list(self.values_list("id", flat=True)))
         if repeaters.exists():
             raise models.ProtectedError(
                 "Cannot delete ConnectionSettings with related Repeater(s)",


### PR DESCRIPTION
Follow-up to https://github.com/dimagi/commcare-hq/pull/33055

Prevents `ProgrammingError: relation "motech_connectionsettings" does not exist` when `ConnectionSettings` and `Repeater` are not in the same database. The previous fix was incomplete is because `values_list()` returns a `QuerySet`, which Django will automatically try to convert to a subquery.

This resolves the error listed above, but may not resolve a subsequent error where for some reason `Repeater` rows still exist, even after `ModelDeletion('repeaters', 'Repeater', 'domain')` has apparently been executed. Reason for that failure is still unknown, and we no longer have any domains where we can reproduce it.

## Safety Assurance

### Safety story

Tested while performing domain deletions.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations