### PR TITLE
Fix a bug with alerts & case update rules "ANY" option

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -545,7 +545,7 @@ class CaseRuleCriteriaTest(BaseCaseRuleTest):
             set_case_property_directly(case, 'def', '456x')
             _save_case(self.domain, case)
             case = CommCareCase.objects.get_case(case.case_id, self.domain)
-            self.assertTrue(rule.criteria_match(case, datetime(2022, 4, 15)))  # Notice assert True instead
+            self.assertTrue(rule.criteria_match(case, datetime(2022, 4, 15)))
 
             case.server_modified_on = datetime(2022, 4, 1)
             set_case_property_directly(case, 'abc', '123x')
@@ -555,6 +555,15 @@ class CaseRuleCriteriaTest(BaseCaseRuleTest):
             self.assertTrue(rule.criteria_match(case, datetime(2022, 4, 15)))
 
             case.server_modified_on = datetime(2022, 4, 14)
+            set_case_property_directly(case, 'abc', '123x')
+            set_case_property_directly(case, 'def', '456x')
+            _save_case(self.domain, case)
+            case = CommCareCase.objects.get_case(case.case_id, self.domain)
+            self.assertFalse(rule.criteria_match(case, datetime(2022, 4, 15)))
+
+            rule.filter_on_server_modified = False
+            rule.server_modified_boundary = None
+            rule.save()
             set_case_property_directly(case, 'abc', '123x')
             set_case_property_directly(case, 'def', '456x')
             _save_case(self.domain, case)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR fixes an existing bug with conditional alerts & case update rules ([jira support ticket](https://dimagi-dev.atlassian.net/browse/SUPPORT-17160?atlOrigin=eyJpIjoiZDVmYjA2ZDBhMTM0NDRjOGJlZTE2MGMxYTc2OWRhOWMiLCJwIjoiaiJ9)) where the rule/alert _always_ fires when the "ANY" option is chosen for the rule. It only doesn't fire when the "case not modified since" setting is used on the rule. We believe this bug was introduced when the ANY option was originally introduced (#31540), and simply wasn't noticed until now because USH projects were the main customers of this feature and often used the "case not modified since" setting. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The logic was set up such that if `filter_on_server_modified` was `False`, the rule would always fire for the "ANY" option. This PR fixes that logic.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

We've tested conditional alerts on staging, and tested case update rules in a django shell session.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

This PR changes tests to cover the original bug.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
