### PR TITLE
Catches an error caused by the definition of an old app

### DIFF
--- a/corehq/apps/data_dictionary/management/commands/generate_data_dictionary.py
+++ b/corehq/apps/data_dictionary/management/commands/generate_data_dictionary.py
@@ -1,9 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from corehq.apps.data_dictionary.util import (
-    OldExportsEnabledException,
-    generate_data_dictionary,
-)
+from corehq.apps.data_dictionary.util import generate_data_dictionary
 from corehq.apps.domain.models import Domain
 from corehq.util.log import with_progress_bar
 
@@ -22,7 +19,7 @@ class Command(BaseCommand):
         for domain in with_progress_bar(domains):
             try:
                 generate_data_dictionary(domain)
-            except OldExportsEnabledException:
+            except Exception:
                 failed_domains.append(domain)
         print('--- Failed Domains ---')
         for domain in failed_domains:

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -19,10 +19,6 @@ from corehq.motech.fhir.utils import update_fhir_resource_property
 from corehq.util.quickcache import quickcache
 
 
-class OldExportsEnabledException(Exception):
-    pass
-
-
 def generate_data_dictionary(domain):
     case_type_to_properties = _get_all_case_properties(domain)
     _create_properties_for_case_types(domain, case_type_to_properties)

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -45,11 +45,7 @@ def _get_all_case_properties(domain):
             if len(item.path) > 1:
                 continue
 
-            if item.tag:
-                name = item.tag
-            else:
-                name = item.path[-1].name
-
+            name = item.tag if item.tag else item.path[-1].name
             if '/' not in name:
                 # Filter out index and parent properties as some are stored as parent/prop in item.path
                 properties.add(name)

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -48,6 +48,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_app_ids_in_domain,
     get_built_app_ids_with_submissions_for_app_id,
     get_built_app_ids_with_submissions_for_app_ids_and_versions,
+    get_case_types_from_apps,
     get_latest_app_ids_and_versions,
 )
 from corehq.apps.app_manager.models import (
@@ -57,8 +58,10 @@ from corehq.apps.app_manager.models import (
     OpenSubCaseAction,
     RemoteApp,
 )
+from corehq.apps.data_dictionary.util import get_deprecated_fields
 from corehq.apps.domain.models import Domain
 from corehq.apps.export.const import (
+    ALL_CASE_TYPE_EXPORT,
     CASE_ATTRIBUTES,
     CASE_CLOSE_TO_BOOLEAN,
     CASE_CREATE_ELEMENTS,
@@ -83,7 +86,6 @@ from corehq.apps.export.const import (
     UNKNOWN_INFERRED_FROM,
     USER_DEFINED_SPLIT_TYPES,
     SharingOption,
-    ALL_CASE_TYPE_EXPORT,
 )
 from corehq.apps.export.dbaccessors import (
     get_case_inferred_schema,
@@ -94,7 +96,7 @@ from corehq.apps.export.dbaccessors import (
 from corehq.apps.export.esaccessors import (
     get_case_export_base_query,
     get_form_export_base_query,
-    get_sms_export_base_query
+    get_sms_export_base_query,
 )
 from corehq.apps.export.utils import is_occurrence_deleted
 from corehq.apps.locations.models import SQLLocation
@@ -113,12 +115,9 @@ from corehq.blobs.models import BlobMeta
 from corehq.blobs.util import random_url_id
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 from corehq.util.global_request import get_request_domain
+from corehq.util.html_utils import strip_tags
 from corehq.util.timezones.utils import get_timezone_for_domain
 from corehq.util.view_utils import absolute_reverse
-from corehq.util.html_utils import strip_tags
-from corehq.apps.data_dictionary.util import get_deprecated_fields
-from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
-
 
 DAILY_SAVED_EXPORT_ATTACHMENT_NAME = "payload"
 
@@ -973,15 +972,15 @@ class ExportInstance(BlobMixin, Document):
 
     def _insert_system_properties(self, domain, export_type, table):
         from corehq.apps.export.system_properties import (
-            ROW_NUMBER_COLUMN,
-            TOP_MAIN_FORM_TABLE_PROPERTIES,
-            BOTTOM_MAIN_FORM_TABLE_PROPERTIES,
-            TOP_MAIN_CASE_TABLE_PROPERTIES,
             BOTTOM_MAIN_CASE_TABLE_PROPERTIES,
+            BOTTOM_MAIN_FORM_TABLE_PROPERTIES,
             CASE_HISTORY_PROPERTIES,
             PARENT_CASE_TABLE_PROPERTIES,
-            STOCK_COLUMN,
+            ROW_NUMBER_COLUMN,
             SMS_TABLE_PROPERTIES,
+            STOCK_COLUMN,
+            TOP_MAIN_CASE_TABLE_PROPERTIES,
+            TOP_MAIN_FORM_TABLE_PROPERTIES,
         )
 
         nested_repeat_count = len([node for node in table.path if node.is_repeat])

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1724,16 +1724,27 @@ class ExportDataSchema(Document):
         return current_schema
 
     @classmethod
-    def generate_schema_from_builds(cls, domain, app_id, identifier, force_rebuild=False,
-            only_process_current_builds=False, task=None):
-        """Builds a schema from Application builds for a given identifier
+    def generate_schema_from_builds(
+        cls,
+        domain,
+        app_id,
+        identifier,
+        force_rebuild=False,
+        only_process_current_builds=False,
+        task=None,
+    ):
+        """
+        Builds a schema from Application builds for a given identifier
 
         :param domain: The domain that the export belongs to
-        :param app_id: The app_id that the export belongs to (or None if export is not associated with an app.
-        :param identifier: The unique identifier of the schema being exported.
-            case_type for Case Exports and xmlns for Form Exports
-        :param only_process_current_builds: Only process the current apps, not any builds. This
-            means that deleted items may not be present in the schema since past builds have not been
+        :param app_id: The app_id that the export belongs to or None if
+            the export is not associated with an app.
+        :param identifier: The unique identifier of the schema being
+            exported: case_type for Case Exports and xmlns for Form
+            Exports
+        :param only_process_current_builds: Only process the current
+            apps, not any builds. This means that deleted items may not
+            be present in the schema since past builds have not been
             processed.
         :param task: A celery task to update the progress of the build
         :returns: Returns a ExportDataSchema instance

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -19,6 +19,7 @@ from couchdbkit import (
     SchemaListProperty,
     SchemaProperty,
 )
+from jsonobject.exceptions import BadValueError
 from memoized import memoized
 
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
@@ -1912,7 +1913,15 @@ class ExportDataSchema(Document):
                     and app_doc.get('copy_of')):
                 continue
 
-            app = Application.wrap(app_doc)
+            try:
+                app = Application.wrap(app_doc)
+            except BadValueError as err:
+                logging.exception(
+                    f"Bad definition for Application {app_doc['_id']}",
+                    exc_info=err,
+                )
+                continue
+
             try:
                 schema = cls._process_app_build(
                     schema,


### PR DESCRIPTION
## Technical Summary

While testing generating Data Dictionary models, I encountered an error parsing the definition of an app in a very old domain.

This change gracefully skips that app by adding a `try` block immediately above an existing `try` block. I chose to add a new block instead of just extending the existing one so that it would be easier to track the newly caught error in the logs.

The meat of this PR is in commit 88aaf065bf8b9c1298021d02c05d40a4a776db01. Everything else is cleanup and a couple of very picky nits.

More context: https://dimagi-dev.atlassian.net/browse/SC-2817

## Feature Flag

Related to Data Dictionary

## Safety Assurance

### Safety story

Catches a previously uncaught exception. Handles the error the same way as the existing `try` block immediately below.

### Automated test coverage

The error is not covered by tests.

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
