### PR TITLE
Default case tile pagination in small screen to 5 per page

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -667,7 +667,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 currentPage: this.options.currentPage,
                 endPage: paginateItems.endPage,
                 pageCount: paginateItems.pageCount,
-                rowRange: [10, 25, 50, 100],
+                rowRange: [5, 10, 25, 50, 100],
                 limit: casesPerPage,
                 styles: this.options.styles,
                 breadcrumbs: this.options.breadcrumbs,
@@ -803,8 +803,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         templateContext: function () {
             const dict = CaseTileListView.__super__.templateContext.apply(this, arguments);
+            const casesPerPage = parseInt($.cookie("cases-per-page-limit")) || (this.smallScreenEnabled ? 5 : 10);
             dict.useTiles = true;
             dict.isMultiSelect = this.options.isMultiSelect;
+            dict.limit = casesPerPage;
             return dict;
         },
 


### PR DESCRIPTION
## Product Description
Adds "5 per page" option for web apps case lists and changes default cases per page limit to 5 when entering a case tile list in a small screen.

## Technical Summary
[USH-3515](https://dimagi-dev.atlassian.net/browse/USH-3515)
The 5 per page option is set here on load rather than being dynamic based on screen size as that could cause confusion when resizing windows. Keeps the existing behavior of using the cookie-set page limit if there is one.

NOTE: this WIP currently only changes the _display_ option for cases per page, not the pagination, unless "5 per page" is selected by the user

## Feature Flag
case_list_tile

## Safety Assurance

### Safety story
Changes are very straightforward and the modification to default page limit only affects the `CaseTileListView`.

### Automated test coverage
n/a

### QA Plan
QA as part of [USH-3485](https://dimagi-dev.atlassian.net/browse/USH-3485)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3515]: https://dimagi-dev.atlassian.net/browse/USH-3515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-3485]: https://dimagi-dev.atlassian.net/browse/USH-3485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ