### PR TITLE
Check payload_id

### DIFF
--- a/corehq/apps/hqwebapp/doc_lookup.py
+++ b/corehq/apps/hqwebapp/doc_lookup.py
@@ -47,6 +47,8 @@ def lookup_doc_id(doc_id):
     :param doc_id: ID of document to look for
     :returns: LookupResult or None
     """
+    if doc_id is None:
+        raise TypeError('`doc_id` is NoneType, expected str.')
     result, _ = lookup_id_in_databases(doc_id, get_databases().values())
     return result
 

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -83,15 +83,22 @@ class MotechLogDetailView(BaseProjectSettingsView, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        result = lookup_doc_id(context['log'].payload_id)
+
         doc_link = None
-        if result:
-            doc_info = get_doc_info(result.doc)
-            if doc_info:
-                user = self.request.couch_user
-                has_permission = doc_info.user_has_permissions(context['log'].domain, user, result.doc)
-                if has_permission:
-                    doc_link = doc_info.link
+        if context['log'].payload_id:
+            # Not all API calls are related to a payload.
+            result = lookup_doc_id(context['log'].payload_id)
+            if result:
+                doc_info = get_doc_info(result.doc)
+                if doc_info:
+                    user = self.request.couch_user
+                    has_permission = doc_info.user_has_permissions(
+                        context['log'].domain,
+                        user,
+                        result.doc
+                    )
+                    if has_permission:
+                        doc_link = doc_info.link
 
         context.update({
             "doc_link": doc_link


### PR DESCRIPTION
## Technical Summary

Fixes an error that occurs on the RequestLog details page, when the RequestLog instance is not associated with a payload.

This can happen when the request is made by testing connection settings, or `OpenmrsImporter` importing cases from an OpenMRS report, or the `poll_openmrs_atom_feeds()` task polling for updates, etc.

Context:
* https://dimagi-dev.atlassian.net/browse/SC-3005
* [Sentry](https://dimagi.sentry.io/issues/4010445224/?project=136860)


## Feature Flag

N/A

## Safety Assurance

### Safety story

Reproduced and tested locally.

### Automated test coverage

Not covered

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
