### PR TITLE
color links in tiles

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -38,6 +38,10 @@
     vertical-align: top;
     background-color: @cc-bg;
     container-type: inline-size;
+
+    a {
+      color: @cc-brand-mid;
+    }
   }
 
   .highlighted-case {


### PR DESCRIPTION
## Product Description

Links in case list tiles should be blue like everywhere else.

The class `ui-widget-content` from jquery.css was coloring it black. The only way to fix it was to override it in a more specific class.

![image](https://github.com/dimagi/commcare-hq/assets/1946138/67337bab-3a93-447e-ad44-cb97f8c37817)


## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3509

## Feature Flag
 	
* REC/USH: Case tile templates

## Safety Assurance

### Safety story

Looked at the page. Links were blue now. Pretty specific css change. Should have minimal impact.

### Automated test coverage

### QA Plan

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
