### PR TITLE
Fix: Test Connection button not working with custom auth options

### DIFF
--- a/corehq/motech/static/motech/js/connection_settings_detail.js
+++ b/corehq/motech/static/motech/js/connection_settings_detail.js
@@ -133,6 +133,9 @@ hqDefine("motech/js/connection_settings_detail", [
                 client_id: $('#id_client_id').val(),
                 plaintext_client_secret: $('#id_plaintext_client_secret').val(),
                 skip_cert_verify: $('#id_skip_cert_verify').prop('checked'),
+                token_url: $("#id_token_url").val(),
+                refresh_url: $("#id_refresh_url").val(),
+                auth_preset: $("#id_auth_preset").val()
             };
             $testConnectionButton.disableButton();
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This change fixes the Test Connection button on Connection Settings page in Data Forwarding.

## Technical Summary
The Test Connection button currently does not work with custom auth option specified as the `auth_preset, token_url and refresh_url` inputs were not passed to the API request which triggered the auth test, and that resulted in a Internal Server error as the request was tried against a invalid endpoint (None in this case).
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
