### PR TITLE
Fix form submission logging

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_audit_logging.py
+++ b/corehq/apps/receiverwrapper/tests/test_audit_logging.py
@@ -71,7 +71,7 @@ class TestAuditLoggingForFormSubmission(TestCase):
 
     def test_commcare_user_regular_submission(self):
         url = reverse(secure_post, args=[self.domain])
-        user = self._create_user(access_api=False, access_mobile_endpoints=True, user_cls=CommCareUser)
+        self._create_user(access_api=False, access_mobile_endpoints=True, user_cls=CommCareUser)
         with patch('corehq.apps.receiverwrapper.views.notify_exception') as mock_notify_exception:
             self.assert_api_response(200, url)
             mock_notify_exception.assert_not_called()
@@ -92,5 +92,5 @@ class TestAuditLoggingForFormSubmission(TestCase):
     def test_web_user_no_api_access(self):
         url = reverse(post_api, args=[self.domain])
         self._create_user(access_api=False, access_mobile_endpoints=True)
-        with patch('corehq.apps.receiverwrapper.views.notify_exception') as mock_notify_exception:
+        with patch('corehq.apps.receiverwrapper.views.notify_exception'):
             self.assert_api_response(403, url)

--- a/corehq/apps/receiverwrapper/tests/test_audit_logging.py
+++ b/corehq/apps/receiverwrapper/tests/test_audit_logging.py
@@ -21,8 +21,9 @@ def return_submission_run_resp(*args, **kwargs):
     return submission_post_run
 
 
-@patch('corehq.apps.receiverwrapper.views.couchforms.get_instance_and_attachment', return_value=(Mock(), Mock()))
-@patch('corehq.apps.receiverwrapper.views._record_metrics')
+@patch('corehq.apps.receiverwrapper.views.couchforms.get_instance_and_attachment',
+       new=Mock(return_value=(Mock(), Mock())))
+@patch('corehq.apps.receiverwrapper.views._record_metrics', new=Mock())
 @patch('corehq.apps.receiverwrapper.views.SubmissionPost.run', new=return_submission_run_resp)
 class TestAuditLoggingForFormSubmission(TestCase):
     domain = "submission-api-test"
@@ -37,10 +38,12 @@ class TestAuditLoggingForFormSubmission(TestCase):
     def tearDownClass(cls):
         cls.domain_obj.delete()
 
-    def _create_user(self, edit_data=False, access_api=False):
+    def _create_user(self, access_api, access_mobile_endpoints):
         role = UserRole.create(
             self.domain, 'api-user', permissions=HqPermissions(
-                edit_data=edit_data, access_api=access_api
+                edit_data=access_api,
+                access_api=access_api,
+                access_mobile_endpoints=access_mobile_endpoints,
             )
         )
         web_user = WebUser.create(self.domain, self.username, self.password,
@@ -52,16 +55,23 @@ class TestAuditLoggingForFormSubmission(TestCase):
         self.client.login(username=self.username, password=self.password)
         self.assertEqual(self.client.post(url).status_code, status)
 
-    def test_valid_request_not_logged(self, mock_record_metrics, mock_couchform_instance):
+    def test_api_user_api_endpoint(self):
         url = reverse(post_api, args=[self.domain])
-        self._create_user(edit_data=True, access_api=True)
+        self._create_user(access_api=True, access_mobile_endpoints=False)
         with patch('corehq.apps.receiverwrapper.views.notify_exception') as mock_notify_exception:
             self.assert_api_response(200, url)
             mock_notify_exception.assert_not_called()
 
-    def test_invalid_request_logged(self, mock_record_metrics, mock_couchform_instance):
+    def test_mobile_user_regular_submission(self):
         url = reverse(secure_post, args=[self.domain])
-        user = self._create_user(edit_data=True, access_api=True)
+        self._create_user(access_api=False, access_mobile_endpoints=True)
+        with patch('corehq.apps.receiverwrapper.views.notify_exception') as mock_notify_exception:
+            self.assert_api_response(200, url)
+            mock_notify_exception.assert_not_called()
+
+    def test_api_user_regular_submission_gets_logged(self):
+        url = reverse(secure_post, args=[self.domain])
+        user = self._create_user(access_api=True, access_mobile_endpoints=False)
         with patch('corehq.apps.receiverwrapper.views.notify_exception') as mock_notify_exception:
             self.assert_api_response(200, url)
             mock_notify_exception.assert_called_once_with(ANY, message=ANY)

--- a/corehq/apps/receiverwrapper/tests/test_audit_logging.py
+++ b/corehq/apps/receiverwrapper/tests/test_audit_logging.py
@@ -86,6 +86,11 @@ class TestAuditLoggingForFormSubmission(TestCase):
 
             self.assertIsInstance(args[0], WSGIRequest)
 
-            expected_message = (f'Restricted access by user samiam with id {user.get_id} and app_id None. '
-                                f'Error details: Request not made from post_api handler for user')
+            expected_message = f'Restricted access by user {user.get_id} to app_id None.'
             self.assertEqual(expected_message, kwargs.get("message"))
+
+    def test_web_user_no_api_access(self):
+        url = reverse(post_api, args=[self.domain])
+        self._create_user(access_api=False, access_mobile_endpoints=True)
+        with patch('corehq.apps.receiverwrapper.views.notify_exception') as mock_notify_exception:
+            self.assert_api_response(403, url)

--- a/corehq/apps/receiverwrapper/tests/test_audit_logging.py
+++ b/corehq/apps/receiverwrapper/tests/test_audit_logging.py
@@ -86,7 +86,7 @@ class TestAuditLoggingForFormSubmission(TestCase):
 
             self.assertIsInstance(args[0], WSGIRequest)
 
-            expected_message = f'Restricted access by user {user.get_id} to app_id None.'
+            expected_message = f"NoMobileEndpointsAccess: invalid request by {user.get_id} on {self.domain}"
             self.assertEqual(expected_message, kwargs.get("message"))
 
     def test_web_user_no_api_access(self):

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import logging
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Follow up to https://github.com/dimagi/commcare-hq/pull/33258/ - that checked `request.user` instead of `request.couch_user`, which means that normal form submissions by mobile workers were logged:
https://dimagi.sentry.io/issues/?query=is%3Aunresolved+Restricted+access+by+user&referrer=issue-list&statsPeriod=14d

I fixed that line and added some additional tests.  I also made some simplifications to the code to minimize the chance for errors or misunderstandings.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

Besides false positives, I think the biggest risk with this is some bug caused by unanticipated code pathways.  For instance, if the `request.couch_user.has_permission(domain, 'access_mobile_endpoints')` line failed because `couch_user` wasn't added to the request.  I don't think this is likely, as it's only called if `authenticated=True`, and everything that calls this with `authenticated=True` also passed in `user_id=request.couch_user.get_id`, so we can safely assume it's present.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
