### PR TITLE
check xpath expressions in text for instance references

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -172,10 +172,7 @@ class InstancesHelper(PostProcessor):
         # multiple menus can have the same ID - merge them first
         xpaths_by_menu_id = defaultdict(set)
         for menu in self.suite.menus:
-            if menu.relevant:
-                xpaths_by_menu_id[menu.id].add(menu.relevant)
-            for assertion in menu.assertions:
-                xpaths_by_menu_id[menu.id].add(assertion.test)
+            xpaths_by_menu_id[menu.id] = menu.get_all_xpaths()
 
         return defaultdict(set, {
             command.id: xpaths_by_menu_id[menu.id]

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -145,7 +145,7 @@ class InstancesHelper(PostProcessor):
         if not self.app.supports_menu_instances:
             xpaths.update(self._menu_xpaths_by_command[entry.command.id])
 
-        if self.app.enable_localized_menu_media:
+        if self.app.enable_localized_menu_media and hasattr(entry, 'localized_command'):
             xpaths.update(entry.localized_command.get_all_xpaths())
         else:
             xpaths.update(entry.command.get_all_xpaths())

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -142,7 +142,7 @@ class Text(XmlObject):
         if self.xpath:
             for variable in self.xpath.variables:
                 if variable.xpath:
-                    result.add(str(variable.xpath.function))
+                    result.add(variable.xpath.function)
         return result - {None}
 
 
@@ -305,7 +305,7 @@ class MediaText(XmlObject):
         if self.xpath:
             for variable in self.xpath.variables:
                 if variable.xpath:
-                    result.add(str(variable.xpath.function))
+                    result.add(variable.xpath.function)
         return result - {None}
 
 

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -137,6 +137,14 @@ class Text(XmlObject):
     locale = NodeField('locale', Locale)
     locale_id = StringField('locale/@id')
 
+    def get_all_xpaths(self):
+        result = {self.xpath_function}
+        if self.xpath:
+            for variable in self.xpath.variables:
+                if variable.xpath:
+                    result.add(str(variable.xpath.function))
+        return result - {None}
+
 
 class ConfigurationItem(Text):
     ROOT_NAME = "text"
@@ -271,6 +279,14 @@ class DisplayNode(XmlObject):
         elif text:
             self.text = text
 
+    def get_all_xpaths(self):
+        result = set()
+        if self.text:
+            result.update(self.text.get_all_xpaths())
+        if self.display:
+            result.update(self.display.text.get_all_xpaths())
+        return result - {None}
+
 
 class LocaleId(XmlObject):
     ROOT_NAME = 'locale'
@@ -283,6 +299,14 @@ class MediaText(XmlObject):
     locale = NodeField('locale', LocaleId)
     xpath = NodeField('xpath', TextXPath)
     xpath_function = XPathField('xpath/@function')
+
+    def get_all_xpaths(self):
+        result = {self.xpath_function}
+        if self.xpath:
+            for variable in self.xpath.variables:
+                if variable.xpath:
+                    result.add(str(variable.xpath.function))
+        return result - {None}
 
 
 class LocalizedMediaDisplay(XmlObject):
@@ -331,6 +355,15 @@ class TextOrDisplay(XmlObject):
             )
         elif text:
             self.text = text
+
+    def get_all_xpaths(self):
+        result = set()
+        if self.text:
+            result.update(self.text.get_all_xpaths())
+        if self.display:
+            for text in self.display.media_text:
+                result.update(text.get_all_xpaths())
+        return result - {None}
 
 
 class CommandMixin(XmlObject):
@@ -576,9 +609,12 @@ class Entry(OrderedXmlObject, XmlObject):
 
     form = StringField('form')
     post = NodeField('post', RemoteRequestPost)
-    command = NodeField('command', Command)
-    instances = NodeListField('instance', Instance)
 
+    # command and localized_command are mutually exclusive based on the app version
+    command = NodeField('command', Command)
+    localized_command = NodeField('command', LocalizedCommand)
+
+    instances = NodeListField('instance', Instance)
     datums = NodeListField('session/datum', SessionDatum)
     queries = NodeListField('session/query', RemoteRequestQuery)
     session_children = NodeListField('session/*', _wrap_session_datums)
@@ -636,14 +672,26 @@ class Menu(MenuMixin, DisplayNode, IdNode):
     """
         For CC < 2.21
     """
-    pass
+
+    def get_all_xpaths(self):
+        result = super().get_all_xpaths()
+        result.update({assertion.test for assertion in self.assertions})
+        if self.relevant:
+            result.add(self.relevant)
+        return result - {None}
 
 
 class LocalizedMenu(MenuMixin, TextOrDisplay, IdNode):
     """
         For CC >= 2.21
     """
-    pass
+
+    def get_all_xpaths(self):
+        result = super().get_all_xpaths()
+        result.update({assertion.test for assertion in self.assertions})
+        if self.relevant:
+            result.add(self.relevant)
+        return result - {None}
 
 
 class AbstractTemplate(XmlObject):
@@ -921,12 +969,8 @@ class Detail(OrderedXmlObject, IdNode):
                     result.add(series.nodeset)
                     result.update(_get_graph_config_xpaths(series.configuration))
             else:
-                result.add(field.header.text.xpath_function)
-                result.add(field.template.text.xpath_function)
-                if field.template.text.xpath:
-                    for variable in field.template.text.xpath.variables:
-                        if variable.xpath:
-                            result.add(str(variable.xpath.function))
+                result.update(field.header.text.get_all_xpaths())
+                result.update(field.template.text.get_all_xpaths())
 
         for detail in self.details:
             result.update(detail.get_all_xpaths())
@@ -985,7 +1029,11 @@ class Suite(OrderedXmlObject):
 
     details = NodeListField('detail', Detail)
     entries = NodeListField('entry', Entry)
+
+    # menus and localized_menus are mutually exclusive based on the app version
     menus = NodeListField('menu', Menu)
+    localized_menus = NodeListField('menu', LocalizedMenu)
+
     endpoints = NodeListField('endpoint', SessionEndpoint)
     remote_requests = NodeListField('remote-request', RemoteRequest)
 

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -309,7 +309,7 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
         self.app = Application.new_app('domain', "my app")
         self.module = self.app.add_module(Module.new_module("Module 1", None))
         self.form = self.app.new_form(0, "Form 1", None)
-        self.min_spec = BuildSpec.from_string('2.21.0/latest')
+        self.min_spec = BuildSpec.from_string('2.54.0/latest')
         self.app.build_spec = self.min_spec
 
     def makeXML(self, menu_locale_id, image_locale_id, audio_locale_id):
@@ -398,7 +398,7 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
     def test_custom_icons_in_modules(self):
         self._test_custom_icon_in_suite(
             self.module, "modules.m0",
-            id_strings.module_custom_icon_locale, "./menu[@id='m0']/display")
+            id_strings.module_custom_icon_locale, "./menu[@id='m0']", "display")
 
     @patch_get_xform_resource_overrides()
     def test_case_list_form_media(self):
@@ -428,7 +428,7 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
     def test_custom_icons_in_forms(self):
         self._test_custom_icon_in_suite(
             self.form, "forms.m0f0",
-            id_strings.form_custom_icon_locale, "./entry/command[@id='m0-f0']/")
+            id_strings.form_custom_icon_locale, "./entry", "command[@id='m0-f0']/")
 
     @patch_get_xform_resource_overrides()
     def test_case_list_menu_media(self):
@@ -595,13 +595,16 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
         app_strings = commcare_translations.loads(app.create_app_strings(lang))
         self.assertEqual(app_strings[media_locale_id], media_path)
 
-    def _test_custom_icon_in_suite(self, form_or_module, locale_id, custom_icon_locale_method, xml_node):
+    def _test_custom_icon_in_suite(self, form_or_module, locale_id, custom_icon_locale_method, xpath_base,
+                                   xpath_display_node):
         """
         :param form_or_module: form or module for which to test
         :param locale_id: text locale id in display block for form or module
         :param custom_icon_locale_method: method to find locale id in app strings for custom icon
         :param xml_node: where to find the xml partial for comparison
         """
+
+        xpath_full = f"{xpath_base}/{xpath_display_node}"
         custom_icon = CustomIcon(form="badge", text={'en': 'IconText', 'hin': 'चित्र'})
         form_or_module.custom_icons = [custom_icon]
 
@@ -623,7 +626,7 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
         # check for text locale
         custom_icon_block = custom_icon_block_template.format(locale_id=locale_id,
                                                               locale_or_xpath=text_locale_partial)
-        self.assertXmlPartialEqual(custom_icon_block, self.app.create_suite(), xml_node)
+        self.assertXmlPartialEqual(custom_icon_block, self.app.create_suite(), xpath_full)
         self._assert_app_strings_available(self.app, 'en')
 
         # check for translation for text locale
@@ -633,11 +636,18 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
         self._assert_valid_media_translation(self.app, 'secret', custom_icon_locale, custom_icon.text['en'])
 
         # check for xpath being set for custom icon
-        custom_icon.xpath = "if(1=1, 'a', 'b')"
+        custom_icon.xpath = "if(1=1, 'a', instance('casedb')/casedb/case[@case_id='b']/case_name)"
         custom_icon.text = {}
         form_or_module.custom_icons = [custom_icon]
         custom_icon_block = custom_icon_block_template.format(
             locale_id=locale_id,
             locale_or_xpath='<xpath function="{xpath}"/>'.format(xpath=custom_icon.xpath)
         )
-        self.assertXmlPartialEqual(custom_icon_block, self.app.create_suite(), xml_node)
+        suite = self.app.create_suite()
+        self.assertXmlPartialEqual(custom_icon_block, suite, xpath_full)
+        expected_instances = """
+        <partial>
+            <instance id="casedb" src="jr://instance/casedb"/>
+        </partial>
+        """
+        self.assertXmlPartialEqual(expected_instances, suite, f"{xpath_base}/instance")


### PR DESCRIPTION
## Product Description
If a display text xpath expression references an `instance` the instance is not included in the SuiteXML. An example of where this might happen is when adding Custom Icons to menus or forms.

## Technical Summary
Update the suite XML instance processing to check xpath functions and expressions for `instances`.

## Feature Flag
At least CUSTOM_ICON_BADGES

## Safety Assurance

### Safety story
This code replicates existing functionality into new areas and is well covered by tests.

### Automated test coverage
Good existing tests which have been updated to verify new behaviour.

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
