### PR TITLE
Split Screen Case Search: Dynamically update results

### DIFF
--- a/corehq/apps/app_manager/management/commands/enable_dynamic_results_ff_for_sscs_domains.py
+++ b/corehq/apps/app_manager/management/commands/enable_dynamic_results_ff_for_sscs_domains.py
@@ -1,0 +1,14 @@
+from django.core.management import BaseCommand
+from corehq.toggles import SPLIT_SCREEN_CASE_SEARCH, DYNAMICALLY_UPDATE_SEARCH_RESULTS, NAMESPACE_DOMAIN
+
+
+class Command(BaseCommand):
+    help = """
+    Enabled DYNAMICALLY_UPDATE_SEARCH_RESULTS feature flag for domains with SPLIT_SCREEN_CASE_SEARCH enabled.
+    """
+
+    def handle(self, **options):
+        sscs_enabled_domains = SPLIT_SCREEN_CASE_SEARCH.get_enabled_domains()
+        print("Processing " + str(len(sscs_enabled_domains)) + " domains")
+        for domain in sscs_enabled_domains:
+            DYNAMICALLY_UPDATE_SEARCH_RESULTS.set(domain, True, NAMESPACE_DOMAIN)

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -10,7 +10,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         formEntryUtils = hqImport("cloudcare/js/form_entry/utils"),
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
         formplayerUtils = hqImport("cloudcare/js/formplayer/utils/utils"),
-        initialPageData = hqImport("hqwebapp/js/initial_page_data");
+        initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+        toggles = hqImport("hqwebapp/js/toggles");
 
     var separator = " to ",
         serverSeparator = "__",
@@ -438,6 +439,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             // only here to maintain backward compatibility and can be removed
             // once web apps fully transition using keys to convey select prompt selection.
             this.selectValuesByKeys = false;
+            this.dynamicSearchEnabled = toggles.toggleEnabled('DYNAMICALLY_UPDATE_SEARCH_RESULTS') &&
+                this.options.sidebarEnabled;
 
             for (let model of this.parentModel) {
                 if ("itemsetChoicesKey" in model.attributes) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -523,7 +523,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         submitAction: function (e) {
             var self = this;
             e.preventDefault();
+            self.performSubmit();
+        },
 
+        performSubmit: function () {
+            var self = this;
             self.validateAllFields().done(function () {
                 FormplayerFrontend.trigger(
                     "menu:query",

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -513,6 +513,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     }
                 }
             });
+            if (self.dynamicSearchEnabled) {
+                self.updateSearchResults();
+            }
         },
 
         clearAction: function () {
@@ -539,6 +542,19 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     self.options.sidebarEnabled
                 );
             });
+        },
+
+        updateSearchResults: function () {
+            var self = this;
+            var invalidRequiredFields = [];
+            self.children.each(function (childView) {
+                if (childView.hasRequiredError()) {
+                    invalidRequiredFields.push(childView.model.get('text'));
+                }
+            });
+            if (invalidRequiredFields.length === 0) {
+                self.performSubmit();
+            }
         },
 
         validateFieldChange: function (changedChildView) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_spec.js
@@ -11,6 +11,8 @@ hqDefine("cloudcare/js/formplayer/spec/menu_list_spec", function () {
                 {
                     CHANGE_FORM_LANGUAGE: false,
                     SPLIT_SCREEN_CASE_SEARCH: false,
+                    DYNAMICALLY_UPDATE_SEARCH_RESULTS: false,
+
                 }
             );
             sinon.stub(Utils, 'getCurrentQueryInputs').callsFake(function () { return {}; });

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1030,6 +1030,15 @@ USH_EMPTY_CASE_LIST_TEXT = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN]
 )
 
+DYNAMICALLY_UPDATE_SEARCH_RESULTS = StaticToggle(
+    'dynamically_update_search_results',
+    "In case search with split screen case search enabled, search results update when a search field is updated"
+    " without requiring the user to manually press a button to search.",
+    TAG_CUSTOM,
+    help_link='https://confluence.dimagi.com/display/USH/Split+Screen+Case+Search',
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 SPLIT_SCREEN_CASE_SEARCH = StaticToggle(
     'split_screen_case_search',
     "Split screen case search: In case search, show the search filters in a sidebar on the left and the results"
@@ -1037,7 +1046,7 @@ SPLIT_SCREEN_CASE_SEARCH = StaticToggle(
     TAG_CUSTOM,
     help_link='https://confluence.dimagi.com/display/USH/Split+Screen+Case+Search',
     namespaces=[NAMESPACE_DOMAIN],
-    parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
+    parent_toggles=[SYNC_SEARCH_CASE_CLAIM, DYNAMICALLY_UPDATE_SEARCH_RESULTS]
 )
 
 USH_USERCASES_FOR_WEB_USERS = StaticToggle(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Main build PR for [this ticket](https://dimagi-dev.atlassian.net/browse/USH-3544) but builds off https://github.com/dimagi/commcare-hq/pull/33428 that was combined in this PR

![dynamic (1)](https://github.com/dimagi/commcare-hq/assets/36681924/b4d9c81b-3dca-43b0-af6f-b419d1b62f9e)

Note in the gif the first results are not filtered for DOB since Name is a required field, once that is filled out the results are filtered after field change. 


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
If the FF is enabled and the sidebar, then on field change it checks if all required fields are non-empty, and if so then perfrom a search. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DYNAMICALLY_UPDATE_SEARCH_RESULTS and SPLIT_SCREEN_CASE_SEARCH
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This will be tested on staging including for performance implications. Our biggest concern is the number of requests added if a search is performed after each field change. This is FF'ed separately from SSCS so if problems arise, the previous behavior of SSCS can be enabled without requiring a deploy immediately. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Planning on dev testing on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
