### PR TITLE
Make "Access APIs" require "Full Organization Access"

### DIFF
--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -296,7 +296,18 @@ hqDefine('users/js/roles',[
                         allowCheckboxPermission: null,
                     },
                     {
-                        showOption: true,
+                        // Since disabling "Full Organization Access" automatically disables "Access APIs"
+                        // and we never want "Access APIs" without "Full Organization Access",
+                        // we hide "Access APIs" when "Full Organization Access" is disabled.
+                        // If "Access APIs" is checked though, even if "Full Organization Access" isn't
+                        // we always want to show it.
+                        // One can no longer make this combination happen in the UI,
+                        // but for the small number of existing roles that have this combination
+                        // we want it to be displayed.
+                        // Unchecking "Access APIs" in this situation will then make the option disappear.
+                        showOption: ko.pureComputed(function() {
+                            return self.permissions.access_all_locations() || self.permissions.access_api();
+                        }),
                         editPermission: self.permissions.access_api,
                         viewPermission: null,
                         text: gettext("<strong>Access APIs</strong> &mdash; use CommCare HQ APIs to read and update data. Specific APIs may require additional permissions."),
@@ -497,6 +508,12 @@ hqDefine('users/js/roles',[
                         }
                     ),
                 ];
+                // Automatically disable "Access APIs" when "Full Organization Access" is disabled
+                self.permissions.access_all_locations.subscribe(() => {
+                    if(!self.permissions.access_all_locations() && self.permissions.access_api()) {
+                        self.permissions.access_api(false);
+                    }
+                });
 
                 self.validate = function () {
                     self.registryPermissions.forEach((perm) => {


### PR DESCRIPTION
## Product Description
This change makes it impossible using the UI to end up with a user role that is configured to allow Access API but does not have Full Organization Access enabled. Because APIs operate under a different permission mechanism based on the API key, the restriction implied by denying Full Organization Access does not apply to API access. This PR makes eliminates the creation of this unintuitive combination altogether, but allows for existing roles that have this combination to be properly displayed.

More information can be found in https://dimagi-dev.atlassian.net/browse/SAAS-13073?focusedCommentId=278427.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-13073

## Safety Assurance

### Safety story
The change in this PR is entirely contained within the frontend, which eliminates the possibility of difficult-to-anticipate frontend-backend interaction issues. I've tested the behavior of the interface manually to make sure that it behaves in the manner described under "QA Plan".


### Automated test coverage

There is no automated test coverage for this UI.

### QA Plan

- Begin with a new role that has Full Organization Access enabled and Access APIs disabled OR enabled.
  - [x] Then: Toggling Access APIs behaves as expected with no further behavior.
  - [x] Then: Disabling Full Organization Access causes Access APIs to disappear. Re-enabling Full Organization Access causes Access APIs to reappear, disabled.
- Begin with a new role that has Full Organization Access disabled and Access APIs enabled.
  - [x] Then: Enabling Full Organization Access and then re-disabling it will cause the Access API option to disappear. Re-enabling it will cause Access APIs to reappear, disabled.
  - [x] Then: Simply disabling Access APIs will cause that option to disappear. Enabling Full Organization Access causes Access APIs to reappear, disabled.

Finally, I checked that clicking around furiously in the role configuration modal does not cause any console errors and behaves as I expected it to.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
