### PR TITLE
Remove pickle protocol workaround for django-redis

### DIFF
--- a/corehq/tests/test_pickle.py
+++ b/corehq/tests/test_pickle.py
@@ -1,7 +1,5 @@
 import pickle
 
-from django.conf import settings
-from django_redis.serializers.pickle import PickleSerializer
 from testil import eq
 
 
@@ -25,16 +23,3 @@ def test_dump_and_load_all_protocols():
 
     for protocol in range(1, pickle.HIGHEST_PROTOCOL + 1):
         yield test, protocol
-
-
-def test_django_redis_protocol():
-    # Override default pickle protocol to allow smoother Python upgrades.
-    # Heroics like this will not be necessary once we have upgraded to a
-    # version of django_redis that uses pickle.DEFAULT_PROTOCOL. See:
-    # https://github.com/jazzband/django-redis/issues/547
-    # https://github.com/jazzband/django-redis/pull/555
-    #
-    # This test may be removed after upgrading django_redis.
-    # In the mean time, test for effective protocol override in settings.py
-    pkl = PickleSerializer(settings.CACHES['default'].get("OPTIONS", {}))
-    eq(pkl.dumps(False)[1], pickle.DEFAULT_PROTOCOL)

--- a/settings.py
+++ b/settings.py
@@ -2026,15 +2026,6 @@ if 'locmem' not in CACHES:
 if 'dummy' not in CACHES:
     CACHES['dummy'] = {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}
 
-# Make django_redis use pickle.DEFAULT_PROTOCOL by default.
-# Remove after upgrading django_redis to a version that does that.
-# See also corehq.tests.test_pickle.test_django_redis_protocol
-from pickle import DEFAULT_PROTOCOL as _protocol
-for _value in CACHES.values():
-    if _value.get("BACKEND", "").startswith("django_redis"):
-        _value.setdefault("OPTIONS", {}).setdefault("PICKLE_VERSION", _protocol)
-del _value, _protocol
-
 
 REST_FRAMEWORK = {
     'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%S.%fZ',


### PR DESCRIPTION
Django-redis has been [upgraded](https://github.com/dimagi/commcare-hq/pull/33136) to a version that uses `pickle.DEFAULT_PROTOCOL` instead of `pickle.HIGHEST_PROTOCOL`. See https://github.com/jazzband/django-redis/pull/555

## Safety Assurance

### Safety story

Removes old/obsolete code.

### Automated test coverage

N/A

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations