### PR TITLE
Add support for throttling reindex and setting replicas after reindex

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -387,8 +387,11 @@ class ElasticManageAdapter(BaseAdapter):
         elif "*" in index:
             raise ValueError(f"refusing to operate with index wildcards: {index}")
 
-    def reindex(self, source, dest, wait_for_completion=False,
-                refresh=False, batch_size=1000, purge_ids=False):
+    def reindex(
+            self, source, dest, wait_for_completion=False,
+            refresh=False, batch_size=1000, purge_ids=False,
+            requests_per_second=None,
+    ):
         """
         Starts the reindex process in elastic search cluster
 
@@ -396,6 +399,8 @@ class ElasticManageAdapter(BaseAdapter):
         :param dest: ``str`` name of the destination index
         :param wait_for_completion: ``bool`` would block the request until reindex is complete
         :param refresh: ``bool`` refreshes index
+        :param requests_per_second: ``int`` throttles rate at which reindex issues batches of
+                            index operations by padding each batch with a wait time.
         :param batch_size: ``int`` The size of the scroll batch used by the reindex process. larger
                            batches may process more quickly but risk errors if the documents are too
                            large. 1000 is the recommended maximum and elasticsearch default,
@@ -426,11 +431,15 @@ class ElasticManageAdapter(BaseAdapter):
         if purge_ids:
             reindex_body["script"] = {"inline": "if (ctx._source._id) {ctx._source.remove('_id')}"}
 
-        reindex_info = self._es.reindex(
-            reindex_body,
-            wait_for_completion=wait_for_completion,
-            refresh=refresh
-        )
+        reindex_kwargs = {
+            "wait_for_completion": wait_for_completion,
+            "refresh": refresh,
+        }
+
+        if requests_per_second:
+            reindex_kwargs["requests_per_second"] = requests_per_second
+
+        reindex_info = self._es.reindex(reindex_body, **reindex_kwargs)
         if not wait_for_completion:
             return reindex_info['task']
 

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -344,6 +344,10 @@ class Command(BaseCommand):
         ./manage.py elastic_sync_multiplexed copy_checkpoints <index_cname>
         ```
 
+    If replicas are not set during the time of reindex, they can be set on secondary index by
+        ```bash
+        ./manage.py elastic_sync_multiplexed set_replicas <index_cname>
+        ```
     """
 
     help = ("Reindex management command to sync Multiplexed HQ indices")
@@ -440,6 +444,15 @@ class Command(BaseCommand):
             help="""Cannonical Name of the index whose checkpoints are to be copied""",
         )
 
+        # Set replicas for secondary index
+        set_replicas_cmd = subparsers.add_parser("set_replicas")
+        set_replicas_cmd.set_defaults(func=self.es_helper.set_replicas_for_secondary_index)
+        set_replicas_cmd.add_argument(
+            'index_cname',
+            choices=INDEXES,
+            help="""Cannonical Name of the index whose replicas are to be set"""
+        )
+
     def handle(self, **options):
         sub_cmd = options['sub_command']
         cmd_func = options.get('func')
@@ -459,3 +472,5 @@ class Command(BaseCommand):
             cmd_func(stdout=self.stdout)
         elif sub_cmd == 'copy_checkpoints':
             cmd_func(options['index_cname'])
+        elif sub_cmd == 'set_replicas':
+            cmd_func(options["index_cname"])

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -78,6 +78,12 @@ class ESSyncUtil:
             logger.info("Preparing Index for normal use")
             self._prepare_index_for_normal_usage(adapter.secondary)
             print("\n\n")
+        else:
+            logger.info(f"Replicas are not being set for index {destination_index}")
+            logger.info("You can manually set them by running")
+            print("\n\n")
+            print(f"\t./manage.py elastic_sync_multiplexed set_replicas {cname}")
+            print("\n\n")
 
         self._get_source_destination_doc_count(adapter)
 

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -84,7 +84,7 @@ class ESSyncUtil:
         logger.info("You can use commcare-cloud to extract reindex logs from cluster")
         print("\n\t"
             + f"cchq {settings.SERVER_ENVIRONMENT} run-shell-command elasticsearch "
-            + f"\"grep '{task_id}.*ReindexResponse' /opt/data/elasticsearch*/logs/*es.log\""
+            + f"\"grep '{task_id}.*ReindexResponse' /opt/data/elasticsearch*/logs/*.log\""
             + "\n\n")
 
     def _get_source_destination_indexes(self, adapter):

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -366,6 +366,14 @@ class Command(BaseCommand):
                  "but is necessary if existings docs contain _ids in the source, as it is now a reserved property."
         )
 
+        start_cmd.add_argument(
+            "--requests_per_second",
+            default=None,
+            type=int,
+            help="""throttles rate at which reindex issues batches of
+                    index operations by padding each batch with a wait time"""
+        )
+
         # Get ReIndex Process Status
         status_cmd = subparsers.add_parser("status")
         status_cmd.set_defaults(func=self.es_helper.reindex_status)
@@ -415,7 +423,10 @@ class Command(BaseCommand):
         sub_cmd = options['sub_command']
         cmd_func = options.get('func')
         if sub_cmd == 'start':
-            cmd_func(options['index_cname'], options['batch_size'], options['purge_ids'])
+            cmd_func(
+                options['index_cname'], options['batch_size'],
+                options['purge_ids'], options['requests_per_second']
+            )
         elif sub_cmd == 'delete':
             cmd_func(options['index_cname'])
         elif sub_cmd == 'cleanup':

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -40,7 +40,7 @@ class ESSyncUtil:
     def __init__(self):
         self.es = get_client()
 
-    def start_reindex(self, cname, reindex_batch_size=1000, purge_ids=False):
+    def start_reindex(self, cname, reindex_batch_size=1000, purge_ids=False, requests_per_second=None):
 
         adapter = doc_adapter_from_cname(cname)
 
@@ -56,7 +56,8 @@ class ESSyncUtil:
         logger.info("Starting ReIndex process")
         task_info = es_manager.reindex(
             source_index, destination_index,
-            batch_size=reindex_batch_size, purge_ids=purge_ids
+            batch_size=reindex_batch_size, purge_ids=purge_ids,
+            requests_per_second=requests_per_second
         )
         logger.info(f"Copying docs from index {source_index} to index {destination_index}")
         task_id = task_info.split(':')[1]

--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -474,6 +474,30 @@ class TestElasticManageAdapter(AdapterWithIndexTestCase):
             self.adapter.index_refresh(self.index)
             patched.assert_called_once_with([self.index])
 
+    def test_reindex_with_all_params(self):
+        """A happy path test for all the reindex paramters passed to es client.
+        Should ensure validity of reindex api params in newer versions of ES.
+        If any new parameters are added to ElasticManageAdapter.reindex then they should be added in this test
+        """
+        SECONDARY_INDEX = 'secondary_index'
+
+        with temporary_index(test_adapter.index_name, test_adapter.type, test_adapter.mapping):
+
+            all_ids = self._index_test_docs_for_reindex()
+
+            with temporary_index(SECONDARY_INDEX, test_adapter.type, test_adapter.mapping):
+
+                # purge_ids is not added here as it is required temporarily
+                # And setting it would require turning on inline script updates on test es docker
+                manager.reindex(
+                    test_adapter.index_name, SECONDARY_INDEX,
+                    wait_for_completion=True,
+                    refresh=True,
+                    requests_per_second=2,
+                )
+
+                self.assertEqual(self._get_all_doc_ids_in_index(SECONDARY_INDEX), all_ids)
+
     def test_reindex_with_wait_for_completion_is_true(self):
         SECONDARY_INDEX = 'secondary_index'
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi-dev.atlassian.net/browse/SAAS-14752
While reindexing `case-search` we encountered couple of errors described in the ticket above.  So to work around these we are adding the ability of throttling scroll queries that ElasticSearch makes in the reindex. 
This PR also adds the ability to skip creating replicas during the reindex and adds a management command to perform that later.

Review by 🐟 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Tested locally only affects reindex command
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
Changes covered by tests
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
