### PR TITLE
Default case list pagination in small windows to 5 per page

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -123,7 +123,8 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                         defer.reject();
                     },
                 };
-                var casesPerPage = parseInt($.cookie("cases-per-page-limit")) || 10;
+                var casesPerPage = parseInt($.cookie("cases-per-page-limit"))
+                    || (window.innerWidth <= constants.SMALL_SCREEN_WIDTH_PX ? 5 : 10);
                 const data = {
                     "username": user.username,
                     "restoreAs": user.restoreAs,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -649,7 +649,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         templateContext: function () {
             const paginateItems = formplayerUtils.paginateOptions(this.options.currentPage, this.options.pageCount);
-            const casesPerPage = parseInt($.cookie("cases-per-page-limit")) || 10;
+            const casesPerPage = parseInt($.cookie("cases-per-page-limit")) || (this.smallScreenEnabled ? 5 : 10);
             const boldSortedCharIcon = (header) => {
                 const headerWords = header.trim().split(' ');
                 const lastChar = headerWords.pop();
@@ -667,7 +667,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 currentPage: this.options.currentPage,
                 endPage: paginateItems.endPage,
                 pageCount: paginateItems.pageCount,
-                rowRange: [10, 25, 50, 100],
+                rowRange: [5, 10, 25, 50, 100],
                 limit: casesPerPage,
                 styles: this.options.styles,
                 breadcrumbs: this.options.breadcrumbs,


### PR DESCRIPTION
## Product Description
Adds "5 per page" option for case list/tile pagination and changes default limit to 5 when using web apps in a small screen. Other numbers per page (10, 25, etc) are still able to be selected by the user.

## Technical Summary
[USH-3515](https://dimagi-dev.atlassian.net/browse/USH-3515)
The 5 per page option is set here when the request for cases is made to Formplayer and does not need to change dynamically, so it directly calls `window.innerWidth` rather than the `smallScreenEnabled` helper function. The `CaseListView` still calls its own property based on this helper function, since the property already exists on the view.
Keeps the existing behavior of using the cookie-set page limit if there is one, and falling back to 10-per-page on larger screens.

## Safety Assurance

### Safety story
Changes are very straightforward and the modification to default page limit only affects small screens. 

### Automated test coverage
n/a

### QA Plan
QA as part of [USH-3485](https://dimagi-dev.atlassian.net/browse/USH-3485)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3515]: https://dimagi-dev.atlassian.net/browse/USH-3515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-3485]: https://dimagi-dev.atlassian.net/browse/USH-3485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ