### PR TITLE
SSCS: Add check for minimum version requirement on build

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -234,3 +234,10 @@ class CommCareFeatureSupportMixin(object):
             toggles.CASE_LIST_TILE.enabled(self.domain)
             and self._require_minimum_version('2.54')
         )
+
+    @property
+    def supports_split_screen_case_search(self):
+        return (
+            toggles.SPLIT_SCREEN_CASE_SEARCH.enabled(self.domain)
+            and self._require_minimum_version('2.54')
+        )

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -216,7 +216,7 @@ class RemoteRequestFactory(object):
                 data=self._remote_request_query_datums,
                 prompts=self.build_query_prompts(),
                 default_search=self.module.search_config.default_search,
-                results_title=self.build_results_title(),
+                results_title=self.build_results_title() if self.app.supports_split_screen_case_search else None,
             )
         ]
 

--- a/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/multi_select_case_list/basic_remote_request.xml
@@ -20,11 +20,6 @@
     <instance id="search_selected_cases" src="jr://instance/selected-entities/search_selected_cases"/>
     <session>
       <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/multiple-referrals/phone/search/{app_id}/">
-        <results-title>
-          <text>
-            <locale id="case_search.m0"/>
-          </text>
-        </results-title>
         <title>
           <text>
             <locale id="case_search.m0.inputs"/>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -25,11 +25,6 @@
              default_search="false"
              storage-instance="results"
              template="case">
-        <results-title>
-          <text>
-            <locale id="case_search.{module_id}"/>
-          </text>
-        </results-title>
         <title>
           <text>
             <locale id="case_search.{module_id}.inputs"/>

--- a/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request_custom_detail.xml
@@ -23,11 +23,6 @@
              default_search="false"
              storage-instance="results"
              template="case">
-        <results-title>
-          <text>
-            <locale id="case_search.m0"/>
-          </text>
-        </results-title>
         <title>
           <text>
             <locale id="case_search.m0.inputs"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_blacklisted_owners.xml
@@ -22,11 +22,6 @@
              default_search="false"
              storage-instance="results"
              template="case">
-        <results-title>
-          <text>
-            <locale id="case_search.m0"/>
-          </text>
-        </results-title>
         <title>
           <text>
             <locale id="case_search.m0.inputs"/>

--- a/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
+++ b/corehq/apps/app_manager/tests/data/suite/search_config_default_only.xml
@@ -23,11 +23,6 @@
              default_search="false"
              storage-instance="results"
              template="case">
-        <results-title>
-          <text>
-            <locale id="case_search.m0"/>
-          </text>
-        </results-title>
         <title>
           <text>
             <locale id="case_search.m0.inputs"/>

--- a/corehq/apps/app_manager/tests/data/suite/smart_link_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/smart_link_remote_request.xml
@@ -16,11 +16,6 @@
     <instance id="results" src="jr://instance/remote/results"/>
     <session>
       <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/test_domain/phone/search/{app_id}/">
-        <results-title>
-          <text>
-            <locale id="case_search.m1"/>
-          </text>
-        </results-title>
         <title>
           <text>
             <locale id="case_search.m1.inputs"/>

--- a/corehq/apps/app_manager/tests/data/suite_inline_search/shadow_module_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_inline_search/shadow_module_entry.xml
@@ -17,11 +17,6 @@
         <session>
             <query default_search="false" storage-instance="results:inline" template="case"
                    url="http://localhost:8000/a/test_domain/phone/search/456/">
-                <results-title>
-                  <text>
-                    <locale id="case_search.m1"/>
-                  </text>
-                </results-title>
                 <title>
                     <text>
                         <locale id="case_search.m1.inputs"/>

--- a/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/form_link_followup_module_registry.xml
@@ -11,11 +11,6 @@
         <instance id="results" src="jr://instance/remote/results"/>
         <session>
           <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="results" template="case" default_search="false">
-            <results-title>
-              <text>
-                <locale id="case_search.m0"/>
-              </text>
-            </results-title>
             <title>
               <text>
                 <locale id="case_search.m0.inputs"/>

--- a/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_entry.xml
@@ -11,11 +11,6 @@
     <instance id="results" src="jr://instance/remote/results"/>
     <session>
       <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/test_domain/phone/search/456/">
-        <results-title>
-          <text>
-            <locale id="case_search.m1"/>
-          </text>
-        </results-title>
         <title>
           <text>
             <locale id="case_search.m1.inputs"/>

--- a/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite_registry/shadow_module_remote_request.xml
@@ -16,11 +16,6 @@
     <instance id="results" src="jr://instance/remote/results"/>
     <session>
       <query default_search="false" storage-instance="results" template="case" url="https://www.example.com/a/test_domain/phone/search/456/">
-        <results-title>
-          <text>
-            <locale id="case_search.m1"/>
-          </text>
-        </results-title>
         <title>
           <text>
             <locale id="case_search.m1.inputs"/>

--- a/corehq/apps/app_manager/tests/test_advanced_suite.py
+++ b/corehq/apps/app_manager/tests/test_advanced_suite.py
@@ -391,11 +391,6 @@ class AdvancedSuiteTest(SimpleTestCase, SuiteMixin):
             <session>
               <query url="http://localhost:8000/a/domain/phone/search/123/"
                 storage-instance="results" template="case" default_search="false">
-                <results-title>
-                  <text>
-                    <locale id="case_search.m0"/>
-                  </text>
-                </results-title>
                 <title>
                     <text>
                         <locale id="case_search.m0.inputs"/>

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -104,11 +104,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             <session>
                 <query url="http://localhost:8000/a/test_domain/phone/search/123/"
                     storage-instance="{RESULTS_INSTANCE_INLINE}" template="case" default_search="false">
-                  <results-title>
-                    <text>
-                      <locale id="case_search.m0"/>
-                    </text>
-                  </results-title>
                   <title>
                     <text>
                       <locale id="case_search.m0.inputs"/>
@@ -152,11 +147,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             <session>
                 <query url="http://localhost:8000/a/test_domain/phone/search/123/"
                     storage-instance="{RESULTS_INSTANCE_INLINE}" template="case" default_search="false">
-                  <results-title>
-                    <text>
-                      <locale id="case_search.m0"/>
-                    </text>
-                  </results-title>
                   <title>
                     <text>
                         <locale id="case_search.m0.inputs"/>
@@ -212,11 +202,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                 <query url="http://localhost:8000/a/test_domain/phone/search/123/"
                     storage-instance="{RESULTS_INSTANCE_INLINE}"
                     template="case" default_search="false">
-                  <results-title>
-                    <text>
-                      <locale id="case_search.m0"/>
-                    </text>
-                  </results-title>
                   <title>
                     <text>
                         <locale id="case_search.m0.inputs"/>
@@ -411,11 +396,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                 value="./@case_id" detail-select="m2_case_short"/>
               <query url="http://localhost:8000/a/test_domain/phone/search/123/"
                 storage-instance="{RESULTS_INSTANCE_INLINE}" template="case" default_search="false">
-                <results-title>
-                  <text>
-                    <locale id="case_search.m0"/>
-                  </text>
-                </results-title>
                 <title>
                   <text>
                       <locale id="case_search.m0.inputs"/>
@@ -585,11 +565,6 @@ class InlineSearchChildModuleTest(SimpleTestCase, SuiteMixin):
                 value="./@case_id" detail-select="m0_case_short"/>
               <query url="http://localhost:8000/a/test_domain/phone/search/123/"
                 storage-instance="{RESULTS_INSTANCE_INLINE}" template="case" default_search="false">
-                <results-title>
-                  <text>
-                    <locale id="case_search.m1"/>
-                  </text>
-                </results-title>
                 <title>
                   <text>
                       <locale id="case_search.m1.inputs"/>

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -104,11 +104,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
           <session>
             <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="results"
                 template="case" default_search="false">
-                <results-title>
-                  <text>
-                    <locale id="case_search.m0"/>
-                  </text>
-                </results-title>
                 <title>
                     <text>
                         <locale id="case_search.m0.inputs"/>
@@ -557,11 +552,6 @@ class InlineSearchDataRegistryModuleTest(SimpleTestCase, SuiteMixin):
             <session>
                 <query url="http://localhost:8000/a/test_domain/phone/search/123/" storage-instance="{RESULTS_INSTANCE_INLINE}"
                     template="case" default_search="false">
-                  <results-title>
-                    <text>
-                      <locale id="case_search.m0"/>
-                    </text>
-                  </results-title>
                   <title>
                     <text>
                       <locale id="case_search.m0.inputs"/>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This was raised on this PR: [here](https://github.com/dimagi/commcare-hq/pull/33261)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Both the minimum version and the FF is not necessary required, but I figured the reason it wasn't behind a FF was because it already required a rebuild when the FF is enabled and that has not been changed yet so I'll make a note to also change the FF if we happen to make progress on that other work. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
SPLIT_SCREEN_CASE_SEARCH

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This adds more safety to the feature by restricting what versions and apps have the suite changes made in the previous PR. This is not adding on only restricting and the only people that would notice the restriction would have it enabled for the apps since the benefit is only seen if SPLIT_SCREEN_CASE_SEARCH is enabled. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests to be updated to reflect the FF status

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
