### PR TITLE
Don't show Case List Session Endpoint on forms

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_session_endpoint.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_session_endpoint.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+
+            <div class="form-group">
+              <label class="control-label {% css_label_class %}">
+                {% trans 'Case List Session Endpoint ID' %}
+                <span class="hq-help-template"
+                      data-title="{% trans 'Case List Session Endpoint ID' %}"
+                      data-content="{% blocktrans %}A session endpoint ID to navigate to this
+                                    case list without doing selection on the case list.{% endblocktrans %}"></span>
+              </label>
+              <div id="case-list-session-endpoint-id"
+                   class="{% css_field_class %} commcare-feature"
+                   data-since-version="2.51"
+                   class="{% css_field_class %}">
+                <input class="code form-control"
+                       type="text"
+                       id="case_list_session_endpoint_id"
+                       name="case_list_session_endpoint_id"
+                       value="{{ module.case_list_session_endpoint_id|default:'' }}" />
+              </div>
+            </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -251,6 +251,9 @@
 
             {% if session_endpoints_enabled %}
               {% include "app_manager/partials/session_endpoints.html" with module_or_form=module %}
+              {% if not module.is_surveys %}
+                {% include "app_manager/partials/case_list_session_endpoint.html" with module=module %}
+              {% endif %}
             {% endif %}
 
             {% if request|toggle_enabled:'USH_EMPTY_CASE_LIST_TEXT' %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/session_endpoints.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/session_endpoints.html
@@ -20,24 +20,3 @@
                        value="{{ module_or_form.session_endpoint_id|default:'' }}" />
               </div>
             </div>
-            {% if not module_or_form.is_surveys %}
-              <div class="form-group">
-                  <label class="control-label {% css_label_class %}">
-                    {% trans 'Case List Session Endpoint ID' %}
-                    <span class="hq-help-template"
-                          data-title="{% trans 'Case List Session Endpoint ID' %}"
-                          data-content="{% blocktrans %}A session endpoint ID to navigate to this
-                                        case list without doing selection on the case list.{% endblocktrans %}"></span>
-                  </label>
-                  <div id="case-list-session-endpoint-id"
-                       class="{% css_field_class %} commcare-feature"
-                       data-since-version="2.51"
-                       class="{% css_field_class %}">
-                    <input class="code form-control"
-                           type="text"
-                           id="case_list_session_endpoint_id"
-                           name="case_list_session_endpoint_id"
-                           value="{{ module_or_form.case_list_session_endpoint_id|default:'' }}" />
-                  </div>
-              </div>
-            {% endif %}


### PR DESCRIPTION
## Product Description

On prod you currently see a non-functional "Case List Session Endpoint ID" on all forms when session endpoints are enabled.  This is only supposed to be present for case lists.

![image](https://github.com/dimagi/commcare-hq/assets/2367539/97fce9ce-7902-4116-afed-da63b3a2c701)

## Technical Summary
This reverts commit cbf504df046d8e74f38087077767cf900228ad59 from https://github.com/dimagi/commcare-hq/pull/33183#discussion_r1253176292
Merging the two templates meant that both were rendered on the module settings page and form settings page.  In the latter context, `is_survey` is not defined, so that conditional defaults to True.

I initially tried deduplicating the templates like this:

```jinja
{% include "app_manager/partials/session_endpoints.html" with
    label=_("Session Endpoint ID")
    help_text=_("A session endpoint ID allows Android apps to call in to CommCare at this position.")
    css_id=session_endpoint_id
    value=module.session_endpoint_id|default:''
%}
```

But apparently you can't do multi-line template tags, and it looks horrible on one line (though it does work), so I gave up and went for the revert.

## Feature Flag
Session Endpoints

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally, plus this only affects how the HTML is rendered, which is fairly simple

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
