### PR TITLE
add test for num of columns

### DIFF
--- a/corehq/apps/app_manager/tests/test_suite_case_tiles.py
+++ b/corehq/apps/app_manager/tests/test_suite_case_tiles.py
@@ -114,15 +114,18 @@ def add_columns_for_one_one_two_case_details(_module):
 class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
     file_path = ('data', 'suite')
 
-    # Keeps the number of columns in parity with what mobile can handle
+    # Keeps the number of columns in parity with what mobile allows
     def test_case_tile_column_count(self):
         for choice in CaseTileTemplates.choices:
             template_name = choice[0]
-            fields = case_tile_template_config(template_name).fields
-            if len(fields) > 12:
-                message = "Number of fields in Case Tile Template '{}' " \
-                    "exceeds the limit of 12".format(template_name)
-                raise AssertionError(message)
+            template_grid = case_tile_template_config(template_name).grid
+
+            for field in template_grid.values():
+                absWidth = field.get('x') + field.get('width')
+                if absWidth > 12:
+                    message = "Number of columns in template '{}' " \
+                        "exceeds the limit of 12".format(template_name)
+                    raise AssertionError(message)
 
     def ensure_module_session_datum_xml(self, factory, detail_inline_attr, detail_persistent_attr):
         suite = factory.app.create_suite()

--- a/corehq/apps/app_manager/tests/test_suite_case_tiles.py
+++ b/corehq/apps/app_manager/tests/test_suite_case_tiles.py
@@ -121,8 +121,8 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
             template_grid = case_tile_template_config(template_name).grid
 
             for field in template_grid.values():
-                absWidth = field.get('x') + field.get('width')
-                if absWidth > 12:
+                absolute_width = field.get('x') + field.get('width')
+                if absolute_width > 12:
                     message = "Number of columns in template '{}' " \
                         "exceeds the limit of 12".format(template_name)
                     raise AssertionError(message)

--- a/corehq/apps/app_manager/tests/test_suite_case_tiles.py
+++ b/corehq/apps/app_manager/tests/test_suite_case_tiles.py
@@ -10,7 +10,7 @@ from corehq.apps.app_manager.models import (
     Module,
     SortElement,
 )
-from corehq.apps.app_manager.suite_xml.features.case_tiles import CaseTileTemplates
+from corehq.apps.app_manager.suite_xml.features.case_tiles import CaseTileTemplates, case_tile_template_config
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -113,6 +113,16 @@ def add_columns_for_one_one_two_case_details(_module):
 @patch_get_xform_resource_overrides()
 class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
     file_path = ('data', 'suite')
+
+    # Keeps the number of columns in parity with what mobile can handle
+    def test_case_tile_column_count(self):
+        for choice in CaseTileTemplates.choices:
+            template_name = choice[0]
+            fields = case_tile_template_config(template_name).fields
+            if len(fields) > 12:
+                message = "Number of fields in Case Tile Template '{}' " \
+                    "exceeds the limit of 12".format(template_name)
+                raise AssertionError(message)
 
     def ensure_module_session_datum_xml(self, factory, detail_inline_attr, detail_persistent_attr):
         suite = factory.app.create_suite()


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This add a tests to keep the number of columns in case tile templates in parity with what mobile can handle, currently 12.
jira ticket: https://dimagi-dev.atlassian.net/browse/USH-3332

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
relates to Case Tiles feature flags: https://confluence.dimagi.com/display/saas/Allow+Configuration+of+Case+List+Tiles
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
this is a test

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
