### PR TITLE
Fix bug affecting multiple files with the precommit hook

### DIFF
--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -50,9 +50,9 @@ fi
 status=0
 git diff-index --check --cached $against --
 if [ $? != 0 ]; then status=1; fi
-pyfiles=$(git diff --staged --name-only | grep "\.py$")
+pyfiles=($(git diff --staged --name-only | grep "\.py$"))
 if [ -n "$pyfiles" ]; then
-    flake8 --show-source --config=.flake8 "$pyfiles"
+    flake8 --show-source --config=.flake8 "${pyfiles[@]}"
 	if [ $? != 0 ]; then status=1; fi
 fi
 


### PR DESCRIPTION
## Technical Summary
If multiple files were modified, the previous syntax was creating an error, as flake8 was interpreting them all as a single file.

## Safety Assurance

### Safety story
Locally tested

### Automated test coverage

N/A

### QA Plan
No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
