### PR TITLE
Add new case tile template

### DIFF
--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/icon_text_grid.json
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/icon_text_grid.json
@@ -6,9 +6,9 @@
       "middle_left_image", "middle_left_text", "middle_right_image", "middle_right_text",
       "bottom_left_image", "bottom_left_text"],
     "grid": {
-        "top_left_image": {"x": 0, "y": 0, "width": 1, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "top_left_image": {"x": 0, "y": 0, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},
         "top_left_text": {"x": 1, "y": 0, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "top_right_image": {"x": 6, "y": 0, "width": 1, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "top_right_image": {"x": 6, "y": 0, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},
         "top_right_text": {"x": 7, "y": 0, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
 
         "middle_left_image": {"x": 0, "y": 1, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/icon_text_grid.json
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/icon_text_grid.json
@@ -6,17 +6,17 @@
       "middle_left_image", "middle_left_text", "middle_right_image", "middle_right_text",
       "bottom_left_image", "bottom_left_text"],
     "grid": {
-        "top_left_image": {"x": 0, "y": 0, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "top_left_image": {"x": 0, "y": 0, "width": 1, "height": 1, "horz-align": "center", "vert-align": "top"},
         "top_left_text": {"x": 1, "y": 0, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "top_right_image": {"x": 6, "y": 0, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "top_right_image": {"x": 6, "y": 0, "width": 1, "height": 1, "horz-align": "center", "vert-align": "top"},
         "top_right_text": {"x": 7, "y": 0, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
 
-        "middle_left_image": {"x": 0, "y": 1, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "middle_left_image": {"x": 0, "y": 1, "width": 1, "height": 1, "horz-align": "center", "vert-align": "top"},
         "middle_left_text": {"x": 1, "y": 1, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
-        "middle_right_image": {"x": 6, "y": 1, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "middle_right_image": {"x": 6, "y": 1, "width": 1, "height": 1, "horz-align": "center", "vert-align": "top"},
         "middle_right_text": {"x": 7, "y": 1, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
 
-        "bottom_left_image": {"x": 0, "y": 2, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "bottom_left_image": {"x": 0, "y": 2, "width": 1, "height": 1, "horz-align": "center", "vert-align": "top"},
         "bottom_left_text": {"x": 1, "y": 2, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"}
     }
 }

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/icon_text_grid.json
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/icon_text_grid.json
@@ -1,0 +1,22 @@
+{
+    "slug": "icon_text_grid",
+    "filename": "icon_text_grid.xml",
+    "has_map": false,
+    "fields": ["top_left_image", "top_left_text", "top_right_image", "top_right_text",
+      "middle_left_image", "middle_left_text", "middle_right_image", "middle_right_text",
+      "bottom_left_image", "bottom_left_text"],
+    "grid": {
+        "top_left_image": {"x": 0, "y": 0, "width": 1, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "top_left_text": {"x": 1, "y": 0, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "top_right_image": {"x": 6, "y": 0, "width": 1, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "top_right_text": {"x": 7, "y": 0, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
+
+        "middle_left_image": {"x": 0, "y": 1, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "middle_left_text": {"x": 1, "y": 1, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
+        "middle_right_image": {"x": 6, "y": 1, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "middle_right_text": {"x": 7, "y": 1, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"},
+
+        "bottom_left_image": {"x": 0, "y": 2, "width": 1, "height": 1, "horz-align": "center", "vert-align": "center"},
+        "bottom_left_text": {"x": 1, "y": 2, "width": 5, "height": 1, "horz-align": "left", "vert-align": "center"}
+    }
+}

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/icon_text_grid.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/icon_text_grid.xml
@@ -1,0 +1,182 @@
+<detail id="{detail_id}">
+  <title>
+    <text>
+      <locale id="{title_text_id}"/>
+    </text>
+  </title>
+
+  <field>
+    <style horz-align="center" vert-align="center" font-size="small">
+      <grid grid-height="1" grid-width="1" grid-x="0" grid-y="0" />
+    </style>
+    <header>
+      <text/>
+    </header>
+    <template form="{top_left_image[format]}">
+      <text>
+        <xpath function="{top_left_image[xpath_function]}">
+          {top_left_image[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="center" font-size="medium">
+      <grid grid-height="1" grid-width="5" grid-x="1" grid-y="0"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{top_left_text[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{top_left_text[format]}">
+      <text>
+        <locale id="{top_left_text[locale_id]}"/> <!-- This line ends with a FOUR-PER-EM SPACE U+2005 character to replicate a space without being trimmed -->
+        <xpath function="{top_left_text[xpath_function]}">
+          {top_left_text[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="center" vert-align="center" font-size="small">
+      <grid grid-height="1" grid-width="1" grid-x="6" grid-y="0" />
+    </style>
+    <header>
+      <text/>
+    </header>
+    <template form="{top_right_image[format]}">
+      <text>
+        <xpath function="{top_right_image[xpath_function]}">
+          {top_right_image[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="center" font-size="medium">
+      <grid grid-height="1" grid-width="5" grid-x="7" grid-y="0"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{top_right_text[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{top_right_text[format]}">
+      <text>
+        <locale id="{top_right_text[locale_id]}"/> <!-- This line ends with a FOUR-PER-EM SPACE U+2005 character to replicate a space without being trimmed -->
+        <xpath function="{top_right_text[xpath_function]}">
+          {top_right_text[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="center" vert-align="center" font-size="small">
+      <grid grid-height="1" grid-width="1" grid-x="0" grid-y="1" />
+    </style>
+    <header>
+      <text/>
+    </header>
+    <template form="{middle_left_image[format]}">
+      <text>
+        <xpath function="{middle_left_image[xpath_function]}">
+          {middle_left_image[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="center" font-size="medium">
+      <grid grid-height="1" grid-width="5" grid-x="1" grid-y="1"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{middle_left_text[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{middle_left_text[format]}">
+      <text>
+        <locale id="{middle_left_text[locale_id]}"/> <!-- This line ends with a FOUR-PER-EM SPACE U+2005 character to replicate a space without being trimmed -->
+        <xpath function="{middle_left_text[xpath_function]}">
+          {middle_left_text[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="center" vert-align="center" font-size="small">
+      <grid grid-height="1" grid-width="1" grid-x="6" grid-y="1" />
+    </style>
+    <header>
+      <text/>
+    </header>
+    <template form="{middle_right_image[format]}">
+      <text>
+        <xpath function="{middle_right_image[xpath_function]}">
+          {middle_right_image[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="center" font-size="medium">
+      <grid grid-height="1" grid-width="5" grid-x="7" grid-y="1"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{middle_right_text[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{middle_right_text[format]}">
+      <text>
+        <locale id="{middle_right_text[locale_id]}"/> <!-- This line ends with a FOUR-PER-EM SPACE U+2005 character to replicate a space without being trimmed -->
+        <xpath function="{middle_right_text[xpath_function]}">
+          {middle_right_text[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="center" vert-align="center" font-size="small">
+      <grid grid-height="1" grid-width="1" grid-x="0" grid-y="2" />
+    </style>
+    <header>
+      <text/>
+    </header>
+    <template form="{bottom_left_image[format]}">
+      <text>
+        <xpath function="{bottom_left_image[xpath_function]}">
+          {bottom_left_image[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+
+  <field>
+    <style horz-align="left" vert-align="center" font-size="medium">
+      <grid grid-height="1" grid-width="5" grid-x="1" grid-y="2"/>
+    </style>
+    <header>
+      <text>
+        <locale id="{bottom_left_text[locale_id]}"/>
+      </text>
+    </header>
+    <template form="{bottom_left_text[format]}">
+      <text>
+        <locale id="{bottom_left_text[locale_id]}"/> <!-- This line ends with a FOUR-PER-EM SPACE U+2005 character to replicate a space without being trimmed -->
+        <xpath function="{bottom_left_text[xpath_function]}">
+          {bottom_left_text[variables]}
+        </xpath>
+      </text>
+    </template>
+  </field>
+</detail>

--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/icon_text_grid.xml
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/icon_text_grid.xml
@@ -6,7 +6,7 @@
   </title>
 
   <field>
-    <style horz-align="center" vert-align="center" font-size="small">
+    <style horz-align="center" vert-align="top" font-size="small">
       <grid grid-height="1" grid-width="1" grid-x="0" grid-y="0" />
     </style>
     <header>
@@ -41,7 +41,7 @@
   </field>
 
   <field>
-    <style horz-align="center" vert-align="center" font-size="small">
+    <style horz-align="center" vert-align="top" font-size="small">
       <grid grid-height="1" grid-width="1" grid-x="6" grid-y="0" />
     </style>
     <header>
@@ -76,7 +76,7 @@
   </field>
 
   <field>
-    <style horz-align="center" vert-align="center" font-size="small">
+    <style horz-align="center" vert-align="top" font-size="small">
       <grid grid-height="1" grid-width="1" grid-x="0" grid-y="1" />
     </style>
     <header>
@@ -111,7 +111,7 @@
   </field>
 
   <field>
-    <style horz-align="center" vert-align="center" font-size="small">
+    <style horz-align="center" vert-align="top" font-size="small">
       <grid grid-height="1" grid-width="1" grid-x="6" grid-y="1" />
     </style>
     <header>
@@ -146,7 +146,7 @@
   </field>
 
   <field>
-    <style horz-align="center" vert-align="center" font-size="small">
+    <style horz-align="center" vert-align="top" font-size="small">
       <grid grid-height="1" grid-width="1" grid-x="0" grid-y="2" />
     </style>
     <header>

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -29,6 +29,7 @@ class CaseTileTemplates(models.TextChoices):
     ONE_3X_TWO_4X_ONE_2X = ("one_3X_two_4X_one_2X", _("Three upper rows, four rows with two cells, two lower rows "
                                                     "and map"))
     ONE_TWO_TWO = ("one_two_two", _("Title row, second row with two cells, third row with two cells"))
+    ICON_TEXT_GRID = ("icon_text_grid", _("2 x 3 grid of image and text"))
 
 
 @dataclass

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -47,7 +47,9 @@
             </label>
             <select data-bind="options:caseTileTemplateOptions, optionsText: 'templateName', optionsValue: 'templateValue', value:caseTileTemplate" class="form-control"></select>
           </div>
-          <div class="col-sm-6" data-bind="visible: caseTilePreviewForTemplate">
+        </div>
+        <div class="row">
+          <div class="col-sm-12" data-bind="visible: caseTilePreviewForTemplate">
             <label></label>
             <div data-bind="html: caseTilePreviewForTemplate"></div>
           </div>


### PR DESCRIPTION
## Product Description

Add a new case tile template with 2.5 rows of icon, text, icon text. Moved the preview so it can take up the whole width to support wider templates.

<img width="653" alt="image" src="https://github.com/dimagi/commcare-hq/assets/1946138/7f559f32-d899-45f2-be88-ca03c7a5cbb4">

<img width="1145" alt="image" src="https://github.com/dimagi/commcare-hq/assets/1946138/67fdf9d8-04dd-4454-a94d-209194b23668">

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3608

## Feature Flag

REC/USH: Case tile templates …

## Safety Assurance

### Safety story

Very similar to previously added templates. Does not touch any code. None of the existing templates are affected. Tested locally and on staging

### Automated test coverage

None

### QA Plan

Create case list using the new template.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
