### PR TITLE
Fix error message display on expression debugger

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -986,7 +986,7 @@ def evaluate_expression(request, domain):
         result = parsed_expression(doc, EvaluationContext(doc))
         return JsonResponse({"result": result})
     except HttpException as e:
-        return JsonResponse({'message': e.message}, status=e.status)
+        return JsonResponse({'error': e.message}, status=e.status)
     except Exception as e:
         return JsonResponse({"error": str(e)}, status=500)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
User will see error message on UCR Expression debugger view in case of errors like when case/form requested is not found in the domain.
This bug was probably introduced when there was code refactor done earlier [here](https://github.com/dimagi/commcare-hq/commit/3a736276ca0c02b7cbf18d2437464ff77fdc670e#diff-317e2709070b8f05f4b8887b06c70baa61461b17e9d461ec584c7a76398a2409R973)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Updates to use the expected key "error" in JSON as used in [Javascript](https://github.com/dimagi/commcare-hq/blob/43eeb03411a9665e8cc9f766e478ec45b149e1bb/corehq/apps/userreports/static/userreports/js/expression_evaluator.js#L117) later to show the error message.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
USER_CONFIGURABLE_REPORTS

## Safety Assurance
Tested locally that this works as expected now.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Expression debugger view is the only page that use evaluate_expression via AJAX, which is the view this PR is editing. So this change would not effect any other view

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
