### PR TITLE
Export Data Source endpoint to support JSON and pagination

### DIFF
--- a/corehq/apps/aggregate_ucrs/views.py
+++ b/corehq/apps/aggregate_ucrs/views.py
@@ -83,7 +83,7 @@ def export_aggregate_ucr(request, domain, table_id):
     )
     aggregate_table_adapter = get_indicator_adapter(table_definition, load_source='export_aggregate_ucr')
     url = reverse('export_aggregate_ucr', args=[domain, table_definition.table_id])
-    return export_sql_adapter_view(request, domain, aggregate_table_adapter, url)
+    return export_sql_adapter_view(request, aggregate_table_adapter, url)
 
 
 @login_and_domain_required

--- a/corehq/apps/userreports/tests/test_export.py
+++ b/corehq/apps/userreports/tests/test_export.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase
 import sqlalchemy
 
 from ..sql import get_indicator_table
-from ..views import _construct_db_query_from_params, process_url_params
+from ..views import _get_db_query_from_user_params, process_url_params
 from .test_data_source_config import get_sample_data_source
 from corehq.apps.userreports.util import get_indicator_adapter
 
@@ -44,7 +44,7 @@ class ParameterTest(SimpleTestCase):
     def test_pagination_params_specified(self):
         params = process_url_params({'offset': 1, 'limit': 2}, self.columns)
         indicator_adapter = get_indicator_adapter(self.config, load_source='export_data_source')
-        query = _construct_db_query_from_params(indicator_adapter, params)
+        query = _get_db_query_from_user_params(indicator_adapter, params)
         self.assertEqual(params.offset, 1)
         self.assertEqual(query._offset, 1)
         self.assertEqual(params.limit, 2)
@@ -53,7 +53,7 @@ class ParameterTest(SimpleTestCase):
     def test_pagination_params_not_specified(self):
         params = process_url_params({'count-range': '10..30'}, self.columns)
         indicator_adapter = get_indicator_adapter(self.config, load_source='export_data_source')
-        query = _construct_db_query_from_params(indicator_adapter, params)
+        query = _get_db_query_from_user_params(indicator_adapter, params)
         self.assertEqual(params.offset, None)
         self.assertEqual(query._offset, None)
         self.assertEqual(params.limit, None)

--- a/corehq/apps/userreports/tests/test_export.py
+++ b/corehq/apps/userreports/tests/test_export.py
@@ -46,7 +46,7 @@ class ParameterTest(SimpleTestCase):
     def test_pagination_params_specified(self):
         params = process_url_params({'offset': 1, 'limit': 2}, self.columns)
         indicator_adapter = get_indicator_adapter(self.config, load_source='export_data_source')
-        query = _get_db_query_from_user_params(indicator_adapter, params)
+        query = _get_db_query_from_user_params(indicator_adapter.get_query_object(), params)
         self.assertEqual(params.offset, 1)
         self.assertEqual(query._offset, 1)
         self.assertEqual(params.limit, 2)

--- a/corehq/apps/userreports/tests/test_export.py
+++ b/corehq/apps/userreports/tests/test_export.py
@@ -4,10 +4,12 @@ from django.test import SimpleTestCase
 
 import sqlalchemy
 
+from corehq.apps.userreports.util import get_indicator_adapter
+
 from ..sql import get_indicator_table
 from ..views import _get_db_query_from_user_params, process_url_params
 from .test_data_source_config import get_sample_data_source
-from corehq.apps.userreports.util import get_indicator_adapter
+
 
 class ParameterTest(SimpleTestCase):
 

--- a/corehq/apps/userreports/tests/test_export.py
+++ b/corehq/apps/userreports/tests/test_export.py
@@ -55,7 +55,7 @@ class ParameterTest(SimpleTestCase):
     def test_pagination_params_not_specified(self):
         params = process_url_params({'count-range': '10..30'}, self.columns)
         indicator_adapter = get_indicator_adapter(self.config, load_source='export_data_source')
-        query = _get_db_query_from_user_params(indicator_adapter, params)
+        query = _get_db_query_from_user_params(indicator_adapter.get_query_object(), params)
         self.assertEqual(params.offset, None)
         self.assertEqual(query._offset, None)
         self.assertEqual(params.limit, None)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1500,7 +1500,7 @@ def _get_db_query_from_user_params(query, params):
     for sql_filter in params.sql_filters:
         query = query.filter(sql_filter)
 
-    if params.offset is None or params.limit is None:
+    if params.offset is not None and params.limit is not None:
         query = query.order_by('inserted_at')
         query = query.offset(params.offset)
         query = query.limit(params.limit)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1500,7 +1500,7 @@ def _get_db_query_from_user_params(query, params):
     for sql_filter in params.sql_filters:
         query = query.filter(sql_filter)
 
-    if params.offset and params.limit:
+    if params.offset is None or params.limit is None:
         query = query.order_by('inserted_at')
         query = query.offset(params.offset)
         query = query.limit(params.limit)


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2993)
Refer to the ticket for the spec doc

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No user facing effects.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
### Background
This is preparation work for the DET to support exporting UCRs. The endpoint that I updated here is [used by HQ Superset](https://github.com/dimagi/hq_superset/blob/42cef3630682011638f33aae0c5b0c3bbcac0930/hq_superset/utils.py#L15) to export UCRs. Since this endpoint already provides us with a framework to export UCRs with, it was decided to hit this endpoint from the DET when exporting UCRs. Since the DET expects JSON, we need to update this endpoint to also support JSON.

### The change
This code updates the endpoint mentioned above to support JSON responses, as well as pagination query parameters. This will be used by the DET to paginate UCR exports. Do see the ticket and spec for more details.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Local testing
- Some unit tests

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

## Some beauties (actually only 1)
![image](https://github.com/dimagi/commcare-hq/assets/64970009/19c33f3d-d03a-4d99-8b4e-f2f6b2c3e2fa)
