### PR TITLE
fix issue if flower settings are missing

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -211,7 +211,7 @@ class DataSourceBuildInformation(DocumentSchema):
         Returns ``True`` if the rebuild failed, ``False`` if it succeeded
         or has not yet failed, or ``None`` if Flower is not available.
         """
-        flower_url = getattr(settings, 'CELERY_FLOWER_URL')
+        flower_url = getattr(settings, 'CELERY_FLOWER_URL', None)
 
         def none_max(a, b):
             if a is None:
@@ -1515,6 +1515,7 @@ class UCRExpression(models.Model):
             description = f"{self.description[:64]}…"
         description = f": {description}" if description else ""
         return f"{self.name}{description}"
+
 
 def get_datasource_config_infer_type(config_id, domain):
     return get_datasource_config(config_id, domain, guess_data_source_type(config_id))


### PR DESCRIPTION
## Technical Summary
This just fixes a bug that occurred locally for me when `CELERY_FLOWER_URL` was not included in my settings. As I don't see that setting in either _settings.py_ or _dev_settings.py_, I think it is important to default this to `None`

## Safety Assurance

### Safety story
This shouldn't pose any issue to safety -- if the setting is set, this changes nothing. If the setting is not sent, this prevents a crash.

### Automated test coverage

No tests for this.

### QA Plan

No QA required.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
