### PR TITLE
Migration to remove free 50 sms

### DIFF
--- a/corehq/apps/accounting/bootstrap/config/remove_free_50_sms_sep_2023.py
+++ b/corehq/apps/accounting/bootstrap/config/remove_free_50_sms_sep_2023.py
@@ -1,0 +1,30 @@
+from decimal import Decimal
+
+from corehq.apps.accounting.models import FeatureType, SoftwarePlanEdition
+
+BOOTSTRAP_CONFIG = {
+    (SoftwarePlanEdition.STANDARD, False, False): {
+        'role': 'standard_plan_v1',
+        'product_rate_monthly_fee': Decimal('300.00'),
+        'feature_rates': {
+            FeatureType.USER: dict(monthly_limit=125, per_excess_fee=Decimal('2.00')),
+            FeatureType.SMS: dict(monthly_limit=0),
+        },
+    },
+    (SoftwarePlanEdition.PRO, False, False): {
+        'role': 'pro_plan_v1',
+        'product_rate_monthly_fee': Decimal('600.00'),
+        'feature_rates': {
+            FeatureType.USER: dict(monthly_limit=250, per_excess_fee=Decimal('2.00')),
+            FeatureType.SMS: dict(monthly_limit=0),
+        },
+    },
+    (SoftwarePlanEdition.ADVANCED, False, False): {
+        'role': 'advanced_plan_v0',
+        'product_rate_monthly_fee': Decimal('1200.00'),
+        'feature_rates': {
+            FeatureType.USER: dict(monthly_limit=500, per_excess_fee=Decimal('2.00')),
+            FeatureType.SMS: dict(monthly_limit=0),
+        }
+    },
+}

--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -8,11 +8,7 @@ from corehq.apps.accounting.utils import (
     log_accounting_info,
 )
 
-FEATURE_TYPES = [
-    FeatureType.USER,
-    FeatureType.SMS,
-    FeatureType.WEB_USER,
-]
+FEATURE_TYPES = list(dict(FeatureType.CHOICES))
 
 
 def ensure_plans(config, verbose, apps):

--- a/corehq/apps/accounting/migrations/0085_remove_free_50_sms.py
+++ b/corehq/apps/accounting/migrations/0085_remove_free_50_sms.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+from corehq.apps.accounting.bootstrap.config.remove_free_50_sms_sep_2023 import (
+    BOOTSTRAP_CONFIG,
+)
+from corehq.apps.accounting.bootstrap.utils import ensure_plans
+
+
+def _bootstrap_new_standard_pricing(apps, schema_editor):
+    ensure_plans(BOOTSTRAP_CONFIG, verbose=True, apps=apps)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0084_copy_cases_priv'),
+    ]
+
+    operations = [
+        migrations.RunPython(_bootstrap_new_standard_pricing),
+    ]

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -562,6 +562,7 @@ class TestWebUserLineItem(BaseInvoiceTestCase):
 
 
 class TestSmsLineItem(BaseInvoiceTestCase):
+    is_using_test_plans = True
 
     @classmethod
     def setUpClass(cls):
@@ -654,7 +655,13 @@ class TestSmsLineItem(BaseInvoiceTestCase):
         self.assertEqual(sms_line_item.subtotal, Decimal('0.0000'))
         self.assertEqual(sms_line_item.total, Decimal('0.0000'))
 
-    def test_multipart_over_limit(self):
+    def test_multipart_over_limit_and_part_of_the_billable_is_under_limit(self):
+        """
+        In this test, we particularly test the scenario that
+        half of the billable is within the limit, the remaining half exceeds the limit.
+        Current monthly_limit for sms i 0. I'll override the monthly_limit to 1 in this test.
+        """
+
         def _set_billable_date_sent_day(sms_billable, day):
             sms_billable.date_sent = datetime.date(
                 sms_billable.date_sent.year,

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -659,7 +659,7 @@ class TestSmsLineItem(BaseInvoiceTestCase):
         """
         In this test, we particularly test the scenario that
         half of the billable is within the limit, the remaining half exceeds the limit.
-        Current monthly_limit for sms i 0. I'll override the monthly_limit to 1 in this test.
+        So it's crucial to use test plan in this test instead of default plan whose limit is 0.
         """
 
         def _set_billable_date_sent_day(sms_billable, day):

--- a/migrations.lock
+++ b/migrations.lock
@@ -104,6 +104,7 @@ accounting
  0082_application_error_report_priv
  0083_data_dictionary_priv
  0084_copy_cases_priv
+ 0085_remove_free_50_sms
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This change will remove the free 50 sms from the plan that the client can subscribe by themselves at this page:
`Standard`, `Pro`, and `Advanced`
![image](https://github.com/dimagi/commcare-hq/assets/39149002/0f6d5b7d-0acf-407d-bcff-7e64df0e6594)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-13123

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally, the three plans we want to make changes to, no longer have free 50 sms.
We also have test for `ensure_plans` function.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I didn't make any functional change. 
But we have `test_ensure_plans.py` for the `ensure_plans`, the function I used in migration.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations


This PR Cannot be reverted, because I didn't write reverse function. Is it required?

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
