### PR TITLE
[B5] Replace page-header with bootstrap 5's styling

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_type.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_type.scss
@@ -90,10 +90,3 @@ code {
 a {
     cursor: pointer;
 }
-
-// we should eventually get rid of this as bootstrap5+ doesn't natively support
-.page-header {
-    padding-bottom: 7.5px;
-    margin: 34px 0 17px;
-    border-bottom: 1px solid #eeeeee;
-}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_page.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_page.html
@@ -21,7 +21,7 @@
     {% endif %}
   {% endblock page_breadcrumbs %}
   <div class="container">
-    <div class="page-header">
+    <div class="border-bottom pb-1 my-4">
       <h1>{% block page_name %}{{ current_page.page_name }}{% endblock %}</h1>
     </div>
     {% block page_content %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_page.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_page.html.diff.txt
@@ -6,3 +6,12 @@
  {% load hq_shared_tags %}
  
  {% block title %}{{ section.page_name }}{% if current_page.title %}: {{ current_page.title }}{% endif %}{% endblock %}
+@@ -21,7 +21,7 @@
+     {% endif %}
+   {% endblock page_breadcrumbs %}
+   <div class="container">
+-    <div class="page-header">
++    <div class="border-bottom pb-1 my-4">
+       <h1>{% block page_name %}{{ current_page.page_name }}{% endblock %}</h1>
+     </div>
+     {% block page_content %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/typography._type.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/typography._type.style.diff.txt
@@ -28,14 +28,9 @@
  }
  
  .no-border {
-@@ -89,3 +90,10 @@
+@@ -88,4 +89,4 @@
+ 
  a {
      cursor: pointer;
- }
-+
-+// we should eventually get rid of this as bootstrap5+ doesn't natively support
-+.page-header {
-+    padding-bottom: 7.5px;
-+    margin: 34px 0 17px;
-+    border-bottom: 1px solid #eeeeee;
+-}
 +}


### PR DESCRIPTION
## Technical Summary
I was debating whether I should preserve the old bootstrap 3 `page-header` css class and decided against it when seeing the recommended approach for bootstrap 5. 

## Safety Assurance

### Safety story
very safe styling change that only affects migrated bootstrap 5 pages (which are the license pages right now)

### Automated test coverage
Yes

### QA Plan
Not needed. Safe change


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
