### PR TITLE
Skip django user update on user reporting metadata update

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1466,7 +1466,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
     bulk_save = save_docs
 
-    def save(self, fire_signals=True, **params):
+    def save(self, fire_signals=True, update_django_user=True, **params):
         # HEADS UP!
         # When updating this method, please also ensure that your updates also
         # carry over to bulk_auto_deactivate_commcare_users.
@@ -1478,7 +1478,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             if by_username and by_username['id'] != self._id:
                 raise self.Inconsistent("CouchUser with username %s already exists" % self.username)
 
-            if self._rev and not self.to_be_deleted():
+            if update_django_user and self._rev and not self.to_be_deleted():
                 django_user = self.sync_to_django_user()
                 django_user.save()
 
@@ -3025,7 +3025,7 @@ class UserReportingMetadataStaging(models.Model):
                 fcm_token=self.fcm_token, fcm_token_timestamp=self.last_heartbeat, save_user=False
             )
         if save:
-            user.save(fire_signals=False)
+            user.save(fire_signals=False, update_django_user=False)
 
     class Meta(object):
         unique_together = ('domain', 'user_id', 'app_id')

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3025,6 +3025,13 @@ class UserReportingMetadataStaging(models.Model):
                 fcm_token=self.fcm_token, fcm_token_timestamp=self.last_heartbeat, save_user=False
             )
         if save:
+            # update_django_user=False below is an optimization that allows us to update the CouchUser
+            # without propagating that change to SQL.
+            # This is an optimization we're able to do safely only because we happen to know that
+            # the present workflow only updates properties that are *not* stored on the django (SQL) user model.
+            # We have seen that these frequent updates to the SQL user table
+            # occasionally create deadlocks or pile-ups,
+            # which can be avoided by omitting that extraneous write entirely.
             user.save(fire_signals=False, update_django_user=False)
 
     class Meta(object):


### PR DESCRIPTION
## Technical Summary

https://dimagi-dev.atlassian.net/browse/SAAS-14814

We've had an ongoing issue with the UserReportingMetadataStaging workflow causing a deadlock involving updates to that table and the Django User table.

This PR attempts to work around the problem entirely by just not updating the Django user when the workflow updates the user in couch. None of the user properties that this workflow updates are actually properties of on the Django User, so right no we're doing frequent no-op writes to the Django User table. Perhaps by just not doing that, the deadlock issue will also stop happening.

## Safety Assurance

### Safety story
I checked code coverage and the few lines updated in this PR are all covered by our tests. That doesn't by itself prove that this change does what I want it to do, but it does prove that simply hitting any of these lines on "the happy path" doesn't cause an exception. That it does what I intend it to do is something I'm pretty comfortable with given the small size of the change, and the test covers gives me the assurance that I didn't make some typo-level error.

### Automated test coverage

https://github.com/dimagi/commcare-hq/blob/db8d2640d8ef56e44064ba9e13a6604f7f617224/corehq/ex-submodules/casexml/apps/phone/tests/test_synclog_pillow.py#L115-L155 in particular tests the batched user metadata update workflow that this PR modifies.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
