### PR TITLE
[USH-3425] Updated user-controlled repeat group buttons in web apps

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -34,10 +34,10 @@
                 data-bind="
                   html: ko.utils.unwrapObservable($data.caption_markdown) || caption(),
                 "></span>
-          <button class="btn btn-xs btn-danger del pull-right" href="#" data-bind="
+          <button class="btn btn-danger del pull-right" href="#" data-bind="
                       visible: isRepetition,
                       click: deleteRepeat
-                  ">{% trans "Delete repeat" %}</button>
+                  "><i class="fa fa-remove"></i></button>
         </legend>
       </div>
       <div data-bind="if: collapsible">
@@ -48,10 +48,10 @@
         </div>
         <span class="caption" data-bind="html: caption(), attr: {id: captionId()}"></span><!-- Markdown interferes with header styling -->
         <i class="fa fa-warning text-danger pull-right" data-bind="visible: hasError() && !showChildren()"></i>
-        <button class="btn btn-xs btn-danger del pull-right" href="#" data-bind="
+        <button class="btn btn-danger del pull-right" href="#" data-bind="
                     visible: isRepetition,
                     click: deleteRepeat
-                ">{% trans "Delete repeat" %}</button>
+                "><i class="fa fa-remove"></i></button>
       </div>
       <span class="ix"></span>
     </fieldset>
@@ -310,9 +310,12 @@
       </div>
     </div>
     <div class="panel-footer">
-      <button class="btn btn-default btn-xs add" href="#"
-              data-bind="click: newRepeat, text: getTranslation('repeat.dialog.add.new', '{% trans_html_attr 'Add new repeat' %}')"
-              id="repeat-add-new" />
+      <button class="btn btn-default add" href="#"
+              data-bind="click: newRepeat"
+              id="repeat-add-new">
+              <i class="fa fa-plus"></i>
+              <!-- ko text: getTranslation('repeat.dialog.add.new', '{% trans_html_attr 'Add new repeat' %}') --><!-- /ko -->
+      </button>
     </div>
   </div>
 </script>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/form.less
@@ -38,3 +38,8 @@ legend {
     display: none;
   }
 }
+
+.gr.repetition:not(:first-child) {
+    border-top: @cc-neutral-hi solid 1px;
+    padding-top: 20px;
+}


### PR DESCRIPTION
## Product Description
A couple of UX tweaks to user-controlled repeat groups in Web Apps:
* Increase buttons to standard size
* Replace delete text with an X icon
* Add a plus icon to the add button
* Add a light border between repeat groups

https://dimagi-dev.atlassian.net/browse/USH-3425

## Safety Assurance

### Safety story
This is web apps UI, but it's largely HTML. The main risk would have been a syntax error. Locally tested.

### Automated test coverage

Unlikely

### QA Plan

Not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
