### PR TITLE
Orphan case warning on Mobile Worker locations edit page

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -660,7 +660,7 @@ class DomainGlobalSettingsForm(forms.Form):
             setting_obj.save()
 
     def _save_orphan_case_alerts_setting(self, domain):
-        domain.orphan_case_alerts_warning = self.cleaned_data.get("orphan_case_alerts_warning")
+        domain.orphan_case_alerts_warning = self.cleaned_data.get("orphan_case_alerts_warning", False)
 
     def save(self, request, domain):
         domain.hr_name = self.cleaned_data['hr_name']

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -437,7 +437,7 @@ class DomainGlobalSettingsForm(forms.Form):
     )
 
     orphan_case_alerts_warning = BooleanField(
-        label=gettext_lazy("Orphan Case Alerts on Mobile Worker Edit Page"),
+        label=gettext_lazy("Show Orphan Case Alerts on Mobile Worker Edit Page"),
         required=False,
         help_text=gettext_lazy(
             """

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -436,6 +436,19 @@ class DomainGlobalSettingsForm(forms.Form):
         )
     )
 
+    orphan_case_alerts_warning = BooleanField(
+        label=gettext_lazy("Orphan Case Alerts on Mobile Worker Edit Page"),
+        required=False,
+        help_text=gettext_lazy(
+            """
+            Displays a warning message on the mobile worker location edit page
+            for locations that owns cases and only one assigned mobile worker.
+            This helps prevent situations where cases are being orphaned by moving
+            the only assigned mobile worker out of its location.
+            """
+        )
+    )
+
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop('domain', None)
         self.domain = self.project.name
@@ -445,6 +458,7 @@ class DomainGlobalSettingsForm(forms.Form):
         self.helper[5] = twbscrispy.PrependedText('delete_logo', '')
         self.helper[6] = twbscrispy.PrependedText('call_center_enabled', '')
         self.helper[14] = twbscrispy.PrependedText('release_mode_visibility', '')
+        self.helper[15] = twbscrispy.PrependedText('orphan_case_alerts_warning', '')
         self.helper.all().wrap_together(crispy.Fieldset, _('Edit Basic Information'))
         self.helper.layout.append(
             hqcrispy.FormActions(
@@ -480,6 +494,7 @@ class DomainGlobalSettingsForm(forms.Form):
         self._handle_call_limit_visibility()
         self._handle_account_confirmation_by_sms_settings()
         self._handle_release_mode_setting_value()
+        self._handle_orphan_case_alerts_setting_value()
 
     def _handle_account_confirmation_by_sms_settings(self):
         if not TWO_STAGE_USER_PROVISIONING_BY_SMS.enabled(self.domain):
@@ -511,6 +526,9 @@ class DomainGlobalSettingsForm(forms.Form):
     def _handle_release_mode_setting_value(self):
         self.fields['release_mode_visibility'].initial = AppReleaseModeSetting.get_settings(
             domain=self.domain).is_visible
+
+    def _handle_orphan_case_alerts_setting_value(self):
+        self.fields['orphan_case_alerts_warning'].initial = self.project.orphan_case_alerts_warning
 
     def _add_range_validation_to_integer_input(self, settings_name, min_value, max_value):
         setting = self.fields.get(settings_name)
@@ -641,6 +659,9 @@ class DomainGlobalSettingsForm(forms.Form):
             setting_obj.is_visible = self.cleaned_data.get("release_mode_visibility")
             setting_obj.save()
 
+    def _save_orphan_case_alerts_setting(self, domain):
+        domain.orphan_case_alerts_warning = self.cleaned_data.get("orphan_case_alerts_warning")
+
     def save(self, request, domain):
         domain.hr_name = self.cleaned_data['hr_name']
         domain.project_description = self.cleaned_data['project_description']
@@ -658,6 +679,7 @@ class DomainGlobalSettingsForm(forms.Form):
         self._save_timezone_configuration(domain)
         self._save_account_confirmation_settings(domain)
         self._save_release_mode_setting(domain)
+        self._save_orphan_case_alerts_setting(domain)
         domain.save()
         return True
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -442,9 +442,9 @@ class DomainGlobalSettingsForm(forms.Form):
         help_text=gettext_lazy(
             """
             Displays a warning message on the mobile worker location edit page
-            for locations that owns cases and only one assigned mobile worker.
+            about locations that owns cases and only have one assigned mobile worker.
             This helps prevent situations where cases are being orphaned by moving
-            the only assigned mobile worker out of its location.
+            the only assigned mobile worker out of the location owning that cases.
             """
         )
     )

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -446,6 +446,8 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     default_mobile_ucr_sync_interval = IntegerProperty()
 
     ga_opt_out = BooleanProperty(default=False)
+    orphan_case_alerts_warning = BooleanProperty(default=False)
+
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -8,6 +8,7 @@
   {% initial_page_data 'location_types' location_types %}
   {% initial_page_data 'commtrack_enabled' commtrack_enabled %}
   {% initial_page_data 'suggest_orphan_case_alerts_setting' suggest_orphan_case_alerts_setting %}
+  {% initial_page_data 'project_settings_url' project_settings_url %}
   <div class="row">
     <div class="col-sm-8">
       <h2>{% trans "Organization Levels" %}</h2>
@@ -29,15 +30,8 @@
       {% blocktrans %}
         If you have multiple organization levels and at least one can own cases,
         consider enabling the
-      {% endblocktrans %}
-      <a href="{% url 'domain_settings_default' domain %}">
-        {% blocktrans %}
-          Orphan Case Alerts on Edit Mobile Workers Page project setting
-        {% endblocktrans %}
-      </a>
-      {% blocktrans %}
-        to alert users about potentially creating orphan cases
-        when modifying cases or locations.
+        <a href="{{ project_settings_url }}"> Orphan Case Alerts on Edit Mobile Workers Page project setting </a>
+        to alert users about potentially creating orphan cases when modifying cases or locations.
       {% endblocktrans %}
     </div>
 

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -28,10 +28,9 @@
   {% if suggest_orphan_case_alerts_setting %}
     <div class="alert alert-info">
       {% blocktrans %}
-        If you have multiple organization levels and at least one can own cases,
-        consider enabling the
-        <a href="{{ project_settings_url }}"> Orphan Case Alerts on Edit Mobile Workers Page project setting </a>
-        to alert users about potentially creating orphan cases when modifying cases or locations.
+        If you have organization levels that can own cases, consider enabling the
+        <a href="{{ project_settings_url }}"> Show Orphan Case Alerts on Mobile Worker Edit Page </a>
+        project setting to alert users about potentially creating orphan cases when modifying cases or locations.
       {% endblocktrans %}
     </div>
 

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -7,6 +7,7 @@
 {% block page_content %}
   {% initial_page_data 'location_types' location_types %}
   {% initial_page_data 'commtrack_enabled' commtrack_enabled %}
+  {% initial_page_data 'suggest_orphan_case_alerts_setting' suggest_orphan_case_alerts_setting %}
   <div class="row">
     <div class="col-sm-8">
       <h2>{% trans "Organization Levels" %}</h2>
@@ -23,6 +24,24 @@
       </p>
     </div>
   </div>
+  {% if suggest_orphan_case_alerts_setting %}
+    <div class="alert alert-info">
+      {% blocktrans %}
+        If you have multiple organization levels and at least one can own cases,
+        consider enabling the
+      {% endblocktrans %}
+      <a href="{% url 'domain_settings_default' domain %}">
+        {% blocktrans %}
+          Orphan Case Alerts on Edit Mobile Workers Page project setting
+        {% endblocktrans %}
+      </a>
+      {% blocktrans %}
+        to alert users about potentially creating orphan cases
+        when modifying cases or locations.
+      {% endblocktrans %}
+    </div>
+
+  {% endif %}
   <form id="settings" class="form form-horizontal" method="post">
     {% csrf_token %}
     <fieldset>

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -308,7 +308,8 @@ class LocationTypesView(BaseDomainView):
         return {
             'location_types': self._location_types,
             'commtrack_enabled': self.domain_object.commtrack_enabled,
-            'suggest_orphan_case_alerts_setting': self._suggest_orphan_case_alerts_setting
+            'suggest_orphan_case_alerts_setting': self._suggest_orphan_case_alerts_setting,
+            'project_settings_url': reverse('domain_settings_default', args=[self.domain])
         }
 
     @property

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -7,6 +7,7 @@ from django.http import Http404, HttpResponseRedirect
 from django.http.response import HttpResponseServerError
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.decorators import method_decorator
+from django.utils.functional import cached_property
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
@@ -305,11 +306,23 @@ class LocationTypesView(BaseDomainView):
     @property
     def page_context(self):
         return {
-            'location_types': self._get_loc_types(),
+            'location_types': self._location_types,
             'commtrack_enabled': self.domain_object.commtrack_enabled,
+            'suggest_orphan_case_alerts_setting': self._suggest_orphan_case_alerts_setting
         }
 
-    def _get_loc_types(self):
+    @property
+    def _suggest_orphan_case_alerts_setting(self):
+        """Determine if the `orphan_case_alerts_warning` info banner should be shown. It should be shown when
+        the setting is disabled and any organization level can own cases
+        """
+        if self.domain_object.orphan_case_alerts_warning:
+            return False
+
+        return any(filter(lambda location_type: location_type['shares_cases'], self._location_types))
+
+    @cached_property
+    def _location_types(self):
         return [{
             'pk': loc_type.pk,
             'name': loc_type.name,

--- a/corehq/apps/users/templates/users/partials/edit_commtrack_user_settings.html
+++ b/corehq/apps/users/templates/users/partials/edit_commtrack_user_settings.html
@@ -28,14 +28,6 @@
           to those locations.
         </p>
       </div>
-    {% elif location_info.shared_locations|length > 0 %}
-      <div class="alert alert-info">
-        <p>
-          {% blocktrans %}
-            The user shares all assigned locations with one or more other users.
-          {% endblocktrans %}
-        </p>
-      </div>
     {% endif %}
     <div class="form-actions">
       <div class="col-sm-offset-3 col-md-offset-2 col-sm-9 col-md-8 col-lg-6">

--- a/corehq/apps/users/templates/users/partials/edit_commtrack_user_settings.html
+++ b/corehq/apps/users/templates/users/partials/edit_commtrack_user_settings.html
@@ -10,14 +10,14 @@
     {% crispy commtrack.update_form %}
   </fieldset>
   {% if not request.is_view_only %}
-    {% if location_info.orphaned_case_count_per_location %}
+    {% if warning_banner_info and warning_banner_info.orphaned_case_count_per_location %}
       <div class="alert alert-warning">
         <p>
           {% blocktrans %}
             The user is the only assigned user who can view cases in the following locations:
           {% endblocktrans %}
         </p>
-        {% for location, case_count in location_info.orphaned_case_count_per_location.items %}
+        {% for location, case_count in warning_banner_info.orphaned_case_count_per_location.items %}
           <ul>
             <li>{{ location }} ({{ case_count }})</li>
           </ul>

--- a/corehq/apps/users/templates/users/partials/edit_commtrack_user_settings.html
+++ b/corehq/apps/users/templates/users/partials/edit_commtrack_user_settings.html
@@ -23,9 +23,11 @@
           </ul>
         {% endfor %}
         <p>
-          Depending on your application's case sharing configuration, changing one or more of these
-          locations may result in some cases not being visible to any user until a new user is assigned
-          to those locations.
+          {% blocktrans %}
+            Depending on your application's case sharing configuration, changing one or more of these
+            locations may result in some cases not being visible to any user until a new user is assigned
+            to those locations.
+          {% endblocktrans %}
         </p>
       </div>
     {% endif %}

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -293,11 +293,13 @@ class EditCommCareUserView(BaseEditUserView):
             make_form_readonly(self.form_user_update.user_form)
             make_form_readonly(self.form_user_update.custom_data.form)
 
-        location_info = get_user_location_info(
-            domain=self.domain,
-            user_location_ids=self.editable_user.assigned_location_ids,
-            user_id=self.editable_user.user_id
-        )
+        warning_banner_info = None
+        if self.domain_object.orphan_case_alerts_warning:
+            warning_banner_info = get_user_location_info(
+                domain=self.domain,
+                user_location_ids=self.editable_user.assigned_location_ids,
+                user_id=self.editable_user.user_id
+            )
 
         can_edit_groups = self.request.couch_user.has_permission(self.domain, 'edit_groups')
         can_access_all_locations = self.request.couch_user.has_permission(self.domain, 'access_all_locations')
@@ -316,7 +318,7 @@ class EditCommCareUserView(BaseEditUserView):
             'needs_to_downgrade_locations': locations_present and not request_has_locations_privilege,
             'demo_restore_date': naturaltime(demo_restore_date_created(self.editable_user)),
             'group_names': [g.name for g in self.groups],
-            'location_info': location_info
+            'warning_banner_info': warning_banner_info
         }
         if self.commtrack_form.errors:
             messages.error(self.request, _(


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2927)
The discussion doc is linked in the ticket
[Demo link](https://dimagi.slack.com/archives/C05EZGP724C/p1690874162061629)
Documentation update: See the following pages' drafts:
- [Setting up Organization Levels and Structures](https://confluence.dimagi.com/display/commcarepublic/Setting+up+Organization+Levels+and+Structure)
- [Assigning Mobile Workers to a Location](https://confluence.dimagi.com/display/commcarepublic/Assigning+Mobile+Workers+to+a+Location)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A new `Orphan Case Alerts on Mobile Worker Edit Page` project setting is added. This is to display a warning message on the mobile worker location edit page about locations that owns cases and only have one assigned mobile worker. Note that setting is **disabled** by default.

## The new project setting
![Screenshot from 2023-08-02 08-08-33](https://github.com/dimagi/commcare-hq/assets/64970009/52022335-4f54-4145-ba9f-0429c6a6bca8)


The user will be notified of this setting on the Organization Levels page when they have an organization level that can own cases.

## The info banner on the Organization Levels page
This only shows when
1. the `Orphan Case Alerts on Mobile Worker Edit Page` setting is **not enabled** for this domain
2. at least one level can own cases

![Screenshot from 2023-08-02 08-09-02](https://github.com/dimagi/commcare-hq/assets/64970009/5984bcda-b258-4d3e-95f3-768b91731c1b)

On the mobile worker location edit page, when this new setting is enabled and the current mobile worker is the only one in a specific location with that location owning cases, the warning banner will be shown:

![image](https://github.com/dimagi/commcare-hq/assets/64970009/82ecb127-2907-4f61-8046-455752d872e7)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The warning message on the mobile worker location edit page now only shows when the `orphan_case_alerts_warning` setting is enabled and it meets the existing criteria for showing. Regarding the info banner on the `Organization Level` page, it only shows when the `Orphan Case Alerts on Mobile Worker Edit Page` project setting is not enabled and there are organization levels that can own cases.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Tested on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
