### PR TITLE
XPath Date Timezone Conversion Bug Fix

### DIFF
--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -101,6 +101,39 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         mock_get_timezone.assert_not_called()
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
+    @patch("corehq.apps.case_search.xpath_functions.comparison.get_timezone_for_domain",
+           return_value=pytz.timezone('America/Los_Angeles'))
+    def test_datetime_special_case_property_equality_comparison(self, mock_get_timezone):
+        parsed = parse_xpath("last_modified='2023-01-10'")
+
+        expected_filter = {
+            "nested": {
+                "path": "case_properties",
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {
+                                "term": {
+                                    "case_properties.key.exact": "last_modified"
+                                }
+                            }
+                        ],
+                        "must": {
+                            "range": {
+                                "case_properties.value.date": {
+                                    "gte": "2023-01-10T08:00:00",
+                                    "lte": "2023-01-11T08:00:00"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
+        mock_get_timezone.assert_called_once()
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
     def test_not_filter(self):
         parsed = parse_xpath("not(name = 'farid')")
 

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -2,6 +2,8 @@ from django.test import SimpleTestCase, TestCase
 
 from eulxml.xpath import parse as parse_xpath
 from freezegun import freeze_time
+import pytz
+from unittest.mock import patch
 
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from couchforms.geopoint import GeoPoint
@@ -58,6 +60,45 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
             }
         }
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
+    @patch("corehq.apps.case_search.xpath_functions.comparison.get_timezone_for_domain",
+           return_value=pytz.timezone('America/Los_Angeles'))
+    def test_simple_filter_with_date(self, mock_get_timezone):
+        parsed = parse_xpath("dob = '2023-06-03'")
+
+        expected_filter = {
+            "nested": {
+                "path": "case_properties",
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {
+                                "bool": {
+                                    "filter": (
+                                        {
+                                            "term": {
+                                                "case_properties.key.exact": "dob"
+                                            }
+                                        },
+                                        {
+                                            "term": {
+                                                "case_properties.value.exact": "2023-06-03"
+                                            }
+                                        }
+                                    )
+                                }
+                            }
+                        ],
+                        "must": {
+                            "match_all": {}
+                        }
+                    }
+                }
+            }
+        }
+        built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
+        mock_get_timezone.assert_not_called()
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_not_filter(self):

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -25,7 +25,6 @@ def property_comparison_query(context, case_property_name_raw, op, value_raw, no
     value = unwrap_value(value_raw, context)
     if case_property_name in SPECIAL_CASE_PROPERTIES:
         try:
-            # this might be inconsistent in daylight savings situations
             timezone = get_timezone_for_domain(context.domain)
             return _create_timezone_adjusted_datetime_query(case_property_name, op, value, node, timezone)
         except (XPathFunctionException, AssertionError):
@@ -58,6 +57,11 @@ def _case_property_range_query(case_property_name: str, op_value_dict, node):
 
 
 def _create_timezone_adjusted_datetime_query(case_property_name, op, value, node, timezone):
+    """
+    Given a date, it gets the equivalent starting time of that date in UTC. i.e 2023-06-05
+    in Asia/Seoul timezone begins at 2023-06-04T20:00:00 UTC.
+    This might be inconsistent in daylight savings situations.
+    """
     utc_equivalent_datetime_value = adjust_input_date_by_timezone(value_to_date(node, value), timezone, op)
     if op in [EQ, NEQ]:
         day_start_datetime = utc_equivalent_datetime_value.isoformat()

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -7,7 +7,7 @@ from eulxml.xpath.ast import Step
 from corehq.apps.case_search.dsl_utils import unwrap_value
 from corehq.apps.case_search.exceptions import CaseFilterError, XPathFunctionException
 from corehq.apps.case_search.xpath_functions.value_functions import value_to_date
-from corehq.apps.case_search.const import RANGE_OP_MAPPING, EQ, NEQ
+from corehq.apps.case_search.const import RANGE_OP_MAPPING, EQ, NEQ, SPECIAL_CASE_PROPERTIES
 from corehq.apps.es import filters
 from corehq.apps.es.case_search import case_property_query, case_property_range_query
 from corehq.util.timezones.utils import get_timezone_for_domain
@@ -25,14 +25,16 @@ def property_comparison_query(context, case_property_name_raw, op, value_raw, no
     value = unwrap_value(value_raw, context)
     # adjust the user's input date based on project timezones
     is_user_input = False
-    try:
-        # this might be inconsistent in daylight savings situations
-        value = adjust_input_date_by_timezone(value_to_date(node, value),
-                                              get_timezone_for_domain(context.domain), op)
-        is_user_input = True
-    except (XPathFunctionException, AssertionError):
-        # AssertionError is caused by tests that use domains without a valid timezone (in get_timezeone_for_domain)
-        pass
+    if case_property_name in SPECIAL_CASE_PROPERTIES:
+        try:
+            # this might be inconsistent in daylight savings situations
+            value = adjust_input_date_by_timezone(value_to_date(node, value),
+                                                get_timezone_for_domain(context.domain), op)
+            is_user_input = True
+        except (XPathFunctionException, AssertionError):
+            # AssertionError is caused by tests that use domains without
+            # a valid timezone (in get_timezeone_for_domain)
+            pass
     if op in [EQ, NEQ]:
         query = case_property_query(case_property_name, value, fuzzy=context.fuzzy)
         if op == NEQ:

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -41,9 +41,16 @@ def property_comparison_query(context, case_property_name_raw, op, value_raw, no
             query = filters.NOT(query)
         return query
     else:
+        op_value_dict = {RANGE_OP_MAPPING[op]: value}
+        return _case_property_range_query(case_property_name, op_value_dict, node,
+                                          is_user_input)
+
+
+def _case_property_range_query(case_property_name: str, op_value_dict, node,
+                               is_user_input: bool = False):
         try:
             return case_property_range_query(case_property_name, is_user_input=is_user_input,
-                                             **{RANGE_OP_MAPPING[op]: value})
+                                             **op_value_dict)
         except (TypeError, ValueError):
             raise CaseFilterError(
                 gettext("The right hand side of a comparison must be a number or date. "

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -80,7 +80,7 @@ def _create_timezone_adjusted_datetime_query(case_property_name, op, value, node
 
 
 def adjust_input_date_by_timezone(date, timezone, op):
-    date = datetime.combine(date, datetime.min.time())
+    date = datetime(date.year, date.month, date.day)
     if op == '>' or op == '<=':
         date += timedelta(days=1)
     return UserTime(date, tzinfo=timezone).server_time().done()

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -61,7 +61,7 @@ def _case_property_range_query(case_property_name: str, op_value_dict, node,
 
 def _create_timezone_adjusted_datetime_query(case_property_name, op, value, node, timezone):
     utc_datetime_value = adjust_input_date_by_timezone(value_to_date(node, value), timezone, op)
-    op_val_dict = {RANGE_OP_MAPPING[op]: utc_datetime_value}
+    op_val_dict = {RANGE_OP_MAPPING[op]: utc_datetime_value.isoformat()}
     return _case_property_range_query(case_property_name, op_val_dict, node, is_user_input=True)
 
 
@@ -69,4 +69,4 @@ def adjust_input_date_by_timezone(date, timezone, op):
     date = datetime.combine(date, datetime.min.time())
     if op == '>' or op == '<=':
         date += timedelta(days=1)
-    return UserTime(date, tzinfo=timezone).server_time().done().isoformat()
+    return UserTime(date, tzinfo=timezone).server_time().done()

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -46,11 +46,9 @@ def _create_query(context, case_property_name, op, value, node):
         return _case_property_range_query(case_property_name, op_value_dict, node)
 
 
-def _case_property_range_query(case_property_name: str, op_value_dict, node,
-                               is_user_input: bool = False):
+def _case_property_range_query(case_property_name: str, op_value_dict, node):
         try:
-            return case_property_range_query(case_property_name, is_user_input=is_user_input,
-                                             **op_value_dict)
+            return case_property_range_query(case_property_name, **op_value_dict)
         except (TypeError, ValueError):
             raise CaseFilterError(
                 gettext("The right hand side of a comparison must be a number or date. "
@@ -68,13 +66,13 @@ def _create_timezone_adjusted_datetime_query(case_property_name, op, value, node
             RANGE_OP_MAPPING[">="]: day_start_datetime,
             RANGE_OP_MAPPING["<="]: day_end_datetime,
         }
-        query = _case_property_range_query(case_property_name, op_value_dict, node, is_user_input=True)
+        query = _case_property_range_query(case_property_name, op_value_dict, node)
         if op == NEQ:
             query = filters.NOT(query)
         return query
     else:
         op_value_dict = {RANGE_OP_MAPPING[op]: utc_equivalent_datetime_value.isoformat()}
-        return _case_property_range_query(case_property_name, op_value_dict, node, is_user_input=True)
+        return _case_property_range_query(case_property_name, op_value_dict, node)
 
 
 def adjust_input_date_by_timezone(date, timezone, op):

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -23,8 +23,6 @@ def property_comparison_query(context, case_property_name_raw, op, value_raw, no
 
     case_property_name = serialize(case_property_name_raw)
     value = unwrap_value(value_raw, context)
-    # adjust the user's input date based on project timezones
-    is_user_input = False
     if case_property_name in SPECIAL_CASE_PROPERTIES:
         try:
             # this might be inconsistent in daylight savings situations
@@ -34,10 +32,10 @@ def property_comparison_query(context, case_property_name_raw, op, value_raw, no
             # AssertionError is caused by tests that use domains without
             # a valid timezone (in get_timezeone_for_domain)
             pass
-    return _create_query(context, case_property_name, op, value, node, is_user_input)
+    return _create_query(context, case_property_name, op, value, node)
 
 
-def _create_query(context, case_property_name, op, value, node, is_user_input):
+def _create_query(context, case_property_name, op, value, node):
     if op in [EQ, NEQ]:
         query = case_property_query(case_property_name, value, fuzzy=context.fuzzy)
         if op == NEQ:
@@ -45,7 +43,7 @@ def _create_query(context, case_property_name, op, value, node, is_user_input):
         return query
     else:
         op_value_dict = {RANGE_OP_MAPPING[op]: value}
-        return _case_property_range_query(case_property_name, op_value_dict, node, is_user_input)
+        return _case_property_range_query(case_property_name, op_value_dict, node)
 
 
 def _case_property_range_query(case_property_name: str, op_value_dict, node,

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -25,7 +25,10 @@ def property_comparison_query(context, case_property_name_raw, op, value_raw, no
     value = unwrap_value(value_raw, context)
     if case_property_name in SPECIAL_CASE_PROPERTIES:
         try:
-            timezone = get_timezone_for_domain(context.domain)
+            domain = context.domain
+            if isinstance(domain, set):
+                domain = list(domain)
+            timezone = get_timezone_for_domain(domain)
             return _create_timezone_adjusted_datetime_query(case_property_name, op, value, node, timezone)
         except (XPathFunctionException, AssertionError):
             # AssertionError is caused by tests that use domains without

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -281,7 +281,7 @@ def case_property_starts_with(case_property_name, value):
     )
 
 
-def case_property_range_query(case_property_name, gt=None, gte=None, lt=None, lte=None, is_user_input=False):
+def case_property_range_query(case_property_name, gt=None, gte=None, lt=None, lte=None):
     """Returns cases where case property `key` fall into the range provided.
 
     """

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -297,12 +297,12 @@ def case_property_range_query(case_property_name, gt=None, gte=None, lt=None, lt
     except ValueError:
         pass
 
-    # if its a date, use it
+    # if its a date or datetime, use it
     # date range
-    parse = parse_datetime if is_user_input else parse_date
     kwargs = {
-        key: parse(value) for key, value in kwargs.items()
-        if value is not None and parse(value) is not None
+        key: parse_date(value) if parse_date(value) else parse_datetime(value)
+        for key, value in kwargs.items()
+        if value is not None and (parse_date(value) or parse_datetime(value))
     }
     if not kwargs:
         raise TypeError()       # Neither a date nor number was passed in

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -559,7 +559,7 @@ class TestForwardTimezoneAdjustment(TestCase):
         A case with last_modified displayed as 2023-06-04 is actually 2023-06-03T20:00:00 in ES
         Input modified to be last_modified < "2023-06-03T15:00:00" to exclude above case"""
         # user input: last_modified < '2023-06-04'
-        self.assertEqual('2023-06-03T15:00:00',
+        self.assertEqual(datetime(2023, 6, 3, 15, 0, 0),
                          adjust_input_date_by_timezone(date(2023, 6, 4), self.timezone, '<'))
 
     def test_user_input_forward_timezone_adjustment_2(self):
@@ -568,7 +568,7 @@ class TestForwardTimezoneAdjustment(TestCase):
         A case with last_modified displayed as 2023-06-05 is actually 2023-06-04T20:00:00 in ES
         Input modified to be last_modified > "2023-06-04T15:00:00" to include above case"""
         # user input: last_modified > '2023-06-04'
-        self.assertEqual('2023-06-04T15:00:00',
+        self.assertEqual(datetime(2023, 6, 4, 15, 0, 0),
                          adjust_input_date_by_timezone(date(2023, 6, 4), self.timezone, '>'))
 
     def test_user_input_forward_timezone_adjustment_3(self):
@@ -577,7 +577,7 @@ class TestForwardTimezoneAdjustment(TestCase):
         A case with last_modified displayed as 2023-06-05 is actually 2023-06-04T20:00:00 in ES
         Input modified to be last_modified <= "2023-06-04T15:00:00" to exclude above case"""
         # user input: last_modified <= '2023-06-04'
-        self.assertEqual('2023-06-04T15:00:00',
+        self.assertEqual(datetime(2023, 6, 4, 15, 0, 0),
                          adjust_input_date_by_timezone(date(2023, 6, 4), self.timezone, '<='))
 
     def test_user_input_forward_timezone_adjustment_4(self):
@@ -586,7 +586,7 @@ class TestForwardTimezoneAdjustment(TestCase):
         A case with last_modified displayed as 2023-06-04 is actually 2023-06-03T20:00:00 in ES
         Input modified to be last_modified >= "2023-06-03T15:00:00" to include above case"""
         # user input: last_modified >= '2023-06-04'
-        self.assertEqual('2023-06-03T15:00:00',
+        self.assertEqual(datetime(2023, 6, 3, 15, 0, 0),
                          adjust_input_date_by_timezone(date(2023, 6, 4), self.timezone, '>='))
 
 
@@ -602,7 +602,7 @@ class TestBackwardTimezoneAdjustment(TestCase):
         A case with last_modified displayed as 2023-06-03 is actually 2023-06-04T05:00:00 in ES
         Input modified to be last_modified > "2023-06-04T10:00:00" to exclude above case"""
         # user input: last_modified > '2023-06-03'
-        self.assertEqual('2023-06-04T10:00:00',
+        self.assertEqual(datetime(2023, 6, 4, 10, 0, 0),
                          adjust_input_date_by_timezone(date(2023, 6, 3), self.timezone, '>'))
 
     def test_user_input_backwards_timezone_adjustment_2(self):
@@ -611,7 +611,7 @@ class TestBackwardTimezoneAdjustment(TestCase):
         A case with last_modified displayed as 2023-06-02 is actually 2023-06-03T05:00:00 in ES
         Input modified to be last_modified > "2023-06-03T10:00:00" to include above case"""
         # user input: last_modified > '2023-06-03'
-        self.assertEqual('2023-06-03T10:00:00',
+        self.assertEqual(datetime(2023, 6, 3, 10, 0, 0),
                          adjust_input_date_by_timezone(date(2023, 6, 3), self.timezone, '<'))
 
     def test_user_input_backwards_timezone_adjustment_3(self):
@@ -620,7 +620,7 @@ class TestBackwardTimezoneAdjustment(TestCase):
         A case with last_modified displayed as 2023-06-02 is actually 2023-06-03T05:00:00 in ES
         Input modified to be last_modified > "2023-06-03T10:00:00" to exclude above case"""
         # user input: last_modified <= '2023-06-03'
-        self.assertEqual('2023-06-03T10:00:00',
+        self.assertEqual(datetime(2023, 6, 3, 10, 0, 0),
                          adjust_input_date_by_timezone(date(2023, 6, 3), self.timezone, '>='))
 
     def test_user_input_backwards_timezone_adjustment_4(self):
@@ -629,5 +629,5 @@ class TestBackwardTimezoneAdjustment(TestCase):
         A case with last_modified displayed as 2023-06-03 is actually 2023-06-04T05:00:00 in ES
         Input modified to be last_modified >= "2023-06-04T10:00:00" to include above case"""
         # user input: last_modified >= '2023-06-04'
-        self.assertEqual('2023-06-04T10:00:00',
+        self.assertEqual(datetime(2023, 6, 4, 10, 0, 0),
                          adjust_input_date_by_timezone(date(2023, 6, 3), self.timezone, '<='))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://github.com/dimagi/commcare-hq/pull/33022 introduced converting user inputs to UTC for querying. 

However, project-specific properties are stored as standalone time or dates meaning that no conversion to UTC is required while generating the query. The conversion causes the generated query to use the incorrect date/datetime. For example, with the bug, the user xpath input "date_of_birth = '2023-06-03'" with a project timezone of "Asia/Seoul" is converted to and querying for "2023-06-03T05:00:00" even though in ES, the value for "date_of_birth" is "2023-06-03".

Two changes are introduced in this PR.
1. This change adds a check to apply the timezone conversion to only datetime [special case properties](https://github.com/dimagi/commcare-hq/blob/6061f316efb9083f3ff89c32653dc80049ef81c1/corehq/apps/case_search/const.py#L38-L54) since they are stored in ES as UTC timestamps.

2. This change also introduces a new feature. Exact matches of [special case properties](https://github.com/dimagi/commcare-hq/blob/6061f316efb9083f3ff89c32653dc80049ef81c1/corehq/apps/case_search/const.py#L38-L54) now work.  i.e "last_modified = '2023-06-03'"  will return cases that were modified on project timezone's date "2023-06-03". Originally, exact matches of special case properties do not work because in ES, special case properties are stored as timestamps, meaning "'2023-06-03" won't be an exact match. 


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi-dev.atlassian.net/browse/USH-3435
Related to this change: https://github.com/dimagi/commcare-hq/pull/33022
Some additional informal technical discussions: https://docs.google.com/document/d/1GifR60eOI6xhXh8R0jTXQxUcj6TPtuzl6m4LmGbZWAA/edit
Review commit by commit.
 A lot of the line changes shown are just refactoring.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing and also good test coverage of case search exists. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added unit tests checks the following xpath expression provided the expected ES query:
1. dob = '2023-06-03' (related to change 1)
2. last_modified='2023-01-10' (related to change 2)

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
