### PR TITLE
Add missing class to bootstrap5 template

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/global_navigation_bar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/global_navigation_bar.html
@@ -64,7 +64,7 @@
           {% endif %}
           {% if user.is_superuser %}
           <li>
-            <a href="{% url "feature_flags_and_privileges" domain %}" class="track-usage-link"
+            <a href="{% url "feature_flags_and_privileges" domain %}" class="dropdown-item track-usage-link"
                data-category="Nav Bar" data-action="Gear Icon" data-label="Current Subscription">
               <i class="fa fa-flag dropdown-icon"></i> {% trans "Feature Flags and Privileges" %}
             </a>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/global_navigation_bar.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/global_navigation_bar.html.diff.txt
@@ -127,7 +127,7 @@
 +          {% endif %}
 +          {% if user.is_superuser %}
 +          <li>
-+            <a href="{% url "feature_flags_and_privileges" domain %}" class="track-usage-link"
++            <a href="{% url "feature_flags_and_privileges" domain %}" class="dropdown-item track-usage-link"
 +               data-category="Nav Bar" data-action="Gear Icon" data-label="Current Subscription">
 +              <i class="fa fa-flag dropdown-icon"></i> {% trans "Feature Flags and Privileges" %}
 +            </a>


### PR DESCRIPTION
## Product Description


## Technical Summary
https://github.com/dimagi/commcare-hq/commit/3be0f37fcf42ef091413fd8ae1d12aa389f480c8#r123325206
> `class="dropdown-item track-usage-link"` should be the full class for bootstrap 5 dropdowns

## Feature Flag


## Safety Assurance

### Safety story
trivial

### Automated test coverage


### QA Plan



### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
