### PR TITLE
Upgrade cryptography and pyOpenSSL

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -102,8 +102,9 @@ contextlib2==21.6.0
     #   schema
 coverage==7.1.0
     # via -r test-requirements.in
-cryptography==39.0.1
+cryptography==41.0.2
     # via
+    #   -r sso-requirements.in
     #   jwcrypto
     #   oic
     #   pyjwt
@@ -562,7 +563,7 @@ pyjwt[crypto]==2.7.0
     #   twilio
 pynacl==1.5.0
     # via pygithub
-pyopenssl==23.0.0
+pyopenssl==23.2.0
     # via
     #   -r docs-requirements.in
     #   -r sso-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -84,7 +84,7 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
-cryptography==39.0.1
+cryptography==41.0.2
     # via
     #   jwcrypto
     #   oic

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -86,9 +86,10 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
-cryptography==39.0.1
+cryptography==41.0.2
     # via
     #   -r prod-requirements.in
+    #   -r sso-requirements.in
     #   jwcrypto
     #   oic
     #   pyjwt
@@ -476,7 +477,7 @@ pyjwt[crypto]==2.7.0
     #   twilio
 pynacl==1.5.0
     # via pygithub
-pyopenssl==23.0.0
+pyopenssl==23.2.0
     # via
     #   -r prod-requirements.in
     #   -r sso-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -80,8 +80,9 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
-cryptography==39.0.1
+cryptography==41.0.2
     # via
+    #   -r sso-requirements.in
     #   jwcrypto
     #   oic
     #   pyjwt
@@ -434,7 +435,7 @@ pyjwt[crypto]==2.7.0
     #   twilio
 pynacl==1.5.0
     # via pygithub
-pyopenssl==23.0.0
+pyopenssl==23.2.0
     # via -r sso-requirements.in
 pyparsing==3.0.7
     # via httplib2

--- a/requirements/sso-requirements.in
+++ b/requirements/sso-requirements.in
@@ -1,2 +1,3 @@
-pyOpenSSL>=22.1.0  # min version for cryptography==39.0.0
+pyOpenSSL>=23.2.0  # for cryptography>=41
+cryptography>=41   # for security vulnerability
 python3-saml

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -89,8 +89,9 @@ contextlib2==21.6.0
     # via schema
 coverage==7.1.0
     # via -r test-requirements.in
-cryptography==39.0.1
+cryptography==41.0.2
     # via
+    #   -r sso-requirements.in
     #   jwcrypto
     #   oic
     #   pyjwt
@@ -471,7 +472,7 @@ pyjwt[crypto]==2.7.0
     #   twilio
 pynacl==1.5.0
     # via pygithub
-pyopenssl==23.0.0
+pyopenssl==23.2.0
     # via -r sso-requirements.in
 pyparsing==3.0.7
     # via httplib2


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-14733

Reviewed [change log](https://cryptography.io/en/latest/changelog/) for backward incompatibilities. None apply to us at this point, although one may apply to self-hosters that are still on Ubuntu 18.04:

> **BACKWARDS INCOMPATIBLE**: Support for OpenSSL less than 1.1.1d has been removed. Users on older version of OpenSSL will need to upgrade.

It is [unclear](https://launchpad.net/ubuntu/bionic/+source/openssl) if the latest version of OpenSSL available on 18.04 is newer than 1.1.1d.

Question: do we need to post a change log for third-parties who have not yet upgraded beyond 18.04?

### Safety story

Updates an intermediate dependency that is not used directly by our code.

### Automated test coverage

Unknown.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations