### PR TITLE
Hide deprecated GPS properties

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geo_config.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geo_config.js
@@ -11,13 +11,20 @@ hqDefine("geospatial/js/geo_config", [
         'use strict';
         var self = {};
 
-        const gpsCaseProps = configData.get('gps_case_props_deprecated_state');
-        self.geoCasePropOptions = ko.observableArray(Object.keys(gpsCaseProps));
-
         var data = configData.get('config');
         self.customUserFieldName = ko.observable(data.user_location_property_name);
         self.geoCasePropertyName = ko.observable(data.case_location_property_name);
-        self.isCasePropDeprecated = ko.observable(gpsCaseProps[self.geoCasePropertyName()]);
+
+        const gpsCasePropsDepState = configData.get('gps_case_props_deprecated_state');
+        let gpsCaseProps = [];
+        for (const key in gpsCasePropsDepState) {
+            if (!gpsCasePropsDepState[key] || key === data.case_location_property_name) {
+                gpsCaseProps.push(key);
+            }
+        }
+        self.geoCasePropOptions = ko.observableArray(gpsCaseProps);
+
+        self.isCasePropDeprecated = ko.observable(gpsCasePropsDepState[self.geoCasePropertyName()]);
         self.savedGeoCasePropName = ko.observable(data.case_location_property_name);
         self.hasGeoCasePropChanged = ko.observable(false);
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Deprecated case properties will no longer show on the Microplanning Settings page.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3112).

Based on work from [this](https://github.com/dimagi/commcare-hq/pull/33426) PR.

Small PR that hides deprecated case properties from the case property dropdown in the Microplanning Settings page. The only exception to this is that if the currently selected case property is deprecated, it will still be shown to give the user an opportunity to change their selected case property.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Small UI change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
