### PR TITLE
USH Feature flag: "Hide Sync Button in Web Apps"

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -4,6 +4,7 @@ hqDefine("cloudcare/js/formplayer/apps/controller", function () {
     var constants = hqImport("cloudcare/js/formplayer/constants"),
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
         settingsViews = hqImport("cloudcare/js/formplayer/layout/views/settings"),
+        Toggles = hqImport("hqwebapp/js/toggles"),
         views = hqImport("cloudcare/js/formplayer/apps/views");
 
     return {
@@ -60,6 +61,11 @@ hqDefine("cloudcare/js/formplayer/apps/controller", function () {
             settings.push(
                 new Backbone.Model({ slug: slugs.CLEAR_USER_DATA })
             );
+            if (Toggles.toggleEnabled('HIDE_SYNC_BUTTON')) {
+                settings.push(
+                    new Backbone.Model({ slug: slugs.SYNC })
+                );
+            }
             collection = new Backbone.Collection(settings);
             settingsView = settingsViews.SettingsView({
                 collection: collection,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
@@ -9,6 +9,7 @@ hqDefine("cloudcare/js/formplayer/layout/views/settings", function () {
         SET_DISPLAY: 'display',
         CLEAR_USER_DATA: 'clear-user-data',
         BREAK_LOCKS: 'break-locks',
+        SYNC: 'sync',
     };
 
     /**
@@ -112,6 +113,25 @@ hqDefine("cloudcare/js/formplayer/layout/views/settings", function () {
         },
     });
 
+    /**
+     * Sync button
+     * The feature flag HIDE_SYNC_BUTTON moves the sync button here
+     */
+    var SyncView = Marionette.View.extend({
+        template: _.template($("#sync-setting-template").html() || ""),
+        tagName: 'tr',
+        ui: {
+            sync: '.js-sync',
+        },
+        events: {
+            'click @ui.sync': 'onClickSync',
+        },
+        onClickSync: function (e) {
+            FormplayerFrontend.trigger('sync');
+            $(e.currentTarget).prop('disabled', true);
+        },
+    });
+
     var SettingsView = Marionette.CollectionView.extend({
         childViewContainer: 'tbody',
         childView: function (item) {
@@ -123,6 +143,8 @@ hqDefine("cloudcare/js/formplayer/layout/views/settings", function () {
                 return ClearUserDataView;
             } else if (item.get('slug') === slugs.BREAK_LOCKS) {
                 return BreakLocksView;
+            } else if (item.get('slug') === slugs.SYNC) {
+                return SyncView;
             }
         },
         ui: {

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -22,6 +22,7 @@
     </div>
     <% } %>
 
+    {% if not request|toggle_enabled:"HIDE_SYNC_BUTTON" %}
     <div class=" grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
       <div class="js-sync-item appicon appicon-sync" role="link" tabindex="0" aria-labelledby="grid-template-sync-heading">
         <i class="ff ff-sync appicon-icon" aria-hidden="true"></i>
@@ -30,6 +31,7 @@
         </div>
       </div>
     </div>
+    {% endif %}
 
     {% if request|can_use_restore_as %}
       <div class="grid-item col-xs-6 col-sm-4 col-lg-3 formplayer-request">
@@ -52,6 +54,7 @@
   </div>
 </script>
 
+{# App Preview #}
 <script id="single-app-template" type="text/template">
   <ol class="breadcrumb">
     <li class="breadcrumb-text"><%- appName %></li>

--- a/corehq/apps/cloudcare/templates/formplayer/settings_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/settings_view.html
@@ -38,6 +38,10 @@
   <td><button class="js-clear-user-data btn btn-sm btn-danger">{% trans "Clear" %}</button></td>
 </script>
 <script type="text/template" id="break-locks-setting-template">
-	  <th>{% trans "Break Pending Request Locks" %}</th>
-	    <td><button class="js-break-locks btn btn-sm btn-danger">{% trans "Break" %}</button></td>
+  <th>{% trans "Break Pending Request Locks" %}</th>
+  <td><button class="js-break-locks btn btn-sm btn-danger">{% trans "Break" %}</button></td>
+</script>
+<script type="text/template" id="sync-setting-template">
+  <th>{% trans "Sync User Data" %}</th>
+  <td><button class="js-sync btn btn-sm btn-danger">{% trans "Sync" %}</button></td>
 </script>

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1046,8 +1046,6 @@ USH_USERCASES_FOR_WEB_USERS = StaticToggle(
     TAG_CUSTOM,
     help_link='https://confluence.dimagi.com/display/saas/USH%3A+Enable+Web+User+Usercase+Creation',
     namespaces=[NAMESPACE_DOMAIN],
-    description="""
-    Toggle to enable the creation of usercases for web users."""
 )
 
 WEBAPPS_STICKY_SEARCH = StaticToggle(
@@ -1056,6 +1054,13 @@ WEBAPPS_STICKY_SEARCH = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
     help_link='https://confluence.dimagi.com/display/saas/COVID%3A+Web+Apps+Sticky+Search',
+)
+
+HIDE_SYNC_BUTTON = StaticToggle(
+    "hide_sync_button",
+    "USH: Hide Sync Button in Web Apps",
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
 )
 
 


### PR DESCRIPTION
## Product Description

Adds a feature flag to hide the sync button in web apps and move it behind the settings icon.  Notice no blue icon here:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/7e5c29f2-6b8b-445e-8e12-48ab0cffca19)

And instead, under the gear icon above, this bottom row is new:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/defc53d1-469e-46a8-8942-aba7b3e670b5)


## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3415

## Feature Flag

USH: Hide Sync Button in Web Apps 

## Safety Assurance

### Safety story

The changes are pretty simple, and there aren't many variables involved.  I'm comfortable with local testing.

### Automated test coverage


### QA Plan

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
