### PR TITLE
fix issues with subscription-less domains

### DIFF
--- a/corehq/apps/domain/exceptions.py
+++ b/corehq/apps/domain/exceptions.py
@@ -8,3 +8,7 @@ class NameUnavailableException(Exception):
 
 class DomainDoesNotExist(Exception):
     pass
+
+
+class ErrorInitializingDomain(Exception):
+    pass

--- a/corehq/apps/registration/tests/test_utils.py
+++ b/corehq/apps/registration/tests/test_utils.py
@@ -95,6 +95,7 @@ class TestRequestNewDomain(TestCase):
         domain = Domain.get_by_name('subscription-failed')
         self.assertIsNone(domain)
 
+    @mock.patch('corehq.apps.registration.utils._setup_subscription', _noop)
     @mock.patch('corehq.apps.registration.utils.initialize_domain_with_default_roles', _issue_initializing_domain)
     @mock.patch('corehq.apps.registration.utils.notify_exception', _noop)
     def test_default_roles_exception_raises_error(self):

--- a/corehq/apps/registration/tests/test_utils.py
+++ b/corehq/apps/registration/tests/test_utils.py
@@ -51,6 +51,9 @@ class TestRequestNewDomain(TestCase):
         cls.new_user.delete(cls.domain_test, deleted_by=None)
         super().tearDownClass()
 
+    # if we don't patch the following, NoBrokersAvailable is thrown due to publish_domain_saved
+    @mock.patch('corehq.apps.registration.utils._setup_subscription', _noop)
+    @mock.patch('corehq.apps.registration.utils.notify_exception', _noop)
     def test_domain_is_active_for_new_sso_user(self):
         """
         Ensure that the first domain created by a new SSO user is active.
@@ -64,6 +67,9 @@ class TestRequestNewDomain(TestCase):
         domain = Domain.get_by_name(domain_name)
         self.assertTrue(domain.is_active)
 
+    # if we don't patch the following, NoBrokersAvailable is thrown due to publish_domain_saved
+    @mock.patch('corehq.apps.registration.utils._setup_subscription', _noop)
+    @mock.patch('corehq.apps.registration.utils.notify_exception', _noop)
     def test_domain_is_not_active_for_new_user(self):
         """
         Ensure that the first domain created by a new user is not active.

--- a/corehq/apps/registration/tests/test_utils.py
+++ b/corehq/apps/registration/tests/test_utils.py
@@ -84,7 +84,9 @@ class TestRequestNewDomain(TestCase):
 
     @mock.patch('corehq.apps.registration.utils._setup_subscription', _issue_initializing_domain)
     @mock.patch('corehq.apps.registration.utils.notify_exception', _noop)
-    def test_subscription_exception_raises_error(self):
+    def test_subscription_exception_raises_error_and_domain_is_deleted(self):
+        # We want to ensure that errors during the Subscription initialization process
+        # do not result in incomplete domains (a domain without a Subscription)
         with self.assertRaisesMessage(ErrorInitializingDomain,
                                       "Subscription setup failed for 'subscription-failed'"):
             request_new_domain(

--- a/corehq/apps/registration/tests/test_utils.py
+++ b/corehq/apps/registration/tests/test_utils.py
@@ -94,17 +94,3 @@ class TestRequestNewDomain(TestCase):
             )
         domain = Domain.get_by_name('subscription-failed')
         self.assertIsNone(domain)
-
-    @mock.patch('corehq.apps.registration.utils._setup_subscription', _noop)
-    @mock.patch('corehq.apps.registration.utils.initialize_domain_with_default_roles', _issue_initializing_domain)
-    @mock.patch('corehq.apps.registration.utils.notify_exception', _noop)
-    def test_default_roles_exception_raises_error(self):
-        with self.assertRaisesMessage(ErrorInitializingDomain,
-                                      "Subscription setup failed for 'init-default-roles-failed'"):
-            request_new_domain(
-                self.request,
-                'init-default-roles-failed',
-                is_new_user=True,
-            )
-        domain = Domain.get_by_name('init-default-roles-failed')
-        self.assertIsNone(domain)

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -13,6 +13,7 @@ from corehq.apps.users.role_utils import initialize_domain_with_default_roles
 from corehq.util.soft_assert import soft_assert
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.couch.database import get_safe_write_kwargs
+from dimagi.utils.logging import notify_exception
 from dimagi.utils.name_to_url import name_to_url
 from dimagi.utils.web import get_ip, get_url_base, get_static_url_prefix
 
@@ -34,6 +35,7 @@ from corehq.apps.analytics.tasks import (
     HUBSPOT_CREATED_NEW_PROJECT_SPACE_FORM_ID,
     send_hubspot_form,
 )
+from corehq.apps.domain.exceptions import ErrorInitializingDomain
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.tasks import send_html_email_async, send_mail_async
 from corehq.apps.registration.models import RegistrationRequest
@@ -144,9 +146,31 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
     dom_req.domain = new_domain.name
 
     if not settings.ENTERPRISE_MODE:
-        _setup_subscription(new_domain.name, current_user)
+        try:
+            _setup_subscription(new_domain.name, current_user)
+        except Exception as error:
+            notify_exception(request, "Error initializing subscription for new domain", details={
+                'domain': new_domain.name,
+                'hr_name': project_name,
+                'creating_user': current_user.username,
+                'first_domain_for_user': is_new_user,
+                'error': str(error),
+            })
+            new_domain.delete()
+            raise ErrorInitializingDomain(f"Subscription setup failed for '{name}'")
 
-    initialize_domain_with_default_roles(new_domain.name)
+    try:
+        initialize_domain_with_default_roles(new_domain.name)
+    except Exception as error:
+        notify_exception(request, "Error initializing default roles for new domain", details={
+            'domain': new_domain.name,
+            'hr_name': project_name,
+            'creating_user': current_user.username,
+            'first_domain_for_user': is_new_user,
+            'error': str(error),
+        })
+        new_domain.delete()
+        raise ErrorInitializingDomain(f"Default Roles initialization failed for '{name}'")
 
     if request.user.is_authenticated:
         if not current_user:

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -159,18 +159,7 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
             new_domain.delete()
             raise ErrorInitializingDomain(f"Subscription setup failed for '{name}'")
 
-    try:
-        initialize_domain_with_default_roles(new_domain.name)
-    except Exception as error:
-        notify_exception(request, "Error initializing default roles for new domain", details={
-            'domain': new_domain.name,
-            'hr_name': project_name,
-            'creating_user': current_user.username,
-            'first_domain_for_user': is_new_user,
-            'error': str(error),
-        })
-        new_domain.delete()
-        raise ErrorInitializingDomain(f"Default Roles initialization failed for '{name}'")
+    initialize_domain_with_default_roles(new_domain.name)
 
     if request.user.is_authenticated:
         if not current_user:

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -149,6 +149,10 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
         try:
             _setup_subscription(new_domain.name, current_user)
         except Exception as error:
+            # any error thrown in this process will cause the transaction.atomic() block that
+            # the subscription setup is wrapped in to fail and any SQL changes related to the subscription
+            # to roll back. Since we don't want a Subscription-less domain to exist, we should raise the
+            # error and delete the domain.
             notify_exception(request, "Error initializing subscription for new domain", details={
                 'domain': new_domain.name,
                 'hr_name': project_name,

--- a/corehq/apps/sso/utils/login_helpers.py
+++ b/corehq/apps/sso/utils/login_helpers.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.utils.translation import gettext as _
 
-from corehq.apps.domain.exceptions import NameUnavailableException
+from corehq.apps.domain.exceptions import NameUnavailableException, ErrorInitializingDomain
 from corehq.apps.registration.models import AsyncSignupRequest
 from corehq.apps.registration.utils import request_new_domain
 
@@ -26,4 +26,12 @@ def process_async_signup_requests(request, user):
                   "because the name was already taken."
                   "Please contact support.")
             )
+        except ErrorInitializingDomain:
+            messages.error(
+                request,
+                _("We were unable to create your requested project "
+                  "due to an unexpected issue. Please try again in a few minutes."
+                  "If the issue persists, please contact support.")
+            )
+
     AsyncSignupRequest.clear_data_for_username(user.username)

--- a/corehq/apps/sso/utils/login_helpers.py
+++ b/corehq/apps/sso/utils/login_helpers.py
@@ -23,8 +23,7 @@ def process_async_signup_requests(request, user):
             messages.error(
                 request,
                 _("We were unable to create your requested project "
-                  "because the name was already taken."
-                  "Please contact support.")
+                  "because the name was already taken.")
             )
         except ErrorInitializingDomain:
             messages.error(


### PR DESCRIPTION
## Technical Summary
This addresses the bug in this ticket: https://dimagi-dev.atlassian.net/browse/SAAS-13909

What's going on is that the domain creation depends on multiple systems, and if any one of those systems errors out, we have an inconsistent domain setup.

The domain is first created in couch. After that we have the initial subscription creation happening in a `transaction.atomic()` block. If postgres was unavailable or unreachable during the domain setup it would throw a 500 error and roll back all the SQL related changes in the block. However, since the domain lives in couchdb, it remains.

I also discovered during testing that if [this bit of code](https://github.com/dimagi/commcare-hq/blob/bf4655c601521de99b06f5730c3b5acd5ec40ffd/corehq/apps/accounting/models.py#L1187) is called and Kafka is unreachable for some reason, a `NoBrokerAvailable` error is thrown, which also kills the whole `transaction.atomic()` block.

These changes:
- communicate a more useful message to the user when unexpected errors arise due to infrastructure issues
- deletes the domain that the user was trying to create so that the system is not in an inconsistent state and the user can try creating the domain again without finding that the domain name is already taken
- `notify_exception` with additional information about the errors so that we can followup if necessary

## Safety Assurance

### Safety story
This change is already an improvement on the 500s that would be thrown to the user if an error did occur. Adding `notify_exception` is a safe change and we also have tests to ensure this works as expected.

### Automated test coverage
Yes

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
