### PR TITLE
Upgraded flake8 to be compatible with our github workflow

### DIFF
--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -50,7 +50,7 @@ fi
 status=0
 git diff-index --check --cached $against --
 if [ $? != 0 ]; then status=1; fi
-pyfiles=$(git diff --staged --name-only | grep \*.py$)
+pyfiles=$(git diff --staged --name-only | grep "\.py$")
 if [ -n "$pyfiles" ]; then
     flake8 --show-source --config=.flake8 "$pyfiles"
 	if [ $? != 0 ]; then status=1; fi

--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -50,8 +50,11 @@ fi
 status=0
 git diff-index --check --cached $against --
 if [ $? != 0 ]; then status=1; fi
-git diff --cached -U0 | flake8 --diff --show-source --config=.flake8
-if [ $? != 0 ]; then status=1; fi
+pyfiles=$(git diff --staged --name-only | grep \*.py$)
+if [ -n "$pyfiles" ]; then
+    flake8 --show-source --config=.flake8 "$pyfiles"
+	if [ $? != 0 ]; then status=1; fi
+fi
 
 if [ $status != 0 ]
 then

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -12,6 +12,6 @@ sniffer
 wheel
 
 # linting/formatting
-flake8
+flake8>=6.0
 isort
 yapf

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -258,7 +258,7 @@ firebase-admin==6.1.0
     # via -r base-requirements.in
 fixture==1.5.11
     # via -r dev-requirements.in
-flake8==3.9.2
+flake8==6.1.0
     # via -r dev-requirements.in
 flaky==3.7.0
     # via -r test-requirements.in
@@ -426,7 +426,7 @@ markupsafe==2.1.2
     #   werkzeug
 matplotlib-inline==0.1.3
     # via ipython
-mccabe==0.6.1
+mccabe==0.7.0
     # via flake8
 mdit-py-plugins==0.4.0
     # via myst-parser
@@ -535,7 +535,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pycodestyle==2.7.0
+pycodestyle==2.11.0
     # via flake8
 pycparser==2.20
     # via cffi
@@ -545,7 +545,7 @@ pycryptodomex==3.14.1
     # via
     #   oic
     #   pyjwkest
-pyflakes==2.3.1
+pyflakes==3.1.0
     # via flake8
 pygithub==1.55
     # via -r base-requirements.in


### PR DESCRIPTION
## Technical Summary
We've been using a very out-dated version of flake8 (3.92). The current version is 6.1. This is an issue now, as our github workflow is using at least 6.0, which introduces new errors. With the outdated version, files would pass cleanly through locally, but complain of errors on github.

## Safety Assurance

### Safety story
This is just a dev tool, so shouldn't have any effect on prod code.

### Automated test coverage

N/A

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
