### PR TITLE
Remove unused ICDS code

### DIFF
--- a/corehq/apps/es/utils.py
+++ b/corehq/apps/es/utils.py
@@ -9,7 +9,6 @@ from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 from corehq.apps.es.exceptions import TaskError, TaskMissing
 from corehq.util.es.elasticsearch import SerializationError
 from corehq.util.json import CommCareJSONEncoder
-from corehq.util.metrics import metrics_counter
 
 
 TASK_POLL_DELAY = 10  # number of seconds to sleep between polling for task info
@@ -71,16 +70,6 @@ def flatten_field_dict(results, fields_property='fields'):
             new_val = val[0]
         field_dict[key] = new_val
     return field_dict
-
-
-def track_es_report_load(domain, report_slug, owner_count):
-    # Intended mainly for ICDs to track load of user filter counts when hitting ES
-    if hasattr(settings, 'TRACK_ES_REPORT_LOAD'):
-        metrics_counter(
-            'commcare.es.user_filter_count',
-            owner_count,
-            tags={'report_slug': report_slug, 'domain': domain}
-        )
 
 
 def es_format_datetime(val):

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -7,7 +7,6 @@ from corehq.util.es.elasticsearch import TransportError
 from memoized import memoized
 
 from corehq.apps.es import cases as case_es
-from corehq.apps.es.utils import track_es_report_load
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.api import ReportDataSource
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
@@ -83,7 +82,6 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
             or EMWF.selected_group_ids(mobile_user_and_group_slugs)
             or EMWF.selected_location_ids(mobile_user_and_group_slugs)
         ):
-            track_es_report_load(self.domain, self.slug, len(self.case_owners))
             case_owner_filters.append(case_es.owner(self.case_owners))
 
         query = query.OR(*case_owner_filters)

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -6,7 +6,6 @@ from memoized import memoized
 
 from corehq.apps.es import filters as es_filters
 from corehq.apps.es import forms as form_es
-from corehq.apps.es.utils import track_es_report_load
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.display import FormDisplay
@@ -87,7 +86,6 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
                                        mobile_user_and_group_slugs,
                                        self.request.couch_user)
                     .values_list('_id', flat=True))
-        track_es_report_load(self.domain, self.slug, len(user_ids))
         if HQUserType.UNKNOWN in EMWF.selected_user_types(mobile_user_and_group_slugs):
             user_ids.append(SYSTEM_USER_ID)
 

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -24,7 +24,6 @@ from corehq.apps.es.aggregations import (
     MissingAggregation,
     TermsAggregation,
 )
-from corehq.apps.es.utils import track_es_report_load
 from corehq.apps.locations.permissions import (
     conditionally_location_safe,
     location_safe,
@@ -389,7 +388,6 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
 
     @property
     def rows(self):
-        track_es_report_load(self.domain, self.slug, len(self.paginated_user_ids))
         es_results = self.es_queryset(
             user_ids=self.paginated_user_ids,
             size=self.pagination.start + self.pagination.count
@@ -716,11 +714,9 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
                     USER_QUERY_LIMIT,
                 )
             )
-        selected_users = self.selected_simplified_users
-        track_es_report_load(self.domain, self.slug, len(self.selected_simplified_users))
 
         totals = [0] * (len(self.all_relevant_forms) + 1)
-        for simplified_user in selected_users:
+        for simplified_user in self.selected_simplified_users:
             row = []
             if self.all_relevant_forms:
                 for form in self.all_relevant_forms.values():
@@ -924,7 +920,6 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
         else:
             users = self.users_by_username(order)
 
-        track_es_report_load(self.domain, self.slug, len(users))
         # Todo; this hits ES seperately for each user
         #   should instead aggregate by user in one ES query
         rows = [self.get_row(user) for user in users]
@@ -1055,8 +1050,6 @@ class FormCompletionTimeReport(WorkerMonitoringFormReportTableBase, DatespanMixi
         app_id = self.selected_form_data['app_id']
         xmlns = self.selected_form_data['xmlns']
 
-        track_es_report_load(self.domain, self.slug, len(self.users))
-
         data_map = get_form_duration_stats_by_user(
             self.domain,
             app_id,
@@ -1139,7 +1132,6 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
             user_map = {user.user_id: user
                         for user in users if user.user_id}
             user_ids = [user.user_id for user in users if user.user_id]
-            track_es_report_load(self.domain, self.slug, len(self.user_ids))
 
             xmlnss = []
             app_ids = []
@@ -1801,7 +1793,6 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
         if self.view_by_groups:
             rows = self._rows_by_group(report_data)
         else:
-            track_es_report_load(self.domain, self.slug, len(self.users_to_iterate))
             rows = self._rows_by_user(report_data, self.users_to_iterate)
 
         self.total_row = self._format_total_row(self._total_row(rows, report_data, self.users_to_iterate))


### PR DESCRIPTION
## Product Description
N/A

## Technical Summary
I came across this when looking for datadog metrics in elasticsearch code.  Looks like it was built for ICDS, and it's not enabled for any Dimagi envs or documented anywhere that I could find, so it feels pretty safe to remove.

See also https://github.com/dimagi/commcare-cloud/pull/6059

## Feature Flag


## Safety Assurance

### Safety story

I didn't find any references to this in the environment files in `commcare-cloud`, and I double checked by logging in to prod and confirming that that setting is not present.

### Automated test coverage


### QA Plan



### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
