### PR TITLE
GA "Use latest build in Web Apps"

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -78,7 +78,7 @@ from corehq.apps.hqwebapp.templatetags.hq_shared_tags import can_use_restore_as
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.formdetails import readable
 from corehq.apps.users.decorators import require_can_login_as
-from corehq.apps.users.models import CouchUser
+from corehq.apps.users.models import CouchUser, is_option_enabled
 from corehq.apps.users.util import format_username
 from corehq.apps.users.views import BaseUserSettingsView
 from corehq.apps.integration.util import integration_contexts
@@ -216,14 +216,14 @@ class FormplayerMain(View):
 
 
 def _fetch_build(domain, username, app_id):
-    if (toggles.CLOUDCARE_LATEST_BUILD.enabled(domain) or toggles.CLOUDCARE_LATEST_BUILD.enabled(username)):
+    if is_option_enabled('use_latest_build_cloudcare', username, domain):
         return get_latest_build_doc(domain, app_id)
     else:
         return get_latest_released_app_doc(domain, app_id)
 
 
 def _fetch_build_id(domain, username, app_id):
-    if (toggles.CLOUDCARE_LATEST_BUILD.enabled(domain) or toggles.CLOUDCARE_LATEST_BUILD.enabled(username)):
+    if is_option_enabled('use_latest_build_cloudcare', username, domain):
         return get_latest_build_id(domain, app_id)
     else:
         return get_latest_released_build_id(domain, app_id)

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -450,6 +450,7 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('domain', 'AppReleaseModeSetting', 'domain'),
     ModelDeletion('events', 'Event', 'domain'),
     ModelDeletion('events', 'AttendanceTrackingConfig', 'domain'),
+    ModelDeletion('domain', 'DomainOptionToggles', 'domain'),
 ]
 
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -71,6 +71,7 @@ from corehq.apps.accounting.utils import (
     is_downgrade,
     log_accounting_error,
 )
+from corehq.apps.accounting.utils.subscription import is_domain_enterprise
 from corehq.apps.app_manager.const import (
     AMPLIFIES_NO,
     AMPLIFIES_NOT_SET,
@@ -436,6 +437,18 @@ class DomainGlobalSettingsForm(forms.Form):
         )
     )
 
+    use_latest_build_cloudcare = BooleanField(
+        label=gettext_lazy("Use latest build for Web Apps"),
+        required=False,
+        help_text=gettext_lazy(
+            """
+            By default Web Apps will have the latest published build of an app.
+            Check this box to give all users the latest build of an app in Web
+            Apps regardless of whether it is published.
+            """
+        )
+    )
+
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop('domain', None)
         self.domain = self.project.name
@@ -445,6 +458,7 @@ class DomainGlobalSettingsForm(forms.Form):
         self.helper[5] = twbscrispy.PrependedText('delete_logo', '')
         self.helper[6] = twbscrispy.PrependedText('call_center_enabled', '')
         self.helper[14] = twbscrispy.PrependedText('release_mode_visibility', '')
+        self.helper[15] = twbscrispy.PrependedText('use_latest_build_cloudcare', '')
         self.helper.all().wrap_together(crispy.Fieldset, _('Edit Basic Information'))
         self.helper.layout.append(
             hqcrispy.FormActions(
@@ -460,6 +474,9 @@ class DomainGlobalSettingsForm(forms.Form):
         if not self.can_use_custom_logo:
             del self.fields['logo']
             del self.fields['delete_logo']
+
+        if not is_domain_enterprise(self.domain):
+            del self.fields['use_latest_build_cloudcare']
 
         if self.project:
             if not self.project.call_center_config.enabled:

--- a/corehq/apps/domain/migrations/0015_domainoptiontoggles.py
+++ b/corehq/apps/domain/migrations/0015_domainoptiontoggles.py
@@ -1,0 +1,49 @@
+from django.db import migrations, models
+
+from corehq.apps.domain.models import DomainOptionToggles
+from corehq.toggles import NAMESPACE_DOMAIN, Toggle
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+def get_enabled_domains():
+    toggle = Toggle.cached_get('use_latest_build_cloudcare')
+    if not toggle:
+        return []
+    prefix = NAMESPACE_DOMAIN + ':'
+    skip = len(prefix)
+    return [d[skip:] for d in toggle.enabled_users if d.startswith(prefix)]
+
+
+@skip_on_fresh_install
+def _upsert_domain_option_toggles(apps, schema_editor):
+    for domain in get_enabled_domains():
+        DomainOptionToggles.objects.update_or_create(
+            domain=domain,
+            defaults={'use_latest_build_cloudcare': True},
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('domain', '0014_appreleasemodesetting'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DomainOptionToggles',
+            fields=[
+                ('domain', models.CharField(
+                    max_length=126,
+                    primary_key=True,
+                    serialize=False,
+                )),
+                ('use_latest_build_cloudcare', models.BooleanField(default=False)),
+            ],
+        ),
+        migrations.RunPython(
+            _upsert_domain_option_toggles,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True
+        ),
+    ]

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -1157,3 +1157,11 @@ class AppReleaseModeSetting(models.Model):
     def get_settings(domain):
         domain_obj, created = AppReleaseModeSetting.objects.get_or_create(domain=domain)
         return domain_obj
+
+
+class DomainOptionToggles(models.Model):
+    """
+    Additional option toggles for a domain
+    """
+    domain = models.CharField(max_length=126, primary_key=True)
+    use_latest_build_cloudcare = models.BooleanField(default=False)

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -216,6 +216,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('domain.AppReleaseModeSetting', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('events.Event', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('events.AttendanceTrackingConfig', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('domain.DomainOptionToggles', SimpleFilter('domain')),
 ]]
 
 

--- a/corehq/apps/users/migrations/0054_useroptiontoggles.py
+++ b/corehq/apps/users/migrations/0054_useroptiontoggles.py
@@ -1,0 +1,57 @@
+from django.conf import settings
+from django.db import migrations, models
+
+from corehq.apps.users.models import CouchUser, UserOptionToggles
+from corehq.toggles import ALL_NAMESPACES, NAMESPACE_USER, Toggle
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+def get_enabled_users():
+    toggle = Toggle.cached_get('use_latest_build_cloudcare')
+    if not toggle:
+        return []
+    prefixes = tuple(ns + ':' for ns in ALL_NAMESPACES if ns != NAMESPACE_USER)
+    return [u for u in toggle.enabled_users if not u.startswith(prefixes)]
+
+
+@skip_on_fresh_install
+def _upsert_user_option_toggles(apps, schema_editor):
+    for username in get_enabled_users():
+        django_user = CouchUser(username=username).get_django_user()
+        UserOptionToggles.objects.update_or_create(
+            user=django_user,
+            defaults={'use_latest_build_cloudcare': True},
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('users', '0053_userreportingmetadatastaging_fcm_token'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserOptionToggles',
+            fields=[
+                ('id', models.AutoField(
+                    auto_created=True,
+                    primary_key=True,
+                    serialize=False,
+                    verbose_name='ID',
+                )),
+                ('use_latest_build_cloudcare', models.BooleanField(default=False)),
+                ('user', models.OneToOneField(
+                    on_delete=models.deletion.CASCADE,
+                    related_name='option_toggles',
+                    to=settings.AUTH_USER_MODEL,
+                )),
+            ],
+        ),
+        migrations.RunPython(
+            _upsert_user_option_toggles,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True
+        ),
+    ]

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2991,6 +2991,18 @@ class UserReportingMetadataStaging(models.Model):
         unique_together = ('domain', 'user_id', 'app_id')
 
 
+class UserOptionToggles(models.Model):
+    """
+    Additional option toggles for a user
+    """
+    user = models.OneToOneField(
+        User,
+        related_name='option_toggles',
+        on_delete=models.CASCADE,
+    )
+    use_latest_build_cloudcare = models.BooleanField(default=False)
+
+
 class ApiKeyManager(models.Manager):
     def get_queryset(self):
         return super().get_queryset()\

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1505,13 +1505,6 @@ OVERRIDE_EXPANDED_COLUMN_LIMIT_IN_REPORT_BUILDER = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-CLOUDCARE_LATEST_BUILD = StaticToggle(
-    'use_latest_build_cloudcare',
-    'Uses latest build for Web Apps instead of latest published',
-    TAG_SOLUTIONS_OPEN,
-    [NAMESPACE_DOMAIN, NAMESPACE_USER]
-)
-
 CAUTIOUS_MULTIMEDIA = StaticToggle(
     'cautious_multimedia',
     'More cautious handling of multimedia: do not delete multimedia files, add logging, etc.',

--- a/migrations.lock
+++ b/migrations.lock
@@ -362,6 +362,7 @@ domain
  0012_operatorcalllimitsettings
  0013_accountconfirmationsettings_squashed_0016_alter_smsaccountconfirmationsettings_project_name (4 squashed migrations)
  0014_appreleasemodesetting
+ 0015_domainoptiontoggles
 domain_migration_flags
  0001_initial
  0002_migrate_data_from_tzmigration
@@ -1135,6 +1136,7 @@ users
  0051_add_attendance_tracking_privilege
  0052_hqapikey_last_used
  0053_userreportingmetadatastaging_fcm_token
+ 0054_useroptiontoggles
 util
  0001_initial
  0002_complaintbouncemeta_permanentbouncemeta_transientbounceemail


### PR DESCRIPTION
## Product Description

This change makes the "Use latest build in Web Apps" feature flag generally available for Enterprise Plan customers and Dimagi users.

#### Why?

This feature flag is part of an initiative to clean up the feature flags in HQ, and to make more functionality accessible to more users.

#### What's new?

There is a new checkbox on the "Basic Information" page under "Project Settings":
![image](https://github.com/dimagi/commcare-hq/assets/708421/d2c2bc62-4963-4797-bb9c-764903eb94e5)

There is also a new checkbox on the Edit Mobile Worker page, under the "Basic" tab. (More about this checkbox in the "Technical Summary" below.)
![image](https://github.com/dimagi/commcare-hq/assets/708421/b94383db-3dbb-4eaf-a3c9-88910bc400c0)

This new checkbox is visible for _Dimagi users only_, on the "My Information" page, under "Other Options":
![image](https://github.com/dimagi/commcare-hq/assets/708421/e647cb7a-1328-4969-9e69-1c16e0ea7179)


## Technical Summary

I am opening this as a _draft_ pull request at first, because there are a few things I'd like more certainty about.

If you feel that Slack would be a better channel to provide feedback than commenting on this PR, please don't hesitate to reach out to me, or check my calendar to join me in a call on Tuesdays between 09:00 - 11:00 UTC if the timeslot suits you and voice is better for this than text.

* I have created two new models to enable/disable additional options for users and domains. When I created these, I thought that models like this would have made sense a long time ago, and wondered why they didn't already exist. Then I thought there must be a good reason for that. Do you know that reason? What alternative approach should I be using?

* The Edit Mobile Worker page pulls in from a complicated hierarchy of Form classes. That specific form in the screenshot above does not use django-crispy-forms for its layout, which is why the label is janky, and appears to the right of the checkbox. I don't like it. But I also don't like breaking a bunch of other Form classes, and then fixing all of them, and then pulling in QA to double-check that I definitely fixed them all, in order to move one janky label into the left column. But I will, cos that feels like the right thing to do. Am I wrong?

* There is some documentation to write to accompany this change.

#### More information:

* Ticket for code change: [SC-2868](https://dimagi-dev.atlassian.net/browse/SC-2868)
* Ticket for docs: [SC-2869](https://dimagi-dev.atlassian.net/browse/SC-2869)

At the time of opening this PR there are only five commits :tropical_fish: :blowfish: :fish: :shark: :dolphin: but if PR feedback makes things more complicated, it might be easier to review all together. :office: 

## Feature Flag

"Use latest build in Web Apps"

## Safety Assurance

### Safety story

* Functionality has been tested locally
* Migrations have been tested locally for both toggle-enabled domains and users.

### Automated test coverage

Unit tests cover the new function and new models. Changes to forms are not covered.

### QA Plan

If I need to break and then fix the forms for editing mobile workers, I will probably request QA.

### Migrations
- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2868]: https://dimagi-dev.atlassian.net/browse/SC-2868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ