### PR TITLE
Ignore bootstrap5_diffs

### DIFF
--- a/scripts/make-translations.sh
+++ b/scripts/make-translations.sh
@@ -6,10 +6,10 @@ function abort () {
 }
 
 echo "Gathering all translation strings.  Note that this will probably take a while"
-./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs/_build' --ignore 'coverage-report' --ignore 'submodules/formdesigner' --add-location file "$@"
+./manage.py makemessages --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs/_build' --ignore 'coverage-report' --ignore 'submodules/formdesigner' --ignore 'corehq/apps/hqwebapp/tests/data/bootstrap5_diffs' --add-location file "$@"
 
 echo "Gathering javascript translation strings.  This will also probably take a while"
-./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs' --ignore 'coverage-report' --ignore 'submodules/formdesigner' --add-location file "$@"
+./manage.py makemessages -d djangojs --all --ignore 'corehq/apps/app_manager/tests/data/v2_diffs*' --ignore 'node_modules' --ignore 'docs' --ignore 'coverage-report' --ignore 'submodules/formdesigner' --ignore 'corehq/apps/hqwebapp/tests/data/bootstrap5_diffs' --add-location file "$@"
 
 echo "Compiling translation files."
 if ! ./manage.py compilemessages; then


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Have errors when update-translation, so have this PR to ignore all bootstrap diff files
```
Traceback (most recent call last):
  File "/home/runner/work/commcare-hq/commcare-hq/./manage.py", line 189, in <module>
    main()
  File "/home/runner/work/commcare-hq/commcare-hq/./manage.py", line 47, in main
    execute_from_command_line(sys.argv)
  File "/opt/hostedtoolcache/Python/3.9.17/x[64](https://github.com/dimagi/commcare-hq/actions/runs/6021144690/job/16333530557#step:8:65)/lib/python3.9/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/home/runner/work/commcare-hq/commcare-hq/hqscripts/management/commands/makemessages.py", line 23, in handle
    super().handle(*args, **options)
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/django/core/management/commands/makemessages.py", line 382, in handle
    potfiles = self.build_potfiles()
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/django/core/management/commands/makemessages.py", line 432, in build_potfiles
    self.process_files(file_list)
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/django/core/management/commands/makemessages.py", line 503, in process_files
    self.process_locale_dir(locale_dir, files)
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/django/core/management/commands/makemessages.py", line 522, in process_locale_dir
    build_file.preprocess()
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/django/core/management/commands/makemessages.py", line 112, in preprocess
    content = templatize(src_data, origin=self.path[2:])
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/django/utils/translation/__init__.py", line 304, in templatize
    return templatize(src, **kwargs)
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/django/utils/translation/template.py", line 126, in templatize
    raise SyntaxError(
SyntaxError: Translation blocks must not include other block tags: csrf_token (file corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/maintenance_alerts.html.diff.txt, line 28)
```

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally with `make-migrations.sh`, the result looks good.
Learned from @dannyroberts :
> As part of upgrade from Bootstrap 3 to 5, we need to keep two versions of many files: one for Bootstrap 3 and one for Bootstrap 5
> And to make sure there isn’t “drift” as people accidentally edit one but not the other, we’re also committing the diff between those two files

Ignore those diffs file are safe

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
