### PR TITLE
Make split screen case search filters collapsible on small screens

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -26,5 +26,7 @@ hqDefine("cloudcare/js/formplayer/constants", function () {
         FORMAT_ADDRESS_POPUP: "AddressPopup",
 
         SMALL_SCREEN_WIDTH_PX: 992,
+
+        BREADCRUMB_HEIGHT_PX: 46.125,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -28,5 +28,6 @@ hqDefine("cloudcare/js/formplayer/constants", function () {
         SMALL_SCREEN_WIDTH_PX: 992,
 
         BREADCRUMB_HEIGHT_PX: 46.125,
+        BREADCRUMB_WIDTH_OFFSET_PX: 106.5, // unavailable breadcrumb space i.e. padding, home and hamburger icons
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -899,13 +899,19 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             return {
                 "role": "link",
                 "tabindex": "0",
+                "style": this.buildMaxWidth(),
             };
         },
         events: {
             "click": "crumbClick",
             "keydown": "crumbKeyAction",
         },
-
+        buildMaxWidth: function () {
+            // to avoid overflow, compute the max width in CSS based on number of breadcrumbs
+            const fullWidthOffset = 106.5; // padding including home and hamburger icons
+            const crumbCount = this.model.collection.length;
+            return `max-width: calc((100vw - ${fullWidthOffset}px) / ${crumbCount});`;
+        },
         crumbClick: function (e) {
             e.preventDefault();
             const crumbId = this.options.model.get('id');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -428,7 +428,26 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         events: CaseListViewEvents(),
 
         handleSmallScreenChange: function (enabled) {
-            this.smallScreenEnabled = enabled;
+            const self = this;
+            self.smallScreenEnabled = enabled;
+            if (self.options.sidebarEnabled) {
+                self.positionStickyItems(enabled);
+            }
+        },
+
+        positionStickyItems: function (smallScreenEnabled) {
+            const $caseListHeader = $('#case-list-menu-header');
+            const $caseListMap = $('#module-case-list-map');
+            const stickyHeaderId = 'small-screen-sticky-header';
+            if (smallScreenEnabled) {
+                $caseListHeader.wrap(`<div class="sticky sticky-header" id="${stickyHeaderId}"></div>`);
+                $caseListMap.appendTo($(`#${stickyHeaderId}`));
+            } else {
+                if ($caseListHeader.parent()[0] === $(`#${stickyHeaderId}`)[0]) {
+                    $caseListHeader.unwrap();
+                }
+                $caseListMap.prependTo($('#module-case-list-container__results-container'));
+            }
         },
 
         caseListAction: function (e) {
@@ -654,6 +673,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             if (self.showMap) {
                 self.loadMap();
             }
+            self.handleSmallScreenChange(self.smallScreenEnabled);
         },
 
         templateContext: function () {
@@ -844,7 +864,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             if (this.options.isMultiSelect) {
                 this.reconcileMultiSelectUI();
             }
-            this.handleSmallScreenChange(this.smallScreenEnabled);
         },
 
         onDestroy: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -574,6 +574,22 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             });
         },
 
+        getMapScrollOffset: function (addressMap) {
+            const $mapEl = $('#module-case-list-map');
+            const $stickyHeader = $('#small-screen-sticky-header');
+            let scrollTopOffset = parseInt(($mapEl).css('top'));
+            if (this.smallScreenEnabled) {
+                if ($stickyHeader[0]) {
+                    scrollTopOffset = parseInt($stickyHeader.css('top')) + $stickyHeader.outerHeight();
+                } else if (addressMap.isFullscreen()) {
+                    scrollTopOffset = $('#breadcrumb-region').outerHeight();
+                } else {
+                    scrollTopOffset += $mapEl.outerHeight();
+                }
+            }
+            return scrollTopOffset;
+        },
+
         loadMap: function () {
             const token = initialPageData.get("mapbox_access_token");
 
@@ -640,12 +656,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                                     markers.forEach(m => m.setIcon(locationIcon));
                                     marker.setIcon(selectedLocationIcon);
 
-                                    let scrollTopOffset = 47.125; // standard height of breadcrumbs with shadow
-                                    if (this.smallScreenEnabled && !addressMap.isFullscreen()) {
-                                        scrollTopOffset += addressMap.getSize().y;
-                                    }
                                     $([document.documentElement, document.body]).animate({
-                                        scrollTop: $(`#${rowId}`).offset().top - scrollTopOffset,
+                                        scrollTop: $(`#${rowId}`).offset().top - this.getMapScrollOffset(addressMap),
                                     }, 500);
 
                                     addressMap.panTo(markerCoordinates);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -370,6 +370,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             columnHeader: '.header-clickable',
             paginationGoText: '#goText',
             casesPerPageLimit: '.per-page-limit',
+            searchMoreButton: '#search-more',
         };
     };
 
@@ -380,6 +381,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             'click @ui.paginators': 'paginateAction',
             'click @ui.paginationGoButton': 'paginationGoAction',
             'click @ui.columnHeader': 'columnSortAction',
+            'click @ui.searchMoreButton': 'searchMoreAction',
             'keypress @ui.columnHeader': 'columnSortAction',
             'change @ui.casesPerPageLimit': 'onPerPageLimitChange',
             'keypress @ui.searchTextBox': 'searchTextKeyAction',
@@ -464,6 +466,14 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             e.preventDefault();
             const searchText = $('#searchText').val();
             FormplayerFrontend.trigger("menu:search", searchText);
+        },
+
+        searchMoreAction: function () {
+            if (!$('#sidebar-region').hasClass('in')) {
+                $([document.documentElement, document.body]).animate({
+                    scrollTop: $('#content-container').offset().top - constants.BREADCRUMB_HEIGHT_PX,
+                }, 350);
+            }
         },
 
         searchTextKeyAction: function (event) {
@@ -582,7 +592,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 if ($stickyHeader[0]) {
                     scrollTopOffset = parseInt($stickyHeader.css('top')) + $stickyHeader.outerHeight();
                 } else if (addressMap.isFullscreen()) {
-                    scrollTopOffset = $('#breadcrumb-region').outerHeight();
+                    scrollTopOffset = constants.BREADCRUMB_HEIGHT_PX;
                 } else {
                     scrollTopOffset += $mapEl.outerHeight();
                 }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -949,9 +949,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
         buildMaxWidth: function () {
             // to avoid overflow, compute the max width in CSS based on number of breadcrumbs
-            const fullWidthOffset = 106.5; // padding including home and hamburger icons
             const crumbCount = this.model.collection.length;
-            return `max-width: calc((100vw - ${fullWidthOffset}px) / ${crumbCount});`;
+            return `max-width: calc((100vw - ${constants.BREADCRUMB_WIDTH_OFFSET_PX}px) / ${crumbCount});`;
         },
         crumbClick: function (e) {
             e.preventDefault();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -445,6 +445,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     break;
                 }
             }
+            this.smallScreenEnabled = cloudcareUtils.watchSmallScreenEnabled(this.handleSmallScreenChange.bind(this));
+            this.handleSmallScreenChange(this.smallScreenEnabled);
         },
 
         templateContext: function () {
@@ -466,6 +468,17 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         events: {
             'click @ui.clearButton': 'clearAction',
             'click @ui.submitButton': 'submitAction',
+        },
+
+        handleSmallScreenChange: function (enabled) {
+            this.smallScreenEnabled = enabled;
+            if (this.options.sidebarEnabled) {
+                if (this.smallScreenEnabled) {
+                    $('#sidebar-region').addClass('collapse');
+                } else {
+                    $('#sidebar-region').removeClass('collapse');
+                }
+            }
         },
 
         getAnswers: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -544,6 +544,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     self.selectValuesByKeys,
                     self.options.sidebarEnabled
                 );
+                if (self.smallScreenEnabled && self.options.sidebarEnabled) {
+                    $('#sidebar-region').collapse('hide');
+                }
             });
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -352,7 +352,7 @@ hqDefine('cloudcare/js/utils', [
      *      });
      */
     var watchSmallScreenEnabled = function (callback) {
-        var shouldEnableSmallScreen = () => window.innerWidth <= constants.SMALL_SCREEN_WIDTH_PX;
+        var shouldEnableSmallScreen = () => window.innerWidth < constants.SMALL_SCREEN_WIDTH_PX;
         var smallScreenEnabled = shouldEnableSmallScreen();
 
         $(window).on("resize", () => {

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -33,7 +33,7 @@
 
     <div id="module-case-list-container__results-container" class="row row-no-gutters">
       <% if (showMap) { %>
-        <div id="module-case-list-map" class="sticky-map col-md-5 col-md-push-9<% if (useTiles) { %> white-border<% } %> noprint-sub-container"></div>
+        <div id="module-case-list-map" class="sticky sticky-map col-md-5 col-md-push-9<% if (useTiles) { %> white-border<% } %> noprint-sub-container"></div>
       <% } %>
       <div id="module-case-list" class="col-md<% if (showMap) { %>-7 col-md-pull-5<% } %>">
         <% if (useTiles) { %>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -5,6 +5,12 @@
   <div class="module-case-list-container">
 
     <div class="page-header menu-header" id="case-list-menu-header">
+      <% if (sidebarEnabled) {%>
+        <button id="search-more" class="btn btn-primary visible-xs visible-sm pull-right" type="button"
+          data-toggle="collapse" data-target="#sidebar-region" aria-expanded="false" aria-controls="sidebar-region">
+          {% trans "Refine search" %}
+        </button>
+      <% } %>
       <% if (title.length > 0) {%>
       <h1  aria-label="<%- title %>" tabindex="0" class="page-title"><%- title %></h1>
       <% } %>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -12,7 +12,8 @@
         <button class="btn btn-default" type="button" id="query-clear-button">
           <div>{% trans "Clear" %}</div>
         </button>
-        <button class="btn btn-primary" type="submit" id="query-submit-button">
+        <button class="btn btn-primary" type="submit" id="query-submit-button"
+          data-toggle="collapse" data-target="#sidebar-region" aria-expanded="false" aria-controls="sidebar-region">
           <div>{% trans "Search" %}</div>
         </button>
       </div>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -4,6 +4,10 @@
 <script type="text/template" id="query-view-list-template">
   <form>
     <% if (sidebarEnabled) {%>
+      <button type="button" class="close visible-xs visible-sm" aria-label="{% trans "Close" %}"
+        data-toggle="collapse" data-target="#sidebar-region" aria-expanded="false" aria-controls="sidebar-region">
+        <span aria-hidden="true">&times;</span>
+      </button>
       <div class="query-button-container">
         <button class="btn btn-default" type="button" id="query-clear-button">
           <div>{% trans "Clear" %}</div>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -12,8 +12,7 @@
         <button class="btn btn-default" type="button" id="query-clear-button">
           <div>{% trans "Clear" %}</div>
         </button>
-        <button class="btn btn-primary" type="submit" id="query-submit-button"
-          data-toggle="collapse" data-target="#sidebar-region" aria-expanded="false" aria-controls="sidebar-region">
+        <button class="btn btn-primary" type="submit" id="query-submit-button">
           <div>{% trans "Search" %}</div>
         </button>
       </div>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/breadcrumbs.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/breadcrumbs.less
@@ -13,7 +13,6 @@
       vertical-align: top;
       line-height: 28px;
     }
-    max-width: 300px;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
@@ -15,6 +15,10 @@ body {
 #case-list-menu-header{
   padding-left: 1.5rem;
   padding-right: 1.5rem;
+  background-color: white;
+  @media (max-width: @screen-sm-max) {
+    min-height: 70px;
+  }
   h1 {
     padding-left: 0px;
   }

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
@@ -14,6 +14,7 @@ body {
 
 #case-list-menu-header{
   padding-left: 1.5rem;
+  padding-right: 1.5rem;
   h1 {
     padding-left: 0px;
   }

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -37,7 +37,7 @@
     height: calc(~"100vh - 65px");
 
     @media (max-width: @screen-sm-max) {
-      height: 250px;
+      height: 25vh;
     }
 
     .marker-pin {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -2,10 +2,15 @@
   background: transparent;
 }
 
-.sticky-map {
-  position: sticky !important; // Has to be important so the leaflet code does not set it to relative
-  top: 46px; // based on the height of the crumbs bar
-  z-index: 1; // keep map on top of case list
+.sticky {
+  position: sticky !important;
+  z-index: 1; // keep sticky elements on top of case list
+  &-header {
+    top: 32px; // header scrolls excess padding under breadcrumbs
+  }
+  &-map {
+    top: 46px; // map sits directly against breadcrumbs
+  }
 }
 
 // override leaflet-fullscreen styles to fix icon alignment in mapbox.js

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -3,13 +3,17 @@
 }
 
 .sidebar-push {
-  margin-left: 310px;
+  @media (min-width: @screen-md-min) {
+    margin-left: 310px;
+  }
 }
 
 #sidebar-region {
   background: transparent;
-  width: 300px;
-  position: absolute;
+  @media (min-width: @screen-md-min) {
+    width: 300px;
+    position: absolute;
+  }
 
   table {
     table-layout: fixed;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -9,7 +9,7 @@
 }
 
 #search-more {
-  margin-top: 17px;
+  margin-top: 12px;
 }
 
 #sidebar-region {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -8,11 +8,19 @@
   }
 }
 
+#search-more {
+  margin-top: 17px;
+}
+
 #sidebar-region {
   background: transparent;
   @media (min-width: @screen-md-min) {
     width: 300px;
     position: absolute;
+  }
+  @media (max-width: @screen-sm-max) {
+    max-width: 600px;
+    margin: auto;
   }
 
   table {


### PR DESCRIPTION
## Product Description
When using split screen case search on small screens:
- case search filters are collapsible
- header containing the "refine search" button sticks to the top of the screen, above the case list map if applicable

https://github.com/dimagi/commcare-hq/assets/100609770/83232b44-1cf2-4c2b-a706-67e4ee653a2a


## Technical Summary
[USH-3482](https://dimagi-dev.atlassian.net/browse/USH-3482)
Uses Bootstrap's `collapse` class and controls for core functionality. Modifies breadcrumbs to keep them a consistent height regardless of screen size (important for "sticky" case list header and map). Makes tweaks to the case list map and case list header elements on small screens to allow the two to be sticky together at the top of the screen, and to how the case list map determines where to scroll on pin click.

## Feature Flag
Most functionality only applies with SPLIT_SCREEN_CASE_SEARCH enabled

## Safety Assurance

### Safety story
Tested different configs locally with split screen/regular case search, map/no map, large and small screens, considering interactions with existing small screen layout and functionality.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
QA as part of [USH-3485](https://dimagi-dev.atlassian.net/browse/USH-3485)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3482]: https://dimagi-dev.atlassian.net/browse/USH-3482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-3485]: https://dimagi-dev.atlassian.net/browse/USH-3485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ