### PR TITLE
Rc/hide secondary header

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -188,6 +188,11 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         var mapping = {
             caption: {
                 update: function (options) {
+                    let parentForm = getParentForm(self);
+                    let oqps = parentForm.displayOptions.oneQuestionPerScreen != undefined && parentForm.displayOptions.oneQuestionPerScreen();
+                    if (!oqps) {
+                        return null;
+                    }
                     return options.data ? DOMPurify.sanitize(options.data.replace(/\n/g, '<br/>')) : null;
                 },
             },

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -1,6 +1,6 @@
 /* global DOMPurify, mdAnchorRender */
 hqDefine("cloudcare/js/form_entry/form_ui", function () {
-    var cloudcareUtils = hqImport("cloudcare/js/utils");
+    var cloudcareUtils = hqImport("cloudcare/js/utils"),
         constants = hqImport("cloudcare/js/form_entry/const"),
         entries = hqImport("cloudcare/js/form_entry/entries"),
         formEntryUtils = hqImport("cloudcare/js/form_entry/utils");
@@ -70,7 +70,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
 
     function getIx(o) {
         var ix = o.rel_ix();
-        while (ix[0] == '-') {
+        while (ix[0] === '-') {
             o = o.parent;
             if (!o || ko.utils.unwrapObservable(o.rel_ix) === undefined) {
                 break;
@@ -119,7 +119,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             meta.maxdiff = style.after !== null ? +style.after : null;
         } else if (type === "int" || type === "float") {
             meta.unit = style.unit;
-        } else if (type == 'str') {
+        } else if (type === 'str') {
             meta.autocomplete = (style.mode === 'autocomplete');
             meta.autocomplete_key = style["autocomplete-key"];
             meta.mask = style.mask;
@@ -306,7 +306,9 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         });
 
         self.enablePreviousButton = ko.computed(function () {
-            if (!self.showInFormNavigation()) return false;
+            if (!self.showInFormNavigation()) {
+                return false;
+            }
             return self.currentIndex() !== "0" && self.currentIndex() !== "-1" && !self.atFirstIndex();
         });
 
@@ -331,7 +333,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             for (var i = 0; i < questions.length; i++) {
                 // eslint-disable-next-line
                 if (questions[i].error() != null || questions[i].serverError() != null
-                            || (questions[i].required() && questions[i].answer() == null)) {
+                            || (questions[i].required() && questions[i].answer() === null)) {
                     qs.push(questions[i]);
                 }
             }
@@ -463,7 +465,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.rel_ix = ko.observable(relativeIndex(self.ix()));
         self.isRepetition = parent instanceof Repeat;
         let parentForm = getParentForm(self);
-        let oneQuestionPerScreen = parentForm.displayOptions.oneQuestionPerScreen != undefined && parentForm.displayOptions.oneQuestionPerScreen();
+        let oneQuestionPerScreen = parentForm.displayOptions.oneQuestionPerScreen !== undefined && parentForm.displayOptions.oneQuestionPerScreen();
 
         if (!oneQuestionPerScreen && self.isRepetition) {
             self.caption(null);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -145,6 +145,14 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         return meta;
     }
 
+    function getParentForm(self) {
+        let curr = self;
+        while (curr.parent) {
+            curr = curr.parent;
+        }
+        return curr;
+    }
+
     /**
      * Base abstract prototype for Repeat, Group and Form. Adds methods to
      * objects that contain a children array for rendering nested questions.
@@ -554,10 +562,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
 
         self.getTranslation = function (translationKey, defaultTranslation) {
             // Find the root level element which contains the translations.
-            var curParent = self.parent;
-            while (curParent.parent) {
-                curParent = curParent.parent;
-            }
+            var curParent = getParentForm(self);
             var translations = curParent.translations;
 
             if (translations) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -188,9 +188,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         var mapping = {
             caption: {
                 update: function (options) {
-                    let parentForm = getParentForm(self);
-                    let oqps = parentForm.displayOptions.oneQuestionPerScreen != undefined && parentForm.displayOptions.oneQuestionPerScreen();
-                    if (!oqps) {
+                    if (self.hideCaption) {
                         return null;
                     }
                     return options.data ? DOMPurify.sanitize(options.data.replace(/\n/g, '<br/>')) : null;
@@ -464,6 +462,13 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.groupId = groupNum++;
         self.rel_ix = ko.observable(relativeIndex(self.ix()));
         self.isRepetition = parent instanceof Repeat;
+        let parentForm = getParentForm(self);
+        let oneQuestionPerScreen = parentForm.displayOptions.oneQuestionPerScreen != undefined && parentForm.displayOptions.oneQuestionPerScreen();
+
+        if (!oneQuestionPerScreen && self.isRepetition) {
+            self.caption(null);
+            self.hideCaption = true;
+        }
         if (_.has(json, 'domain_meta') && _.has(json, 'style')) {
             self.domain_meta = parseMeta(json.datatype, json.style);
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/fixtures.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/fixtures.js
@@ -143,6 +143,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
         groupJSON: (options = {}) => (_.defaults(options, {
             "type": "sub-group",
             "ix": "1",
+            "caption": "Group",
             "children": [
                 {
                     "type": "sub-group",

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/fixtures.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/fixtures.js
@@ -26,7 +26,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
             "help_video": null,
             "hint": null,
             "output": null,
-            "add-choice": null
+            "add-choice": null,
         })),
 
         selectJSON: (options = {}) => (_.defaults(options, {
@@ -55,7 +55,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
             "help_video": null,
             "hint": null,
             "output": null,
-            "add-choice": null
+            "add-choice": null,
         })),
 
         labelJSON: (options = {}) => (_.defaults(options, {
@@ -84,7 +84,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
             "help_video": null,
             "hint": null,
             "output": null,
-            "add-choice": null
+            "add-choice": null,
         })),
 
         repeatJSON: (options = {}) => (_.defaults(options, {
@@ -171,7 +171,7 @@ hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
                     "children": [],
                 },
             ],
-        })
+        }),
 
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
@@ -45,6 +45,7 @@ hqDefine("cloudcare/js/form_entry/spec/utils_spec", function () {
             [groupInRepeat] = repeat.children();
             [textInRepeat] = groupInRepeat.children();
 
+            assert.equal(groupInRepeat.caption(), null);
             assert.equal(utils.getRootForm(text), form);
             assert.equal(utils.getRootForm(groupInRepeat), form);
             assert.equal(utils.getRootForm(textInRepeat), form);


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This removes the header for repeat groups, but leaves them in app preview when `oneQuestionPerScreen` is on.
Before: 
<img width="600" alt="257931409-ad8047f2-44f3-4f3e-b33e-682359879c47" src="https://github.com/dimagi/commcare-hq/assets/42388648/f5f16385-321c-4176-9a95-6f23a0e0165d">

After: 
<img width="600" alt="257930741-019b4a51-9e6b-4fd1-ab8d-c1c509bb05e2" src="https://github.com/dimagi/commcare-hq/assets/42388648/3ba3e7cb-65a2-428e-8d0c-554269381d74">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
jira ticket: https://dimagi-dev.atlassian.net/browse/USH-3423

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
appearance change that doesn't affect any data
tested locally
will also be tested on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
