### PR TITLE
Remove repeat header

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_session_endpoint.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_session_endpoint.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+
+            <div class="form-group">
+              <label class="control-label {% css_label_class %}">
+                {% trans 'Case List Session Endpoint ID' %}
+                <span class="hq-help-template"
+                      data-title="{% trans 'Case List Session Endpoint ID' %}"
+                      data-content="{% blocktrans %}A session endpoint ID to navigate to this
+                                    case list without doing selection on the case list.{% endblocktrans %}"></span>
+              </label>
+              <div id="case-list-session-endpoint-id"
+                   class="{% css_field_class %} commcare-feature"
+                   data-since-version="2.51"
+                   class="{% css_field_class %}">
+                <input class="code form-control"
+                       type="text"
+                       id="case_list_session_endpoint_id"
+                       name="case_list_session_endpoint_id"
+                       value="{{ module.case_list_session_endpoint_id|default:'' }}" />
+              </div>
+            </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -251,6 +251,9 @@
 
             {% if session_endpoints_enabled %}
               {% include "app_manager/partials/session_endpoints.html" with module_or_form=module %}
+              {% if not module.is_surveys %}
+                {% include "app_manager/partials/case_list_session_endpoint.html" with module=module %}
+              {% endif %}
             {% endif %}
 
             {% if request|toggle_enabled:'USH_EMPTY_CASE_LIST_TEXT' %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/session_endpoints.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/session_endpoints.html
@@ -20,24 +20,3 @@
                        value="{{ module_or_form.session_endpoint_id|default:'' }}" />
               </div>
             </div>
-            {% if not module_or_form.is_surveys %}
-              <div class="form-group">
-                  <label class="control-label {% css_label_class %}">
-                    {% trans 'Case List Session Endpoint ID' %}
-                    <span class="hq-help-template"
-                          data-title="{% trans 'Case List Session Endpoint ID' %}"
-                          data-content="{% blocktrans %}A session endpoint ID to navigate to this
-                                        case list without doing selection on the case list.{% endblocktrans %}"></span>
-                  </label>
-                  <div id="case-list-session-endpoint-id"
-                       class="{% css_field_class %} commcare-feature"
-                       data-since-version="2.51"
-                       class="{% css_field_class %}">
-                    <input class="code form-control"
-                           type="text"
-                           id="case_list_session_endpoint_id"
-                           name="case_list_session_endpoint_id"
-                           value="{{ module_or_form.case_list_session_endpoint_id|default:'' }}" />
-                  </div>
-              </div>
-            {% endif %}

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -188,6 +188,11 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         var mapping = {
             caption: {
                 update: function (options) {
+                    let parentForm = getParentForm(self);
+                    let oqps = parentForm.displayOptions.oneQuestionPerScreen != undefined && parentForm.displayOptions.oneQuestionPerScreen();
+                    if (!oqps) {
+                        return null;
+                    }
                     return options.data ? DOMPurify.sanitize(options.data.replace(/\n/g, '<br/>')) : null;
                 },
             },
@@ -611,6 +616,13 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         // until the question has received a response from the server.
         self.pendingAnswer = ko.observable(constants.NO_PENDING_ANSWER);
         self.pendingAnswer.subscribe(function () { self.hasAnswered = true; });
+        self.form = function () {
+            var parent = self.parent;
+            while (parent.type && parent.type() !== null) {
+                parent = parent.parent;
+            }
+            return parent;
+        };
         self.dirty = ko.computed(function () {
             return self.pendingAnswer() !== constants.NO_PENDING_ANSWER;
         });
@@ -669,7 +681,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             $('html, body').animate({
                 scrollTop: $(el).offset().top - 60,
             });
-            getParentForm(self).currentJumpPoint = self;
+            self.form().currentJumpPoint = self;
             el.fadeOut(200).fadeIn(200).fadeOut(200).fadeIn(200);
         };
     }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -145,6 +145,14 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         return meta;
     }
 
+    function getParentForm(self) {
+        let curr = self;
+        while (curr.parent) {
+            curr = curr.parent;
+        }
+        return curr;
+    }
+
     /**
      * Base abstract prototype for Repeat, Group and Form. Adds methods to
      * objects that contain a children array for rendering nested questions.
@@ -554,10 +562,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
 
         self.getTranslation = function (translationKey, defaultTranslation) {
             // Find the root level element which contains the translations.
-            var curParent = self.parent;
-            while (curParent.parent) {
-                curParent = curParent.parent;
-            }
+            var curParent = getParentForm(self);
             var translations = curParent.translations;
 
             if (translations) {
@@ -616,14 +621,6 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             return (self.error() || self.serverError()) && !self.dirty();
         });
 
-        self.form = function () {
-            var parent = self.parent;
-            while (parent.type && parent.type() !== null) {
-                parent = parent.parent;
-            }
-            return parent;
-        };
-
         self.isValid = function () {
             return self.error() === null && self.serverError() === null;
         };
@@ -672,7 +669,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             $('html, body').animate({
                 scrollTop: $(el).offset().top - 60,
             });
-            self.form().currentJumpPoint = self;
+            getParentForm(self).currentJumpPoint = self;
             el.fadeOut(200).fadeIn(200).fadeOut(200).fadeIn(200);
         };
     }


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This removes the header for repeat groups, but leaves them in app preview when `oneQuestionPerScreen` is on.
Before: 
<img width="600" alt="257931409-ad8047f2-44f3-4f3e-b33e-682359879c47" src="https://github.com/dimagi/commcare-hq/assets/42388648/f5f16385-321c-4176-9a95-6f23a0e0165d">

After: 
<img width="600" alt="257930741-019b4a51-9e6b-4fd1-ab8d-c1c509bb05e2" src="https://github.com/dimagi/commcare-hq/assets/42388648/3ba3e7cb-65a2-428e-8d0c-554269381d74">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
jira ticket: https://dimagi-dev.atlassian.net/browse/USH-3423

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
appearance change that doesn't affect any data
tested locally
will also be tested on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
