### PR TITLE
[B5] Update migration script to catch prototype usage of B3 plugins

### DIFF
--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -72,6 +72,20 @@ def test_flag_changed_javascript_plugins_bootstrap5():
                'New docs: https://getbootstrap.com/docs/5.3/components/modal/#via-javascript\n'])
 
 
+def test_flag_extended_changed_javascript_plugins_bootstrap5():
+    line = """    var oldHide = $.fn.popover.Constructor.prototype.hide;\n"""
+    flags = flag_changed_javascript_plugins(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    eq(flags, ['The `popover` plugin has been restructured since the removal of jQuery.\n'
+               '\nThere is now a new way of triggering popover events and interacting '
+               'with popovers in javascript.\n\nPlease feel free to update this help text'
+               ' as you find common replacements/restructuring\nfor our usage of this '
+               'plugin. Thanks!\n\nOld docs: https://getbootstrap.com/docs/3.4/'
+               'javascript/#popovers\nNew docs: https://getbootstrap.com/docs/5.3/'
+               'components/popovers/\n'])
+
+
 def test_flag_path_references_to_migrated_javascript_files_bootstrap5():
     line = """    'hqwebapp/js/bootstrap3/crud_paginated_list',\n"""
     flags = flag_path_references_to_migrated_javascript_files(

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -41,6 +41,10 @@ def _get_plugin_regex(js_plugin):
     return r"(\.)(" + js_plugin + r")(\([\{\"\'])"
 
 
+def _get_extension_regex(js_plugin):
+    return r"(\$\.fn\.)(" + js_plugin + r")(\.Constructor)"
+
+
 def _get_path_reference_regex(path_reference):
     return r"([\"\'])(" + path_reference + r")([\"\'])"
 
@@ -104,8 +108,9 @@ def flag_changed_css_classes(line, spec):
 def flag_changed_javascript_plugins(line, spec):
     flags = []
     for plugin in spec['flagged_js_plugins']:
-        regex = _get_plugin_regex(plugin)
-        if re.search(regex, line):
+        plugin_regex = _get_plugin_regex(plugin)
+        extension_regex = _get_extension_regex(plugin)
+        if re.search(plugin_regex, line) or re.search(extension_regex, line):
             flags.append(_get_change_guide(f"js-{plugin}"))
     return flags
 


### PR DESCRIPTION
## Technical Summary
This updates the Bootstrap 5 migration script to detect when we use constructors from Bootstrap 3 plugins. This ensures that we split any files where we do this.

This came from noticing that in `hq.helpers` the script previously failed to detect 
```
$.fn.popover.Constructor.prototype.hide
```
Which will, of course, throw errors in Bootstrap 5 since the plugins are all standalone / separate from jQuery now.

## Safety Assurance

### Safety story
Just an update to management command.

### Automated test coverage
Yes.

### QA Plan
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
