### PR TITLE
Corrected an xform pillow assertion and formatting

### DIFF
--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -51,9 +51,9 @@ def xform_pillow_filter(doc_dict):
     :return: True to filter out doc
     """
     return (
-        doc_dict.get('xmlns', None) == DEVICE_LOG_XMLNS or
-        doc_dict.get('domain', None) is None or
-        doc_dict['form'] is None
+        doc_dict.get('xmlns', None) == DEVICE_LOG_XMLNS
+        or doc_dict.get('domain', None) is None
+        or doc_dict['form'] is None
     )
 
 
@@ -103,7 +103,7 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
       - :py:class:`corehq.apps.data_interfaces.pillow.CaseDeduplicationPillow``
     """
     if topics:
-        assert set(topics).issubset(FORM_TOPICS), "This is a pillow to process cases only"
+        assert set(topics).issubset(FORM_TOPICS), "This is a pillow to process forms only"
     topics = topics or FORM_TOPICS
     change_feed = KafkaChangeFeed(
         topics, client_id=pillow_id, num_processes=num_processes, process_num=process_num,


### PR DESCRIPTION
## Technical Summary
I came across what I suspect to be a copy/paste oversight.  I suspect it was copied from [get_case_pillow](https://github.com/dimagi/commcare-hq/blob/master/corehq/pillows/case.py#L84).

## Safety Assurance

### Safety story
This is just rewording the assertion message, which should never occur anyway.

### Automated test coverage

No tests.

### QA Plan

No QA required.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
