### PR TITLE
Further specify expectations around blob meta

### DIFF
--- a/corehq/apps/hqadmin/views/data.py
+++ b/corehq/apps/hqadmin/views/data.py
@@ -12,7 +12,7 @@ from corehq.apps.hqwebapp.doc_lookup import (
     get_db_from_db_name,
     lookup_id_in_databases,
 )
-from corehq.blobs import get_blob_db
+from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.models import BlobMeta
 from corehq.form_processor.models import XFormInstance
 from corehq.util.download import get_download_response
@@ -119,7 +119,12 @@ def download_blob(request):
     """Pairs with the get_download_url utility and command"""
     key = request.GET.get("key")
     try:
-        meta = BlobMeta.objects.partitioned_get(partition_value=key, key=key)
+        meta = BlobMeta.objects.partitioned_get(
+            domain='__system__',
+            type_code=CODES.tempfile,
+            partition_value=key,
+            key=key,
+        )
     except BlobMeta.DoesNotExist:
         raise Http404()
     blob = get_blob_db().get(meta=meta)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary

https://docs.google.com/document/d/1L6CLWa69-OiWpW_NF2vKKXH2xKiISis8bfMyyvpiKtU/edit#

Add a couple extra filters to the `download_blob` view added in https://github.com/dimagi/commcare-hq/pull/33162 in accordance with how it's expected to be used.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
This only touches a superuser-only workflow that's not widely used yet anyways

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
