### PR TITLE
Add `__repr__`s for app, module, and form

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1045,6 +1045,9 @@ class FormBase(DocumentSchema):
     # computed datums IDs that are allowed in endpoints
     function_datum_endpoints = StringListProperty()
 
+    def __repr__(self):
+        return f"{self.doc_type}(id='{self.id}', name='{self.default_name()}')"
+
     @classmethod
     def wrap(cls, data):
         data.pop('validation_cache', '')
@@ -2246,6 +2249,9 @@ class ModuleBase(IndexedSchema, ModuleMediaMixin, NavMenuItemMediaMixin, Comment
     def __init__(self, *args, **kwargs):
         super(ModuleBase, self).__init__(*args, **kwargs)
         self.assign_references()
+
+    def __repr__(self):
+        return f"{self.doc_type}(id='{self.id}', name='{self.default_name()}')"
 
     @property
     def is_surveys(self):
@@ -4590,6 +4596,10 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
     custom_assertions = SchemaListProperty(CustomAssertion)
 
     family_id = StringProperty()  # ID of earliest parent app across copies and linked apps
+
+    def __repr__(self):
+        return (f"{self.doc_type}(id='{self._id}', domain='{self.domain}', "
+                f"name='{self.name}', is_build={bool(self.copy_of)})")
 
     def has_modules(self):
         return len(self.get_modules()) > 0 and not self.is_remote_app()

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1046,7 +1046,7 @@ class FormBase(DocumentSchema):
     function_datum_endpoints = StringListProperty()
 
     def __repr__(self):
-        return f"{self.doc_type}(id='{self.id}', name='{self.default_name()}')"
+        return f"{self.doc_type}(id='{self.id}', name='{self.default_name()}', unique_id='{self.unique_id}')"
 
     @classmethod
     def wrap(cls, data):
@@ -2251,7 +2251,7 @@ class ModuleBase(IndexedSchema, ModuleMediaMixin, NavMenuItemMediaMixin, Comment
         self.assign_references()
 
     def __repr__(self):
-        return f"{self.doc_type}(id='{self.id}', name='{self.default_name()}')"
+        return f"{self.doc_type}(id='{self.id}', name='{self.default_name()}', unique_id='{self.unique_id}')"
 
     @property
     def is_surveys(self):
@@ -4599,7 +4599,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
 
     def __repr__(self):
         return (f"{self.doc_type}(id='{self._id}', domain='{self.domain}', "
-                f"name='{self.name}', is_build={bool(self.copy_of)})")
+                f"name='{self.name}', copy_of={repr(self.copy_of)})")
 
     def has_modules(self):
         return len(self.get_modules()) > 0 and not self.is_remote_app()


### PR DESCRIPTION
## Product Description


## Technical Summary
As-is, these reprs fill up more than an entire terminal screen, making them worse than useless.  Here's the new version:

```python
In [2]: app
Out[2]: Application(id='fdd0c9c32b09dc47e0f84241b401fb10', domain='esoergel', name='My app!!', is_build=False)

In [3]: app.modules
Out[3]: [Module(id='0', name='Surveys'), Module(id='1', name='Case List')]

In [4]: app.modules[0].forms
Out[4]: [Form(id='0', name='How are you?')]
```

I'm shooting for including the minimum identifying information.

* For apps, `id` and `domain` are obviously needed.  
* `name` makes these things easier to find in the UI
* `app.is_build` is needed because we don't have different doc types for apps and builds.
* For modules and forms, I went with the index `id` instead of `unique_id`, though I could be convinced to include both
* I opted not to include the domain and app with modules and forms, under the assumption that that information would typically be available through other contexts, as they are not standalone documents

This change hides information, so there's some risks to debugging, but I think that is outweighed by the increased usability.  It looks like apps are filtered in sentry anyways:

![image](https://github.com/dimagi/commcare-hq/assets/2367539/8aba09ed-fff3-4476-a101-c8aa2944c295)

And modules and forms get truncated, so you can't even see name or ID in sentry.

I'd love to see more `__repr__`s defined for other models if you're keen!

## Feature Flag


## Safety Assurance

### Safety story

local testing

### Automated test coverage


### QA Plan

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
