### PR TITLE
media upload clear button

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -61,6 +61,7 @@ hqDefine("cloudcare/js/form_entry/const", function () {
         NEW_FORM: 'new-form',
         ANSWER: 'answer',
         ANSWER_MEDIA: 'answer_media',
+        CLEAR_ANSWER: 'clear_answer',
         CURRENT: 'current',
         EVALUATE_XPATH: 'evaluate-xpath',
         NEW_REPEAT: 'new-repeat',

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -897,7 +897,6 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             self.rawAnswer(constants.NO_ANSWER);
             self.xformAction = constants.CLEAR_ANSWER;
             self.question.onClear();
-            self.xformAction= constants.ANSWER_MEDIA;
         };
     }
     FileEntry.prototype = Object.create(EntrySingleAnswer.prototype);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -892,6 +892,13 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         };
         self.file = ko.observable();
         self.extensionsMap = initialPageData.get("valid_multimedia_extensions_map");
+        self.onClear = function () {
+            self.file(null);
+            self.rawAnswer(constants.NO_ANSWER);
+            self.xformAction = constants.CLEAR_ANSWER;
+            self.question.onClear();
+            self.xformAction= constants.ANSWER_MEDIA;
+        };
     }
     FileEntry.prototype = Object.create(EntrySingleAnswer.prototype);
     FileEntry.prototype.constructor = EntrySingleAnswer;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -910,10 +910,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
             }
             self.answer(newValue.replace(constants.FILE_PREFIX, ""));
         } else {
-            self.file(null);
-            self.answer(constants.NO_ANSWER);
-            self.rawAnswer(constants.NO_ANSWER);
-            self.question.error(null);
+            self.onClear();
         }
     };
     FileEntry.prototype.onAnswerChange = function (newValue) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -746,6 +746,14 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         }, self.throttle);
         self.onchange = self.triggerAnswer;
 
+        self.triggerClear = function () {
+            publishClearEvent();
+        };
+        var publishClearEvent = _.throttle(function () {
+            $.publish('formplayer.' + constants.CLEAR_ANSWER, self);
+        }, self.throttle)
+        self.onClear = self.triggerClear;
+
         self.mediaSrc = function (resourceType) {
             if (!resourceType || !_.isFunction(formEntryUtils.resourceMap)) { return ''; }
             return formEntryUtils.resourceMap(resourceType);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -746,13 +746,9 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         }, self.throttle);
         self.onchange = self.triggerAnswer;
 
-        self.triggerClear = function () {
-            publishClearEvent();
-        };
-        var publishClearEvent = _.throttle(function () {
+        self.onClear = _.throttle(function () {
             $.publish('formplayer.' + constants.CLEAR_ANSWER, self);
-        }, self.throttle)
-        self.onClear = self.triggerClear;
+        }, self.throttle);
 
         self.mediaSrc = function (resourceType) {
             if (!resourceType || !_.isFunction(formEntryUtils.resourceMap)) { return ''; }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -250,6 +250,7 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
             var self = this;
             $.unsubscribe([
                 'formplayer.' + constants.ANSWER,
+                'formplayer.' + constants.CLEAR_ANSWER,
                 'formplayer.' + constants.DELETE_REPEAT,
                 'formplayer.' + constants.NEW_REPEAT,
                 'formplayer.' + constants.EVALUATE_XPATH,
@@ -264,6 +265,9 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
                 self.submitForm(form);
             });
             $.subscribe('formplayer.' + constants.ANSWER, function (e, question) {
+                self.answerQuestion(question);
+            });
+            $.subscribe('formplayer.' + constants.CLEAR_ANSWER, function (e, question) {
                 self.answerQuestion(question);
             });
             $.subscribe('formplayer.' + constants.DELETE_REPEAT, function (e, group) {
@@ -321,7 +325,7 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
         self.answerQuestion = function (q) {
             var self = this;
             var ix = formUI.getIx(q);
-            var answer = q.answer();
+            var answer = q.entry.xformAction == constants.CLEAR_ANSWER ? constants.NO_ANSWER : q.answer();
             var oneQuestionPerScreen = self.isOneQuestionPerScreen();
             var form = q.form();
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -325,7 +325,7 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
         self.answerQuestion = function (q) {
             var self = this;
             var ix = formUI.getIx(q);
-            var answer = q.entry.xformAction == constants.CLEAR_ANSWER ? constants.NO_ANSWER : q.answer();
+            var answer = q.entry.xformAction === constants.CLEAR_ANSWER ? constants.NO_ANSWER : q.answer();
             var oneQuestionPerScreen = self.isOneQuestionPerScreen();
             var form = q.form();
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -342,6 +342,7 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
                 }, q.entry.xformParams()),
                 function (resp) {
                     q.formplayerProcessed = true;
+                    q.entry.xformAction = constants.ANSWER_MEDIA;
                     $.publish('session.reconcile', [resp, q]);
                     if (self.answerCallback !== undefined) {
                         self.answerCallback(self.session_id);
@@ -353,6 +354,7 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
                 constants.BLOCK_SUBMIT,
                 function () {
                     q.formplayerProcessed = false;
+                    q.entry.xformAction = constants.ANSWER_MEDIA;
                     q.serverError(
                         gettext("We were unable to save this answer. Please try again later."));
                     q.pendingAnswer(constants.NO_PENDING_ANSWER);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -341,8 +341,8 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
                     'oneQuestionPerScreen': oneQuestionPerScreen,
                 }, q.entry.xformParams()),
                 function (resp) {
+                    self.updateXformAction(q);
                     q.formplayerProcessed = true;
-                    q.entry.xformAction = constants.ANSWER_MEDIA;
                     $.publish('session.reconcile', [resp, q]);
                     if (self.answerCallback !== undefined) {
                         self.answerCallback(self.session_id);
@@ -353,12 +353,18 @@ hqDefine("cloudcare/js/form_entry/web_form_session", function () {
                 },
                 constants.BLOCK_SUBMIT,
                 function () {
+                    self.updateXformAction(q);
                     q.formplayerProcessed = false;
-                    q.entry.xformAction = constants.ANSWER_MEDIA;
                     q.serverError(
                         gettext("We were unable to save this answer. Please try again later."));
                     q.pendingAnswer(constants.NO_PENDING_ANSWER);
                 });
+        };
+
+        self.updateXformAction = function (q) {
+            if (q.entry.xformAction === constants.CLEAR_ANSWER) {
+                q.entry.xformAction = q.entry.templateType === "file" ? constants.ANSWER_MEDIA : constants.ANSWER;
+            }
         };
 
         self.nextQuestion = function (opts) {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -453,6 +453,9 @@
         },
     "/>
   <span class="help-block type" aria-hidden="true" data-bind="text: helpText()"></span>
+  <button class="btn btn-default btn-xs pull-right" data-bind="click: onClear">
+    {% trans "Clear" %}
+  </button>
 </script>
 
 <script type="text/html" id="address-entry-ko-template">


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This adds a clear button to media upload questions that clears the input and makes a call to formplayer, which then deletes the file from the file system. 
![clear-button](https://github.com/dimagi/commcare-hq/assets/42388648/964976c8-77ea-4c9a-98d6-8d673da03db8)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
jira ticket: https://dimagi-dev.atlassian.net/browse/USH-3448
spec doc: https://docs.google.com/document/d/1lRYWe-IRUWN7OTYK9mVvGYhPoy_Wo85NnF0dooSw1rY/edit#heading=h.d7s2sycdfk92
formplayer PR: https://github.com/dimagi/formplayer/pull/1459

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
USH: Support signature, image, audio, and video questions in Web Apps
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
changes restricted to feature flag
tested locally and on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
