### PR TITLE
Fix duplicate icon in Action column

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -567,9 +567,9 @@ class WireInvoiceInterface(InvoiceInterfaceBase):
                 contact_info.state_province_region,
                 contact_info.postal_code,
                 contact_info.country,
-                invoice.date_start,
-                invoice.date_end,
-                invoice.date_due,
+                format_datatables_data(invoice.date_start, invoice.date_start),
+                format_datatables_data(invoice.date_end, invoice.date_end),
+                format_datatables_data(invoice.date_due if invoice.date_due else "None", invoice.date_due),
                 get_exportable_column(invoice.subtotal),
                 get_exportable_column(invoice.balance),
                 "Paid" if invoice.is_paid else "Not paid",
@@ -745,9 +745,9 @@ class InvoiceInterface(InvoiceInterfaceBase):
                 contact_info.country,
                 invoice.subscription.account.salesforce_account_id or "--",
                 invoice.subscription.salesforce_contract_id or "--",
-                invoice.date_start,
-                invoice.date_end,
-                invoice.date_due,
+                format_datatables_data(invoice.date_start, invoice.date_start),
+                format_datatables_data(invoice.date_end, invoice.date_end),
+                format_datatables_data(invoice.date_due if invoice.date_due else "None", invoice.date_due),
             ]
 
             plan_subtotal, plan_deduction = get_subtotal_and_deduction(
@@ -1025,9 +1025,9 @@ class CustomerInvoiceInterface(InvoiceInterfaceBase):
                 contact_info.postal_code,
                 contact_info.country,
                 invoice.account.salesforce_account_id or "--",
-                invoice.date_start,
-                invoice.date_end,
-                invoice.date_due,
+                format_datatables_data(invoice.date_start, invoice.date_start),
+                format_datatables_data(invoice.date_end, invoice.date_end),
+                format_datatables_data(invoice.date_due if invoice.date_due else "None", invoice.date_due),
             ]
 
             plan_subtotal, plan_deduction = get_subtotal_and_deduction(

--- a/corehq/apps/reports/templates/reports/async/partials/tabular_cell.html
+++ b/corehq/apps/reports/templates/reports/async/partials/tabular_cell.html
@@ -1,4 +1,4 @@
 {% if not col.unwrap %}<td{% if not col or col.html != None and not col.html %} class="null-entry"{% endif %}>{% endif %}
-  <span title="{% if col.sort_key %}{{ col.sort_key }}{% else %}{{ col }}{% endif %}"></span>
+  <span title="{% if col.sort_key != "" %}{{ col.sort_key }}{% else %}{{ col }}{% endif %}"></span>
   {% if col.html != None %}{{ col.html }}{% else %}{{ col }}{% endif %}
 {% if not col.unwrap %}</td>{% endif %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Jira Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-14739

The issues is, there is duplicate icon in Action column in Accounting module
![image](https://github.com/dimagi/commcare-hq/assets/39149002/f806288c-ca85-44ac-8d9e-67cf13401b6f)

Fix the duplication and now those Action button only have one in each cell.
<img width="248" alt="image" src="https://github.com/dimagi/commcare-hq/assets/39149002/d78315b9-6ab8-49f7-aa61-cd1fe03392cc">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is a side effect of my changes in this [PR](https://github.com/dimagi/commcare-hq/pull/33200)

In this ticket, I changed `tabular_cell.html` template, 
from `<span title="{% if col.sort_key != "" %}{{ col.sort_key }}{% else %}{{ col }}{% endif %}"></span>`
to `<span title="{% if col.sort_key %}{{ col.sort_key }}{% else %}{{ col }}{% endif %}"></span>`

This change means when there isn't a `sort_key` in the `col`, we will just use `col`'s value as title, we then sort by title. (Here we sort by title because [I gave those date column a sort type](https://github.com/dimagi/commcare-hq/blob/54893f9b7fcefd8efbde06b63f2e479394d33c2f/corehq/apps/accounting/interface.py#L521-L524))

**But this brings another problem:**
Here is an example of `col` value: `'<a href="#adjustBalanceModal-33"\n \n data-toggle="modal"\n \n data-target="#adjustBalanceModal-33"\n \n class="btn btn-default"\n \n>Adjust Balance</a>\n’`

According to [how django template handle `!=` operator](https://docs.djangoproject.com/en/4.2/ref/templates/builtins/#id1), the `!=` operator evaluates to True if the variable is not equal the value we want to test, or if the variable doesn't exist. Previously, for data in Action column, title would be `col.sort_key`, because `col.sort_key` doesn't exsit. So we would have `<span title=""></span>`. But now, after our change to `tabular_cell.html`, we would have `<span title="<a href=" #adjustbalancemodal-33"="" data-toggle="modal" data-target="#adjustBalanceModal-33" class="btn btn-default">Adjust Balance
"&gt;</span>`, which then introduced duplicate icon.

To fix it:
We can: 
- [`format_datatables_data`](https://github.com/dimagi/commcare-hq/blob/bf19b1df7716aaa776d3af0ae0302f19a0081629/corehq/apps/reports/util.py#L252-L258) to the Action column, so it will give `col` a `sort_key`, avoid giving them the whole `col` value as `sort_key` later.
- Revert my changes in `tabular_cell.html`. And apply `format_datatables_data` to those date columns to give them a sort_key.

I go with option 2, since I'm afraid my previous change in `tabular_cell.html` will have an effect in other report's columns as well, which might require `format_datatables_data` to all the affected columns. If I only apply `format_datatables_data` to those date columns, I can limit the affect in accounting modules.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The changes is in accounting module, which will only be visible to internal staff.
I have tested both locally and on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will link the QA ticket later.
Will ask QA to test, the date sorting in accounting module still work, and there is no duplicate icon.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
