### PR TITLE
Web apps: Updated minimal dropdown attribute to allow for other attributes

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1163,7 +1163,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                 });
                 break;
             case constants.SELECT:
-                isMinimal = style === constants.MINIMAL;
+                isMinimal = question.stylesContains(constants.MINIMAL);
                 if (style) {
                     isCombobox = question.stylesContains(constants.COMBOBOX);
                 }
@@ -1211,7 +1211,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
                 }
                 break;
             case constants.MULTI_SELECT:
-                isMinimal = style === constants.MINIMAL;
+                isMinimal = question.stylesContains(constants.MINIMAL);
                 if (style) {
                     isLabel = style === constants.LABEL;
                     hideLabel = style === constants.LIST_NOLABEL;


### PR DESCRIPTION
## Product Description
[Question tiles](https://github.com/dimagi/commcare-hq/pull/33333) and [minimal dropdowns](https://github.com/dimagi/commcare-hq/pull/29488) don't work together.

There are other appearance attributes implemented this way, where they don't support additional appearance attributes, this PR is to unblock this specific combination for USH delivery's current app building.

https://dimagi-dev.atlassian.net/browse/USH-3587

## Safety Assurance

### Safety story
Web apps UI, but a pretty minimal change. I locally tested a question just using `minimal` and one using `minimal question-tile 3-per-row`

### Automated test coverage

None

### QA Plan

Not requesting QA, see safety story.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
