### PR TITLE
Revert "Escape question labels"

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -180,7 +180,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         var mapping = {
             caption: {
                 update: function (options) {
-                    return options.data ? _.escape(DOMPurify.sanitize(options.data)).replace(/\n/g, '<br/>') : null;
+                    return options.data ? DOMPurify.sanitize(options.data.replace(/\n/g, '<br/>')) : null;
                 },
             },
             caption_markdown: {
@@ -687,7 +687,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         var mapping = {
             caption: {
                 update: function (options) {
-                    return options.data ? _.escape(DOMPurify.sanitize(options.data)).replace(/\n/g, '<br/>') : null;
+                    return options.data ? DOMPurify.sanitize(options.data.replace(/\n/g, '<br/>')) : null;
                 },
             },
             caption_markdown: {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -300,7 +300,7 @@
 <script type="text/html" id="repeat-juncture-fullform-ko-template">
   <div class="panel panel-default rep">
     <div class="panel-heading">
-      <h3 class="caption" data-bind="html: caption()" tabindex="0"></h3>
+      <h3 class="caption" data-bind="html: header" tabindex="0"></h3>
       <span class="ix" data-bind="text: ixInfo($data)"></span>
     </div>
     <div class="panel-body">

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -143,7 +143,7 @@ hqDefine("reports/js/data_corrections", [
         self.breakWord = function (str) {
             // Break words on slashes (as in question paths) or underscores (as in case properties and also questions)
             // Don't break on slashes that are present because they're in an HTML end tag
-            return _.escape(str).replace(/([^<]\s*[\/_])/g, "$1\u200B");     // eslint-disable-line no-useless-escape
+            return str.replace(/([^<]\s*[\/_])/g, "$1\u200B");     // eslint-disable-line no-useless-escape
         };
         var innerTemplate = _.map(self.displayProperties, function (p) {
             return _.template("<span data-bind='html: $root.breakWord(<%= property %>), visible: $root.displayProperty() === \"<%= property %>\"'></span>")(p);


### PR DESCRIPTION
Reverts dimagi/commcare-hq#33068

Reverting this temporarily to unblock a project for a workflow they use for printing pages on webapps which uses HTML tags in labels.