### PR TITLE
(FF) Add Export Datasource Data page

### DIFF
--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -163,7 +163,7 @@ def generate_from_datasource_export_instance(export_instance, output_file):
         name=input_table.label,
         source=UCR_SOURCE,
         filter_name='data_source_id',
-        filter_value=export_instance.config.data_source_id,
+        filter_value=export_instance.data_source_id,
         rows=[],
     )
     _add_rows_for_table(input_table, output_table, helper=DatasourceDETSchemaHelper())

--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -15,6 +15,7 @@ PROPERTIES_PREFIX = 'properties.'
 ID_FIELD = 'id'
 FORM_ID_SOURCE = 'id'
 CASE_ID_SOURCE = 'case_id'
+DATASOURCE_ID_SOURCE = 'doc_id'
 
 CASE_SOURCE = 'case'
 FORM_SOURCE = 'form'
@@ -167,6 +168,7 @@ def generate_from_datasource_export_instance(export_instance, output_file):
         rows=[],
     )
     _add_rows_for_table(input_table, output_table, helper=DatasourceDETSchemaHelper())
+    _add_id_row_if_necessary(output_table, DATASOURCE_ID_SOURCE)
 
     output = DETConfig(name=export_instance.name, tables=[output_table])
     output.export_to_file(output_file)

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -1108,7 +1108,7 @@ class DatasourceExportDownloadForm(forms.Form):
                     _("Download Data Export Tool query file"),
                     type="submit",
                     css_class="btn-primary",
-                    id="datasources_export_submit_button_id"
+                    data_bind="enable: haveDatasources"
                 ),
             )
         )

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -1079,7 +1079,7 @@ class FilterSmsESExportDownloadForm(BaseFilterExportDownloadForm):
 class DatasourceExportDownloadForm(forms.Form):
 
     data_source = forms.ChoiceField(
-        label=gettext_lazy("Select project datasource"),
+        label=gettext_lazy("Select project data source"),
         required=True,
     )
 

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -1105,7 +1105,7 @@ class DatasourceExportDownloadForm(forms.Form):
             ),
             hqcrispy.FormActions(
                 StrictButton(
-                    _("Download DET Config file"),
+                    _("Download Data Export Tool query file"),
                     type="submit",
                     css_class="btn-primary",
                     id="datasources_export_submit_button_id"

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -8,6 +8,9 @@ from django.utils.translation import gettext_lazy
 
 import dateutil
 from crispy_forms import layout as crispy
+from crispy_forms.helper import FormHelper
+from corehq.apps.hqwebapp import crispy as hqcrispy
+from crispy_forms.bootstrap import StrictButton
 
 from corehq import privileges
 from dimagi.utils.dates import DateSpan
@@ -51,6 +54,7 @@ from corehq.apps.reports.models import HQUserType
 from corehq.apps.reports.util import datespan_from_beginning
 from corehq.toggles import FILTER_ON_GROUPS_AND_LOCATIONS
 from corehq.util import flatten_non_iterable_list
+from corehq.apps.userreports.dbaccessors import get_datasources_for_domain
 
 
 class DateSpanField(forms.CharField):
@@ -1070,3 +1074,45 @@ class FilterSmsESExportDownloadForm(BaseFilterExportDownloadForm):
                 data_bind='value: dateRange',
             ),
         ]
+
+
+class DatasourceExportDownloadForm(forms.Form):
+
+    data_source = forms.ChoiceField(
+        label=gettext_lazy("Select project datasource"),
+        required=True,
+    )
+
+    def __init__(self, domain, *args, **kwargs):
+        super(DatasourceExportDownloadForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.label_class = 'col-sm-3 col-md-2 col-lg-2'
+        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-3'
+
+        self.fields['data_source'].choices = self.domain_datasources(domain)
+
+        self.helper.layout = crispy.Layout(
+            crispy.Fieldset(
+                "",
+                crispy.Div(
+                    crispy.Field(
+                        'data_source',
+                        css_class='input-xlarge',
+                        data_bind='value: dataSource'
+                    ),
+                    data_bind='visible: haveDatasources'
+                ),
+            ),
+            hqcrispy.FormActions(
+                StrictButton(
+                    _("Download DET file"),
+                    type="submit",
+                    css_class="btn-primary",
+                    id="datasources_export_submit_button_id"
+                ),
+            )
+        )
+
+    @staticmethod
+    def domain_datasources(domain):
+        return [(ds.data_source_id, ds.display_name) for ds in get_datasources_for_domain(domain)]

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -1105,7 +1105,7 @@ class DatasourceExportDownloadForm(forms.Form):
             ),
             hqcrispy.FormActions(
                 StrictButton(
-                    _("Download DET file"),
+                    _("Download DET Config file"),
                     type="submit",
                     css_class="btn-primary",
                     id="datasources_export_submit_button_id"

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from .new import (
     CASE_HISTORY_TABLE,
     MAIN_TABLE,

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -41,6 +41,7 @@ from .new import (
     StockItem,
     TableConfiguration,
     UserDefinedExportColumn,
+    DataSourceExportInstance,
 )
 
 from .export_settings import (

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -3108,3 +3108,28 @@ PARENT_CASE_TABLE = [PathNode(name='indices', is_repeat=True)]
 
 # Used to identify tables in a bulk case export
 ALL_CASE_TYPE_TABLE = PathNode(name=ALL_CASE_TYPE_EXPORT)
+
+
+def get_datasource_export_from_config(config):
+    from corehq.apps.userreports.util import get_indicator_adapter
+    adapter = get_indicator_adapter(config)
+    table = adapter.get_table()
+
+    def get_export_column(column):
+        return ExportColumn(
+            label=column.id,
+            item=ExportItem(
+                path=[PathNode(name=column.id)],
+                label=column.id,
+                datatype=column.datatype,
+            ),
+            selected=True,
+        )
+
+    return TableConfiguration(
+        label=table.name,
+        columns=[
+            get_export_column(col)
+            for _, col in config.columns_by_id.items()
+        ],
+    )

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -118,7 +118,6 @@ from corehq.util.timezones.utils import get_timezone_for_domain
 from corehq.util.view_utils import absolute_reverse
 from corehq.apps.data_dictionary.util import get_deprecated_fields
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain
-from corehq.apps.userreports.models import DataSourceConfiguration
 from corehq.apps.userreports.util import get_indicator_adapter
 
 
@@ -1374,7 +1373,7 @@ class SMSExportInstance(ExportInstance):
 
 class DataSourceExportInstance(ExportInstance):
     type = 'datasource'
-    config = SchemaProperty(DataSourceConfiguration)
+    data_source_id = StringProperty()
 
 
 class ExportInstanceDefaults(object):
@@ -3144,5 +3143,5 @@ def datasource_export_instance(config):
                 ],
             )
         ],
-        config=config,
+        data_source_id=config.data_source_id,
     )

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -3140,7 +3140,7 @@ def datasource_export_instance(config):
                 label=table.name,
                 columns=[
                     get_export_column(col)
-                    for _, col in config.columns_by_id.items()
+                    for col in config.columns_by_id.values()
                 ],
             )
         ],

--- a/corehq/apps/export/static/export/js/datasource_export.js
+++ b/corehq/apps/export/static/export/js/datasource_export.js
@@ -1,0 +1,27 @@
+hqDefine("export/js/datasource_export",[
+    'jquery',
+    'knockout',
+    'hqwebapp/js/initial_page_data',
+], function ($, ko, initialPageData) {
+
+     function datasourceExportViewModel () {
+        'use strict';
+        var self = {};
+
+        self.dataSource = ko.observable();
+        self.haveDatasources = ko.computed(function () {
+           if (self.dataSource() == undefined) { return false; }
+             return self.dataSource().length > 0;
+        });
+        self.updateExportButton = ko.computed(function () {
+            $("#datasources_export_submit_button_id").prop('disabled', !self.haveDatasources());
+        });
+
+        return self;
+     }
+
+     $(function () {
+        var datasourceExportModel = datasourceExportViewModel();
+        $("#datasources_export_id").koApplyBindings(datasourceExportModel);
+     });
+});

--- a/corehq/apps/export/static/export/js/datasource_export.js
+++ b/corehq/apps/export/static/export/js/datasource_export.js
@@ -11,9 +11,6 @@ hqDefine("export/js/datasource_export",[
         self.haveDatasources = ko.computed(function () {
             return self.dataSource() !== undefined && self.dataSource().length;
         });
-        self.updateExportButton = ko.computed(function () {
-            $("#datasources_export_submit_button_id").prop('disabled', !self.haveDatasources());
-        });
 
         return self;
     }

--- a/corehq/apps/export/static/export/js/datasource_export.js
+++ b/corehq/apps/export/static/export/js/datasource_export.js
@@ -1,27 +1,26 @@
 hqDefine("export/js/datasource_export",[
     'jquery',
     'knockout',
-    'hqwebapp/js/initial_page_data',
-], function ($, ko, initialPageData) {
+], function ($, ko) {
 
-     function datasourceExportViewModel () {
+    function datasourceExportViewModel() {
         'use strict';
         var self = {};
 
         self.dataSource = ko.observable();
         self.haveDatasources = ko.computed(function () {
-           if (self.dataSource() == undefined) { return false; }
-             return self.dataSource().length > 0;
+            if (self.dataSource() === undefined) { return false; }
+            return self.dataSource().length > 0;
         });
         self.updateExportButton = ko.computed(function () {
             $("#datasources_export_submit_button_id").prop('disabled', !self.haveDatasources());
         });
 
         return self;
-     }
+    }
 
-     $(function () {
+    $(function () {
         var datasourceExportModel = datasourceExportViewModel();
         $("#datasources_export_id").koApplyBindings(datasourceExportModel);
-     });
+    });
 });

--- a/corehq/apps/export/static/export/js/datasource_export.js
+++ b/corehq/apps/export/static/export/js/datasource_export.js
@@ -9,8 +9,7 @@ hqDefine("export/js/datasource_export",[
 
         self.dataSource = ko.observable();
         self.haveDatasources = ko.computed(function () {
-            if (self.dataSource() === undefined) { return false; }
-            return self.dataSource().length > 0;
+            return self.dataSource() !== undefined && self.dataSource().length;
         });
         self.updateExportButton = ko.computed(function () {
             $("#datasources_export_submit_button_id").prop('disabled', !self.haveDatasources());

--- a/corehq/apps/export/templates/export/datasource_export_view.html
+++ b/corehq/apps/export/templates/export/datasource_export_view.html
@@ -7,13 +7,13 @@
 {% requirejs_main 'export/js/datasource_export' %}
 
 {% block page_title %}
-{% trans "Export Datasource Data" %}
+{% trans "Export Data Source Data" %}
 {% endblock %}
 
 {% block page_content %}
   <p>
     {% blocktrans %}
-    Generate a DET query file from any of the project's datasources.
+    Generate a DET query file from any of the project's data sources.
     {% endblocktrans %}
   </p>
   <div id="datasources_export_id" class="form form-horizontal">

--- a/corehq/apps/export/templates/export/datasource_export_view.html
+++ b/corehq/apps/export/templates/export/datasource_export_view.html
@@ -1,0 +1,27 @@
+{%  extends 'hqwebapp/bootstrap3/base_section.html' %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% load compress %}
+{% load hq_shared_tags %}
+
+{% requirejs_main 'export/js/datasource_export' %}
+
+{% block page_title %}
+{% trans "Export Datasource Data" %}
+{% endblock %}
+
+{% block page_content %}
+  <p>
+    {% blocktrans %}
+    Generate a DET query file from any of the project's datasources.
+    {% endblocktrans %}
+  </p>
+  <div id="datasources_export_id" class="form form-horizontal">
+    <div data-bind='hidden: haveDatasources'>
+      {% blocktrans %}
+      The project have no datasources configured.
+      {% endblocktrans %}
+    </div>
+    {% crispy form %}
+  </div>
+{% endblock %}

--- a/corehq/apps/export/templates/export/datasource_export_view.html
+++ b/corehq/apps/export/templates/export/datasource_export_view.html
@@ -19,7 +19,7 @@
   <div id="datasources_export_id" class="form form-horizontal">
     <div data-bind='hidden: haveDatasources'>
       {% blocktrans %}
-      The project has no datasources configured.
+      The project has no data sources configured.
       {% endblocktrans %}
     </div>
     {% crispy form %}

--- a/corehq/apps/export/templates/export/datasource_export_view.html
+++ b/corehq/apps/export/templates/export/datasource_export_view.html
@@ -13,7 +13,7 @@
 {% block page_content %}
   <p>
     {% blocktrans %}
-    Generate a DET query file from any of the project's data sources.
+    Generate a query file for the Data Export Tool from any of the project's data sources.
     {% endblocktrans %}
   </p>
   <div id="datasources_export_id" class="form form-horizontal">

--- a/corehq/apps/export/templates/export/datasource_export_view.html
+++ b/corehq/apps/export/templates/export/datasource_export_view.html
@@ -19,7 +19,7 @@
   <div id="datasources_export_id" class="form form-horizontal">
     <div data-bind='hidden: haveDatasources'>
       {% blocktrans %}
-      The project have no datasources configured.
+      The project has no datasources configured.
       {% endblocktrans %}
     </div>
     {% crispy form %}

--- a/corehq/apps/export/tests/test_det_schema_generation.py
+++ b/corehq/apps/export/tests/test_det_schema_generation.py
@@ -231,12 +231,13 @@ class TestDatasourceInstance(SimpleTestCase, TestFileMixin):
             data_by_headings = [dict(zip(headings, row)) for row in ws_data]
 
             self.assertEqual(data_by_headings[0]['Data Source'], "ucr")
-            self.assertEqual(data_by_headings[1]['Source Field'], "inserted_at")
-            self.assertEqual(data_by_headings[1]['Map Via'], "str2date")
-            self.assertEqual(data_by_headings[2]['Source Field'], "name_string")
-            self.assertEqual(data_by_headings[3]['Source Field'], "computed_owner_name")
-            self.assertEqual(data_by_headings[4]['Source Field'], "age_string")
-            self.assertEqual(data_by_headings[5]['Source Field'], "closed_string")
+            self.assertEqual(data_by_headings[1]['Source Field'], "doc_id")
+            self.assertEqual(data_by_headings[2]['Source Field'], "inserted_at")
+            self.assertEqual(data_by_headings[2]['Map Via'], "str2date")
+            self.assertEqual(data_by_headings[3]['Source Field'], "name_string")
+            self.assertEqual(data_by_headings[4]['Source Field'], "computed_owner_name")
+            self.assertEqual(data_by_headings[5]['Source Field'], "age_string")
+            self.assertEqual(data_by_headings[6]['Source Field'], "closed_string")
 
     @classmethod
     def _sample_data_source_dict(cls):

--- a/corehq/apps/export/tests/test_det_schema_generation.py
+++ b/corehq/apps/export/tests/test_det_schema_generation.py
@@ -8,11 +8,15 @@ from openpyxl import load_workbook
 
 from corehq.apps.export.det.exceptions import DETConfigError
 from corehq.apps.export.det.schema_generator import (
+    FormDETSchemaHelper,
     generate_from_form_export_instance,
     generate_from_case_export_instance,
-    FormDETSchemaHelper)
+    generate_from_datasource_export_instance,
+)
 from corehq.apps.export.models import FormExportInstance, CaseExportInstance
 from corehq.util.test_utils import TestFileMixin
+from corehq.apps.userreports.models import DataSourceConfiguration
+from corehq.apps.export.models.new import datasource_export_instance
 
 
 class TestDETFCaseInstance(SimpleTestCase, TestFileMixin):
@@ -202,3 +206,120 @@ class TestDETFormInstanceWithRepeat(SimpleTestCase, TestFileMixin):
         self.assertEqual('form.form.children[*]', rows_by_headings[0]['Data Source'])
         self.assertEqual('child_name', rows_by_headings[1]['Source Field'])
         self.assertEqual('child_dob', rows_by_headings[2]['Source Field'])
+
+
+class TestDatasourceInstance(SimpleTestCase, TestFileMixin):
+
+    domain = "test-domain"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.config = DataSourceConfiguration(**cls._sample_data_source_dict())
+
+    def test_generate_from_datasource_export_instance(self):
+        export_instance = datasource_export_instance(self.config)
+
+        with tempfile.NamedTemporaryFile(mode='wb', suffix='.xlsx') as tmp:
+            generate_from_datasource_export_instance(export_instance, tmp)
+            wb = load_workbook(filename=tmp.name)
+
+            self.assertEqual(len(wb.worksheets), 1)
+            ws = wb.worksheets[0]
+            ws_data = list(ws.values)
+            headings = ws_data.pop(0)
+            data_by_headings = [dict(zip(headings, row)) for row in ws_data]
+
+            self.assertEqual(data_by_headings[0]['Data Source'], "ucr")
+            self.assertEqual(data_by_headings[1]['Source Field'], "inserted_at")
+            self.assertEqual(data_by_headings[1]['Map Via'], "str2date")
+            self.assertEqual(data_by_headings[2]['Source Field'], "name_string")
+            self.assertEqual(data_by_headings[3]['Source Field'], "computed_owner_name")
+            self.assertEqual(data_by_headings[4]['Source Field'], "age_string")
+            self.assertEqual(data_by_headings[5]['Source Field'], "closed_string")
+
+    @classmethod
+    def _sample_data_source_dict(cls):
+        return {
+            'domain': cls.domain,
+            'table_id': 'table_id',
+            'display_name': 'Test datasource',
+            'referenced_doc_type': 'CommCareCase',
+            'configured_filter': {
+                'type': 'boolean_expression',
+                'operator': 'eq',
+                'expression': {
+                    'type': 'property_name',
+                    'property_name': 'type',
+                    'datatype': None
+                },
+                'property_value': 'case',
+                'comment': None
+            },
+            'configured_indicators': [
+                {
+                    'type': 'expression',
+                    'column_id': 'name_string',
+                    'datatype': 'string',
+                    'display_name': 'name',
+                    'expression': {
+                        'type': 'property_name',
+                        'property_name': 'name',
+                        'datatype': None
+                    },
+                    'is_nullable': True,
+                    'is_primary_key': False,
+                    'create_index': False,
+                    'transform': {},
+                    'comment': None
+                },
+                {
+                    'datatype': 'string',
+                    'type': 'expression',
+                    'column_id': 'computed_owner_name',
+                    'expression': {
+                        'type': 'property_name',
+                        'property_name': 'owner_id',
+                        'datatype': 'string'
+                    },
+                    'is_nullable': True,
+                    'is_primary_key': False,
+                    'create_index': False,
+                    'transform': {},
+                    'display_name': None,
+                    'comment': None
+                },
+                {
+                    'type': 'expression',
+                    'column_id': 'age_string',
+                    'datatype': 'string',
+                    'display_name': 'age',
+                    'expression': {
+                        'type': 'property_name',
+                        'property_name': 'age',
+                        'datatype': None
+                    },
+                    'is_nullable': True,
+                    'is_primary_key': False,
+                    'create_index': False,
+                    'transform': {},
+                    'comment': None
+                },
+                {
+                    'type': 'expression',
+                    'column_id': 'closed_string',
+                    'datatype': 'string',
+                    'display_name': 'closed',
+                    'expression': {
+                        'type': 'property_name',
+                        'property_name': 'closed',
+                        'datatype': None
+                    },
+                    'is_nullable': True,
+                    'is_primary_key': False,
+                    'create_index': False,
+                    'transform': {},
+                    'comment': None
+                }
+            ],
+        }

--- a/corehq/apps/export/urls.py
+++ b/corehq/apps/export/urls.py
@@ -6,6 +6,7 @@ from corehq.apps.export.views.download import (
     DownloadNewCaseExportView,
     DownloadNewFormExportView,
     DownloadNewSmsExportView,
+    DownloadNewDatasourceExportView,
     add_export_email_request,
     has_multimedia,
     poll_custom_export_download,
@@ -142,6 +143,9 @@ urlpatterns = [
     url(r"^custom/new/sms/download/$",
         DownloadNewSmsExportView.as_view(),
         name=DownloadNewSmsExportView.urlname),
+    url(r"^custom/new/datasource/download/$",
+        DownloadNewDatasourceExportView.as_view(),
+        name=DownloadNewDatasourceExportView.urlname),
 
     # Schema Download views
     url(r"^custom/schema/det/download/(?P<export_instance_id>[\w\-]+)/$",

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -50,6 +50,7 @@ from corehq.apps.export.forms import (
     EmwfFilterFormExport,
     FilterCaseESExportDownloadForm,
     FilterSmsESExportDownloadForm,
+    DatasourceExportDownloadForm,
 )
 from corehq.apps.export.models import FormExportInstance
 from corehq.apps.export.models.new import EmailExportWhenDoneRequest
@@ -72,6 +73,7 @@ from corehq.apps.settings.views import BaseProjectDataView
 from corehq.apps.users.models import CouchUser
 from corehq.toggles import PAGINATED_EXPORTS
 from corehq.util.view_utils import is_ajax
+from corehq.toggles import EXPORT_DATA_SOURCE_DATA
 
 
 class DownloadExportViewHelper(object):
@@ -517,6 +519,33 @@ class DownloadNewCaseExportView(BaseDownloadExportView):
             'title': CaseExportListView.page_title,
             'url': reverse(CaseExportListView.urlname, args=(self.domain,)),
         }]
+
+
+@location_safe
+class DownloadNewDatasourceExportView(BaseProjectDataView):
+    urlname = "data_export_page"
+    page_title = gettext_noop("Export Datasource Data")
+    template_name = 'export/datasource_export_view.html'
+
+    def dispatch(self, *args, **kwargs):
+        if not EXPORT_DATA_SOURCE_DATA.enabled(self.domain):
+            raise Http404()
+        return super(DownloadNewDatasourceExportView, self).dispatch(*args, **kwargs)
+
+    @property
+    def page_context(self):
+        context = super(DownloadNewDatasourceExportView, self).page_context
+        context["form"] = self.form
+        return context
+
+    def post(self, request, *args, **kwargs):
+        ...
+
+    @property
+    def form(self):
+        if self.request.method == 'POST':
+            ...
+        return DatasourceExportDownloadForm(self.domain)
 
 
 class DownloadNewSmsExportView(BaseDownloadExportView):

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -527,7 +527,7 @@ class DownloadNewCaseExportView(BaseDownloadExportView):
 @location_safe
 class DownloadNewDatasourceExportView(BaseProjectDataView):
     urlname = "data_export_page"
-    page_title = gettext_noop("Export Datasource Data")
+    page_title = gettext_noop("Export Data Source Data")
     template_name = 'export/datasource_export_view.html'
 
     def dispatch(self, *args, **kwargs):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -211,8 +211,7 @@ class DataSourceBuildInformation(DocumentSchema):
         Returns ``True`` if the rebuild failed, ``False`` if it succeeded
         or has not yet failed, or ``None`` if Flower is not available.
         """
-        # flower_url = getattr(settings, 'CELERY_FLOWER_URL')
-        flower_url = None
+        flower_url = getattr(settings, 'CELERY_FLOWER_URL')
 
         def none_max(a, b):
             if a is None:

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -211,7 +211,8 @@ class DataSourceBuildInformation(DocumentSchema):
         Returns ``True`` if the rebuild failed, ``False`` if it succeeded
         or has not yet failed, or ``None`` if Flower is not available.
         """
-        flower_url = getattr(settings, 'CELERY_FLOWER_URL')
+        # flower_url = getattr(settings, 'CELERY_FLOWER_URL')
+        flower_url = None
 
         def none_max(a, b):
             if a is None:

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -507,6 +507,15 @@ class ProjectDataTab(UITab):
 
     @property
     @memoized
+    def can_export_data_source(self):
+        return (
+            toggles.EXPORT_DATA_SOURCE_DATA.enabled(self.domain)
+            and self.can_view_case_exports
+            and self.can_view_form_exports
+        )
+
+    @property
+    @memoized
     def should_see_daily_saved_export_list_view(self):
         return (
             self.can_view_form_or_case_exports
@@ -756,7 +765,7 @@ class ProjectDataTab(UITab):
                         ] if _f]
                     })
 
-            if toggles.EXPORT_DATA_SOURCE_DATA and self.can_view_case_exports and self.can_view_form_exports:
+            if self.can_export_data_source:
                 export_data_views.append(
                     {
                         'title': _(DownloadNewDatasourceExportView.page_title),

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -670,6 +670,7 @@ class ProjectDataTab(UITab):
                 DownloadNewCaseExportView,
                 DownloadNewFormExportView,
                 DownloadNewSmsExportView,
+                DownloadNewDatasourceExportView,
             )
             from corehq.apps.export.views.edit import (
                 EditCaseDailySavedExportView,
@@ -753,6 +754,16 @@ class ProjectDataTab(UITab):
                                 'urlname': EditNewCustomCaseExportView.urlname,
                             } if self.can_edit_commcare_data else None,
                         ] if _f]
+                    })
+
+            if toggles.EXPORT_DATA_SOURCE_DATA and self.can_view_case_exports and self.can_view_form_exports:
+                export_data_views.append(
+                    {
+                        'title': _(DownloadNewDatasourceExportView.page_title),
+                        'url': reverse(DownloadNewDatasourceExportView.urlname,
+                                       args=(self.domain,)),
+                        'show_in_dropdown': True,
+                        'icon': 'icon icon-share fa fa-database',
                     })
 
             if self.can_view_sms_exports:

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1400,8 +1400,7 @@ EXPORT_DATA_SOURCE_DATA = StaticToggle(
     'Add Export Data Source Data page',
     TAG_SOLUTIONS_OPEN,
     [NAMESPACE_USER, NAMESPACE_DOMAIN],
-    description=("This flag makes failed messages appear in the Message Log "
-                 "Report, and adds Status and Event columns"),
+    description="Add the Export Data Source Data page to the Data tab",
 )
 
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1395,6 +1395,16 @@ SMS_LOG_CHANGES = StaticToggle(
                  "Report, and adds Status and Event columns"),
 )
 
+EXPORT_DATA_SOURCE_DATA = StaticToggle(
+    'export_data_source_data',
+    'Add Export Data Source Data page',
+    TAG_CUSTOM,
+    [NAMESPACE_USER, NAMESPACE_DOMAIN],
+    description=("This flag makes failed messages appear in the Message Log "
+                 "Report, and adds Status and Event columns"),
+)
+
+
 ENABLE_INCLUDE_SMS_GATEWAY_CHARGING = StaticToggle(
     'enable_include_sms_gateway_charging',
     'Enable include SMS gateway charging',

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1398,7 +1398,7 @@ SMS_LOG_CHANGES = StaticToggle(
 EXPORT_DATA_SOURCE_DATA = StaticToggle(
     'export_data_source_data',
     'Add Export Data Source Data page',
-    TAG_CUSTOM,
+    TAG_SOLUTIONS_OPEN,
     [NAMESPACE_USER, NAMESPACE_DOMAIN],
     description=("This flag makes failed messages appear in the Message Log "
                  "Report, and adds Status and Event columns"),


### PR DESCRIPTION
## Product Description
The user will be presented with a new page (behind FF), called `Export Datasource Data`, situated below `Export Case Data`. 

An example of what this looks like can be seen below. This page simply allows a user to download a DET query file based on the selected project data source.

#### With data sources on project

![image](https://github.com/dimagi/commcare-hq/assets/44245062/9e2ed052-4226-4165-ae09-043aea280d98)


#### Without data sources on project

![image](https://github.com/dimagi/commcare-hq/assets/44245062/f6e6bf0d-320d-48f3-94db-163b9af071a5)


## Technical Summary
In order to reuse the current implementation of the DET export (i.e. `generate_from_export_instance`), the selected data source configuration is wrapped as an `ExportInstance`. The [datasource_export_instance](https://github.com/dimagi/commcare-hq/blob/07c393992d50f4dc941be35aaa289644b8834ac8/corehq/apps/export/models/new.py#L3103) 
 and [generate_from_datasource_export_instance](https://github.com/dimagi/commcare-hq/blob/07c393992d50f4dc941be35aaa289644b8834ac8/corehq/apps/export/det/schema_generator.py#L158) functions are the important parts of this PR.

#### Why not use `DownloadExportViewHelper` as the other export classes do?
`DownloadExportViewHelper` is useful for tracking metrics whilst preparing the necessary exports, but this feature only adds the ability to create and download a DET query file which is not a resource intensive operation as it uses meta-data and not actual data to populate the query file. Also, given what this feature delivers, the effort and intrusiveness needed to conform the `DownloadExportViewHelper` and all it's associated files to support this new type of export (which is not really an export, only the DET query file generation part of the export feature) does not warrant the effort in my opinion.  

## Feature Flag
Add Export Data Source Data page

## Safety Assurance

### Safety story
Did local testing. Testing on staging will also be done manually.

### Automated test coverage
Added one automated test.

### QA Plan
Formal QA not planned.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
