### PR TITLE
Riese/zoom control

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1031,7 +1031,13 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                 let lon = self.rawAnswer().length ? self.rawAnswer()[1] : self.DEFAULT.lon;
                 let zoom = self.rawAnswer().length ? self.DEFAULT.anszoom : self.DEFAULT.zoom;
 
-                self.map = L.map(self.entryId).setView([lat, lon], zoom);
+                self.map = L.map(self.entryId, {
+                    zoomControl: false,
+                }).setView([lat, lon], zoom);
+                L.control.zoom({
+                    position: 'bottomright'
+                }).addTo(self.map);
+
                 L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token='
                             + token, {
                     id: 'mapbox/streets-v11',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -563,7 +563,15 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 const lat = 30;
                 const lon = 15;
                 const zoom = 3;
-                const addressMap = L.map('module-case-list-map').setView([lat, lon], zoom);
+                const addressMap = L.map(
+                    'module-case-list-map', {
+                        zoomControl: false,
+                    }).setView([lat, lon], zoom);
+
+                L.control.zoom({
+                    position: 'bottomright'
+                }).addTo(addressMap);
+
                 L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=' + token, {
                     id: 'mapbox/streets-v11',
                     attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> ©' +

--- a/corehq/apps/reports/static/reports/js/maps_utils.js
+++ b/corehq/apps/reports/static/reports/js/maps_utils.js
@@ -1629,14 +1629,17 @@ hqDefine("reports/js/maps_utils", function () {
             trackResize: false,
             zoomControl: false,
         }).setView(default_pos, default_zoom);
-        L.control.zoom({
-            position: 'bottomright'
-        }).addTo(map);
         initLayers(map, layers);
 
         new ZoomToFitControl().addTo(map);
         new ToggleTableControl().addTo(map);
         L.control.scale().addTo(map);
+
+        // Moving all the zoom controls to the bottom right for consistency.
+        // Could not test this instance because of other issues.
+        L.control.zoom({
+            position: 'bottomright'
+        }).addTo(map);
 
         return map;
     }

--- a/corehq/apps/reports/static/reports/js/maps_utils.js
+++ b/corehq/apps/reports/static/reports/js/maps_utils.js
@@ -1625,7 +1625,13 @@ hqDefine("reports/js/maps_utils", function () {
 
     // initialize leaflet map
     function initMap($div, layers, default_pos, default_zoom) {
-        var map = L.map($div.attr('id'), {trackResize: false}).setView(default_pos, default_zoom);
+        var map = L.map($div.attr('id'), {
+            trackResize: false,
+            zoomControl: false,
+        }).setView(default_pos, default_zoom);
+        L.control.zoom({
+            position: 'bottomright'
+        }).addTo(map);
         initLayers(map, layers);
 
         new ZoomToFitControl().addTo(map);

--- a/corehq/apps/reports_core/static/reports_core/js/maps.js
+++ b/corehq/apps/reports_core/static/reports_core/js/maps.js
@@ -27,6 +27,7 @@ hqDefine('reports_core/js/maps', function () {
                 layers: [streets],
                 // remove attribution control to duplicate "Leaflet" attribute
                 attributionControl: false,
+                zoomControl: false,
             }).setView([0, 0], 3);
 
             var baseMaps = {};
@@ -43,6 +44,10 @@ hqDefine('reports_core/js/maps', function () {
             // scale is now placed on the bottom right because it is easier to layout with the attributes than with the wordmark
             L.control.attribution({position: 'bottomright'}).addAttribution('&copy; <a href="http://www.mapbox.com/about/maps/">MapBox</a> | &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>').addTo(privates.map);
             L.control.scale({position: 'bottomright'}).addTo(privates.map);
+
+            L.control.zoom({
+                position: 'bottomright'
+            }).addTo(privates.map);
             $('#zoomtofit').css('display', 'block');
         } else {
             if (privates.map.activeOverlay) {


### PR DESCRIPTION
## Product Description

Move the zoom control to the bottom right so there is less chance of a conflict with popups

In reports
<img width="1008" alt="image" src="https://github.com/dimagi/commcare-hq/assets/1946138/31a34f43-ca8d-4f57-8fa9-c3a8e28c46d3">

Form entry
<img width="1008" alt="image" src="https://github.com/dimagi/commcare-hq/assets/1946138/cb5a485e-6d47-4e8c-9363-c0506803f457">

Case list
<img width="1008" alt="image" src="https://github.com/dimagi/commcare-hq/assets/1946138/385e9fed-b095-4f30-b2ad-6e1878681f1c">


## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3386

## Feature Flag

"USH: Allow use of a map in the case list in Web Apps" for the case list map

## Safety Assurance

Tested on Staging

### Safety story

### Automated test coverage

None

### QA Plan

* Check map in reports looks ok
* Check map in case list looks ok
* Check map in form entry looks ok

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
