### PR TITLE
Fullscreen option for case list map

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -571,6 +571,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     position: 'bottomright',
                 }).addTo(addressMap);
 
+                L.control.fullscreen({
+                    pseudoFullscreen: true,
+                    position: 'bottomright',
+                }).addTo(addressMap);
+
                 L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=' + token, {
                     id: 'mapbox/streets-v11',
                     attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> ©' +

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -618,7 +618,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                                     marker.setIcon(selectedLocationIcon);
 
                                     let scrollTopOffset = 47.125; // standard height of breadcrumbs with shadow
-                                    if (this.smallScreenEnabled) {
+                                    if (this.smallScreenEnabled && !addressMap.isFullscreen()) {
                                         scrollTopOffset += addressMap.getSize().y;
                                     }
                                     $([document.documentElement, document.body]).animate({

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -21,7 +21,7 @@
 
     <div class="row row-no-gutters">
       <% if (showMap) { %>
-        <div id="module-case-list-map" class="col-sm-5 col-sm-push-9<% if (useTiles) { %> white-border<% } %>"></div>
+        <div id="module-case-list-map" class="sticky-map col-sm-5 col-sm-push-9<% if (useTiles) { %> white-border<% } %>"></div>
       <% } %>
       <div id="module-case-list" class="col-sm<% if (showMap) { %>-7 col-sm-pull-5<% } %>">
         <% if (useTiles) { %>

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -55,6 +55,7 @@
   <script src="{% static 'cloudcare/js/form_entry/form_ui.js' %}"></script>
   <script src="{% static 'cloudcare/js/form_entry/web_form_session.js' %}"></script>
   <script src="{% static '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min.js' %}"></script>
+  <script src="{% static 'leaflet-fullscreen/dist/Leaflet.fullscreen.min.js' %}"></script>
 {% endcompress %}
 
 {% compress js %}
@@ -117,4 +118,9 @@
   rel="stylesheet"
   type="text/css"
   href="{% static 'calendars/dist/css/jquery.calendars.picker.css' %}"
+/>
+
+<link
+  rel="stylesheet"
+  href="{% static 'leaflet-fullscreen/dist/leaflet.fullscreen.css' %}"
 />

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -8,6 +8,16 @@
   z-index: 1; // keep map on top of case list
 }
 
+// override leaflet-fullscreen styles to fix icon alignment in mapbox.js
+.leaflet-touch {
+  .leaflet-control-fullscreen a {
+    background-position: 0px 0px !important;
+  }
+  &.leaflet-fullscreen-on .leaflet-control-fullscreen a {
+    background-position: 0px -26px !important;
+  }
+}
+
 #menu-region .module-menu-container,
 #menu-region .module-case-list-container {
   background-color: white;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -2,6 +2,12 @@
   background: transparent;
 }
 
+.sticky-map {
+  position: sticky !important; // Has to be important so the leaflet code does not set it to relative
+  top: 46px; // based on the height of the crumbs bar
+  z-index: 1; // keep map on top of case list
+}
+
 #menu-region .module-menu-container,
 #menu-region .module-case-list-container {
   background-color: white;
@@ -14,9 +20,6 @@
 
   #module-case-list-map {
     height: calc(~"100vh - 65px");
-    position: sticky !important; // Has to be important so the leaflet code does not set it to relative
-    top: 46px; // based on the height of the crumbs bar
-    z-index: 1; // keep map on top of case list
 
     @media (max-width: @screen-xs-max) {
       height: 250px;

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "knockout-sortable": "1.2.2",
         "knockout-validation": "Knockout-Contrib/Knockout-Validation#2.0.4",
         "leaflet": "0.7.7",
+        "leaflet-fullscreen": "^1.0.2",
         "less": "3.10.3",
         "marionette.approuter": "^1.0.2",
         "marionette.templatecache": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3083,6 +3083,11 @@ knockout@3.5.1:
   resolved "https://registry.yarnpkg.com/knockout/-/knockout-3.5.1.tgz#62c81e81843bea2008fd23c575edd9ca978e75cf"
   integrity sha512-wRJ9I4az0QcsH7A4v4l0enUpkS++MBx0BnL/68KaLzJg7x1qmbjSlwEoCNol7KTYZ+pmtI7Eh2J0Nu6/2Z5J/Q==
 
+leaflet-fullscreen@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/leaflet-fullscreen/-/leaflet-fullscreen-1.0.2.tgz#09c61c4bac45f63b2ee126afd87e5cd97650fc1b"
+  integrity sha512-1Yxm8RZg6KlKX25+hbP2H/wnOAphH7hFcvuADJFb4QZTN7uOSN9Hsci5EZpow8vtNej9OGzu59Jxmn+0qKOO9Q==
+
 leaflet@0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-0.7.7.tgz#1e352ba54e63d076451fa363c900890cb2cf75ee"
@@ -5725,7 +5730,7 @@ wide-align@^1.1.5:
   dependencies:
     string-width "^1.0.2 || 2 || 3 || 4"
 
-word-wrap@^1.2.3, "word-wrap@npm:@aashutoshrathi/word-wrap@1.2.5", word-wrap@~1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.5.tgz#383aeebd5c176c320d6364fb869669559bbdbac9"
   integrity sha512-plhoNEfSVdHMKXQyAxvH0Zyv3/4NL8r6pwgMQdmHR2vBUXn2t74PN2pBRppqKUa6RMT0yldyvOHG5Dbjwy2mBQ==


### PR DESCRIPTION
## Product Description
Adds a fullscreen control for map in case list to maximize map to the window size.

https://github.com/dimagi/commcare-hq/assets/100609770/535a2e02-fe1a-452d-9faf-8a471895a0d0

## Technical Summary
[USH-3483](https://dimagi-dev.atlassian.net/browse/USH-3483)
Adds a lightweight leaflet plugin `leaflet-fullscreen` as a dependency to be able to fullscreen the case list map pane. Makes some tweaks to styles and scrolling so the fullscreen functionality works right.

## Feature Flag
case_list_map

## Safety Assurance

### Safety story
UI change only. Tested locally to make sure fullscreen works in various case list/tiles/split screen/map configs.

### Automated test coverage
We don't currently have tests for pure UI changes and given that the functionality here is from a library, I don't know that this PR needs it.

### QA Plan
Will get QA as part of greater ongoing responsive design work.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3483]: https://dimagi-dev.atlassian.net/browse/USH-3483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ