### PR TITLE
WebUser feature should not be required when updating software plan

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -1655,10 +1655,15 @@ class SoftwarePlanVersionForm(forms.Form):
             self._errors.setdefault('feature_rates', errors)
 
         required_types = [FeatureType.USER, FeatureType.SMS]
+        all_types = list(dict(FeatureType.CHOICES))
         feature_types = [r.feature.feature_type for r in rate_instances]
-        if any([feature_types.count(t) != 1 for t in required_types]):
+        if any([feature_types.count(t) == 0 for t in required_types]):
             raise ValidationError(_(
-                "You must specify exactly one rate per feature type "
+                "You must specify a rate for SMS and USER feature type"
+            ))
+        if any([feature_types.count(t) > 1 for t in all_types]):
+            raise ValidationError(_(
+                "You can only specify one rate per feature type "
                 "(SMS, USER, etc.)"
             ))
 

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -1654,7 +1654,7 @@ class SoftwarePlanVersionForm(forms.Form):
         if errors:
             self._errors.setdefault('feature_rates', errors)
 
-        required_types = list(dict(FeatureType.CHOICES))
+        required_types = [FeatureType.USER, FeatureType.SMS]
         feature_types = [r.feature.feature_type for r in rate_instances]
         if any([feature_types.count(t) != 1 for t in required_types]):
             raise ValidationError(_(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Ops will see error "You must specify exactly one rate per feature type (SMS, USER, etc)" when updating software plan, even though they have specified User Feature and SMS Feature:
![image](https://github.com/dimagi/commcare-hq/assets/39149002/73d52618-68cf-4fcd-9eff-7a6b3a3ee65d)

This PR will fix this issue.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-14883

Since the error message is "You must specify exactly one rate per feature type (SMS, USER, etc.)":

- Exactly one rate ✅: After specifying exactly one rate for SMS and USER, without specifying Web User, user should be able to update software plan
- Zero rate ❌: Without specifying SMS and User, user will receive error
- More than one rate ❌: Specifying more than one rate for SMS, USER, Web User, user will receive error

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Tested locally
- Pretty simple logic
- Will have QA test

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket: https://dimagi-dev.atlassian.net/browse/QA-5572
-->
Will ask QA to test the three scenarios described in technical summary
[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-5572)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
