### PR TITLE
Case Tiles "Sort By" UI

### DIFF
--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_one_two.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_one_two.xml
@@ -18,6 +18,7 @@
     </style>
     <header>
       <text>
+        <locale id="{title[locale_id]}"/>
       </text>
     </header>
     <template form="{title[format]}">
@@ -42,6 +43,7 @@
     </style>
     <header>
       <text>
+        <locale id="{top[locale_id]}"/>
       </text>
     </header>
     <template form="{top[format]}">
@@ -66,6 +68,7 @@
     </style>
     <header>
       <text>
+        <locale id="{bottom_left[locale_id]}"/>
       </text>
     </header>
     <template form="{bottom_left[format]}">
@@ -90,6 +93,7 @@
     </style>
     <header>
       <text>
+        <locale id="{bottom_right[locale_id]}"/>
       </text>
     </header>
     <template form="{bottom_right[format]}">
@@ -104,6 +108,7 @@
   <field>
     <header>
       <text>
+        <locale id="{map[locale_id]}"/>
       </text>
     </header>
     <template form="{map[format]}" width="0">
@@ -117,6 +122,7 @@
   <field>
     <header>
       <text>
+        <locale id="{map_popup[locale_id]}"/>
       </text>
     </header>
     <template form="{map_popup[format]}" width="0">

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_one.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_one.xml
@@ -26,6 +26,7 @@
   <field>
     <header>
       <text>
+        <locale id="{map[locale_id]}"/>
       </text>
     </header>
     <template form="{map[format]}" width="0">
@@ -40,6 +41,7 @@
   <field>
     <header>
       <text>
+        <locale id="{map_popup[locale_id]}"/>
       </text>
     </header>
     <template form="{map_popup[format]}" width="0">

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_one_one.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_one_one.xml
@@ -26,6 +26,7 @@
   <field>
     <header>
       <text>
+        <locale id="{map[locale_id]}"/>
       </text>
     </header>
     <template form="{map[format]}" width="0">
@@ -40,6 +41,7 @@
   <field>
     <header>
       <text>
+        <locale id="{map_popup[locale_id]}"/>
       </text>
     </header>
     <template form="{map_popup[format]}" width="0">

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/person_simple.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/person_simple.xml
@@ -146,7 +146,7 @@
     </style>
     <header>
       <text>
-        <locale id="{header[locale_id]}"/>
+        <locale id="{bottom_left[locale_id]}"/>
       </text>
     </header>
     <template form="{bottom_left[format]}">
@@ -179,7 +179,7 @@
     </style>
     <header>
       <text>
-        <locale id="{header[locale_id]}"/>
+        <locale id="{date[locale_id]}"/>
       </text>
     </header>
     <template form="{date[format]}">

--- a/corehq/apps/app_manager/tests/data/suite/suite-case-detail-instances.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-case-detail-instances.xml
@@ -220,7 +220,7 @@
        </style>
       <header>
         <text>
-          <locale id="m1.case_short.case_name_1.header"/>
+          <locale id="m1.case_short.case_name_3.header"/>
         </text>
       </header>
       <template form="plain">
@@ -245,7 +245,7 @@
        </style>
       <header>
         <text>
-          <locale id="m1.case_short.case_name_1.header"/>
+          <locale id="m1.case_short.case_name_5.header"/>
         </text>
       </header>
       <template form="plain">

--- a/corehq/apps/app_manager/tests/data/suite/suite-case-tiles.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-case-tiles.xml
@@ -139,7 +139,7 @@
        </style>
       <header>
         <text>
-          <locale id="m0.case_short.case_calculated_property_1.header"/>
+          <locale id="m0.case_short.case_mother_name_3.header"/>
         </text>
       </header>
       <template form="plain">
@@ -164,7 +164,7 @@
        </style>
       <header>
         <text>
-          <locale id="m0.case_short.case_calculated_property_1.header"/>
+          <locale id="m0.case_short.case_calculated_property_5.header"/>
         </text>
       </header>
       <template form="plain">

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -658,10 +658,18 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         templateContext: function () {
             const paginateItems = formplayerUtils.paginateOptions(this.options.currentPage, this.options.pageCount);
             const casesPerPage = parseInt($.cookie("cases-per-page-limit")) || 10;
+            const boldSortedCharIcon = (header) => {
+                const header_words = header.trim().split(' ');
+                const lastChar = header_words.pop();
+
+                return lastChar === "Λ" || lastChar === "V"
+                  ? `${header_words.join(' ')} <b>${lastChar}</b>`
+                  : header;
+              };
             return {
                 startPage: paginateItems.startPage,
                 title: this.options.title,
-                headers: this.headers,
+                headers: this.headers.map(boldSortedCharIcon),
                 widthHints: this.options.widthHints,
                 actions: this.options.actions,
                 currentPage: this.options.currentPage,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -383,6 +383,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             'click @ui.paginators': 'paginateAction',
             'click @ui.paginationGoButton': 'paginationGoAction',
             'click @ui.columnHeader': 'columnSortAction',
+            'keypress @ui.columnHeader': 'columnSortAction',
             'change @ui.casesPerPageLimit': 'onPerPageLimitChange',
             'keypress @ui.searchTextBox': 'searchTextKeyAction',
             'keypress @ui.paginationGoTextBox': 'paginationGoKeyAction',
@@ -488,8 +489,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         columnSortAction: function (e) {
-            const columnSelection = $(e.currentTarget).data("id") + 1;
-            FormplayerFrontend.trigger("menu:sort", columnSelection);
+            if (e.type === 'click' || (e.type === 'keypress' && e.keyCode === 13)) {
+                const columnSelection = $(e.currentTarget).data("id") + 1;
+                FormplayerFrontend.trigger("menu:sort", columnSelection);
+            }
         },
 
         _allCaseIds: function () {

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -35,7 +35,7 @@
               <div class="dropdown">
                 <button class="btn" data-toggle="dropdown"> <span> {% trans "Sort By" %} </span><i class="fa fa-sort"></i>
                 </button>
-                <ul class="dropdown-menu">
+                <ul class="dropdown-menu dropdown-menu-right">
                   <%  _.each(headers, function(header, index) { %>
                     <% if (columnSortable(index)) { %>
                     <li class="header-clickable formplayer-request" data-id="<%- index %>"><a> <%- header %></a></li>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -37,7 +37,7 @@
               <ul class="dropdown-menu">
                 <%  _.each(headers, function(header, index) { %>
                   <% if (columnSortable(index)) { %>
-                  <li><a> <%- header %></a></li>
+                  <li class="header-clickable formplayer-request" data-id="<%- index %>"><a> <%- header %></a></li>
                   <% } %>
                 <% }); %>
               </ul>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -31,6 +31,17 @@
                 <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
               <% } %>
             </div>
+            <div>
+              <button class="btn"> <span> {% trans "Sort By" %} </span><i class="fa fa-sort"></i>
+              </button>
+              <ul>
+                <%  _.each(headers, function(header, index) { %>
+                  <% if (columnSortable(index)) { %>
+                  <li><a> <%- header %></a></li>
+                  <% } %>
+                <% }); %>
+              </ul>
+            </div>
           <% } %>
           <section  class="js-case-container clearfix list-cell-container-style"></section>
         <% } else { %>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -31,10 +31,10 @@
                 <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
               <% } %>
             </div>
-            <div>
-              <button class="btn"> <span> {% trans "Sort By" %} </span><i class="fa fa-sort"></i>
+            <div class="dropdown">
+              <button class="btn" data-toggle="dropdown"> <span> {% trans "Sort By" %} </span><i class="fa fa-sort"></i>
               </button>
-              <ul>
+              <ul class="dropdown-menu">
                 <%  _.each(headers, function(header, index) { %>
                   <% if (columnSortable(index)) { %>
                   <li><a> <%- header %></a></li>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -24,10 +24,12 @@
         <% if (useTiles) { %>
           <% if (hasNoItems) { %>
             {% include 'formplayer/no_items_text.html' %}
-          <% } else if (isMultiSelect) { %>
+          <% } else { %>
             <div id="select-all-tile-wrapper">
-              <input type="checkbox" id="select-all-tile-checkbox"/>
-              <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
+              <% if (isMultiSelect) { %>
+                <input type="checkbox" id="select-all-tile-checkbox"/>
+                <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
+              <% } %>
             </div>
           <% } %>
           <section  class="js-case-container clearfix list-cell-container-style"></section>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -39,16 +39,7 @@
                 <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="case-list-sort-by">
                   <%  _.each(headers, function(header, index) { %>
                     <% if (columnSortable(index)) { %>
-                    <li tabindex="0" class="header-clickable formplayer-request" data-id="<%- index %>" role="menuitem"><a>
-                      <% var words = header.trim().split(' '); %>
-                      <% var lastWord = words[words.length - 1]; %>
-                      <% if (lastWord === "Λ" || lastWord === "V") { %>
-                        <% var remainingWords = words.slice(0, -1).join(' '); %>
-                        <%= remainingWords %> <strong><%= lastWord %></strong>
-                      <% } else { %>
-                        <%= header %>
-                      <% } %>
-                    </a></li>
+                    <li tabindex="0" class="header-clickable formplayer-request" data-id="<%- index %>" role="menuitem"><a><%= header %></a></li>
                     <% } %>
                   <% }); %>
                 </ul>
@@ -67,9 +58,9 @@
                   <%  _.each(headers, function(header, index) { %>
                     <% if (columnVisible(index)) { %>
                       <% if (columnSortable(index)) { %>
-                        <th class="module-case-list-header header-clickable formplayer-request" data-id="<%- index %>"> <%- header %></th>
+                        <th class="module-case-list-header header-clickable formplayer-request" data-id="<%- index %>"> <%= header %></th>
                       <% } else { %>
-                        <th class="module-case-list-header" data-id="<%- index %>"> <%- header %></th>
+                        <th class="module-case-list-header" data-id="<%- index %>"> <%= header %></th>
                       <% } %>
                     <% } %>
                   <% }); %>
@@ -242,7 +233,7 @@
         <tr>
           <% _.each(headers, function(header, index) { %>
           <% if (!(styles[index].widthHint === 0)) { %>
-          <th class="module-case-list-header"> <%- header %></th>
+          <th class="module-case-list-header"> <%= header %></th>
           <% } %>
           <% }); %>
         </tr>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -27,10 +27,10 @@
           <% } else { %>
             <div id="case-list-search-controls">
               <div>
-              <% if (isMultiSelect) { %>
-                <input type="checkbox" id="select-all-tile-checkbox"/>
-                <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
-              <% } %>
+                <% if (isMultiSelect) { %>
+                  <input type="checkbox" id="select-all-tile-checkbox"/>
+                  <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
+                <% } %>
               </div>
               <div class="dropdown">
                 <button class="btn" data-toggle="dropdown"> <span> {% trans "Sort By" %} </span><i class="fa fa-sort"></i>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -25,22 +25,24 @@
           <% if (hasNoItems) { %>
             {% include 'formplayer/no_items_text.html' %}
           <% } else { %>
-            <div id="select-all-tile-wrapper">
+            <div id="case-list-search-controls">
+              <div>
               <% if (isMultiSelect) { %>
                 <input type="checkbox" id="select-all-tile-checkbox"/>
                 <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
               <% } %>
-            </div>
-            <div class="dropdown">
-              <button class="btn" data-toggle="dropdown"> <span> {% trans "Sort By" %} </span><i class="fa fa-sort"></i>
-              </button>
-              <ul class="dropdown-menu">
-                <%  _.each(headers, function(header, index) { %>
-                  <% if (columnSortable(index)) { %>
-                  <li class="header-clickable formplayer-request" data-id="<%- index %>"><a> <%- header %></a></li>
-                  <% } %>
-                <% }); %>
-              </ul>
+              </div>
+              <div class="dropdown">
+                <button class="btn" data-toggle="dropdown"> <span> {% trans "Sort By" %} </span><i class="fa fa-sort"></i>
+                </button>
+                <ul class="dropdown-menu">
+                  <%  _.each(headers, function(header, index) { %>
+                    <% if (columnSortable(index)) { %>
+                    <li class="header-clickable formplayer-request" data-id="<%- index %>"><a> <%- header %></a></li>
+                    <% } %>
+                  <% }); %>
+                </ul>
+              </div>
             </div>
           <% } %>
           <section  class="js-case-container clearfix list-cell-container-style"></section>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -33,7 +33,7 @@
                 <% } %>
               </div>
               <div class="dropdown">
-                <button class="btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <button class="btn" id="case-list-sort-by-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   <span> {% trans "Sort By" %} </span><i class="fa fa-sort" aria-hidden="true"></i>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="case-list-sort-by">

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -39,7 +39,16 @@
                 <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="case-list-sort-by">
                   <%  _.each(headers, function(header, index) { %>
                     <% if (columnSortable(index)) { %>
-                    <li tabindex="0" class="header-clickable formplayer-request" data-id="<%- index %>" role="menuitem"><a> <%- header %></a></li>
+                    <li tabindex="0" class="header-clickable formplayer-request" data-id="<%- index %>" role="menuitem"><a>
+                      <% var words = header.trim().split(' '); %>
+                      <% var lastWord = words[words.length - 1]; %>
+                      <% if (lastWord === "Λ" || lastWord === "V") { %>
+                        <% var remainingWords = words.slice(0, -1).join(' '); %>
+                        <%= remainingWords %> <strong><%= lastWord %></strong>
+                      <% } else { %>
+                        <%= header %>
+                      <% } %>
+                    </a></li>
                     <% } %>
                   <% }); %>
                 </ul>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -33,19 +33,20 @@
                 <% } %>
               </div>
               <div class="dropdown">
-                <button class="btn" data-toggle="dropdown"> <span> {% trans "Sort By" %} </span><i class="fa fa-sort"></i>
+                <button class="btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <span> {% trans "Sort By" %} </span><i class="fa fa-sort" aria-hidden="true"></i>
                 </button>
-                <ul class="dropdown-menu dropdown-menu-right">
+                <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="case-list-sort-by">
                   <%  _.each(headers, function(header, index) { %>
                     <% if (columnSortable(index)) { %>
-                    <li class="header-clickable formplayer-request" data-id="<%- index %>"><a> <%- header %></a></li>
+                    <li tabindex="0" class="header-clickable formplayer-request" data-id="<%- index %>" role="menuitem"><a> <%- header %></a></li>
                     <% } %>
                   <% }); %>
                 </ul>
               </div>
             </div>
           <% } %>
-          <section  class="js-case-container clearfix list-cell-container-style"></section>
+          <section class="js-case-container clearfix list-cell-container-style"></section>
         <% } else { %>
         <div class="module-case-list-table-container">
           <table class="table module-table module-table-case-list">

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
@@ -52,6 +52,9 @@ body {
   border: 1px solid white;
   display: flex;
   justify-content: space-between;
+    #case-list-sort-by-btn {
+      background-color: transparent;
+    }
 }
 
 #select-all-tile-checkbox {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
@@ -47,9 +47,11 @@ body {
   }
 }
 
-#select-all-tile-wrapper {
+#case-list-search-controls {
   background-color: @cc-bg;
   border: 1px solid white;
+  display: flex;
+  justify-content: space-between;
 }
 
 #select-all-tile-checkbox {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Case Tile already supports sorting and this change adds a UI to change which field to sort by. After selecting the dropdown button, a list of the configured sort properties are displayed (or the default sort value if no sort properties are configured). Selecting an option will trigger sorting the cases according to the selected property and add a "Λ" or "V" for descending and ascending order respectively. The "V" and "V" are bolded for both regular case lists and case tiles (however, headers in regular case lists are already bolded so this change has no visual affect). 

https://github.com/dimagi/commcare-hq/assets/88759246/58918f44-9816-46c6-acc2-b2bd3e395cc0

![Screen Shot 2023-07-27 at 6 02 49 PM](https://github.com/dimagi/commcare-hq/assets/88759246/c5993a8c-55d1-4c95-840c-84e9296ae3f4)



## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi-dev.atlassian.net/browse/USH-3200

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[CASE_LIST_TILE](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=saas&title=Allow+Configuration+of+Case+List+Tiles)
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing. Changes are mostly UI limited to case tiles.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
