### PR TITLE
Case List Explorer incorrect labels fix

### DIFF
--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
@@ -6,7 +6,7 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
         var self = this;
         self.currentCaseType = ko.observable('');
         $('#report_filter_case_type').on('change', function (e) {
-            self.currentCaseType(e.val);
+            self.currentCaseType(e.currentTarget.value);
         });
 
         self.suggestedProperties = ko.computed(function () {

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
@@ -38,9 +38,13 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
         self.label = ko.observable(label).trimmed();
 
         self._value = function () {
-            return _.find($parent.allSuggestions, function (prop) {
+            const valueList = _.filter($parent.allSuggestions, function (prop) {
                 return prop.name === self.name();
             });
+            if (valueList.length === 1) {
+                return valueList[0];
+            }
+            return null;
         };
 
         self.meta_type = ko.computed(() => {
@@ -52,9 +56,11 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
         });
 
         self.name.subscribe(() => {
-            var value = self._value();
-            if (value) {
-                self.label(value.label || self.name());
+            const value = self._value();
+            if (value && value.label) {
+                self.label(value.label);
+            } else if (self.name()) {
+                self.label(self.name());
             }
         });
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No UI changes, however the behaviour of the "Edit Columns" filter UI has been changed as follows:

Selecting a case property that exists in multiple case types will auto-populate the label field with the case property name
![cle_all_case_types](https://github.com/dimagi/commcare-hq/assets/122617251/9c6c9191-566e-46ba-b65e-44bf169186e4)

Selecting a case property that only exists in one case type will auto-populate the label field with the correct case property label
![cle_all_case_types_single](https://github.com/dimagi/commcare-hq/assets/122617251/d498b4bc-3313-468e-a5f0-e6761168c6e0)

Changing the case type filter will correctly filter the dropdown of suggested case properties
![cle_filtered](https://github.com/dimagi/commcare-hq/assets/122617251/1bd9ca45-98bc-4a07-9824-3ccc29aba04b)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2915).

This change addresses a pre-existing bug on the Case List Explorer when the `DATA_DICTIONARY` feature flag is enabled and the user has selected "All Case Types" as the case type filter. Specifically, when a user selects a suggested case property that exists for more than one case type in the "Edit Columns" filter, the "Label" field will be incorrectly pre-populated with the label of the first found case property definition in the DD. This PR makes it so that now, when more than one case type shares a case property, the "Label" field will instead simply be populated with the case property name.

Another issue that is also addressed is the broken filtering of the case property suggestions when a user changes the case type filter. Currently, an invalid reference is being used and so the case type change is picked up as `null`, causing the "Edit Columns" filter to filter out all case property suggestions. This has been fixed to correctly filter based on the selected case type.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`CASE_LIST_EXPLORER` which is being GA'ed

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Have done local testing.
- Small UI change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
