### PR TITLE
Add 'Feature Flags and Privileges' to dropdown

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/global_navigation_bar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/global_navigation_bar.html
@@ -57,6 +57,14 @@
                 </a>
             </li>
             {% endif %}
+            {% if user.is_superuser %}
+            <li>
+                <a href="{% url "feature_flags_and_privileges" domain %}" class="track-usage-link"
+                   data-category="Nav Bar" data-action="Gear Icon" data-label="Current Subscription">
+                    <i class="fa fa-flag dropdown-icon"></i> {% trans "Feature Flags and Privileges" %}
+                </a>
+            </li>
+            {% endif %}
             {% if request|toggle_enabled:"SUPPORT" %}
             <li class="nav-divider divider"></li>
             <li class="dropdown-header nav-header">{% trans 'Support Options' %}</li>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/global_navigation_bar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/global_navigation_bar.html
@@ -62,6 +62,14 @@
             </a>
           </li>
           {% endif %}
+          {% if user.is_superuser %}
+          <li>
+            <a href="{% url "feature_flags_and_privileges" domain %}" class="track-usage-link"
+               data-category="Nav Bar" data-action="Gear Icon" data-label="Current Subscription">
+              <i class="fa fa-flag dropdown-icon"></i> {% trans "Feature Flags and Privileges" %}
+            </a>
+          </li>
+          {% endif %}
           {% if request|toggle_enabled:"SUPPORT" %}
             <li><hr class="dropdown-divider"></li>
             <li class="dropdown-header nav-header">{% trans 'Support Options' %}</li>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/global_navigation_bar.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/global_navigation_bar.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -3,169 +3,207 @@
+@@ -3,177 +3,215 @@
  {% load hq_shared_tags %}
  
  {% if request.couch_user %}
@@ -99,6 +99,14 @@
 -            </li>
 +              </li>
              {% endif %}
+-            {% if user.is_superuser %}
+-            <li>
+-                <a href="{% url "feature_flags_and_privileges" domain %}" class="track-usage-link"
+-                   data-category="Nav Bar" data-action="Gear Icon" data-label="Current Subscription">
+-                    <i class="fa fa-flag dropdown-icon"></i> {% trans "Feature Flags and Privileges" %}
+-                </a>
+-            </li>
+-            {% endif %}
 -            {% if request|toggle_enabled:"SUPPORT" %}
 -            <li class="nav-divider divider"></li>
 +          <li><hr class="dropdown-divider"></li>
@@ -114,6 +122,14 @@
 +            <a href="{% url "domain_subscription_view" domain %}" class="dropdown-item track-usage-link"
 +               data-category="Nav Bar" data-action="Gear Icon" data-label="Current Subscription">
 +              <i class="fa fa-dashboard icon-dashboard dropdown-icon"></i> {% trans "Current Subscription" %}
++            </a>
++          </li>
++          {% endif %}
++          {% if user.is_superuser %}
++          <li>
++            <a href="{% url "feature_flags_and_privileges" domain %}" class="track-usage-link"
++               data-category="Nav Bar" data-action="Gear Icon" data-label="Current Subscription">
++              <i class="fa fa-flag dropdown-icon"></i> {% trans "Feature Flags and Privileges" %}
 +            </a>
 +          </li>
 +          {% endif %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/ace_cle._ace_cle.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/ace_cle._ace_cle.style.diff.txt
@@ -1,5 +1,5 @@
----
-+++
+--- 
++++ 
 @@ -1,5 +1,5 @@
  .ace_editor.ace_autocomplete {
 -  font-family: @font-family-sans-serif !important;
@@ -23,7 +23,7 @@
 -
 -      .label-variant(@label-default-bg);
      }
-
+ 
      .ace_completion-highlight {
        font-weight: bold;
 -      color: @cc-brand-mid;


### PR DESCRIPTION
## Product Description

![image](https://github.com/dimagi/commcare-hq/assets/2367539/1b501505-d5f0-4d38-a5f2-0bf81a844bb5)

Superuser-only change to add this page to the dropdown.  I use it a lot and I'm sure others do too, and I don't have concerns about cluttering up the UI for those users.

## Technical Summary


## Feature Flag
all of them!

## Safety Assurance

### Safety story
superuser-only

### Automated test coverage


### QA Plan
none

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
