### PR TITLE
Add script to generate local javascript test coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ ptop*.json
 
 /.coverage
 /coverage-report
+/coverage-js
 
 # pyenv
 .python-version

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -1118,6 +1118,21 @@ For example:
 http://localhost:8000/mocha/app_manager/b3
 ```
 
+### Measuring test coverage
+
+To generate a JavaScript test coverage report, ensure the development server is
+active on port 8000 and run:
+
+```sh
+./scripts/coverage-js.sh
+```
+
+This script goes through the steps to prepare a report for test coverage of
+JavaScript files _that are touched by tests_, i.e., apps and files with 0% test
+coverage will not be shown. A coverage summary is output to the terminal and a
+detailed html report is generated at ``coverage-js/index.html``.
+
+
 ## Sniffer
 
 You can also use sniffer to auto run the Python tests.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,8 +89,13 @@ module.exports = function(grunt) {
             if (grunt.option('coverage')) {
                 var coverageDir = './coverage-js/',
                     filePath = coverageDir + currentApp.replace(/\//g, '-') + '.json';
-                if (!fs.existsSync(coverageDir)) { fs.mkdir(coverageDir, err => console.log(err)); }
-                fs.writeFile(filePath, JSON.stringify(data.coverage), {flag: 'w+'}, err => console.log(err));
+                if (!fs.existsSync(coverageDir)) {
+                    fs.mkdir(coverageDir, error =>
+                        error && grunt.log.write(error));
+                }
+                fs.writeFile(filePath, JSON.stringify(data.coverage), {flag: 'w+'}, error =>
+                    error && grunt.log.write(error)
+                );
             }
             finishedTests.push(currentApp);
             runTest(

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,8 @@
 module.exports = function(grunt) {
     var headless = require('mocha-headless-chrome'),
         _ = require('lodash'),
-        colors = require('colors');
+        colors = require('colors'),
+        fs = require('fs');
 
     // use localhost unless we're running on travis
     var BASE_ADDRESS = process.env.WEB_TEST_PORT_8000_TCP_ADDR || 'localhost',
@@ -84,6 +85,12 @@ module.exports = function(grunt) {
         headless.runner(runner_options).then(function (data) {
             if (data.result.failures.length) {
                 failures[currentApp] = data.result.failures;
+            }
+            if (grunt.option('coverage')) {
+                var coverageDir = './coverage-js/',
+                    filePath = coverageDir + currentApp.replace(/\//g, '-') + '.json';
+                if (!fs.existsSync(coverageDir)) { fs.mkdir(coverageDir, err => console.log(err)); }
+                fs.writeFile(filePath, JSON.stringify(data.coverage), {flag: 'w+'}, err => console.log(err));
             }
             finishedTests.push(currentApp);
             runTest(

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,8 @@
 /* globals process */
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
     var headless = require('mocha-headless-chrome'),
         _ = require('lodash'),
-        colors = require('colors'),
         fs = require('fs');
 
     // use localhost unless we're running on travis
@@ -66,7 +65,7 @@ module.exports = function(grunt) {
             currentTestPath = BASE_URL + currentApp,
             testText = "Running Test '" + currentApp + "'",
             reporter = grunt.option('verbose') ? 'spec' : 'dot',
-            runner_options = {
+            runnerOptions = {
                 file: currentTestPath,
                 visible: false,
                 timeout: 120000,
@@ -75,14 +74,14 @@ module.exports = function(grunt) {
 
         // For running in docker/travis
         if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD) {
-            runner_options.executablePath = 'google-chrome-unstable';
+            runnerOptions.executablePath = 'google-chrome-unstable';
         }
 
         grunt.log.writeln("\n");
         grunt.log.writeln(testText.bold);
         grunt.log.write(currentTestPath.italic.cyan);
 
-        headless.runner(runner_options).then(function (data) {
+        headless.runner(runnerOptions).then(function (data) {
             if (data.result.failures.length) {
                 failures[currentApp] = data.result.failures;
             }
@@ -93,7 +92,7 @@ module.exports = function(grunt) {
                     fs.mkdir(coverageDir, error =>
                         error && grunt.log.write(error));
                 }
-                fs.writeFile(filePath, JSON.stringify(data.coverage), {flag: 'w+'}, error =>
+                fs.writeFile(filePath, JSON.stringify(data.coverage), { flag: 'w+' }, error =>
                     error && grunt.log.write(error)
                 );
             }
@@ -140,7 +139,7 @@ module.exports = function(grunt) {
         }
     );
 
-    grunt.registerTask('list', 'Lists all available apps to test', function() {
+    grunt.registerTask('list', 'Lists all available apps to test', function () {
         testPaths.forEach(function (app) { console.log('"' + app + '"'); });
     });
 };

--- a/scripts/coverage-js.sh
+++ b/scripts/coverage-js.sh
@@ -1,7 +1,8 @@
 # Run this with local development server active to report Javascript test coverage
 
-# Save the local file state
-git commit -a -m "temp coverage-js commit"
+# Save the local file state in a temporary branch
+git checkout -b "temp-coverage-js"
+git commit --allow-empty --no-verify -a -m "temp commit"
 
 # Instrument HQ Javascript in place
 npx nyc instrument -x "**/sentry" -x "**/spec" -x "**/mocha" -x "**/lib" \
@@ -15,8 +16,11 @@ npx nyc merge "./coverage-js" "./coverage-js/merged/coverage.json"
 
 # Reset to previous git state before creating report
 # This is done before the report is built to get accurate line-by-line coverage
-git reset --hard && git reset HEAD~1
+git reset --hard
 
 # Build the report based on merged coverage data
 npx nyc report --temp-dir "./coverage-js/merged" --report-dir "./coverage-js" \
     --reporter "html" --reporter "text-summary"
+
+# Unstage current changes, switch to prior working branch, delete temporary branch
+git reset HEAD~1 && git switch - && git branch -D "temp-coverage-js"

--- a/scripts/coverage-js.sh
+++ b/scripts/coverage-js.sh
@@ -1,5 +1,11 @@
 # Run this with local development server active to report Javascript test coverage
 
+# Clean up the report directory if it already exists
+if [ -d "./coverage-js" ]
+then
+    rm -r "./coverage-js"
+fi
+
 # Save the local file state in a temporary branch
 git checkout -b "temp-coverage-js"
 git commit --allow-empty --no-verify -a -m "temp commit"

--- a/scripts/coverage-js.sh
+++ b/scripts/coverage-js.sh
@@ -29,4 +29,8 @@ npx nyc report --temp-dir "./coverage-js/merged" --report-dir "./coverage-js" \
     --reporter "html" --reporter "text-summary"
 
 # Unstage current changes, switch to prior working branch, delete temporary branch
-git reset HEAD~1 && git switch - && git branch -D "temp-coverage-js"
+git reset HEAD~1
+if git branch --show-current | grep -q "temp-coverage-js"
+then
+    git switch - && git branch -D "temp-coverage-js"
+fi

--- a/scripts/coverage-js.sh
+++ b/scripts/coverage-js.sh
@@ -1,4 +1,14 @@
-# Run this with local development server active to report Javascript test coverage
+# Generates local Javascript test coverage report
+
+echo "Before running, please confirm:
+   grunt is installed via npm or yarn
+   local development server is active\n"
+read -p "Do you want to proceed? (y/n) " proceed
+case $proceed in
+    y ) echo "Running Javascript coverage report"
+        break;;
+    * ) exit;;
+esac
 
 # Clean up the report directory if it already exists
 if [ -d "./coverage-js" ]
@@ -27,6 +37,7 @@ git reset --hard
 # Build the report based on merged coverage data
 npx nyc report --temp-dir "./coverage-js/merged" --report-dir "./coverage-js" \
     --reporter "html" --reporter "text-summary"
+echo "\nView the full coverage report at:\033[96m\033[1m $(pwd)/coverage-js/index.html \033[0m\n"
 
 # Unstage current changes, switch to prior working branch, delete temporary branch
 git reset HEAD~1

--- a/scripts/coverage-js.sh
+++ b/scripts/coverage-js.sh
@@ -21,7 +21,8 @@ git checkout -b "temp-coverage-js"
 git commit --allow-empty --no-verify -a -m "temp commit"
 
 # Instrument HQ Javascript in place
-npx nyc instrument -x "**/sentry" -x "**/spec" -x "**/mocha" -x "**/lib" \
+npx nyc instrument -x "**/lib" -x "**/sentry" -x "**/spec"  \
+    -x "mocha" -x "hqmedia/static/hqmedia/MediaUploader" \
     "corehq/apps" "corehq/apps" --in-place
 
 # Run tests through grunt test task with coverage flag

--- a/scripts/coverage-js.sh
+++ b/scripts/coverage-js.sh
@@ -1,0 +1,22 @@
+# Run this with local development server active to report Javascript test coverage
+
+# Save the local file state
+git commit -a -m "temp coverage-js commit"
+
+# Instrument HQ Javascript in place
+npx nyc instrument -x "**/sentry" -x "**/spec" -x "**/mocha" -x "**/lib" \
+    "corehq/apps" "corehq/apps" --in-place
+
+# Run tests through grunt test task with coverage flag
+grunt test --coverage
+
+# Merge coverage data from multiple apps
+npx nyc merge "./coverage-js" "./coverage-js/merged/coverage.json"
+
+# Reset to previous git state before creating report
+# This is done before the report is built to get accurate line-by-line coverage
+git reset --hard && git reset HEAD~1
+
+# Build the report based on merged coverage data
+npx nyc report --temp-dir "./coverage-js/merged" --report-dir "./coverage-js" \
+    --reporter "html" --reporter "text-summary"


### PR DESCRIPTION
## Product Description
Measuring JavaScript test coverage in HQ is a challenge for a few different reasons (described in some detail [here](https://docs.google.com/document/d/1V8n1H_3AyzTu8HnuXQekNQ_AQMU2e_h9ht1dIthoLKw/edit?usp=sharing)). This is an attempt at a script to generate a Javascript test coverage report in a limited way -- on a local dev environment, for files that are already touched by tests. The report is saved as an html page and the summary is printed to the terminal:
```
=============================== Coverage summary ===============================
Statements   : 45.26% ( 3629/8018 )
Branches     : 32.62% ( 1010/3096 )
Functions    : 35.61% ( 677/1901 )
Lines        : 45.35% ( 3598/7933 )
================================================================================

View the full coverage report at: ~/commcare-hq/coverage-js/index.html
```

## Technical Summary
[USH-3106](https://dimagi-dev.atlassian.net/browse/USH-3106)
This adds a `coverage-js` shell script that uses `git`, `nyc` (istanbul), and `grunt` commands to instrument Javascript files in place, generate coverage report under the directory `coverage-js`, and reset the file state to before Javascript was instrumented. Under the hood, `mocha-headless-chrome` is recording coverage for files touched while running tests. Because of the different pieces working together, there is a not a simple way to include coverage for files _untouched_ by tests (that is, those with 0% coverage)

Also adds a `coverage` flag to the `grunt test` task that, when included, will write coverage data to json files for each app tested (though files must be instrumented first to measure coverage, so it is only useful as part of the script).

## Safety Assurance

### Safety story
The `git` commands do some lifting here to make sure local file state is saved and restored after running the report. I am new to working with shell scripts and Grunt so there may be safety concerns I have not considered.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
I don't think QA is applicable here.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3106]: https://dimagi-dev.atlassian.net/browse/USH-3106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ