### PR TITLE
Web apps flag for small screen mode

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -24,5 +24,7 @@ hqDefine("cloudcare/js/formplayer/constants", function () {
 
         FORMAT_ADDRESS: "Address",
         FORMAT_ADDRESS_POPUP: "AddressPopup",
+
+        SMALL_SCREEN_WIDTH_PX: 768,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -110,13 +110,11 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var changeFormLanguage = toggles.toggleEnabled('CHANGE_FORM_LANGUAGE');
         var enablePrintOption = !menuResponse.queryKey;
         var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview;
-        var smallScreenEnabled = window.innerWidth <= constants.SMALL_SCREEN_WIDTH_PX;
 
         if (sidebarEnabled && menuResponse.type === "query") {
             var menuData = menusUtils.getMenuData(menuResponse);
             menuData["triggerEmptyCaseList"] = true;
             menuData["sidebarEnabled"] = true;
-            menuData["smallScreenEnabled"] = smallScreenEnabled;
             menuData["title"] = menuResponse.resultsTitle;
             var caseListView = menusUtils.getCaseListView(menuResponse)
             FormplayerFrontend.regions.getRegion('main').show(caseListView(menuData));

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -110,11 +110,13 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var changeFormLanguage = toggles.toggleEnabled('CHANGE_FORM_LANGUAGE');
         var enablePrintOption = !menuResponse.queryKey;
         var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview;
+        var smallScreenEnabled = window.innerWidth <= constants.SMALL_SCREEN_WIDTH_PX;
 
         if (sidebarEnabled && menuResponse.type === "query") {
             var menuData = menusUtils.getMenuData(menuResponse);
             menuData["triggerEmptyCaseList"] = true;
             menuData["sidebarEnabled"] = true;
+            menuData["smallScreenEnabled"] = smallScreenEnabled;
             menuData["title"] = menuResponse.resultsTitle;
             var caseListView = menusUtils.getCaseListView(menuResponse)
             FormplayerFrontend.regions.getRegion('main').show(caseListView(menuData));

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -423,7 +423,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             const addressFieldPresent = !!_.find(this.styles, function (style) { return style.displayFormat === constants.FORMAT_ADDRESS; });
 
             self.showMap = addressFieldPresent && !appPreview && !self.hasNoItems && toggles.toggleEnabled('CASE_LIST_MAP')
-            self.smallScreenEnabled = window.innerWidth <= constants.SMALL_SCREEN_WIDTH_PX;
+            self.smallScreenEnabled = cloudcareUtils.watchSmallScreenEnabled(enabled => self.smallScreenEnabled = enabled);
         },
 
         ui: CaseListViewUI(),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -423,6 +423,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             const addressFieldPresent = !!_.find(this.styles, function (style) { return style.displayFormat === constants.FORMAT_ADDRESS; });
 
             self.showMap = addressFieldPresent && !appPreview && !self.hasNoItems && toggles.toggleEnabled('CASE_LIST_MAP')
+            self.smallScreenEnabled = window.innerWidth <= constants.SMALL_SCREEN_WIDTH_PX;
         },
 
         ui: CaseListViewUI(),
@@ -689,6 +690,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 showMap: this.showMap,
                 columnStyle: this.columnStyle(),
                 sidebarEnabled: this.options.sidebarEnabled,
+                smallScreenEnabled: this.smallScreenEnabled,
                 triggerEmptyCaseList: this.options.triggerEmptyCaseList,
 
                 columnSortable: function (index) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -859,8 +859,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         childViewOptions: function (model) {
             const dict = CaseTileGroupedListView.__super__.childViewOptions.apply(this, arguments);
-            dict.groupHeaderRows = this.options.collection.groupHeaderRows
-            dict.groupModelsList = this.groupedModels[model.get("groupKey")]
+            dict.groupHeaderRows = this.options.collection.groupHeaderRows;
+            dict.groupModelsList = this.groupedModels[model.get("groupKey")];
             dict.headerRowIndices = this.headerRowIndices;
             return dict;
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1,4 +1,4 @@
-/*globals DOMPurify, Marionette */
+/*globals Marionette */
 
 hqDefine("cloudcare/js/formplayer/menus/views", function () {
     const kissmetrics = hqImport("analytix/js/kissmetrix"),
@@ -240,7 +240,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             let modelId = this.model.get('id');
             return {
                 "tabindex": "0",
-                "id": `row-${modelId}`
+                "id": `row-${modelId}`,
             };
         },
 
@@ -337,17 +337,17 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             let indexedRowDataList = [];
             for (let model of this.options.groupModelsList) {
                 let indexedRowData = model.get('data')
-                .reduce((acc, data, i) => {
-                    if (!this.options.headerRowIndices.includes(i) &&
-                        this.options.styles[i].widthHint!==0) {
-                        acc[i] = data;
-                    }
-                    return acc;
-                }, {});
+                    .reduce((acc, data, i) => {
+                        if (!this.options.headerRowIndices.includes(i) &&
+                            this.options.styles[i].widthHint !== 0) {
+                            acc[i] = data;
+                        }
+                        return acc;
+                    }, {});
                 if (Object.keys(indexedRowData).length !== 0) {
                     indexedRowDataList.push(indexedRowData);
                 }
-            };
+            }
             return indexedRowDataList;
         },
     });
@@ -418,11 +418,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 self.selectedCaseIds = [];
             }
             const user = FormplayerFrontend.currentUser;
-            const displayOptions = user.displayOptions
+            const displayOptions = user.displayOptions;
             const appPreview = displayOptions.singleAppMode;
             const addressFieldPresent = !!_.find(this.styles, function (style) { return style.displayFormat === constants.FORMAT_ADDRESS; });
 
-            self.showMap = addressFieldPresent && !appPreview && !self.hasNoItems && toggles.toggleEnabled('CASE_LIST_MAP')
+            self.showMap = addressFieldPresent && !appPreview && !self.hasNoItems && toggles.toggleEnabled('CASE_LIST_MAP');
             self.smallScreenEnabled = cloudcareUtils.watchSmallScreenEnabled(enabled => self.smallScreenEnabled = enabled);
         },
 
@@ -580,7 +580,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     }).setView([lat, lon], zoom);
 
                 L.control.zoom({
-                    position: 'bottomright'
+                    position: 'bottomright',
                 }).addTo(addressMap);
 
                 L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=' + token, {
@@ -595,8 +595,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 const popupIndex = _.findIndex(this.styles, function (style) { return style.displayFormat === constants.FORMAT_ADDRESS_POPUP; });
                 L.mapbox.accessToken = token;
 
-                const allCoordinates = []
-                const markers = []
+                const allCoordinates = [];
+                const markers = [];
                 this.options.collection.models
                     .forEach(model => {
                         const addressCoordinates = model.attributes.data[addressIndex];
@@ -607,9 +607,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                                 const popupText = cloudcareUtils.renderMarkdown(model.attributes.data[popupIndex]);
                                 let marker = L.marker(markerCoordinates, {icon: locationIcon});
                                 markers.push(marker);
-                                marker = marker.addTo(addressMap)
+                                marker = marker.addTo(addressMap);
                                 if (popupIndex >= 0) {
-                                    marker = marker.bindPopup(popupText)
+                                    marker = marker.bindPopup(popupText);
                                 }
 
                                 marker.on('click', () => {
@@ -626,7 +626,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
                                     $([document.documentElement, document.body]).animate({
                                         // -50 Stay clear of the breadcrumbs
-                                        scrollTop: $(`#${rowId}`).offset().top - 50
+                                        scrollTop: $(`#${rowId}`).offset().top - 50,
                                     }, 500);
 
                                     addressMap.panTo(markerCoordinates);
@@ -660,13 +660,13 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             const paginateItems = formplayerUtils.paginateOptions(this.options.currentPage, this.options.pageCount);
             const casesPerPage = parseInt($.cookie("cases-per-page-limit")) || 10;
             const boldSortedCharIcon = (header) => {
-                const header_words = header.trim().split(' ');
-                const lastChar = header_words.pop();
+                const headerWords = header.trim().split(' ');
+                const lastChar = headerWords.pop();
 
                 return lastChar === "Λ" || lastChar === "V"
-                  ? `${header_words.join(' ')} <b>${lastChar}</b>`
-                  : header;
-              };
+                    ? `${headerWords.join(' ')} <b>${lastChar}</b>`
+                    : header;
+            };
             return {
                 startPage: paginateItems.startPage,
                 title: this.options.title,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -3,7 +3,6 @@
 hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function () {
     describe('Split Screen Case Search', function () {
         const API = hqImport("cloudcare/js/formplayer/menus/api"),
-            constants = hqImport('cloudcare/js/formplayer/constants'),
             Controller = hqImport('cloudcare/js/formplayer/menus/controller'),
             FakeFormplayer = hqImport('cloudcare/js/formplayer/spec/fake_formplayer'),
             FormplayerFrontend = hqImport('cloudcare/js/formplayer/app'),
@@ -109,19 +108,6 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
                 Controller.showMenu(splitScreenCaseListResponse);
 
                 assert.isTrue(stubs.regions['sidebar'].empty.called);
-            });
-
-            it('should set enable small screen mode based on window width', function () {
-                const responseWithTypeQuery = _.extend({}, splitScreenCaseListResponse, { 'type': 'query' });
-                const showMain = stubs.regions['main'].show;
-
-                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX;
-                Controller.showMenu(responseWithTypeQuery);
-                assert.isTrue(showMain.getCalls()[0].args[0].options.smallScreenEnabled);
-
-                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX + 1;
-                Controller.showMenu(responseWithTypeQuery);
-                assert.isFalse(showMain.getCalls()[1].args[0].options.smallScreenEnabled);
             });
         });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -13,7 +13,7 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
 
         const currentUrl = new Utils.CloudcareUrl({ appId: 'abc123' }),
             sandbox = sinon.sandbox.create(),
-            stubs = {},
+            stubs = {};
 
         before(function () {
             sandbox.stub(Marionette.CollectionView.prototype, 'render').returns();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -14,12 +14,6 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
         const currentUrl = new Utils.CloudcareUrl({ appId: 'abc123' }),
             sandbox = sinon.sandbox.create(),
             stubs = {},
-            REGIONS = {
-                main: 'main',
-                sidebar: 'sidebar',
-            };
-
-        let getRegion;
 
         before(function () {
             sandbox.stub(Marionette.CollectionView.prototype, 'render').returns();
@@ -47,7 +41,6 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
                 },
                 addRegions: function () { return; },
             };
-            getRegion = sandbox.spy(FormplayerFrontend.regions, 'getRegion');
             stubs.splitScreenToggleEnabled = sandbox.stub(Toggles, 'toggleEnabled').withArgs('SPLIT_SCREEN_CASE_SEARCH');
         });
 
@@ -57,7 +50,6 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
         });
 
         afterEach(function () {
-            getRegion.reset();
             sandbox.resetHistory();
         });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -3,6 +3,7 @@
 hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function () {
     describe('Split Screen Case Search', function () {
         const API = hqImport("cloudcare/js/formplayer/menus/api"),
+            constants = hqImport('cloudcare/js/formplayer/constants'),
             Controller = hqImport('cloudcare/js/formplayer/menus/controller'),
             FakeFormplayer = hqImport('cloudcare/js/formplayer/spec/fake_formplayer'),
             FormplayerFrontend = hqImport('cloudcare/js/formplayer/app'),
@@ -116,6 +117,19 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
                 Controller.showMenu(splitScreenCaseListResponse);
 
                 assert.isTrue(stubs.regions['sidebar'].empty.called);
+            });
+
+            it('should set enable small screen mode based on window width', function () {
+                const responseWithTypeQuery = _.extend({}, splitScreenCaseListResponse, { 'type': 'query' });
+                const showMain = stubs.regions['main'].show;
+
+                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX;
+                Controller.showMenu(responseWithTypeQuery);
+                assert.isTrue(showMain.getCalls()[0].args[0].options.smallScreenEnabled);
+
+                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX + 1;
+                Controller.showMenu(responseWithTypeQuery);
+                assert.isFalse(showMain.getCalls()[1].args[0].options.smallScreenEnabled);
             });
         });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
@@ -1,0 +1,32 @@
+/* eslint-env mocha */
+hqDefine("cloudcare/js/cloudcare/spec/utils_spec", function () {
+    describe("Cloudcare Utils", function () {
+        const constants = hqImport("cloudcare/js/formplayer/constants"),
+            utils = hqImport("cloudcare/js/utils");
+
+        describe('Small Screen Listener', function () {
+            it('should initially enable small screen mode in small window', function () {
+                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX;
+                const smallScreenEnabled = utils.watchSmallScreenEnabled(function () {});
+                assert.isTrue(smallScreenEnabled);
+            });
+
+            it('should initially disable small screen mode in large window', function () {
+                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX + 1;
+                const smallScreenEnabled = utils.watchSmallScreenEnabled(function () {});
+                assert.isFalse(smallScreenEnabled);
+            });
+
+            it('should update small screen mode on window resize', function () {
+                let smallScreenEnabled = utils.watchSmallScreenEnabled(enabled => smallScreenEnabled = enabled);
+                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX;
+                $(window).trigger("resize");
+                assert.isTrue(smallScreenEnabled);
+
+                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX + 1;
+                $(window).trigger("resize");
+                assert.isFalse(smallScreenEnabled);
+            });
+        });
+    });
+});

--- a/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-hqDefine("cloudcare/js/cloudcare/spec/utils_spec", function () {
+hqDefine("cloudcare/js/spec/utils_spec", function () {
     describe("Cloudcare Utils", function () {
         const constants = hqImport("cloudcare/js/formplayer/constants"),
             utils = hqImport("cloudcare/js/utils");

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -1,4 +1,4 @@
-/* global DOMPurify, moment, NProgress */
+/* global DOMPurify, moment, NProgress, Sentry */
 hqDefine('cloudcare/js/utils', [
     'jquery',
     'hqwebapp/js/initial_page_data',
@@ -206,7 +206,7 @@ hqDefine('cloudcare/js/utils', [
                         errorType: data.type,
                     },
                     extra: sentryData,
-                    level: "error"
+                    level: "error",
                 });
 
                 $.ajax({
@@ -235,7 +235,7 @@ hqDefine('cloudcare/js/utils', [
     function renderMarkdown(text) {
         const md = window.markdownit({ breaks: true });
         return md.render(DOMPurify.sanitize(text || "").replaceAll("&#10;", "\n"));
-    };
+    }
 
     function chainedRenderer(matcher, transform, target) {
         return function (tokens, idx, options, env, self) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -435,6 +435,27 @@ hqDefine('cloudcare/js/utils', [
         $el.on("focusout", $el.data("DateTimePicker").hide);
     };
 
+    /**
+     *  Listen for screen size changes to enable or disable small screen functionality.
+     *  Accepts a callback function that should take in the new value of smallScreenEnabled.
+     *  e.g.,
+     *      watchSmallScreenEnabled(enabled => {
+     *          this.smallScreenEnabled = enabled;
+     *          this.render();
+     *      });
+     */
+    var watchSmallScreenEnabled = function (callback) {
+        var shouldEnableSmallScreen = () => window.innerWidth <= constants.SMALL_SCREEN_WIDTH_PX;
+        var smallScreenEnabled = shouldEnableSmallScreen();
+
+        $(window).on("resize", () => {
+            if (smallScreenEnabled !== shouldEnableSmallScreen()) {
+                smallScreenEnabled = shouldEnableSmallScreen();
+                callback(smallScreenEnabled);
+            }
+        });
+    };
+
     return {
         dateFormat: dateFormat,
         convertTwoDigitYear: convertTwoDigitYear,
@@ -455,5 +476,6 @@ hqDefine('cloudcare/js/utils', [
         formplayerSyncComplete: formplayerSyncComplete,
         reportFormplayerErrorToHQ: reportFormplayerErrorToHQ,
         injectMarkdownAnchorTransforms: injectMarkdownAnchorTransforms,
+        watchSmallScreenEnabled: watchSmallScreenEnabled,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -454,6 +454,7 @@ hqDefine('cloudcare/js/utils', [
                 callback(smallScreenEnabled);
             }
         });
+        return smallScreenEnabled;
     };
 
     return {

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
@@ -13,6 +13,7 @@
 {% endblock %}
 
 {% block mocha_tests %}
+  <script src="{% static 'cloudcare/js/spec/utils_spec.js' %}"></script>
   <script src="{% static 'cloudcare/js/formplayer/spec/hq_events_spec.js' %}"></script>
   <script src="{% static 'cloudcare/js/formplayer/spec/menu_list_spec.js' %}"></script>
   <script src="{% static 'cloudcare/js/formplayer/spec/user_spec.js' %}"></script>


### PR DESCRIPTION
## Product Description
Nothing visible; setup for further responsive design work.

## Technical Summary
[USH-3480](https://dimagi-dev.atlassian.net/browse/USH-3480)
Adds a util function to get initial `smallScreenEnabled` value, and can be used to listen to screen size changes and re-render the view or perform other actions when it crosses the "small screen" threshold. In this PR the function is called to set an initial value in `CaseListView`; it may also be useful for other views.

## Feature Flag
Functionality based on this will be limited to case search/case list screens, but these changes are not explicitly behind a flag.

## Safety Assurance

### Safety story
This isn't impacting any functionality yet, so by that measure it's pretty safe, and nothing affects data here at all. Using `window.innerWidth` is also [widely supported](https://caniuse.com/?search=window.innerWidth).

### Automated test coverage
Adds automated tests for new util function.

### QA Plan
No QA for this particular change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3480]: https://dimagi-dev.atlassian.net/browse/USH-3480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ