### PR TITLE
Fix typo in docstring

### DIFF
--- a/corehq/apps/hqadmin/management/commands/fix_checkpoint_after_rewind.py
+++ b/corehq/apps/hqadmin/management/commands/fix_checkpoint_after_rewind.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
     You must first stop the targeted pillow before running this command, and be
     sure to start the pillow again once complete. An example usage is:
     ``cchq --control <env> service pillowtop stop --only=<pillow_name>``
-    ``cchq --control <env> django-manage manage.py fix_checkpoint_after_rewind <pillow_name>``
+    ``cchq --control <env> django-manage fix_checkpoint_after_rewind <pillow_name>``
     ``cchq --control <env> service pillowtop start --only=<pillow_name>``
     """
     help = ("Update the sequence ID of a pillow that has been rewound due to a cloudant issue")


### PR DESCRIPTION
## Technical Summary
I came across this a few weeks ago when I wanted to run this command. The error in the doc string was easy to figure out, but I wanted to leave it smoother for the next person.
## Safety Assurance

### Safety story
It's doc-string only and replacing a command that failed for obvious reasons with one that works.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
