### PR TITLE
Nearly all linting

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/couch/cache/cache_core/__init__.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/cache/cache_core/__init__.py
@@ -12,7 +12,7 @@ MOCK_REDIS_CACHE = None
 
 try:
     REDIS_CACHE = cache.caches['redis']
-except:
+except InvalidCacheBackendError:
     REDIS_CACHE = None
 
 DEBUG_TRACE = False

--- a/corehq/ex-submodules/dimagi/utils/couch/cache/cache_core/__init__.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/cache/cache_core/__init__.py
@@ -64,6 +64,6 @@ def key_doc_id(doc_id):
 
 # has to be down here because of cyclic dependency
 # todo: move all above out of init; this should really be the only thing in init
-from .api import *
-from .gen import *
-from .const import *
+from .api import *  # noqa: E402
+from .gen import *  # noqa: E402
+from .const import *  # noqa: E402

--- a/corehq/ex-submodules/dimagi/utils/couch/debugdb/__init__.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/debugdb/__init__.py
@@ -44,7 +44,7 @@ def tidy_stacktrace(strace):
     for s in strace[:-1]:
         s_path = os.path.realpath(s[0])
         if getattr(settings, 'DEBUG_TOOLBAR_CONFIG', {}).get('HIDE_DJANGO_SQL', True) \
-            and django_path in s_path and not 'django/contrib' in s_path:
+            and django_path in s_path and 'django/contrib' not in s_path:
             continue
         if socketserver_path in s_path:
             continue

--- a/corehq/ex-submodules/dimagi/utils/couch/debugdb/debugdatabase.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/debugdb/debugdatabase.py
@@ -104,7 +104,7 @@ class DebugViewResults64(ViewResults):
         for key in self._dynamic_keys:
             try:
                 delattr(self, key)
-            except:
+            except AttributeError:
                 pass
         self._dynamic_keys = []
 
@@ -170,7 +170,7 @@ class DebugViewResults57(ViewResults):
         for key in self._dynamic_keys:
             try:
                 delattr(self, key)
-            except:
+            except AttributeError:
                 pass
         self._dynamic_keys = []
 

--- a/corehq/ex-submodules/dimagi/utils/couch/debugdb/debugdatabase.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/debugdb/debugdatabase.py
@@ -1,7 +1,7 @@
 __author__ = 'dmyung'
 from datetime import datetime
 from couchdbkit import Database
-from dimagi.utils.couch.debugdb import tidy_stacktrace, SQL_WARNING_THRESHOLD, process_key, ms_from_timedelta
+from dimagi.utils.couch.debugdb import tidy_stacktrace, SQL_WARNING_THRESHOLD, ms_from_timedelta
 
 #taken from the django debug toolbar sql panel
 import traceback

--- a/corehq/ex-submodules/dimagi/utils/couch/debugdb/debugdatabase.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/debugdb/debugdatabase.py
@@ -227,8 +227,6 @@ class DebugViewResults57(ViewResults):
 
 if couchdbkit.version_info < (0, 6, 0):
     DebugViewResults = DebugViewResults57
-
-    couchdbkit.client.ViewResults = DebugViewResults57
 else:
     DebugViewResults = DebugViewResults64
 

--- a/corehq/ex-submodules/dimagi/utils/couch/resource_conflict.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/resource_conflict.py
@@ -7,8 +7,12 @@ class RetryResourceError(Exception):
     def __init__(self, fn, attempts):
         self.fn = fn
         self.attempts = attempts
+
     def __str__(self):
-        return repr("Tried function `%s` %s time(s) and conflicted every time." % (self.fn.__name__, self.attempts))
+        return repr(
+            f"Tried function `{self.fn.__name__}` {self.attempts} time(s) and "
+            "conflicted every time."
+        )
 
 
 def retry_resource(n):

--- a/corehq/ex-submodules/dimagi/utils/couch/undo.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/undo.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from dimagi.ext.couchdbkit import *
+
+from dimagi.ext.couchdbkit import DateTimeProperty, Document, StringProperty
 
 DELETED_SUFFIX = '-Deleted'
 

--- a/corehq/ex-submodules/dimagi/utils/decorators/datespan.py
+++ b/corehq/ex-submodules/dimagi/utils/decorators/datespan.py
@@ -1,9 +1,7 @@
 from datetime import datetime
-from django.http import HttpRequest, HttpResponseBadRequest
 from dimagi.utils.dates import DateSpan
 from dimagi.utils.django.request import request_from_args_or_kwargs
 from dimagi.utils.parsing import ISO_DATE_FORMAT
-import six
 
 
 def datespan_in_request(from_param="from", to_param="to",
@@ -17,9 +15,8 @@ def datespan_in_request(from_param="from", to_param="to",
     # if you don't it will pull the value from the last default_days
     # in. If you override default_function, default_days is ignored.
     if default_function is None:
-        default_function = lambda: DateSpan.since(default_days,
-                                                  format=format_string,
-                                                  inclusive=inclusive)
+        def default_function():
+            return DateSpan.since(default_days, format=format_string, inclusive=inclusive)
 
     # this is loosely modeled after example number 4 of decorator
     # usage here: http://www.python.org/dev/peps/pep-0318/

--- a/corehq/ex-submodules/dimagi/utils/django/cached_object.py
+++ b/corehq/ex-submodules/dimagi/utils/django/cached_object.py
@@ -1,5 +1,3 @@
-import hashlib
-import logging
 import os
 import simplejson
 from memoized import memoized

--- a/corehq/ex-submodules/dimagi/utils/django/cached_object.py
+++ b/corehq/ex-submodules/dimagi/utils/django/cached_object.py
@@ -125,8 +125,19 @@ class CachedImageMeta(CachedObjectMeta):
     width = 0
     meta_type = "image"
 
-    def __init__(self, size_key=OBJECT_ORIGINAL, width=0, height=0, content_length=0, content_type='application/octet-stream'):
-        super(CachedImageMeta, self).__init__(size_key=size_key, content_length=content_length, content_type=content_type)
+    def __init__(
+        self,
+        size_key=OBJECT_ORIGINAL,
+        width=0,
+        height=0,
+        content_length=0,
+        content_type='application/octet-stream',
+    ):
+        super().__init__(
+            size_key=size_key,
+            content_length=content_length,
+            content_type=content_type,
+        )
         self.width = width
         self.height = height
 
@@ -172,8 +183,11 @@ class CachedImageMeta(CachedObjectMeta):
 class CachedObject(object):
     def __init__(self, cache_key):
         """
-        cache_key is the supposedly unique cache key you will want to create for keeping track of your cacheable assets.
-        like cache.set(key, value) - it's the implementor's responsibility to make sure to have a universally unique cache key for the assets you want to cache.
+        ``cache_key`` is the supposedly unique cache key you will want
+        to create for keeping track of your cacheable assets. Like
+        ``cache.set(key, value)`` - it's the implementor's
+        responsibility to make sure to have a universally unique cache
+        key for the assets you want to cache.
         """
         self.cache_key = cache_key
 
@@ -324,7 +338,9 @@ class CachedImage(CachedObject):
         """
         rcache = self.rcache
         if not self.has_size(size_key):
-            #make size from the next available largest size (so if there's a small_320 and you want small, generate it from next size up
+            # make size from the next available largest size (so if
+            # there's a small_320 and you want small, generate it from
+            # next size up)
             size_seq = IMAGE_SIZE_ORDERING.index(size_key)
             source_key = OBJECT_ORIGINAL
             target_size = (OBJECT_SIZE_MAP[size_key]['width'], OBJECT_SIZE_MAP[size_key]['height'])
@@ -349,7 +365,11 @@ class CachedImage(CachedObject):
                 target_handle = io.BytesIO()
                 target_image_obj.save(target_handle, mime_ext)
                 target_handle.seek(0)
-                target_meta = CachedImageMeta.make_meta(target_handle, size_key, metadata={'content_type': source_meta.content_type})
+                target_meta = CachedImageMeta.make_meta(
+                    target_handle,
+                    size_key,
+                    metadata={'content_type': source_meta.content_type}
+                )
 
                 rcache.set(self.stream_key(size_key), target_handle.read())
                 rcache.set(self.meta_key(size_key), simplejson.dumps(target_meta.to_json()))

--- a/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py
+++ b/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py
@@ -68,18 +68,18 @@ class ProfileMiddleware(MiddlewareMixin):
         sum = 0
 
         for s in stats_str:
-            fields = words_re.split(s);
+            fields = words_re.split(s)
             if len(fields) == 7:
                 time = float(fields[2])
                 sum += time
                 file = fields[6].split(":")[0]
 
-                if not file in mystats:
+                if file not in mystats:
                     mystats[file] = 0
                 mystats[file] += time
 
                 group = self.get_group(file)
-                if not group in mygroups:
+                if group not in mygroups:
                     mygroups[ group ] = 0
                 mygroups[ group ] += time
 

--- a/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py
+++ b/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py
@@ -5,7 +5,8 @@
 import sys
 import os
 import re
-import hotshot, hotshot.stats
+import hotshot
+import hotshot.stats
 import tempfile
 import StringIO
 

--- a/corehq/ex-submodules/dimagi/utils/django/settingsutil.py
+++ b/corehq/ex-submodules/dimagi/utils/django/settingsutil.py
@@ -29,4 +29,6 @@ def default_logging(logfile):
         handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(message)s'))
         root.addHandler(handler)
 
-from dimagi.utils.repo import get_revision
+
+# Fetch repo revision info
+from dimagi.utils.repo import get_revision  # noqa: E402, F401

--- a/corehq/ex-submodules/dimagi/utils/management/commands/prime_views.py
+++ b/corehq/ex-submodules/dimagi/utils/management/commands/prime_views.py
@@ -1,14 +1,18 @@
 from couchdbkit.exceptions import ResourceNotFound
-# http://www.gevent.org/gevent.monkey.html#module-gevent.monkey
-from gevent import monkey; monkey.patch_all()
-import sys
-import gevent
-from gevent.pool import Pool
-from django.core.management.base import BaseCommand
 
-from django.conf import settings
+# https://www.gevent.org/api/gevent.monkey.html#use-as-a-module
+from gevent import monkey
+monkey.patch_all()
+
+import sys  # noqa: E402
+import gevent  # noqa: E402
+from gevent.pool import Pool  # noqa: E402
+from django.core.management.base import BaseCommand  # noqa: E402
+
+from django.conf import settings  # noqa: E402
 setattr(settings, 'COUCHDB_TIMEOUT', 999999)
-from couchdbkit.ext.django.loading import get_db
+
+from couchdbkit.ext.django.loading import get_db  # noqa: E402
 
 DESIGN_DOC_VIEW = '_all_docs'
 DESIGN_SK = "_design"
@@ -65,7 +69,12 @@ class Command(BaseCommand):
         for app in unique_dbs:
             try:
                 db = get_db(app)
-                design_docs = db.view(DESIGN_DOC_VIEW, startkey=DESIGN_SK, endkey=DESIGN_EK, include_docs=True).all()
+                design_docs = db.view(
+                    DESIGN_DOC_VIEW,
+                    startkey=DESIGN_SK,
+                    endkey=DESIGN_EK,
+                    include_docs=True
+                ).all()
                 for res in design_docs:
                     design_doc = res['doc']
                     design_doc_name = design_doc['_id'].split('/')[-1]  # _design/app_name

--- a/corehq/ex-submodules/dimagi/utils/memory/utils.py
+++ b/corehq/ex-submodules/dimagi/utils/memory/utils.py
@@ -26,7 +26,9 @@ def total_size(o, handlers={}, verbose=False):
         print(total_size(d, verbose=True))
 
     """
-    dict_handler = lambda d: chain.from_iterable(list(d.items()))
+    def dict_handler(d):
+        return chain.from_iterable(list(d.items()))
+
     all_handlers = {
         tuple: iter,
         list: iter,

--- a/corehq/ex-submodules/dimagi/utils/parsing.py
+++ b/corehq/ex-submodules/dimagi/utils/parsing.py
@@ -12,7 +12,8 @@ def string_to_boolean(val):
     A very dumb string to boolean converter.  Will fail hard
     if the conversion doesn't succeed.
     """
-    if val is None: return False
+    if val is None:
+        return False
     if isinstance(val, bool):
         return val
     if val.lower().strip() in TRUE_STRINGS:

--- a/corehq/ex-submodules/dimagi/utils/repo.py
+++ b/corehq/ex-submodules/dimagi/utils/repo.py
@@ -14,7 +14,7 @@ def get_revision(vcs, reporoot, dirtyfunc=lambda rev, **kw: rev + '*'):
         return None
 
     rev, dirty = revinfo
-    return dirtyfunc(rev, repo=reporoot, vcs=vcs) if dirty and dirtyfunc != None else rev
+    return dirtyfunc(rev, repo=reporoot, vcs=vcs) if dirty and dirtyfunc is not None else rev
 
 
 def get_raw_revision(vcs, reporoot, untracked_is_dirty=False):
@@ -35,7 +35,8 @@ def get_raw_revision(vcs, reporoot, untracked_is_dirty=False):
         }
     }
     
-    exec_ = lambda cmd: shell_exec(cmd, reporoot)
+    def exec_(cmd):
+        return shell_exec(cmd, reporoot)
 
     rev = funcs[vcs]['rev'](exec_)
     if rev:

--- a/corehq/ex-submodules/dimagi/utils/system.py
+++ b/corehq/ex-submodules/dimagi/utils/system.py
@@ -15,7 +15,7 @@ def shell_exec(cmd, cwd=None):
     note: common directories will be automatically added to the syspath"""
     try:
         return shell_exec_checked(cmd, cwd)
-    except ShellCommandError as e:
+    except ShellCommandError:
         logging.exception('error executing command [%s]' % cmd)
         return None
 


### PR DESCRIPTION
## Technical Summary

Linting with [Ruff](https://beta.ruff.rs/docs/).

This change makes this command pass:
```bash
$ ruff check corehq/ex-submodules/dimagi/utils/
```

It was run with the following configuration:
```toml
[tool.ruff]
# Code review in a maximized browser at 1920x1080 wraps after 115
line-length = 115

# CommCare HQ uses Python 3.9
target-version = "py39"

[tool.ruff.per-file-ignores]
# Ignore in all `__init__.py` files:
# * `F401` imported but unused
# * `F403` `from ... import *` used; unable to detect undefined names
"__init__.py" = ["F401", "F403"]

# Ignore `E501` (Line too long) in migrations
"*/migrations/*" = ["E501"]
```

Commits daefb546497 and 4818dba130e are not just linting. They fix bare exceptions.

I tested that trying to fetch a cache that is not defined raises `InvalidCacheBackendError`.

But I _assumed_ that when `DebugViewResultsXX` tries to delete an attribute that does not exist, it is going to get an `AttributeError`, but I did not test this. It seems `debugdatabase` is only used for profiling, manually, and not used anywhere in the codebase.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Almost all lint. Non-lint changes are tested or not used in the codebase.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
