### PR TITLE
Require message for bulk conditional alert uploads

### DIFF
--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -56,7 +56,9 @@ class TestBulkConditionalAlerts(TestCase):
             default_timezone='America/New_York',
         )
         cls.domain_obj.save()
+        cls.addClassCleanup(cls.domain_obj.delete)
         cls.user = CommCareUser.create(cls.domain, 'test1', 'abc', None, None)
+        cls.addClassCleanup(cls.user.delete, cls.domain, deleted_by=None)
         cls.langs = ['en', 'es']
 
     def setUp(self):
@@ -123,12 +125,6 @@ class TestBulkConditionalAlerts(TestCase):
         locked_rule = self._get_rule(self.LOCKED_RULE)
         locked_rule.locked_for_editing = True
         locked_rule.save()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete(cls.domain, deleted_by=None)
-        cls.domain_obj.delete()
-        super(TestBulkConditionalAlerts, cls).tearDownClass()
 
     def tearDown(self):
         for rule in AutomaticUpdateRule.objects.filter(domain=self.domain):

--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -226,7 +226,7 @@ class TestBulkConditionalAlerts(TestCase):
         return self._add_rule(timed_schedule_id=schedule.schedule_id)
 
     def _add_rule(self, alert_schedule_id=None, timed_schedule_id=None):
-        assert(alert_schedule_id or timed_schedule_id)
+        assert alert_schedule_id or timed_schedule_id
         rule = create_empty_rule(self.domain, AutomaticUpdateRule.WORKFLOW_SCHEDULING)
         self.addCleanup(rule.delete)
         rule.add_action(

--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -582,10 +582,10 @@ class TestBulkConditionalAlerts(TestCase):
         data = (
             ("translated", (
                 (self._get_rule(self.DAILY_RULE).id, 'test daily', '', 'Más Oxidado'),
-                (self._get_rule(self.MONTHLY_RULE).id, 'test monthly', '', ''),
+                (self._get_rule(self.MONTHLY_RULE).id, 'test monthly', 'The Far Side', ''),
             )),
             ("not translated", (
-                (self._get_rule(self.UNTRANSLATED_IMMEDIATE_RULE).id, 'test untranslated', ''),
+                (self._get_rule(self.UNTRANSLATED_IMMEDIATE_RULE).id, 'test untranslated', 'Cannot be blank'),
             )),
         )
 
@@ -602,14 +602,14 @@ class TestBulkConditionalAlerts(TestCase):
         monthly_rule = self._get_rule(self.MONTHLY_RULE)
         monthly_content = monthly_rule.get_schedule().memoized_events[0].content
         self.assertEqual(monthly_content.message, {
-            'en': '',
+            'en': 'The Far Side',
             'es': '',
         })
         self.assertIn("Updated 1 rule(s) in 'not translated' sheet", msgs)
         untranslated_rule = self._get_rule(self.UNTRANSLATED_IMMEDIATE_RULE)
         untranslated_content = untranslated_rule.get_schedule().memoized_events[0].content
         self.assertEqual(untranslated_content.message, {
-            '*': '',
+            '*': 'Cannot be blank',
         })
 
     @patch('corehq.messaging.scheduling.view_helpers.get_language_list')

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -364,5 +364,7 @@ class UntranslatedConditionalAlertUploader(ConditionalAlertUploader):
 
     def update_message(self, message, row):
         if 'message' in row:
+            if not row['message']:
+                raise RuleUpdateError(_("Missing message"))
             return {'*': row['message']}
         return message

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -345,7 +345,9 @@ class TranslatedConditionalAlertUploader(ConditionalAlertUploader):
         for lang in self.langs:
             key = 'message_' + lang
             if key in row:
-                message.update({lang: row[key]})
+                message[lang] = row[key]
+        if not any(message.values()):
+            raise RuleUpdateError(_("Missing message"))
         return message
 
 

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -229,7 +229,7 @@ class ConditionalAlertUploader(object):
         message_dirty = False
         new_messages = []
         row_index = 0
-        for index, event in enumerate(events):
+        for event in events:
             old_message = event.content.message
             new_message = copy(old_message)
             if self.event_is_relevant(event) or allow_sheet_swap:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11652

It has been possible to clear rule messages when bulk-uploading conditional alert definitions. This is inconsistent with the web rule editing interface, which requires at least one message per rule. This change set adds validation and error feedback if a bulk upload attempts to remove a rule message.

After implementing this fix I discovered [`test_upload_blank_content`](https://github.com/dimagi/commcare-hq/blob/e5787bf3f9615068791796becdfea267c6488f4a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py#L580) implemented in https://github.com/dimagi/commcare-hq/pull/27243, which "Allows blank messages to be uploaded using conditional alert bulk uploader." That test cleared all messages for some rules, but the original author confirmed that that was a mistake.

## Safety Assurance

### Safety story

Adds extra validation checks. Includes minor refactoring for improved code clarity.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations