### PR TITLE
Web apps responsive case tile/list improvements

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -47,10 +47,10 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         FormplayerFrontend.regions = new RegionContainer();
         let sidebar = FormplayerFrontend.regions.getRegion('sidebar');
         sidebar.on('show', function () {
-            $('#menu-container .flex-container').addClass('full-width');
+            $('#content-container').addClass('full-width');
         });
         sidebar.on('hide empty', function () {
-            $('#menu-container .flex-container').removeClass('full-width');
+            $('#content-container').removeClass('full-width');
         });
 
         hqRequire(["cloudcare/js/formplayer/router"], function (Router) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -48,9 +48,11 @@ hqDefine("cloudcare/js/formplayer/app", function () {
         let sidebar = FormplayerFrontend.regions.getRegion('sidebar');
         sidebar.on('show', function () {
             $('#content-container').addClass('full-width');
+            $('#menu-region').addClass('sidebar-push');
         });
         sidebar.on('hide empty', function () {
             $('#content-container').removeClass('full-width');
+            $('#menu-region').removeClass('sidebar-push');
         });
 
         hqRequire(["cloudcare/js/formplayer/router"], function (Router) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -420,12 +420,16 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             const addressFieldPresent = !!_.find(this.styles, function (style) { return style.displayFormat === constants.FORMAT_ADDRESS; });
 
             self.showMap = addressFieldPresent && !appPreview && !self.hasNoItems && toggles.toggleEnabled('CASE_LIST_MAP');
-            self.smallScreenEnabled = cloudcareUtils.watchSmallScreenEnabled(enabled => self.smallScreenEnabled = enabled);
+            self.smallScreenEnabled = cloudcareUtils.watchSmallScreenEnabled(self.handleSmallScreenChange.bind(self));
         },
 
         ui: CaseListViewUI(),
 
         events: CaseListViewEvents(),
+
+        handleSmallScreenChange: function (enabled) {
+            this.smallScreenEnabled = enabled;
+        },
 
         caseListAction: function (e) {
             const index = $(e.currentTarget).data().index,
@@ -804,6 +808,16 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             $.getScript(gridPolyfillPath);
 
             registerContinueListener(this, options);
+            this.handleSmallScreenChange(this.smallScreenEnabled);
+        },
+
+        handleSmallScreenChange: function (enabled) {
+            CaseTileListView.__super__.handleSmallScreenChange.apply(this, arguments);
+            if (enabled) {
+                $('#content-container').addClass('full-width');
+            } else if (!this.options.sidebarEnabled) {
+                $('#content-container').removeClass('full-width');
+            }
         },
 
         childViewOptions: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -846,6 +846,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 this.reconcileMultiSelectUI();
             }
         },
+
+        onDestroy: function () {
+            $('#content-container').removeClass('full-width');
+        },
     });
 
     const CaseTileGroupedListView = CaseTileListView.extend({

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -808,7 +808,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             $.getScript(gridPolyfillPath);
 
             registerContinueListener(this, options);
-            this.handleSmallScreenChange(this.smallScreenEnabled);
         },
 
         handleSmallScreenChange: function (enabled) {
@@ -845,6 +844,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             if (this.options.isMultiSelect) {
                 this.reconcileMultiSelectUI();
             }
+            this.handleSmallScreenChange(this.smallScreenEnabled);
         },
 
         onDestroy: function () {

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -105,9 +105,9 @@
       <div class="container case-tile-container">
         <div id="persistent-case-tile" class="print-container"></div>
       </div>
-      <div id="content-container" class="container flex-container">
-        <div id="sidebar-region" class="container noprint-sub-container flex-child flex-child-sidebar"></div>
-        <div id="menu-region" class="container print-container flex-child flex-child-menu"></div>
+      <div id="content-container" class="container">
+        <div id="sidebar-region" class="noprint-sub-container"></div>
+        <div id="menu-region" class="print-container"></div>
       </div>
       <section id="webforms" data-bind="
                 template: {

--- a/corehq/apps/cloudcare/templates/formplayer/pagination.html
+++ b/corehq/apps/cloudcare/templates/formplayer/pagination.html
@@ -6,7 +6,7 @@
 {% block pagination_templates %}
   <div class="container pagination-container">
     <div class="row">
-      <div class="col-sm-2 module-per-page-container">
+      <div class="col-xs-6 col-sm-3 module-per-page-container">
         <div class="form-inline input-group-lg">
           <select class="form-control per-page-limit">
             <% for(var i = 0; i < rowRange.length; i++) { %>
@@ -20,7 +20,15 @@
         </div>
       </div>
       <% if (pageCount > 1) { %>
-        <div class="col-sm-7 text-center">
+        <div class="col-xs-6 col-sm-3 col-sm-push-6 module-go-container">
+          <div class="input-group input-group-lg">
+            <input type="text" class="form-control" placeholder='{% trans_html_attr "Go to page" %}' id="goText">
+            <div class="input-group-btn">
+              <button class="btn btn-default" type="button" id="pagination-go-button">{% trans "Go" %}</button>
+            </div>
+          </div>
+        </div>
+        <div class="col-xs-12 col-sm-6 col-sm-pull-3 text-center">
           <nav class="module-pagination-container">
             <ul class="pagination">
               <!-- Render Previous button -->
@@ -91,14 +99,6 @@
               <% } %>
             </ul>
           </nav>
-        </div>
-        <div class="col-sm-3 module-go-container">
-          <div class="input-group input-group-lg">
-            <input type="text" class="form-control" placeholder='{% trans_html_attr "Go to page" %}' id="goText">
-            <div class="input-group-btn">
-              <button class="btn btn-default" type="button" id="pagination-go-button">{% trans "Go" %}</button>
-            </div>
-          </div>
         </div>
       <% } %>
     </div>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
@@ -151,8 +151,8 @@
 
 .pagination-container {
   width: inherit;
-  padding-left: 27px;
-  padding-right: 27px;
+  padding-left: 17px;
+  padding-right: 17px;
   min-height: 76px;
 }
 

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
@@ -146,17 +146,18 @@
 }
 
 .module-go-container {
-  margin: 17px;
-  width: 190px;
+  margin-top: 17px;
 }
 
 .pagination-container {
   width: inherit;
+  padding-left: 27px;
+  padding-right: 27px;
 }
 
 .module-per-page-container {
   display: inline-block;
-  margin: 17px;
+  margin-top: 17px;
 }
 
 .module-table-case-list tbody tr:hover .module-case-list-column-empty {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
@@ -153,6 +153,7 @@
   width: inherit;
   padding-left: 27px;
   padding-right: 27px;
+  min-height: 76px;
 }
 
 .module-per-page-container {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -1,24 +1,19 @@
-.flex-container {
-  display: flex;
-  align-items: stretch;
-}
-
 .full-width {
   width: 100%;
 }
 
-.flex-child {
-  flex: 1;
-  min-width: 200px;
-  &:empty {
-    display: none;
-  }
+.sidebar-push {
+  margin-left: 310px;
 }
 
-.flex-child-sidebar {
-  max-width: 400px;
+#sidebar-region {
+  background: transparent;
+  width: 300px;
+  position: absolute;
+
   table {
     table-layout: fixed;
+    background: white;
   }
   .query-input-group {
     margin-right: 8px;
@@ -40,17 +35,6 @@
   .select2-container .select2-selection--multiple {
     min-height: inherit;
   }
-}
-
-#sidebar-region {
-  background: transparent;
-  table {
-    background: white;
-  }
-}
-
-.flex-child-menu {
-  flex: 2;
 }
 
 .query-field > .checkbox {


### PR DESCRIPTION
## Product Description
Two primary changes: 
- case tiles are full width on smaller screens (<= 992px)
- pagination controls are responsive to screen size as shown (previously controls would wrap awkwardly on anything less than a 1200px wide screen).
    Screens wider than 768px: 
    ![800px-pagination](https://github.com/dimagi/commcare-hq/assets/100609770/d77378d3-5299-4c66-9f56-858e735b680d)
    Very small screens narrower than 768px:
    ![image](https://github.com/dimagi/commcare-hq/assets/100609770/eebf2dc5-4228-4f67-b00c-67b17d556c3f)


Also makes split screen sidebar a static width on all screen sizes (note that in an upcoming responsive design ticket its appearance will change significantly on smaller screens).


## Technical Summary
[USH-3516](https://dimagi-dev.atlassian.net/browse/USH-3516)
Uses the `full-width` class to make case tiles full width when `smallScreenEnabled` is true. Removes some custom flexbox styles in favor of a static sidebar width and a responsive case list/map pane. Uses bootstrap classes to make pagination controls responsive to screen size.

## Feature Flag
Not feature flagged. Changes to sidebar are only visible with split_screen_case_search flag.

## Safety Assurance

### Safety story
Tested locally with different split screen/standard/case list/tile configs at various screen sizes to ensure layout and spacing stays reasonable and interactions all work as expected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
QA with [USH-3485](https://dimagi-dev.atlassian.net/browse/USH-3485)

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3516]: https://dimagi-dev.atlassian.net/browse/USH-3516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-3485]: https://dimagi-dev.atlassian.net/browse/USH-3485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ