### PR TITLE
Ensure email content reflects report filters

### DIFF
--- a/corehq/apps/reports/static/reports/js/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/hq_report.js
@@ -231,6 +231,7 @@ hqDefine("reports/js/hq_report", [
             self.recipient_emails = ko.observable();
             self.notes = ko.observable();
             self.getReportRenderUrl = hqReport.getReportRenderUrl;
+            self.params = hqReport.getReportParams;
 
             self.unwrap = function () {
                 var data = ko.mapping.toJS(self, {

--- a/corehq/apps/saved_reports/tasks.py
+++ b/corehq/apps/saved_reports/tasks.py
@@ -202,20 +202,21 @@ def create_config_for_email(report_type, report_slug, user_id, domain, request_d
                 else:
                     filters[field] = value
         if field not in exclude:
-            filters[field] = GET.get(field)
+            filters[field] = GET.get(field) or filters[field]
 
     config.filters = filters
 
-    if 'startdate' in config.filters:
-        config.start_date = datetime.strptime(config.filters['startdate'], '%Y-%m-%d').date()
-    else:
-        config.start_date = request_data['datespan'].startdate.date()
-    if request_data['datespan'].enddate:
-        config.date_range = 'range'
-        config.end_date = request_data['datespan'].enddate.date()
-        if 'enddate' in config.filters:
-            config.end_date = datetime.strptime(config.filters['enddate'], '%Y-%m-%d').date()
-    else:
-        config.date_range = 'since'
+    if report_slug != 'case_list_explorer':
+        if 'startdate' in config.filters:
+            config.start_date = datetime.strptime(config.filters['startdate'], '%Y-%m-%d').date()
+        else:
+            config.start_date = request_data['datespan'].startdate.date()
+        if request_data['datespan'].enddate:
+            config.date_range = 'range'
+            config.end_date = request_data['datespan'].enddate.date()
+            if 'enddate' in config.filters:
+                config.end_date = datetime.strptime(config.filters['enddate'], '%Y-%m-%d').date()
+        else:
+            config.date_range = 'since'
 
     return config

--- a/corehq/apps/saved_reports/tasks.py
+++ b/corehq/apps/saved_reports/tasks.py
@@ -156,7 +156,11 @@ def send_email_report(self, recipient_emails, domain, report_slug, report_type,
             params = params.split('&')
             for param in params:
                 field, value = tuple(param.split('=', 1))
-                filters[field] = value
+                if field in filters:
+                    filters[field] = filters[field] + [value] if isinstance(filters[field], list) \
+                        else [filters[field]] + [value]
+                else:
+                    filters[field] = value
         if field not in exclude:
             filters[field] = GET.get(field)
 

--- a/corehq/apps/saved_reports/tasks.py
+++ b/corehq/apps/saved_reports/tasks.py
@@ -195,12 +195,12 @@ def create_config_for_email(report_type, report_slug, user_id, domain, request_d
             params = unquote(GET.get(field)[0])
             params = params.split('&')
             for param in params:
-                field, value = tuple(param.split('=', 1))
-                if field in filters:
-                    filters[field] = filters[field] + [value] if isinstance(filters[field], list) \
-                        else [filters[field]] + [value]
+                key, value = tuple(param.split('=', 1))
+                if key in filters:
+                    filters[key] = filters[key] + [value] if isinstance(filters[key], list) \
+                        else [filters[key]] + [value]
                 else:
-                    filters[field] = value
+                    filters[key] = value
         if field not in exclude:
             filters[field] = GET.get(field) or filters[field]
 
@@ -213,9 +213,5 @@ def create_config_for_email(report_type, report_slug, user_id, domain, request_d
             config.end_date = datetime.strptime(config.filters['enddate'], '%Y-%m-%d').date()
         else:
             config.date_range = 'since'
-
-    print(config.start_date)
-    print(config.end_date)
-    print(config.date_range)
 
     return config

--- a/corehq/apps/saved_reports/tasks.py
+++ b/corehq/apps/saved_reports/tasks.py
@@ -206,17 +206,16 @@ def create_config_for_email(report_type, report_slug, user_id, domain, request_d
 
     config.filters = filters
 
-    if report_slug != 'case_list_explorer':
-        if 'startdate' in config.filters:
-            config.start_date = datetime.strptime(config.filters['startdate'], '%Y-%m-%d').date()
-        else:
-            config.start_date = request_data['datespan'].startdate.date()
-        if request_data['datespan'].enddate:
+    if 'startdate' in config.filters and report_slug != 'project_health':
+        config.start_date = datetime.strptime(config.filters['startdate'], '%Y-%m-%d').date()
+        if 'enddate' in config.filters:
             config.date_range = 'range'
-            config.end_date = request_data['datespan'].enddate.date()
-            if 'enddate' in config.filters:
-                config.end_date = datetime.strptime(config.filters['enddate'], '%Y-%m-%d').date()
+            config.end_date = datetime.strptime(config.filters['enddate'], '%Y-%m-%d').date()
         else:
             config.date_range = 'since'
+
+    print(config.start_date)
+    print(config.end_date)
+    print(config.date_range)
 
     return config

--- a/corehq/apps/saved_reports/tests/test_models.py
+++ b/corehq/apps/saved_reports/tests/test_models.py
@@ -27,10 +27,10 @@ class TestReportConfig(TestCase):
         self.assertFalse(self.config.is_shared_on_domain())
 
     def test_report_config_contents(self):
-        self.domain = 'test-domain'
-        self.user_id = 'nothing'
-        self.report_slug = 'case_list_explorer'
-        self.report_type = 'project_report'
+        domain = 'test-domain'
+        user_id = 'nothing'
+        report_slug = 'case_list_explorer'
+        report_type = 'project_report'
 
         GET = {'send_to_owner': 'true',
                'subject': 'Case List Explorer',
@@ -51,22 +51,22 @@ class TestReportConfig(TestCase):
         GET_dict.update(GET)
         test_date = datetime(2023, 7, 25)
 
-        self.request_data = {
+        request_data = {
             'GET': GET_dict,
             'META': {'QUERY_STRING': '', 'PATH_INFO': '/a/test-domain/reports/email_onceoff/case_list_explorer/'},
             'datespan': DateSpan(
                 startdate=test_date - timedelta(days=30),
                 enddate=test_date
             ),
-            'couch_user': self.user_id,
+            'couch_user': user_id,
             'can_access_all_locations': True
         }
 
-        config = create_config_for_email(self.report_type, self.report_slug, self.user_id,
-                                         self.domain, self.request_data)
+        self.config = create_config_for_email(report_type, report_slug, user_id, domain, request_data)
+        self.config.save()
 
-        self.assertEqual(config.filters.get('search_xpath'), 'case_name="EXAMPLEXPATH"')
-        self.assertEqual(config.filters.get('explorer_columns'),
+        self.assertEqual(self.config.filters.get('search_xpath'), 'case_name="EXAMPLEXPATH"')
+        self.assertEqual(self.config.filters.get('explorer_columns'),
                          '[{"name":"@case_type","label":"@case_type"},'
                          '{"name":"case_name","label":"case_name"},'
                          '{"name":"last_modified","label":"last_modified"}]')

--- a/corehq/apps/saved_reports/tests/test_models.py
+++ b/corehq/apps/saved_reports/tests/test_models.py
@@ -49,15 +49,10 @@ class TestReportConfig(TestCase):
                }
         GET_dict = QueryDict('', mutable=True)
         GET_dict.update(GET)
-        test_date = datetime(2023, 7, 25)
 
         request_data = {
             'GET': GET_dict,
             'META': {'QUERY_STRING': '', 'PATH_INFO': '/a/test-domain/reports/email_onceoff/case_list_explorer/'},
-            'datespan': DateSpan(
-                startdate=test_date - timedelta(days=30),
-                enddate=test_date
-            ),
             'couch_user': user_id,
             'can_access_all_locations': True
         }

--- a/corehq/apps/saved_reports/tests/test_models.py
+++ b/corehq/apps/saved_reports/tests/test_models.py
@@ -53,13 +53,11 @@ class TestReportConfig(TestCase):
             'can_access_all_locations': True
         }
 
-    def tearDown(self) -> None:
-        self.config.delete()
-
     def test_report_is_shared_on_domain(self):
         self.config = ReportConfig(
             domain=self.domain,
         )
+        self.addCleanup(self.config.delete)
         self.config.save()
         self.assertFalse(self.config.is_shared_on_domain())
 
@@ -68,6 +66,7 @@ class TestReportConfig(TestCase):
             self.report_type, self.report_slug, self.user_id, self.domain, self.request_data
         )
         self.config.save()
+        self.addCleanup(self.config.delete)
         self.assertEqual(self.config.filters.get('search_xpath'), 'case_name="EXAMPLEXPATH"')
         self.assertEqual(self.config.filters.get('explorer_columns'),
                          '[{"name":"@case_type","label":"@case_type"},'
@@ -79,6 +78,7 @@ class TestReportConfig(TestCase):
             self.report_type, self.report_slug, self.user_id, self.domain, self.request_data
         )
         self.config.save()
+        self.addCleanup(self.config.delete)
         self.assertEqual(self.config.filters.get('startdate'), None)
         self.assertEqual(self.config.filters.get('enddate'), None)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Previously, when using the Email Report button on the few reports that supported the feature, the email contents would ignore all of the report filter configurations set by the user and send a report with default configs. This was most noticeable in Case List Explorer, which has a lot of configs (including what columns to show) but was revealed to affect all reports that had the feature. 

This PR corrects the way report configs are built during the email report process to include the necessary configs that were present in `getReportRenderUrl` but not separated out in the `ReportConfig` object itself. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-14665)

I believe the previous rationale was that `getReportRenderUrl` would be used to construct the `filters` portion of the `ReportConfig` but either ReportConfig changed in a way that broke this or this feature never had worked. In any case, since I'm still not entirely sure what the motive for including the whole url was, I added the report parameters that appear at the end of the url as its own param within the email request. Since this param has a predictable structure (bunch of configs separated by `&`) this is now used to break down the url into the filter components (like xpath or column configs). I separated out the ReportConfig construction step to make it easier to test. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Case List Explorer and a handful of other reports. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging. Passed QA

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added a test to confirm `create_config_for_email` works as it should, with the expected inputs. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

[Main QA ticket](https://dimagi-dev.atlassian.net/browse/QA-5442)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
