### PR TITLE
Add elasticsearch query timing/error information

### DIFF
--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -121,6 +121,7 @@ from dimagi.utils.logging import notify_exception
 from dimagi.utils.modules import to_function
 
 from corehq.apps.celery import periodic_task
+from corehq.util.quickcache import quickcache
 from corehq.util.timer import TimingContext
 
 from .const import ALERT_INFO, COMMON_TAGS, MPM_ALL
@@ -311,6 +312,33 @@ class metrics_track_errors(ContextDecorator):
             metrics_counter(self.succeeded_name)
         else:
             metrics_counter(self.failed_name)
+
+
+def limit_domains(domain_name):
+    """Return the domain name if it's among a privileged set that get tagged individually
+
+    Else return __other__.  This is used to limit the number of tag combinations sent to datadog.
+    """
+    if not settings.IS_SAAS_ENVIRONMENT:
+        return domain_name
+    if domain_name and domain_name in _domains_to_tag():
+        return domain_name
+    return '__other__'
+
+
+@quickcache([], timeout=24 * 60 * 60)
+def _domains_to_tag():
+    # Only tag big projects individually
+    # I expect this implementation may need to evolve
+    from corehq.apps.accounting import models
+    return set(models.Subscription.visible_objects.filter(
+        is_active=True,
+        plan_version__plan__edition=models.SoftwarePlanEdition.ENTERPRISE,
+        service_type__in=[models.SubscriptionType.IMPLEMENTATION, models.SubscriptionType.SANDBOX],
+    ).values_list(
+        'subscriber__domain',
+        flat=True
+    ))
 
 
 def push_metrics():

--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -245,7 +245,6 @@ class metrics_histogram_timer(TimingContext):
     :param metric: Name of the metric (must start with 'commcare.')
     :param tags: metric tags to include
     :param timing_buckets: sequence of numbers representing time thresholds, in seconds
-    :param bucket_tag: The name of the bucket tag to use (if used by the underlying provider)
     :param callback: a callable which will be called when exiting the context manager with a single argument
                      of the timer duration
     :return: A context manager that will perform the specified timing
@@ -253,12 +252,11 @@ class metrics_histogram_timer(TimingContext):
     """
 
     def __init__(self, metric: str, timing_buckets: Iterable[int], tags: Dict[str, str] = None,
-                 bucket_tag: str = 'duration', callback: Callable = None):
+                 callback: Callable = None):
         super().__init__()
         self._metric = metric
         self._timing_buckets = timing_buckets
         self._tags = tags
-        self._bucket_tag = bucket_tag
         self._callback = callback
 
     def stop(self, name=None):
@@ -266,9 +264,8 @@ class metrics_histogram_timer(TimingContext):
         if self._callback:
             self._callback(self.duration)
         metrics_histogram(
-            self._metric, self.duration,
-            bucket_tag=self._bucket_tag, buckets=self._timing_buckets, bucket_unit='s',
-            tags=self._tags
+            self._metric, self.duration, bucket_tag='duration',
+            buckets=self._timing_buckets, bucket_unit='s', tags=self._tags
         )
         timer_name = self._metric
         if self._metric.startswith('commcare.'):

--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -271,7 +271,7 @@ class metrics_histogram_timer(TimingContext):
             buckets=self._timing_buckets, bucket_unit='s', tags=self._tags
         )
         if self._errored:
-            metrics_counter(self._metric, tags={**self._tags, 'duration': 'error'})
+            metrics_counter(f'{self._metric}.error', tags=self._tags)
         timer_name = self._metric
         if self._metric.startswith('commcare.'):
             timer_name = ".".join(self._metric.split('.')[1:])  # remove the 'commcare.' prefix

--- a/corehq/util/metrics/utils.py
+++ b/corehq/util/metrics/utils.py
@@ -1,7 +1,6 @@
 import re
 from datetime import timedelta
 
-
 WILDCARD = '*'
 
 

--- a/corehq/util/soft_assert/api.py
+++ b/corehq/util/soft_assert/api.py
@@ -2,7 +2,6 @@ import logging
 
 from django.conf import settings
 
-from corehq.util.log import get_sanitized_request_repr
 from corehq.util.global_request import get_request
 from corehq.util.soft_assert.core import SoftAssert
 
@@ -10,6 +9,7 @@ logger = logging.getLogger('soft_asserts')
 
 
 def _send_message(info, backend):
+    from corehq.util.log import get_sanitized_request_repr
     request = get_request()
     request_repr = get_sanitized_request_repr(request)
 


### PR DESCRIPTION
## Product Description


## Technical Summary
This PR adds a new datadog metric (`commcare.elasticsearch.search.timing`) to record ES search timing and a count of errors.  This is tagged by index and domain (depending on the domain - see comments for more)

I have a number of comments about implementation specifics, which I'll add as comments in-line.

## Feature Flag

## Safety Assurance

### Safety story
I tried this out on staging and it seems to give [the results I'd expect](https://app.datadoghq.com/metric/explorer?fullscreen_end_ts=1690571415971&fullscreen_paused=true&fullscreen_start_ts=1690567815971&start=1690567815971&end=1690571415971&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMiZOKqqmRhGAHRwmBoSRXBNmYzNWj19aqIwwABUPAAEAEZYk8BQdRiiFFB42p6SIjzNGBpOtXgiCAAUAJQgPAC6VK7ueO3WoHeqDxgxpfGXNyAdWGg5UDyDAAhAIHJJHAwA7tDQQTKJNCiOBOOSKZTpJFQRHIpz0JjKERuDxoS78CD2TBYVEKCFIkRKa48Pi-eRIhAAYSkwhgKBEDzQPCAA)

TODO: check metric usage costs a week or so after merging to ensure this isn't super costly

### Automated test coverage


### QA Plan
none

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
