### PR TITLE
Split Screen Case Search Title and Subtitle Display

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -234,10 +234,3 @@ class CommCareFeatureSupportMixin(object):
             toggles.CASE_LIST_TILE.enabled(self.domain)
             and self._require_minimum_version('2.54')
         )
-
-    @property
-    def supports_split_screen_case_search(self):
-        return (
-            toggles.SPLIT_SCREEN_CASE_SEARCH.enabled(self.domain)
-            and self._require_minimum_version('2.54')
-        )

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -185,11 +185,6 @@ class RemoteRequestFactory(object):
             text=Text(locale_id=id_strings.case_search_title_translation(self.module))
         )
 
-    def build_results_title(self):
-        return Display(
-            text=Text(locale_id=id_strings.case_search_locale(self.module))
-        )
-
     def build_description(self):
         return Display(
             text=Text(locale_id=id_strings.case_search_description_locale(self.module))
@@ -216,7 +211,6 @@ class RemoteRequestFactory(object):
                 data=self._remote_request_query_datums,
                 prompts=self.build_query_prompts(),
                 default_search=self.module.search_config.default_search,
-                results_title=self.build_results_title() if self.app.supports_split_screen_case_search else None,
             )
         ]
 

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -78,7 +78,6 @@ from corehq.apps.app_manager.xpath import (
 from corehq.apps.case_search.const import COMMCARE_PROJECT, EXCLUDE_RELATED_CASES_FILTER
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
-    case_search_sync_cases_on_form_entry_enabled_for_domain,
     CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY,
     CASE_SEARCH_REGISTRY_ID_KEY,
     CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -539,7 +539,6 @@ class RemoteRequestQuery(OrderedXmlObject, XmlObject):
     data = NodeListField('data', QueryData)
     prompts = NodeListField('prompt', QueryPrompt)
     default_search = BooleanField("@default_search")
-    results_title = NodeField('results-title', DisplayNode)
 
     @property
     def id(self):

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -514,12 +514,10 @@ class MultiSelectChildModuleDatumIDTests(SimpleTestCase, SuiteMixin):
             ('instance-datum', 'parent_selected_cases'),
         ])
 
-    @patch("corehq.apps.app_manager.suite_xml.post_process.remote_requests."
-           "case_search_sync_cases_on_form_entry_enabled_for_domain")
     @patch(
         "corehq.apps.app_manager.suite_xml.sections.entries."
         "case_search_sync_cases_on_form_entry_enabled_for_domain")
-    def test_multi_select_as_child_with_parent_select_case_search(self, mock1, mock2):
+    def test_multi_select_as_child_with_parent_select_case_search(self, mock1):
         # parent select from parent module to child (seems weird)
         self.set_parent_select(self.m2, self.m4)
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -32,7 +32,6 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
             'title',
             'type',
             'noItemsText',
-            'resultsTitle',
         ],
 
         entityProperties: [

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -114,7 +114,8 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             var menuData = menusUtils.getMenuData(menuResponse);
             menuData["triggerEmptyCaseList"] = true;
             menuData["sidebarEnabled"] = true;
-            menuData["title"] = menuResponse.resultsTitle;
+            menuData["description"] = menuResponse.description;
+
             var caseListView = menusUtils.getCaseListView(menuResponse);
             FormplayerFrontend.regions.getRegion('main').show(caseListView(menuData));
         } else if (menuListView) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -664,9 +664,16 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     ? `${headerWords.join(' ')} <b>${lastChar}</b>`
                     : header;
             };
+            let description = this.options.description
+            let title = this.options.title
+            if (this.options.sidebarEnabled && this.options.collection.queryResponse) {
+                description = this.options.collection.queryResponse.description
+                title = this.options.collection.queryResponse.title
+            }
             return {
                 startPage: paginateItems.startPage,
-                title: this.options.title,
+                title: title,
+                description: description,
                 headers: this.headers.map(boldSortedCharIcon),
                 widthHints: this.options.widthHints,
                 actions: this.options.actions,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -672,8 +672,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             }
             return {
                 startPage: paginateItems.startPage,
-                title: title,
-                description: description,
+                title: title.trim(),
+                description: description === undefined ? "" : DOMPurify.sanitize(markdown.render(description.trim())),
                 headers: this.headers.map(boldSortedCharIcon),
                 widthHints: this.options.widthHints,
                 actions: this.options.actions,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1,4 +1,4 @@
-/*globals Marionette */
+/*globals DOMPurify, Marionette */
 
 hqDefine("cloudcare/js/formplayer/menus/views", function () {
     const kissmetrics = hqImport("analytix/js/kissmetrix"),
@@ -664,11 +664,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     ? `${headerWords.join(' ')} <b>${lastChar}</b>`
                     : header;
             };
-            let description = this.options.description
-            let title = this.options.title
+            let description = this.options.description;
+            let title = this.options.title;
             if (this.options.sidebarEnabled && this.options.collection.queryResponse) {
-                description = this.options.collection.queryResponse.description
-                title = this.options.collection.queryResponse.title
+                description = this.options.collection.queryResponse.description;
+                title = this.options.collection.queryResponse.title;
             }
             return {
                 startPage: paginateItems.startPage,

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -4,8 +4,12 @@
 <script type="text/template" id="case-view-list-template">
   <div class="module-case-list-container">
 
-    <div aria-label="<%- title %>" tabindex="0" class="page-header menu-header"><h1 class="page-title"><%- title %></h1></div>
-
+    <div class="page-header menu-header">
+      <h1  aria-label="<%- title %>" tabindex="0" class="page-title"><%- title %></h1>
+      <% if (sidebarEnabled && description.length > 0) {%>
+        <div aria-label="<%- description %>" tabindex="0" class="query-description"><%= description %></div>
+      <% } %>
+    </div>
     <% if (!sidebarEnabled) { %>
     <div class="module-search-container">
       <div class="input-group input-group-lg">

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -4,7 +4,7 @@
 <script type="text/template" id="case-view-list-template">
   <div class="module-case-list-container">
 
-    <div class="page-header menu-header">
+    <div class="page-header menu-header" id="case-list-menu-header">
       <h1  aria-label="<%- title %>" tabindex="0" class="page-title"><%- title %></h1>
       <% if (sidebarEnabled && description.length > 0) {%>
         <div aria-label="<%- description %>" tabindex="0" class="query-description"><%= description %></div>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -5,7 +5,9 @@
   <div class="module-case-list-container">
 
     <div class="page-header menu-header" id="case-list-menu-header">
+      <% if (title.length > 0) {%>
       <h1  aria-label="<%- title %>" tabindex="0" class="page-title"><%- title %></h1>
+      <% } %>
       <% if (sidebarEnabled && description.length > 0) {%>
         <div aria-label="<%- description %>" tabindex="0" class="query-description"><%= description %></div>
       <% } %>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -17,7 +17,7 @@
       <h2 tabindex="0"><%- title %></h2>
     <% } %>
     <% if (description.length > 0 && !sidebarEnabled) {%>
-      <div id="query-description" tabindex="0">
+      <div class="query-description" tabindex="0">
         <%= description %>
       </div>
     <% } %>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
@@ -12,6 +12,13 @@ body {
   display: none;
 }
 
+#case-list-menu-header{
+  padding-left: 1.5rem;
+  h1 {
+    padding-left: 0px;
+  }
+}
+
 .page-header {
   border-bottom: none;
   padding: 14px 8px 7px;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -62,7 +62,7 @@
   }
 }
 
-#query-description {
+.query-description {
   a {
     color: @cc-brand-mid;
   }


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Two changes for Split Screen Case Search:
1. The "title" is now configured via "Search Screen Title". It was previously configured via "Label for Searching"
2. The "description"/"subtitle" is now displayed (and is configured as normal via "Search Screen Subtitle")

![Screen Shot 2023-08-15 at 10 11 01 AM](https://github.com/dimagi/commcare-hq/assets/88759246/b281ec31-7a34-4082-b41a-e3673e80c0c7)

![Screen Shot 2023-08-15 at 10 11 06 AM](https://github.com/dimagi/commcare-hq/assets/88759246/ef8c1f05-df1a-4289-8c0c-ced14c3c5d3e)

![Screen Shot 2023-08-15 at 10 02 28 AM](https://github.com/dimagi/commcare-hq/assets/88759246/7234b312-eeee-46df-af6b-27694b6a60cb)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi-dev.atlassian.net/browse/USH-3539
Related to https://github.com/dimagi/commcare-hq/pull/33261
Formplayer PR: https://github.com/dimagi/commcare-core/pull/1320

Split Screen case search has two view states: 
1. Pre-search view (`query` type `menuResponse`)
2. Post-search results view (`entity` type `menuResponse`)
In 1, the description is pulled from `this.options.description` and in 2, the description is pulled from `this.options.collection.queryResponse.description`

Reasoning for why "title" configuration was switched to using "Search Screen Title":
In app configuration, there is both “Label for Searching” and “Search Screen Title” where:
- ”Label for Searching” would be the text for the “search” button AND the header of search results
- “Search Screen Title” is the text for the header of the Case Search screen

With SSCS, both the search screen and results screen are the same thing. In the original implementation [here](https://github.com/dimagi/commcare-hq/pull/33261), the “Label for Searching” is used as the header. But when [USH_INLINE_SEARCH](https://www.commcarehq.org/hq/flags/edit/inline_case_search/?__hstc=240960668.3a8f9bf02bba22cb899ac9b22ad61999.1677781986891.1691980965112.1692031507022.370&__hssc=240960668.2.1692031507022&__hsfp=2926660606) is enabled, the “Label for Searching” configuration is hidden so it can't be configured. "Search Screen Title" is still available.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
SPLIT_SCREEN_CASE_SEARCH

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing. The change only affects Split Screen Case Search which has limited usage. The change only affects display of title and subtitle.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No Automated test
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
