### PR TITLE
[B5] Fix requirejs references to es6 modules in a local environment

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -51,6 +51,23 @@ function hqDefine(path, dependencies, moduleAccessor) {
 
     (function (factory) {
         if (typeof define === 'function' && define.amd && window.USE_REQUIREJS) {
+
+            // Before running build_requirejs, define doesn't know how to handle modules tagged with `es6!`
+            // After requirejs is built on production, es6 modules are always referenced without the es6! prefix
+            // when included as a dependency. However, when running locally without build_requirejs, it
+            // is essential to reference the es6 module with the es6! prefix.
+            if (window.IS_LOCAL_REQUIREJS_ES6) {
+                var es6Dependencies = [
+                    'hqwebapp/js/bootstrap5_loader',
+                ];
+                for (var i = 0; i < dependencies.length; i++) {
+                    var dependency = dependencies[i];
+                    if (es6Dependencies.indexOf(dependency) >= 0) {
+                        dependencies[i] = 'es6!' + dependency;
+                    }
+                }
+            }
+
             // HQ's requirejs build process (build_requirejs.py) replaces hqDefine calls with
             // define calls, so it's important that this do nothing but pass through to require
             define(path, dependencies, factory);

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
@@ -6,6 +6,7 @@
   // this fails for form designer, which currently uses RequireJS for vellum but not for the surrounding page.
   window.USE_REQUIREJS = {{ requirejs_main|BOOL }};
   window.USE_BOOTSTRAP5 = {{ use_bootstrap5|BOOL }};
+  window.IS_LOCAL_REQUIREJS_ES6 = {{ is_local_requirejs_es6|BOOL }};
 </script>
 
 {% if requirejs_main %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
@@ -23,7 +23,7 @@
       deps: [
           'knockout',
           'ko.mapping',
-          {% if use_bootstrap5 %}'es6!bootstrap5_loader'{% else %}'bootstrap'{% endif %},
+          {% if use_bootstrap5 %}'hqwebapp/js/bootstrap5_loader'{% else %}'bootstrap'{% endif %},
       ],
       callback: function (ko, mapping{% if use_bootstrap5 %}, bootstrap5{% endif %}) {
         ko.mapping = mapping;

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
@@ -26,9 +26,8 @@
           'ko.mapping',
           {% if use_bootstrap5 %}'hqwebapp/js/bootstrap5_loader'{% else %}'bootstrap'{% endif %},
       ],
-      callback: function (ko, mapping{% if use_bootstrap5 %}, bootstrap5{% endif %}) {
+      callback: function (ko, mapping) {
         ko.mapping = mapping;
-        {% if use_bootstrap5 %}window.bootstrap5 = bootstrap5;{% endif %}
       }
     });
     requirejs([

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -311,3 +311,9 @@ def bootstrap5(request):
     return {
         "use_bootstrap5": bootstrap.get_bootstrap_version() == bootstrap.BOOTSTRAP_5,
     }
+
+
+def es6_requirejs(request):
+    return {
+        'is_local_requirejs_es6': settings.IS_LOCAL_REQUIREJS_ES6,
+    }

--- a/settings.py
+++ b/settings.py
@@ -20,6 +20,10 @@ DEBUG = True
 VELLUM_DEBUG = None
 
 
+# For loading es6 requirejs modules in a local environment, set this to True
+IS_LOCAL_REQUIREJS_ES6 = DEBUG
+
+
 # For Single Sign On (SSO) Implementations
 SAML2_DEBUG = False
 ENFORCE_SSO_LOGIN = False
@@ -1274,6 +1278,7 @@ TEMPLATES = [
                 'corehq.util.context_processors.sentry',
                 'corehq.util.context_processors.bootstrap5',
                 'corehq.util.context_processors.js_privileges',
+                'corehq.util.context_processors.es6_requirejs',
             ],
             'debug': DEBUG,
             'loaders': [


### PR DESCRIPTION
## Technical Summary
The use of the `es6!` tag when defining modules requiring `es6` support works as expected in a production environment where `build_requirejs` is run. However, in a local environment, define gets confused with how to track down the references to the `es6` modules. In production, dependency referenced are written without with `es6!` prefix (`es6!` is ONLY used in the module definition), and once babel translates the `es6!`-defined module it redefines the module without the prefix so that the non-prefixed dependency references work as expected. However, as this does not occur locally, requirejs does not know how to find a module prefixed with `es6!`, like bootstrap5.

This fix:
- adds a new `settings` variable `IS_LOCAL_REQUIREJS_ES6` which defaults to the `DEBUG` value (`False` in production environments)
- adds a new `context_processor` called `es6_requirejs` which ensures that the value of this setting makes it into the template context
- this value is then passed to `window` in `hqwebapp/partials/requirejs.html`
- finally in `hqModules` we check for `window.IS_LOCAL_REQUIREJS_ES6`. If it's present and `define` finds a module that matches the list of `es6` modules, we prepend `es6!` to that module path/name and the reference works as expected.

## Safety Assurance

### Safety story
This will only affect bootstrap 5 requirejs pages (of which there are no active ones yet), and only local environments.

### Automated test coverage
Yes

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
