### PR TITLE
Create new groups when included in bulk mobile worker upload

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -278,6 +278,7 @@ def create_or_update_groups(domain, group_specs):
                 group = group_memoizer.by_name(group_name)
                 if not group:
                     group = group_memoizer.create(domain=domain, name=group_name)
+                    group.save()
         except ResourceNotFound:
             log["errors"].append('There are no groups on CommCare HQ with id "%s"' % group_id)
         except MultipleResultsFound:
@@ -450,7 +451,7 @@ def clean_phone_numbers(phone_numbers):
 def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload_user, upload_record_id,
                                                group_memoizer=None,
                                                update_progress=None):
-    """"
+    """
     Creates and Updates CommCare Users
     For the associated web user username passed, for each CommCareUser
         if corresponding web user is present
@@ -488,7 +489,6 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             update_progress(current)
             current += 1
 
-        status_row = {}
         username = row.get('username')
         domain = row.get('domain') or upload_domain
         try:
@@ -517,7 +517,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             row['password'] = str(row.get('password'))
         try:
             domain_info = get_domain_info(domain, upload_domain, user_specs, domain_info_by_domain,
-            group_memoizer)
+                                          group_memoizer=group_memoizer)
             for validator in domain_info.validators:
                 validator(row)
         except UserUploadError as e:
@@ -635,7 +635,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
                         ).format(web_user_username=web_user_username))
                     if web_user and not web_user.is_member_of(domain) and is_account_confirmed:
                         # add confirmed account to domain
-                        # role_qualified_id would be be present here as confirmed in check_user_role
+                        # role_qualified_id would be present here as confirmed in check_user_role
                         web_user_importer.add_to_domain(role_qualified_id, user.location_id)
                     elif not web_user or not web_user.is_member_of(domain):
                         create_or_update_web_user_invite(web_user_username, domain, role_qualified_id,

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -514,7 +514,7 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
             password = ''.join(random.choices(string_set, k=10))
             row['password'] = password
 
-        if(row.get('password')):
+        if row.get('password'):
             row['password'] = str(row.get('password'))
         try:
             domain_info = get_domain_info(domain, upload_domain, user_specs, domain_info_by_domain,
@@ -754,7 +754,6 @@ def create_or_update_web_users(upload_domain, user_specs, upload_user, upload_re
 
         location_codes = row.get('location_code', []) if 'location_code' in row else None
         location_codes = format_location_codes(location_codes)
-
 
         try:
             remove = spec_value_to_boolean_or_none(row, 'remove')

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -289,6 +289,7 @@ def create_or_update_groups(domain, group_specs):
             group.case_sharing = case_sharing
             group.reporting = reporting
             group.metadata = data
+            group.save()
     return group_memoizer, log
 
 

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -25,7 +25,6 @@ from corehq.apps.custom_data_fields.models import (
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.groups.models import Group
-from corehq.apps.groups.tests.test_utils import delete_all_groups
 from corehq.apps.reports.models import TableauUser, TableauServer
 from corehq.apps.reports.const import HQ_TABLEAU_GROUP_NAME
 from corehq.apps.reports.tests.test_tableau_api_session import _setup_test_tableau_server
@@ -244,7 +243,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertEqual(self.user.location_id, self.loc1._id)
         self.assertEqual(self.user.location_id, self.user.metadata.get('commcare_location_id'))
         # multiple locations
-        self.assertListEqual([l._id for l in [self.loc1, self.loc2]], self.user.assigned_location_ids)
+        self.assertListEqual([loc._id for loc in [self.loc1, self.loc2]], self.user.assigned_location_ids)
         # non-primary location
         self.assertTrue(self.loc2._id in self.user.metadata.get('commcare_location_ids'))
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR fixes a bug where including a new group in the bulk mobile user upload excel sheet didn't save successfully. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13612)

All it needed was `group.save()`


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and added a couple test scenarios. Tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added new tests to cover new group uploading scenarios.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
