### PR TITLE
Added backwards compatibility support for TLS 1.1 messaging gateways

### DIFF
--- a/corehq/messaging/smsbackends/http/models.py
+++ b/corehq/messaging/smsbackends/http/models.py
@@ -4,8 +4,8 @@ import sys
 from django.conf import settings
 
 import six
-from six.moves.urllib.parse import urlencode
-from six.moves.urllib.request import urlopen
+from urllib.parse import urlencode
+from urllib.request import urlopen
 
 from corehq.apps.sms.mixin import BackendProcessingException
 from corehq.apps.sms.models import SQLSMSBackend
@@ -73,24 +73,38 @@ class SQLHttpBackend(SQLSMSBackend):
         verify_sms_url(config.url, msg, backend=self)
 
         url_params = urlencode(params)
+        ssl_context = self.create_ssl_context()
         try:
-            unverified = ssl._create_unverified_context()
             if config.method == "GET":
                 urlopen(
                     "%s?%s" % (config.url, url_params),
-                    context=unverified,
+                    context=ssl_context,
                     timeout=settings.SMS_GATEWAY_TIMEOUT,
                 ).read()
             else:
                 urlopen(
                     config.url,
                     url_params,
-                    context=unverified,
+                    context=ssl_context,
                     timeout=settings.SMS_GATEWAY_TIMEOUT,
                 ).read()
         except Exception as e:
             msg = "Error sending message from backend: '{}'\n\n{}".format(self.pk, str(e))
             six.reraise(BackendProcessingException, BackendProcessingException(msg), sys.exc_info()[2])
+
+    def create_ssl_context(self):
+        # Protocol and ciphers are explicitly set for backwards compatibility reasons with older versions
+        # of OpenSSL. Clients still using older SSL versions will break without these changes.
+        # See: https://github.com/curl/curl/issues/10002#issuecomment-1331413797
+        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_1)
+        context.set_ciphers('DEFAULT@SECLEVEL=0')
+        # Check hostname and verify_mode are set here to allow self-signed/unsigned HTTPS requests,
+        # which some of our clients currently use. This is obviously not secure, so if we can get our
+        # clients to use signed certificates instead (or somehow incorporate their signing root),
+        # we should modify this. See: https://stackoverflow.com/a/35876782
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        return context
 
     @staticmethod
     def _encode_http_message(text):


### PR DESCRIPTION
## Technical Summary
Associated ticket: https://dimagi-dev.atlassian.net/browse/SAAS-14715. Upgrading our servers to Ubuntu 22.04 also updated OpenSSL from 1.1.1 to 3.0, which caused some breaking changes. This attempts to provide backwards compatibility for messaging servers still using TLS 1.1.

## Safety Assurance

### Safety story
I've verified that this fixes the bug locally as well as within a shell on staging. However, I am concerned that this approach is not particularly secure, and also that it could break servers that are using verified certificates. I still need to verify that this isn't the case.

### Automated test coverage

No automated tests -- this is a low level OS issue that seems like it would require hitting a TLS 1.1 server.

### QA Plan

No QA required -- I'll verify that this doesn't break existing servers.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
