### PR TITLE
Duplicate data dictionary case properties

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -154,7 +154,9 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.fhirResourceType = ko.observable();
         self.removefhirResourceType = ko.observable(false);
         self.newPropertyName = ko.observable();
+        self.newPropertyNameUnique = ko.observable(true);
         self.newGroupName = ko.observable();
+        self.newGroupNameUnique = ko.observable(true);
         self.caseGroupList = ko.observableArray();
         self.showAll = ko.observable(false);
         self.availableDataTypes = typeChoices;

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -274,6 +274,40 @@ hqDefine("data_dictionary/js/data_dictionary", [
             self.saveButton.setState('saved');
         };
 
+        self.newPropertyName.subscribe(function(newValue) {
+            if (!newValue) {
+                self.newPropertyNameUnique(true);
+                return;
+            }
+
+            const newValueFormatted = newValue.toLowerCase().trim();
+            const activeCaseTypeData = self.activeCaseTypeData();
+            for (const group of activeCaseTypeData) {
+                if (group.properties().some(v => v.name.toLowerCase() === newValueFormatted)) {
+                    self.newPropertyNameUnique(false);
+                    return;
+                }
+            }
+            self.newPropertyNameUnique(true);
+        });
+
+        self.newGroupName.subscribe(function(newValue) {
+            if (!newValue) {
+                self.newGroupNameUnique(true);
+                return;
+            }
+
+            const newValueFormatted = newValue.toLowerCase().trim();
+            const activeCaseTypeData = self.activeCaseTypeData();
+            for (const group of activeCaseTypeData) {
+                if (group.name().toLowerCase() === newValueFormatted) {
+                    self.newGroupNameUnique(false);
+                    return;
+                }
+            }
+            self.newGroupNameUnique(true);
+        });
+
         self.newCaseProperty = function () {
             if (_.isString(self.newPropertyName()) && self.newPropertyName().trim()) {
                 let lastGroup = self.caseGroupList()[self.caseGroupList().length - 1];

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -154,9 +154,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.fhirResourceType = ko.observable();
         self.removefhirResourceType = ko.observable(false);
         self.newPropertyName = ko.observable();
-        self.newPropertyNameUnique = ko.observable(true);
         self.newGroupName = ko.observable();
-        self.newGroupNameUnique = ko.observable(true);
         self.caseGroupList = ko.observableArray();
         self.showAll = ko.observable(false);
         self.availableDataTypes = typeChoices;

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -274,38 +274,34 @@ hqDefine("data_dictionary/js/data_dictionary", [
             self.saveButton.setState('saved');
         };
 
-        self.newPropertyName.subscribe(function(newValue) {
-            if (!newValue) {
-                self.newPropertyNameUnique(true);
-                return;
+        self.newPropertyNameUnique = ko.computed(function() {
+            if (!self.newPropertyName()) {
+                return true;
             }
 
-            const newValueFormatted = newValue.toLowerCase().trim();
+            const propertyNameFormatted = self.newPropertyName().toLowerCase().trim();
             const activeCaseTypeData = self.activeCaseTypeData();
             for (const group of activeCaseTypeData) {
-                if (group.properties().some(v => v.name.toLowerCase() === newValueFormatted)) {
-                    self.newPropertyNameUnique(false);
-                    return;
+                if (group.properties().some(v => v.name.toLowerCase() === propertyNameFormatted)) {
+                    return false;
                 }
             }
-            self.newPropertyNameUnique(true);
+            return true;
         });
 
-        self.newGroupName.subscribe(function(newValue) {
-            if (!newValue) {
-                self.newGroupNameUnique(true);
-                return;
+        self.newGroupNameUnique = ko.computed(function() {
+            if (!self.newGroupName()) {
+                return true;
             }
 
-            const newValueFormatted = newValue.toLowerCase().trim();
+            const groupNameFormatted = self.newGroupName().toLowerCase().trim();
             const activeCaseTypeData = self.activeCaseTypeData();
             for (const group of activeCaseTypeData) {
-                if (group.name().toLowerCase() === newValueFormatted) {
-                    self.newGroupNameUnique(false);
-                    return;
+                if (group.name().toLowerCase() === groupNameFormatted) {
+                    return false;
                 }
             }
-            self.newGroupNameUnique(true);
+            return true;
         });
 
         self.newCaseProperty = function () {

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -289,18 +289,28 @@
         {% if not request.is_view_only %}
           <form class="form-inline">
             <input class="form-control" placeholder="Case Property" data-bind="value: newPropertyName">
-            <button class="btn btn-default" data-bind="click: $root.newCaseProperty">
+            <button class="btn btn-default" data-bind="click: $root.newCaseProperty, enable: newPropertyNameUnique()">
               <i class="fa fa-plus"></i>
               {% trans "Add Case Property" %}
             </button>
+            <div class="help-block">
+              <span class="text-danger" data-bind="visible: !newPropertyNameUnique()">
+                {% trans "A case property with this name already exists." %}
+              </span>
+            </div>
           </form>
           <br />
           <form class="form-inline">
             <input class="form-control" placeholder="Group Name" data-bind="value: newGroupName">
-            <button class="btn btn-default" data-bind="click: $root.newGroup">
+            <button class="btn btn-default" data-bind="click: $root.newGroup, enable: newGroupNameUnique()">
               <i class="fa fa-plus"></i>
               {% trans "Add Case Property Group" %}
             </button>
+            <div class="help-block">
+              <span class="text-danger" data-bind="visible: !newGroupNameUnique()">
+                {% trans "A case property group with this name already exists." %}
+              </span>
+            </div>
           </form>
         {% endif %}
       </div>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When the user inputs a case property name or case property group name that already exists for the case type, then they will be met with the following error:
![Screenshot from 2023-07-12 15-12-31](https://github.com/dimagi/commcare-hq/assets/122617251/01044e5f-d140-4306-b1e9-a0ddbea6610a)

While this error is active the relevant add button will be disabled.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2946).

This change fixes a pre-existing issue in the Data Dictionary admin page where users are able to create new case properties and case property groups with the same name as ones that already exist for that case type. It should be noted however, that when saving these duplicate case properties will not be persisted. In saying that, it is still good to not allow adding duplicate case properties on the front-end as this could be confusing to users.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`DATA_DICTIONARY`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Small UI change.
- Local testing.
- Tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
