### PR TITLE
[B5] fix js flags in bootstrap 5 migration command

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -333,7 +333,7 @@ class Command(BaseCommand):
     def get_flags_in_javascript_line(javascript_line, spec):
         flags = flag_changed_javascript_plugins(javascript_line, spec)
         reference_flags = flag_path_references_to_migrated_javascript_files(javascript_line, "bootstrap3")
-        flags.append(reference_flags)
+        flags.extend(reference_flags)
         return flags
 
     @staticmethod


### PR DESCRIPTION
## Technical Summary
This fixes a very small but annoying bug in the bootstrap 5 migration command where I accidentally used `append` on the flag list when it should have been `extend`

## Safety Assurance

### Safety story
Small change. management command only

### Automated test coverage
N/A

### QA Plan
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
