### PR TITLE
eslint ignore vellum files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/* global module */
 // http://eslint.org/
 module.exports = {
     "extends": "eslint:recommended",
@@ -47,7 +48,7 @@ module.exports = {
         "curly": ["error"],
         "eqeqeq": ["error"],
         "func-call-spacing": ["error"],
-        "indent": ["warn", 4, {"SwitchCase":1, "FunctionDeclaration": {"parameters": "first"}}],
+        "indent": ["warn", 4, {"SwitchCase": 1, "FunctionDeclaration": {"parameters": "first"}}],
         "linebreak-style": ["error", "unix"],
         "key-spacing": ["error"],
         "keyword-spacing": ["error"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,5 +64,6 @@ module.exports = {
         "space-before-blocks": ["error"],
         "space-in-parens": ["error", "never"],
         "space-infix-ops": ["error"],   // match flake8 E225
-    }
+    },
+    "ignorePatterns": ["**/vellum/src/*.js"],
 };


### PR DESCRIPTION
## Technical Summary
Change ESLint config to ignore Vellum files since those are not technically part of the HQ codebase and are managed via automated scripts.


## Safety Assurance

### Safety story
Lint only change

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
