### PR TITLE
Make split-screen case search take up the full display width

### DIFF
--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_one_one.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_one_one.xml
@@ -6,7 +6,7 @@
   </title>
 
   <field>
-    <style horz-align="left" vert-align="center" font-size="medium">
+    <style horz-align="left" vert-align="center" font-size="small">
       <grid grid-height="1" grid-width="12" grid-x="0" grid-y="0"/>
     </style>
     <header>
@@ -52,7 +52,7 @@
   </field>
 
   <field>
-    <style horz-align="left" vert-align="center" font-size="medium">
+    <style horz-align="left" vert-align="center" font-size="small">
       <grid grid-height="1" grid-width="7" grid-x="0" grid-y="1"/>
     </style>
     <header>
@@ -70,7 +70,7 @@
   </field>
 
   <field>
-    <style horz-align="left" vert-align="center" font-size="medium">
+    <style horz-align="left" vert-align="center" font-size="small">
       <grid grid-height="1" grid-width="4" grid-x="8" grid-y="1"/>
     </style>
     <header>
@@ -89,7 +89,7 @@
 
 
   <field>
-    <style horz-align="left" vert-align="center" font-size="medium">
+    <style horz-align="left" vert-align="center" font-size="small">
       <grid grid-height="1" grid-width="12" grid-x="0" grid-y="2"/>
     </style>
     <header>
@@ -107,7 +107,7 @@
   </field>
 
   <field>
-    <style horz-align="center" vert-align="center" font-size="medium">
+    <style horz-align="center" vert-align="center" font-size="small">
       <grid grid-height="1" grid-width="12" grid-x="0" grid-y="3"/>
     </style>
     <header>

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -722,7 +722,7 @@ hqDefine("cloudcare/js/formplayer/app", function () {
             appId,
             currentUser = FormplayerFrontend.getChannel().request('currentUser');
         urlObject.clearExceptApp();
-        urlObject.clearSidebar();
+        FormplayerFrontend.regions.getRegion('sidebar').empty();
         FormplayerFrontend.regions.getRegion('breadcrumb').empty();
         if (currentUser.displayOptions.singleAppMode) {
             appId = FormplayerFrontend.getChannel().request('getCurrentAppId');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -46,6 +46,14 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         });
 
         FormplayerFrontend.regions = new RegionContainer();
+        let sidebar = FormplayerFrontend.regions.getRegion('sidebar');
+        sidebar.on('show', function () {
+            $('#menu-container .flex-container').addClass('full-width');
+        });
+        sidebar.on('hide empty', function (region) {
+            $('#menu-container .flex-container').removeClass('full-width');
+        });
+
         hqRequire(["cloudcare/js/formplayer/router"], function (Router) {
             FormplayerFrontend.router = Router.start();
         });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -128,11 +128,25 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var queryResponse = menuResponse.queryResponse;
         if (sidebarEnabled && menuResponse.type === "entities" && queryResponse != null)  {
             var queryCollection = new Collection(queryResponse.displays);
-            FormplayerFrontend.regions.getRegion('sidebar').show(QueryListView({collection: queryCollection, title: menuResponse.title, description: menuResponse.description,  sidebarEnabled: true}).render());
+            FormplayerFrontend.regions.getRegion('sidebar').show(
+                QueryListView({
+                    collection: queryCollection,
+                    title: menuResponse.title,
+                    description: menuResponse.description,
+                    sidebarEnabled: true,
+                }).render()
+            );
         } else if (sidebarEnabled && menuResponse.type === "query") {
-            FormplayerFrontend.regions.getRegion('sidebar').show(QueryListView({collection: menuResponse, title: menuResponse.title, description: menuResponse.description, sidebarEnabled: true}).render());
+            FormplayerFrontend.regions.getRegion('sidebar').show(
+                QueryListView({
+                    collection: menuResponse,
+                    title: menuResponse.title,
+                    description: menuResponse.description,
+                    sidebarEnabled: true,
+                }).render()
+            );
         } else {
-                FormplayerFrontend.regions.getRegion('sidebar').empty();
+            FormplayerFrontend.regions.getRegion('sidebar').empty();
         }
 
         if (menuResponse.breadcrumbs) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -125,6 +125,13 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         } else {
             FormplayerFrontend.regions.getRegion('persistentCaseTile').empty();
         }
+
+        if (sidebarEnabled && _.contains(['query', 'entities'], menuResponse.type)) {
+            $('#menu-container .flex-container').addClass('full-width');
+        } else {
+            $('#menu-container .flex-container').removeClass('full-width');
+        }
+
         var queryResponse = menuResponse.queryResponse;
         if (sidebarEnabled && menuResponse.type === "entities" && queryResponse != null)  {
             var queryCollection = new Collection(queryResponse.displays);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -126,12 +126,6 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             FormplayerFrontend.regions.getRegion('persistentCaseTile').empty();
         }
 
-        if (sidebarEnabled && _.contains(['query', 'entities'], menuResponse.type)) {
-            $('#menu-container .flex-container').addClass('full-width');
-        } else {
-            $('#menu-container .flex-container').removeClass('full-width');
-        }
-
         var queryResponse = menuResponse.queryResponse;
         if (sidebarEnabled && menuResponse.type === "entities" && queryResponse != null)  {
             var queryCollection = new Collection(queryResponse.displays);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -109,9 +109,9 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var appPreview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
         var changeFormLanguage = toggles.toggleEnabled('CHANGE_FORM_LANGUAGE');
         var enablePrintOption = !menuResponse.queryKey;
-        var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH');
+        var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview;
 
-        if (sidebarEnabled && !appPreview && menuResponse.type === "query") {
+        if (sidebarEnabled && menuResponse.type === "query") {
             var menuData = menusUtils.getMenuData(menuResponse);
             menuData["triggerEmptyCaseList"] = true;
             menuData["sidebarEnabled"] = true;
@@ -126,10 +126,10 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             FormplayerFrontend.regions.getRegion('persistentCaseTile').empty();
         }
         var queryResponse = menuResponse.queryResponse;
-        if (sidebarEnabled && !appPreview && menuResponse.type === "entities" && queryResponse != null)  {
+        if (sidebarEnabled && menuResponse.type === "entities" && queryResponse != null)  {
             var queryCollection = new Collection(queryResponse.displays);
             FormplayerFrontend.regions.getRegion('sidebar').show(QueryListView({collection: queryCollection, title: menuResponse.title, description: menuResponse.description,  sidebarEnabled: true}).render());
-        } else if (sidebarEnabled && !appPreview && menuResponse.type === "query") {
+        } else if (sidebarEnabled && menuResponse.type === "query") {
             FormplayerFrontend.regions.getRegion('sidebar').show(QueryListView({collection: menuResponse, title: menuResponse.title, description: menuResponse.description, sidebarEnabled: true}).render());
         } else {
                 FormplayerFrontend.regions.getRegion('sidebar').empty();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -157,7 +157,7 @@ hqDefine("cloudcare/js/formplayer/router", function () {
             });
         } else {
             urlObject.addSelection(index);
-            urlObject.clearSidebar();
+            FormplayerFrontend.regions.getRegion('sidebar').empty();
         }
         utils.setUrlToObject(urlObject);
         API.listMenus();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -12,7 +12,6 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
 
         const currentUrl = new Utils.CloudcareUrl({ appId: 'abc123' }),
             sandbox = sinon.sandbox.create(),
-            clearSidebar = sandbox.spy(currentUrl, 'clearSidebar'),
             stubs = {},
             REGIONS = {
                 main: 'main',
@@ -56,7 +55,6 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
 
         afterEach(function () {
             getRegion.reset();
-            clearSidebar.reset();
             sandbox.resetHistory();
         });
 
@@ -130,15 +128,15 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
 
         describe('FormplayerFrontend actions', function () {
             it('should clear sidebar on menu:select', function () {
+                assert.isFalse(getRegion('sidbar').empty.called);
                 FormplayerFrontend.trigger('menu:select', 0);
-
-                assert.isTrue(clearSidebar.calledOnce);
+                assert.isTrue(getRegion('sidbar').empty.called);
             });
 
             it('should clear sidebar on navigateHome', function () {
+                assert.isFalse(getRegion('sidbar').empty.called);
                 FormplayerFrontend.trigger('navigateHome');
-
-                assert.isTrue(clearSidebar.calledOnce);
+                assert.isTrue(getRegion('sidbar').empty.called);
             });
         });
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -331,10 +331,6 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             this.sessionId = null;
         };
 
-        this.clearSidebar = function () {
-            $('#sidebar-region').html("");
-            $('#menu-container .flex-container').removeClass('full-width');
-        };
     };
 
     Utils.CloudcareUrl.prototype.toJson = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -333,6 +333,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
 
         this.clearSidebar = function () {
             $('#sidebar-region').html("");
+            $('#menu-container .flex-container').removeClass('full-width');
         };
     };
 

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -3,6 +3,10 @@
   align-items: stretch;
 }
 
+.full-width {
+  width: 100%;
+}
+
 .flex-child {
   flex: 1;
   min-width: 200px;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -16,6 +16,7 @@
 }
 
 .flex-child-sidebar {
+  max-width: 400px;
   table {
     table-layout: fixed;
   }


### PR DESCRIPTION
## Product Description

![image](https://github.com/dimagi/commcare-hq/assets/2367539/285b5ca9-632b-40e2-92ba-a370469e7619)

This does a few things, the biggest of which is that the split-screen case search view now takes up the full display width.  It also caps the maximum size of the sidebar in that view to 400px (an arbitrary number that seemed fine).

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3374
Items 2, 3, and 4 from this spec: https://docs.google.com/document/d/1PNrzAmrZeNNbWR7-EcSDcvKhxQOJ1TPrc6ur1fOKv1M/edit

Best reviewed by commit

## Feature Flag
Split Screen Case Search

## Safety Assurance

### Safety story

Testing on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
