### PR TITLE
Disable dynamic search if response type is query

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -144,6 +144,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
                     title: menuResponse.title,
                     description: menuResponse.description,
                     sidebarEnabled: true,
+                    disableDynamicSearch: true,
                 }).render()
             );
         } else {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -456,8 +456,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             // only here to maintain backward compatibility and can be removed
             // once web apps fully transition using keys to convey select prompt selection.
             this.selectValuesByKeys = false;
-            this.dynamicSearchEnabled = toggles.toggleEnabled('DYNAMICALLY_UPDATE_SEARCH_RESULTS') &&
-                this.options.sidebarEnabled;
+            this.dynamicSearchEnabled = options.disableDynamicSearch ? false:
+                (toggles.toggleEnabled('DYNAMICALLY_UPDATE_SEARCH_RESULTS') && this.options.sidebarEnabled);
 
             for (let model of this.parentModel) {
                 if ("itemsetChoicesKey" in model.attributes) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -456,7 +456,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             // only here to maintain backward compatibility and can be removed
             // once web apps fully transition using keys to convey select prompt selection.
             this.selectValuesByKeys = false;
-            this.dynamicSearchEnabled = options.disableDynamicSearch ? false:
+            this.dynamicSearchEnabled = options.disableDynamicSearch ? false :
                 (toggles.toggleEnabled('DYNAMICALLY_UPDATE_SEARCH_RESULTS') && this.options.sidebarEnabled);
 
             for (let model of this.parentModel) {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Followup PR from testing in [USH-3532](https://dimagi-dev.atlassian.net/browse/USH-3532) that will _wait_ for dynamic search to be enabled until the user has performed a search as requested by delivery and noted in the spec

https://github.com/dimagi/commcare-hq/assets/36681924/61fcfb3f-dc43-4e8f-8bb6-bbdfc8ef2d5f



## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This adds a flag 'disableDynamicSearch' if the response type is `query`, so dynamic search will only be enabled if the response type is `entities` and the FF is enabled and the sidebar is enabled, AND all the required field are non-empty

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DYNAMICALLY_UPDATE_SEARCH_RESULTS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is behind a FF of a feature not yet in use by any domain on prod and will be tested on staging and test prod domains prior to release

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated test coverage

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA and rather opting for dev-lead QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3532]: https://dimagi-dev.atlassian.net/browse/USH-3532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ