### PR TITLE
Management command to add an index on `inserted_at` columns for data sources

### DIFF
--- a/corehq/apps/userreports/management/commands/add_inserted_at_index.py
+++ b/corehq/apps/userreports/management/commands/add_inserted_at_index.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         for config in tables:
             adapters.append(
                 get_indicator_adapter(
-                    config, load_source='find_datasource_mismatches'
+                    config, load_source='add_inserted_at_index'
                 )
             )
 

--- a/corehq/apps/userreports/management/commands/add_inserted_at_index.py
+++ b/corehq/apps/userreports/management/commands/add_inserted_at_index.py
@@ -1,0 +1,106 @@
+import logging
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand
+
+from sqlalchemy import text
+
+from corehq.apps.userreports.alembic_diffs import DiffTypes
+from corehq.apps.userreports.models import (
+    DataSourceActionLog,
+    DataSourceConfiguration,
+    StaticDataSourceConfiguration,
+)
+from corehq.apps.userreports.pillow_utils import (
+    _is_datasource_active,
+    get_table_diffs,
+)
+from corehq.apps.userreports.rebuild import _get_indexes_diffs_to_change
+from corehq.apps.userreports.sql import get_metadata
+from corehq.apps.userreports.util import get_indicator_adapter
+from corehq.sql_db.connections import connection_manager
+from corehq.util.log import with_progress_bar
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Adds an index on all `inserted_at` columns of data sources for the specified domain'
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument(
+            '--initiated-by',
+            action='store',
+            required=True,
+            dest='initiated_by',
+            help='Who initiated the migration',
+        )
+
+    def handle(self, domain, initiated_by, *args, **kwargs):
+        tables = StaticDataSourceConfiguration.by_domain(domain)
+        tables.extend(DataSourceConfiguration.by_domain(domain))
+        adapters = []
+        for config in tables:
+            adapters.append(
+                get_indicator_adapter(
+                    config, load_source='find_datasource_mismatches'
+                )
+            )
+
+        tables_by_engine = defaultdict(dict)
+        for adapter in adapters:
+            if _is_datasource_active(adapter):
+                tables_by_engine[adapter.engine_id][
+                    adapter.get_table().name
+                ] = adapter
+
+        for engine_id, table_map in with_progress_bar(tables_by_engine.items(), oneline=False):
+            table_names = list(table_map)
+            engine = connection_manager.get_engine(engine_id)
+
+            diffs = get_table_diffs(
+                engine, table_names, get_metadata(engine_id)
+            )
+            index_diffs = _get_indexes_diffs_to_change(diffs)
+            # Filter for diffs where we 1. add an index to 2. the inserted_at column
+            add_index_to_inserted_at_diffs = list(
+                filter(
+                    lambda diff: diff.type == DiffTypes.ADD_INDEX
+                    and hasattr(diff.index.columns, 'inserted_at'),
+                    index_diffs,
+                )
+            )
+
+            index_diff_pairs = [(diff.index, diff) for diff in add_index_to_inserted_at_diffs]
+            if not index_diff_pairs:
+                continue
+
+            num_diffs_to_attend = len(index_diff_pairs)
+            diffs_addressed = []
+            try:
+                with engine.connect() as connection:
+                    connection.execution_options(isolation_level='AUTOCOMMIT')
+                    for index, diff in index_diff_pairs:
+                        column_names = ', '.join(c.name for c in index.columns)
+                        table_name = index.table.name
+                        sql_query = f'CREATE INDEX CONCURRENTLY "{index.name}" ON "{table_name}" ({column_names})'
+                        connection.execute(text(sql_query))
+                        diffs_addressed.append(diff.to_dict())
+            except Exception as ex:
+                logger.exception(ex)
+            finally:
+                adapter._log_action(
+                    initiated_by=initiated_by,
+                    source='management-command',
+                    action=DataSourceActionLog.MIGRATE,
+                    diffs=diffs_addressed,
+                )
+                logger.info(f'{len(diffs_addressed)} indecies added')
+                if not len(diffs_addressed) == num_diffs_to_attend:
+                    num_diffs_not_attended = num_diffs_to_attend - len(
+                        diffs_addressed
+                    )
+                    logger.warning(
+                        f'{num_diffs_not_attended} indecies were not added'
+                    )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No visible change

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
In [this PR](https://github.com/dimagi/commcare-hq/pull/33380) an index is added to data sources' `inserted_at` columns by setting `create_index=True` when building the `inserted_at` column. The pillow code is also updated to exclude all tables from being migrated (or rather, [show the index create SQL](https://github.com/dimagi/commcare-hq/blob/0d0de2d87068a2aaf34e3484852ee6fb0c83938d/corehq/apps/userreports/rebuild.py#L143-L146), since we don't actually create the indecies), where the only change between the datasource's configured and actual state is this index.

This does mean that the index will only be added to a data source when it rebuilt. Ideally we'd want a way to add this index to certain domains ourselves, especially for those that needs the `EXPORT_DATA_SOURCE_DATA` enabled. This management command does exactly that.

Note: When a project wants to export data sources using the DET, they will need the `EXPORT_DATA_SOURCE_DATA` FF enabled, but we need to run this command for them (if needed) before enabling the FF

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Tested it locally
- Test on staging pending
 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
