### PR TITLE
Update error text for restore state

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -394,7 +394,7 @@ class RestoreState:
 
                 if self.params.is_webapps:
                     # ignore this from webapps for now and just report
-                    notify_error("State hash mistmatch from webapps", details={
+                    notify_error("State hash mismatch from webapps", details={
                         'synclog_id': self.params.sync_log_id,
                         'device_id': self.params.device_id,
                         'app_id': self.params.app_id,


### PR DESCRIPTION
## Technical Summary

While reviewing a sentry error and an associated Jira ticket, I found that the error message describing the restore state error that is thrown (`State hash mistmatch from webapps`), had a misspelling in the word `mistmatch` which I changed to `mismatch`.

References:

https://dimagi-dev.atlassian.net/browse/USH-2537
https://dimagi.sentry.io/discover/results/?field=title&field=release&field=timestamp&field=domain&field=user.username&name=State+hash+mistmatch+from+webapps&project=136860&query=issue%3ACOMMCAREHQ-89CF+and+domain%3Aco-carecoordination%2A&sort=-timestamp&statsPeriod=7d&yAxis=count%28%29


## Feature Flag

Not specific to a feature flag.

## Safety Assurance

### Safety story

Corrects the misspelling of a word.

### Automated test coverage

The error is not covered by tests.

### QA Plan

No QA planned.


### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
