### PR TITLE
Make case list map resize with window

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -545,9 +545,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         columnStyle: function () {
             const self = this;
             if (self.showMap) {
-                return "display: grid;grid-template-columns: [tiles] auto [map] 300px;grid-template-rows: auto";
+                return "display: grid;grid-template-columns: [tiles] 7fr [map] 5fr;grid-template-rows: auto";
             } else {
-                return"display: grid;grid-template-columns: [tiles] 100%;grid-template-rows: auto";
+                return "display: grid;grid-template-columns: [tiles] 100%;grid-template-rows: auto";
             }
         },
 
@@ -555,7 +555,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             return L.divIcon({
                 html: `<i class='fa ${iconName} fa-4x'></i>`,
                 iconSize: [12, 12],
-                className: 'marker-pin'
+                className: 'marker-pin',
             });
         },
 

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -29,7 +29,7 @@
 
   #module-case-list-column-next-to-map {
     // Horizontal scroll bar on table will disappear without this.
-    min-width: 100%;
+    overflow-x: scroll;
   }
 
   .list-cell-wrapper-style {


### PR DESCRIPTION
## Product Description
Changes the case list map width in web apps from a static 300px to a 5 / 7 ratio with the case list/case tiles, which allows it to scale based on window size.

https://github.com/dimagi/commcare-hq/assets/100609770/9ff51d6f-eaab-4a0f-ab29-2de227e86227


## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3411
Changes case list grid, when map is enabled, from `auto` (case list width) and `300px` (map width) to `7fr` and `5fr`, respectively. Updates the `#module-case-list-column-next-to-map` style to ensure horizontal case list scrolling works with this change.

## Feature Flag
CASE_LIST_MAP

## Safety Assurance

### Safety story
Small changes to CSS styling. Verified locally that this has the intended effect of allowing the map to resize and not overlap the case list pane at small screen sizes. Checked combinations with and without split screen case search and case tiles and confirmed horizontal case list scrolling still works as well.

### Automated test coverage
None

### QA Plan
QA should not be needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
