### PR TITLE
Remove obsolete TestCase.icds_dbs

### DIFF
--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -139,9 +139,8 @@ def patch_testcase_databases():
     """Lift Django 2.2 restriction on database access in tests
 
     Allows `TestCase` and `TransactionTestCase` to access all databases
-    by default. ICDS-specific databases are only accessible in icds
-    tests. This can be overridden by setting `databases` on test case
-    subclasses.
+    by default. This can be overridden by setting `databases` on test
+    case subclasses.
 
     Similar to pre-Django 2.2, transactions are disabled on all
     databases except "default". This can be overridden by setting
@@ -159,25 +158,16 @@ def patch_testcase_databases():
     #
     # Similar error reported elsewhere:
     # https://code.djangoproject.com/ticket/30541
-    default_dbs = frozenset(k for k in settings.DATABASES.keys() if "icds" not in k)
-    icds_dbs = frozenset(settings.DATABASES.keys())
+    default_dbs = frozenset(settings.DATABASES)
 
-    def is_icds(cls):
-        # TODO remove when custom.icds packages have been moved to new repo
-        return cls.__module__.startswith("icds")
-
-    @classproperty
-    def databases(cls):
-        return icds_dbs if is_icds(cls) else default_dbs
-    TestCase.databases = databases
-    TransactionTestCase.databases = databases
+    TestCase.databases = default_dbs
+    TransactionTestCase.databases = default_dbs
 
     @classproperty
     def transaction_exempt_databases(cls):
-        databases = icds_dbs if is_icds(cls) else default_dbs
-        if cls.databases is databases:
-            return frozenset(db for db in databases if db != "default")
-        return frozenset(db for db in databases if db not in cls.databases)
+        if cls.databases is default_dbs:
+            return frozenset(db for db in default_dbs if db != "default")
+        return frozenset(db for db in default_dbs if db not in cls.databases)
     TransactionTestCase.transaction_exempt_databases = transaction_exempt_databases
 
     @classmethod


### PR DESCRIPTION
Remove obsolete code for ICDS tests.

## Safety Assurance

### Safety story

Only affects tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations