### PR TITLE
New Case Tile Template "Three upper rows, four rows with two cells, two lower rows and map"

### DIFF
--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_3X_two_4X_one_2X.json
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_3X_two_4X_one_2X.json
@@ -17,8 +17,6 @@
         "middle4_left_img": {"x": 0, "y": 6, "width": 1, "height": 1, "horz-align": "center", "vert-align": "top"},
         "middle4_right": {"x": 1, "y": 6, "width": 11, "height": 1, "horz-align": "left", "vert-align": "top"},
         "middle5": {"x": 0, "y": 7, "width": 12, "height": 1, "horz-align": "center", "vert-align": "center"},
-        "bottom": {"x": 0, "y": 8, "width": 12, "height": 1, "horz-align": "center", "vert-align": "center"},
-        "map": {"x": 0, "y": 9, "width": 12, "height": 1, "horz-align": "center", "vert-align": "center"},
-        "map_popup": {"x": 0, "y": 10, "width": 12, "height": 1, "horz-align": "center", "vert-align": "center"}
+        "bottom": {"x": 0, "y": 8, "width": 12, "height": 1, "horz-align": "center", "vert-align": "center"}
         }
 }

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_3X_two_4X_one_2X.json
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_3X_two_4X_one_2X.json
@@ -1,0 +1,24 @@
+{
+    "slug": "one_3X_two_4X_one_2X",
+    "filename": "one_3X_two_4X_one_2X.xml",
+    "has_map": true,
+    "fields": ["header", "top", "middle0", "middle1_left_img", "middle1_right", "middle2_left_img", "middle2_right", "middle3_left_img",
+        "middle3_right", "middle4_left_img", "middle4_right", "middle5", "bottom", "map", "map_popup"],
+    "grid": {
+        "header": {"x": 0, "y": 0, "width": 12, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "top": {"x": 0, "y": 1, "width": 12, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "middle0": {"x": 0, "y": 2, "width": 12, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "middle1_left_img": {"x": 0, "y": 3, "width": 1, "height": 1, "horz-align": "center", "vert-align": "top"},
+        "middle1_right": {"x": 1, "y": 3, "width": 11, "height": 1, "horz-align": "left", "vert-align": "top"},
+        "middle2_left_img": {"x": 0, "y": 4, "width": 1, "height": 1, "horz-align": "center", "vert-align": "top"},
+        "middle2_right": {"x": 1, "y": 4, "width": 11, "height": 1, "horz-align": "left", "vert-align": "top"},
+        "middle3_left_img": {"x": 0, "y": 5, "width": 1, "height": 1, "horz-align": "center", "vert-align": "top"},
+        "middle3_right": {"x": 1, "y": 5, "width": 11, "height": 1, "horz-align": "left", "vert-align": "top"},
+        "middle4_left_img": {"x": 0, "y": 6, "width": 1, "height": 1, "horz-align": "center", "vert-align": "top"},
+        "middle4_right": {"x": 1, "y": 6, "width": 11, "height": 1, "horz-align": "left", "vert-align": "top"},
+        "middle5": {"x": 0, "y": 7, "width": 12, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "bottom": {"x": 0, "y": 8, "width": 12, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "map": {"x": 0, "y": 9, "width": 12, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "map_popup": {"x": 0, "y": 10, "width": 12, "height": 1, "horz-align": "center", "vert-align": "center"}
+        }
+}

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_3X_two_4X_one_2X.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_3X_two_4X_one_2X.xml
@@ -1,0 +1,260 @@
+<detail id="{detail_id}">
+  <title>
+    <text>
+      <locale id="{title_text_id}"/>
+    </text>
+  </title>
+
+  <field>
+    <style horz-align="left" vert-align="center" font-size="small">
+      <grid grid-height="1" grid-width="12" grid-x="0" grid-y="0"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{header[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{header[format]}">
+      <text>
+        <xpath function="{header[xpath_function]}">
+          {header[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="center" font-size="small">
+      <grid grid-height="1" grid-width="12" grid-x="0" grid-y="1"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{top[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{top[format]}">
+      <text>
+        <xpath function="{top[xpath_function]}">
+          {top[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="center" font-size="small">
+      <grid grid-height="1" grid-width="12" grid-x="0" grid-y="2"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{middle0[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{middle0[format]}">
+      <text>
+        <xpath function="{middle0[xpath_function]}">
+          {middle0[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="center" vert-align="top" font-size="small">
+      <grid grid-height="1" grid-width="1" grid-x="0" grid-y="3" />
+    </style>
+    <header>
+      <text>
+      </text>
+    </header>
+    <template form="image">
+      <text>
+        <xpath function="{middle1_left_img[xpath_function]}"/>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="top" font-size="small">
+      <grid grid-height="1" grid-width="11" grid-x="1" grid-y="3"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{middle1_right[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{middle1_right[format]}">
+      <text>
+        <xpath function="{middle1_right[xpath_function]}">
+          {middle1_right[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="center" vert-align="top" font-size="small">
+      <grid grid-height="1" grid-width="1" grid-x="0" grid-y="4" />
+    </style>
+    <header>
+      <text>
+      </text>
+    </header>
+    <template form="image">
+      <text>
+        <xpath function="{middle2_left_img[xpath_function]}"/>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="top" font-size="small">
+      <grid grid-height="1" grid-width="11" grid-x="1" grid-y="4"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{middle2_right[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{middle2_right[format]}">
+      <text>
+        <xpath function="{middle2_right[xpath_function]}">
+          {middle2_right[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="center" vert-align="top" font-size="small">
+      <grid grid-height="1" grid-width="1" grid-x="0" grid-y="5" />
+    </style>
+    <header>
+      <text>
+      </text>
+    </header>
+    <template form="image">
+      <text>
+        <xpath function="{middle3_left_img[xpath_function]}"/>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="top" font-size="small">
+      <grid grid-height="1" grid-width="11" grid-x="1" grid-y="5"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{middle3_right[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{middle3_right[format]}">
+      <text>
+        <xpath function="{middle3_right[xpath_function]}">
+          {middle3_right[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="center" vert-align="top" font-size="small">
+      <grid grid-height="1" grid-width="1" grid-x="0" grid-y="6" />
+    </style>
+    <header>
+      <text>
+      </text>
+    </header>
+    <template form="image">
+      <text>
+        <xpath function="{middle4_left_img[xpath_function]}"/>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="top" font-size="small">
+      <grid grid-height="1" grid-width="11" grid-x="1" grid-y="6"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{middle4_right[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{middle4_right[format]}">
+      <text>
+        <xpath function="{middle4_right[xpath_function]}">
+          {middle4_right[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="center" vert-align="center" font-size="small">
+      <grid grid-height="1" grid-width="12" grid-x="0" grid-y="7"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{middle5[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{middle5[format]}">
+      <text>
+        <xpath function="{middle5[xpath_function]}">
+          {middle5[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="center" vert-align="center" font-size="small">
+      <grid grid-height="1" grid-width="12" grid-x="0" grid-y="8"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{bottom[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{bottom[format]}">
+      <text>
+        <xpath function="{bottom[xpath_function]}">
+          {bottom[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <header>
+      <text>
+        <locale id="{map[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{map[format]}" width="0">
+      <text>
+        <xpath function="concat({map[xpath_function]}, if(here(), '', ''))"> <!-- Without the here() call sessionStorage.locationLat will not be populated -->
+          {map[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <header>
+      <text>
+        <locale id="{map_popup[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{map_popup[format]}" width="0">
+      <text>
+        <xpath function="{map_popup[xpath_function]}">
+          {map_popup[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+</detail>

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -27,7 +27,8 @@ class CaseTileTemplates(models.TextChoices):
     ONE_TWO_ONE = ("one_two_one", _("Title row, second row with two cells, third row, and map"))
     ONE_TWO_ONE_ONE = ("one_two_one_one", _("Title row, second row with two cells, third and "
                                             "fourth rows, and map"))
-
+    ONE_3X_TWO_4X_ONE_2X = ("one_3X_two_4X_one_2X", _("Three upper rows, four rows with two cells, two lower rows "
+                                                    "and map"))
 
 @dataclass
 class CaseTileTemplateConfig:

--- a/corehq/apps/hqwebapp/static/app_manager/less/content.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/content.less
@@ -275,7 +275,7 @@
 .case-tile-preview {
     display: grid;
     grid-template-columns: repeat(12, 1fr) min-content 5px;
-    grid-template-rows: repeat(3, auto) min-content 5px;
+    grid-template-rows: repeat(9, auto) min-content 5px;
 
     .case-tile-preview-mapping {
         border: 1px @cc-light-cool-accent-low dotted;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
See this [documentation](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=saas&title=Allow+Configuration+of+Case+List+Tiles) for explanation of Case Tiles/ Case Tile Templates. This change adds the case tile template "Three upper rows, four rows with two cells, two lower rows and map" which is the following layout:
![Screen Shot 2023-07-17 at 3 22 04 PM](https://github.com/dimagi/commcare-hq/assets/88759246/2b80cfd1-29e8-4f6c-834d-757bbc67a1c9)
![image](https://github.com/dimagi/commcare-hq/assets/88759246/825293e1-59d9-4fb4-a1cf-2e48a99b707d)

This is an example of how to define an image for mappings "middle1_left_img" and "middle2_left_img"
![Screen Shot 2023-07-17 at 3 42 54 PM](https://github.com/dimagi/commcare-hq/assets/88759246/1825c8a1-fcaf-4492-bf1e-9b8d15cfd9ba)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This template was requested per this [support ticket](https://dimagi-dev.atlassian.net/browse/SUPPORT-17102).
Tech Ticket: https://dimagi-dev.atlassian.net/browse/USH-3414

This template uses a hardcoded "image" for the template element's "form" hint. Additionally, there is currently a limitation on uploading arbitrary multimedia such that it is added to the media suite. This means images to be used for this template would need to first be directly added to the app (as documented [here](https://confluence.dimagi.com/display/commcarepublic/Multimedia+Manager#MultimediaManager-STEP1:Addingamultimediareference)). The workaround is to create a throwaway, hidden case list as described in the ticket  [USH-3414](https://dimagi-dev.atlassian.net/browse/USH-3414?focusedCommentId=276875).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[CASE_LIST_TILE
](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=saas&title=Allow+Configuration+of+Case+List+Tiles)[CASE_LIST_MAP](https://www.commcarehq.org/hq/flags/edit/case_list_map/?__hstc=240960668.3a8f9bf02bba22cb899ac9b22ad61999.1677781986891.1689621365087.1689632747800.309&__hssc=240960668.2.1689632747800&__hsfp=1912911101)
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing. Only affects case tiles, and should not affect project that doesn't deliberately choose the template.

### Automated test coverage
<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3414]: https://dimagi-dev.atlassian.net/browse/USH-3414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ