### PR TITLE
First Action Time API Adjustment

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1206,7 +1206,8 @@ class NavigationEventAuditResource(HqBaseResource, Resource):
                 params_string = b64decode(original_params['cursor']).decode('utf-8')
                 cursor_params = QueryDict(params_string, mutable=True)
             else:
-                cursor_params = QueryDict(mutable=True)
+                cursor_params = original_params.copy()
+                cursor_params.pop('limit', None)
 
             last_object = data['objects'][-1]
             cursor_params['cursor_local_date'] = last_object.data['local_date']

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1090,10 +1090,9 @@ class NavigationEventAuditResourceParams:
         if raw_params:
             self.cursor = raw_params.get('cursor')
             self.limit = raw_params.get('limit')
-            self._validate_keys(raw_params)
             if self.cursor:
                 raw_params = self._process_cursor()
-                self._validate_keys(raw_params)
+            self._validate_keys(raw_params)
 
             self._set_compound_keys(raw_params)
             self.users = raw_params.getlist('users')

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1200,7 +1200,7 @@ class NavigationEventAuditResource(HqBaseResource, Resource):
         data['meta']['total_count'] = self.count
 
         if data['meta']['total_count'] > data['meta']['limit']:
-            original_params = request.GET.copy()  # Makes params mutable for creating next_url below
+            original_params = request.GET
             if 'cursor' in original_params:
                 params_string = b64decode(original_params['cursor']).decode('utf-8')
                 cursor_params = QueryDict(params_string, mutable=True)

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1083,6 +1083,7 @@ class NavigationEventAuditResourceParams:
     cursor_local_date: str = None
     cursor_user: str = None
     UTC_start_time_start: str = None
+    UTC_start_time_end: str = None
 
     def __post_init__(self, domain, default_limit, max_limit, raw_params=None):
         if raw_params:
@@ -1097,6 +1098,7 @@ class NavigationEventAuditResourceParams:
             self.users = raw_params.getlist('users')
             self.local_timezone = raw_params.get('local_timezone')
             self.UTC_start_time_start = raw_params.get('UTC_start_time_start')
+            self.UTC_start_time_end = raw_params.get('UTC_start_time_end')
 
         if self.limit:
             self._process_limit(default_limit, max_limit)
@@ -1104,7 +1106,7 @@ class NavigationEventAuditResourceParams:
 
     def _validate_keys(self, params):
         valid_keys = {'users', 'limit', 'local_timezone', 'cursor', 'format', 'local_date',
-                    'UTC_start_time_start'}
+                    'UTC_start_time_start', 'UTC_start_time_end'}
         standardized_keys = set()
 
         for key in params.keys():
@@ -1248,6 +1250,9 @@ class NavigationEventAuditResource(HqBaseResource, Resource):
         if params.UTC_start_time_start:
             UTC_start_time_start = parse_str_to_date(params.UTC_start_time_start)
             queryset = queryset.filter(UTC_start_time__gte=UTC_start_time_start)
+        if params.UTC_start_time_end:
+            UTC_start_time_end = parse_str_to_date(params.UTC_start_time_end)
+            queryset = queryset.filter(UTC_end_time__lte=UTC_start_time_end)
 
         with override_settings(USE_TZ=True):
             cls.count = queryset.count()

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1197,7 +1197,7 @@ class NavigationEventAuditResource(HqBaseResource, Resource):
             }
             encoded_cursor = b64encode(urlencode(cursor).encode('utf-8'))
             params['cursor'] = encoded_cursor
-            next_url = '{}?{}'.format(request.path, params.urlencode())
+            next_url = f'?{urlencode(params)}'
             data['meta']['next'] = next_url
         return data
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1252,7 +1252,7 @@ class NavigationEventAuditResource(HqBaseResource, Resource):
         if params.UTC_start_time_start:
             queryset = queryset.filter(UTC_start_time__gte=params.UTC_start_time_start)
         if params.UTC_start_time_end:
-            queryset = queryset.filter(UTC_end_time__lte=params.UTC_start_time_end)
+            queryset = queryset.filter(UTC_start_time__lte=params.UTC_start_time_end)
 
         with override_settings(USE_TZ=True):
             cls.count = queryset.count()

--- a/corehq/apps/api/tests/audit_resources.py
+++ b/corehq/apps/api/tests/audit_resources.py
@@ -202,10 +202,10 @@ class TestNavigationEventAuditResource(APIResourceTest):
         self.assertEqual(result_objects, expected_result_objects)
 
     def test_request_with_UTC_start_time_start_param(self):
-        start_date = datetime(2023, 5, 2, 1, tzinfo=pytz.timezone('UTC')).isoformat()
+        start_datetime = datetime(2023, 5, 2, 1, tzinfo=pytz.timezone('UTC')).isoformat()
 
         params = {
-            'UTC_start_time_start': start_date,
+            'UTC_start_time_start': start_datetime,
         }
         list_endpoint = f'{self.list_endpoint}?{urlencode(params)}'
         response = self._assert_auth_get_resource(list_endpoint)
@@ -214,16 +214,16 @@ class TestNavigationEventAuditResource(APIResourceTest):
         result_objects = json.loads(response.content)['objects']
         expected_result_objects = [
             item for item in self.domain1_audits.expected_response_objects if
-            (item['UTC_start_time'] >= start_date)
+            (item['UTC_start_time'] >= start_datetime)
         ]
 
         self.assertEqual(result_objects, expected_result_objects)
 
     def test_request_with_UTC_start_time_end_param(self):
-        end_date = datetime(2023, 5, 2, 6, tzinfo=pytz.timezone('UTC')).isoformat()
+        end_datetime = datetime(2023, 5, 2, 6, tzinfo=pytz.timezone('UTC')).isoformat()
 
         params = {
-            'UTC_start_time_end': end_date,
+            'UTC_start_time_end': end_datetime,
         }
         list_endpoint = f'{self.list_endpoint}?{urlencode(params)}'
         response = self._assert_auth_get_resource(list_endpoint)
@@ -232,7 +232,7 @@ class TestNavigationEventAuditResource(APIResourceTest):
         result_objects = json.loads(response.content)['objects']
         expected_result_objects = [
             item for item in self.domain1_audits.expected_response_objects if
-            (item['UTC_start_time'] <= end_date)
+            (item['UTC_start_time'] <= end_datetime)
         ]
 
         self.assertEqual(result_objects, expected_result_objects)
@@ -415,9 +415,9 @@ class TestNavigationEventAuditResource(APIResourceTest):
         self.assertListEqual(expected_results, results)
 
     def test_query_filter_by_UTC_start_time_start(self):
-        start_date = datetime(2023, 5, 2, 1, tzinfo=pytz.timezone('UTC'))
+        start_datetime = datetime(2023, 5, 2, 1, tzinfo=pytz.timezone('UTC'))
         params = self.base_params(domain=self.domain1_audits.domain)
-        params.UTC_start_time_start = start_date
+        params.UTC_start_time_start = start_datetime
         params.local_timezone = self.domain1_audits.timezone
         results = self.resource.cursor_query(
             self.domain1_audits.domain,
@@ -425,15 +425,15 @@ class TestNavigationEventAuditResource(APIResourceTest):
         )
         expected_results = [
             item for item in self.domain1_audits.expected_query_result if
-            (item['UTC_start_time'] >= start_date)
+            (item['UTC_start_time'] >= start_datetime)
         ]
 
         self.assertListEqual(expected_results, results)
 
     def test_query_filter_by_UTC_start_time_end(self):
-        end_date = datetime(2023, 5, 2, 6, tzinfo=pytz.timezone('UTC'))
+        end_datetime = datetime(2023, 5, 2, 6, tzinfo=pytz.timezone('UTC'))
         params = self.base_params(domain=self.domain1_audits.domain)
-        params.UTC_start_time_end = end_date
+        params.UTC_start_time_end = end_datetime
         params.local_timezone = self.domain1_audits.timezone
         results = self.resource.cursor_query(
             self.domain1_audits.domain,
@@ -441,7 +441,7 @@ class TestNavigationEventAuditResource(APIResourceTest):
         )
         expected_results = [
             item for item in self.domain1_audits.expected_query_result if
-            (item['UTC_end_time'] <= end_date)
+            (item['UTC_end_time'] <= end_datetime)
         ]
 
         self.assertListEqual(expected_results, results)

--- a/corehq/apps/api/tests/audit_resources.py
+++ b/corehq/apps/api/tests/audit_resources.py
@@ -278,6 +278,7 @@ class TestNavigationEventAuditResource(APIResourceTest):
         response_next_url = json.loads(response.content)['meta']['next']
 
         expected_page_zero_cursor = {
+            'limit': 1,
             'local_date.lte': local_date_filter,
             'cursor_local_date': date(2023, 5, 1).isoformat(),
             'cursor_user': self.username1
@@ -285,7 +286,6 @@ class TestNavigationEventAuditResource(APIResourceTest):
         encoded_expected_cursor = b64encode(urlencode(expected_page_zero_cursor).encode('utf-8'))
         expected_next_params = {
             'cursor': encoded_expected_cursor,
-            'limit': 1
         }
         expected_next_url = f'?{urlencode(expected_next_params)}'
         self.assertEqual(expected_next_url, response_next_url)
@@ -302,6 +302,7 @@ class TestNavigationEventAuditResource(APIResourceTest):
         response_next_url = json.loads(response.content)['meta']['next']
 
         expected_page_one_cursor = {
+            'limit': 1,
             'local_date.lte': local_date_filter,
             'cursor_local_date': date(2023, 5, 1).isoformat(),
             'cursor_user': self.username2
@@ -309,7 +310,6 @@ class TestNavigationEventAuditResource(APIResourceTest):
         encoded_expected_cursor = b64encode(urlencode(expected_page_one_cursor).encode('utf-8'))
         expected_next_params = {
             'cursor': encoded_expected_cursor,
-            'limit': 1
         }
         expected_next_url = f'?{urlencode(expected_next_params)}'
         self.assertEqual(expected_next_url, response_next_url)

--- a/corehq/apps/api/tests/audit_resources.py
+++ b/corehq/apps/api/tests/audit_resources.py
@@ -398,7 +398,7 @@ class TestNavigationEventAuditResource(APIResourceTest):
     def test_query_filter_by_UTC_start_time_start(self):
         start_date = datetime(2023, 5, 2, 1, tzinfo=pytz.timezone('UTC'))
         params = self.base_params(domain=self.domain1_audits.domain)
-        params.UTC_start_time_start = start_date.isoformat()
+        params.UTC_start_time_start = start_date
         params.local_timezone = self.domain1_audits.timezone
         results = self.resource.cursor_query(
             self.domain1_audits.domain,
@@ -414,7 +414,7 @@ class TestNavigationEventAuditResource(APIResourceTest):
     def test_query_filter_by_UTC_start_time_end(self):
         end_date = datetime(2023, 5, 2, 6, tzinfo=pytz.timezone('UTC'))
         params = self.base_params(domain=self.domain1_audits.domain)
-        params.UTC_start_time_end = end_date.isoformat()
+        params.UTC_start_time_end = end_date
         params.local_timezone = self.domain1_audits.timezone
         results = self.resource.cursor_query(
             self.domain1_audits.domain,

--- a/corehq/apps/api/tests/audit_resources.py
+++ b/corehq/apps/api/tests/audit_resources.py
@@ -220,7 +220,7 @@ class TestNavigationEventAuditResource(APIResourceTest):
         self.assertEqual(result_objects, expected_result_objects)
 
     def test_request_with_UTC_start_time_end_param(self):
-        end_datetime = datetime(2023, 5, 2, 6, tzinfo=pytz.timezone('UTC')).isoformat()
+        end_datetime = datetime(2023, 5, 2, 1, tzinfo=pytz.timezone('UTC')).isoformat()
 
         params = {
             'UTC_start_time_end': end_datetime,

--- a/corehq/apps/api/tests/audit_resources.py
+++ b/corehq/apps/api/tests/audit_resources.py
@@ -204,7 +204,8 @@ class TestNavigationEventAuditResource(APIResourceTest):
     def test_request_with_cursor_param(self):
         cursor = {
             'cursor_user': self.username1,
-            'cursor_local_date': date(2023, 5, 1).isoformat()
+            'cursor_local_date': date(2023, 5, 1).isoformat(),
+            'local_date.lt': date(2023, 5, 2).isoformat()
         }
         encoded_cursor = b64encode(urlencode(cursor).encode('utf-8'))
         params = {
@@ -223,20 +224,6 @@ class TestNavigationEventAuditResource(APIResourceTest):
                 'UTC_start_time': datetime(2023, 5, 2, 0, tzinfo=pytz.timezone('UTC')).isoformat(),
                 'UTC_end_time': datetime(2023, 5, 2, 6, tzinfo=pytz.timezone('UTC')).isoformat()
             },
-            {
-                'user': self.username1,
-                'user_id': self.user1._id,
-                'local_date': date(2023, 5, 2).isoformat(),
-                'UTC_start_time': datetime(2023, 5, 2, 7, tzinfo=pytz.timezone('UTC')).isoformat(),
-                'UTC_end_time': datetime(2023, 5, 2, 23, tzinfo=pytz.timezone('UTC')).isoformat()
-            },
-            {
-                'user': self.username2,
-                'user_id': self.user2._id,
-                'local_date': date(2023, 5, 2).isoformat(),
-                'UTC_start_time': datetime(2023, 5, 2, 7, tzinfo=pytz.timezone('UTC')).isoformat(),
-                'UTC_end_time': datetime(2023, 5, 2, 23, tzinfo=pytz.timezone('UTC')).isoformat()
-            }
         ]
 
         self.assertEqual(result_objects, expected_result_objects)

--- a/corehq/apps/api/tests/audit_resources.py
+++ b/corehq/apps/api/tests/audit_resources.py
@@ -244,7 +244,8 @@ class TestNavigationEventAuditResource(APIResourceTest):
     def test_response_provides_next(self):
         cursor = {
             'cursor_user': self.username1,
-            'cursor_local_date': date(2023, 5, 1).isoformat()
+            'cursor_local_date': date(2023, 5, 1).isoformat(),
+            'local_date.lte': date(2023, 5, 2).isoformat()
         }
         encoded_cursor = b64encode(urlencode(cursor).encode('utf-8'))
         params = {
@@ -258,13 +259,14 @@ class TestNavigationEventAuditResource(APIResourceTest):
         response_next_url = json.loads(response.content)['meta']['next']
 
         expected_cursor = {
-            'cursor_local_date': date(2023, 5, 1).isoformat(),
             'cursor_user': self.username2,
+            'cursor_local_date': date(2023, 5, 1).isoformat(),
+            'local_date.lte': date(2023, 5, 2).isoformat()
         }
         encoded_expected_cursor = b64encode(urlencode(expected_cursor).encode('utf-8'))
         expected_next_params = {
-            'limit': 1,
-            'cursor': encoded_expected_cursor
+            'cursor': encoded_expected_cursor,
+            'limit': 1
         }
         expected_next_url = f'?{urlencode(expected_next_params)}'
 

--- a/corehq/apps/api/tests/audit_resources.py
+++ b/corehq/apps/api/tests/audit_resources.py
@@ -266,7 +266,7 @@ class TestNavigationEventAuditResource(APIResourceTest):
             'limit': 1,
             'cursor': encoded_expected_cursor
         }
-        expected_next_url = f'{self.list_endpoint}?{urlencode(expected_next_params)}'
+        expected_next_url = f'?{urlencode(expected_next_params)}'
 
         self.assertEqual(expected_next_url, response_next_url)
 

--- a/corehq/apps/api/util.py
+++ b/corehq/apps/api/util.py
@@ -85,17 +85,22 @@ def make_date_filter(date_filter):
     def filter_fn(param, val):
         if param not in ['gt', 'gte', 'lt', 'lte']:
             raise ValueError(_("'{param}' is not a valid type of date range.").format(param=param))
-        try:
-            # If it's only a date, don't turn it into a datetime
-            val = datetime.datetime.strptime(val, '%Y-%m-%d').date()
-        except ValueError:
-            try:
-                val = parse(val)
-            except ValueError:
-                raise ValueError(_("Cannot parse datetime '{val}'").format(val=val))
+        val = parse_str_to_date(val)
         return date_filter(**{param: val})
 
     return filter_fn
+
+
+def parse_str_to_date(val):
+    try:
+        # If it's only a date, don't turn it into a datetime
+        val = datetime.datetime.strptime(val, '%Y-%m-%d').date()
+    except ValueError:
+        try:
+            val = parse(val)
+        except ValueError:
+            raise ValueError(_("Cannot parse datetime '{val}'").format(val=val))
+    return val
 
 
 def django_date_filter(field_name, gt=None, gte=None, lt=None, lte=None):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Actions Time API was first introduced in this PR: https://github.com/dimagi/commcare-hq/pull/32922
The additional filters `UTC_start_time_start` & `UTC_start_time_end` and shortening of the `meta.next` value  are a result of a request from the Data and Analytics team.
The `cursor` value also now encodes all parameters that was in the initial request except for the `limit` parameter. This is to prevent manipulating parameters in the `next` url as that can break the cursor pagination. 
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi-dev.atlassian.net/browse/USH-3345

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[ACTION_TIMES_API
](https://www.commcarehq.org/hq/flags/edit/action_times_api/)
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Locally tested. The feature is also behind a user-based feature flag and has a small set of users. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Thorough unit tests exists for the API. A test exists that checks:
- The next url in the response is as expected
- The response contains the expected items when filtered via `UTC_start_time_start` & `UTC_start_time_end`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
