### PR TITLE
Create helper functions for word wrapping

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/vellum/src/main-components.js
+++ b/corehq/apps/app_manager/static/app_manager/js/vellum/src/main-components.js
@@ -31127,7 +31127,7 @@ define('vellum/datasources',[
           return outStr;
         };
 
-        function validateWordLength(inStr, maxLength) {
+        function insertWordBreaks(inStr, maxLength) {
           let words = inStr.split(" ");
           let outStr = "";
           for (word of words) {
@@ -31149,7 +31149,7 @@ define('vellum/datasources',[
 
                 return {
                     name: name,
-                    description: validateWordLength(tree.description, 43),
+                    description: insertWordBreaks(tree.description, 43),
                     hashtag: info.hashtag && !index ? info.hashtag + '/' + name : null,
                     parentPath: parentPath,
                     xpath: path,

--- a/corehq/apps/app_manager/static/app_manager/js/vellum/src/main-components.js
+++ b/corehq/apps/app_manager/static/app_manager/js/vellum/src/main-components.js
@@ -31113,6 +31113,30 @@ define('vellum/datasources',[
      * hashtag and/or xpath expression.
      */
     builders.dataNodes = function (that) {
+        function wordWrap(inStr, maxLength) {
+          if (inStr.length <= maxLength) {
+            return inStr;
+          }
+          outStr = "";
+          bufferStr = inStr;
+          while(bufferStr.length > maxLength) {
+            outStr += bufferStr.slice(0, maxLength) + "\n";
+            bufferStr = bufferStr.slice(maxLength, bufferStr.length);
+          }
+          outStr += "\n" + bufferStr;
+          return outStr;
+        };
+
+        function validateWordLength(inStr, maxLength) {
+          let words = inStr.split(" ");
+          let outStr = "";
+          for (word of words) {
+            outStr += wordWrap(word, maxLength);
+            outStr += " ";
+          }
+          return outStr;
+        };
+
         function node(source, parentPath, info, index) {
             return function (item, id) {
                 if (_.contains(that.invalidCaseProperties, id)) {
@@ -31125,7 +31149,7 @@ define('vellum/datasources',[
 
                 return {
                     name: name,
-                    description: tree.description,
+                    description: validateWordLength(tree.description, 43),
                     hashtag: info.hashtag && !index ? info.hashtag + '/' + name : null,
                     parentPath: parentPath,
                     xpath: path,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Currently, when a case property description contains a very long word, this will not be properly word-wrapped in the app manager:
![wrap_validation_none](https://github.com/dimagi/commcare-hq/assets/122617251/1b893a48-a703-47f8-bd35-fd7be7b7c0cd)

The helper functions from this PR ensure that long words are properly wrapped to fit inside the description popup:
![Screenshot from 2023-08-25 11-06-03](https://github.com/dimagi/commcare-hq/assets/122617251/788ecff5-e383-41c0-90f9-d6ecd7d0f2e4)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3078).

Helper functions have been created to ensure that the length of each word in a case property's description is less than a limit of 43 characters. If a word is longer than this, then it is appropriately wrapped with newlines to stay within the length constraint.

Validation is being done on each word individually since wrapping already occurs between words.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`DATA_DICTIONARY`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Small UI validation change.
- Have done local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
