### PR TITLE
Update 'Shared Exports' permission to 'Manage Shared Exports'

### DIFF
--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -363,7 +363,7 @@ hqDefine('users/js/roles',[
                         showOption: root.ExportOwnershipEnabled,
                         editPermission: self.permissions.edit_shared_exports,
                         viewPermission: null,
-                        text: gettext("<strong>Shared Exports</strong> &mdash; access and edit the content and structure of shared exports"),
+                        text: gettext("<strong>Manage Shared Exports</strong> &mdash; access and edit the content and structure of shared exports"),
                         showEditCheckbox: true,
                         editCheckboxLabel: "edit-shared-exports-checkbox",
                         showViewCheckbox: false,

--- a/corehq/apps/users/templates/users/roles_and_permissions.html
+++ b/corehq/apps/users/templates/users/roles_and_permissions.html
@@ -98,7 +98,7 @@
           </th>
           {% if request|request_has_privilege:"EXPORT_OWNERSHIP" %}
             <th class="text-center">
-              {% trans "Shared Exports" %}
+              {% trans "Manage Shared Exports" %}
             </th>
           {% endif %}
           <th class="text-center">


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2810)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Instead of seeing the `Shared Exports` permission, the user will now see a `Manage Shared Exports` permission, since this makes it a bit clearer what the permission is for.

![image](https://github.com/dimagi/commcare-hq/assets/64970009/b55580df-e80e-4591-a456-f83e28f71acf)
![image](https://github.com/dimagi/commcare-hq/assets/64970009/6b24cc58-408c-4b13-832f-e44b27ce7e23)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Updated the permission naming

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
N/A

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Verified it updated the text locally.

### QA Plan
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
