### PR TITLE
Add "pmievolve-rwanda" to VectorLink domains

### DIFF
--- a/custom/abt/reports/data_sources/late_pmt.json
+++ b/custom/abt/reports/data_sources/late_pmt.json
@@ -13,6 +13,7 @@
     "airszambia",
     "airszimbabwe",
     "kenya-vca",
+    "pmievolve-rwanda",
     "vectorlink-benin",
     "vectorlink-burkina-faso",
     "vectorlink-ethiopia",

--- a/custom/abt/reports/data_sources/sms_case.json
+++ b/custom/abt/reports/data_sources/sms_case.json
@@ -13,6 +13,7 @@
     "airszambia",
     "airszimbabwe",
     "kenya-vca",
+    "pmievolve-rwanda",
     "vectorlink-benin",
     "vectorlink-burkina-faso",
     "vectorlink-ethiopia",

--- a/custom/abt/reports/data_sources/supervisory_v2020.json
+++ b/custom/abt/reports/data_sources/supervisory_v2020.json
@@ -14,6 +14,7 @@
         "airszimbabwe",
         "airsmozambique",
         "kenya-vca",
+        "pmievolve-rwanda",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/incident_report.json
+++ b/custom/abt/reports/incident_report.json
@@ -12,7 +12,6 @@
     "airsmozambique",
     "airskenya",
     "airs-testing",
-    "pmievolve-rwanda",
     "vectorlink-benin",
     "vectorlink-uganda"
   ],

--- a/custom/abt/reports/incident_report.json
+++ b/custom/abt/reports/incident_report.json
@@ -12,6 +12,7 @@
     "airsmozambique",
     "airskenya",
     "airs-testing",
+    "pmievolve-rwanda",
     "vectorlink-benin",
     "vectorlink-uganda"
   ],

--- a/custom/abt/reports/sms_indicator_report.json
+++ b/custom/abt/reports/sms_indicator_report.json
@@ -14,6 +14,7 @@
         "airs-testing",
         "kenya-vca",
         "vectorlink-benin",
+        "pmievolve-rwanda",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",
         "vectorlink-ghana",

--- a/custom/abt/reports/spray_progress_country.json
+++ b/custom/abt/reports/spray_progress_country.json
@@ -13,6 +13,7 @@
         "airskenya",
         "airs-testing",
         "kenya-vca",
+        "pmievolve-rwanda",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/spray_progress_level_1.json
+++ b/custom/abt/reports/spray_progress_level_1.json
@@ -13,6 +13,7 @@
         "airskenya",
         "airs-testing",
         "kenya-vca",
+        "pmievolve-rwanda",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/spray_progress_level_2.json
+++ b/custom/abt/reports/spray_progress_level_2.json
@@ -13,6 +13,7 @@
         "airskenya",
         "airs-testing",
         "kenya-vca",
+        "pmievolve-rwanda",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/spray_progress_level_3.json
+++ b/custom/abt/reports/spray_progress_level_3.json
@@ -12,6 +12,7 @@
         "airskenya",
         "airs-testing",
         "kenya-vca",
+        "pmievolve-rwanda",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/spray_progress_level_4.json
+++ b/custom/abt/reports/spray_progress_level_4.json
@@ -12,6 +12,7 @@
         "airskenya",
         "airs-testing",
         "kenya-vca",
+        "pmievolve-rwanda",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/custom/abt/reports/supervisory_report_v2020.json
+++ b/custom/abt/reports/supervisory_report_v2020.json
@@ -14,6 +14,7 @@
         "airszimbabwe",
         "airsmozambique",
         "kenya-vca",
+        "pmievolve-rwanda",
         "vectorlink-benin",
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",

--- a/settings.py
+++ b/settings.py
@@ -1978,6 +1978,7 @@ DOMAIN_MODULE_MAP = {
     'airszambia': 'custom.abt',
     'airszimbabwe': 'custom.abt',
     'kenya-vca': 'custom.abt',
+    'pmievolve-rwanda': 'custom.abt',
     'vectorlink-benin': 'custom.abt',
     'vectorlink-burkina-faso': 'custom.abt',
     'vectorlink-ethiopia': 'custom.abt',


### PR DESCRIPTION
## Technical Summary

The VectorLink project is transitioning to the PMI Evolve project. "pmievolve-rwanda" is the first domain in that transition.

This change is to give the domain access to all the custom reports it needs.

Jira: [SC-3010](https://dimagi-dev.atlassian.net/browse/SC-3010)

## Safety Assurance

### Safety story

This is a configuration change, not a functionality change. It follows the same pattern as the other VectorLink domains.

### Automated test coverage

Not applicable

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3010]: https://dimagi-dev.atlassian.net/browse/SC-3010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ