### PR TITLE
[B5] Update migration script to use B5 refs in B5 files

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -223,6 +223,7 @@ class Command(BaseCommand):
     def refactor_references(self, old_reference, new_reference, is_template):
         self.stdout.write("updating references...")
         found_references = False
+        bootstrap5_reference = new_reference.replace("/bootstrap3/", "/bootstrap5/")
         file_types = ["**/*.py", "**/*.html", "**/*.md"]
         if not is_template:
             file_types.append("**/*.js")
@@ -232,12 +233,15 @@ class Command(BaseCommand):
                     continue
                 with open(file_path, 'r') as file:
                     filedata = file.read()
-
+                use_bootstrap5_reference = "/bootstrap5/" in str(file_path)
                 if old_reference in filedata:
                     found_references = True
                     self.stdout.write(f"- replaced reference in {str(file_path)}")
                     with open(file_path, 'w') as file:
-                        file.write(filedata.replace(old_reference, new_reference))
+                        file.write(filedata.replace(
+                            old_reference,
+                            bootstrap5_reference if use_bootstrap5_reference else new_reference
+                        ))
         if not found_references:
             self.stdout.write(f"No references were found for {old_reference}...")
 


### PR DESCRIPTION
## Technical Summary
This change ensures that the Bootstrap 5 replacement path is used if the file with the reference to the renamed Bootstrap 3 template is already migrated to Bootstrap 5.

## Safety Assurance

### Safety story
Just updates a management command

### Automated test coverage
No

### QA Plan
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
