### PR TITLE
Add ability to copy checkpoints before swapping indexes

### DIFF
--- a/corehq/apps/es/exceptions.py
+++ b/corehq/apps/es/exceptions.py
@@ -23,3 +23,7 @@ class IndexNotMultiplexedException(Exception):
 
 class IndexMultiplexedException(Exception):
     pass
+
+
+class IndexAlreadySwappedException(Exception):
+    pass

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -190,6 +190,38 @@ class ESSyncUtil:
         older_index = getattr(es_consts, f"HQ_{cname.upper()}_INDEX_NAME")
         return (current_index, older_index)
 
+    def set_checkpoints_for_new_index(self, cname):
+        """
+        Takes in an index cname and create new checkpoint for all the pillows that use the older index name
+        for that cname.
+        Can only be performed when indexes are still multiplexed and not swapped.
+        When we swap the indexes, the primary index changes which updates the checkpoint names.
+        We should stop the pillows and copy the checkpoint to the new checkpoint ids, swap the indexes
+        and then start the pillows.
+        """
+        adapter = doc_adapter_from_cname(cname)
+        if not isinstance(adapter, ElasticMultiplexAdapter):
+            raise IndexNotMultiplexedException(f"""Checkpoints can be copied on multiplexed indexes.
+                Make sure you have set ES_{cname.upper()}_INDEX_MULTIPLEXED to True """)
+
+        current_index_name, older_index_name = self._get_current_and_older_index_name(cname)
+
+        assert adapter.index_name != older_index_name, f"""Current index does not match the source index.
+        Make sure that ES_{cname.upper()}_INDEX_SWAPPED is set to False"""
+
+        all_pillows = get_all_pillow_instances()
+        for pillow in all_pillows:
+            old_checkpoint_id = pillow.checkpoint.checkpoint_id
+            if older_index_name in old_checkpoint_id:
+                new_checkpoint_id = old_checkpoint_id.replace(older_index_name, current_index_name)
+                print(f"Copying checkpoints of Checkpoint ID -  [{old_checkpoint_id}] to [{new_checkpoint_id}]")
+                self._copy_checkpoints(pillow, new_checkpoint_id)
+
+    def _copy_checkpoints(self, pillow, new_checkpoint_id):
+        last_known_checkpoint = pillow.checkpoint.get_current_sequence_as_dict()
+        new_checkpoint = KafkaPillowCheckpoint(new_checkpoint_id, topics=pillow.topics)
+        new_checkpoint.update_to(last_known_checkpoint)
+
     def estimate_disk_space_for_reindex(self, stdout=None):
         indices_info = es_manager.indices_info()
         index_cname_map = self._get_index_name_cname_map()

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -153,8 +153,7 @@ class ESSyncUtil:
 
         """
         adapter = doc_adapter_from_cname(cname)
-        older_index = getattr(es_consts, f"HQ_{cname.upper()}_INDEX_NAME")
-        current_index = getattr(es_consts, f"HQ_{cname.upper()}_SECONDARY_INDEX_NAME")
+        current_index, older_index = self._get_current_and_older_index_name(cname)
         if isinstance(adapter, ElasticMultiplexAdapter):
             raise IndexMultiplexedException(f"""A multiplexed index cannot be deleted.
             Make sure you have set ES_{cname.upper()}_INDEX_MULTIPLEXED to False """)

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -181,6 +181,16 @@ class ESSyncUtil:
 
         es_manager.index_delete(older_index)
 
+    def _get_current_and_older_index_name(cls, cname):
+        """
+        Returns a tuple of current index name and older index name related to the given cname.
+        Older index refers to the source index during reindex process
+        Current index refers to the destination index
+        """
+        current_index = getattr(es_consts, f"HQ_{cname.upper()}_SECONDARY_INDEX_NAME")
+        older_index = getattr(es_consts, f"HQ_{cname.upper()}_INDEX_NAME")
+        return (current_index, older_index)
+
     def estimate_disk_space_for_reindex(self, stdout=None):
         indices_info = es_manager.indices_info()
         index_cname_map = self._get_index_name_cname_map()

--- a/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
+++ b/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
@@ -1,17 +1,16 @@
-from unittest.mock import patch
 import uuid
+from unittest.mock import patch
 
 from django.core.management import CommandError, call_command
 from django.test import SimpleTestCase, TestCase, override_settings
-from corehq.pillows.case import get_case_pillow
 
+import corehq.apps.es.const as es_consts
 from corehq.apps.es import app_adapter, case_adapter, case_search_adapter
 from corehq.apps.es.client import (
     ElasticMultiplexAdapter,
     create_document_adapter,
     manager,
 )
-import corehq.apps.es.const as es_consts
 from corehq.apps.es.const import HQ_APPS_INDEX_CANONICAL_NAME
 from corehq.apps.es.exceptions import (
     IndexAlreadySwappedException,
@@ -22,6 +21,7 @@ from corehq.apps.es.management.commands.elastic_sync_multiplexed import (
     ESSyncUtil,
 )
 from corehq.apps.es.tests.utils import TestDoc, TestDocumentAdapter, es_test
+from corehq.pillows.case import get_case_pillow
 from corehq.util.test_utils import create_and_save_a_case
 from testapps.test_pillowtop.utils import process_pillow_changes
 

--- a/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
+++ b/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
@@ -241,6 +241,7 @@ class TestCopyCheckpointsBeforeIndexSwap(TestCase):
             with self.assertRaises(IndexAlreadySwappedException):
                 ESSyncUtil().set_checkpoints_for_new_index('cases')
 
+    @override_settings(ES_CASES_INDEX_MULTIPLEXED=True)
     def test_set_checkpoints_for_new_index(self):
 
         secondary_case_index = 'cases_secondary'
@@ -275,6 +276,9 @@ class TestCopyCheckpointsBeforeIndexSwap(TestCase):
             with patch(
                 'corehq.apps.es.management.commands.elastic_sync_multiplexed.get_all_pillow_instances',
                 return_value=[case_pillow]
+            ), patch(
+                'corehq.apps.es.management.commands.elastic_sync_multiplexed.doc_adapter_from_cname',
+                return_value=patched_case_adapter
             ):
                 ESSyncUtil().set_checkpoints_for_new_index('cases')
 

--- a/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
+++ b/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
@@ -46,6 +46,28 @@ def mock_iter_index_cnames():
     return list(adapter_cname_map)
 
 
+def _get_patched_adapter(adapter, multiplex_index, swap_index, secondary=None):
+    """
+    Since adapter are initialized while Django boots up, so overriding settings won't
+    return the required adapter config for test. This function would create the adapter with required
+    overridden settings.
+    """
+    cname = adapter.canonical_name
+    multiplex_setting_key = f"ES_{cname.upper()}_INDEX_MULTIPLEXED"
+    swap_setting_key = f"ES_{cname.upper()}_INDEX_SWAPPED"
+    adapter_cls = adapter.__class__
+    if isinstance(adapter, ElasticMultiplexAdapter):
+        adapter_cls = adapter.primary.__class__
+    # strip of test_ from index names because create_document_adapter will append it again for tests
+    index_name = adapter.index_name[5:] if adapter.index_name.startswith('test_') else adapter.index_name
+    with override_settings(**{multiplex_setting_key: multiplex_index, swap_setting_key: swap_index}):
+        patched_adapter = create_document_adapter(
+            adapter_cls, index_name,
+            adapter.type, secondary=secondary
+        )
+    return patched_adapter
+
+
 @es_test(requires=[mutiplexed_adapter_with_overriden_settings()])
 @patch(
     "corehq.apps.es.management.commands.elastic_sync_multiplexed.doc_adapter_from_cname",
@@ -121,13 +143,13 @@ class TestESSyncUtil(SimpleTestCase):
 
     @patch('corehq.apps.es.management.commands.elastic_sync_multiplexed.doc_adapter_from_cname')
     def test_delete_index_fails_on_multiplexed_index(self, adapter_patch):
-        adapter_patch.return_value = self._get_patched_adapter(app_adapter, True, False, secondary='app_secondary')
+        adapter_patch.return_value = _get_patched_adapter(app_adapter, True, False, secondary='app_secondary')
         with self.assertRaises(IndexMultiplexedException):
             ESSyncUtil().delete_index(HQ_APPS_INDEX_CANONICAL_NAME)
 
     @patch('corehq.apps.es.management.commands.elastic_sync_multiplexed.doc_adapter_from_cname')
     def test_delete_index_raises_if_index_not_swapped(self, adapter_patch):
-        adapter_patch.return_value = self._get_patched_adapter(
+        adapter_patch.return_value = _get_patched_adapter(
             app_adapter, False, False, secondary='app_secondary'
         )
         with self.assertRaises(AssertionError):
@@ -146,7 +168,7 @@ class TestESSyncUtil(SimpleTestCase):
     def test_delete_index_fails_for_incorrect_user_input(self, adapter_patch, input_patch):
         secondary_index_name = 'test_apps_secondary'
         # This will return adapter with ``secondary_index_name`` because swapped is set to True
-        patched_adapter = self._get_patched_adapter(app_adapter, False, True, secondary=secondary_index_name[5:])
+        patched_adapter = _get_patched_adapter(app_adapter, False, True, secondary=secondary_index_name[5:])
         adapter_patch.return_value = patched_adapter
         input_patch.return_value = 'N'
         self._setup_indexes([app_adapter.index_name, secondary_index_name])
@@ -168,34 +190,13 @@ class TestESSyncUtil(SimpleTestCase):
     def test_delete_index_deletes_the_older_index(self, adapter_patch, input_patch):
         secondary_index_name = 'test_apps_secondary'
         # This will return adapter with ``secondary_index_name`` because swapped is set to True
-        patched_adapter = self._get_patched_adapter(app_adapter, False, True, secondary=secondary_index_name[5:])
+        patched_adapter = _get_patched_adapter(app_adapter, False, True, secondary=secondary_index_name[5:])
         adapter_patch.return_value = patched_adapter
         self._setup_indexes([app_adapter.index_name, secondary_index_name])
         self.addCleanup(self._delete_indexes, [secondary_index_name])
 
         ESSyncUtil().delete_index(HQ_APPS_INDEX_CANONICAL_NAME)
         self.assertFalse(manager.index_exists(app_adapter.index_name))
-
-    def _get_patched_adapter(self, adapter, multiplex_index, swap_index, secondary=None):
-        """
-        Since adapter are initialized while Django boots up, so overriding settings won't
-        return the required adapter config for test. This function would create the adapter with required
-        overridden settings.
-        """
-        cname = adapter.canonical_name
-        multiplex_setting_key = f"ES_{cname.upper()}_INDEX_MULTIPLEXED"
-        swap_setting_key = f"ES_{cname.upper()}_INDEX_SWAPPED"
-        adapter_cls = app_adapter.__class__
-        if isinstance(app_adapter, ElasticMultiplexAdapter):
-            adapter_cls = app_adapter.primary.__class__
-        # strip of test_ from index names because create_document_adapter will append it again for tests
-        index_name = adapter.index_name[5:] if adapter.index_name.startswith('test_') else adapter.index_name
-        with override_settings(**{multiplex_setting_key: multiplex_index, swap_setting_key: swap_index}):
-            patched_adapter = create_document_adapter(
-                adapter_cls, index_name,
-                adapter.type, secondary=secondary
-            )
-        return patched_adapter
 
     def _setup_indexes(self, indexes):
         for index in indexes:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
While swapping the indexes, the pillow checkpoint id is also updated to use the new index names. Hence the pillow referencing those checkpoint ids are pushed back to the earliest known sequence ids to Kafka.
The change would ensure that we copy the checkpoints to the new ids well in advance before swapping the indexes.

Review by 🐟 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14734
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
Adequate tests are added for the changes and the changes will be tested on staging before merging.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Changes completely covered by tests.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
