### PR TITLE
Restore dev-settings sqlalchemy version

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,6 +1,6 @@
 # CommCare HQ Dependency Policy
 
-We separate our dependencies based on environment, which ensures that 
+We separate our dependencies based on environment, which ensures that
 dependencies are not installed on an environment where they are not needed.
 
 When adding new dependencies, consider what environment(s) require these
@@ -10,12 +10,12 @@ environment(s).
 After making these edits, you need to run
 ```.env
 make requirements
-``` 
+```
 
-`base-requirements` — Every environment, including tests and documentation, 
+`base-requirements` — Every environment, including tests and documentation,
 requires these dependencies
 
-`sso-requirements` — These requirements are needed for SSO and 
+`sso-requirements` — These requirements are needed for SSO and
 are required by all environments that run CommCare HQ. This excludes one
 environment, documentation, which cannot install these requirements.
 

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -18,7 +18,6 @@ django-celery-results
 django-compressor
 django-countries
 django-crispy-forms
-crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
 django-cte
 django-field-audit
 django-formtools

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -18,6 +18,7 @@ django-celery-results
 django-compressor
 django-countries
 django-crispy-forms
+crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
 django-cte
 django-field-audit
 django-formtools

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -102,8 +102,6 @@ contextlib2==21.6.0
     #   schema
 coverage==7.1.0
     # via -r test-requirements.in
-crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
-    # via -r base-requirements.in
 cryptography==41.0.3
     # via
     #   -r sso-requirements.in
@@ -143,11 +141,9 @@ dimagi-memoized==1.1.3
 django==3.2.20
     # via
     #   -r base-requirements.in
-    #   crispy-bootstrap3to5
     #   django-appconf
     #   django-braces
     #   django-bulk-update
-    #   django-crispy-forms
     #   django-extensions
     #   django-formtools
     #   django-logentry-admin
@@ -179,10 +175,8 @@ django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
-django-crispy-forms==2.0.0
-    # via
-    #   -r base-requirements.in
-    #   crispy-bootstrap3to5
+django-crispy-forms==1.10.0
+    # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3
@@ -335,7 +329,6 @@ greenlet==1.1.2
     #   -r base-requirements.in
     #   django-websocket-redis
     #   gevent
-    #   sqlalchemy
 grpcio==1.54.2
     # via
     #   google-api-core
@@ -754,7 +747,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sqlagg==0.17.2
     # via -r base-requirements.in
-sqlalchemy==2.0.17
+sqlalchemy==1.3.19
     # via
     #   -r base-requirements.in
     #   alembic
@@ -794,7 +787,7 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==7.12.0
     # via -r base-requirements.in
-typing-extensions==4.7.1
+typing-extensions==4.1.1
     # via
     #   bytecode
     #   cattrs
@@ -802,7 +795,6 @@ typing-extensions==4.7.1
     #   django-countries
     #   oic
     #   qrcode
-    #   sqlalchemy
 tzdata==2023.3
     # via pandas
 ua-parser==0.10.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -102,6 +102,8 @@ contextlib2==21.6.0
     #   schema
 coverage==7.1.0
     # via -r test-requirements.in
+crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
+    # via -r base-requirements.in
 cryptography==41.0.3
     # via
     #   -r sso-requirements.in
@@ -141,9 +143,11 @@ dimagi-memoized==1.1.3
 django==3.2.20
     # via
     #   -r base-requirements.in
+    #   crispy-bootstrap3to5
     #   django-appconf
     #   django-braces
     #   django-bulk-update
+    #   django-crispy-forms
     #   django-extensions
     #   django-formtools
     #   django-logentry-admin
@@ -175,8 +179,10 @@ django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
-django-crispy-forms==1.10.0
-    # via -r base-requirements.in
+django-crispy-forms==2.0
+    # via
+    #   -r base-requirements.in
+    #   crispy-bootstrap3to5
 django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -84,8 +84,6 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
-crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
-    # via -r base-requirements.in
 cryptography==41.0.3
     # via
     #   jwcrypto
@@ -121,11 +119,9 @@ dimagi-memoized==1.1.3
 django==3.2.20
     # via
     #   -r base-requirements.in
-    #   crispy-bootstrap3to5
     #   django-appconf
     #   django-braces
     #   django-bulk-update
-    #   django-crispy-forms
     #   django-extensions
     #   django-formtools
     #   django-logentry-admin
@@ -157,10 +153,8 @@ django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
-django-crispy-forms==2.0.0
-    # via
-    #   -r base-requirements.in
-    #   crispy-bootstrap3to5
+django-crispy-forms==1.10.0
+    # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -84,6 +84,8 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
+crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
+    # via -r base-requirements.in
 cryptography==41.0.3
     # via
     #   jwcrypto
@@ -119,9 +121,11 @@ dimagi-memoized==1.1.3
 django==3.2.20
     # via
     #   -r base-requirements.in
+    #   crispy-bootstrap3to5
     #   django-appconf
     #   django-braces
     #   django-bulk-update
+    #   django-crispy-forms
     #   django-extensions
     #   django-formtools
     #   django-logentry-admin
@@ -153,8 +157,10 @@ django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
-django-crispy-forms==1.10.0
-    # via -r base-requirements.in
+django-crispy-forms==2.0
+    # via
+    #   -r base-requirements.in
+    #   crispy-bootstrap3to5
 django-cte==1.2.0
     # via -r base-requirements.in
 django-extensions==3.1.3

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -86,8 +86,6 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
-crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
-    # via -r base-requirements.in
 cryptography==41.0.3
     # via
     #   -r prod-requirements.in
@@ -126,11 +124,9 @@ dimagi-memoized==1.1.3
 django==3.2.20
     # via
     #   -r base-requirements.in
-    #   crispy-bootstrap3to5
     #   django-appconf
     #   django-braces
     #   django-bulk-update
-    #   django-crispy-forms
     #   django-formtools
     #   django-logentry-admin
     #   django-oauth-toolkit
@@ -160,10 +156,8 @@ django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
-django-crispy-forms==2.0.0
-    # via
-    #   -r base-requirements.in
-    #   crispy-bootstrap3to5
+django-crispy-forms==1.10.0
+    # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
 django-field-audit==1.2.6

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -86,6 +86,8 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
+crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
+    # via -r base-requirements.in
 cryptography==41.0.3
     # via
     #   -r prod-requirements.in
@@ -124,9 +126,11 @@ dimagi-memoized==1.1.3
 django==3.2.20
     # via
     #   -r base-requirements.in
+    #   crispy-bootstrap3to5
     #   django-appconf
     #   django-braces
     #   django-bulk-update
+    #   django-crispy-forms
     #   django-formtools
     #   django-logentry-admin
     #   django-oauth-toolkit
@@ -156,8 +160,10 @@ django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
-django-crispy-forms==1.10.0
-    # via -r base-requirements.in
+django-crispy-forms==2.0
+    # via
+    #   -r base-requirements.in
+    #   crispy-bootstrap3to5
 django-cte==1.2.0
     # via -r base-requirements.in
 django-field-audit==1.2.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -80,8 +80,6 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
-crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
-    # via -r base-requirements.in
 cryptography==41.0.3
     # via
     #   -r sso-requirements.in
@@ -118,11 +116,9 @@ dimagi-memoized==1.1.3
 django==3.2.20
     # via
     #   -r base-requirements.in
-    #   crispy-bootstrap3to5
     #   django-appconf
     #   django-braces
     #   django-bulk-update
-    #   django-crispy-forms
     #   django-formtools
     #   django-logentry-admin
     #   django-oauth-toolkit
@@ -152,10 +148,8 @@ django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
-django-crispy-forms==2.0.0
-    # via
-    #   -r base-requirements.in
-    #   crispy-bootstrap3to5
+django-crispy-forms==1.10.0
+    # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
 django-field-audit==1.2.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -80,6 +80,8 @@ commcaretranslationchecker==0.9.7
     # via -r base-requirements.in
 contextlib2==21.6.0
     # via schema
+crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
+    # via -r base-requirements.in
 cryptography==41.0.3
     # via
     #   -r sso-requirements.in
@@ -116,9 +118,11 @@ dimagi-memoized==1.1.3
 django==3.2.20
     # via
     #   -r base-requirements.in
+    #   crispy-bootstrap3to5
     #   django-appconf
     #   django-braces
     #   django-bulk-update
+    #   django-crispy-forms
     #   django-formtools
     #   django-logentry-admin
     #   django-oauth-toolkit
@@ -148,8 +152,10 @@ django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
-django-crispy-forms==1.10.0
-    # via -r base-requirements.in
+django-crispy-forms==2.0
+    # via
+    #   -r base-requirements.in
+    #   crispy-bootstrap3to5
 django-cte==1.2.0
     # via -r base-requirements.in
 django-field-audit==1.2.6

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -89,8 +89,6 @@ contextlib2==21.6.0
     # via schema
 coverage==7.1.0
     # via -r test-requirements.in
-crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
-    # via -r base-requirements.in
 cryptography==41.0.3
     # via
     #   -r sso-requirements.in
@@ -127,11 +125,9 @@ dimagi-memoized==1.1.3
 django==3.2.20
     # via
     #   -r base-requirements.in
-    #   crispy-bootstrap3to5
     #   django-appconf
     #   django-braces
     #   django-bulk-update
-    #   django-crispy-forms
     #   django-formtools
     #   django-logentry-admin
     #   django-oauth-toolkit
@@ -161,10 +157,8 @@ django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
-django-crispy-forms==2.0.0
-    # via
-    #   -r base-requirements.in
-    #   crispy-bootstrap3to5
+django-crispy-forms==1.10.0
+    # via -r base-requirements.in
 django-cte==1.2.0
     # via -r base-requirements.in
 django-field-audit==1.2.6

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -89,6 +89,8 @@ contextlib2==21.6.0
     # via schema
 coverage==7.1.0
     # via -r test-requirements.in
+crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
+    # via -r base-requirements.in
 cryptography==41.0.3
     # via
     #   -r sso-requirements.in
@@ -125,9 +127,11 @@ dimagi-memoized==1.1.3
 django==3.2.20
     # via
     #   -r base-requirements.in
+    #   crispy-bootstrap3to5
     #   django-appconf
     #   django-braces
     #   django-bulk-update
+    #   django-crispy-forms
     #   django-formtools
     #   django-logentry-admin
     #   django-oauth-toolkit
@@ -157,8 +161,10 @@ django-compressor==4.1
     # via -r base-requirements.in
 django-countries==7.3.2
     # via -r base-requirements.in
-django-crispy-forms==1.10.0
-    # via -r base-requirements.in
+django-crispy-forms==2.0
+    # via
+    #   -r base-requirements.in
+    #   crispy-bootstrap3to5
 django-cte==1.2.0
     # via -r base-requirements.in
 django-field-audit==1.2.6


### PR DESCRIPTION
## Product Description


## Technical Summary
from https://github.com/dimagi/commcare-hq/pull/33207#discussion_r1294977889

That PR made an inadvertent change bumping the sqlalchemy version for dev requirements.  It looks like running `make requirements` is only an additive operation - it doesn't reset the state of the generated txt files, so I instead undid all the requirements changes and reapplied them.  Specifically:

* I made a commit that reverts the whole PR (not included in this changeset): https://github.com/dimagi/commcare-hq/commit/910ba022e652987c98b40eb0d928e6c164499f7a
* Then I cherry-picked those changes onto my branch without committing:
    `$ git cherry-pick -n https://github.com/dimagi/commcare-hq/commit/910ba022e652987c98b40eb0d928e6c164499f7a`
* Next, I discarded all changes except those in `requirements/`:
    `$ git restore --staged --worktree corehq/ settings.py`
* Then I committed that.
* Lastly, I re-added the line to `base-requirements.in` and ran `make requirements`

I'd recommend reviewers view the individual commits _and_ the monolithic change to understand the differences

## Feature Flag


## Safety Assurance

### Safety story

The dev setup now works as expected - I can load UCRs locally.  The only prod change in this PR is that the crispy forms requirement is pinned to a minor version instead of a point release.  Not sure why the difference there, but I see 17 such requirements, so I guess that means it's okay?

### Automated test coverage


### QA Plan

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change