### PR TITLE
[B5] Update migration script to fix 2 issues and verify references

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             help="Run migration against already split bootstrap 5 files"
         )
         parser.add_argument(
-            '--references',
+            '--verify-references',
             action='store_true',
             default=False,
             help="Verify that all references to migrated files have been updated"
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         template_name = options.get('template_name')
         js_name = options.get('js_name')
         do_re_check = options.get('re_check')
-        verify_references = options.get('references')
+        verify_references = options.get('verify_references')
 
         if verify_references:
             self.stdout.write(f"\n\nVerifying that references to migrated files "

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -13,6 +13,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     flag_changed_css_classes,
     flag_stateful_button_changes_bootstrap5,
     flag_changed_javascript_plugins,
+    flag_path_references_to_migrated_javascript_files,
 )
 
 COREHQ_BASE_DIR = Path(corehq.__file__).resolve().parent
@@ -263,7 +264,10 @@ class Command(BaseCommand):
 
     @staticmethod
     def get_flags_in_javascript_line(javascript_line, spec):
-        return flag_changed_javascript_plugins(javascript_line, spec)
+        flags = flag_changed_javascript_plugins(javascript_line, spec)
+        reference_flags = flag_path_references_to_migrated_javascript_files(javascript_line, "bootstrap3")
+        flags.append(reference_flags)
+        return flags
 
     @staticmethod
     def get_split_file_paths(file_path):

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -256,8 +256,8 @@ class Command(BaseCommand):
                           if f.is_file() and '/bootstrap3/' in str(f) and '/crispy/' not in str(f)]
         app_static_folder = self._get_app_static_folder(app_name)
         migrated_files.extend(
-            [f for f in app_static_folder.glob('**/*.js')
-             if f.is_file() and '/bootstrap3/' in str(f)]
+            f for f in app_static_folder.glob('**/*.js')
+            if f.is_file() and '/bootstrap3/' in str(f)
         )
         return migrated_files
 

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -263,9 +263,9 @@ class Command(BaseCommand):
 
     def verify_migrated_references(self, app_name):
         migrated_files = self._get_migrated_files(app_name)
-        template_path = str(self._get_app_template_folder(app_name))
+        template_path = self._get_app_template_folder(app_name)
         for file_path in migrated_files:
-            is_template = template_path in str(file_path)
+            is_template = file_path.is_relative_to(template_path)
             new_reference = self.get_short_path(app_name, file_path, is_template)
             old_reference = new_reference.replace("/bootstrap3/", "/")
             references = self.update_and_get_references(

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -8,6 +8,8 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     flag_stateful_button_changes_bootstrap5,
     flag_changed_javascript_plugins,
     flag_path_references_to_migrated_javascript_files,
+    file_contains_reference_to_path,
+    replace_path_references,
 )
 
 
@@ -76,3 +78,96 @@ def test_flag_path_references_to_migrated_javascript_files_bootstrap5():
         line, "bootstrap3"
     )
     eq(flags, ['Found reference to a migrated file (bootstrap3)'])
+
+
+def test_file_contains_reference_to_path():
+    filedata = """
+    {# Our Libraries #}
+    {% if not requirejs_main %}
+      {% compress js %}
+        <script src="{% static 'foobarapp/js/bugz.js' %}"></script>
+        <script src="{% static 'foobarapp/js/privileges.js' %}"></script>
+        <script src="{% static 'foobarapp/js/alert_user.js' %}"></script>
+      {% endcompress %}
+    {% endif %}"""
+    contains_ref = file_contains_reference_to_path(filedata, "foobarapp/js/bugz.js")
+    eq(contains_ref, True)
+
+
+def test_file_does_not_contain_reference_to_path():
+    filedata = """
+    {# Our Libraries #}
+    {% if not requirejs_main %}
+      {% compress js %}
+        <script src="{% static 'foobarapp/js/bugz_two.js' %}"></script>
+        <script src="{% static 'foobarapp/js/privileges.js' %}"></script>
+        <script src="{% static 'foobarapp/js/alert_user.js' %}"></script>
+      {% endcompress %}
+    {% endif %}"""
+    contains_ref = file_contains_reference_to_path(filedata, "foobarapp/js/bugz.js")
+    eq(contains_ref, False)
+
+
+def test_javascript_file_contains_reference_to_path():
+    filedata = """hqDefine('foobarapp/js/bugz_two', [
+        'foobarapp/js/bugz'
+        'foobarapp/js/layout'
+    ], function() {
+        // nothing to do, this is just to define the dependencies for foobarapp/base.html
+    });"""
+    contains_ref = file_contains_reference_to_path(filedata, "foobarapp/js/bugz")
+    eq(contains_ref, True)
+
+
+def test_javascript_file_does_not_contain_reference_to_path():
+    filedata = """hqDefine('foobarapp/js/bugz_two', [
+        'foobarapp/js/layout'
+    ], function() {
+        // nothing to do, this is just to define the dependencies for foobarapp/base.html
+    });"""
+    contains_ref = file_contains_reference_to_path(filedata, "foobarapp/js/bugz")
+    eq(contains_ref, False)
+
+
+def test_replace_path_references():
+    filedata = """
+    {# Our Libraries #}
+    {% if not requirejs_main %}
+      {% compress js %}
+        <script src="{% static 'foobarapp/js/bugz.js' %}"></script>
+        <script src="{% static 'foobarapp/js/privileges.js' %}"></script>
+        <script src="{% static 'foobarapp/js/alert_user.js' %}"></script>
+      {% endcompress %}
+    {% endif %}
+    <script src="{% static "foobarapp/js/bugz.js" %}"></script>
+    """
+    result = replace_path_references(filedata, "foobarapp/js/bugz.js", "foobarapp/js/bootstrap3/bugz.js")
+    expected_result = """
+    {# Our Libraries #}
+    {% if not requirejs_main %}
+      {% compress js %}
+        <script src="{% static 'foobarapp/js/bootstrap3/bugz.js' %}"></script>
+        <script src="{% static 'foobarapp/js/privileges.js' %}"></script>
+        <script src="{% static 'foobarapp/js/alert_user.js' %}"></script>
+      {% endcompress %}
+    {% endif %}
+    <script src="{% static "foobarapp/js/bootstrap3/bugz.js" %}"></script>
+    """
+    eq(result, expected_result)
+
+
+def test_replace_path_references_javascript():
+    filedata = """hqDefine('foobarapp/js/bugz_two', [
+    'foobarapp/js/bugz',
+    'foobarapp/js/layout'
+], function() {
+    // nothing to do, this is just to define the dependencies for foobarapp/base.html
+});"""
+    result = replace_path_references(filedata, "foobarapp/js/bugz", "foobarapp/js/bootstrap3/bugz")
+    expected_result = """hqDefine('foobarapp/js/bugz_two', [
+    'foobarapp/js/bootstrap3/bugz',
+    'foobarapp/js/layout'
+], function() {
+    // nothing to do, this is just to define the dependencies for foobarapp/base.html
+});"""
+    eq(result, expected_result)

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -7,6 +7,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     flag_changed_css_classes,
     flag_stateful_button_changes_bootstrap5,
     flag_changed_javascript_plugins,
+    flag_path_references_to_migrated_javascript_files,
 )
 
 
@@ -67,3 +68,11 @@ def test_flag_changed_javascript_plugins_bootstrap5():
                'you find common replacements/restructuring\nfor our usage of this plugin. '
                'Thanks!\n\nOld docs: https://getbootstrap.com/docs/3.4/javascript/#modals\n'
                'New docs: https://getbootstrap.com/docs/5.3/components/modal/#via-javascript\n'])
+
+
+def test_flag_path_references_to_migrated_javascript_files_bootstrap5():
+    line = """    'hqwebapp/js/bootstrap3/crud_paginated_list',\n"""
+    flags = flag_path_references_to_migrated_javascript_files(
+        line, "bootstrap3"
+    )
+    eq(flags, ['Found reference to a migrated file (bootstrap3)'])

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -41,6 +41,10 @@ def _get_plugin_regex(js_plugin):
     return r"(\.)(" + js_plugin + r")(\([\{\"\'])"
 
 
+def _get_path_reference_regex(path_reference):
+    return r"([\"\'])(" + path_reference + r")([\"\'])"
+
+
 def _do_rename(line, change_map, regex_fn, replacement_fn):
     renames = []
     for css_class in change_map.keys():
@@ -120,3 +124,17 @@ def flag_stateful_button_changes_bootstrap5(line):
         flags.append("You are using stateful buttons here, "
                      "which are no longer supported in Bootstrap 5.")
     return flags
+
+
+def file_contains_reference_to_path(filedata, path_reference):
+    regex = _get_path_reference_regex(path_reference)
+    return re.search(regex, filedata) is not None
+
+
+def replace_path_references(filedata, old_reference, new_reference):
+    regex = _get_path_reference_regex(old_reference)
+    return re.sub(
+        pattern=regex,
+        repl=r"\1" + new_reference + r"\3",
+        string=filedata
+    )

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -106,6 +106,13 @@ def flag_changed_javascript_plugins(line, spec):
     return flags
 
 
+def flag_path_references_to_migrated_javascript_files(line, reference):
+    flags = []
+    if "/" + reference + "/" in line:
+        flags.append(f"Found reference to a migrated file ({reference})")
+    return flags
+
+
 def flag_stateful_button_changes_bootstrap5(line):
     flags = []
     regex = r"([\n }])(data-\w*-text)(=[\"\'])"


### PR DESCRIPTION
## Technical Summary
This update to the Bootstrap 5 migration script addresses a few issues I noticed while migrating `hqwebapp`:
- Ensure that javascript files within the migrated app that have references to other migrated javascript files also are migrated/split into bootstrap 3 and 5 versions.
- Ensures that similarly named javascript files are not treated as identical references. For instance `hqwebapp/js/crud_paginated_list` and `hqwebapp/js/crud_paginated_list_init` were being treated as the same reference, when `hqwebapp/js/crud_paginated_list` was the file being split into bootstrap 3 and 5 versions.
- Ensures that the migration script has a utility to check that all references to migrated files are updated. This is needed as sometimes migrating an app takes a while. We need to make sure that no new references to the migrated files were introduced and merged during the migration period (as I discovered with `hqwebapp/js/crud_paginated_list` and the ERM work)

## Safety Assurance

### Safety story
This is a safe change as the scope only affects a management command. Additionally, tests have been added to ensure functionality in the management command works as expected.

### Automated test coverage
Yes

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
