### PR TITLE
Unique multimedia filenames in export zips

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -294,6 +294,7 @@ def _format_filename(form_info, question_id, extension, case_id_to_name):
 def _write_attachments_to_file(fpath, num_forms, forms_info, case_id_to_name):
     total_size = 0
     unique_attachment_ids = set()
+    unique_names = {}
     with zipfile.ZipFile(fpath, 'w') as multimedia_zipfile:
         for form_number, form_info in enumerate(forms_info, 1):
             form = form_info['form']
@@ -312,12 +313,22 @@ def _write_attachments_to_file(fpath, num_forms, forms_info, case_id_to_name):
                     attachment['extension'],
                     case_id_to_name
                 )
+                filename = _make_unique_filename(filename, unique_names)
                 zip_info = zipfile.ZipInfo(filename, attachment['timestamp'])
                 multimedia_zipfile.writestr(zip_info, form.get_attachment(
                     attachment['name']),
                     zipfile.ZIP_STORED
                 )
             DownloadBase.set_progress(build_form_multimedia_zip, form_number, num_forms)
+
+
+def _make_unique_filename(filename, unique_names):
+    while filename in unique_names:
+        unique_names[filename] += 1
+        root, ext = os.path.splitext(filename)
+        filename = f"{root}-{unique_names[filename]}{ext}"
+    unique_names[filename] = 1
+    return filename
 
 
 def _save_and_expose_zip(f, zip_name, domain, download_id, owner_id):

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -251,8 +251,7 @@ def _generate_form_multimedia_zipfile(domain, export, form_ids, download_id, own
     case_id_to_name = _get_case_names(domain, all_case_ids)
 
     with TransientTempfile() as temp_path:
-        with open(temp_path, 'wb') as f:
-            _write_attachments_to_file(temp_path, num_forms, forms_info, case_id_to_name)
+        _write_attachments_to_file(temp_path, num_forms, forms_info, case_id_to_name)
         with open(temp_path, 'rb') as f:
             zip_name = 'multimedia-{}'.format(unidecode(export.name))
             _save_and_expose_zip(f, zip_name, domain, download_id, owner_id)

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -294,31 +294,30 @@ def _format_filename(form_info, question_id, extension, case_id_to_name):
 def _write_attachments_to_file(fpath, num_forms, forms_info, case_id_to_name):
     total_size = 0
     unique_attachment_ids = set()
-    with open(fpath, 'wb') as zfile:
-        with zipfile.ZipFile(zfile, 'w') as multimedia_zipfile:
-            for form_number, form_info in enumerate(forms_info, 1):
-                form = form_info['form']
-                for attachment in form_info['attachments']:
-                    if attachment['id'] in unique_attachment_ids:
-                        continue
+    with zipfile.ZipFile(fpath, 'w') as multimedia_zipfile:
+        for form_number, form_info in enumerate(forms_info, 1):
+            form = form_info['form']
+            for attachment in form_info['attachments']:
+                if attachment['id'] in unique_attachment_ids:
+                    continue
 
-                    unique_attachment_ids.add(attachment['id'])
-                    total_size += attachment['size']
-                    if total_size >= MAX_MULTIMEDIA_EXPORT_SIZE:
-                        raise Exception("Refusing to make multimedia export bigger than {} GB"
-                                        .format(MAX_MULTIMEDIA_EXPORT_SIZE / 1024**3))
-                    filename = _format_filename(
-                        form_info,
-                        attachment['question_id'],
-                        attachment['extension'],
-                        case_id_to_name
-                    )
-                    zip_info = zipfile.ZipInfo(filename, attachment['timestamp'])
-                    multimedia_zipfile.writestr(zip_info, form.get_attachment(
-                        attachment['name']),
-                        zipfile.ZIP_STORED
-                    )
-                DownloadBase.set_progress(build_form_multimedia_zip, form_number, num_forms)
+                unique_attachment_ids.add(attachment['id'])
+                total_size += attachment['size']
+                if total_size >= MAX_MULTIMEDIA_EXPORT_SIZE:
+                    raise Exception("Refusing to make multimedia export bigger than {} GB"
+                                    .format(MAX_MULTIMEDIA_EXPORT_SIZE / 1024**3))
+                filename = _format_filename(
+                    form_info,
+                    attachment['question_id'],
+                    attachment['extension'],
+                    case_id_to_name
+                )
+                zip_info = zipfile.ZipInfo(filename, attachment['timestamp'])
+                multimedia_zipfile.writestr(zip_info, form.get_attachment(
+                    attachment['name']),
+                    zipfile.ZIP_STORED
+                )
+            DownloadBase.set_progress(build_form_multimedia_zip, form_number, num_forms)
 
 
 def _save_and_expose_zip(f, zip_name, domain, download_id, owner_id):

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -1,6 +1,17 @@
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch
+from uuid import uuid4
+from zipfile import ZipFile
+
+from attrs import define, field
+
 from django.test import SimpleTestCase
 
-from corehq.apps.reports.tasks import _get_question_id_for_attachment
+from corehq.apps.reports.tasks import (
+    _get_question_id_for_attachment,
+    _make_unique_filename,
+    _write_attachments_to_file,
+)
 
 
 class GetQuestionIdTests(SimpleTestCase):
@@ -52,3 +63,65 @@ class GetQuestionIdTests(SimpleTestCase):
 
         result = _get_question_id_for_attachment(form, 'attachment.ext')
         self.assertIsNone(result)
+
+
+@patch("soil.DownloadBase.set_progress")
+class TestMultimediaZipFile(SimpleTestCase):
+
+    def test_files_with_same_name_should_be_uniqued(self, ignore):
+        forms = [{
+            "form": FakeForm("deadcafe"),
+            "case_ids": [],
+            "username": "someone",
+            "attachments": [
+                _attachment("img"),
+                _attachment("img"),
+                _attachment("img"),
+            ]
+        }]
+        with NamedTemporaryFile() as fh:
+
+            _write_attachments_to_file(fh.name, 1, forms, {})
+
+            zip = ZipFile(fh.name)
+            names = zip.namelist()
+            self.assertEqual(names, [
+                "img-someone-form_deadcafe.jpg",
+                "img-someone-form_deadcafe-2.jpg",
+                "img-someone-form_deadcafe-3.jpg",
+            ])
+
+
+class TestMakeUniqueFilename(SimpleTestCase):
+
+    def test_collision_with_generated_unique_name(self):
+        unique_names = {}
+        self.assertEqual(_make_unique_filename("pic.jpg", unique_names), "pic.jpg")
+        self.assertEqual(_make_unique_filename("pic.jpg", unique_names), "pic-2.jpg")
+        self.assertEqual(_make_unique_filename("pic-2.jpg", unique_names), "pic-2-2.jpg")
+
+    def test_collision_with_multiple_generated_names(self):
+        unique_names = {}
+        self.assertEqual(_make_unique_filename("pic-2.jpg", unique_names), "pic-2.jpg")
+        self.assertEqual(_make_unique_filename("pic-2.jpg", unique_names), "pic-2-2.jpg")
+        self.assertEqual(_make_unique_filename("pic.jpg", unique_names), "pic.jpg")
+        self.assertEqual(_make_unique_filename("pic.jpg", unique_names), "pic-2-3.jpg")  # multi-collision
+
+
+@define
+class FakeForm:
+    form_id = field()
+
+    def get_attachment(self, name):
+        return b"012345678901234567890123"
+
+
+def _attachment(question_id):
+    return {
+        "id": uuid4().hex,
+        "name": uuid4().hex,
+        "size": 24,
+        "question_id": question_id,
+        "extension": ".jpg",
+        "timestamp": (2023, 8, 9, 21, 36, 20),
+    }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12463

Previously, files in form multimedia exports that contained multimedia collected in a repeat group were not named uniquely, causing some of the files to be inaccessible. This PR adds a function to uniquely name each file before it is added to the export zip file.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

This is a surgical change to the function that creates a zip file containing form multimedia for export. Going forward, export zips will contain all files that they did in the past in addition to files with duplicate names.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations