### PR TITLE
Ensure instances required for menus are present

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -164,16 +164,19 @@ class InstancesHelper(PostProcessor):
 
     @cached_property
     def _menu_xpaths_by_command(self):
-        xpaths_by_command = defaultdict(set)
+        # multiple menus can have the same ID - merge them first
+        xpaths_by_menu_id = defaultdict(set)
         for menu in self.suite.menus:
-            menu_xpaths = set()
             if menu.relevant:
-                menu_xpaths.add(menu.relevant)
+                xpaths_by_menu_id[menu.id].add(menu.relevant)
             for assertion in menu.assertions:
-                menu_xpaths.add(assertion.test)
-            for command in menu.commands:
-                xpaths_by_command[command.id] = menu_xpaths
-        return xpaths_by_command
+                xpaths_by_menu_id[menu.id].add(assertion.test)
+
+        return defaultdict(set, {
+            command.id: xpaths_by_menu_id[menu.id]
+            for menu in self.suite.menus
+            for command in menu.commands
+        })
 
     @cached_property
     def _relevancy_xpaths_by_command(self):

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -266,6 +266,22 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
         self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m0-f0']/../instance")
         self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m0-f1']/../instance")
 
+    def test_module_filter_instances_on_all_forms_merged_modules(self):
+        # instances from module filters result in instance declarations in all forms in the module
+        # and if two modules are display_in_root, then on forms in the other module too
+        factory = AppFactory(build_version='2.20.0')  # enable_module_filtering
+        self.m0, self.m0f0 = factory.new_basic_module('m0', 'case1')
+        self.m0.put_in_root = True
+
+        self.m1, self.m1f0 = factory.new_basic_module('m1', 'case1')
+        self.m1.module_filter = "instance('locations')/locations/"
+        self.m1.put_in_root = True
+
+        suite = factory.app.create_suite()
+        instance_xml = "<partial><instance id='locations' src='jr://fixture/locations' /></partial>"
+        self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m0-f0']/..instance")
+        self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m1-f0']/..instance")
+
 
 @generate_cases([
     ("instance('test')/rows/row", {"test"}),

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -260,17 +260,11 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
         self.module, self.form = factory.new_basic_module('m0', 'case1')
         self.module.module_filter = "instance('locations')/locations/"
         factory.new_form(self.module)
-        # two forms, two entries, two instances
-        self.assertXmlPartialEqual(
-            """
-            <partial>
-                <instance id='locations' src='jr://fixture/locations' />
-                <instance id='locations' src='jr://fixture/locations' />
-            </partial>
-            """,
-            factory.app.create_suite(),
-            "entry/instance"
-        )
+
+        suite = factory.app.create_suite()
+        instance_xml = "<partial><instance id='locations' src='jr://fixture/locations' /></partial>"
+        self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m0-f0']/../instance")
+        self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m0-f1']/../instance")
 
 
 @generate_cases([

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -279,8 +279,8 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
 
         suite = factory.app.create_suite()
         instance_xml = "<partial><instance id='locations' src='jr://fixture/locations' /></partial>"
-        self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m0-f0']/..instance")
-        self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m1-f0']/..instance")
+        self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m0-f0']/../instance")
+        self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m1-f0']/../instance")
 
 
 @generate_cases([


### PR DESCRIPTION
## Product Description
Addresses this error: https://dimagi.sentry.io/discover/commcarehq:740939177fc048389e87590d059eee61/

> [WebApps] The instance "casedb" in expression "instance(casedb)/casedb/case..." used by "/" does not exist in the form. Please correct your form or...

## Technical Summary

https://dimagi-dev.atlassian.net/browse/SUPPORT-17147
https://dimagi-dev.atlassian.net/browse/SUPPORT-17186

Those issues were caused by https://github.com/dimagi/commcare-hq/pull/33037

This PR reverts part of the change from this commit: https://github.com/dimagi/commcare-hq/commit/ac1a51512b372bfdcb4a9ff52dbba43eeec53189
That commit changed two things:

* entry-associated instances were no longer propagated to all entries in the menu
* menu-associated instances were no longer included in entries from other menus with the same menu ID

That latter change was inadvertent - I didn't consider that menus can have multiple IDs, and that from the commcare-core perspective, this makes them essentially the same menu.

Anyways, this commit groups instances required by menus by menu ID, then distributes to all forms in menus with that ID.  The test fails without the associated suite generation change.

## Feature Flag


## Safety Assurance

### Safety story
Automated tests, primarily.  We didn't have any tests exercising the functionality that broke, and it wasn't caught by QA.  I did add that test in this PR.  Since this is a revert to previous behavior (if not previous code), I think this is at least less likely to break things than the current version of the code.

### Automated test coverage


### QA Plan



### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
