### PR TITLE
One Two Two Case Tile Template Adjustment

### DIFF
--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.json
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.json
@@ -4,11 +4,11 @@
     "has_map": false,
     "fields": ["image", "header", "top_left", "top_right", "bottom_left", "bottom_right"],
     "grid": {
-        "image": {"x": 0, "y": 0, "width": 2, "height": 3, "horz-align": "center", "vert-align": "center"},
-        "header": {"x": 3, "y": 0, "width": 8, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "top_left": {"x": 3, "y": 1, "width": 3, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "top_right": {"x": 6, "y": 1, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "bottom_left": {"x": 3, "y": 2, "width": 3, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "bottom_right": {"x": 6, "y": 2, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"}
+        "image": {"x": 0, "y": 0, "width": 2, "height": 10, "horz-align": "center", "vert-align": "center"},
+        "header": {"x": 3, "y": 4, "width": 8, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "top_left": {"x": 3, "y": 5, "width": 3, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "top_right": {"x": 6, "y": 5, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "bottom_left": {"x": 3, "y": 6, "width": 3, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "bottom_right": {"x": 6, "y": 6, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"}
     }
 }

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.json
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.json
@@ -5,10 +5,10 @@
     "fields": ["image", "header", "top_left", "top_right", "bottom_left", "bottom_right"],
     "grid": {
         "image": {"x": 0, "y": 0, "width": 2, "height": 3, "horz-align": "center", "vert-align": "center"},
-        "header": {"x": 2, "y": 0, "width": 8, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "top_left": {"x": 2, "y": 1, "width": 3, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "top_right": {"x": 5, "y": 1, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "bottom_left": {"x": 2, "y": 2, "width": 3, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "bottom_right": {"x": 5, "y": 2, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"}
+        "header": {"x": 3, "y": 0, "width": 8, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "top_left": {"x": 3, "y": 1, "width": 3, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "top_right": {"x": 6, "y": 1, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "bottom_left": {"x": 3, "y": 2, "width": 3, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "bottom_right": {"x": 6, "y": 2, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"}
     }
 }

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.xml
@@ -11,7 +11,7 @@
         vert-align="center"
         font-size="medium">
       <grid
-          grid-height="3"
+          grid-height="10"
           grid-width="2"
           grid-x="0"
           grid-y="0" />
@@ -30,7 +30,7 @@
 
   <field>
     <style horz-align="left" vert-align="center" font-size="medium">
-      <grid grid-height="1" grid-width="8" grid-x="3" grid-y="0"/>
+      <grid grid-height="1" grid-width="8" grid-x="3" grid-y="4"/>
     </style>
     <header>
       <text>
@@ -49,7 +49,7 @@
 
   <field>
     <style horz-align="left" vert-align="center" font-size="small">
-      <grid grid-height="1" grid-width="3" grid-x="3" grid-y="1"/>
+      <grid grid-height="1" grid-width="3" grid-x="3" grid-y="5"/>
     </style>
     <header>
       <text>
@@ -68,7 +68,7 @@
 
   <field>
     <style horz-align="left" vert-align="center" font-size="small">
-      <grid grid-height="1" grid-width="5" grid-x="6" grid-y="1"/>
+      <grid grid-height="1" grid-width="5" grid-x="6" grid-y="5"/>
     </style>
     <header>
       <text>
@@ -87,7 +87,7 @@
 
   <field>
     <style horz-align="left" vert-align="center" font-size="small">
-      <grid grid-height="1" grid-width="3" grid-x="3" grid-y="2"/>
+      <grid grid-height="1" grid-width="3" grid-x="3" grid-y="6"/>
     </style>
     <header>
       <text>
@@ -106,7 +106,7 @@
 
   <field>
     <style horz-align="left" vert-align="center" font-size="small">
-      <grid grid-height="1" grid-width="5" grid-x="6" grid-y="2"/>
+      <grid grid-height="1" grid-width="5" grid-x="6" grid-y="6"/>
     </style>
     <header>
       <text>

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.xml
@@ -30,7 +30,7 @@
 
   <field>
     <style horz-align="left" vert-align="center" font-size="medium">
-      <grid grid-height="1" grid-width="8" grid-x="2" grid-y="0"/>
+      <grid grid-height="1" grid-width="8" grid-x="3" grid-y="0"/>
     </style>
     <header>
       <text>
@@ -49,7 +49,7 @@
 
   <field>
     <style horz-align="left" vert-align="center" font-size="small">
-      <grid grid-height="1" grid-width="3" grid-x="2" grid-y="1"/>
+      <grid grid-height="1" grid-width="3" grid-x="3" grid-y="1"/>
     </style>
     <header>
       <text>
@@ -68,7 +68,7 @@
 
   <field>
     <style horz-align="left" vert-align="center" font-size="small">
-      <grid grid-height="1" grid-width="5" grid-x="5" grid-y="1"/>
+      <grid grid-height="1" grid-width="5" grid-x="6" grid-y="1"/>
     </style>
     <header>
       <text>
@@ -87,7 +87,7 @@
 
   <field>
     <style horz-align="left" vert-align="center" font-size="small">
-      <grid grid-height="1" grid-width="3" grid-x="2" grid-y="2"/>
+      <grid grid-height="1" grid-width="3" grid-x="3" grid-y="2"/>
     </style>
     <header>
       <text>
@@ -106,7 +106,7 @@
 
   <field>
     <style horz-align="left" vert-align="center" font-size="small">
-      <grid grid-height="1" grid-width="5" grid-x="5" grid-y="2"/>
+      <grid grid-height="1" grid-width="5" grid-x="6" grid-y="2"/>
     </style>
     <header>
       <text>

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.xml
@@ -39,7 +39,7 @@
     </header>
     <template form="{header[format]}">
       <text>
-        **<locale id="{header[locale_id]}"/>:** ‎<!-- This line ends with a Left-to-right control character so the space after ** is preserved -->
+        <locale id="{header[locale_id]}"/>
         <xpath function="{header[xpath_function]}">
           {header[variables]}
         </xpath>
@@ -58,7 +58,7 @@
     </header>
     <template form="{top_left[format]}">
       <text>
-        **<locale id="{top_left[locale_id]}"/>:** ‎<!-- This line ends with a Left-to-right control character so the space after ** is preserved -->
+        <locale id="{top_left[locale_id]}"/>
         <xpath function="{top_left[xpath_function]}">
           {top_left[variables]}
         </xpath>
@@ -77,7 +77,7 @@
     </header>
     <template form="{top_right[format]}">
       <text>
-        **<locale id="{top_right[locale_id]}"/>:** ‎<!-- This line ends with a Left-to-right control character so the space after ** is preserved -->
+        <locale id="{top_right[locale_id]}"/>
         <xpath function="{top_right[xpath_function]}">
           {top_right[variables]}
         </xpath>
@@ -96,7 +96,7 @@
     </header>
     <template form="{bottom_left[format]}">
       <text>
-        **<locale id="{bottom_left[locale_id]}"/>:** ‎<!-- This line ends with a Left-to-right control character so the space after ** is preserved -->
+        <locale id="{bottom_left[locale_id]}"/>
         <xpath function="{bottom_left[xpath_function]}">
           {bottom_left[variables]}
         </xpath>
@@ -115,7 +115,7 @@
     </header>
     <template form="{bottom_right[format]}">
       <text>
-        **<locale id="{bottom_right[locale_id]}"/>:** ‎<!-- This line ends with a Left-to-right control character so the space after ** is preserved -->
+        <locale id="{bottom_right[locale_id]}"/>
         <xpath function="{bottom_right[xpath_function]}">
           {bottom_right[variables]}
         </xpath>

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/one_two_two.xml
@@ -39,7 +39,7 @@
     </header>
     <template form="{header[format]}">
       <text>
-        <locale id="{header[locale_id]}"/>
+        <locale id="{header[locale_id]}"/> <!-- This line ends with a FOUR-PER-EM SPACE U+2005 character to replicate a space without being trimmed -->
         <xpath function="{header[xpath_function]}">
           {header[variables]}
         </xpath>
@@ -58,7 +58,7 @@
     </header>
     <template form="{top_left[format]}">
       <text>
-        <locale id="{top_left[locale_id]}"/>
+        <locale id="{top_left[locale_id]}"/> <!-- This line ends with a FOUR-PER-EM SPACE U+2005 character to replicate a space without being trimmed -->
         <xpath function="{top_left[xpath_function]}">
           {top_left[variables]}
         </xpath>
@@ -77,7 +77,7 @@
     </header>
     <template form="{top_right[format]}">
       <text>
-        <locale id="{top_right[locale_id]}"/>
+        <locale id="{top_right[locale_id]}"/> <!-- This line ends with a FOUR-PER-EM SPACE U+2005 character to replicate a space without being trimmed -->
         <xpath function="{top_right[xpath_function]}">
           {top_right[variables]}
         </xpath>
@@ -96,7 +96,7 @@
     </header>
     <template form="{bottom_left[format]}">
       <text>
-        <locale id="{bottom_left[locale_id]}"/>
+        <locale id="{bottom_left[locale_id]}"/> <!-- This line ends with a FOUR-PER-EM SPACE U+2005 character to replicate a space without being trimmed -->
         <xpath function="{bottom_left[xpath_function]}">
           {bottom_left[variables]}
         </xpath>
@@ -115,7 +115,7 @@
     </header>
     <template form="{bottom_right[format]}">
       <text>
-        <locale id="{bottom_right[locale_id]}"/>
+        <locale id="{bottom_right[locale_id]}"/> <!-- This line ends with a FOUR-PER-EM SPACE U+2005 character to replicate a space without being trimmed -->
         <xpath function="{bottom_right[xpath_function]}">
           {bottom_right[variables]}
         </xpath>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -140,7 +140,7 @@
     <div class="<%- prefix %>-grid-style-<%- index %> box">
       <% if (styles[index].displayFormat === 'Image') {
       if(resolveUri(datum)) { %>
-      <img class="module-icon" style="max-width:100%; max-height:100%;" src="<%- resolveUri(datum) %>"/>
+      <img class="module-icon" src="<%- resolveUri(datum) %>"/>
       <% } %>
       <% } else if(styles[index].widthHint === 0) { %>
       <div style="display:none;"><%- datum %></div>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
@@ -132,12 +132,11 @@
   transition: background .6s;
 }
 
-// Apply to all children to cover both regular case lists and case tiles
-.module-table-case-list tbody tr:nth-child(even) > * {
+.module-table-case-list tbody tr:nth-child(even) > td {
   background-color: @cc-bg;
 }
 
-.module-table-case-list tbody tr:hover > * {
+.module-table-case-list tbody tr:hover > td {
   background-color: darken(@cc-bg, 5);
 }
 

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -42,6 +42,11 @@
     a {
       color: @cc-brand-mid;
     }
+
+    &:hover {
+      background-color: darken(@cc-bg, 5);
+      transition: background 0.6s;
+    }
   }
 
   .highlighted-case {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -43,6 +43,11 @@
       color: @cc-brand-mid;
     }
 
+    .webapp-markdown-output img {
+      max-height: 100%;
+      max-width: 100%;
+    }
+
     &:hover {
       background-color: darken(@cc-bg, 5);
       transition: background 0.6s;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -43,6 +43,7 @@
       color: @cc-brand-mid;
     }
 
+    .module-icon,
     .webapp-markdown-output img {
       max-height: 100%;
       max-width: 100%;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This change affects only the "Title row, second row with two cells, third row with two cells" template.

There are four changes:
- An empty column separate the left image and text (columns 3-4 on the grid shown in Screenshot 1)
- On hover, the tile will be darkened as shown on the “No image” case (Screenshot 2)
- You will be able to display only the property by setting the “Display Properties” → “Display Text” as blank (Screenshot 3).
- The block of text will stay vertically centered if a large (to an extent) image is used

Screenshot 1
![image](https://github.com/dimagi/commcare-hq/assets/88759246/0483a720-ee9f-48d0-972e-f936e68b28d7)
Screenshot 2
![Screen Shot 2023-08-29 at 2 49 10 PM](https://github.com/dimagi/commcare-hq/assets/88759246/12e65d37-29be-4a59-b8ef-316c82196f44)
Screenshot 3
![Screen Shot 2023-08-30 at 9 21 57 AM](https://github.com/dimagi/commcare-hq/assets/88759246/5ed06fa0-5e87-4ea7-979d-3addb34d3de3)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi-dev.atlassian.net/browse/USH-3554

To keep the block of text vertically centered, the height was the image was set to 10 rows. 10 is an arbitrary height which I'm guessing a reasonably sized image will not exceed. The 3 rows of text are centered around the middle of the rows, so they populate rows 4, 5, and 6. This will make [“Grouped by Parent Case” ](https://confluence.dimagi.com/display/saas/Allow+Configuration+of+Case+List+Tiles#AllowConfigurationofCaseListTiles-Groupedbyparentcase) feature less intuitive to use. For “Case tile header rows”, app builder will need to input 5 to include the “header” field as the parent header. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case Tiles: https://confluence.dimagi.com/display/saas/Allow+Configuration+of+Case+List+Tiles

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing, this change affects only one case tile template that was recently created so has very contained usage.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No tests
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
