### PR TITLE
Removed another unused var

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -9,8 +9,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         formEntryUtils = hqImport("cloudcare/js/form_entry/utils"),
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
         formplayerUtils = hqImport("cloudcare/js/formplayer/utils/utils"),
-        initialPageData = hqImport("hqwebapp/js/initial_page_data"),
-        md = window.markdownit();
+        initialPageData = hqImport("hqwebapp/js/initial_page_data");
 
     var separator = " to ",
         serverSeparator = "__",


### PR DESCRIPTION
Same as https://github.com/dimagi/commcare-hq/pull/33232 - two PRs are better than one, right?

Checked that there aren't any *other* instances of this.

## Safety Assurance

### Safety story
tiny

### Automated test coverage

no

### QA Plan
no


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
