### PR TITLE
Test empty case type in Case API v0.6

### DIFF
--- a/corehq/apps/hqcase/tests/test_case_api_updates.py
+++ b/corehq/apps/hqcase/tests/test_case_api_updates.py
@@ -1,28 +1,6 @@
-import json
-from dataclasses import dataclass
-from typing import Literal
+from django.test import SimpleTestCase
 
-from django.test import SimpleTestCase, TestCase
-
-from ..api.updates import JsonCaseCreation
-from ..views import _handle_case_update
-
-DOMAIN = 'test-domain'
-
-
-@dataclass
-class FakeUser:
-    user_id: str
-    username: str
-
-
-@dataclass
-class FakeRequest:
-    method: Literal['GET', 'POST', 'PUT']
-    body: bytes
-    META: dict[str, str]
-    domain: str
-    couch_user: FakeUser
+from corehq.apps.hqcase.api.updates import JsonCaseCreation
 
 
 class GetCaseBlockTests(SimpleTestCase):
@@ -70,29 +48,3 @@ class GetCaseBlockTests(SimpleTestCase):
         self.assertIn('<owner_id>abc123</owner_id>', case_block)
         self.assertIn('<external_id>Ewan McGregor</external_id>', case_block)
         self.assertIn('<age>26</age>', case_block)
-
-
-class TestHandleCaseUpdate(TestCase):
-
-    def test_post_empty_type(self):
-        user = FakeUser(
-            user_id='abc123',
-            username=f'irvine@{DOMAIN}.commcarehq.org',
-        )
-        request = FakeRequest(
-            method='POST',
-            body=json.dumps({
-                'case_name': 'Mark Renton',
-                'case_type': '',  # Field is required, but value can be empty
-                'owner_id': 'abc123'
-            }).encode('utf-8'),
-            META={'HTTP_USER_AGENT': __file__},
-            domain=DOMAIN,
-            couch_user=user,
-        )
-        response = _handle_case_update(request, is_creation=True)
-
-        response_json = json.loads(response.content)
-        self.assertNotIn('error', response_json)
-        self.assertEqual(response_json['case']['case_name'], 'Mark Renton')
-        self.assertEqual(response_json['case']['case_type'], '')

--- a/corehq/apps/hqcase/tests/test_case_api_updates.py
+++ b/corehq/apps/hqcase/tests/test_case_api_updates.py
@@ -1,6 +1,28 @@
-from django.test import SimpleTestCase
+import json
+from dataclasses import dataclass
+from typing import Literal
 
-from corehq.apps.hqcase.api.updates import JsonCaseCreation
+from django.test import SimpleTestCase, TestCase
+
+from ..api.updates import JsonCaseCreation
+from ..views import _handle_case_update
+
+DOMAIN = 'test-domain'
+
+
+@dataclass
+class FakeUser:
+    user_id: str
+    username: str
+
+
+@dataclass
+class FakeRequest:
+    method: Literal['GET', 'POST', 'PUT']
+    body: bytes
+    META: dict[str, str]
+    domain: str
+    couch_user: FakeUser
 
 
 class GetCaseBlockTests(SimpleTestCase):
@@ -48,3 +70,29 @@ class GetCaseBlockTests(SimpleTestCase):
         self.assertIn('<owner_id>abc123</owner_id>', case_block)
         self.assertIn('<external_id>Ewan McGregor</external_id>', case_block)
         self.assertIn('<age>26</age>', case_block)
+
+
+class TestHandleCaseUpdate(TestCase):
+
+    def test_post_empty_type(self):
+        user = FakeUser(
+            user_id='abc123',
+            username=f'irvine@{DOMAIN}.commcarehq.org',
+        )
+        request = FakeRequest(
+            method='POST',
+            body=json.dumps({
+                'case_name': 'Mark Renton',
+                'case_type': '',  # Field is required, but value can be empty
+                'owner_id': 'abc123'
+            }).encode('utf-8'),
+            META={'HTTP_USER_AGENT': __file__},
+            domain=DOMAIN,
+            couch_user=user,
+        )
+        response = _handle_case_update(request, is_creation=True)
+
+        response_json = json.loads(response.content)
+        self.assertNotIn('error', response_json)
+        self.assertEqual(response_json['case']['case_name'], 'Mark Renton')
+        self.assertEqual(response_json['case']['case_type'], '')

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -140,6 +140,16 @@ class TestCaseAPI(TestCase):
         self.assertEqual(res.status_code, 400)
         self.assertEqual(res.json()['error'], "'bad_property' is not a valid field.")
 
+    def test_empty_case_type(self):
+        res = self._create_case({
+            'case_type': '',
+            'case_name': 'Elizabeth Harmon',
+            'owner_id': 'methuen_home',
+        }).json()
+        case = CommCareCase.objects.get_case(res['case']['case_id'], self.domain)
+        self.assertEqual(case.name, 'Elizabeth Harmon')
+        self.assertEqual(case.type, '')
+
     def test_no_required_updates(self):
         case = self._make_case()
 


### PR DESCRIPTION
## Technical Summary

To help me think through changes for deprecating case types, I added a test to verify whether the Case API v0.6 requires "case_type" to have a value. (Currently it does not.)

Context: https://github.com/dimagi/commcare-hq/pull/33089
More context: [SC-2733](https://dimagi-dev.atlassian.net/browse/SC-2733)

## Feature Flag

Related to `case_api_v0_6`

## Safety Assurance

### Safety story

This is a unit test

### Automated test coverage

This is a unit test

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2733]: https://dimagi-dev.atlassian.net/browse/SC-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ