### PR TITLE
modify description of SPLIT_SCREEN_CASE_SEARCH feature flag

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1032,8 +1032,10 @@ USH_EMPTY_CASE_LIST_TEXT = StaticToggle(
 
 SPLIT_SCREEN_CASE_SEARCH = StaticToggle(
     'split_screen_case_search',
-    "In case search, show the filters on the left and results on the right.",
+    "Split Screen Case Search: In case search, show the search filters in a sidebar on the left and the results"
+    " on the right.",
     TAG_CUSTOM,
+    help_link='https://confluence.dimagi.com/display/USH/Split+Screen+Case+Search',
     namespaces=[NAMESPACE_DOMAIN],
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
 )

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1032,7 +1032,7 @@ USH_EMPTY_CASE_LIST_TEXT = StaticToggle(
 
 SPLIT_SCREEN_CASE_SEARCH = StaticToggle(
     'split_screen_case_search',
-    "Split Screen Case Search: In case search, show the search filters in a sidebar on the left and the results"
+    "Split screen case search: In case search, show the search filters in a sidebar on the left and the results"
     " on the right.",
     TAG_CUSTOM,
     help_link='https://confluence.dimagi.com/display/USH/Split+Screen+Case+Search',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
There have been feedback from users that they are not being able to find the `SPLIT_SCREEN_CASE_SEARCH` feature flag by searching, so I added the commonly used name to the front of the description so it's easier to search for. I also added the jira documentation link. 

Here's what it looks like to search
<img width="1068" alt="Screenshot 2023-07-24 at 3 21 47 PM" src="https://github.com/dimagi/commcare-hq/assets/36681924/bf076e0b-d424-4db4-bbd3-5d9fc20fc15f">
ch:


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
minor: changes only to toggles.py label

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This does not change code functionality only the description of the toggle

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
