### PR TITLE
Lint corehq/apps/reports

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -1,5 +1,5 @@
 from collections import defaultdict, namedtuple
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.conf import settings
 

--- a/corehq/apps/reports/commtrack/maps.py
+++ b/corehq/apps/reports/commtrack/maps.py
@@ -59,7 +59,9 @@ class StockStatusMapReport(GenericMapReport, CommtrackReportMixin):
         if self.program_id:
             products = [c for c in products if c.program_id == self.program_id]
         for p in products:
-            col_id = lambda c: '%s-%s' % (p._id, c)
+
+            def col_id(c):
+                return "%s-%s" % (p._id, c)
 
             product_cols = []
             for c in ('category', 'current_stock', 'months_remaining', 'consumption'):

--- a/corehq/apps/reports/filters/base.py
+++ b/corehq/apps/reports/filters/base.py
@@ -43,7 +43,8 @@ class BaseReportFilter(object):
     @property
     def is_disabled(self):
         """
-            If necessary, determine whether to show this filter based on the results of surrounding (related) filters.
+        If necessary, determine whether to show this filter based on the
+        results of surrounding (related) filters.
         """
         return False
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -183,7 +183,7 @@ class EmwfUtils(object):
             raise Exception("Unexpcted id: {}".format(id_))
 
         if hasattr(owner, 'is_deleted'):
-            if (callable(owner.is_deleted) and owner.is_deleted()) or owner.is_deleted == True:
+            if (callable(owner.is_deleted) and owner.is_deleted()) or owner.is_deleted is True:
                 # is_deleted may be an attr or callable depending on owner type
                 ret = (ret[0], 'Deleted - ' + ret[1])
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -250,11 +250,13 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
 
     @staticmethod
     def selected_reporting_group_ids(mobile_user_and_group_slugs):
-        return [g[3:] for g in mobile_user_and_group_slugs if g.startswith("g__")]
+        return [grp[3:] for grp in mobile_user_and_group_slugs
+                if grp.startswith("g__")]
 
     @staticmethod
     def selected_location_ids(mobile_user_and_group_slugs):
-        return [l[3:] for l in mobile_user_and_group_slugs if l.startswith("l__")]
+        return [loc[3:] for loc in mobile_user_and_group_slugs
+                if loc.startswith("l__")]
 
     @staticmethod
     def show_all_mobile_workers(mobile_user_and_group_slugs):

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -183,7 +183,7 @@ class EmwfUtils(object):
             raise Exception("Unexpcted id: {}".format(id_))
 
         if hasattr(owner, 'is_deleted'):
-            if (callable(owner.is_deleted) and owner.is_deleted()) or owner.is_deleted is True:
+            if (callable(owner.is_deleted) and owner.is_deleted()) or owner.is_deleted:
                 # is_deleted may be an attr or callable depending on owner type
                 ret = (ret[0], 'Deleted - ' + ret[1])
 

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -142,7 +142,10 @@ class GenericReportView(object):
     show_time_notice = False
     is_admin_report = False
     special_notice = None
-    override_permissions_check = False # whether to ignore the permissions check that's done when rendering the report
+
+    # whether to ignore the permissions check that's done when rendering
+    # the report
+    override_permissions_check = False
 
     report_title = None
     report_subtitles = []
@@ -159,13 +162,11 @@ class GenericReportView(object):
 
     def __init__(self, request, base_context=None, domain=None, **kwargs):
         if not self.name or not self.section_name or self.slug is None or not self.dispatcher:
-            raise NotImplementedError("Missing a required parameter: (name: %(name)s, section_name: %(section_name)s,"
-            " slug: %(slug)s, dispatcher: %(dispatcher)s" % dict(
-                name=self.name,
-                section_name=self.section_name,
-                slug=self.slug,
-                dispatcher=self.dispatcher
-            ))
+            raise NotImplementedError(
+                f'Missing a required parameter: (name: {self.name}, '
+                f'section_name: {self.section_name}, slug: {self.slug}, '
+                f'dispatcher: {self.dispatcher}'
+            )
 
         from corehq.apps.reports.dispatcher import ReportDispatcher
         if isinstance(self.dispatcher, ReportDispatcher):
@@ -181,13 +182,18 @@ class GenericReportView(object):
         self.override_template = "reports/async/email_report.html"
 
     def __str__(self):
-        return "%(klass)s report named '%(name)s' with slug '%(slug)s' in section '%(section)s'.%(desc)s%(fields)s" % dict(
-            klass=self.__class__.__name__,
-            name=self.name,
-            slug=self.slug,
-            section=self.section_name,
-            desc="\n   Report Description: %s" % self.description if self.description else "",
-            fields="\n   Report Fields: \n     -%s" % "\n     -".join(self.fields) if self.fields else ""
+        if self.fields:
+            field_lines = "\n     -".join(self.fields)
+            fields = f"\n   Report Fields: \n     -{field_lines}"
+        else:
+            fields = ""
+        if self.description:
+            desc = f"\n   Report Description: {self.description}"
+        else:
+            desc = ""
+        return (
+            f"{self.__class__.__name__} report named '{self.name}' with slug "
+            f"'{self.slug}' in section '{self.section_name}'.{desc}{fields}"
         )
 
     def __getstate__(self):

--- a/corehq/apps/reports/graph_models.py
+++ b/corehq/apps/reports/graph_models.py
@@ -43,11 +43,14 @@ class MultiBarChart(Chart):
         reduceXTicks: True to reduce the number of X ticks
         rotateLabels: Degrees to rotate X-Axis labels e.g. -45
         tooltips: True to show tooltips
-        tooltipFormat: Seperator text bw x,y values in tooltipContent e.g." in ", " on  "
+        tooltipFormat: Seperator text bw x,y values in tooltipContent
+                       e.g." in ", " on  "
         stacked: True to make default view stacked, False for grouped
         staggerLabels: True to stagger the X-Axis labels.
-        groupSpacing: Used to adjust amount of space between X-Axis groups. Value between 0 and 1.
-        forceY: Used to force values into the Y scale domain. Useful to ensure max / min scales. Must be list of numbers
+        groupSpacing: Used to adjust amount of space between X-Axis
+                      groups. Value between 0 and 1.
+        forceY: Used to force values into the Y scale domain. Useful to
+                ensure max / min scales. Must be list of numbers
         translateLabelsX: Pixels to move X-Axis labels in X direction
         translateLabelsY: Pixels to move X-Axis labels in Y direction
 
@@ -111,8 +114,9 @@ class MultiBarChart(Chart):
 class PieChart(Chart):
     """
     :param title: The chart title
-    "param key: The name of the dataset
-    "param values: List of dicts each with 'label' and 'value' keys e.g. [{'label': 'One', 'value': 1}, ...]
+    :param key: The name of the dataset
+    :param values: List of dicts each with 'label' and 'value' keys
+                   e.g. [{'label': 'One', 'value': 1}, ...]
 
     Class fields:
         marginTop: Top Margin in pixels
@@ -127,7 +131,8 @@ class PieChart(Chart):
     template_partial = 'reports/partials/graphs/pie_chart.html'
 
     def __init__(self, title, key, values, color=None):
-        if not color: color = []
+        if not color:
+            color = []
         self.title = title
         self.data = [dict(key=key, values=values)]
         self.marginTop = 30

--- a/corehq/apps/reports/migrations/0002_auto_20171121_1803.py
+++ b/corehq/apps/reports/migrations/0002_auto_20171121_1803.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 import jsonfield.fields
 
-import corehq.apps.reports.models
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/reports/sqlreport.py
+++ b/corehq/apps/reports/sqlreport.py
@@ -17,7 +17,6 @@ from corehq.apps.reports.datatables import (
 )
 from corehq.apps.reports.util import format_datatables_data
 from corehq.sql_db.connections import DEFAULT_ENGINE_ID, connection_manager
-from corehq.util.soft_assert import soft_assert
 
 
 class SqlReportException(Exception):

--- a/corehq/apps/reports/sqlreport.py
+++ b/corehq/apps/reports/sqlreport.py
@@ -58,30 +58,33 @@ class DatabaseColumn(Column):
 
     def __init__(self, header, agg_column, format_fn=None, slug=None, *args, **kwargs):
         """
-        Args:
-            :param header:
-                The column header.
-            :param args:
-                Additional positional arguments will be passed on when creating the DataTablesColumn
-            :param agg_column:
-                Instance of sqlagg column class. See sqlagg.columns.BaseColumn
-        Kwargs:
-            :param header_group=None:
-                An instance of corehq.apps.reports.datatables.DataTablesColumnGroup to which this column header will
-                be added.
-            :param sortable:
-                Indicates if the column should be sortable. If true and no format_fn is provided then
-                the default datatables format function is used. Defaults to True.
-            :param sort_type:
-                See corehq.apps.reports.datatables.DTSortType
-            :param format_fn=None:
-                Function to apply to value before display. Useful for formatting and sorting.
-                See corehq.apps.reports.util.format_datatables_data
-            :param slug=None:
-                Unique ID for the column. If not supplied assumed to be 'agg_column.name'.
-                This is used by the Report API.
-            :param kwargs:
-                Additional keyword arguments will be passed on when creating the DataTablesColumn
+        :param header:
+            The column header.
+        :param agg_column:
+            Instance of sqlagg column class. See sqlagg.columns.BaseColumn
+        :param args:
+            Additional positional arguments will be passed on when
+            creating the DataTablesColumn
+        :param kwargs:
+            Additional keyword arguments will be passed on when creating
+            the DataTablesColumn
+
+        :keyword header_group=None:
+            An instance of corehq.apps.reports.datatables.DataTablesColumnGroup
+            to which this column header will be added.
+        :keyword sortable:
+            Indicates if the column should be sortable. If true and no
+            format_fn is provided then the default datatables format
+            function is used. Defaults to True.
+        :keyword sort_type:
+            See corehq.apps.reports.datatables.DTSortType
+        :keyword format_fn=None:
+            Function to apply to value before display. Useful for
+            formatting and sorting.
+            See corehq.apps.reports.util.format_datatables_data
+        :keyword slug=None:
+            Unique ID for the column. If not supplied assumed to be
+            'agg_column.name'. This is used by the Report API.
 
         """
         self.slug = slug or agg_column.name
@@ -115,25 +118,27 @@ class AggregateColumn(Column):
 
     def __init__(self, header, aggregate_fn, columns, format_fn=None, slug=None, **kwargs):
         """
-        Args:
-            :param header:
-                The column header.
-            :param aggregate_fn:
-                The function used to aggregate the individual values into a single value.
-            :param columns:
-                List of columns (instances of sqlagg.BaseColumn).
-        Kwargs:
-            :param format_fn=None:
-                Function to apply to value before display. Useful for formatting and sorting.
-                See corehq.apps.reports.util.format_datatables_data
-            :param slug=None:
-                Unique ID for the column. If not supplied assumed to be slugify(header).
-                This is used by the Report API.
-            :param sortable:
-                Indicates if the column should be sortable. If true and no format_fn is provided then
-                the default datatables format function is used. Defaults to True.
-            :param sort_type:
-                See corehq.apps.reports.datatables.DTSortType
+        :param header:
+            The column header.
+        :param aggregate_fn:
+            The function used to aggregate the individual values into a
+            single value.
+        :param columns:
+            List of columns (instances of sqlagg.BaseColumn).
+
+        :keyword format_fn=None:
+            Function to apply to value before display. Useful for
+            formatting and sorting.
+            See corehq.apps.reports.util.format_datatables_data
+        :keyword slug=None:
+            Unique ID for the column. If not supplied assumed to be
+            slugify(header). This is used by the Report API.
+        :keyword sortable:
+            Indicates if the column should be sortable. If true and no
+            format_fn is provided then the default datatables format
+            function is used. Defaults to True.
+        :keyword sort_type:
+            See corehq.apps.reports.datatables.DTSortType
         """
         self.aggregate_fn = aggregate_fn
         self.slug = slug or slugify(header)
@@ -224,12 +229,14 @@ class SqlData(ReportDataSource):
     @memoized
     def keys(self):
         """
-        The list of report keys (e.g. users) or None to just display all the data returned from the query. Each value
-        in this list should be a list of the same dimension as the 'group_by' list. If group_by is None then keys
-        must also be None.
+        The list of report keys (e.g. users) or None to just display all
+        the data returned from the query. Each value in this list
+        should be a list of the same dimension as the 'group_by' list.
+        If group_by is None then keys must also be None.
 
-        These allow you to specify which rows you expect in the output data.
-        Its main use is to add rows for keys that don’t exist in the data.
+        These allow you to specify which rows you expect in the output
+        data. Its main use is to add rows for keys that don’t exist in
+        the data.
 
         e.g.
             group_by = ['region', 'sub_region']

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -24,10 +24,8 @@ from corehq.apps.reports.standard.cases.utils import (
     query_location_restricted_cases,
 )
 from corehq.apps.reports.standard.inspect import ProjectInspectionReport
-from corehq.const import USER_DATETIME_FORMAT_WITH_SEC
 from corehq.elastic import ESError
 from corehq.toggles import CASE_LIST_EXPLORER
-from corehq.util.timezones.conversions import PhoneTime
 
 from .data_sources import CaseDisplayES
 

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -127,7 +127,10 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
             raise ValueError("Case object is not in search result %s" % row)
 
         if case_dict['domain'] != self.domain:
-            raise Exception("case.domain != self.domain; %r and %r, respectively" % (case_dict['domain'], self.domain))
+            raise Exception(
+                f"case.domain != self.domain; {case_dict['domain']!r} and "
+                f"{self.domain!r}, respectively"
+            )
 
         return case_dict
 
@@ -182,7 +185,12 @@ class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
         if self.can_upgrade_to_case_list_explorer:
             messages.warning(
                 self.request,
-                'Hey Dimagi User! Have you tried out the <a href="https://confluence.dimagi.com/display/saas/Case+List+Explorer" target="_blank">Case List Explorer</a> yet? It might be just what you are looking for!',
+
+                'Hey Dimagi User! Have you tried out the <a href="https://'
+                'confluence.dimagi.com/display/saas/Case+List+Explorer" '
+                'target="_blank">Case List Explorer</a> yet? It might be just '
+                'what you are looking for!',
+
                 extra_tags='html',
             )
         return super(CaseListReport, self).view_response

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -34,7 +34,12 @@ from corehq.const import MISSING_APP_ID
 from corehq.toggles import SUPPORT
 
 
-class ProjectInspectionReport(ProjectInspectionReportParamsMixin, GenericTabularReport, ProjectReport, ProjectReportParametersMixin):
+class ProjectInspectionReport(
+    ProjectInspectionReportParamsMixin,
+    GenericTabularReport,
+    ProjectReport,
+    ProjectReportParametersMixin
+):
     """
         Base class for this reporting section
     """

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -6,9 +6,7 @@ from memoized import memoized
 
 from corehq.apps.es import filters as es_filters
 from corehq.apps.es import forms as form_es
-from corehq.apps.es.filters import match_all
 from corehq.apps.es.utils import track_es_report_load
-from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS_MAP
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.display import FormDisplay

--- a/corehq/apps/reports/standard/maps.py
+++ b/corehq/apps/reports/standard/maps.py
@@ -109,7 +109,8 @@ class GenericMapReport(ProjectReport, ProjectReportParametersMixin):
 
         DataSource = to_function(params['report'])
 
-        assert issubclass(DataSource, ReportDataSource), '[%s] does not implement the ReportDataSource API!' % params['report']
+        assert issubclass(DataSource, ReportDataSource), \
+            f"[{params['report']}] does not implement the ReportDataSource API!"
 
         return DataSource(config).get_data()
 

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -243,7 +243,8 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
         landmarks_param = landmarks_param if isinstance(landmarks_param, list) else []
         landmarks_param = [param for param in landmarks_param if isinstance(param, int)]
         landmarks = landmarks_param if landmarks_param else self._default_landmarks
-        return [('landmark_' + str(idx), datetime.timedelta(days=l)) for idx, l in enumerate(landmarks)]
+        return [('landmark_' + str(i), datetime.timedelta(days=lmk))
+                for i, lmk in enumerate(landmarks)]
 
     _default_milestone = 120
 

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -466,7 +466,8 @@ class MessageLogReport(BaseCommConnectLogReport):
                 return phone_number[0:7] if phone_number[0] == "+" else phone_number[0:6]
             return phone_number
 
-        get_direction = lambda d: self._fmt_direction(d)['html']
+        def get_direction(d):
+            return self._fmt_direction(d)['html']
 
         def get_timestamp(date_):
             timestamp = ServerTime(date_).user_time(self.timezone).done()

--- a/corehq/apps/reports/tests/sql_fixture.py
+++ b/corehq/apps/reports/tests/sql_fixture.py
@@ -1,29 +1,31 @@
 from datetime import date
 
 import sqlalchemy
-from sqlalchemy import *
+from sqlalchemy import DATE, INT, Column, String, Table
 
-from corehq.sql_db.connections import connection_manager, DEFAULT_ENGINE_ID
+from corehq.sql_db.connections import DEFAULT_ENGINE_ID, connection_manager
 
 metadata = sqlalchemy.MetaData()
 
-user_table = Table("user_report_data",
-                   metadata,
-                   Column("user", String(50), primary_key=True, autoincrement=False),
-                   Column("date", DATE, primary_key=True, autoincrement=False),
-                   Column("indicator_a", INT),
-                   Column("indicator_b", INT),
-                   Column("indicator_c", INT),
-                   Column("indicator_d", INT)
+user_table = Table(
+    'user_report_data',
+    metadata,
+    Column('user', String(50), primary_key=True, autoincrement=False),
+    Column('date', DATE, primary_key=True, autoincrement=False),
+    Column('indicator_a', INT),
+    Column('indicator_b', INT),
+    Column('indicator_c', INT),
+    Column('indicator_d', INT),
 )
 
-region_table = Table("region_report_data",
-                     metadata,
-                     Column("region", String(50), primary_key=True, autoincrement=False),
-                     Column("sub_region", String(50), primary_key=True, autoincrement=False),
-                     Column("date", DATE, primary_key=True, autoincrement=False),
-                     Column("indicator_a", INT),
-                     Column("indicator_b", INT)
+region_table = Table(
+    'region_report_data',
+    metadata,
+    Column('region', String(50), primary_key=True, autoincrement=False),
+    Column('sub_region', String(50), primary_key=True, autoincrement=False),
+    Column('date', DATE, primary_key=True, autoincrement=False),
+    Column('indicator_a', INT),
+    Column('indicator_b', INT),
 )
 
 
@@ -35,25 +37,98 @@ def load_data():
     metadata.create_all()
 
     user_data = [
-        {"user": "user1", "date": date(2013, 1, 1), "indicator_a": 1, "indicator_b": 0, "indicator_c": 1, "indicator_d": 1},
-        {"user": "user1", "date": date(2013, 2, 1), "indicator_a": 0, "indicator_b": 1, "indicator_c": 1, "indicator_d": 1},
-        {"user": "user2", "date": date(2013, 1, 1), "indicator_a": 0, "indicator_b": 1, "indicator_c": 1, "indicator_d": 2},
-        {"user": "user2", "date": date(2013, 2, 1), "indicator_a": 1, "indicator_b": 0, "indicator_c": 1, "indicator_d": 2},
+        {
+            'user': 'user1',
+            'date': date(2013, 1, 1),
+            'indicator_a': 1,
+            'indicator_b': 0,
+            'indicator_c': 1,
+            'indicator_d': 1,
+        },
+        {
+            'user': 'user1',
+            'date': date(2013, 2, 1),
+            'indicator_a': 0,
+            'indicator_b': 1,
+            'indicator_c': 1,
+            'indicator_d': 1,
+        },
+        {
+            'user': 'user2',
+            'date': date(2013, 1, 1),
+            'indicator_a': 0,
+            'indicator_b': 1,
+            'indicator_c': 1,
+            'indicator_d': 2,
+        },
+        {
+            'user': 'user2',
+            'date': date(2013, 2, 1),
+            'indicator_a': 1,
+            'indicator_b': 0,
+            'indicator_c': 1,
+            'indicator_d': 2,
+        },
     ]
 
     region_data = [
-        {"region": "region1", "sub_region": "region1_a", "date": date(2013, 1, 1), "indicator_a": 1, "indicator_b": 0},
-        {"region": "region1", "sub_region": "region1_a", "date": date(2013, 2, 1), "indicator_a": 1, "indicator_b": 1},
-
-        {"region": "region1", "sub_region": "region1_b", "date": date(2013, 1, 1), "indicator_a": 0, "indicator_b": 1},
-        {"region": "region1", "sub_region": "region1_b", "date": date(2013, 2, 1), "indicator_a": 0, "indicator_b": 0},
-
-        {"region": "region2", "sub_region": "region2_a", "date": date(2013, 1, 1), "indicator_a": 0, "indicator_b": 1},
-        {"region": "region2", "sub_region": "region2_a", "date": date(2013, 2, 1), "indicator_a": 1, "indicator_b": 1},
-
-        {"region": "region2", "sub_region": "region2_b", "date": date(2013, 1, 1), "indicator_a": 1, "indicator_b": 0},
-        {"region": "region2", "sub_region": "region2_b", "date": date(2013, 2, 1), "indicator_a": 0, "indicator_b": 0},
-        ]
+        {
+            'region': 'region1',
+            'sub_region': 'region1_a',
+            'date': date(2013, 1, 1),
+            'indicator_a': 1,
+            'indicator_b': 0,
+        },
+        {
+            'region': 'region1',
+            'sub_region': 'region1_a',
+            'date': date(2013, 2, 1),
+            'indicator_a': 1,
+            'indicator_b': 1,
+        },
+        {
+            'region': 'region1',
+            'sub_region': 'region1_b',
+            'date': date(2013, 1, 1),
+            'indicator_a': 0,
+            'indicator_b': 1,
+        },
+        {
+            'region': 'region1',
+            'sub_region': 'region1_b',
+            'date': date(2013, 2, 1),
+            'indicator_a': 0,
+            'indicator_b': 0,
+        },
+        {
+            'region': 'region2',
+            'sub_region': 'region2_a',
+            'date': date(2013, 1, 1),
+            'indicator_a': 0,
+            'indicator_b': 1,
+        },
+        {
+            'region': 'region2',
+            'sub_region': 'region2_a',
+            'date': date(2013, 2, 1),
+            'indicator_a': 1,
+            'indicator_b': 1,
+        },
+        {
+            'region': 'region2',
+            'sub_region': 'region2_b',
+            'date': date(2013, 1, 1),
+            'indicator_a': 1,
+            'indicator_b': 0,
+        },
+        {
+            'region': 'region2',
+            'sub_region': 'region2_b',
+            'date': date(2013, 2, 1),
+            'indicator_a': 0,
+            'indicator_b': 0,
+        },
+    ]
 
     connection = engine.connect()
     try:

--- a/corehq/apps/reports/tests/sql_reports.py
+++ b/corehq/apps/reports/tests/sql_reports.py
@@ -2,8 +2,7 @@ from numbers import Number
 
 from memoized import memoized
 from nose.tools import nottest
-from sqlagg import *
-from sqlagg.columns import *
+from sqlagg.columns import SimpleColumn, SumColumn
 
 from corehq.apps.reports.filters.dates import DatespanFilter
 from corehq.apps.reports.standard import CustomProjectReport, DatespanMixin

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.test import SimpleTestCase, TestCase
 

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -15,7 +15,7 @@ from corehq.apps.reports.standard.project_health import (
     MonthlyPerformanceSummary,
     ProjectHealthDashboard,
 )
-from corehq.apps.users.models import CommCareUser, DomainMembership, WebUser
+from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.const import MISSING_APP_ID
 
 

--- a/corehq/apps/reports/tests/test_readable_formdata.py
+++ b/corehq/apps/reports/tests/test_readable_formdata.py
@@ -162,7 +162,11 @@ class ReadableFormdataTest(SimpleTestCase):
                 "timeEnd": "2014-04-28T18:27:05Z",
                 "appVersion": {
                     "@xmlns": "http://commcarehq.org/xforms",
-                    "#text": "CommCare ODK, version \"2.11.0\"(29272). App v8. CommCare Version 2.11. Build 29272, built on: February-14-2014"
+                    "#text": (
+                        "CommCare ODK, version \"2.11.0\"(29272). App v8. "
+                        "CommCare Version 2.11. "
+                        "Build 29272, built on: February-14-2014"
+                    )
                 },
                 "timeStart": "2014-04-28T18:26:38Z",
                 "deviceID": "990004280784863"
@@ -280,7 +284,11 @@ class ReadableFormdataTest(SimpleTestCase):
                 "timeEnd": "2014-04-28T18:27:05Z",
                 "appVersion": {
                     "@xmlns": "http://commcarehq.org/xforms",
-                    "#text": "CommCare ODK, version \"2.11.0\"(29272). App v8. CommCare Version 2.11. Build 29272, built on: February-14-2014"
+                    "#text": (
+                        "CommCare ODK, version \"2.11.0\"(29272). "
+                        "App v8. CommCare Version 2.11. "
+                        "Build 29272, built on: February-14-2014"
+                    )
                 },
                 "timeStart": "2014-04-28T18:26:38Z",
                 "deviceID": "990004280784863"

--- a/corehq/apps/reports/tests/test_report_api.py
+++ b/corehq/apps/reports/tests/test_report_api.py
@@ -15,7 +15,9 @@ from .sql_reports import combine_indicator
 
 DOMAIN = "test"
 
-unity = lambda x: x
+
+def unity(x):
+    return x
 
 
 class UserDataSource(SqlData):

--- a/corehq/apps/reports/tests/test_sql_reports.py
+++ b/corehq/apps/reports/tests/test_sql_reports.py
@@ -9,7 +9,6 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
 from corehq.sql_db.connections import Session
 from corehq.util.dates import iso_string_to_date
-from corehq.util.test_utils import softer_assert
 
 from .sql_fixture import load_data
 from .sql_reports import RegionTestReport, UserTestReport, test_report

--- a/corehq/apps/reports/tests/test_views.py
+++ b/corehq/apps/reports/tests/test_views.py
@@ -1,7 +1,6 @@
 import io
 import json
 import unittest
-from urllib.parse import urlencode
 from couchdbkit import ResourceNotFound
 from django.http.response import Http404
 from django.core.exceptions import PermissionDenied

--- a/corehq/apps/reports/v2/utils.py
+++ b/corehq/apps/reports/v2/utils.py
@@ -1,6 +1,4 @@
-from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.util.timezones.conversions import PhoneTime, ServerTime
-from corehq.util.timezones.utils import get_timezone
 
 
 def report_date_to_json(date, timezone, date_format, is_phonetime=True):


### PR DESCRIPTION
## Technical Summary

More late night linting

I ran Ruff against `corehq/apps/reports`.

* The [Lint corehq/apps/reports (part 1/2)](https://github.com/dimagi/commcare-hq/commit/bdf7fdf57022b0648f4be738a3600bb1f64cfcc3) commit contains Ruff's automatic fixes. 

* In [Cleaned using Blue](https://github.com/dimagi/commcare-hq/commit/a26ba5edefed65dfe7c771a5ebcdb928c37d8887) I used Blue to add a whole bunch of newlines.

* And [Lint corehq/apps/reports (part 2/2)](https://github.com/dimagi/commcare-hq/commit/378c8bddd25d9f7b0ef06668f48607c8db90967b) is made up of manual fixes.

(After this `corehq/` is down to 877 lint errors. Next up I am thinking of doing `corehq/apps/sms/`.)

## Feature Flag

N/A

## Safety Assurance

### Safety story

No code changes. Only linting.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
