### PR TITLE
Hide previously GA'ed show_owner_location_property_in_report_builder feature from non-grandfather-privileged projects

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -95,7 +95,7 @@ from corehq.toggles import (
 )
 from corehq import privileges
 from dimagi.utils.couch.undo import undo_delete
-from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.toggles import domain_has_privilege_from_toggle
 
 STATIC_CASE_PROPS = [
     "closed",
@@ -808,7 +808,7 @@ class CaseDataSourceHelper(ManagedReportBuilderDataSourceHelper):
         if SHOW_IDS_IN_REPORT_BUILDER.enabled(self.domain):
             properties['case_id'] = self._get_case_id_pseudo_property()
 
-        if domain_has_privilege(self.domain, privileges.SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER):
+        if domain_has_privilege_from_toggle(privileges.SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER, self.domain):
             properties[COMPUTED_OWNER_LOCATION_PROPERTY_ID] = self._get_owner_location_pseudo_property()
             properties[COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID] = \
                 self._get_owner_location_with_descendants_pseudo_property()

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -146,7 +146,7 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
         self.assertEqual('first_name', first_name_prop.get_id())
         self.assertEqual('first name', first_name_prop.get_text())
 
-    @patch('corehq.apps.userreports.reports.builder.forms.domain_has_privilege', return_value=True)
+    @patch('corehq.apps.userreports.reports.builder.forms.domain_has_privilege_from_toggle', return_value=True)
     def test_owner_as_location(self, *args):
         builder = ApplicationCaseDataSourceHelper(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
 


### PR DESCRIPTION
A note about this PR:
This PR is created as a result of [this comment](https://dimagi-dev.atlassian.net/browse/SC-2912?focusedCommentId=276931). After the `show_owner_location_property_in_report_builder` FF [was GA'ed](https://github.com/dimagi/commcare-hq/pull/33132), it was determined that the features that this FF brought to the table is already achievable by the default standard behaviour of reports in HQ, hence making the GA-ing of the FF redundant.

_We've recently had a discussion in SolTech regarding the process of GA-ing feature flags and determined that a more thorough investigation is needed before a FF is GA'ed where an acceptable outcome could also be not to GA a FF or to deprecate it (as would have been in this case). The GA-ing of this particular FF was done before this discussion and I did not do a thorough investigation into the necessity of the FF before GA-ing it, hence this follow-up PR._   

## Product Description
A feature flag was recently GA'ed which allowed for the following columns and filters to be added to UCRs:
- Case Owner (Location)
- Case Owner (Location w/ Descendants)
- Case Owner (Location w/ Descendants and Archived Locations)

(See screenshot of UI)
![image](https://github.com/dimagi/commcare-hq/assets/44245062/cf039f3a-9500-4d3a-b0db-66a8929e5685)

This PR hides this behaviour from all projects which did not have the FF that was GA'ed enabled before the GA-ing. After this PR all projects would still have the relevant project permission that resulted from the GA-ing, although it's technically a redundant permission.

_Why not simply roll back the GA-ing PR?_

Rolling back the GA-ing PR is much more risky than simply hiding the functionality from the UI. Hiding it is by far the "quickest win", also considering that this is a temporary measure of "removing" it from the UI until we've reached out to all projects that is using this FF and confirmed it's OK to deprecate this feature (hence a PR might follow where we completely remove this behaviour from the code).

No documentation exists currently (in the spirit of why the SolTech discussion was held), so no updates needed there.

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2912)

Hiding this feature involves simply checking whether a domain have the frozen toggle enabled (domain_has_privilege_from_toggle), since a GA'ed FF becomes a frozen toggle, enabling projects which had it enabled access to the feature. 

Before this PR we checked whether a domain have access to this feature by invoking `domain_has_privilege`, which checks
1) whether a project have the correct subscription plan OR
2) whether a project have the frozen toggle enabled (grandfather privileges)

This PR simply checks the latter, effectively removing access to the feature without having the frozen toggle enabled. 

## Feature Flag
Behaviour will technically affect everyone.

## Safety Assurance

### Safety story
Local testing:
1) Created a project report by making use of this feature, i.e. have a column and filter defined with new dropdown items; this simulates any new project making use of the feature after it's been GA'ed.
2) Made the change of this PR
3) Checked whether the report still works: everything is fine, except the column is removed and the filter is not visible, thus making it seem like the feature never existed.

Testing on staging:
1) Found a project which have the frozen toggle enabled (thus have grandfather privileges).
2) Confirmed that this project still have access to this feature.

### Automated test coverage
No automated tests.

### QA Plan
No formal QA planned. Manual testing should suffice.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
