### PR TITLE
Update Appcues Data to Include Software Plan Edition

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/appcues.js
+++ b/corehq/apps/analytics/static/analytix/js/appcues.js
@@ -43,6 +43,7 @@ hqDefine('analytix/js/appcues', [
                 domain: _get("domain"),
                 isDimagi: _get("userIsDimagi"),
                 instance: _get("instance"),
+                softwarePlanEdition: _get("softwarePlanEdition"),
             });
         });
     });

--- a/corehq/apps/analytics/templates/analytics/initial/appcues.html
+++ b/corehq/apps/analytics/templates/analytics/initial/appcues.html
@@ -15,4 +15,5 @@
 {% initial_analytics_data 'appcues.lastName' request.couch_user.last_name %}
 {% initial_analytics_data 'appcues.userIsDimagi' request.couch_user.is_dimagi %}
 {% initial_analytics_data 'appcues.domain' request.domain %}
+{% initial_analytics_data 'appcues.softwarePlanEdition' request.software_plan_edition %}
 {% initial_analytics_data 'appcues.instance' ANALYTICS_CONFIG.HQ_INSTANCE %}

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -155,6 +155,7 @@ def plan_details(request):
     plan_version = Subscription.get_subscribed_plan_by_domain(domain)
     return {
         'privileges': list(get_privileges(plan_version)),
+        'software_plan_edition': plan_version.plan.edition,
     }
 
 

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -142,7 +142,7 @@ def js_toggles(request):
     }
 
 
-def js_privileges(request):
+def plan_details(request):
     domain = None
     if getattr(request, 'project', None):
         domain = request.project.name

--- a/settings.py
+++ b/settings.py
@@ -1271,7 +1271,7 @@ TEMPLATES = [
                 'corehq.util.context_processors.status_page',
                 'corehq.util.context_processors.sentry',
                 'corehq.util.context_processors.bootstrap5',
-                'corehq.util.context_processors.js_privileges',
+                'corehq.util.context_processors.plan_details',
             ],
             'debug': DEBUG,
             'loaders': [


### PR DESCRIPTION
## Technical Summary
Updates appcues data to include software plan edition so that we can segment user traffic by software plan edition in appcues flows.

## Safety Assurance

### Safety story
just a small change to appcues data. tested on staging

### Automated test coverage
no

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
