### PR TITLE
Fix hubspot.js issue on prelogin pages

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/hubspot.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.js
@@ -47,7 +47,7 @@ hqDefine('analytix/js/hubspot', [
      */
     _utils.loadDemoForm = function () {
         let isTrial = _get('isDemoTrial'),
-            isVariant = _get('demoABv2').version === 'variant',
+            isVariant = _get('demoABv2') && _get('demoABv2').version === 'variant',
             $modal = $('#cta-form-get-demo'),
             $form = $('#get-demo-cta-form-content'),
             hasInteractedWithForm = false,


### PR DESCRIPTION
## Technical Summary
This fixes an issue I noticed while debugging some bootstrap 5 related things where some prelogin pages don't specify an A/B test variant, so this context is not present in the javascript and the entire file throws an error.

## Safety Assurance

### Safety story
Fixes a bug. Safe small change

### Automated test coverage
No

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
