### PR TITLE
Add commcare_user_type field to restore

### DIFF
--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -128,6 +128,7 @@ class TestStartSession(TestCase):
                 'commcare_last_name': None,
                 'commcare_phone_number': None,
                 'commcare_project': self.domain,
+                'commcare_user_type': 'web',
             },
             'app_id': None
         }

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1086,7 +1086,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
         session_data = self.metadata
 
-        session_data[COMMCARE_USER_TYPE_KEY] = self._get_user_type()
         if self.is_commcare_user() and self.is_demo_user:
             session_data[COMMCARE_USER_TYPE_KEY] = COMMCARE_USER_TYPE_DEMO
 
@@ -1094,9 +1093,10 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             session_data[COMMCARE_PROJECT] = domain
 
         session_data.update({
-            '{}_first_name'.format(SYSTEM_PREFIX): self.first_name,
-            '{}_last_name'.format(SYSTEM_PREFIX): self.last_name,
-            '{}_phone_number'.format(SYSTEM_PREFIX): self.phone_number,
+            f'{SYSTEM_PREFIX}_first_name': self.first_name,
+            f'{SYSTEM_PREFIX}_last_name': self.last_name,
+            f'{SYSTEM_PREFIX}_phone_number': self.phone_number,
+            f'{SYSTEM_PREFIX}_user_type': self._get_user_type(),
         })
         return session_data
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1086,10 +1086,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
         session_data = self.metadata
 
+        session_data[COMMCARE_USER_TYPE_KEY] = self._get_user_type()
         if self.is_commcare_user() and self.is_demo_user:
-            session_data.update({
-                COMMCARE_USER_TYPE_KEY: COMMCARE_USER_TYPE_DEMO
-            })
+            session_data[COMMCARE_USER_TYPE_KEY] = COMMCARE_USER_TYPE_DEMO
 
         if COMMCARE_PROJECT not in session_data:
             session_data[COMMCARE_PROJECT] = domain

--- a/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from casexml.apps.phone.models import OTARestoreWebUser
 from casexml.apps.case.xml.generator import date_to_xml_string
 
 DUMMY_ID = "foo"
@@ -13,6 +14,7 @@ def dummy_user_xml(user=None):
     user_id = user.user_id if user else DUMMY_ID
     date_joined = user.date_joined if user else datetime.utcnow()
     project = user.domain if user else DUMMY_PROJECT
+    user_type = 'web' if isinstance(user, OTARestoreWebUser) else 'commcare'
 
     return """
     <Registration xmlns="http://openrosa.org/user/registration">
@@ -25,6 +27,7 @@ def dummy_user_xml(user=None):
             <data key="commcare_last_name"/>
             <data key="commcare_phone_number"/>
             <data key="commcare_project">{}</data>
+            <data key="commcare_user_type">{}</data>
             <data key="something">arbitrary</data>
         </user_data>
     </Registration>""".format(
@@ -32,7 +35,8 @@ def dummy_user_xml(user=None):
         password,
         user_id,
         date_to_xml_string(date_joined),
-        project
+        project,
+        user_type,
     )
 
 DUMMY_RESTORE_XML_TEMPLATE = ("""

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -24,7 +24,6 @@ from casexml.apps.phone.tests.utils import (
     deprecated_generate_restore_payload,
 )
 from casexml.apps.phone.utils import get_restore_config, MockDevice
-from corehq.apps.custom_data_fields.models import SYSTEM_PREFIX
 from corehq.apps.domain.models import Domain
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.dbaccessors import delete_all_users
@@ -66,17 +65,15 @@ class SimpleOtaRestoreTest(TestCase):
 
         def assertRegistrationData(key, val):
             if val is None:
-                template = '<data key="{prefix}_{key}"/>'
+                expected = f'<data key="{key}"/>'
             else:
-                template = '<data key="{prefix}_{key}">{val}</data>'
-            self.assertIn(
-                template.format(prefix=SYSTEM_PREFIX, key=key, val=val),
-                payload,
-            )
+                expected = f'<data key="{key}">{val}</data>'
+            self.assertIn(expected, payload)
 
-        assertRegistrationData("first_name", "mclovin")
-        assertRegistrationData("last_name", None)
-        assertRegistrationData("phone_number", "555555")
+        assertRegistrationData("commcare_first_name", "mclovin")
+        assertRegistrationData("commcare_last_name", None)
+        assertRegistrationData("commcare_phone_number", "555555")
+        assertRegistrationData("commcare_user_type", "commcare")
 
 
 class BaseOtaRestoreTest(TestCase, TestFileMixin):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_restore_user.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_restore_user.py
@@ -36,7 +36,6 @@ def test_user_types():
     for user, expected_type in [
             (WebUser(), 'web'),
             (CommCareUser(domain=DOMAIN), 'commcare'),
-            (CommCareUser(domain=DOMAIN, is_demo_user=True), 'demo'),
     ]:
-        user_type = user.to_ota_restore_user(DOMAIN).user_session_data['user_type']
+        user_type = user.to_ota_restore_user(DOMAIN).user_session_data['commcare_user_type']
         yield assert_equal, user_type, expected_type

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_restore_user.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_restore_user.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
-from corehq.apps.domain.models import Domain
 
-from corehq.apps.users.models import CommCareUser, DomainMembership
+from nose.tools import assert_equal
+
+from corehq.apps.domain.models import Domain
 from corehq.apps.users.dbaccessors import delete_all_users
+from corehq.apps.users.models import CommCareUser, DomainMembership, WebUser
 
 DOMAIN = 'fixture-test'
 
@@ -28,3 +30,13 @@ class OtaRestoreUserTest(TestCase):
 
     def test_get_commtrack_location_id(self):
         self.assertEqual(self.restore_user.get_commtrack_location_id(), '1')
+
+
+def test_user_types():
+    for user, expected_type in [
+            (WebUser(), 'web'),
+            (CommCareUser(domain=DOMAIN), 'commcare'),
+            (CommCareUser(domain=DOMAIN, is_demo_user=True), 'demo'),
+    ]:
+        user_type = user.to_ota_restore_user(DOMAIN).user_session_data['user_type']
+        yield assert_equal, user_type, expected_type


### PR DESCRIPTION
## Product Description
Add `commcare_user_type` to registration element user_data in the restore.  The value will be either `web` or `commcare`

## Technical Summary
Just what it says on the tin.  No ticket for this one - delivery was looking for a sure way to distinguish between the two types of users in an app, and this seemed super straightforward.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

This adds information to the restore, which we do from time to time.  It's namespaced, and shouldn't affect anything preexisting.

### Automated test coverage

:+1: 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
