### PR TITLE
Check if Datasource is active before populating SQL adapter list to rebuild

### DIFF
--- a/corehq/apps/userreports/pillow_utils.py
+++ b/corehq/apps/userreports/pillow_utils.py
@@ -1,12 +1,26 @@
 from collections import defaultdict
 
 from corehq.apps.userreports.exceptions import StaleRebuildError, TableRebuildError
+from couchdbkit import ResourceNotFound
 from corehq.apps.userreports.rebuild import migrate_tables, get_tables_rebuild_migrate, get_table_diffs
 from corehq.apps.userreports.sql import get_metadata
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.sql_db.connections import connection_manager
 from corehq.util.soft_assert import soft_assert
 from pillowtop.logger import pillow_logging
+
+
+def _is_datasource_active(adapter):
+    """
+    Tries to fetch a fresh copy of datasource from couchdb to know whether it is deactivated.
+    If it does not exist then it assumed to be deactivated
+    """
+    try:
+        config_id = adapter.config._id
+        config = adapter.config.get(config_id)
+    except ResourceNotFound:
+        return False
+    return config.is_deactivated
 
 
 def rebuild_sql_tables(adapters):
@@ -18,7 +32,15 @@ def rebuild_sql_tables(adapters):
         else:
             all_adapters.append(adapter)
     for adapter in all_adapters:
-        tables_by_engine[adapter.engine_id][adapter.get_table().name] = adapter
+        if not _is_datasource_active(adapter):
+            tables_by_engine[adapter.engine_id][adapter.get_table().name] = adapter
+        else:
+            pillow_logging.info(
+                f"""[rebuild] Tried to rebuild deactivated data source.
+                Id - {adapter.config._id}
+                Domain {adapter.config.domain}.
+                Skipping."""
+            )
 
     _assert = soft_assert(notify_admins=True)
     _notify_rebuild = lambda msg, obj: _assert(False, msg, obj)

--- a/corehq/apps/userreports/pillow_utils.py
+++ b/corehq/apps/userreports/pillow_utils.py
@@ -10,7 +10,7 @@ from corehq.util.soft_assert import soft_assert
 from pillowtop.logger import pillow_logging
 
 
-def _is_datasource_active(adapter):
+def _is_datasource_deactivated(adapter):
     """
     Tries to fetch a fresh copy of datasource from couchdb to know whether it is deactivated.
     If it does not exist then it assumed to be deactivated
@@ -19,7 +19,7 @@ def _is_datasource_active(adapter):
         config_id = adapter.config._id
         config = adapter.config.get(config_id)
     except ResourceNotFound:
-        return False
+        return True
     return config.is_deactivated
 
 
@@ -32,7 +32,7 @@ def rebuild_sql_tables(adapters):
         else:
             all_adapters.append(adapter)
     for adapter in all_adapters:
-        if not _is_datasource_active(adapter):
+        if not _is_datasource_deactivated(adapter):
             tables_by_engine[adapter.engine_id][adapter.get_table().name] = adapter
         else:
             pillow_logging.info(

--- a/corehq/apps/userreports/pillow_utils.py
+++ b/corehq/apps/userreports/pillow_utils.py
@@ -10,17 +10,17 @@ from corehq.util.soft_assert import soft_assert
 from pillowtop.logger import pillow_logging
 
 
-def _is_datasource_deactivated(adapter):
+def _is_datasource_active(adapter):
     """
-    Tries to fetch a fresh copy of datasource from couchdb to know whether it is deactivated.
+    Tries to fetch a fresh copy of datasource from couchdb to know whether it is active.
     If it does not exist then it assumed to be deactivated
     """
     try:
         config_id = adapter.config._id
         config = adapter.config.get(config_id)
     except ResourceNotFound:
-        return True
-    return config.is_deactivated
+        return False
+    return not config.is_deactivated
 
 
 def rebuild_sql_tables(adapters):
@@ -32,7 +32,7 @@ def rebuild_sql_tables(adapters):
         else:
             all_adapters.append(adapter)
     for adapter in all_adapters:
-        if not _is_datasource_deactivated(adapter):
+        if _is_datasource_active(adapter):
             tables_by_engine[adapter.engine_id][adapter.get_table().name] = adapter
         else:
             pillow_logging.info(

--- a/corehq/apps/userreports/tests/test_multi_db.py
+++ b/corehq/apps/userreports/tests/test_multi_db.py
@@ -170,7 +170,7 @@ class UCRMultiDBTest(TestCase):
 
         with (
             patch('pillowtop.models.KafkaCheckpoint.get_or_create_for_checkpoint_id'),
-            patch('corehq.apps.userreports.pillow_utils._is_datasource_deactivated', return_value=False)
+            patch('corehq.apps.userreports.pillow_utils._is_datasource_active', return_value=True)
         ):
             pillow = get_case_pillow(ucr_configs=[ds3])
         sample_doc, _ = get_sample_doc_and_indicators()

--- a/corehq/apps/userreports/tests/test_multi_db.py
+++ b/corehq/apps/userreports/tests/test_multi_db.py
@@ -168,7 +168,10 @@ class UCRMultiDBTest(TestCase):
             with db_adapter.session_context() as session:
                 self.assertEqual(0, session.query(db_adapter.get_table()).count())
 
-        with patch('pillowtop.models.KafkaCheckpoint.get_or_create_for_checkpoint_id'):
+        with (
+            patch('pillowtop.models.KafkaCheckpoint.get_or_create_for_checkpoint_id'),
+            patch('corehq.apps.userreports.pillow_utils._is_datasource_deactivated', return_value=False)
+        ):
             pillow = get_case_pillow(ucr_configs=[ds3])
         sample_doc, _ = get_sample_doc_and_indicators()
         pillow.process_change(doc_to_change(sample_doc))

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -102,6 +102,8 @@ class ConfigurableReportTableManagerDbTest(TestCase):
     def test_table_adapters(self):
         data_source_1 = get_sample_data_source()
         ds_1_domain = data_source_1.domain
+        data_source_1.save()
+
         table_manager = ConfigurableReportTableManager([MockDataSourceProvider({
             ds_1_domain: [data_source_1]
         })])


### PR DESCRIPTION
We have been seeing UCR rebuilds after a domain is being paused. We figured that these rebuilds are [triggered by Pillows](https://www.commcarehq.org/admin/userreports/datasourceactionlog/?o=-0.-4&p=1&q=ny-suffolk-cdcms ) with their cached data sources.

This is best faith effort to ensure that it does not happen. I have tried very hard to reproduce it locally (in which I thought I got success). It was a rabbithole that did not lead me to anywhere.

The fix should solve the issue in question as that is the only place from where pillows can rebuild the SQL tables and if we remove deactivated/deleted data sources from the list, they would never be triggered.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SAAS-14686
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A
## Safety Assurance
Apparently this code should be a no op for the existing workflows, I have tested it locally and the code works without errors. Maybe I will give it a spin on staging too. 
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
NA
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
