### PR TITLE
Allow dot notation in case search property validations

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -338,7 +338,8 @@ class RemoteRequestFactory(object):
             if prop.validations:
                 kwargs['validations'] = [
                     Validation(
-                        test=interpolate_xpath(validation.test),
+                        # don't interpolate dots since "." is a valid reference here
+                        test=interpolate_xpath(validation.test, interpolate_dots=False),
                         text=[Text(
                             locale_id=id_strings.search_property_validation_text(self.module, prop.name, i)
                         )] if validation.has_text else [],

--- a/corehq/apps/app_manager/tests/test_suite_regex.py
+++ b/corehq/apps/app_manager/tests/test_suite_regex.py
@@ -58,3 +58,12 @@ class RegexTest(SimpleTestCase):
         for case in ('./lmp < 570.5', '#case/lmp < 570.5'):
             with self.assertRaises(CaseXPathValidationError):
                 interpolate_xpath(case, None),
+
+    def test_interpolate_dots_flag(self):
+        case = 'string-length(.) = 10'
+        with self.assertRaises(CaseXPathValidationError):
+            interpolate_xpath(case, None)
+        self.assertEqual(
+            interpolate_xpath(case, None, interpolate_dots=False),
+            case
+        )

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -69,21 +69,27 @@ def dot_interpolate(string, replacement):
     return new
 
 
-def interpolate_xpath(string, case_xpath=None, fixture_xpath=None, module=None, form=None):
-    """
-    Replace xpath shortcuts with full value.
-    """
-    if case_xpath is None and any([
+def _validate_case_reference(string, module, form, interpolate_dots=True):
+    bad_references = [
         '#case' in string,
         '#parent' in string,
         '#host' in string,
-        # DOT_INTERPOLATE_PATTERN throws false positives, so if it flags the string,
-        # verify that the string's dots would actually get replaced
-        re.search(DOT_INTERPOLATE_PATTERN, string) and dot_interpolate(string, "") != string,
-    ]):
+    ]
+    if interpolate_dots:
+        bad_references.append(re.search(DOT_INTERPOLATE_PATTERN, string) and dot_interpolate(string, "") != string)
+    if any(bad_references):
         # At the moment this function is only used by module and form filters.
         # If that changes, amend the error message accordingly.
         raise CaseXPathValidationError(_(CASE_REFERENCE_VALIDATION_ERROR), module=module, form=form)
+
+
+def interpolate_xpath(string, case_xpath=None, fixture_xpath=None, module=None, form=None, interpolate_dots=True):
+    """
+    Replace xpath shortcuts with full value.
+    """
+    if case_xpath is None:
+        _validate_case_reference(string, module, form, interpolate_dots)
+
     replacements = {
         '#user': UsercaseXPath().case(),
         '#session/': session_var('', path=''),

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -69,7 +69,7 @@ def dot_interpolate(string, replacement):
     return new
 
 
-def _validate_case_reference(string, module, form, interpolate_dots=True):
+def _ensure_no_case_references(string, module, form, interpolate_dots=True):
     bad_references = [
         '#case' in string,
         '#parent' in string,
@@ -88,7 +88,7 @@ def interpolate_xpath(string, case_xpath=None, fixture_xpath=None, module=None, 
     Replace xpath shortcuts with full value.
     """
     if case_xpath is None:
-        _validate_case_reference(string, module, form, interpolate_dots)
+        _ensure_no_case_references(string, module, form, interpolate_dots)
 
     replacements = {
         '#user': UsercaseXPath().case(),


### PR DESCRIPTION
## Product Description
Allows use of dot notation in case search property validations, e.g.:
![image](https://github.com/dimagi/commcare-hq/assets/100609770/9d7a5ad6-62cc-4fd0-915c-43f8608e0552)


## Technical Summary
[USH-3291](https://dimagi-dev.atlassian.net/browse/USH-3291)
Adds an argument `interpolate_dots` to the `interpolate_xpath` function, which when `True` tries to replace dots with given case xpath (or throws an error if that xpath doesn't exist). This defaults to `True` to keep the existing behavior, and is only set to `False` for case search property validations, where dot notation is valid as-is and does not need replacement.


## Feature Flag
Change is not strictly behind a feature flag, but only visible to users with search_claim enabled.

## Safety Assurance

### Safety story
This leaves the existing validations in place for references that are bad when no case xpath is given (`#case`, `#parent`, `#host`), and by defaulting to existing behavior should only affect case search property validations. Re: mobile compatibility, my local testing seems to show search property validations are not used by mobile, and including a `.` without a case reference has no effect on the app.

### Automated test coverage
Covered in `test_suite_regex` and added a test for the `interpolate_dots` flag

### QA Plan
Will send to QA to confirm that:
- dot notation is usable in case search property validation conditions
- invalid references `#case` etc. are not allowed in validation conditions
- there are no ill effects on mobile when dot notation is used in this context

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3291]: https://dimagi-dev.atlassian.net/browse/USH-3291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ