### PR TITLE
Test buildjet (mostly for relative speed)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,29 +9,16 @@ on:
     - cron: '47 12 * * *'
 jobs:
   tests:
+    runs-on: buildjet-2vcpu-ubuntu-2204
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        TEST:
-          - python
-          - python-sharded-and-javascript
-        NOSE_DIVIDED_WE_RUN:
-          - 05
-          - 6a
-          - bf
-          - ''
-        runs-on:
-          - buildjet-2vcpu-ubuntu-2204
-          - buildjet-4vcpu-ubuntu-2204
-          - buildjet-8vcpu-ubuntu-2204
-          - buildjet-16vcpu-ubuntu-2204
-        exclude:
-          - {TEST: python-sharded-and-javascript, NOSE_DIVIDED_WE_RUN: '05'}
-          - {TEST: python-sharded-and-javascript, NOSE_DIVIDED_WE_RUN: '6a'}
-          - {TEST: python-sharded-and-javascript, NOSE_DIVIDED_WE_RUN: 'bf'}
-          - {TEST: python, NOSE_DIVIDED_WE_RUN: ''}
-    runs-on: ${{matrix.runs-on}}
+        include:
+        - {TEST: python, NOSE_DIVIDED_WE_RUN: '05'}
+        - {TEST: python, NOSE_DIVIDED_WE_RUN: '6a'}
+        - {TEST: python, NOSE_DIVIDED_WE_RUN: 'bf'}
+        - {TEST: python-sharded-and-javascript}
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
     - cron: '47 12 * * *'
 jobs:
   tests:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ${{matrix.runs-on}}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -19,6 +19,12 @@ jobs:
         - {TEST: python, NOSE_DIVIDED_WE_RUN: '6a'}
         - {TEST: python, NOSE_DIVIDED_WE_RUN: 'bf'}
         - {TEST: python-sharded-and-javascript}
+        runs-on:
+          - buildjet-2vcpu-ubuntu-2204
+          - buildjet-4vcpu-ubuntu-2204
+          - buildjet-8vcpu-ubuntu-2204
+          - buildjet-16vcpu-ubuntu-2204
+
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
     - cron: '47 12 * * *'
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,16 +13,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - {TEST: python, NOSE_DIVIDED_WE_RUN: '05'}
-          - {TEST: python, NOSE_DIVIDED_WE_RUN: '6a'}
-          - {TEST: python, NOSE_DIVIDED_WE_RUN: 'bf'}
-          - {TEST: python-sharded-and-javascript}
+        TEST:
+          - python
+          - python-sharded-and-javascript
+        NOSE_DIVIDED_WE_RUN:
+          - 05
+          - 6a
+          - bf
+          - ''
         runs-on:
           - buildjet-2vcpu-ubuntu-2204
           - buildjet-4vcpu-ubuntu-2204
           - buildjet-8vcpu-ubuntu-2204
           - buildjet-16vcpu-ubuntu-2204
+        exclude:
+          - {TEST: python-sharded-and-javascript, NOSE_DIVIDED_WE_RUN: '05'}
+          - {TEST: python-sharded-and-javascript, NOSE_DIVIDED_WE_RUN: '6a'}
+          - {TEST: python-sharded-and-javascript, NOSE_DIVIDED_WE_RUN: 'bf'}
+          - {TEST: python, NOSE_DIVIDED_WE_RUN: ''}
     runs-on: ${{matrix.runs-on}}
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,22 +9,21 @@ on:
     - cron: '47 12 * * *'
 jobs:
   tests:
-    runs-on: ${{matrix.runs-on}}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         include:
-        - {TEST: python, NOSE_DIVIDED_WE_RUN: '05'}
-        - {TEST: python, NOSE_DIVIDED_WE_RUN: '6a'}
-        - {TEST: python, NOSE_DIVIDED_WE_RUN: 'bf'}
-        - {TEST: python-sharded-and-javascript}
+          - {TEST: python, NOSE_DIVIDED_WE_RUN: '05'}
+          - {TEST: python, NOSE_DIVIDED_WE_RUN: '6a'}
+          - {TEST: python, NOSE_DIVIDED_WE_RUN: 'bf'}
+          - {TEST: python-sharded-and-javascript}
         runs-on:
           - buildjet-2vcpu-ubuntu-2204
           - buildjet-4vcpu-ubuntu-2204
           - buildjet-8vcpu-ubuntu-2204
           - buildjet-16vcpu-ubuntu-2204
-
+    runs-on: ${{matrix.runs-on}}
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}


### PR DESCRIPTION
This isn't actually for merging, just for doing test runs of the build. Uses https://buildjet.com/for-github-actions instead of github's own runners, which is supposed to by faster