### PR TITLE
Fix pre 2.54 menu instance references

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -172,7 +172,7 @@ class InstancesHelper(PostProcessor):
         # multiple menus can have the same ID - merge them first
         xpaths_by_menu_id = defaultdict(set)
         for menu in self.suite.menus:
-            xpaths_by_menu_id[menu.id] = menu.get_all_xpaths()
+            xpaths_by_menu_id[menu.id].update(menu.get_all_xpaths())
 
         return defaultdict(set, {
             command.id: xpaths_by_menu_id[menu.id]

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -271,6 +271,7 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
         # and if two modules are display_in_root, then on forms in the other module too
         factory = AppFactory(build_version='2.20.0')  # enable_module_filtering
         self.m0, self.m0f0 = factory.new_basic_module('m0', 'case1')
+        self.m0.module_filter = "instance('groups')/groups/"
         self.m0.put_in_root = True
 
         self.m1, self.m1f0 = factory.new_basic_module('m1', 'case1')
@@ -278,7 +279,10 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
         self.m1.put_in_root = True
 
         suite = factory.app.create_suite()
-        instance_xml = "<partial><instance id='locations' src='jr://fixture/locations' /></partial>"
+        instance_xml = """<partial>
+            <instance id='groups' src='jr://fixture/user-groups' />
+            <instance id='locations' src='jr://fixture/locations' />
+        </partial>"""
         self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m0-f0']/../instance")
         self.assertXmlPartialEqual(instance_xml, suite, "entry/command[@id='m1-f0']/../instance")
 


### PR DESCRIPTION
## Product Description

Resolves an issue [reported on slack](https://dimagi.slack.com/archives/C02D81F4YET/p1694434725304779) where instance references in menu relevancy conditions triggered this error in some circumstances:

> The instance "locations" in expression "instance(locations)/locations/location[@id = instance(commcaresession)/session/user/data/commcare_location_id]/@type" used by "/" does not exist in the form.

See  the slack thread for further details

## Technical Summary

This is sort of a recurrance of an issue I introduced in https://github.com/dimagi/commcare-hq/pull/33037 and then fixed in https://github.com/dimagi/commcare-hq/pull/33271/ See that second PR description for details

This was then broken in https://github.com/dimagi/commcare-hq/pull/33437 in commit https://github.com/dimagi/commcare-hq/commit/8db8f4a27621307125a7ec627a7b05a2f89f1d6d, which had subsequent menus overwriting instances from earlier ones.

The test created in #33271 above demonstrated that instances in the second of two modules with the same ID will be propagated to all forms in both modules, but it neglected to verify that same property of instances required by the first of those two modules.

## Feature Flag


## Safety Assurance

### Safety story

I'm relying on automated tests here, plus this is a return to a previous behavior of the code.  I'm not concerned about introducing a new bug here - seems more likely that I've left out some edge case if anything.

### Automated test coverage

check inside the box

### QA Plan

None

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change