### PR TITLE
fix app API caching bug

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -382,7 +382,7 @@ class ApplicationResource(BaseApplicationResource):
             dehydrated['unique_id'] = module.unique_id
 
             dehydrated['forms'] = []
-            for form in module.forms:
+            for form in module.get_forms():
                 form_unique_id = form.unique_id
                 form_jvalue = {
                     'xmlns': form.xmlns,
@@ -408,7 +408,7 @@ class ApplicationResource(BaseApplicationResource):
 
         # support returning linked applications upon receiving an application list request
         if app.doc_type in [Application._doc_type, LinkedApplication._doc_type]:
-            return [self.dehydrate_module(app, module, app.langs) for module in bundle.obj.modules]
+            return [self.dehydrate_module(app, module, app.langs) for module in bundle.obj.get_modules()]
         elif app.doc_type == RemoteApp._doc_type:
             return []
 

--- a/corehq/apps/api/tests/app_resources.py
+++ b/corehq/apps/api/tests/app_resources.py
@@ -50,6 +50,11 @@ class TestAppResource(APIResourceTest):
             self.get_expected_structure(with_version=False),
         ])
 
+    def test_get_list_cache_bug(self):
+        self.test_get_list()
+        # subsequent requests use cached data which does not have the `_parent` refs set
+        self.test_get_list()
+
     def test_get_list_null_sorting(self):
         another_app = self.make_app()
         another_app.date_created = None


### PR DESCRIPTION
## Technical Summary
Subsequent requests use cached data which results in an error in the output: "'Form' object has no attribute '_parent'"

## Safety Assurance

### Safety story
Minor change localized to the application API. Changes are standard practice.

### Automated test coverage
There is existing test coverage and I have added a new test.

### QA Plan
I was able to reproduce the bug in the unit test and via the local dev server and confirmed that the changes fix the bug.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
