### PR TITLE
remove usage of XFormInstance.DELETED (part 1)

### DIFF
--- a/corehq/apps/data_pipeline_audit/dbacessors.py
+++ b/corehq/apps/data_pipeline_audit/dbacessors.py
@@ -100,7 +100,7 @@ def get_primary_db_form_counts(domain, startdate=None, enddate=None):
         for doc_type, state in doc_type_to_state.items():
             counter[doc_type] += queryset.filter(state=state).count()
 
-        where_clause = 'state & {0} = {0}'.format(XFormInstance.DELETED)
+        where_clause = 'deleted_on IS NOT NULL'
         counter['XFormInstance-Deleted'] += queryset.extra(where=[where_clause]).count()
 
     return counter

--- a/corehq/apps/data_pipeline_audit/management/commands/find_sql_forms_not_in_es.py
+++ b/corehq/apps/data_pipeline_audit/management/commands/find_sql_forms_not_in_es.py
@@ -10,7 +10,7 @@ description here: https://github.com/dimagi/commcare-hq/pull/22477
 import sys
 
 from django.core.management.base import BaseCommand
-from django.db.models import F, Q
+from django.db.models import Q
 from django.db.models.functions import Greatest
 
 from corehq.util.argparse_types import date_type
@@ -64,12 +64,7 @@ def iter_form_ids_by_last_modified(start_datetime, end_datetime):
     return paginate_query_across_partitioned_databases(
         XFormInstance,
         (Q(last_modified__gt=start_datetime, last_modified__lt=end_datetime)
-         & Q(state=F('state').bitand(XFormInstance.DELETED)
-             + F('state').bitand(XFormInstance.DEPRECATED)
-             + F('state').bitand(XFormInstance.DUPLICATE)
-             + F('state').bitand(XFormInstance.ERROR)
-             + F('state').bitand(XFormInstance.SUBMISSION_ERROR_LOG)
-             + F('state'))),
+         & Q(state__in=[XFormInstance.NORMAL, XFormInstance.ARCHIVED])),
         annotate=annotate,
         values=['form_id'],
         load_source='find_sql_forms_not_in_es'

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -1063,7 +1063,7 @@ class HardDeleteFormsAndCasesInDomainTests(TestCase):
         self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.deleted_domain.name)), 0)
 
     def test_soft_deleted_forms_are_deleted(self):
-        create_form_for_test(self.deleted_domain.name, state=XFormInstance.DELETED)
+        create_form_for_test(self.deleted_domain.name, deleted_on=datetime.now())
         call_command('hard_delete_forms_and_cases_in_domain', self.deleted_domain.name, noinput=True)
         self.assertEqual(len(XFormInstance.objects.get_form_ids_in_domain(self.deleted_domain.name)), 0)
 

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from django.conf import settings
 from django.db import InternalError, transaction, router
-from django.db.models import F, Q
+from django.db.models import Q
 from django.db.models.expressions import Value
 from django.db.models.functions import Concat
 
@@ -335,9 +335,8 @@ class FormReindexAccessor(ReindexAccessor):
     def extra_filters(self, for_count=False):
         filters = []
         if not (for_count or self.include_deleted):
-            # don't inlucde in count query since the query planner can't account for it
-            # hack for django: 'state & DELETED = 0' so 'state = state + state & DELETED'
-            filters.append(Q(state=F('state').bitand(XFormInstance.DELETED) + F('state')))
+            # don't include in count query since the query planner can't account for it
+            filters.append(Q(deleted_on__isnull=True))
         if self.domain:
             filters.append(Q(domain=self.domain))
         if self.start_date is not None:

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -209,7 +209,7 @@ class XFormInstanceManager(RequireDBManager):
     def _get_form_ids_for_user(self, domain, user_id, is_deleted):
         with self.model.get_plproxy_cursor(readonly=True) as cursor:
             cursor.execute(
-                'SELECT form_id FROM get_form_ids_for_user(%s, %s, %s)',
+                'SELECT form_id FROM get_form_ids_for_user_2(%s, %s, %s)',
                 [domain, user_id, is_deleted]
             )
             results = fetchall_as_namedtuple(cursor)
@@ -340,7 +340,7 @@ class XFormInstanceManager(RequireDBManager):
         deletion_date = deletion_date or datetime.utcnow()
         with self.model.get_plproxy_cursor() as cursor:
             cursor.execute(
-                'SELECT soft_delete_forms(%s, %s, %s, %s) as affected_count',
+                'SELECT soft_delete_forms_3(%s, %s, %s, %s) as affected_count',
                 [domain, form_ids, deletion_date, deletion_id]
             )
             results = fetchall_as_namedtuple(cursor)
@@ -356,7 +356,7 @@ class XFormInstanceManager(RequireDBManager):
         problem = 'Restored on {}'.format(datetime.utcnow())
         with self.model.get_plproxy_cursor() as cursor:
             cursor.execute(
-                'SELECT soft_undelete_forms(%s, %s, %s) as affected_count',
+                'SELECT soft_undelete_forms_3(%s, %s, %s) as affected_count',
                 [domain, form_ids, problem]
             )
             results = fetchall_as_namedtuple(cursor)

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from io import BytesIO
 
 from django.db import InternalError, models, transaction
-from django.db.models import F, Q
+from django.db.models import Q
 
 from jsonfield.fields import JSONField
 from lxml import etree
@@ -187,8 +187,7 @@ class XFormInstanceManager(RequireDBManager):
         for db_name in get_db_aliases_for_partitioned_query():
             result.extend(
                 self.using(db_name)
-                .annotate(state_deleted=F('state').bitand(XFormInstance.DELETED))
-                .filter(domain=domain, state_deleted=XFormInstance.DELETED)
+                .filter(domain=domain, deleted_on__isnull=False)
                 .values_list('form_id', flat=True)
             )
         return result
@@ -563,9 +562,7 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
 
     @property
     def is_deleted(self):
-        # deleting a form adds the deleted state to the current state
-        # in order to support restoring the pre-deleted state.
-        return self.state & self.DELETED == self.DELETED
+        return bool(self.deleted_on)
 
     @property
     def doc_type(self):
@@ -641,7 +638,7 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
 
     def soft_delete(self):
         type(self).objects.soft_delete_forms(self.domain, [self.form_id])
-        self.state |= self.DELETED
+        self.deleted_on = datetime.utcnow()
 
     def to_json(self, include_attachments=False):
         from ..serializers import XFormInstanceSerializer, lazy_serialize_form_attachments, \

--- a/corehq/sql_accessors/migrations/0068_remove_deleted_state.py
+++ b/corehq/sql_accessors/migrations/0068_remove_deleted_state.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from django.db import migrations
+
+from corehq.sql_db.operations import RawSQLMigration
+
+migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sql_accessors', '0067_livequery_sql_include_deleted_indices'),
+    ]
+
+    operations = [
+        migrator.get_migration('get_form_ids_for_user_2.sql'),
+        migrator.get_migration('soft_delete_forms_3.sql'),
+        migrator.get_migration('soft_undelete_forms_3.sql'),
+    ]

--- a/corehq/sql_accessors/sql_templates/get_form_ids_for_user_2.sql
+++ b/corehq/sql_accessors/sql_templates/get_form_ids_for_user_2.sql
@@ -1,0 +1,18 @@
+DROP FUNCTION IF EXISTS get_form_ids_for_user_2(TEXT, TEXT, BOOLEAN);
+
+CREATE FUNCTION get_form_ids_for_user_2(
+    p_domain TEXT,
+    p_user_id TEXT,
+    is_deleted BOOLEAN) RETURNS TABLE (form_id VARCHAR(255)) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT form_processor_xforminstancesql.form_id FROM form_processor_xforminstancesql WHERE
+        user_id = p_user_id AND
+        domain = p_domain AND
+        CASE WHEN is_deleted THEN
+            deleted_on IS NOT NULL
+        ELSE
+            deleted_on IS NULL
+        END;
+END;
+$$ LANGUAGE plpgsql;

--- a/corehq/sql_accessors/sql_templates/soft_delete_forms_3.sql
+++ b/corehq/sql_accessors/sql_templates/soft_delete_forms_3.sql
@@ -1,0 +1,19 @@
+DROP FUNCTION IF EXISTS soft_delete_forms_3(TEXT, TEXT[], TIMESTAMP, TEXT);
+
+CREATE FUNCTION soft_delete_forms_3(
+    p_domain TEXT,
+    form_ids TEXT[],
+    p_deletion_date TIMESTAMP,
+    p_deletion_id TEXT DEFAULT NULL,
+    affected_count OUT INTEGER) AS $$
+BEGIN
+    UPDATE form_processor_xforminstancesql SET
+        deletion_id = p_deletion_id,
+        deleted_on = p_deletion_date,
+        server_modified_on = p_deletion_date
+    WHERE
+        domain = p_domain
+        AND form_id = ANY(form_ids);
+    GET DIAGNOSTICS affected_count = ROW_COUNT;
+END;
+$$ LANGUAGE plpgsql;

--- a/corehq/sql_accessors/sql_templates/soft_undelete_forms_3.sql
+++ b/corehq/sql_accessors/sql_templates/soft_undelete_forms_3.sql
@@ -1,0 +1,21 @@
+DROP FUNCTION IF EXISTS soft_undelete_forms_3(TEXT, TEXT[], TEXT);
+
+CREATE FUNCTION soft_undelete_forms_3(
+    p_domain TEXT,
+    form_ids TEXT[],
+    p_reason TEXT,
+    affected_count OUT INTEGER) AS $$
+DECLARE
+    curtime TIMESTAMP := clock_timestamp();
+BEGIN
+    UPDATE form_processor_xforminstancesql SET
+        problem = p_reason,
+        deletion_id = NULL,
+        deleted_on = NULL,
+        server_modified_on = curtime
+    WHERE
+        domain = p_domain
+        AND form_id = ANY(form_ids);
+    GET DIAGNOSTICS affected_count = ROW_COUNT;
+END;
+$$ LANGUAGE plpgsql;

--- a/corehq/sql_proxy_accessors/migrations/0050_remove_deleted_state.py
+++ b/corehq/sql_proxy_accessors/migrations/0050_remove_deleted_state.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.db import migrations
+
+from corehq.sql_db.operations import RawSQLMigration
+
+migrator = RawSQLMigration(('corehq', 'sql_proxy_accessors', 'sql_templates'), {
+    'PL_PROXY_CLUSTER_NAME': settings.PL_PROXY_CLUSTER_NAME
+})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sql_proxy_accessors', '0049_drop_unused_function'),
+    ]
+
+    operations = [
+        migrator.get_migration('get_form_ids_for_user_2.sql'),
+        migrator.get_migration('soft_delete_forms_3.sql'),
+        migrator.get_migration('soft_undelete_forms_3.sql'),
+    ]

--- a/corehq/sql_proxy_accessors/sql_templates/get_form_ids_for_user_2.sql
+++ b/corehq/sql_proxy_accessors/sql_templates/get_form_ids_for_user_2.sql
@@ -1,0 +1,6 @@
+DROP FUNCTION IF EXISTS get_form_ids_for_user_2(TEXT, TEXT, BOOLEAN);
+
+CREATE FUNCTION get_form_ids_for_user_2(domain TEXT, user_id TEXT, is_deleted BOOLEAN) RETURNS TABLE (form_id VARCHAR(255)) AS $$
+    CLUSTER '{{ PL_PROXY_CLUSTER_NAME }}';
+    RUN ON ALL;
+$$ LANGUAGE plproxy;

--- a/corehq/sql_proxy_accessors/sql_templates/soft_delete_forms_3.sql
+++ b/corehq/sql_proxy_accessors/sql_templates/soft_delete_forms_3.sql
@@ -1,0 +1,11 @@
+DROP FUNCTION IF EXISTS soft_delete_forms_3(TEXT, TEXT[], TIMESTAMP, TEXT);
+
+CREATE FUNCTION soft_delete_forms_3(
+    p_domain TEXT,
+    form_ids TEXT[],
+    deletion_date TIMESTAMP,
+    deletion_id TEXT DEFAULT NULL) RETURNS SETOF INTEGER AS $$
+    CLUSTER '{{ PL_PROXY_CLUSTER_NAME }}';
+    SPLIT form_ids;
+    RUN ON hash_string(form_ids, 'siphash24');
+$$ LANGUAGE plproxy;

--- a/corehq/sql_proxy_accessors/sql_templates/soft_undelete_forms_3.sql
+++ b/corehq/sql_proxy_accessors/sql_templates/soft_undelete_forms_3.sql
@@ -1,0 +1,10 @@
+DROP FUNCTION IF EXISTS soft_undelete_forms_3(TEXT, TEXT[], TEXT);
+
+CREATE FUNCTION soft_undelete_forms_3(
+    p_domain TEXT,
+    form_ids TEXT[],
+    problem TEXT) RETURNS SETOF INTEGER AS $$
+    CLUSTER '{{ PL_PROXY_CLUSTER_NAME }}';
+    SPLIT form_ids;
+    RUN ON hash_string(form_ids, 'siphash24');
+$$ LANGUAGE plproxy;

--- a/migrations.lock
+++ b/migrations.lock
@@ -976,6 +976,7 @@ sql_accessors
  0066_drop_unused_function
  0067_livequery_sql
  0067_livequery_sql_include_deleted_indices
+ 0068_remove_deleted_state
 sql_proxy_accessors
  0001_initial
  0002_add_sync_functions
@@ -1026,6 +1027,7 @@ sql_proxy_accessors
  0047_remove_get_case_models_functions
  0048_get_ledger_values_for_cases_3
  0049_drop_unused_function
+ 0050_remove_deleted_state
 sql_proxy_standby_accessors
  0001_initial
 sso


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Changes that stemmed from [this comment](https://github.com/dimagi/commcare-hq/pull/33057#discussion_r1219686338) from [this PR](https://github.com/dimagi/commcare-hq/pull/33057) which was blocking that PR from moving forward. 

This part is removing the usage of XFormInstance.DELETED state. Following these [guidelines for updating sql fucntions](https://github.com/dimagi/commcare-hq/blob/master/corehq/form_processor/README.md) (that were making use of that state), those functions have been udpated in a duplicate file, with the removal of the old files/functions to come in a followup PR. Because of that, I can't actually remove the state outright in this PR since those old functions still reference them.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

I'm not sure how to test this beyond having existing tests pass and passing review.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

n/a

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
