### PR TITLE
Fix container background color in web apps

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -104,7 +104,7 @@
       <div class="container case-tile-container">
         <div id="persistent-case-tile" class="print-container"></div>
       </div>
-      <div class="container flex-container">
+      <div id="content-container" class="container flex-container">
         <div id="sidebar-region" class="container print-container flex-child flex-child-sidebar"></div>
         <div id="menu-region" class="container print-container flex-child flex-child-menu"></div>
       </div>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
@@ -37,6 +37,10 @@ body {
   padding-left: 0;
 }
 
+#content-container {
+  background: transparent;
+}
+
 .case-tile-container {
   background: transparent !important;
   > div {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -1,7 +1,6 @@
 .flex-container {
   display: flex;
   align-items: stretch;
-  background: transparent !important;
 }
 
 .full-width {
@@ -18,10 +17,8 @@
 
 .flex-child-sidebar {
   max-width: 400px;
-  background: transparent !important;
   table {
     table-layout: fixed;
-    background: white;
   }
   .query-input-group {
     margin-right: 8px;
@@ -42,6 +39,13 @@
   }
   .select2-container .select2-selection--multiple {
     min-height: inherit;
+  }
+}
+
+#sidebar-region {
+  background: transparent;
+  table {
+    background: white;
   }
 }
 

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -1,6 +1,7 @@
 .flex-container {
   display: flex;
   align-items: stretch;
+  background: transparent !important;
 }
 
 .full-width {
@@ -17,8 +18,10 @@
 
 .flex-child-sidebar {
   max-width: 400px;
+  background: transparent !important;
   table {
     table-layout: fixed;
+    background: white;
   }
   .query-input-group {
     margin-right: 8px;


### PR DESCRIPTION
## Product Description
Fixes a visual issue that was introduced throughout web apps with split screen case search.
<img width="400" alt="Screenshot 2023-07-20 at 2 52 37 PM" src="https://github.com/dimagi/commcare-hq/assets/100609770/95339781-9906-47b9-bc3d-9c052ab29e3e"> <img width="400" alt="Screenshot 2023-07-20 at 2 58 02 PM" src="https://github.com/dimagi/commcare-hq/assets/100609770/fdf317cc-cc56-4dec-b34b-4df191e2d52d">
<img width="400" alt="Screenshot 2023-07-20 at 2 54 27 PM" src="https://github.com/dimagi/commcare-hq/assets/100609770/93783086-fd0f-4d3c-9e2e-4a853b8bb824"> <img width="400" alt="Screenshot 2023-07-20 at 2 57 39 PM" src="https://github.com/dimagi/commcare-hq/assets/100609770/5673035e-dc00-4f00-9a45-2310021267f0">
<img width="400" alt="Screenshot 2023-07-20 at 2 55 59 PM" src="https://github.com/dimagi/commcare-hq/assets/100609770/b360a37f-90ec-48fe-85e7-bcdb3324d0c8"> <img width="400" alt="Screenshot 2023-07-20 at 2 57 19 PM" src="https://github.com/dimagi/commcare-hq/assets/100609770/5cd9265d-7fe1-4bf4-940f-cede52fd7f97">


## Technical Summary
This change comes out of a web apps UI discussion today. jQuery UI sets its own styling on elements in web apps. By adding new `container` elements for split screen case search, their backgrounds defaulted to white (technically #fcfdfd). This uses id styles on those elements to be transparent and also sets the background for search filters to white in split screen case search, because their table is partially transparent. 


## Safety Assurance

### Safety story
Changes css styles only. Checked locally in all pages of web apps with and without split screen case search. 

### Automated test coverage
n/a

### QA Plan
QA should not be needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
