### PR TITLE
Set selections to null on response from formplayer if selections is null

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -82,7 +82,7 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
                 this.appId = urlObject.appId;
                 updateUrl = true;
             }
-            if (response.selections) {
+            if (response.selections || response.selections === null) {
                 urlObject.setSelections(response.selections);
                 updateUrl = true;
             }


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This very small PR fixes about 80% of the errors encapsulated by [this bug ticket](https://dimagi-dev.atlassian.net/browse/USH-2576?atlOrigin=eyJpIjoiZjQ3YTlmZTAyMjA5NDQwMGI1NjNmZmFhN2Q0NTAwYjYiLCJwIjoiaiJ9).

Here's a preview of how this subset of errors is triggered:

https://github.com/dimagi/commcare-hq/assets/6729291/e2c5e936-e121-422c-871c-7749dceca210

The user clicks on the breadcrumbs for the app's root screen in the middle of a page load and the selections list is not properly reset to `null`.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The user's browser submits a request to navigate to the app's root screen after submitting a request to navigate to a case list (or other form/menu). As each request is submitted, web apps updates the URL's list of selections. But upon getting each response, web apps _only_ updates the URL for the menu selection response, _not_ for the breadcrumbs response. The menu selection response is returned after clicking the breadcrumbs, so the URL has an incorrect selections list. The fix here updates the selections list to null upon getting the breadcrumbs response.

An aside, this code area was [almost refactored](https://github.com/dimagi/commcare-hq/pull/31946) and I agree that it'd be nice to touch things up and simplify a little here.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

This is just web apps.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

I've tested some locally. I'm curious to hear whether setting the selections list to null could break anything from those who are probably more familiar with the types of responses web apps gets.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Should I? Seems like too much for a minor change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
