### PR TITLE
Only generate app short code when requested

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -193,7 +193,6 @@ hqDefine('app_manager/js/releases/releases', function () {
             hqImport('analytix/js/google').track.event('App Manager', 'Deploy Button', self.id());
             hqImport('analytix/js/kissmetrix').track.event('Clicked Deploy');
             $.post(releasesMain.reverse('hubspot_click_deploy'));
-            self.get_short_odk_url();
         };
 
         self.clickScan = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -111,14 +111,20 @@ hqDefine('app_manager/js/releases/releases', function () {
             }
         };
 
-        self.get_short_odk_url = function () {
-            var urlType;
+        self.get_odk_url_type = function () {
             if (self.include_media()) {
-                urlType = savedAppModel.URL_TYPES.SHORT_ODK_MEDIA_URL;
+                return savedAppModel.URL_TYPES.SHORT_ODK_MEDIA_URL;
             } else {
-                urlType = savedAppModel.URL_TYPES.SHORT_ODK_URL;
+                return savedAppModel.URL_TYPES.SHORT_ODK_URL;
             }
-            if (!(ko.utils.unwrapObservable(self[urlType])) || self.build_profile()) {
+        };
+        self.short_odk_url_is_available = function () {
+            var urlType = self.get_odk_url_type();
+            return ko.utils.unwrapObservable(self[urlType]) && !self.build_profile();
+        };
+        self.get_short_odk_url = function () {
+            var urlType = self.get_odk_url_type();
+            if (!self.short_odk_url_is_available()) {
                 return self.generate_short_url(urlType);
             } else {
                 var data = ko.utils.unwrapObservable(self[urlType]);

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -199,6 +199,9 @@ hqDefine('app_manager/js/releases/releases', function () {
             hqImport('analytix/js/google').track.event('App Manager', 'Deploy Button', self.id());
             hqImport('analytix/js/kissmetrix').track.event('Clicked Deploy');
             $.post(releasesMain.reverse('hubspot_click_deploy'));
+            if (self.short_odk_url_is_available()) {
+                self.get_short_odk_url();
+            }
         };
 
         self.clickScan = function () {

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_deploy_modal.html
@@ -91,35 +91,37 @@
                             Open the app on your Android and use one of the following installation methods:
                           {% endblocktrans %}
                         </p>
-                        <p>
-                          <a href="#" data-bind="
-                                                        openRemoteModal: full_odk_install_url,
-                                                        click: clickScan
-                                                    ">
-                            {% trans "Scan Application Barcode" %}
-                          </a>
-                        </p>
-                        <p>
-                          <a href="#" data-bind="
-                                                        click: click_app_code,
-                                                        visible: !app_code() && !failed_url_generation() && !generating_url()
-                                                        ">
-                            {% trans "Enter App Code" %}
-                          </a>
-                          <span data-bind="visible: app_code">
-                                                        {% trans "Enter app code on installation screen: " %}
-                                                        <code class="bitly" data-bind="text: app_code"></code>
-                                                    </span>
-                          <i data-bind="visible: generating_url()" class='fa fa-spin fa-spinner'></i>
-                          <span class="text-warning" data-bind="
-                                                        visible: failed_url_generation() && !generating_url()
-                                                        ">
-                                                        {% blocktrans %}
-                                                          (No app code available. If you would like to use an app code instead
-                                                          of scanning the application barcode, try making another version.)
-                                                        {% endblocktrans %}
-                                                    </span>
-                        </p>
+                        <ul>
+                          <li>
+                            <a href="#" data-bind="
+                                                          openRemoteModal: full_odk_install_url,
+                                                          click: clickScan
+                                                      ">
+                              {% trans "Scan Application Barcode" %}
+                            </a>
+                          </li>
+                          <li>
+                            <a href="#" data-bind="
+                                                          click: click_app_code,
+                                                          visible: !app_code() && !failed_url_generation() && !generating_url()
+                                                          ">
+                              {% trans "Enter App Code" %}
+                            </a>
+                            <span data-bind="visible: app_code">
+                                                          {% trans "Enter app code on installation screen: " %}
+                                                          <code class="bitly" data-bind="text: app_code"></code>
+                                                      </span>
+                            <i data-bind="visible: generating_url()" class='fa fa-spin fa-spinner'></i>
+                            <span class="text-warning" data-bind="
+                                                          visible: failed_url_generation() && !generating_url()
+                                                          ">
+                                                          {% blocktrans %}
+                                                            (No app code available. If you would like to use an app code instead
+                                                            of scanning the application barcode, try making another version.)
+                                                          {% endblocktrans %}
+                                                      </span>
+                          </li>
+                        </ul>
                       </div>
                       <div class="tab-pane" id="offline-install-tab">
                         <div data-bind="ifnot: hqImport('app_manager/js/app_manager').versionGE(build_spec.version(), '2.13.0')">


### PR DESCRIPTION
## Product Description

When you first click the "Publish" button in the app release manager, previously it would have generated a short code to show you right away upon opening. Now it'll only generate it if you ask for it (by clicking "Enter App Code"). If you exclusively use the Scan Bar Code option then it will never generate it.

**Before:**
<img width="595" alt="Screenshot 2023-08-25 at 6 29 42 PM" src="https://github.com/dimagi/commcare-hq/assets/137212/db8045aa-14ee-478e-bdcb-4e2d720476ae">

**After:**
<img width="596" alt="Screenshot 2023-08-25 at 6 26 03 PM" src="https://github.com/dimagi/commcare-hq/assets/137212/b03dc00a-571e-4b17-bc32-7c6b7d3b27bc">
...and then you click "Enter App Code"...
<img width="592" alt="Screenshot 2023-08-25 at 6 26 42 PM" src="https://github.com/dimagi/commcare-hq/assets/137212/130814b4-e13c-423a-84fe-7cbc8f246167">

The link will show up right away (without having to click again) if it's already been generated—except if it is a build for a specific "profile". Currently the way that's implemented, that isn't stored in our system; instead we ask bitly for it every time, and bitly detects we've already generated a short link for it and gives us the same short link again. This is something worth fixing in the future, but I decided that for the immediate term this covers the 80% use case nicely, and doesn't fundamentally break anything.

## Technical Summary

https://dimagi-dev.atlassian.net/browse/SAAS-14824
Only generate app short code when requested, to economize on bitly links.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
