### PR TITLE
[B5] fix issue on prelogin pages with bug report modal throwing error

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq-bug-report.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq-bug-report.js
@@ -9,6 +9,11 @@ hqDefine('hqwebapp/js/bootstrap5/hq-bug-report', [
         let self = {};
 
         self.$bugReportModalElement = $('#modalReportIssue');
+        if (self.$bugReportModalElement.length === 0) {
+            // If the modal element is not present on the page, don't continue
+            return;
+        }
+
         self.bugReportModal = new bootstrap.Modal(self.$bugReportModalElement);
         self.$hqwebappBugReportForm = $('#hqwebapp-bugReportForm');
         self.$hqwebappBugReportSubmit = $('#bug-report-submit');

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/hq-bug-report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/hq-bug-report.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,49 +1,58 @@
+@@ -1,49 +1,63 @@
 -hqDefine('hqwebapp/js/bootstrap3/hq-bug-report', [
 -    "jquery", "jquery-form/dist/jquery.form.min", "hqwebapp/js/bootstrap3/hq.helpers",
 -], function ($) {
@@ -32,6 +32,11 @@
 -            $emailFormGroup.removeClass('has-error has-feedback');
 -            $emailFormGroup.find(".label-danger").addClass('hide');
 +        self.$bugReportModalElement = $('#modalReportIssue');
++        if (self.$bugReportModalElement.length === 0) {
++            // If the modal element is not present on the page, don't continue
++            return;
++        }
++
 +        self.bugReportModal = new bootstrap.Modal(self.$bugReportModalElement);
 +        self.$hqwebappBugReportForm = $('#hqwebapp-bugReportForm');
 +        self.$hqwebappBugReportSubmit = $('#bug-report-submit');
@@ -91,7 +96,7 @@
                      return false;
                  }
              }
-@@ -51,57 +60,61 @@
+@@ -51,57 +65,61 @@
                  return false;
              }
  


### PR DESCRIPTION
## Technical Summary
Prelogin pages using bootstrap 5 templates throw javascript errors because the bug report modal element isn't present. This fixes the issue.

## Safety Assurance

### Safety story
very safe change. bug fix

### Automated test coverage
No

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
