### PR TITLE
Make .map css class use isolated stacking context

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/css/webforms.css
+++ b/corehq/apps/hqwebapp/static/cloudcare/css/webforms.css
@@ -78,6 +78,7 @@ input:invalid {
   height: 250px;
   background: #eee;
   max-width: none !important;
+  isolation: isolate;
 }
 
 .coordinate {


### PR DESCRIPTION
## Product Description
Fixes the issue of map controls overlaying the control bar in forms in web apps, which is particularly noticeable on small screens.
<img width="377" alt="image" src="https://github.com/dimagi/commcare-hq/assets/100609770/85198132-7e9f-41fe-a678-71e3e29ca1c0"> => <img width="377" alt="image" src="https://github.com/dimagi/commcare-hq/assets/100609770/5c324cb8-72db-407e-8622-a8d73fdd327c">


## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3363
Applies the css property `isolation` to the existing `.map` class in web apps forms, which creates a new stacking context for the element. This fixes stacking issues that come from Leaflet's controls having really high `z-index` values, without having to manually adjust those values.

## Safety Assurance

### Safety story
Minor change to CSS only.

### Automated test coverage

n/a

### QA Plan
No QA requested.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
