### PR TITLE
Changes required to support ES 5

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -110,7 +110,9 @@ class ElasticManageAdapter(BaseAdapter):
         :returns: ``dict`` with format ``{<alias>: [<index>, ...], ...}``
         """
         aliases = {}
-        for index, alias_info in self._es.indices.get_aliases().items():
+        aliases_obj = (self._es.indices.get_aliases()
+                       if self.elastic_major_version == 2 else self._es.indices.get_alias())
+        for index, alias_info in aliases_obj.items():
             for alias in alias_info.get("aliases", {}):
                 aliases.setdefault(alias, []).append(index)
         return aliases

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -151,9 +151,15 @@ class ElasticManageAdapter(BaseAdapter):
         :returns: ``dict`` of task details
         :raises: ``TaskError`` or ``TaskMissing`` (subclass of ``TaskError``)
         """
-        # NOTE: elasticsearch5 python library doesn't support `task_id` as a
-        # kwarg for the `tasks.list()` method, and uses `tasks.get()` for that
-        # instead.
+        if self.elastic_major_version == 5:
+            try:
+                task_details = self._es.tasks.get(task_id=task_id)
+                task_info = task_details['task']
+                task_info['completed'] = task_details['completed']
+            except NotFoundError as e:
+                # unknown task id provided
+                raise TaskMissing(e)
+            return task_info
         return self._parse_task_result(self._es.tasks.list(task_id=task_id,
                                                            detailed=True))
 

--- a/corehq/apps/es/utils.py
+++ b/corehq/apps/es/utils.py
@@ -102,7 +102,7 @@ def check_task_progress(task_id, just_once=False):
             task_details = manager.get_task(task_id=task_id)
         except TaskMissing:
             if not just_once:
-                return  # task completed
+                return  # task completed ES 2
             raise CommandError(f"Task with id {task_id} not found")
         except TaskError as err:
             raise CommandError(f"Fetching task failed: {err}")
@@ -148,6 +148,8 @@ def check_task_progress(task_id, just_once=False):
                   f"(recent average = {_format_timedelta(remaining_time_relative)})")
         if just_once:
             return
+        if task_details.get("completed"):
+            return  # task completed ES 5
         time.sleep(TASK_POLL_DELAY)
 
 

--- a/corehq/apps/es/utils.py
+++ b/corehq/apps/es/utils.py
@@ -110,8 +110,9 @@ def check_task_progress(task_id, just_once=False):
         status = task_details["status"]
         total = status["total"]
         if total:  # total can be 0 initially
-            created, updated, deleted = status["created"], status["updated"], status["deleted"]
-            progress = created + updated + deleted
+            created, updated = status["created"], status["updated"]
+            deleted, conflicts = status["deleted"], status["version_conflicts"]
+            progress = created + updated + deleted + conflicts
             progress_percent = progress / total * 100
 
             running_time_nanos = task_details["running_time_in_nanos"]

--- a/corehq/apps/es/utils.py
+++ b/corehq/apps/es/utils.py
@@ -66,7 +66,7 @@ def flatten_field_dict(results, fields_property='fields'):
     field_dict = results.get(fields_property, {})
     for key, val in field_dict.items():
         new_val = val
-        if type(val) == list and len(val) == 1:
+        if type(val) is list and len(val) == 1:
             new_val = val[0]
         field_dict[key] = new_val
     return field_dict


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->


This PR is a stripped out version of https://github.com/dimagi/commcare-hq/pull/33436, it adds changes to ensure that our ES code supports both ES 2 and ES5 together. 

Only one commit 3743b5383c0d748fb06883476efa53600f925545 would affect operations on HQ, rest are just changes in functions that are used in Reindex processes.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-12152
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Tested locally
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Does not affect any major part of system and ideally should be a no-op for end user
### Automated test coverage
Changes are covered by tests
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
