### PR TITLE
Add css to center markdown tables

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/less/markdown-table.less
+++ b/corehq/apps/cloudcare/static/cloudcare/less/markdown-table.less
@@ -37,3 +37,9 @@
         }
     }
 }
+
+.text-center {
+  .webapp-markdown-output table {
+    margin: auto;
+  }
+}

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -129,7 +129,6 @@
   }
 }
 
-
 @media print {
   .form-container.print-container {
     margin: 0px;


### PR DESCRIPTION
## Product Description

The “text-align-center” appearance attribute caused the bootstrap `text-center` css class to be applied. This does not have an effect on tables as it just sets `text-align: center;`. With the change `margin: auto;` will be set for tables as well.

Before:
![image](https://github.com/dimagi/commcare-hq/assets/1946138/0058dd20-c5b2-475f-9a44-3d08bed6af48)

After:
![image](https://github.com/dimagi/commcare-hq/assets/1946138/42a46a87-9979-44c1-b66f-cf203b9e4f21)


## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3598

## Feature Flag

None

## Safety Assurance

### Safety story

Tested with and without the extra CSS. Looked good. CSS is fairly specific.


### Automated test coverage

None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
