### PR TITLE
Data Dictionary data type column to feature flag

### DIFF
--- a/corehq/apps/data_dictionary/bulk.py
+++ b/corehq/apps/data_dictionary/bulk.py
@@ -115,7 +115,7 @@ def _process_sheets(domain, workbook, allowed_value_info):
     missing_valid_values = set()
     data_validation_enabled = toggles.CASE_IMPORT_DATA_DICTIONARY_VALIDATION.enabled(domain)
     if data_validation_enabled:
-        column_mapping = COLUMN_MAPPING + DATA_TYPE_MAPPING
+        column_mapping = COLUMN_MAPPING | DATA_TYPE_MAPPING
     else:
         column_mapping = COLUMN_MAPPING
 

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -186,7 +186,9 @@
           {% if fhir_integration_enabled %}
             <div class="row-item">{% trans "FHIR Resource Property Path" %}</div>
           {% endif %}
-          <div class="row-item">{% include "data_dictionary/partials/valid_values_th_content.html" %}</div>
+          {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+            <div class="row-item">{% include "data_dictionary/partials/valid_values_th_content.html" %}</div>
+          {% endif %}
           {% if not request.is_view_only %}
             <div class="row-item-small"></div>
           {% endif %}
@@ -229,7 +231,9 @@
             {% if fhir_integration_enabled %}
               <div class="row-item"></div>
             {% endif %}
-            <div class="row-item"></div>
+            {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+              <div class="row-item"></div>
+            {% endif %}
             {% if not request.is_view_only %}
             <div class="row-item-small">
               <!-- ko if: name() !== '' && !toBeDeprecated() -->
@@ -291,14 +295,16 @@
                 <!-- /ko -->
               </div>
             {% endif %}
-            <div class="row-item">
-              <div data-bind="visible: canHaveAllowedValues()">
-                <div data-bind="jqueryElement: $allowedValues"></div>
+            {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+              <div class="row-item">
+                <div data-bind="visible: canHaveAllowedValues()">
+                  <div data-bind="jqueryElement: $allowedValues"></div>
+                </div>
+                <div data-bind="visible: dataType() === 'date'" class="help-block">
+                  {% trans "YYYY-MM-DD" %}
+                </div>
               </div>
-              <div data-bind="visible: dataType() === 'date'" class="help-block">
-                {% trans "YYYY-MM-DD" %}
-              </div>
-            </div>
+            {% endif %}
             {% if not request.is_view_only %}
               <div class="row-item-small">
                 <!-- ko if: !deprecated() -->

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -179,7 +179,9 @@
           <div class="table-row table-header">
           <div class="row-item-small"></div>
           <div class="row-item">{% trans "Case Property" %}</div>
-          <div class="row-item">{% trans "Data Type" %}</div>
+          {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+            <div class="row-item">{% trans "Data Type" %}</div>
+          {% endif %}
           <div class="row-item">{% trans "Description" %}</div>
           {% if fhir_integration_enabled %}
             <div class="row-item">{% trans "FHIR Resource Property Path" %}</div>
@@ -213,7 +215,9 @@
                             attr: {'placeholder': name}" id="group-name" />
               <!-- /ko -->
             </div>
-            <div class="row-item">{% trans "Case Property Group" %}</div>
+            {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+              <div class="row-item">{% trans "Case Property Group" %}</div>
+            {% endif %}
             <div class="row-item">
               <!-- ko if: name() !== ''-->
               <textarea class="form-control vertical-resize" data-bind="
@@ -258,16 +262,18 @@
                 </div>
                 </div>
               </div>
-              <div class="row-item main-form">
-              <select class="form-control"
-                      data-bind="
-                                  options: $root.availableDataTypes,
-                                  optionsCaption: 'Select a data type',
-                                  optionsText: 'display',
-                                  optionsValue: 'value',
-                                  value: dataType,
-                              "></select>
-              </div>
+              {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+                <div class="row-item main-form">
+                <select class="form-control"
+                        data-bind="
+                                    options: $root.availableDataTypes,
+                                    optionsCaption: 'Select a data type',
+                                    optionsText: 'display',
+                                    optionsValue: 'value',
+                                    value: dataType,
+                                "></select>
+                </div>
+              {% endif %}
               <div class="row-item main-form">
                               <textarea class="form-control vertical-resize" data-bind="
                                 value: $data.description,

--- a/corehq/apps/data_dictionary/tests/test_import_export.py
+++ b/corehq/apps/data_dictionary/tests/test_import_export.py
@@ -17,6 +17,7 @@ from corehq.util.test_utils import flag_enabled, TestFileMixin
 
 
 @flag_enabled('DATA_DICTIONARY')
+@flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
 class DataDictionaryImportTest(TestCase, TestFileMixin):
     domain_name = uuid.uuid4().hex
     file_path = ('data',)
@@ -88,6 +89,7 @@ class DataDictionaryImportTest(TestCase, TestFileMixin):
 
 
 @flag_enabled('DATA_DICTIONARY')
+@flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
 class DataDictionaryExportTest(TestCase):
     domain_name = uuid.uuid4().hex
 

--- a/corehq/apps/data_dictionary/tests/test_import_export.py
+++ b/corehq/apps/data_dictionary/tests/test_import_export.py
@@ -17,7 +17,6 @@ from corehq.util.test_utils import flag_enabled, TestFileMixin
 
 
 @flag_enabled('DATA_DICTIONARY')
-@flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
 class DataDictionaryImportTest(TestCase, TestFileMixin):
     domain_name = uuid.uuid4().hex
     file_path = ('data',)
@@ -41,6 +40,7 @@ class DataDictionaryImportTest(TestCase, TestFileMixin):
         self.url = reverse(UploadDataDictionaryView.urlname, args=[self.domain_name])
         self.client.login(username='test', password='foobar')
 
+    @flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
     def test_clean_import(self):
         fname = self.get_path('clean_data_dictionary', 'xlsx')
         with open(fname, 'rb') as dd_file:
@@ -65,6 +65,7 @@ class DataDictionaryImportTest(TestCase, TestFileMixin):
                             allowed_value=val, description=f'{val} description')
                         self.assertEqual(1, av_qs.count())
 
+    @flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
     def test_broken_import(self):
         fname = self.get_path('broken_data_dictionary', 'xlsx')
         with open(fname, 'rb') as dd_file:
@@ -87,9 +88,25 @@ class DataDictionaryImportTest(TestCase, TestFileMixin):
         received_errors = {elem.text for elem in soup.find_all('li')}
         self.assertEqual(expected_errors, received_errors)
 
+    def test_import_with_warnings(self):
+        fname = self.get_path('clean_data_dictionary', 'xlsx')
+        with open(fname, 'rb') as dd_file:
+            response = self.client.post(self.url, {'bulk_upload_file': dd_file})
+        self.assertEqual(response.status_code, 200)
+        messages = list(response.context['messages'])
+        self.assertEqual(len(messages), 2)
+        soup = BeautifulSoup(str(messages[1]), features="lxml")
+        received_warnings = {elem.text for elem in soup.find_all('li')}
+        expected_warnings = {
+            'The multi-choice sheets (ending in "-vl") in the uploaded Excel file were ignored '
+            'during the import as they are an unsupported format in the Data Dictionary',
+            'The "Data Type" column values were ignored during the import as they are '
+            'an unsupported format in the Data Dictionary',
+        }
+        self.assertEqual(received_warnings, expected_warnings)
+
 
 @flag_enabled('DATA_DICTIONARY')
-@flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
 class DataDictionaryExportTest(TestCase):
     domain_name = uuid.uuid4().hex
 
@@ -128,6 +145,7 @@ class DataDictionaryExportTest(TestCase):
         self.url = reverse(ExportDataDictionaryView.urlname, args=[self.domain_name])
         self.client.login(username='test', password='foobar')
 
+    @flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
     def test_export(self):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
@@ -139,3 +157,15 @@ class DataDictionaryExportTest(TestCase):
             name = self.case_types[i].name
             self.assertEqual(name, workbook.sheetnames[i * 2])
             self.assertEqual(f'{name}{ALLOWED_VALUES_SHEET_SUFFIX}', workbook.sheetnames[i * 2 + 1])
+
+    def test_export_without_data_type(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        workbook = openpyxl.load_workbook(io.BytesIO(response.content), read_only=True)
+        self.assertEqual(len(workbook.sheetnames), len(self.case_types))
+        for i in range(len(self.case_types)):
+            name = self.case_types[i].name
+            self.assertEqual(name, workbook.sheetnames[i])
+            sheet = workbook[name]
+            for row in sheet.iter_rows(min_row=1, max_row=1, min_col=1):
+                self.assertTrue(len(row), 5)

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -13,6 +13,7 @@ from corehq.util.test_utils import flag_enabled
 
 
 @flag_enabled('DATA_DICTIONARY')
+@flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
 class UpdateCasePropertyViewTest(TestCase):
     domain_name = uuid.uuid4().hex
 
@@ -309,3 +310,80 @@ class TestDeprecateOrRestoreCaseTypeView(TestCase):
         self.assertEqual(case_prop_count, 0)
         case_prop_group_count = CasePropertyGroup.objects.filter(case_type=case_type_obj, deprecated=True).count()
         self.assertEqual(case_prop_group_count, 0)
+
+
+@flag_enabled('DATA_DICTIONARY')
+@flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
+class DataDictionaryJsonTest(TestCase):
+    domain_name = uuid.uuid4().hex
+
+    @classmethod
+    def setUpClass(cls):
+        super(DataDictionaryJsonTest, cls).setUpClass()
+        cls.domain = create_domain(cls.domain_name)
+        cls.couch_user = WebUser.create(None, "test", "foobar", None, None)
+        cls.couch_user.add_domain_membership(cls.domain_name, is_admin=True)
+        cls.couch_user.save()
+        cls.case_type_obj = CaseType(name='caseType', domain=cls.domain_name)
+        cls.case_type_obj.save()
+        cls.case_prop_group_obj = CasePropertyGroup(case_type=cls.case_type_obj, name='group')
+        cls.case_prop_group_obj.save()
+        cls.case_prop_obj = CaseProperty(
+            case_type=cls.case_type_obj,
+            name='property',
+            data_type='number',
+            group_obj=cls.case_prop_group_obj
+        )
+        cls.case_prop_obj.save()
+        cls.client = Client()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.case_type_obj.delete()
+        cls.couch_user.delete(cls.domain_name, deleted_by=None)
+        cls.domain.delete()
+        super(DataDictionaryJsonTest, cls).tearDownClass()
+
+    def setUp(self):
+        self.endpoint = reverse('data_dictionary_json', args=[self.domain_name])
+
+    def test_no_access(self):
+        response = self.client.get(self.endpoint)
+        self.assertEqual(response.status_code, 302)
+
+    def test_get_json_success(self):
+        self.client.login(username='test', password='foobar')
+        response = self.client.get(self.endpoint)
+        self.assertEqual(response.status_code, 200)
+        expected_response = {
+            "case_types": [
+                {
+                    "name": "caseType",
+                    "fhir_resource_type": None,
+                    "groups": [
+                        {
+                            "id": self.case_prop_group_obj.id,
+                            "name": "group",
+                            "description": "",
+                            "deprecated": False,
+                            "properties": [
+                                {
+                                    "description": "",
+                                    "label": "",
+                                    "fhir_resource_prop_path": None,
+                                    "name": "property",
+                                    "deprecated": False,
+                                    "allowed_values": {},
+                                    "data_type": "number",
+                                },
+                            ],
+                        },
+                        {"name": "", "properties": []},
+                    ],
+                    "is_deprecated": False,
+                    "module_count": 0,
+                    "properties": [],
+                }
+            ]
+        }
+        self.assertEqual(response.json(), expected_response)

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from unittest.mock import patch
 
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -351,7 +352,8 @@ class DataDictionaryJsonTest(TestCase):
         response = self.client.get(self.endpoint)
         self.assertEqual(response.status_code, 302)
 
-    def test_get_json_success(self):
+    @patch('corehq.apps.data_dictionary.views.get_case_type_app_module_count', return_value={})
+    def test_get_json_success(self, *args):
         self.client.login(username='test', password='foobar')
         response = self.client.get(self.endpoint)
         self.assertEqual(response.status_code, 200)

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -238,10 +238,12 @@ def _export_data_dictionary(domain):
         _('Case Property'),
         _('Label'),
         _('Group'),
-        _('Data Type'),
         _('Description'),
         _('Deprecated')
     ]
+    if toggles.CASE_IMPORT_DATA_DICTIONARY_VALIDATION.enabled(domain):
+        case_prop_headers.append(_('Data Type'))
+
     allowed_value_headers = [_('Case Property'), _('Valid Value'), _('Valid Value Description')]
 
     case_type_data, case_prop_data = _generate_data_for_export(domain, export_fhir_data)
@@ -264,18 +266,19 @@ def _generate_data_for_export(domain, export_fhir_data):
             _('Case Property'): case_prop.name,
             _('Label'): case_prop.label,
             _('Group'): case_prop.group_name,
-            _('Data Type'): case_prop.get_data_type_display() if case_prop.data_type else '',
             _('Description'): case_prop.description,
             _('Deprecated'): case_prop.deprecated
         }
-        if case_prop.data_type == 'select':
-            prop_dict['allowed_values'] = [
-                {
-                    _('Case Property'): case_prop.name,
-                    _('Valid Value'): av.allowed_value,
-                    _('Valid Value Description'): av.description,
-                } for av in case_prop.allowed_values.all()
-            ]
+        if toggles.CASE_IMPORT_DATA_DICTIONARY_VALIDATION.enabled(domain):
+            prop_dict[_('Data Type')] = case_prop.get_data_type_display() if case_prop.data_type else ''
+            if case_prop.data_type == 'select':
+                prop_dict['allowed_values'] = [
+                    {
+                        _('Case Property'): case_prop.name,
+                        _('Valid Value'): av.allowed_value,
+                        _('Valid Value Description'): av.description,
+                    } for av in case_prop.allowed_values.all()
+                ]
         if export_fhir_data:
             prop_dict[_('FHIR Resource Property')] = fhir_resource_prop
         return prop_dict

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -449,11 +449,15 @@ class UploadDataDictionaryView(BaseProjectDataView):
     @method_decorator(atomic)
     def post(self, request, *args, **kwargs):
         bulk_file = self.request.FILES['bulk_upload_file']
-        errors = process_bulk_upload(bulk_file, self.domain)
+        errors, warnings = process_bulk_upload(bulk_file, self.domain)
         if errors:
             messages.error(request, _("Errors in upload: {}").format(
                 "<ul>{}</ul>".format("".join([f"<li>{e}</li>" for e in errors]))
             ), extra_tags="html")
         else:
             messages.success(request, _('Data dictionary import complete'))
+            if warnings:
+                messages.warning(request, _("Warnings in upload: {}").format(
+                    "<ul>{}</ul>".format("".join([f"<li>{e}</li>" for e in warnings]))
+                ), extra_tags="html")
         return self.get(request, *args, **kwargs)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Data Dictionary users will no longer see the "Data Type" and "Valid Values and Formats" columns when viewing case properties for a case type in the Data Dictionary. Furthermore, without the feature flag Data Dictionary exports will now no longer include the "Data  Type" column as well as the multi-choice sheet for each case type.

Warnings have been added when a user tries to import an Excel file containing either a "Data Type" column or multi-choice sheets:
![Screenshot from 2023-08-23 10-22-44](https://github.com/dimagi/commcare-hq/assets/122617251/98d9bab8-bb9b-49bb-bf01-a4d4300b6e1d)

These warnings are non-blocking, and so the user will still be able to successfully import their Excel file with these warnings present.

Documentation for the `CASE_IMPORT_DATA_DICTIONARY_VALIDATION` feature flag will be updated to reflect the new change from this PR.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2986).

This change hides the "Data Type" case property field behind a feature flag. Users will not be able to view or modify this column on domains that do not have the feature flag enabled. Additionally, since the "Valid Values and Formats" column is related to a case property's data type, this has been hidden behind the feature flag as well.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`CASE_IMPORT_DATA_DICTIONARY_VALIDATION`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Unit tests.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests do exist for public-facing data dictionary endpoints. I have added new tests to provide coverage to the `data_dictionary_json()` function, as well as testing imports/exports that do and do not contain the elements that have been put behind a feature flag.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
