### PR TITLE
Refactor `copy_cases` to use `SubmitCaseBlockHandler`

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 from collections import Counter, defaultdict, namedtuple
-from typing import Callable, Optional, Protocol
 
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
@@ -25,11 +24,7 @@ from corehq.apps.receiverwrapper.rate_limiter import rate_limit_submission
 from corehq.apps.users.cases import get_wrapped_owner
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.util import format_username
-from corehq.form_processor.models import (
-    STANDARD_CHARFIELD_LENGTH,
-    CommCareCase,
-    XFormInstance,
-)
+from corehq.form_processor.models import STANDARD_CHARFIELD_LENGTH
 from corehq.toggles import (
     BULK_UPLOAD_DATE_OPENED,
     CASE_IMPORT_DATA_DICTIONARY_VALIDATION,
@@ -352,11 +347,6 @@ class _TimedAndThrottledImporter:
             })
 
 
-class UserProto(Protocol):
-    user_id: str
-    username: str
-
-
 class SubmitCaseBlockHandler:
     """
     ``SubmitCaseBlockHandler`` can handle the submission of large
@@ -368,15 +358,15 @@ class SubmitCaseBlockHandler:
 
     def __init__(
         self,
-        domain: str,
+        domain,
         *,
-        import_results: Optional[_ImportResults],
-        case_type: Optional[str],
-        user: UserProto,
-        record_form_callback: Optional[Callable[[str], None]] = None,
-        throttle: bool = False,
-        add_inferred_props_to_schema: bool = True,
-    ) -> None:
+        import_results,
+        case_type,
+        user,
+        record_form_callback=None,
+        throttle=False,
+        add_inferred_props_to_schema=True,
+    ):
         """
         Initialize ``SubmitCaseBlockHandler``.
 
@@ -405,7 +395,7 @@ class SubmitCaseBlockHandler:
         self.case_type = case_type
         self.user = user
 
-    def add_caseblock(self, caseblock: RowAndCase) -> None:
+    def add_caseblock(self, caseblock):
         self._unsubmitted_caseblocks.append(caseblock)
         # check if we've reached a reasonable chunksize and if so, submit
         if len(self._unsubmitted_caseblocks) >= CASEBLOCK_CHUNKSIZE:
@@ -418,10 +408,7 @@ class SubmitCaseBlockHandler:
             self._unsubmitted_caseblocks = []
             self.uncreated_external_ids = set()
 
-    def submit_and_process_caseblocks(
-        self,
-        caseblocks: list[RowAndCase],
-    ) -> None:
+    def submit_and_process_caseblocks(self, caseblocks):
         if not caseblocks:
             return
         self.pre_submit_hook()
@@ -482,10 +469,7 @@ class SubmitCaseBlockHandler:
             )
             self._total_delayed_duration += self._last_submission_duration
 
-    def submit_case_blocks(
-        self,
-        caseblocks: list[RowAndCase],
-    ) -> tuple[XFormInstance, list[CommCareCase]]:
+    def submit_case_blocks(self, caseblocks):
         if not self.throttle:
             return self._submit_case_blocks(caseblocks)
         timer = None
@@ -496,10 +480,7 @@ class SubmitCaseBlockHandler:
             if timer:
                 self._last_submission_duration = timer.duration
 
-    def _submit_case_blocks(
-        self,
-        caseblocks: list[RowAndCase],
-    ) -> tuple[XFormInstance, list[CommCareCase]]:
+    def _submit_case_blocks(self, caseblocks):
         return submit_case_blocks(
             [cb.case.as_text() for cb in caseblocks],
             self.domain,

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -362,7 +362,8 @@ class SubmitCaseBlockHandler:
     ``SubmitCaseBlockHandler`` can handle the submission of large
     numbers of case blocks. It supports throttling.
 
-    Used by this module and by ``corehq.apps.data_interfaces.tasks``.
+    Used by this module, ``corehq.apps.data_interfaces.tasks`` and
+    ``corehq.apps.reports.filters.api``.
     """
 
     def __init__(

--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -36,8 +36,13 @@ def bulk_import_async(config_list_json, domain, excel_id):
         for index, config_json in enumerate(config_list_json):
             config = ImporterConfig.from_json(config_json)
             with case_upload.get_spreadsheet(index) as spreadsheet:
-                result = do_import(spreadsheet, config, domain, task=bulk_import_async,
-                                record_form_callback=case_upload.record_form)
+                result = do_import(
+                    spreadsheet,
+                    config,
+                    domain,
+                    task=bulk_import_async,
+                    record_form_callback=case_upload.record_form,
+                )
                 all_results.append(result)
 
         result = _merge_import_results(all_results)

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -259,7 +259,12 @@ def bulk_case_reassign_async(domain, user_id, owner_id, download_id, report_url)
     DownloadBase.set_progress(task, 0, len(case_ids))
     user = CouchUser.get_by_user_id(user_id)
     submission_handler = SubmitCaseBlockHandler(
-        domain, None, None, user, None, throttle=True
+        domain,
+        import_results=None,
+        case_type=None,
+        user=user,
+        record_form_callback=None,
+        throttle=True,
     )
     for idx, case_id in enumerate(case_ids):
         submission_handler.add_caseblock(

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -2,6 +2,8 @@
 Some of these constants correspond to constants set in corehq/apps/export/static/export/js/const.js
 so if changing a value, ensure that both places reflect the change
 """
+from typing import Literal
+
 from couchexport.deid import deid_date, deid_ID
 
 from corehq.apps.export.transforms import (
@@ -24,6 +26,7 @@ SMS_DATA_SCHEMA_VERSION = 1
 
 DEID_ID_TRANSFORM = "deid_id"
 DEID_DATE_TRANSFORM = "deid_date"
+DeidTransformName = Literal['deid_id', 'deid_date']
 DEID_TRANSFORM_FUNCTIONS = {
     DEID_ID_TRANSFORM: deid_ID,
     DEID_DATE_TRANSFORM: deid_date,

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -2,8 +2,6 @@
 Some of these constants correspond to constants set in corehq/apps/export/static/export/js/const.js
 so if changing a value, ensure that both places reflect the change
 """
-from typing import Literal
-
 from couchexport.deid import deid_date, deid_ID
 
 from corehq.apps.export.transforms import (
@@ -26,7 +24,6 @@ SMS_DATA_SCHEMA_VERSION = 1
 
 DEID_ID_TRANSFORM = "deid_id"
 DEID_DATE_TRANSFORM = "deid_date"
-DeidTransformName = Literal['deid_id', 'deid_date']
 DEID_TRANSFORM_FUNCTIONS = {
     DEID_ID_TRANSFORM: deid_ID,
     DEID_DATE_TRANSFORM: deid_date,

--- a/corehq/apps/hqcase/case_helper.py
+++ b/corehq/apps/hqcase/case_helper.py
@@ -1,13 +1,8 @@
-import uuid
 from dataclasses import dataclass
 
 from corehq.apps.users.models import CouchUser
-from corehq.form_processor.models.cases import CommCareCase
-from corehq.apps.hqcase.utils import submit_case_blocks, get_deidentified_data
-from casexml.apps.case.mock import CaseBlock
 
 from .api.updates import BaseJsonCaseChange, handle_case_update
-from corehq.apps.users.util import SYSTEM_USER_ID
 
 
 class CaseHelper:
@@ -167,128 +162,6 @@ class CaseHelper:
             device_id=device_id,
             is_creation=False,
         )
-
-    @classmethod
-    def copy_cases(
-        cls,
-        domain,
-        case_ids,
-        to_owner,
-        censor_data=None,
-        count_only=False
-    ):
-        """
-        Copies the cases governed by 'case_ids' to the respective 'to_owner'
-        and replacing the relevant case properties with the specified 'replace_props'
-        on the copied cases (useful for hiding sensitive data).
-
-        :param domain: the domain string
-        :param case_ids: case ids of the cases to copy
-        :param to_owner: the owner to copy the cases to
-        :param censor_data: the attributes/properties to be censored, specified as a dict.
-                The keys corresponding to the property/attribute and the value specifies
-                the type of censored data, i.e. number or date
-        :param count_only: specifies whether to return only the number of copied cases.
-
-        :return: The copied cases. If `count_only` is True only the count will be returned.
-        """
-        from corehq.apps.hqcase.utils import CASEBLOCK_CHUNKSIZE
-
-        if not to_owner:
-            raise Exception('Must copy cases to valid new owner')
-
-        original_cases = CommCareCase.objects.get_cases(case_ids=case_ids, domain=domain)
-        if not any(original_cases):
-            return [] if not count_only else 0
-
-        processed_cases = {}
-        copied_cases_case_blocks = []
-
-        def _get_new_identifier_index(case_identifier_index):
-            _identifier_index = {**case_identifier_index}
-            original_referenced_id = _identifier_index['case_id']
-
-            # We need the copied case's case_id for the new index
-            if original_referenced_id in processed_cases:
-                _identifier_index['case_id'] = processed_cases[original_referenced_id].case_id
-            else:
-                # Need to process the referenced case first to get the case_id of the copied case
-                try:
-                    original_parent_case = next((
-                        orig_case for orig_case in original_cases if orig_case.case_id == original_referenced_id
-                    ))
-                except StopIteration:
-                    return {}
-                referenced_case_block = _create_case_block(original_parent_case)
-                _identifier_index['case_id'] = referenced_case_block.case_id
-            return (
-                _identifier_index['case_type'],
-                _identifier_index['case_id'],
-                _identifier_index['relationship'],
-            )
-
-        def _get_new_index_map(_case):
-            new_case_index = {}
-            for identifier in _case.get_index_map():
-                identifier_index = _get_new_identifier_index(
-                    _case.get_index_map()[identifier]
-                )
-                if identifier_index:
-                    new_case_index[identifier] = identifier_index
-            return new_case_index
-
-        def _create_case_block(_case):
-            if _case.case_id in processed_cases:
-                return
-
-            censored_attributes, censored_properties = get_deidentified_data(_case, censor_data)
-            case_name = censored_attributes.get('case_name') or censored_attributes.get('name')
-
-            case_block = CaseBlock(
-                create=True,
-                case_id=uuid.uuid4().hex,
-                owner_id=to_owner,
-                case_name=case_name or _case.name,
-                case_type=_case.type,
-                update={**_case.case_json, **censored_properties},
-                index=_get_new_index_map(_case),
-                external_id=censored_attributes.get('external_id', _case.external_id),
-                date_opened=censored_attributes.get('date_opened', _case.opened_on),
-                user_id=SYSTEM_USER_ID,
-            )
-
-            copied_cases_case_blocks.append(case_block.as_text())
-            processed_cases[_case.case_id] = case_block
-
-            return case_block
-
-        case_blocks = []
-        copied_cases = []
-
-        for c in original_cases:
-            if c.owner_id == to_owner:
-                raise Exception("Cannot copy case to self")
-
-            case_blocks.append(_create_case_block(c))
-            if len(case_blocks) >= CASEBLOCK_CHUNKSIZE:
-                _, cases = submit_case_blocks(
-                    case_blocks=copied_cases_case_blocks,
-                    domain=domain,
-                )
-                copied_cases.extend(cases)
-                case_blocks = []
-
-        if case_blocks:
-            _, cases = submit_case_blocks(
-                case_blocks=copied_cases_case_blocks,
-                domain=domain,
-            )
-            copied_cases.extend(cases)
-
-        if count_only:
-            return len(copied_cases)
-        else:
-            return copied_cases
 
     @staticmethod
     def _clean_serialized_case(case_data):

--- a/corehq/apps/hqcase/case_helper.py
+++ b/corehq/apps/hqcase/case_helper.py
@@ -8,7 +8,8 @@ from .api.updates import BaseJsonCaseChange, handle_case_update
 class CaseHelper:
     """
     CaseHelper aims to offer a simple interface for simple operations on
-    cases.
+    a single case. (For managing caseblock submissions for many cases,
+    take a look at `SubmitCaseBlockHandler`.)
 
     Initialize ``CaseHelper`` with an existing case ... ::
 

--- a/corehq/apps/hqcase/tests/test_case_helper.py
+++ b/corehq/apps/hqcase/tests/test_case_helper.py
@@ -3,14 +3,12 @@ import uuid
 from contextlib import contextmanager
 
 from django.test import TestCase
-from couchexport.deid import deid_ID
 from casexml.apps.case.const import CASE_INDEX_CHILD
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.models import CommCareCase
 from corehq.util.test_utils import generate_cases
-from corehq.apps.users.util import SYSTEM_USER_ID
 
 from ..api.core import UserError, serialize_case
 from ..case_helper import CaseHelper
@@ -313,104 +311,6 @@ class CaseHelperTests(TestCase):
                     'case_name': 'Namaka',
                     field_name: '2005-06-30 12:00:00',
                 })
-
-
-class TestCaseCopy(TestCase):
-
-    def test_no_cases_to_copy(self):
-        cases = CaseHelper(domain=DOMAIN).copy_cases(
-            domain=DOMAIN,
-            case_ids=[],
-            to_owner='new owner'
-        )
-        self.assertEqual(cases, [])
-
-    def test_copy_case_to_blank_owner(self):
-        with self.assertRaises(Exception) as context:
-            _ = CaseHelper(domain=DOMAIN).copy_cases(
-                domain=DOMAIN,
-                case_ids=[],
-                to_owner=''
-            )
-        self.assertEqual(str(context.exception), 'Must copy cases to valid new owner')
-
-    def test_copy_case_to_same_owner(self):
-        with get_mother_case(owner_id='owner_id') as case:
-            with self.assertRaises(Exception) as context:
-                _ = CaseHelper(domain=DOMAIN).copy_cases(
-                    domain=DOMAIN,
-                    case_ids=[case.case_id],
-                    to_owner=case.owner_id
-                )
-        self.assertEqual(str(context.exception), 'Cannot copy case to self')
-
-    def test_copy_case_to_new_owner(self):
-        properties = {
-            'family_name': 'Nature',
-        }
-
-        with get_mother_case('owner_id', update=properties) as case:
-            cases = CaseHelper(domain=DOMAIN).copy_cases(
-                domain=DOMAIN,
-                case_ids=[case.case_id],
-                to_owner='new_owner_id'
-            )
-        self.assertEqual(cases[0].owner_id, 'new_owner_id')
-        self.assertEqual(cases[0].case_json['family_name'], 'Nature')
-        self.assertEqual(cases[0].opened_by, SYSTEM_USER_ID)
-
-    def test_copy_case_with_sensitive_properties(self):
-        properties = {
-            'age': '34',
-        }
-
-        with get_mother_case('owner_id', update=properties) as case:
-            cases = CaseHelper(domain=DOMAIN).copy_cases(
-                domain=DOMAIN,
-                case_ids=[case.case_id],
-                to_owner='new_owner_id',
-                censor_data={
-                    'age': self.id_transform,
-                    'case_name': self.id_transform,
-                }
-            )
-            self.assertTrue(cases[0].name != case.name)
-            self.assertTrue(cases[0].case_json['age'] != case.case_json['age'])
-        self.assertEqual(cases[0].owner_id, 'new_owner_id')
-
-    def test_indices_copied(self):
-        with get_child_case() as case:
-            parent_case_id = case.get_indices()[0].referenced_id
-            cases = CaseHelper(domain=DOMAIN).copy_cases(
-                domain=DOMAIN,
-                case_ids=[case.case_id, parent_case_id],
-                to_owner='new_owner_id',
-            )
-        self.assertEqual(len(cases), 2)
-        mother_case = next((c for c in cases if c.type == 'mother'))
-        child_case = next((c for c in cases if c.type == 'child'))
-
-        self.assertEqual(mother_case.owner_id, 'new_owner_id')
-        self.assertEqual(child_case.owner_id, 'new_owner_id')
-
-        self.assertEqual(mother_case.get_indices(), [])
-        self.assertEqual(len(child_case.get_indices()), 1)
-        self.assertEqual(child_case.get_indices()[0].referenced_id, mother_case.case_id)
-
-    def test_indices_not_copied_if_not_in_case_list(self):
-        with get_child_case() as case:
-            cases = CaseHelper(domain=DOMAIN).copy_cases(
-                domain=DOMAIN,
-                case_ids=[case.case_id],
-                to_owner='new_owner_id',
-            )
-        self.assertEqual(len(cases), 1)
-        self.assertEqual(cases[0].owner_id, 'new_owner_id')
-        self.assertEqual(cases[0].get_indices(), [])
-
-    @property
-    def id_transform(self):
-        return deid_ID.__name__
 
 
 @contextmanager

--- a/corehq/apps/hqcase/tests/test_utils.py
+++ b/corehq/apps/hqcase/tests/test_utils.py
@@ -68,8 +68,8 @@ class TestGetCensoredCaseData(TestCase):
             'date_opened': str(datetime.utcnow()),
         }
         censor_data = {
-            'date_opened': self.date_transform,
-            'captain': self.id_transform,
+            'date_opened': DEID_DATE_TRANSFORM,
+            'captain': DEID_ID_TRANSFORM,
         }
         with get_case(update=properties, **attrs) as case:
             censored_attrs, censored_props = get_deidentified_data(case, censor_data)
@@ -79,7 +79,7 @@ class TestGetCensoredCaseData(TestCase):
 
     def test_missing_properties(self):
         censor_data = {
-            'captain': self.id_transform,
+            'captain': DEID_ID_TRANSFORM,
         }
         with get_case() as case:
             censored_attrs, censored_props = get_deidentified_data(case, censor_data)
@@ -91,25 +91,13 @@ class TestGetCensoredCaseData(TestCase):
             'captain': 'Jack Sparrow',
         }
         censor_data = {
-            'captain': self.invalid_transform,
+            'captain': 'invalid_deid_transform',
         }
         with get_case(update=properties) as case:
             censored_attrs, censored_props = get_deidentified_data(case, censor_data)
 
         self.assertTrue(censored_attrs == {})
         self.assertTrue(censored_props['captain'] == '')
-
-    @property
-    def date_transform(self):
-        return DEID_DATE_TRANSFORM
-
-    @property
-    def id_transform(self):
-        return DEID_ID_TRANSFORM
-
-    @property
-    def invalid_transform(self):
-        return 'invalid'
 
 
 @contextmanager

--- a/corehq/apps/hqcase/tests/test_utils.py
+++ b/corehq/apps/hqcase/tests/test_utils.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from django.test import TestCase
 from contextlib import contextmanager
 from casexml.apps.case.mock import CaseFactory
-from couchexport.deid import deid_date, deid_ID
+from corehq.apps.export.const import DEID_ID_TRANSFORM, DEID_DATE_TRANSFORM
 
 from corehq.apps.hqcase.utils import (
     get_case_value,
@@ -101,11 +101,11 @@ class TestGetCensoredCaseData(TestCase):
 
     @property
     def date_transform(self):
-        return deid_date.__name__
+        return DEID_DATE_TRANSFORM
 
     @property
     def id_transform(self):
-        return deid_ID.__name__
+        return DEID_ID_TRANSFORM
 
     @property
     def invalid_transform(self):

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -281,21 +281,21 @@ def get_deidentified_data(case: CommCareCase, censor_data: dict):
     props = {}
 
     if censor_data:
-        for k, v in censor_data.items():
-            case_value, is_case_property = get_case_value(case, k)
+        for attr_or_prop, transform in censor_data.items():
+            case_value, is_case_property = get_case_value(case, attr_or_prop)
 
             if not case_value:
                 continue
 
             censored_value = ''
-            if v == DEID_DATE_TRANSFORM:
+            if transform == DEID_DATE_TRANSFORM:
                 censored_value = deid_date(case_value, None, key=case.case_id)
-            if v == DEID_ID_TRANSFORM:
+            if transform == DEID_ID_TRANSFORM:
                 censored_value = deid_ID(case_value, None)
 
             if is_case_property:
-                props[k] = censored_value
+                props[attr_or_prop] = censored_value
             else:
-                attrs[k] = censored_value
+                attrs[attr_or_prop] = censored_value
 
     return attrs, props

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -13,6 +13,7 @@ from couchexport.deid import deid_date, deid_ID
 from corehq.apps.case_search.const import SPECIAL_CASE_PROPERTIES_MAP
 from corehq.apps.es import filters
 from corehq.apps.es.cases import CaseES
+from corehq.apps.export.const import DEID_ID_TRANSFORM, DEID_DATE_TRANSFORM
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.exceptions import CaseNotFound, MissingFormXml
@@ -287,9 +288,9 @@ def get_deidentified_data(case: CommCareCase, censor_data: dict):
                 continue
 
             censored_value = ''
-            if v == deid_date.__name__:
+            if v == DEID_DATE_TRANSFORM:
                 censored_value = deid_date(case_value, None, key=case.case_id)
-            if v == deid_ID.__name__:
+            if v == DEID_ID_TRANSFORM:
                 censored_value = deid_ID(case_value, None)
 
             if is_case_property:

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -1,6 +1,5 @@
 import datetime
 import uuid
-from typing import Any, Union
 from xml.etree import cElementTree as ElementTree
 
 from django.template.loader import render_to_string
@@ -15,11 +14,7 @@ from corehq.apps.case_search.const import SPECIAL_CASE_PROPERTIES_MAP
 from corehq.apps.data_interfaces.deduplication import DEDUPE_XMLNS
 from corehq.apps.es import filters
 from corehq.apps.es.cases import CaseES
-from corehq.apps.export.const import (
-    DEID_DATE_TRANSFORM,
-    DEID_ID_TRANSFORM,
-    DeidTransformName,
-)
+from corehq.apps.export.const import DEID_DATE_TRANSFORM, DEID_ID_TRANSFORM
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.exceptions import CaseNotFound, MissingFormXml
@@ -248,10 +243,7 @@ def get_last_non_blank_value(case, case_property):
             return property_changed_info.new_value
 
 
-def get_case_value(
-    case: CommCareCase,
-    value: str,
-) -> tuple[Any, Union[bool, None]]:
+def get_case_value(case, value):
     """
     Returns the case's ``value`` and whether it's a property on the case
     (as opposed to attribute).
@@ -272,14 +264,7 @@ def get_case_value(
     return None, None
 
 
-CaseAttrDict = dict[str, Any]  # {case attribute name: value}
-CasePropDict = dict[str, Any]  # {case property name: value}
-
-
-def get_deidentified_data(
-    case: CommCareCase,
-    censor_data: dict[str, DeidTransformName],
-) -> tuple[CaseAttrDict, CasePropDict]:
+def get_deidentified_data(case, censor_data):
     """
     This function is used to get the data on the specified case, but
     with the ``censor_data`` properties censored.

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -5,7 +5,6 @@ import logging
 import json
 import uuid
 from dataclasses import dataclass
-from typing import Union, TypedDict
 
 from django.views.generic import View
 from django.http import JsonResponse
@@ -260,12 +259,6 @@ def copy_cases(request, domain, *args, **kwargs):
     )
 
 
-class IndexDict(TypedDict):
-    case_type: str
-    case_id: str
-    relationship: str
-
-
 @dataclass
 class UserDuck:
     """Quacks like a User"""
@@ -371,17 +364,14 @@ class CaseCopier:
 
     def _get_new_index_map(self, case):
         orig_index_map = case.get_index_map()
-        new_index_map: dict[str, IndexAttrs] = {}
+        new_index_map = {}
         for identifier, orig_index_dict in orig_index_map.items():
             new_index_attrs = self._get_new_index_attrs(orig_index_dict)
             if new_index_attrs:
                 new_index_map[identifier] = new_index_attrs
         return new_index_map
 
-    def _get_new_index_attrs(
-        self,
-        index_dict: IndexDict,
-    ) -> Union[IndexAttrs, None]:
+    def _get_new_index_attrs(self, index_dict):
         index_dict = index_dict.copy()  # Don't change original by reference
         orig_parent_case_id = index_dict['case_id']
 

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -3,6 +3,7 @@ API endpoints for filter options
 """
 import logging
 import json
+import uuid
 
 from django.views.generic import View
 from django.http import JsonResponse
@@ -11,6 +12,11 @@ from django.utils.translation import gettext_lazy as _
 
 from braces.views import JSONResponseMixin
 from memoized import memoized
+
+from casexml.apps.case.mock import CaseBlock
+from corehq.apps.hqcase.utils import get_deidentified_data, submit_case_blocks
+from corehq.apps.users.util import SYSTEM_USER_ID
+from corehq.form_processor.models import CommCareCase
 
 from dimagi.utils.logging import notify_exception
 from phonelog.models import DeviceReportEntry
@@ -29,7 +35,6 @@ from corehq.apps.reports.filters.controllers import (
 )
 from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.elastic import ESError
-from corehq.apps.hqcase.case_helper import CaseHelper
 from django_prbac.decorators import requires_privilege
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -234,7 +239,7 @@ def copy_cases(request, domain, *args, **kwargs):
     censor_data = {prop['name']: prop['label'] for prop in body.get('sensitive_properties', [])}
 
     try:
-        copied_count = CaseHelper(domain=domain).copy_cases(
+        copied_count = _copy_cases(
             domain=domain,
             case_ids=case_ids,
             to_owner=new_owner,
@@ -246,3 +251,130 @@ def copy_cases(request, domain, *args, **kwargs):
         })
     except Exception as e:
         return JsonResponse({'error': _(str(e))}, status=400)
+
+
+def _copy_cases(
+    domain,
+    case_ids,
+    to_owner,
+    censor_data=None,
+    count_only=False
+):
+    """
+    Copies the cases governed by ``case_ids`` to the respective
+    ``to_owner`` and replacing the relevant case properties with the
+    specified 'replace_props' on the copied cases (useful for hiding
+    sensitive data).
+
+    :param domain: the domain string
+    :param case_ids: case ids of the cases to copy
+    :param to_owner: the owner to copy the cases to
+    :param censor_data: the attributes/properties to be censored,
+        specified as a dict. The keys corresponding to the
+        property/attribute and the value specifies the type of censored
+        data, i.e. number or date
+    :param count_only: specifies whether to return only the number
+        of copied cases.
+
+    :return: The copied cases. If `count_only` is True only the count
+        will be returned.
+    """
+    from corehq.apps.hqcase.utils import CASEBLOCK_CHUNKSIZE
+
+    if not to_owner:
+        raise Exception('Must copy cases to valid new owner')
+
+    original_cases = CommCareCase.objects.get_cases(case_ids=case_ids, domain=domain)
+    if not any(original_cases):
+        return [] if not count_only else 0
+
+    processed_cases = {}
+    copied_cases_case_blocks = []
+
+    def _get_new_identifier_index(case_identifier_index):
+        _identifier_index = {**case_identifier_index}
+        original_referenced_id = _identifier_index['case_id']
+
+        # We need the copied case's case_id for the new index
+        if original_referenced_id in processed_cases:
+            _identifier_index['case_id'] = processed_cases[original_referenced_id].case_id
+        else:
+            # Need to process the referenced case first to get the case_id of the copied case
+            try:
+                original_parent_case = next((
+                    orig_case for orig_case in original_cases
+                    if orig_case.case_id == original_referenced_id
+                ))
+            except StopIteration:
+                return {}
+            #
+            referenced_case_block = _create_case_block(original_parent_case)
+            _identifier_index['case_id'] = referenced_case_block.case_id
+        return (
+            _identifier_index['case_type'],
+            _identifier_index['case_id'],
+            _identifier_index['relationship'],
+        )
+
+    def _get_new_index_map(_case):
+        new_case_index = {}
+        for identifier in _case.get_index_map():
+            identifier_index = _get_new_identifier_index(
+                _case.get_index_map()[identifier]
+            )
+            if identifier_index:
+                new_case_index[identifier] = identifier_index
+        return new_case_index
+
+    def _create_case_block(_case):
+        if _case.case_id in processed_cases:
+            return
+
+        censored_attributes, censored_properties = get_deidentified_data(_case, censor_data)
+        case_name = censored_attributes.get('case_name') or censored_attributes.get('name')
+
+        case_block = CaseBlock(
+            create=True,
+            case_id=uuid.uuid4().hex,
+            owner_id=to_owner,
+            case_name=case_name or _case.name,
+            case_type=_case.type,
+            update={**_case.case_json, **censored_properties},
+            index=_get_new_index_map(_case),
+            external_id=censored_attributes.get('external_id', _case.external_id),
+            date_opened=censored_attributes.get('date_opened', _case.opened_on),
+            user_id=SYSTEM_USER_ID,
+        )
+
+        copied_cases_case_blocks.append(case_block.as_text())
+        processed_cases[_case.case_id] = case_block
+
+        return case_block
+
+    case_blocks = []
+    copied_cases = []
+
+    for c in original_cases:
+        if c.owner_id == to_owner:
+            raise Exception("Cannot copy case to self")
+
+        case_blocks.append(_create_case_block(c))
+        if len(case_blocks) >= CASEBLOCK_CHUNKSIZE:
+            _, cases = submit_case_blocks(
+                case_blocks=copied_cases_case_blocks,
+                domain=domain,
+            )
+            copied_cases.extend(cases)
+            case_blocks = []
+
+    if case_blocks:
+        _, cases = submit_case_blocks(
+            case_blocks=copied_cases_case_blocks,
+            domain=domain,
+        )
+        copied_cases.extend(cases)
+
+    if count_only:
+        return len(copied_cases)
+    else:
+        return copied_cases

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -5,6 +5,7 @@ import logging
 import json
 import uuid
 from dataclasses import dataclass
+from typing import Union, TypedDict
 
 from django.views.generic import View
 from django.http import JsonResponse
@@ -14,7 +15,7 @@ from django.utils.translation import gettext_lazy as _
 from braces.views import JSONResponseMixin
 from memoized import memoized
 
-from casexml.apps.case.mock import CaseBlock
+from casexml.apps.case.mock import CaseBlock, IndexAttrs
 from corehq.apps.hqcase.utils import get_deidentified_data
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.models import CommCareCase
@@ -246,12 +247,12 @@ def copy_cases(request, domain, *args, **kwargs):
         for prop in body.get('sensitive_properties', [])
     }
 
-    case_id_pairs, errors = _copy_cases(
-        domain=domain,
-        case_ids=case_ids,
+    case_copier = CaseCopier(
+        domain,
         to_owner=new_owner,
         censor_data=censor_data,
     )
+    case_id_pairs, errors = case_copier.copy_cases(case_ids)
     count = len(case_id_pairs)
     return JsonResponse(
         {'copied_cases': count, 'error': errors},
@@ -259,124 +260,147 @@ def copy_cases(request, domain, *args, **kwargs):
     )
 
 
-def _copy_cases(
-    domain,
-    case_ids,
-    to_owner,
-    censor_data=None,
-):
-    """
-    Copies the cases governed by ``case_ids`` to the respective
-    ``to_owner`` and replacing the relevant case properties with the
-    specified 'replace_props' on the copied cases (useful for hiding
-    sensitive data).
+class IndexDict(TypedDict):
+    case_type: str
+    case_id: str
+    relationship: str
 
-    :param domain: the domain string
-    :param case_ids: case ids of the cases to copy
-    :param to_owner: the owner to copy the cases to
-    :param censor_data: the attributes/properties to be censored,
-        specified as a dict. The keys corresponding to the
-        property/attribute and the value specifies the type of censored
-        data, i.e. number or date
-    :returns: A list of original- and new case ID pairs and a list of
-        errors encountered.
-    """
 
-    if not to_owner:
-        return [], [_('Must copy cases to valid new owner')]
+@dataclass
+class UserDuck:
+    """Quacks like a User"""
+    user_id: str
+    username: str
 
-    original_cases = CommCareCase.objects.get_cases(case_ids, domain)
-    if not original_cases:
-        return [], []
 
-    @dataclass
-    class UserDuck:
-        """Quacks like a User"""
-        user_id: str
-        username: str
+class CaseCopier:
+    """A helper class for copying cases."""
 
-    system_user = UserDuck(user_id=SYSTEM_USER_ID, username='system')
-    submission_handler = SubmitCaseBlockHandler(
-        domain,
-        import_results=None,
-        case_type=None,
-        user=system_user,
-        record_form_callback=None,
-        throttle=True,
-        add_inferred_props_to_schema=False,
-    )
+    def __init__(self, domain, *, to_owner, censor_data=None):
+        """
+        Initialize ``CaseCopier``
 
-    processed_cases = {}
+        :param domain: The domain name
+        :param to_owner: The ID of the CouchUser who will own the new
+            cases.
+        :param censor_data: A dictionary, where keys are the case
+            attributes and case properties to be de-identified, and
+            values are the de-id function to use. See
+            ``corehq.apps.export.const.DEID_TRANSFORM_FUNCTIONS``
+        """
+        self.domain = domain
+        self.to_owner = to_owner
+        self.censor_data = censor_data or {}
 
-    def _get_new_identifier_index(case_identifier_index):
-        _identifier_index = {**case_identifier_index}
-        original_referenced_id = _identifier_index['case_id']
+        self.original_cases = {}  # {case_id: commcare_case}
+        self.processed_cases = {}  # {orig_case_id: new_caseblock}
 
-        # We need the copied case's case_id for the new index
-        if original_referenced_id in processed_cases:
-            _identifier_index['case_id'] = processed_cases[original_referenced_id].case_id
-        else:
-            # Need to process the referenced case first to get the case_id of the copied case
-            try:
-                original_parent_case = next(
-                    orig_case for orig_case in original_cases
-                    if orig_case.case_id == original_referenced_id
-                )
-            except StopIteration:
-                return {}
-            if original_parent_case.case_id not in processed_cases:
-                referenced_caseblock = _create_caseblock(original_parent_case)
-                processed_cases[original_parent_case.case_id] = referenced_caseblock
-                _identifier_index['case_id'] = referenced_caseblock.case_id
-        return (
-            _identifier_index['case_type'],
-            _identifier_index['case_id'],
-            _identifier_index['relationship'],
+    def copy_cases(self, case_ids):
+        """
+        Copies the cases specified by ``case_ids`` to ``self.to_owner``.
+
+        :param case_ids: The case IDs of the cases to copy.
+        :returns: A list of original- and new case ID pairs and a list
+            of any errors encountered.
+        """
+        if not self.to_owner:
+            return [], [_('Must copy cases to valid new owner')]
+
+        original_cases = CommCareCase.objects.get_cases(
+            case_ids,
+            self.domain,
         )
+        if not original_cases:
+            return [], []
+        self.original_cases = {c.case_id: c for c in original_cases}
+        self.processed_cases = {}
 
-    def _get_new_index_map(_case):
-        new_case_index = {}
-        index_map = _case.get_index_map()
-        for identifier, index_dict in index_map.items():
-            identifier_index = _get_new_identifier_index(index_dict)
-            if identifier_index:
-                new_case_index[identifier] = identifier_index
-        return new_case_index
+        system_user = UserDuck(user_id=SYSTEM_USER_ID, username='system')
+        submission_handler = SubmitCaseBlockHandler(
+            self.domain,
+            import_results=None,
+            case_type=None,
+            user=system_user,
+            record_form_callback=None,
+            throttle=True,
+            add_inferred_props_to_schema=False,
+        )
+        errors = []
+        for i, orig_case in enumerate(original_cases):
+            if orig_case.owner_id == self.to_owner:
+                errors.append(_(
+                    'Original case owner {owner_id} cannot copy '
+                    'case {case_id} to themselves.'
+                ).format(
+                    owner_id=orig_case.owner_id,
+                    case_id=orig_case.case_id,
+                ))
+                continue
+            if orig_case.case_id not in self.processed_cases:
+                caseblock = self._create_caseblock(orig_case)
+                self.processed_cases[orig_case.case_id] = caseblock
+                submission_handler.add_caseblock(
+                    RowAndCase(row=i, case=caseblock)
+                )
+        submission_handler.commit_caseblocks()
 
-    def _create_caseblock(_case):
-        deid_attrs, deid_props = get_deidentified_data(_case, censor_data)
+        orig_new_case_id_pairs = [
+            (orig_case_id, caseblock.case_id)
+            for orig_case_id, caseblock in self.processed_cases.items()
+        ]
+        return orig_new_case_id_pairs, errors
+
+    def _create_caseblock(self, case):
+        deid_attrs, deid_props = get_deidentified_data(case, self.censor_data)
         case_name = deid_attrs.get('case_name') or deid_attrs.get('name')
+        index_map = self._get_new_index_map(case)
+        # TODO: Are there any deid_attrs we care about other than
+        #       case_name, name, external_id and date_opened?
         return CaseBlock(
             create=True,
             case_id=uuid.uuid4().hex,
-            owner_id=to_owner,
-            case_name=case_name or _case.name,
-            case_type=_case.type,
-            update={**_case.case_json, **deid_props},
-            index=_get_new_index_map(_case),
-            external_id=deid_attrs.get('external_id', _case.external_id),
-            date_opened=deid_attrs.get('date_opened', _case.opened_on),
+            owner_id=self.to_owner,
+            case_name=case_name or case.name,
+            case_type=case.type,
+            update={**case.case_json, **deid_props},
+            index=index_map,
+            external_id=deid_attrs.get('external_id', case.external_id),
+            date_opened=deid_attrs.get('date_opened', case.opened_on),
             user_id=SYSTEM_USER_ID,
         )
 
-    errors = []
-    for i, orig_case in enumerate(original_cases):
-        if orig_case.owner_id == to_owner:
-            errors.append(_(
-                'Original case owner {owner_id} cannot copy case '
-                '{case_id} to themselves.'
-            ).format(
-                owner_id=orig_case.owner_id,
-                case_id=orig_case.case_id,
-            ))
-            continue
-        if orig_case.case_id not in processed_cases:
-            caseblock = _create_caseblock(orig_case)
-            processed_cases[orig_case.case_id] = caseblock
-            submission_handler.add_caseblock(RowAndCase(row=i, case=caseblock))
-    submission_handler.commit_caseblocks()
+    def _get_new_index_map(self, case):
+        orig_index_map = case.get_index_map()
+        new_index_map: dict[str, IndexAttrs] = {}
+        for identifier, orig_index_dict in orig_index_map.items():
+            new_index_attrs = self._get_new_index_attrs(orig_index_dict)
+            if new_index_attrs:
+                new_index_map[identifier] = new_index_attrs
+        return new_index_map
 
-    orig_new_case_id_pairs = [
-        (orig_id, cb.case_id) for orig_id, cb in processed_cases.items()
-    ]
-    return orig_new_case_id_pairs, errors
+    def _get_new_index_attrs(
+        self,
+        index_dict: IndexDict,
+    ) -> Union[IndexAttrs, None]:
+        index_dict = index_dict.copy()  # Don't change original by reference
+        orig_parent_case_id = index_dict['case_id']
+
+        # We need the copied case's case_id for the new index
+        if orig_parent_case_id in self.processed_cases:
+            new_parent_caseblock = self.processed_cases[orig_parent_case_id]
+            index_dict['case_id'] = new_parent_caseblock.case_id
+        else:
+            # Need to process the referenced case first to get the
+            # case_id of the copied case
+            if orig_parent_case_id not in self.original_cases:
+                return None
+            if orig_parent_case_id not in self.processed_cases:
+                orig_parent_case = self.original_cases[orig_parent_case_id]
+                new_parent_caseblock = self._create_caseblock(orig_parent_case)
+                self.processed_cases[orig_parent_case_id] = new_parent_caseblock
+                index_dict['case_id'] = new_parent_caseblock.case_id
+        return IndexAttrs(
+            index_dict['case_type'],
+            index_dict['case_id'],
+            index_dict['relationship'],
+        )

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -24,10 +24,8 @@ from corehq.apps.reports.filters.base import (
 )
 from corehq import toggles, privileges
 
-# TODO: Replace with library method
 
-
-mark_safe_lazy = lazy(mark_safe, str)
+mark_safe_lazy = lazy(mark_safe, str)  # TODO: Replace with library method
 
 
 class CaseSearchFilter(BaseSimpleFilter):

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -4,7 +4,8 @@ from collections import Counter
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy, gettext
 from django.utils.functional import lazy
-from couchexport.deid import deid_date, deid_ID
+
+from corehq.apps.export.const import DEID_ID_TRANSFORM, DEID_DATE_TRANSFORM
 
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.app_schemas.case_properties import (
@@ -172,8 +173,8 @@ class SensitiveCaseProperties(CaseListExplorerColumns):
     @property
     def property_label_options(self):
         return [
-            {'type': deid_ID.__name__, 'name': gettext_lazy('Sensitive ID')},
-            {'type': deid_date.__name__, 'name': gettext_lazy('Sensitive Date')},
+            {'type': DEID_ID_TRANSFORM, 'name': gettext_lazy('Sensitive ID')},
+            {'type': DEID_DATE_TRANSFORM, 'name': gettext_lazy('Sensitive Date')},
         ]
 
     def get_column_suggestions(self):

--- a/corehq/apps/reports/tests/test_api.py
+++ b/corehq/apps/reports/tests/test_api.py
@@ -8,38 +8,29 @@ from corehq.apps.export.const import DEID_ID_TRANSFORM
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.models import CommCareCase
 
-from ..filters.api import _copy_cases
+from ..filters.api import CaseCopier
 
 DOMAIN = 'test-domain'
 
 
-class TestCaseCopy(TestCase):
+class TestCaseCopier(TestCase):
 
     def test_no_cases_to_copy(self):
-        case_id_pairs, errors = _copy_cases(
-            domain=DOMAIN,
-            case_ids=[],
-            to_owner='new owner'
-        )
+        case_copier = CaseCopier(DOMAIN, to_owner='new owner')
+        case_id_pairs, errors = case_copier.copy_cases([])
         self.assertEqual(case_id_pairs, [])
         self.assertEqual(errors, [])
 
     def test_copy_case_to_blank_owner(self):
-        case_id_pairs, errors = _copy_cases(
-            domain=DOMAIN,
-            case_ids=[],
-            to_owner=''
-        )
+        case_copier = CaseCopier(DOMAIN, to_owner='')
+        case_id_pairs, errors = case_copier.copy_cases([])
         self.assertEqual(case_id_pairs, [])
         self.assertEqual(errors, ['Must copy cases to valid new owner'])
 
     def test_copy_case_to_same_owner(self):
         with get_mother_case(owner_id='owner_id') as case:
-            case_id_pairs, errors = _copy_cases(
-                domain=DOMAIN,
-                case_ids=[case.case_id],
-                to_owner=case.owner_id
-            )
+            case_copier = CaseCopier(DOMAIN, to_owner=case.owner_id)
+            case_id_pairs, errors = case_copier.copy_cases([case.case_id])
             self.assertEqual(case_id_pairs, [])
             self.assertEqual(errors, [
                 'Original case owner owner_id cannot copy case '
@@ -52,11 +43,8 @@ class TestCaseCopy(TestCase):
         }
 
         with get_mother_case('owner_id', update=properties) as case:
-            case_id_pairs, errors = _copy_cases(
-                domain=DOMAIN,
-                case_ids=[case.case_id],
-                to_owner='new_owner_id'
-            )
+            case_copier = CaseCopier(DOMAIN, to_owner='new_owner_id')
+            case_id_pairs, errors = case_copier.copy_cases([case.case_id])
 
             self.assertEqual(len(case_id_pairs), 1)
             orig_case_id, new_case_id = case_id_pairs[0]
@@ -71,15 +59,15 @@ class TestCaseCopy(TestCase):
         }
 
         with get_mother_case('owner_id', update=properties) as case:
-            case_id_pairs, errors = _copy_cases(
-                domain=DOMAIN,
-                case_ids=[case.case_id],
+            case_copier = CaseCopier(
+                DOMAIN,
                 to_owner='new_owner_id',
                 censor_data={
                     'age': DEID_ID_TRANSFORM,
                     'case_name': DEID_ID_TRANSFORM,
                 }
             )
+            case_id_pairs, errors = case_copier.copy_cases([case.case_id])
 
             self.assertEqual(len(case_id_pairs), 1)
             orig_case_id, new_case_id = case_id_pairs[0]
@@ -91,15 +79,14 @@ class TestCaseCopy(TestCase):
     def test_indices_copied(self):
         with get_child_case() as case:
             parent_case_id = case.get_indices()[0].referenced_id
-            case_id_pairs, errors = _copy_cases(
-                domain=DOMAIN,
-                case_ids=[case.case_id, parent_case_id],
-                to_owner='new_owner_id',
+            case_copier = CaseCopier(DOMAIN, to_owner='new_owner_id')
+            case_id_pairs, errors = case_copier.copy_cases(
+                [case.case_id, parent_case_id]
             )
 
-            self.assertEqual(len(case_id_pairs), 2)
             new_case_ids = [pair[1] for pair in case_id_pairs]
             new_cases = CommCareCase.objects.get_cases(new_case_ids, DOMAIN)
+            self.assertEqual(len(new_cases), 2)
             mother_case = next(c for c in new_cases if c.type == 'mother')
             child_case = next(c for c in new_cases if c.type == 'child')
 
@@ -115,16 +102,52 @@ class TestCaseCopy(TestCase):
 
     def test_indices_not_copied_if_not_in_case_list(self):
         with get_child_case() as case:
-            case_id_pairs, errors = _copy_cases(
-                domain=DOMAIN,
-                case_ids=[case.case_id],
-                to_owner='new_owner_id',
+            case_copier = CaseCopier(DOMAIN, to_owner='new_owner_id')
+            case_id_pairs, errors = case_copier.copy_cases([case.case_id])
+
+            self.assertEqual(len(case_id_pairs), 1)
+            orig_case_id, new_case_id = case_id_pairs[0]
+            new_case = CommCareCase.objects.get_case(new_case_id, DOMAIN)
+            self.assertEqual(new_case.owner_id, 'new_owner_id')
+            self.assertEqual(new_case.get_indices(), [])
+
+    def test_create_caseblock(self):
+        with get_mother_case('owner_id') as case:
+            case_copier = CaseCopier(DOMAIN, to_owner='new_owner_id')
+            caseblock = case_copier._create_caseblock(case)
+
+            self.assertNotEqual(caseblock.case_id, case.case_id)
+            self.assertEqual(caseblock.case_name, case.name)
+            self.assertEqual(caseblock.case_type, case.type)
+            self.assertEqual(caseblock.owner_id, 'new_owner_id')
+            self.assertEqual(caseblock.user_id, SYSTEM_USER_ID)
+
+    def test_get_new_index_attrs(self):
+        with get_child_case() as case:
+            index_map = case.get_index_map()
+
+            case_copier = CaseCopier(DOMAIN, to_owner='new_owner_id')
+            # Prime `CaseCopier.original_cases` with parent case
+            case_copier.copy_cases([index_map['mother']['case_id']])
+            index_attrs = case_copier._get_new_index_attrs(index_map['mother'])
+
+            self.assertNotEqual(
+                index_attrs.case_id,
+                index_map['mother']['case_id'],
             )
-        self.assertEqual(len(case_id_pairs), 1)
-        orig_case_id, new_case_id = case_id_pairs[0]
-        new_case = CommCareCase.objects.get_case(new_case_id, DOMAIN)
-        self.assertEqual(new_case.owner_id, 'new_owner_id')
-        self.assertEqual(new_case.get_indices(), [])
+            self.assertEqual(index_attrs.case_type, 'mother')
+            self.assertEqual(index_attrs.relationship, 'child')
+
+    def test_get_new_index_attrs_no_parent(self):
+        with get_child_case() as case:
+            index_map = case.get_index_map()
+
+            case_copier = CaseCopier(DOMAIN, to_owner='new_owner_id')
+            case_copier.copy_cases([case.case_id])
+            # `CaseCopier.original_cases` does not include parent case
+            index_attrs = case_copier._get_new_index_attrs(index_map['mother'])
+
+            self.assertIsNone(index_attrs)
 
 
 @contextmanager

--- a/corehq/apps/reports/tests/test_api.py
+++ b/corehq/apps/reports/tests/test_api.py
@@ -67,8 +67,8 @@ class TestCaseCopy(TestCase):
                 case_ids=[case.case_id],
                 to_owner='new_owner_id',
                 censor_data={
-                    'age': self.id_transform,
-                    'case_name': self.id_transform,
+                    'age': DEID_ID_TRANSFORM,
+                    'case_name': DEID_ID_TRANSFORM,
                 }
             )
             self.assertTrue(cases[0].name != case.name)
@@ -104,10 +104,6 @@ class TestCaseCopy(TestCase):
         self.assertEqual(len(cases), 1)
         self.assertEqual(cases[0].owner_id, 'new_owner_id')
         self.assertEqual(cases[0].get_indices(), [])
-
-    @property
-    def id_transform(self):
-        return DEID_ID_TRANSFORM
 
 
 @contextmanager

--- a/corehq/apps/reports/tests/test_api.py
+++ b/corehq/apps/reports/tests/test_api.py
@@ -1,0 +1,148 @@
+from contextlib import contextmanager
+
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
+from couchexport.deid import deid_ID
+
+from corehq.apps.users.util import SYSTEM_USER_ID
+
+from ..filters.api import _copy_cases
+
+DOMAIN = 'test-domain'
+
+
+class TestCaseCopy(TestCase):
+
+    def test_no_cases_to_copy(self):
+        cases = _copy_cases(
+            domain=DOMAIN,
+            case_ids=[],
+            to_owner='new owner'
+        )
+        self.assertEqual(cases, [])
+
+    def test_copy_case_to_blank_owner(self):
+        with self.assertRaises(Exception) as context:
+            _ = _copy_cases(
+                domain=DOMAIN,
+                case_ids=[],
+                to_owner=''
+            )
+        self.assertEqual(str(context.exception), 'Must copy cases to valid new owner')
+
+    def test_copy_case_to_same_owner(self):
+        with get_mother_case(owner_id='owner_id') as case:
+            with self.assertRaises(Exception) as context:
+                _ = _copy_cases(
+                    domain=DOMAIN,
+                    case_ids=[case.case_id],
+                    to_owner=case.owner_id
+                )
+        self.assertEqual(str(context.exception), 'Cannot copy case to self')
+
+    def test_copy_case_to_new_owner(self):
+        properties = {
+            'family_name': 'Nature',
+        }
+
+        with get_mother_case('owner_id', update=properties) as case:
+            cases = _copy_cases(
+                domain=DOMAIN,
+                case_ids=[case.case_id],
+                to_owner='new_owner_id'
+            )
+        self.assertEqual(cases[0].owner_id, 'new_owner_id')
+        self.assertEqual(cases[0].case_json['family_name'], 'Nature')
+        self.assertEqual(cases[0].opened_by, SYSTEM_USER_ID)
+
+    def test_copy_case_with_sensitive_properties(self):
+        properties = {
+            'age': '34',
+        }
+
+        with get_mother_case('owner_id', update=properties) as case:
+            cases = _copy_cases(
+                domain=DOMAIN,
+                case_ids=[case.case_id],
+                to_owner='new_owner_id',
+                censor_data={
+                    'age': self.id_transform,
+                    'case_name': self.id_transform,
+                }
+            )
+            self.assertTrue(cases[0].name != case.name)
+            self.assertTrue(cases[0].case_json['age'] != case.case_json['age'])
+        self.assertEqual(cases[0].owner_id, 'new_owner_id')
+
+    def test_indices_copied(self):
+        with get_child_case() as case:
+            parent_case_id = case.get_indices()[0].referenced_id
+            cases = _copy_cases(
+                domain=DOMAIN,
+                case_ids=[case.case_id, parent_case_id],
+                to_owner='new_owner_id',
+            )
+        self.assertEqual(len(cases), 2)
+        mother_case = next((c for c in cases if c.type == 'mother'))
+        child_case = next((c for c in cases if c.type == 'child'))
+
+        self.assertEqual(mother_case.owner_id, 'new_owner_id')
+        self.assertEqual(child_case.owner_id, 'new_owner_id')
+
+        self.assertEqual(mother_case.get_indices(), [])
+        self.assertEqual(len(child_case.get_indices()), 1)
+        self.assertEqual(child_case.get_indices()[0].referenced_id, mother_case.case_id)
+
+    def test_indices_not_copied_if_not_in_case_list(self):
+        with get_child_case() as case:
+            cases = _copy_cases(
+                domain=DOMAIN,
+                case_ids=[case.case_id],
+                to_owner='new_owner_id',
+            )
+        self.assertEqual(len(cases), 1)
+        self.assertEqual(cases[0].owner_id, 'new_owner_id')
+        self.assertEqual(cases[0].get_indices(), [])
+
+    @property
+    def id_transform(self):
+        return deid_ID.__name__
+
+
+@contextmanager
+def get_mother_case(*args, **kwargs):
+    factory = CaseFactory(DOMAIN)
+    mother = factory.create_case(
+        case_type='mother',
+        case_name='Haumea',
+        **kwargs,
+    )
+    try:
+        yield mother
+    finally:
+        factory.close_case(mother.case_id)
+
+
+@contextmanager
+def get_child_case():
+    factory = CaseFactory(DOMAIN)
+    with get_mother_case() as mother:
+        struct = CaseStructure(
+            attrs={
+                'case_type': 'child',
+                'case_name': 'Namaka',
+                'create': True,
+            },
+            indices=[CaseIndex(
+                relationship='child',
+                identifier='mother',
+                related_structure=CaseStructure(case_id=mother.case_id),
+                related_type='mother',
+            )],
+        )
+        child, __ = factory.create_or_update_cases([struct])
+        try:
+            yield child
+        finally:
+            factory.close_case(child.case_id)

--- a/corehq/apps/reports/tests/test_api.py
+++ b/corehq/apps/reports/tests/test_api.py
@@ -6,6 +6,7 @@ from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 
 from corehq.apps.export.const import DEID_ID_TRANSFORM
 from corehq.apps.users.util import SYSTEM_USER_ID
+from corehq.form_processor.models import CommCareCase
 
 from ..filters.api import _copy_cases
 
@@ -15,31 +16,35 @@ DOMAIN = 'test-domain'
 class TestCaseCopy(TestCase):
 
     def test_no_cases_to_copy(self):
-        cases = _copy_cases(
+        case_id_pairs, errors = _copy_cases(
             domain=DOMAIN,
             case_ids=[],
             to_owner='new owner'
         )
-        self.assertEqual(cases, [])
+        self.assertEqual(case_id_pairs, [])
+        self.assertEqual(errors, [])
 
     def test_copy_case_to_blank_owner(self):
-        with self.assertRaises(Exception) as context:
-            _ = _copy_cases(
-                domain=DOMAIN,
-                case_ids=[],
-                to_owner=''
-            )
-        self.assertEqual(str(context.exception), 'Must copy cases to valid new owner')
+        case_id_pairs, errors = _copy_cases(
+            domain=DOMAIN,
+            case_ids=[],
+            to_owner=''
+        )
+        self.assertEqual(case_id_pairs, [])
+        self.assertEqual(errors, ['Must copy cases to valid new owner'])
 
     def test_copy_case_to_same_owner(self):
         with get_mother_case(owner_id='owner_id') as case:
-            with self.assertRaises(Exception) as context:
-                _ = _copy_cases(
-                    domain=DOMAIN,
-                    case_ids=[case.case_id],
-                    to_owner=case.owner_id
-                )
-        self.assertEqual(str(context.exception), 'Cannot copy case to self')
+            case_id_pairs, errors = _copy_cases(
+                domain=DOMAIN,
+                case_ids=[case.case_id],
+                to_owner=case.owner_id
+            )
+            self.assertEqual(case_id_pairs, [])
+            self.assertEqual(errors, [
+                'Original case owner owner_id cannot copy case '
+                f'{case.case_id} to themselves.'
+            ])
 
     def test_copy_case_to_new_owner(self):
         properties = {
@@ -47,14 +52,18 @@ class TestCaseCopy(TestCase):
         }
 
         with get_mother_case('owner_id', update=properties) as case:
-            cases = _copy_cases(
+            case_id_pairs, errors = _copy_cases(
                 domain=DOMAIN,
                 case_ids=[case.case_id],
                 to_owner='new_owner_id'
             )
-        self.assertEqual(cases[0].owner_id, 'new_owner_id')
-        self.assertEqual(cases[0].case_json['family_name'], 'Nature')
-        self.assertEqual(cases[0].opened_by, SYSTEM_USER_ID)
+
+            self.assertEqual(len(case_id_pairs), 1)
+            orig_case_id, new_case_id = case_id_pairs[0]
+            new_case = CommCareCase.objects.get_case(new_case_id, DOMAIN)
+            self.assertEqual(new_case.owner_id, 'new_owner_id')
+            self.assertEqual(new_case.case_json['family_name'], 'Nature')
+            self.assertEqual(new_case.opened_by, SYSTEM_USER_ID)
 
     def test_copy_case_with_sensitive_properties(self):
         properties = {
@@ -62,7 +71,7 @@ class TestCaseCopy(TestCase):
         }
 
         with get_mother_case('owner_id', update=properties) as case:
-            cases = _copy_cases(
+            case_id_pairs, errors = _copy_cases(
                 domain=DOMAIN,
                 case_ids=[case.case_id],
                 to_owner='new_owner_id',
@@ -71,39 +80,51 @@ class TestCaseCopy(TestCase):
                     'case_name': DEID_ID_TRANSFORM,
                 }
             )
-            self.assertTrue(cases[0].name != case.name)
-            self.assertTrue(cases[0].case_json['age'] != case.case_json['age'])
-        self.assertEqual(cases[0].owner_id, 'new_owner_id')
+
+            self.assertEqual(len(case_id_pairs), 1)
+            orig_case_id, new_case_id = case_id_pairs[0]
+            new_case = CommCareCase.objects.get_case(new_case_id, DOMAIN)
+            self.assertTrue(new_case.name != case.name)
+            self.assertTrue(new_case.case_json['age'] != case.case_json['age'])
+            self.assertEqual(new_case.owner_id, 'new_owner_id')
 
     def test_indices_copied(self):
         with get_child_case() as case:
             parent_case_id = case.get_indices()[0].referenced_id
-            cases = _copy_cases(
+            case_id_pairs, errors = _copy_cases(
                 domain=DOMAIN,
                 case_ids=[case.case_id, parent_case_id],
                 to_owner='new_owner_id',
             )
-        self.assertEqual(len(cases), 2)
-        mother_case = next((c for c in cases if c.type == 'mother'))
-        child_case = next((c for c in cases if c.type == 'child'))
 
-        self.assertEqual(mother_case.owner_id, 'new_owner_id')
-        self.assertEqual(child_case.owner_id, 'new_owner_id')
+            self.assertEqual(len(case_id_pairs), 2)
+            new_case_ids = [pair[1] for pair in case_id_pairs]
+            new_cases = CommCareCase.objects.get_cases(new_case_ids, DOMAIN)
+            mother_case = next(c for c in new_cases if c.type == 'mother')
+            child_case = next(c for c in new_cases if c.type == 'child')
 
-        self.assertEqual(mother_case.get_indices(), [])
-        self.assertEqual(len(child_case.get_indices()), 1)
-        self.assertEqual(child_case.get_indices()[0].referenced_id, mother_case.case_id)
+            self.assertEqual(mother_case.owner_id, 'new_owner_id')
+            self.assertEqual(child_case.owner_id, 'new_owner_id')
+
+            self.assertEqual(mother_case.get_indices(), [])
+            self.assertEqual(len(child_case.get_indices()), 1)
+            self.assertEqual(
+                child_case.get_indices()[0].referenced_id,
+                mother_case.case_id,
+            )
 
     def test_indices_not_copied_if_not_in_case_list(self):
         with get_child_case() as case:
-            cases = _copy_cases(
+            case_id_pairs, errors = _copy_cases(
                 domain=DOMAIN,
                 case_ids=[case.case_id],
                 to_owner='new_owner_id',
             )
-        self.assertEqual(len(cases), 1)
-        self.assertEqual(cases[0].owner_id, 'new_owner_id')
-        self.assertEqual(cases[0].get_indices(), [])
+        self.assertEqual(len(case_id_pairs), 1)
+        orig_case_id, new_case_id = case_id_pairs[0]
+        new_case = CommCareCase.objects.get_case(new_case_id, DOMAIN)
+        self.assertEqual(new_case.owner_id, 'new_owner_id')
+        self.assertEqual(new_case.get_indices(), [])
 
 
 @contextmanager

--- a/corehq/apps/reports/tests/test_api.py
+++ b/corehq/apps/reports/tests/test_api.py
@@ -3,8 +3,8 @@ from contextlib import contextmanager
 from django.test import TestCase
 
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
-from couchexport.deid import deid_ID
 
+from corehq.apps.export.const import DEID_ID_TRANSFORM
 from corehq.apps.users.util import SYSTEM_USER_ID
 
 from ..filters.api import _copy_cases
@@ -107,7 +107,7 @@ class TestCaseCopy(TestCase):
 
     @property
     def id_transform(self):
-        return deid_ID.__name__
+        return DEID_ID_TRANSFORM
 
 
 @contextmanager

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -825,13 +825,13 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
 
 
 def get_index_map(indices):
-    return dict([
-        (index.identifier, {
+    return {
+        index.identifier: {
             "case_type": index.referenced_type,
             "case_id": index.referenced_id,
             "relationship": index.relationship,
-        }) for index in indices
-    ])
+        } for index in indices
+    }
 
 
 class CaseAttachmentManager(RequireDBManager):

--- a/corehq/form_processor/tests/test_cases.py
+++ b/corehq/form_processor/tests/test_cases.py
@@ -1,4 +1,5 @@
 import uuid
+from contextlib import contextmanager
 from datetime import datetime
 
 import attr
@@ -36,6 +37,31 @@ class BaseCaseManagerTest(TestCase):
             FormProcessorTestUtils.delete_all_sql_forms(DOMAIN)
             FormProcessorTestUtils.delete_all_sql_cases(DOMAIN)
         super(BaseCaseManagerTest, self).tearDown()
+
+    @contextmanager
+    def get_case_and_indices(self, mother_id, task_id):
+        case = _create_case()
+        mother_index = CommCareCaseIndex(
+            case=case,
+            identifier='parent',
+            referenced_type='mother',
+            referenced_id=mother_id,
+            relationship_id=CommCareCaseIndex.CHILD
+        )
+        case.track_create(mother_index)
+        task_index = CommCareCaseIndex(
+            case=case,
+            identifier='task',
+            referenced_type='task',
+            referenced_id=task_id,
+            relationship_id=CommCareCaseIndex.EXTENSION
+        )
+        case.track_create(task_index)
+        case.save(with_tracked_models=True)
+        try:
+            yield case, mother_index, task_index
+        except:
+            pass
 
 
 @sharded
@@ -436,6 +462,35 @@ class TestCommCareCase(BaseCaseManagerTest):
         ))
         self.assertEqual(len(case.get_closing_transactions()), 2)
 
+    def test_get_index_map(self):
+        mother_id = uuid.uuid4().hex
+        task_id = uuid.uuid4().hex
+        with self.get_case_and_indices(
+            mother_id=mother_id,
+            task_id=task_id,
+        ) as (case, index1, index2):
+            index_map = case.get_index_map()
+            self.assertEqual(index_map, {
+                'parent': {
+                    'case_id': mother_id,
+                    'case_type': 'mother',
+                    'relationship': 'child',
+                },
+                'task': {
+                    'case_id': task_id,
+                    'case_type': 'task',
+                    'relationship': 'extension',
+                },
+            })
+
+    def test_get_index_map_reversed(self):
+        with self.get_case_and_indices(
+            mother_id=uuid.uuid4().hex,
+            task_id=uuid.uuid4().hex,
+        ) as (case, index1, index2):
+            index_map = case.get_index_map(reversed=True)
+            self.assertEqual(index_map, {})  # Nothing indexes `case`
+
 
 @sharded
 class TestCaseAttachmentManager(BaseCaseManagerTest):
@@ -511,28 +566,16 @@ class TestCaseAttachmentManager(BaseCaseManagerTest):
 class TestCommCareCaseIndexManager(BaseCaseManagerTest):
 
     def test_get_indices(self):
-        case = _create_case()
-        index1 = CommCareCaseIndex(
-            case=case,
-            identifier='parent',
-            referenced_type='mother',
-            referenced_id=uuid.uuid4().hex,
-            relationship_id=CommCareCaseIndex.CHILD
-        )
-        case.track_create(index1)
-        index2 = CommCareCaseIndex(
-            case=case,
-            identifier='task',
-            referenced_type='task',
-            referenced_id=uuid.uuid4().hex,
-            relationship_id=CommCareCaseIndex.EXTENSION
-        )
-        case.track_create(index2)
-        case.save(with_tracked_models=True)
-
-        indices = CommCareCaseIndex.objects.get_indices(case.domain, case.case_id)
-        indices.sort(key=lambda x: x.identifier)  # "parent" comes before "task"
-        self.assertEqual([index1, index2], indices)
+        with self.get_case_and_indices(
+            mother_id=uuid.uuid4().hex,
+            task_id=uuid.uuid4().hex,
+        ) as (case, index1, index2):
+            indices = CommCareCaseIndex.objects.get_indices(
+                case.domain,
+                case.case_id,
+            )
+            indices.sort(key=lambda x: x.identifier)  # "parent" comes before "task"
+            self.assertEqual([index1, index2], indices)
 
     def test_get_reverse_indices(self):
         referenced_case_id = uuid.uuid4().hex
@@ -543,53 +586,41 @@ class TestCommCareCaseIndexManager(BaseCaseManagerTest):
         self.assertEqual([index], indices)
 
     def test_get_all_reverse_indices_info(self):
-        # Create case and indexes
-        case = _create_case()
         referenced_id1 = uuid.uuid4().hex
         referenced_id2 = uuid.uuid4().hex
-        extension_index = CommCareCaseIndex(
-            case=case,
-            identifier="task",
-            referenced_type="task",
-            referenced_id=referenced_id1,
-            relationship_id=CommCareCaseIndex.EXTENSION
-        )
-        case.track_create(extension_index)
-        child_index = CommCareCaseIndex(
-            case=case,
-            identifier='parent',
-            referenced_type='mother',
-            referenced_id=referenced_id2,
-            relationship_id=CommCareCaseIndex.CHILD
-        )
-        case.track_create(child_index)
-        case.save(with_tracked_models=True)
+        with self.get_case_and_indices(
+            mother_id=referenced_id2,
+            task_id=referenced_id1,
+        ) as (case, child_index, extension_index):
 
-        # Create irrelevant case and index
-        _create_case_with_index(case.case_id)
+            # Create irrelevant case and index
+            _create_case_with_index(case.case_id)
 
-        # create index on deleted case
-        _create_case_with_index(referenced_id1, case_is_deleted=True)
+            # create index on deleted case
+            _create_case_with_index(referenced_id1, case_is_deleted=True)
 
-        self.assertEqual(
-            set(CommCareCaseIndex.objects.get_all_reverse_indices_info(DOMAIN, [referenced_id1, referenced_id2])),
-            {
-                CaseIndexInfo(
-                    case_id=case.case_id,
-                    identifier='task',
-                    referenced_id=referenced_id1,
-                    referenced_type='task',
-                    relationship=CommCareCaseIndex.EXTENSION,
-                ),
-                CaseIndexInfo(
-                    case_id=case.case_id,
-                    identifier='parent',
-                    referenced_id=referenced_id2,
-                    referenced_type='mother',
-                    relationship=CommCareCaseIndex.CHILD
-                ),
-            }
-        )
+            self.assertEqual(
+                set(CommCareCaseIndex.objects.get_all_reverse_indices_info(
+                    DOMAIN,
+                    [referenced_id1, referenced_id2],
+                )),
+                {
+                    CaseIndexInfo(
+                        case_id=case.case_id,
+                        identifier='task',
+                        referenced_id=referenced_id1,
+                        referenced_type='task',
+                        relationship=CommCareCaseIndex.EXTENSION,
+                    ),
+                    CaseIndexInfo(
+                        case_id=case.case_id,
+                        identifier='parent',
+                        referenced_id=referenced_id2,
+                        referenced_type='mother',
+                        relationship=CommCareCaseIndex.CHILD
+                    ),
+                }
+            )
 
     def test_get_extension_case_ids(self):
         # There are similar tests for get_extension_case_ids in the


### PR DESCRIPTION
## Technical Summary

**NOTE:** The base branch is **cs/SC-2636-copy_cases_to_test_user**.

Easiest to review one :blowfish: commit :fish: at :tropical_fish: a time. There are 18 (currently) but most of them are very small. I have added longer commit messages to some commits, which may be useful for context or clarity. (Maybe also worth noting, if you are reviewing by commit, that I add type hints to help me to refactor. Those type hints are removed in later commits.)

This is a refactor to move the `CaseHelper.copy_cases()` method into its own function, and make it use `SubmitCaseBlockHandler`, which is also used by case imports, and is better suited for managing bulk case submissions than `CaseHelper`.

The change was prompted by [this PR comment](https://github.com/dimagi/commcare-hq/pull/33054#discussion_r1230750889).

fyi @sravfeyn 

Jira: [SC-2903](https://dimagi-dev.atlassian.net/browse/SC-2903)

## Feature Flag

Copy Cases

## Safety Assurance

### Safety story

* Is not merged into master
* Adds tests, and enables more, narrower tests to be added

### Automated test coverage

Tests added

### QA Plan

The "Copy Cases" feature will be QAed: [QA-5187](https://dimagi-dev.atlassian.net/browse/QA-5187)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-2903]: https://dimagi-dev.atlassian.net/browse/SC-2903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-5187]: https://dimagi-dev.atlassian.net/browse/QA-5187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ