### PR TITLE
Move case list map to top of screen in small windows

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -612,9 +612,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                                     markers.forEach(m => m.setIcon(locationIcon));
                                     marker.setIcon(selectedLocationIcon);
 
+                                    // Offset by breadcrumbs w/w/o small screen map
+                                    const scrollTopOffset = this.smallScreenEnabled ? 300 : 50;
                                     $([document.documentElement, document.body]).animate({
-                                        // -50 Stay clear of the breadcrumbs
-                                        scrollTop: $(`#${rowId}`).offset().top - 50,
+                                        scrollTop: $(`#${rowId}`).offset().top - scrollTopOffset,
                                     }, 500);
 
                                     addressMap.panTo(markerCoordinates);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -612,7 +612,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                                     markers.forEach(m => m.setIcon(locationIcon));
                                     marker.setIcon(selectedLocationIcon);
 
-                                    // Offset by breadcrumbs w/w/o small screen map
+                                    // Offset by breadcrumbs with or without small screen map
                                     const scrollTopOffset = this.smallScreenEnabled ? 300 : 50;
                                     $([document.documentElement, document.body]).animate({
                                         scrollTop: $(`#${rowId}`).offset().top - scrollTopOffset,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -612,8 +612,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                                     markers.forEach(m => m.setIcon(locationIcon));
                                     marker.setIcon(selectedLocationIcon);
 
-                                    // Offset by breadcrumbs with or without small screen map
-                                    const scrollTopOffset = this.smallScreenEnabled ? 300 : 50;
+                                    let scrollTopOffset = 47.125; // standard height of breadcrumbs with shadow
+                                    if (this.smallScreenEnabled) {
+                                        scrollTopOffset += addressMap.getSize().y;
+                                    }
                                     $([document.documentElement, document.body]).animate({
                                         scrollTop: $(`#${rowId}`).offset().top - scrollTopOffset,
                                     }, 500);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -543,15 +543,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             }
         },
 
-        columnStyle: function () {
-            const self = this;
-            if (self.showMap) {
-                return "display: grid;grid-template-columns: [tiles] 7fr [map] 5fr;grid-template-rows: auto";
-            } else {
-                return "display: grid;grid-template-columns: [tiles] 100%;grid-template-rows: auto";
-            }
-        },
-
         fontAwesomeIcon: function (iconName) {
             return L.divIcon({
                 html: `<i class='fa ${iconName} fa-4x'></i>`,
@@ -685,7 +676,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 selectedCaseIds: this.selectedCaseIds,
                 isMultiSelect: false,
                 showMap: this.showMap,
-                columnStyle: this.columnStyle(),
                 sidebarEnabled: this.options.sidebarEnabled,
                 smallScreenEnabled: this.smallScreenEnabled,
                 triggerEmptyCaseList: this.options.triggerEmptyCaseList,

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -19,8 +19,11 @@
     </div>
     <% } %>
 
-    <div style="<%- columnStyle %>">
-      <div id="module-case-list-column-next-to-map">
+    <div class="row row-no-gutters">
+      <% if (showMap) { %>
+        <div id="module-case-list-map" class="col-sm-5 col-sm-push-9<% if (useTiles) { %> white-border<% } %>"></div>
+      <% } %>
+      <div id="module-case-list-column-next-to-map" class="col-sm<% if (showMap) { %>-7 col-sm-pull-5<% } %>">
         <% if (useTiles) { %>
           <% if (hasNoItems) { %>
             {% include 'formplayer/no_items_text.html' %}
@@ -76,9 +79,6 @@
         </div>
         <% } %>
       </div>
-      <% if (showMap) { %>
-        <div id="module-case-list-map" class="map <% if (useTiles) { %> white-border<% } %>"></div>
-      <% } %>
     </div>
     <% if (actions || isMultiSelect) { %>
     <div class="case-list-actions">

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -23,7 +23,7 @@
       <% if (showMap) { %>
         <div id="module-case-list-map" class="col-sm-5 col-sm-push-9<% if (useTiles) { %> white-border<% } %>"></div>
       <% } %>
-      <div id="module-case-list-column-next-to-map" class="col-sm<% if (showMap) { %>-7 col-sm-pull-5<% } %>">
+      <div id="module-case-list" class="col-sm<% if (showMap) { %>-7 col-sm-pull-5<% } %>">
         <% if (useTiles) { %>
           <% if (hasNoItems) { %>
             {% include 'formplayer/no_items_text.html' %}

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -16,7 +16,7 @@
     height: calc(~"100vh - 65px");
     position: sticky !important; // Has to be important so the leaflet code does not set it to relative
     top: 47.125px; // based on the height of the crumbs bar
-    z-index: 1;
+    z-index: 1; // keep map on top of case list
 
     @media (max-width: @screen-xs-max) {
       height: 250px;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -15,7 +15,7 @@
   #module-case-list-map {
     height: calc(~"100vh - 65px");
     position: sticky !important; // Has to be important so the leaflet code does not set it to relative
-    top: 47.125px; // based on the height of the crumbs bar
+    top: 46px; // based on the height of the crumbs bar
     z-index: 1; // keep map on top of case list
 
     @media (max-width: @screen-xs-max) {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -15,7 +15,12 @@
   #module-case-list-map {
     height: calc(~"100vh - 65px");
     position: sticky !important; // Has to be important so the leaflet code does not set it to relative
-    top: 50px; // based on the height of the crumbs bar
+    top: 47.125px; // based on the height of the crumbs bar
+    z-index: 1;
+
+    @media (max-width: 767px) {
+      height: 250px;
+    }
 
     .marker-pin {
       text-align: center;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -32,11 +32,6 @@
     }
   }
 
-  #module-case-list-column-next-to-map {
-    // Horizontal scroll bar on table will disappear without this.
-    overflow-x: scroll;
-  }
-
   .list-cell-wrapper-style {
     border: 1px solid white;
     border-collapse: collapse;
@@ -75,5 +70,3 @@
 #menu-region .module-menu-container {
   padding-bottom: 6px;
 }
-
-

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -18,7 +18,7 @@
     top: 47.125px; // based on the height of the crumbs bar
     z-index: 1;
 
-    @media (max-width: 767px) {
+    @media (max-width: @screen-xs-max) {
       height: 250px;
     }
 


### PR DESCRIPTION
## Product Description
Moves case list map to top of screen in small windows ~~(<=768px wide)~~ https://github.com/dimagi/commcare-hq/commit/71dfcb563d9e177933c51480da57405e29d5a19f makes this <=992px wide.

https://github.com/dimagi/commcare-hq/assets/100609770/b380f14b-ebf7-4c67-b0d2-84f8f7bdece7

## Technical Summary
[USH-3481](https://dimagi-dev.atlassian.net/browse/USH-3481)
Uses bootstrap styles to define column sizes and orientation between the case list and map containers and adjusts the scroll on map pin click action to account for small screen mode.

## Feature Flag
case_list_map

## Safety Assurance

### Safety story
Changes only affect styling, not data. Tested with combinations of small screen, large screen, split screen case search, regular case search/case list, case tiles, and no map (to ensure newly-added bootstrap classes don't have unintended consequences).

### Automated test coverage
None

### QA Plan
Will go through QA, approach TBD. May be tested on its own or as part of a suite of ongoing responsive design changes in web apps.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3481]: https://dimagi-dev.atlassian.net/browse/USH-3481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ