### PR TITLE
Only add hidden input for form session endpoints if enabled

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -138,9 +138,11 @@
                                              selectedOptions: excludedFormIds"></select>
                     {# POST a value, even if no forms are excluded #}
                     <input name="excl_form_ids" type="checkbox" value="0" checked="">
-                    <div data-bind="foreach: formSessionEndpointIds()">
-                      <input type="hidden" name="form_session_endpoints" data-bind="value: $data">
-                    </div>
+                    {% if session_endpoints_enabled %}
+                      <div data-bind="foreach: formSessionEndpointIds()">
+                        <input type="hidden" name="form_session_endpoints" data-bind="value: $data">
+                      </div>
+                    {% endif %}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Product Description

When trying to save shadow menu without the "Enable Session Endpoints" feature flag enabled the user gets an error. This is because the form sends `form_session_endpoints` when it shouldn't confusing the validator.

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3562

https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/81/SUPPORT-17404

https://github.com/dimagi/commcare-hq/pull/33296

## Feature Flag

NOT "Enable session endpoints"

## Safety Assurance

### Safety story

Tested that I could not reproduce on staging after the change was deployed

### Automated test coverage

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
