### PR TITLE
Add appearance attributes to control text alignment in web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -36,6 +36,8 @@ hqDefine("cloudcare/js/form_entry/const", function () {
         ETHIOPIAN: 'ethiopian',
         SIGNATURE: 'signature',
         PER_ROW: '-per-row',
+        TEXT_ALIGN_CENTER: 'text-align-center',
+        TEXT_ALIGN_RIGHT: 'text-align-right',
 
         // Note it's important to differentiate these two
         NO_PENDING_ANSWER: undefined,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1255,7 +1255,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             case constants.GEO:
                 entry = new GeoPointEntry(question, {});
                 break;
-            case constants.INFO:
+            case constants.INFO: // it's a label
                 entry = new InfoEntry(question, {});
                 break;
             case constants.BINARY:

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -135,7 +135,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             curr = curr.parent;
         }
         return curr;
-    };
+    }
 
     /**
      * Base abstract prototype for Repeat, Group, GroupedQuestionTileRow, and Form. Adds methods to
@@ -160,7 +160,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
                 return child.hasError();
             });
         });
-    };
+    }
 
     /**
      * Reconciles the JSON representation of a Container (Group, Repeat, Form) and renders it into
@@ -170,8 +170,8 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
     Container.prototype.fromJS = function (json) {
         var self = this;
 
-        if (!json.type){
-            Container.groupQuestions(json)
+        if (!json.type) {
+            Container.groupQuestions(json);
         }
 
         var mapping = {
@@ -191,7 +191,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             children: {
                 create: function (options) {
                     if (options.data.type === constants.GROUPED_QUESTION_TILE_ROW_TYPE) {
-                        return new GroupedQuestionTileRow(options.data, self)
+                        return new GroupedQuestionTileRow(options.data, self);
                     } else if (options.data.type === constants.QUESTION_TYPE) {
                         return new Question(options.data, self);
                     } else if (options.data.type === constants.GROUP_TYPE) {
@@ -268,7 +268,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
                 newChildren.push(currentGroup);
             }
             currentGroup.children.push(child);
-        };
+        }
 
         function resetCurrentGroup() {
             if (currentGroup) {
@@ -277,7 +277,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             }
             currentGroup = null;
             usedWidth = 0;
-        };
+        }
 
         for (let child of json.children) {
             if (child.type === constants.QUESTION_TYPE) {
@@ -287,7 +287,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
                     resetCurrentGroup();
                     usedWidth += questionTileWidth;
                 }
-                addToCurrentGroup(child)
+                addToCurrentGroup(child);
             } else if (child.type === constants.GROUP_TYPE || child.type === constants.REPEAT_TYPE) {
                 const newGroup = Container.groupQuestions(child);
                 newChildren.push(newGroup);
@@ -297,10 +297,10 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
                 resetCurrentGroup();
             }
         }
-        resetCurrentGroup()
+        resetCurrentGroup();
         json.children = newChildren;
         return json;
-    }
+    };
 
     /**
      * Represents the entire form. There is only one of these on a page.
@@ -338,7 +338,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
                 return true;
             }
 
-            let questions = getQuestions(self)
+            let questions = getQuestions(self);
             return _.every(questions, function (q) {
                 return (q.answer() === constants.NO_ANSWER && !q.required()) || q.answer() !== null;
             });
@@ -354,7 +354,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
                 return false;
             }
 
-            let questions = getQuestions(self)
+            let questions = getQuestions(self);
             var allValidAndNotPending = _.every(questions, function (q) {
                 return q.isValid() && !q.pendingAnswer();
             });
@@ -659,10 +659,10 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.parent = parent;
         Container.call(self, json);
 
-        self.required = ko.observable(0)
+        self.required = ko.observable(0);
         self.childrenRequired = ko.computed(function () {
             return _.find(self.children(), function (child) {
-                return child.required()
+                return child.required();
             });
         });
     }
@@ -809,7 +809,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
     Question.prototype.stylesContaining = function (pattern) {
         var self = this;
         var styleStr = (self.style) ? ko.utils.unwrapObservable(self.style.raw) : null;
-        return getMatchingStyles(pattern, styleStr)
+        return getMatchingStyles(pattern, styleStr);
     };
 
     /**
@@ -823,7 +823,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
     };
 
     Question.prototype.setWidths = function () {
-        const columnWidth = Question.calculateColumnWidthForPerRowStyle(this.style)
+        const columnWidth = Question.calculateColumnWidthForPerRowStyle(this.style);
 
         if (columnWidth === constants.GRID_COLUMNS) {
             this.controlWidth = constants.CONTROL_WIDTH;
@@ -841,7 +841,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
      * based on Bootstrap's 12 column grid system and returns the column width.
      * @param {Object} style - the appearance attributes
      */
-    Question.calculateColumnWidthForPerRowStyle= function(style) {
+    Question.calculateColumnWidthForPerRowStyle = function (style) {
         const styleStr = (style) ? ko.utils.unwrapObservable(style.raw) : null;
         const perRowPattern = new RegExp(`\\d+${constants.PER_ROW}(\\s|$)`);
         const matchingPerRowStyles = getMatchingStyles(perRowPattern, styleStr);
@@ -849,7 +849,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         const itemsPerRow = perRowStyle !== null ? parseInt(perRowStyle.split("-")[0], 10) : null;
 
         return itemsPerRow !== null ? Math.round(constants.GRID_COLUMNS / itemsPerRow) : constants.GRID_COLUMNS;
-      }
+    };
 
     return {
         getIx: getIx,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -813,9 +813,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
     };
 
     /**
-     * Returns a boolean of whether the styles contain a pattern
-     * If a regex is provided, returns regex matches. If a string is provided
-     * an exact match is returned.
+     * Returns a boolean of whether the styles contain a pattern.
      * @param {Object} pattern - the regex or string used to find matching styles.
      */
     Question.prototype.stylesContains = function (pattern) {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -210,7 +210,11 @@
             }
         ">
     <label class="caption control-label" data-bind="css: labelWidth, attr: {'for': entry.entryId}">
-      <div data-bind="css: {'row': help()}">
+      <div data-bind="css: {
+          'row': help(),
+          'text-center': stylesContains('text-align-center'),
+          'text-right': stylesContains('text-align-right'),
+        }">
         <span class="webapp-markdown-output" tabindex="0"
               data-bind="
                 html: ko.utils.unwrapObservable($data.caption_markdown) || caption(),
@@ -281,7 +285,10 @@
   <!-- /ko -->
   <!-- ko if: datatype() === 'info' -->
   <div class="info panel panel-default">
-    <div class="panel-body">
+    <div class="panel-body" data-bind="css: {
+        'text-center': stylesContains('text-align-center'),
+        'text-right': stylesContains('text-align-right'),
+      }">
       <span class="ix" data-bind="text: ixInfo($data)">></span>
       <span class="caption webapp-markdown-output"
             data-bind="

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -294,12 +294,12 @@
       >
       </div>
       <div class="widget-container controls" data-bind="css: controlWidth">
-      <!-- labels only deal with server errors, since there's no data type validation for the browser to do-->
-      <div class="text-danger error-message" data-bind="
-                visible: serverError,
-                text: serverError
-      "></div>
-    </div>
+        <!-- labels only deal with server errors, since there's no data type validation for the browser to do-->
+        <div class="text-danger error-message" data-bind="
+          visible: serverError,
+          text: serverError
+          "></div>
+      </div>
     </div>
   </div>
   <!-- /ko -->

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -210,6 +210,7 @@
             }
         ">
     <label class="caption control-label" data-bind="css: labelWidth, attr: {'for': entry.entryId}">
+      {# appearance attributes TEXT_ALIGN_CENTER TEXT_ALIGN_RIGHT #}
       <div data-bind="css: {
           'row': help(),
           'text-center': stylesContains('text-align-center'),
@@ -285,6 +286,7 @@
   <!-- /ko -->
   <!-- ko if: datatype() === 'info' -->
   <div class="info panel panel-default">
+    {# appearance attributes TEXT_ALIGN_CENTER TEXT_ALIGN_RIGHT #}
     <div class="panel-body" data-bind="css: {
         'text-center': stylesContains('text-align-center'),
         'text-right': stylesContains('text-align-right'),


### PR DESCRIPTION
## Product Description
Add two new appearance attributes: `text-align-center` and `text-align-right`, which can be added to questions and labels in forms.  These are only supported in web apps.

#### In form builder:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/2d181736-186d-40b6-90d8-289a3894ff0c)

#### In Web Apps:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/7ccfd1ea-f42a-4d4e-8754-74001b4ef063)

#### It also works fine with question tiles:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/5c7339a9-b352-4f00-88a4-bb4e94ca9778)


## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3549

This is pretty trivially implemented - it just applies the corresponding bootstrap class when an appearance attribute is set.  The ask was primarily for labels, but I don't see a downside to supporting question labels as well.  Let me know if you disagree. 

## Feature Flag

## Safety Assurance

### Safety story

It's a very simple feature, and shouldn't impact existing configurations, so I think it's safe to try out on prod after local testing.

### Automated test coverage

N/A

### QA Plan
 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
