### PR TITLE
Add form and case types to deletable doc types

### DIFF
--- a/corehq/apps/cleanup/deletable_doc_types.py
+++ b/corehq/apps/cleanup/deletable_doc_types.py
@@ -43,4 +43,16 @@ DELETABLE_COUCH_DOC_TYPES = {
     'FixtureDataType': (FIXTURES_DB,),
     'FixtureDataItem': (FIXTURES_DB,),
     'FixtureOwnership': (FIXTURES_DB,),
+
+    # form and case types
+    'XFormInstance': (MAIN_DB,),
+    'XFormArchived': (MAIN_DB,),
+    'XFormDeprecated': (MAIN_DB,),
+    'XFormDuplicate': (MAIN_DB,),
+    'XFormError': (MAIN_DB,),
+    'SubmissionErrorLog': (MAIN_DB,),
+    'XFormInstance-Deleted': (MAIN_DB,),
+    'HQSubmission': (MAIN_DB,),
+    'CommCareCase': (MAIN_DB,),
+    'CommCareCase-Deleted': (MAIN_DB,),
 }


### PR DESCRIPTION
These were overlooked a long time ago, probably because there was so much other [code to remove](https://github.com/dimagi/commcare-hq/pull/30240).

## Safety Assurance

### Safety story

This code is primarily for documentation purposes.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations