### PR TITLE
Pull reassign cases data from ES seperately

### DIFF
--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -117,11 +117,17 @@ class CaseReassignmentInterface(CaseListMixin, BulkDataInterface):
                 _("An owner_id needs to be specified to bulk reassign cases")
             )
 
+        # If we use self.es_results we're limited to the pagination set on the
+        # UI by the user
+        es_results = self._build_query()\
+            .size(self.total_records)\
+            .NOT(case_es.case_type(USERCASE_TYPE))\
+            .run().raw
+
         case_ids = [
             self.get_case(row)['_id']
-            for row in self.es_results['hits'].get('hits', [])
+            for row in es_results['hits'].get('hits', [])
         ]
-
         task_ref = expose_cached_download(
             payload=case_ids, expiry=60 * 60, file_extension=None
         )

--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -50,10 +50,13 @@ class CaseReassignmentInterface(CaseListMixin, BulkDataInterface):
     @property
     @memoized
     def es_results(self):
+        return self._es_query.run().raw
+
+    @property
+    def _es_query(self):
         query = self._build_query()
         # FB 183468: Don't allow user cases to be reassigned
-        query = query.NOT(case_es.case_type(USERCASE_TYPE))
-        return query.run().raw
+        return query.NOT(case_es.case_type(USERCASE_TYPE))
 
     @property
     def template_context(self):
@@ -119,9 +122,8 @@ class CaseReassignmentInterface(CaseListMixin, BulkDataInterface):
 
         # If we use self.es_results we're limited to the pagination set on the
         # UI by the user
-        es_results = self._build_query()\
+        es_results = self._es_query\
             .size(self.total_records)\
-            .NOT(case_es.case_type(USERCASE_TYPE))\
             .run().raw
 
         case_ids = [


### PR DESCRIPTION
## Product Description
No user-facing changes.

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2928)

When a user invokes a case reassignment action the `CaseReassignmentInterface` class relies on the `CaseListMixin`'s `_build_query` method to fetch the cases relevant to the reassignment (it applies the necessary user-selected filters, etc). Amongst other things, the `_build_query` limits the ES case results based on the pagination size set on the UI by the user. 

This behaviour of automatically paginating the results resulted in only a limited number of cases (corresponding to the pagination size set) being reassigned to the user when the user actually selected that all cases should be reassigned.

This PR makes the bulk reassignment rely not on the `es_results` method of `CaseReassignmentInterface` to fetch the cases, but rather constructs the query manually and override the size limitation to the size of the total number of cases satisfying the criteria set by the user on the UI. 

## Feature Flag
All users

## Safety Assurance

### Safety story
Tested locally.

### Automated test coverage
No automated tests.

### QA Plan
No formal QA planned.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
