### PR TITLE
Release Case List Explorer to Pro and Above

### DIFF
--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -75,7 +75,7 @@ Alternatively, you can run `ptop_reindexer_v2` as needed to sync individual inde
 Running it without any arguments will list the available indexes. The indexes you're most likely to use:
 + `sql-form` and `sql-case` populate form-based and case-based reports and exports
 + `user` and `group` may be useful, depending on what you're working on
-+ `case_search` populates the Case list Explorer and Explore Case Data reports, as well as the case search/claim feature. This is relevant only for those domains with the CASE_LIST_EXPLORER, EXPLORE_CASE_DATA or SEARCH_CLAIM feature flags enabled.
++ `case_search` populates the Case list Explorer and Explore Case Data reports, as well as the case search/claim feature. For now, this data stands as a duplicate but different format of the origin `case` index and at some point in the future, features that use the legacy `case` index will move to using `case-search`.
 + `sms` populates messaging reports and SMS exports
 + You do **not** care about `case` or `form`, which are only used on legacy domains that store forms and cases in CouchDB.
 

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-from django.contrib import messages
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
@@ -25,7 +23,6 @@ from corehq.apps.reports.standard.cases.utils import (
 )
 from corehq.apps.reports.standard.inspect import ProjectInspectionReport
 from corehq.elastic import ESError
-from corehq.toggles import CASE_LIST_EXPLORER
 
 from .data_sources import CaseDisplayES
 
@@ -169,31 +166,6 @@ class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
                 'urlname': CaseDataView.urlname,
             },
         ]
-
-    @property
-    def can_upgrade_to_case_list_explorer(self):
-        if settings.ENTERPRISE_MODE:
-            return False
-
-        if self.request.couch_user.is_dimagi and not CASE_LIST_EXPLORER.enabled(self.domain):
-            return True
-
-        return False
-
-    @property
-    def view_response(self):
-        if self.can_upgrade_to_case_list_explorer:
-            messages.warning(
-                self.request,
-
-                'Hey Dimagi User! Have you tried out the <a href="https://'
-                'confluence.dimagi.com/display/saas/Case+List+Explorer" '
-                'target="_blank">Case List Explorer</a> yet? It might be just '
-                'what you are looking for!',
-
-                extra_tags='html',
-            )
-        return super(CaseListReport, self).view_response
 
     @classmethod
     def display_in_dropdown(cls, domain=None, project=None, user=None):

--- a/corehq/apps/reports/tests/test_case_list_explorer_report.py
+++ b/corehq/apps/reports/tests/test_case_list_explorer_report.py
@@ -9,7 +9,7 @@ from corehq.apps.users.models import (
     DomainMembership,
     WebUser,
 )
-from corehq.util.test_utils import flag_enabled
+from corehq.util.test_utils import flag_enabled, privilege_enabled
 
 
 class TestCaseListExplorer(TestCase):
@@ -35,6 +35,7 @@ class TestCaseListExplorer(TestCase):
         cls.domain.delete()
 
     @flag_enabled('CASE_LIST_EXPLORER')
+    @privilege_enabled('CASE_LIST_EXPLORER')
     def test_with_explorer_columns_legacy(self):
         legacy_columns = ['@case_type', 'case_name', 'last_modified']
         get_query_dict = QueryDict('', mutable=True)
@@ -59,6 +60,7 @@ class TestCaseListExplorer(TestCase):
             self.assertIn(column, header_prop_names)
 
     @flag_enabled('CASE_LIST_EXPLORER')
+    @privilege_enabled('CASE_LIST_EXPLORER')
     def test_with_explorer_columns(self):
         columns = [
             {'name': '@case_type', 'label': '@case_type'},

--- a/corehq/apps/reports/tests/test_case_list_explorer_report.py
+++ b/corehq/apps/reports/tests/test_case_list_explorer_report.py
@@ -9,7 +9,7 @@ from corehq.apps.users.models import (
     DomainMembership,
     WebUser,
 )
-from corehq.util.test_utils import flag_enabled, privilege_enabled
+from corehq.util.test_utils import privilege_enabled
 
 
 class TestCaseListExplorer(TestCase):
@@ -34,7 +34,6 @@ class TestCaseListExplorer(TestCase):
         super().tearDownClass()
         cls.domain.delete()
 
-    @flag_enabled('CASE_LIST_EXPLORER')
     @privilege_enabled('CASE_LIST_EXPLORER')
     def test_with_explorer_columns_legacy(self):
         legacy_columns = ['@case_type', 'case_name', 'last_modified']
@@ -59,7 +58,6 @@ class TestCaseListExplorer(TestCase):
             self.assertIn(column, header_names)
             self.assertIn(column, header_prop_names)
 
-    @flag_enabled('CASE_LIST_EXPLORER')
     @privilege_enabled('CASE_LIST_EXPLORER')
     def test_with_explorer_columns(self):
         columns = [

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -99,7 +99,11 @@ def REPORTS(project):
     inspect_reports = [
         inspect.SubmitHistory, CaseListReport,
     ]
-    if toggles.CASE_LIST_EXPLORER.enabled(project.name):
+
+    from corehq.apps.accounting.utils import domain_has_privilege
+
+    domain_can_access_case_list_explorer = domain_has_privilege(project.name, privileges.CASE_LIST_EXPLORER)
+    if toggles.CASE_LIST_EXPLORER.enabled(project.name) or domain_can_access_case_list_explorer:
         inspect_reports.append(CaseListExplorer)
 
     if toggles.CASE_DEDUPE.enabled(project.name):
@@ -130,7 +134,6 @@ def REPORTS(project):
 
     reports = list(_get_report_builder_reports(project)) + reports
 
-    from corehq.apps.accounting.utils import domain_has_privilege
     messaging_reports = []
 
     project_can_use_sms = domain_has_privilege(project.name, privileges.OUTBOUND_SMS)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2494,7 +2494,7 @@ CASE_LIST_EXPLORER = FrozenPrivilegeToggle(
     tag=TAG_SOLUTIONS_OPEN,
     namespaces=[NAMESPACE_DOMAIN],
     save_fn=_ensure_search_index_is_enabled,
-    help_link='#todo',
+    help_link='https://confluence.dimagi.com/display/commcarepublic/Case+List+Explorer',
 )
 
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1074,14 +1074,6 @@ def _ensure_search_index_is_enabled(domain, enabled):
         reindex_case_search_for_domain.delay(domain)
 
 
-CASE_LIST_EXPLORER = StaticToggle(
-    'case_list_explorer',
-    'Show the case list explorer report',
-    TAG_SOLUTIONS_OPEN,
-    namespaces=[NAMESPACE_DOMAIN],
-    save_fn=_ensure_search_index_is_enabled,
-)
-
 EXPLORE_CASE_DATA = StaticToggle(
     'explore_case_data',
     'Show the Explore Case Data report (in dev)',
@@ -2493,6 +2485,18 @@ VIEW_APP_CHANGES = FrozenPrivilegeToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER],
     help_link="https://confluence.dimagi.com/display/saas/Viewing+App+Changes+between+versions",
 )
+
+
+CASE_LIST_EXPLORER = FrozenPrivilegeToggle(
+    privileges.CASE_LIST_EXPLORER,
+    'case_list_explorer',
+    label='Show the case list explorer report',
+    tag=TAG_SOLUTIONS_OPEN,
+    namespaces=[NAMESPACE_DOMAIN],
+    save_fn=_ensure_search_index_is_enabled,
+    help_link='#todo',
+)
+
 
 DATA_FILE_DOWNLOAD = FrozenPrivilegeToggle(
     privileges.DATA_FILE_DOWNLOAD,


### PR DESCRIPTION
## Technical Summary
To be merged alongside https://github.com/dimagi/commcare-hq/pull/33048

This PR ensures that plans with the `CASE_LIST_EXPLORER` privilege can now view the Case List Explorer report.
It also moves the previous `CASE_LIST_EXPLORER` feature flag to a `FrozenFeatureFlag`.

Any projects that previously had access to the CLE will continue to have access to the CLE as they will still be a part of the `FrozenFeatureFlag` list.

See
https://dimagi-dev.atlassian.net/browse/SAAS-14679 and associated tickets

## Safety Assurance

### Safety story
Very small set of changes isolated to the Case List Explorer Report.
Also deployed changes to staging.

### Automated test coverage
Yes, relevant tests updated

### QA Plan
Not needed for this PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
