### PR TITLE
Ensure pre-filled filters get checked before pulling data

### DIFF
--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -86,6 +86,9 @@ class ChoiceProvider(metaclass=ABCMeta):
 
     def get_choices_for_values(self, values, user):
         choices = set(self.get_choices_for_known_values(values, user))
+        if self.location_safe and not user.has_permission(self.domain, 'access_all_locations'):
+            return choices
+
         used_values = {value for value, _ in choices}
         for value in values:
             if value not in used_values:
@@ -344,14 +347,6 @@ class LocationChoiceProvider(ChainableChoiceProvider):
             else:
                 return loc.display_name
         return [Choice(loc.location_id, display(loc)) for loc in locations]
-
-    def get_sorted_choices_for_values(self, choices, user):
-        locations = SQLLocation.objects if self.show_all_locations else SQLLocation.active_objects
-        accessible_locations = (locations.accessible_to_user(self.domain, user)
-                                .filter(domain=self.domain)
-                                .values_list("location_id", flat=True))
-        accessible_choices = [c for c in choices if c in accessible_locations]
-        return super(LocationChoiceProvider, self).get_sorted_choices_for_values(accessible_choices, user)
 
 
 class UserChoiceProvider(ChainableChoiceProvider):


### PR DESCRIPTION
## Product Description
This PR fixes an issue that existed where a location restricted user could view data belonging to another location this user is not part of when the location filter is pre-filled in the URL.

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-14851)

When a pre-filled report filter URL was processed the values of the filters was not checked, hence if you knew what you were doing you could potentially see data from locations which you're not supposed to. This PR filters out any filter value the request user cannot access. 

## Feature Flag
Show an additional "Owner (Location)" property in report builder reports

## Safety Assurance

### Safety story
Tested locally
Staging testing to commence

### Automated test coverage
No additional automated tests

### QA Plan
No formal QA planned except what is done as part of the ticket.
 

### Migrations
- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
