### PR TITLE
Linting only

### DIFF
--- a/corehq/util/bitly.py
+++ b/corehq/util/bitly.py
@@ -55,4 +55,5 @@ elif getattr(settings, 'BITLY_LOGIN', None) and getattr(settings, 'BITLY_APIKEY'
     shorten = partial(shorten_v3, login=settings.BITLY_LOGIN, api_key=settings.BITLY_APIKEY)
     BITLY_CONFIGURED = True
 else:
-    shorten = lambda url: url
+    def shorten(url):
+        return url

--- a/corehq/util/bounced_email_manager.py
+++ b/corehq/util/bounced_email_manager.py
@@ -199,7 +199,7 @@ class BouncedEmailManager(object):
                             )
                     elif aws_meta.notification_type == NotificationType.COMPLAINT:
                         self._record_complaint(aws_meta, uid)
-            except Exception as e:
+            except Exception:
                 metrics_counter('commcare.bounced_email_manager.formatting_issues')
                 self._label_problem_email(
                     uid,

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -106,7 +106,11 @@ def js_api_keys(request):
         'ANALYTICS_CONFIG': settings.ANALYTICS_CONFIG.copy(),
         'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN,
     }
-    if getattr(request, 'project', None) and request.project.ga_opt_out and api_keys['ANALYTICS_IDS'].get('GOOGLE_ANALYTICS_API_ID'):
+    if (
+        getattr(request, 'project', None)
+        and request.project.ga_opt_out
+        and api_keys['ANALYTICS_IDS'].get('GOOGLE_ANALYTICS_API_ID')
+    ):
         del api_keys['ANALYTICS_IDS']['GOOGLE_ANALYTICS_API_ID']
 
     if (api_keys['ANALYTICS_IDS'].get('HUBSPOT_API_ID')

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -24,7 +24,7 @@ def handle_uncaught_exceptions(mail_admins=True):
         def _handle_exceptions(*args, **kwargs):
             try:
                 return fn(*args, **kwargs)
-            except Exception as e:
+            except Exception:
                 msg = "Uncaught exception from {}.{}".format(fn.__module__, fn.__name__)
                 if mail_admins:
                     notify_exception(get_request(), msg)

--- a/corehq/util/email_event_utils.py
+++ b/corehq/util/email_event_utils.py
@@ -173,6 +173,14 @@ def get_emails_to_never_bounce():
 
 def get_bounced_system_emails():
     system_emails = get_emails_to_never_bounce()
-    general_bounces = BouncedEmail.objects.filter(email__in=system_emails).values_list('email', flat=True)
-    transient_bounces = TransientBounceEmail.objects.filter(email__in=system_emails).values_list('email', flat=True)
+    general_bounces = (
+        BouncedEmail.objects
+        .filter(email__in=system_emails)
+        .values_list('email', flat=True)
+    )
+    transient_bounces = (
+        TransientBounceEmail.objects
+        .filter(email__in=system_emails)
+        .values_list('email', flat=True)
+    )
     return list(general_bounces) + list(transient_bounces)

--- a/corehq/util/hmac_request.py
+++ b/corehq/util/hmac_request.py
@@ -18,7 +18,9 @@ def convert_to_bytestring_if_unicode(shared_key):
 
 
 def get_hmac_digest(shared_key, data):
-    hm = hmac.new(convert_to_bytestring_if_unicode(shared_key), convert_to_bytestring_if_unicode(data), hashlib.sha256)
+    shared_key_bytes = convert_to_bytestring_if_unicode(shared_key)
+    data_bytes = convert_to_bytestring_if_unicode(data)
+    hm = hmac.new(shared_key_bytes, data_bytes, hashlib.sha256)
     digest = base64.b64encode(hm.digest())
     return digest.decode('utf-8')
 

--- a/corehq/util/management/commands/check_bounced_email.py
+++ b/corehq/util/management/commands/check_bounced_email.py
@@ -105,13 +105,13 @@ class Command(BaseCommand):
         )
 
         self.stdout.write(
-            f'\nEmail\t\t'
-            f'\tNumber Permanent'
-            f'\tLast Recorded on'
-            f'\t\tNumber Complaints'
-            f'\tLast Recorded on'
-            f'\t\tNumber Transient'
-            f'\tLast Recorded on'
+            '\nEmail\t\t'
+            '\tNumber Permanent'
+            '\tLast Recorded on'
+            '\t\tNumber Complaints'
+            '\tLast Recorded on'
+            '\t\tNumber Transient'
+            '\tLast Recorded on'
         )
 
         self.stdout.write(
@@ -161,7 +161,7 @@ class Command(BaseCommand):
                     f'\t{record.timestamp}'
                 )
                 for key, val in record.headers.items():
-                    self.stdout.write(f'\t' * 10 +
+                    self.stdout.write('\t' * 10 +
                                       f'{key}:\t{val}')
             self.stdout.write('\n\nt')
 
@@ -185,9 +185,9 @@ class Command(BaseCommand):
                     f'\t{record.reason}'
                 )
                 for key, val in record.headers.items():
-                    self.stdout.write(f'\t' * 15 +
+                    self.stdout.write('\t' * 15 +
                                       f'{key}:\t{val}')
-                self.stdout.write(f'\t' * 15 +
+                self.stdout.write('\t' * 15 +
                                   f'destination:\t{record.destination}')
             self.stdout.write('\n\n')
 
@@ -209,18 +209,18 @@ class Command(BaseCommand):
                     f'\t{record.created}'
                 )
                 self.stdout.write(
-                    f'\t' * 8 +
+                    '\t' * 8 +
                     f'\t{record.feedback_type}'
                 )
                 self.stdout.write(
-                    f'\t' * 11 +
+                    '\t' * 11 +
                     f'\t{record.sub_type}'
                 )
                 self.stdout.write(
-                    f'\t' * 14 +
+                    '\t' * 14 +
                     f'destination: {record.destination}'
                 )
                 for key, val in record.headers.items():
-                    self.stdout.write(f'\t' * 14 +
+                    self.stdout.write('\t' * 14 +
                                       f'{key}:\t{val}')
             self.stdout.write('\n\n')

--- a/corehq/util/management/commands/create_couchdb_replication.py
+++ b/corehq/util/management/commands/create_couchdb_replication.py
@@ -1,7 +1,5 @@
-import base64
 import json
 
-from django.conf import settings
 from django.core.management import CommandError
 from django.core.management.base import BaseCommand
 

--- a/corehq/util/management/commands/show_celery_workers.py
+++ b/corehq/util/management/commands/show_celery_workers.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from corehq.util.celery_utils import get_running_workers
 
 

--- a/corehq/util/management/commands/unbounce_email.py
+++ b/corehq/util/management/commands/unbounce_email.py
@@ -57,4 +57,4 @@ class Command(BaseCommand):
             bounced_email__email=bounced_email
         ).all().delete()
         BouncedEmail.objects.filter(email=bounced_email).all().delete()
-        self.stdout.write(f'\nDone.\n\n')
+        self.stdout.write('\nDone.\n\n')

--- a/corehq/util/metrics/metrics.py
+++ b/corehq/util/metrics/metrics.py
@@ -26,13 +26,13 @@ def _enforce_prefix(name, prefix):
 
 def _validate_tag_names(tag_names):
     tag_names = set(tag_names or [])
-    for l in tag_names:
-        if not METRIC_TAG_NAME_RE.match(l):
-            raise ValueError('Invalid metric tag name: ' + l)
-        if RESERVED_METRIC_TAG_NAME_RE.match(l):
-            raise ValueError('Reserved metric tag name: ' + l)
-        if l in RESERVED_METRIC_TAG_NAMES:
-            raise ValueError('Reserved metric tag name: ' + l)
+    for tag_name in tag_names:
+        if not METRIC_TAG_NAME_RE.match(tag_name):
+            raise ValueError('Invalid metric tag name: ' + tag_name)
+        if RESERVED_METRIC_TAG_NAME_RE.match(tag_name):
+            raise ValueError('Reserved metric tag name: ' + tag_name)
+        if tag_name in RESERVED_METRIC_TAG_NAMES:
+            raise ValueError('Reserved metric tag name: ' + tag_name)
     return tag_names
 
 

--- a/corehq/util/metrics/utils.py
+++ b/corehq/util/metrics/utils.py
@@ -1,7 +1,6 @@
 import re
 from datetime import timedelta
 
-from django.conf import settings
 
 WILDCARD = '*'
 

--- a/corehq/util/mixin.py
+++ b/corehq/util/mixin.py
@@ -1,5 +1,4 @@
 import uuid
-from corehq.util.exceptions import AccessRestricted
 
 
 class UUIDGeneratorException(Exception):

--- a/corehq/util/teeout.py
+++ b/corehq/util/teeout.py
@@ -23,7 +23,7 @@ def tee_output(stream, sys=sys):
         yield
     except SystemExit:
         raise
-    except:
+    except:  # noqa: E722  # Do not use bare `except`
         etype, exc, tb = sys.exc_info()
         if stream:
             stream.write("".join(traceback.format_exception(etype, exc, tb)))

--- a/corehq/util/tests/test_celery_utils.py
+++ b/corehq/util/tests/test_celery_utils.py
@@ -48,14 +48,63 @@ def test_run_periodic_task_again():
     one_second_ago = now - one_second
     run_every_minute = crontab(nowfun=nowfun)
     tests = [
-        ('cron_already_triggered', run_every_minute, now - timedelta(minutes=2), one_second, False),
-        ('cron_enough_time', run_every_minute, one_second_ago, one_second, True),
-        ('cron_not_enough_time', run_every_minute, one_second_ago, timedelta(seconds=70), False),
-        ('cron_inside_window', crontab(hour=now.hour, nowfun=nowfun), one_second_ago, one_second, True),
-        ('cron_outside_window', crontab(hour=all_hours_except_now, nowfun=nowfun), one_second_ago, one_second, False),
+        # (
+        #   name,
+        #   run_every,
+        #   last_run,
+        #   duration,
+        #   expected
+        # ),
+        (
+            'cron_already_triggered',
+            run_every_minute,
+            now - timedelta(minutes=2),
+            one_second,
+            False
+        ),
+        (
+            'cron_enough_time',
+            run_every_minute,
+            one_second_ago,
+            one_second,
+            True
+        ),
+        (
+            'cron_not_enough_time',
+            run_every_minute,
+            one_second_ago,
+            timedelta(seconds=70),
+            False
+        ),
+        (
+            'cron_inside_window',
+            crontab(hour=now.hour, nowfun=nowfun),
+            one_second_ago,
+            one_second,
+            True
+        ),
+        (
+            'cron_outside_window',
+            crontab(hour=all_hours_except_now, nowfun=nowfun),
+            one_second_ago,
+            one_second,
+            False
+        ),
 
-        ('repeat_enough_time', timedelta(minutes=1), now - timedelta(seconds=30), timedelta(seconds=20), True),
-        ('repeat_not_enough_time', timedelta(minutes=1), now - timedelta(seconds=30), timedelta(seconds=40), False),
+        (
+            'repeat_enough_time',
+            timedelta(minutes=1),
+            now - timedelta(seconds=30),
+            timedelta(seconds=20),
+            True
+        ),
+        (
+            'repeat_not_enough_time',
+            timedelta(minutes=1),
+            now - timedelta(seconds=30),
+            timedelta(seconds=40),
+            False
+        ),
     ]
 
     for name, run_every, last_run, duration, expected in tests:

--- a/corehq/util/tests/test_celery_utils.py
+++ b/corehq/util/tests/test_celery_utils.py
@@ -41,18 +41,18 @@ def test_run_periodic_task_again():
         eq(run_again, expected)
 
     now = datetime.utcnow()
-    nowfun = lambda : now
+    def nowfun(): return now
     all_hours = list(range(0, 24))
     all_hours_except_now = list(set(all_hours) - {now.hour})
-    one_scond = timedelta(seconds=1)
-    one_second_ago = now - one_scond
+    one_second = timedelta(seconds=1)
+    one_second_ago = now - one_second
     run_every_minute = crontab(nowfun=nowfun)
     tests = [
-        ('cron_already_triggered', run_every_minute, now - timedelta(minutes=2), one_scond, False),
-        ('cron_enough_time', run_every_minute, one_second_ago, one_scond, True),
+        ('cron_already_triggered', run_every_minute, now - timedelta(minutes=2), one_second, False),
+        ('cron_enough_time', run_every_minute, one_second_ago, one_second, True),
         ('cron_not_enough_time', run_every_minute, one_second_ago, timedelta(seconds=70), False),
-        ('cron_inside_window', crontab(hour=now.hour, nowfun=nowfun), one_second_ago, one_scond, True),
-        ('cron_outside_window', crontab(hour=all_hours_except_now, nowfun=nowfun), one_second_ago, one_scond, False),
+        ('cron_inside_window', crontab(hour=now.hour, nowfun=nowfun), one_second_ago, one_second, True),
+        ('cron_outside_window', crontab(hour=all_hours_except_now, nowfun=nowfun), one_second_ago, one_second, False),
 
         ('repeat_enough_time', timedelta(minutes=1), now - timedelta(seconds=30), timedelta(seconds=20), True),
         ('repeat_not_enough_time', timedelta(minutes=1), now - timedelta(seconds=30), timedelta(seconds=40), False),

--- a/corehq/util/tests/test_email_event_utils.py
+++ b/corehq/util/tests/test_email_event_utils.py
@@ -1,18 +1,20 @@
+import datetime
 import json
 import os
-import datetime
 
 from django.test import TestCase
 
-from corehq.util.email_event_utils import get_relevant_aws_meta, \
-    handle_email_sns_event
+from corehq.util.email_event_utils import (
+    get_relevant_aws_meta,
+    handle_email_sns_event,
+)
 from corehq.util.models import (
+    AwsMeta,
+    BouncedEmail,
+    BounceSubType,
     ComplaintBounceMeta,
     PermanentBounceMeta,
-    BouncedEmail,
     TransientBounceEmail,
-    AwsMeta,
-    BounceSubType,
 )
 from corehq.util.test_utils import TestFileMixin
 
@@ -116,7 +118,10 @@ class TestBouncedEmailManager(TestSnsEmailBase):
                     main_type='Permanent',
                     sub_type='General',
                     email='permanent_general_bounce@company.org',
-                    reason='smtp; 550 5.4.1 Recipient address rejected: Access denied. AS(redacted) [redacted.outlook.com]',
+                    reason=(
+                        'smtp; 550 5.4.1 Recipient address rejected: Access '
+                        'denied. AS(redacted) [redacted.outlook.com]'
+                    ),
                     headers={
                         'returnPath': 'noreplyemail@company.com',
                         'from': ['noreplyemail@company.com'],
@@ -154,11 +159,15 @@ class TestBouncedEmailManager(TestSnsEmailBase):
                     main_type='Permanent',
                     sub_type='Suppressed',
                     email='permanent.suppressed@company.org',
-                    reason='Amazon SES has suppressed sending to this address because '
-                           'it has a recent history of bouncing as an invalid address. '
-                           'For more information about how to remove an address from the '
-                           'suppression list, see the Amazon SES Developer Guide: '
-                           'http://docs.aws.amazon.com/ses/latest/DeveloperGuide/remove-from-suppressionlist.html ',
+                    reason=(
+                        'Amazon SES has suppressed sending to this address '
+                        'because it has a recent history of bouncing as an '
+                        'invalid address. For more information about how to '
+                        'remove an address from the suppression list, see the '
+                        'Amazon SES Developer Guide: '
+                        'http://docs.aws.amazon.com/ses/latest/DeveloperGuide/'
+                        'remove-from-suppressionlist.html '
+                    ),
                     headers={
                         'returnPath': 'noreplyemail@company.com',
                         'from': ['noreplyemail@company.com'],
@@ -197,7 +206,11 @@ class TestBouncedEmailManager(TestSnsEmailBase):
                     main_type='Transient',
                     sub_type='General',
                     email='transientEmail@company.org',
-                    reason='smtp; 554 4.4.7 Message expired: unable to deliver in 840 minutes.<421 4.4.0 Unable to lookup DNS for company.org>',
+                    reason=(
+                        'smtp; 554 4.4.7 Message expired: unable to deliver '
+                        'in 840 minutes.<421 4.4.0 Unable to lookup DNS for '
+                        'company.org>'
+                    ),
                     headers={
                         'returnPath': 'noreplyemail@company.com',
                         'from': ['noreplyemail@company.com'],

--- a/corehq/util/tests/test_itertools.py
+++ b/corehq/util/tests/test_itertools.py
@@ -30,8 +30,9 @@ def test_zip_with_gaps_key_funcs():
         ('Nick', 'Pellegrino', 'nickpell'),
         ('Simon', 'Kelly', 'snopoke'),
     ]
-    some_first_names = [WithFirstName(u, f) for i, (f, l, u) in enumerate(devs) if i < 4]
-    all_last_names = [WithLastName(u, l) for f, l, u in devs]
+    some_first_names = [WithFirstName(usr, fst) for i, (fst, lst, usr)
+                        in enumerate(devs) if i < 4]
+    all_last_names = [WithLastName(usr, lst) for fst, lst, usr in devs]
 
     zipped = zip_with_gaps(
         sorted(all_last_names, key=get_username),
@@ -39,7 +40,7 @@ def test_zip_with_gaps_key_funcs():
         all_items_key=get_username,
         some_items_key=get_username
     )
-    names = [(f.first_name, l.last_name) for l, f in zipped]
+    names = [(fst.first_name, lst.last_name) for lst, fst in zipped]
     eq(names, [
         ('Biyeun', 'Buczyk'),
         ('Cory', 'Zue'),

--- a/corehq/util/timezones/forms.py
+++ b/corehq/util/timezones/forms.py
@@ -6,7 +6,7 @@ from corehq.util.timezones.utils import coerce_timezone_value
 class TimeZoneChoiceField(forms.TypedChoiceField):
 
     def __init__(self, *args, **kwargs):
-        if not "choices" in kwargs:
+        if "choices" not in kwargs:
             kwargs["choices"] = zones.PRETTY_TIMEZONE_CHOICES
         kwargs["coerce"] = coerce_timezone_value
         super(TimeZoneChoiceField, self).__init__(*args, **kwargs)

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -4,7 +4,6 @@ import pytz
 from functools import reduce
 from memoized import memoized
 
-from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from corehq.apps.domain.models import Domain

--- a/corehq/util/workbook_json/excel.py
+++ b/corehq/util/workbook_json/excel.py
@@ -316,7 +316,10 @@ def alphanumeric_sort_key(key):
     Thanks to http://stackoverflow.com/a/2669120/240553
     """
     import re
-    convert = lambda text: int(text) if text.isdigit() else text
+
+    def convert(text):
+        return int(text) if text.isdigit() else text
+
     return [convert(c) for c in re.split('([0-9]+)', key)]
 
 

--- a/corehq/util/workbook_reading/adapters/xlsx.py
+++ b/corehq/util/workbook_reading/adapters/xlsx.py
@@ -1,14 +1,19 @@
 from contextlib import contextmanager
-from zipfile import BadZipfile
 from datetime import datetime, time
+from zipfile import BadZipfile
 
-from memoized import memoized
 import openpyxl
-from openpyxl.utils.datetime import from_excel
+from memoized import memoized
 from openpyxl.utils.exceptions import InvalidFileException
 
-from corehq.util.workbook_reading import Worksheet, Cell, Workbook, \
-    SpreadsheetFileNotFound, SpreadsheetFileInvalidError, SpreadsheetFileEncrypted
+from corehq.util.workbook_reading import (
+    Cell,
+    SpreadsheetFileEncrypted,
+    SpreadsheetFileInvalidError,
+    SpreadsheetFileNotFound,
+    Workbook,
+    Worksheet,
+)
 
 # Got this from running hexdump and then googling
 # which matched something on https://en.wikipedia.org/wiki/List_of_file_signatures:


### PR DESCRIPTION
## Technical Summary

Linting with [Ruff](https://beta.ruff.rs/docs/).

This change is to make the following command pass:
```bash
$ ruff check corehq/util
```

I am using the following configuration:
```toml
[tool.ruff]
# Code review in a maximized browser at 1920x1080 wraps after 115
line-length = 115

# CommCare HQ uses Python 3.9
target-version = "py39"

[tool.ruff.per-file-ignores]
# Ignore `F401` (imported but unused) in all `__init__.py` files
"__init__.py" = ["F401"]
# Ignore `E501` (Line too long) in migrations
"*/migrations/*" = ["E501"]

```

Fun fact: Commit 4e6c45c284cb9ca1cfd3f6256a70a585cf7b847f is (almost all) automatic fixes. (I changed the line breaks around the function definitions, and ran `isort` on `xslx.py`.)

## Feature Flag
N/A

## Safety Assurance

### Safety story

_Linting only._

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
