### PR TITLE
Improve remove_duplicate_domains

### DIFF
--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -73,9 +73,13 @@ class Command(BaseCommand):
                     f'\n')
 
             if not dry_run:
+                self.stdout.write('')
+                self.stdout.write(f'{chosen_domain_doc._id} chosen\n')
                 for dom in other_domain_docs:
+                    self.stdout.write(f'{dom._id} ...', ending='')
                     dom.doc_type = 'Domain-DUPLICATE'
                     dom.save()
+                    self.stdout.write(' archived\n')
 
 
 @memoized

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -104,6 +104,7 @@ def score_domain_doc(domain_doc, *, is_currently_chosen):
         score += 2
     if domain_doc.is_active:
         score += 3
-    # add to the score the square root of the number of times the doc has been updated
-    score += float(domain_doc._rev.split('-')[0])**(.5)
-    return score / 6
+    # add to the score the square root of the number of times the doc has been updated (since initial creation)
+    rev_count = float(domain_doc._rev.split('-')[0])
+    score += (rev_count - 1) ** .5
+    return score / 5

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
                 seen.add(domain.name)
 
         if not dups:
-            self.stdout.write('Found no duplicate domains\n')
+            self.stdout.write('Found no duplicate domains')
 
         for domain in list(dups):
             currently_chosen_domain_doc = Domain.get_by_name(domain)
@@ -46,8 +46,7 @@ class Command(BaseCommand):
 
             other_domain_docs = [d for d in all_domain_docs if d.get_id != chosen_domain_doc.get_id]
 
-
-            self.stdout.write(f'Found duplicate docs for domain: {domain}\n')
+            self.stdout.write(f'Found duplicate docs for domain: {domain}')
             self.stdout.write(
                 f'Chosen\t'
                 f'{"_id":32}\t'
@@ -56,7 +55,6 @@ class Command(BaseCommand):
                 f'{"date_created":26}\t'
                 f'{"_rev":32}\t'
                 f'score'
-                f'\n'
             )
 
             for domain_doc in all_domain_docs:
@@ -70,16 +68,16 @@ class Command(BaseCommand):
                     f'{domain_doc.date_created}\t'
                     f'{domain_doc._rev}\t'
                     f'{score_domain_doc(domain_doc, is_currently_chosen=chosen):.2f}'
-                    f'\n')
+                )
 
             if not dry_run:
                 self.stdout.write('')
-                self.stdout.write(f'{chosen_domain_doc._id} chosen\n')
+                self.stdout.write(f'{chosen_domain_doc._id} chosen')
                 for dom in other_domain_docs:
                     self.stdout.write(f'{dom._id} ...', ending='')
                     dom.doc_type = 'Domain-DUPLICATE'
                     dom.save()
-                    self.stdout.write(' archived\n')
+                    self.stdout.write(' archived')
 
 
 @memoized

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -6,7 +6,10 @@ from corehq.apps.domain.models import Domain
 class Command(BaseCommand):
     help = "Detects and removes duplicate domains"
 
-    def handle(self, **options):
+    def add_arguments(self, parser):
+        parser.add_argument('--dry-run', action='store_true', default=False)
+
+    def handle(self, dry_run, **options):
         domains = Domain.get_all()
         seen = set([])
         dups = set([])
@@ -32,6 +35,7 @@ class Command(BaseCommand):
             self.stdout.write(" -- _id of correct domain: %s\n" % currently_chosen_domain_doc.get_id)
             self.stdout.write(" -- ids of duplicate domains: %s\n" % [d.get_id for d in other_domain_docs])
 
-            for dom in other_domain_docs:
-                dom.doc_type = 'Domain-DUPLICATE'
-                dom.save()
+            if not dry_run:
+                for dom in other_domain_docs:
+                    dom.doc_type = 'Domain-DUPLICATE'
+                    dom.save()

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -1,4 +1,5 @@
 from django.core.management import BaseCommand
+from memoized import memoized
 
 from corehq.apps.domain.models import Domain
 
@@ -7,9 +8,15 @@ class Command(BaseCommand):
     help = "Detects and removes duplicate domains"
 
     def add_arguments(self, parser):
+        parser.add_argument('--selection-method', choices=['default', 'smart'], default='default', help="""
+        'default' selects the domain doc currently given by Domain.get_by_name.
+        'smart' uses additional signals to attempt to determine the best domain doc.
+        Note that this may be different from the one currently given by Domain.get_by_name,
+        and thus this will result in a change in the domain doc actively used by the system.
+        """)
         parser.add_argument('--dry-run', action='store_true', default=False)
 
-    def handle(self, dry_run, **options):
+    def handle(self, selection_method, dry_run, **options):
         domains = Domain.get_all()
         seen = set([])
         dups = set([])
@@ -29,17 +36,48 @@ class Command(BaseCommand):
                 reduce=False,
                 include_docs=True,
             ).all()
-            other_domain_docs = [d for d in all_domain_docs if d.get_id != currently_chosen_domain_doc.get_id]
+
+            if selection_method == 'default':
+                chosen_domain_doc = currently_chosen_domain_doc
+            elif selection_method == 'smart':
+                chosen_domain_doc = sorted(all_domain_docs, key=lambda d: score_domain_doc(d, is_currently_chosen=(d.get_id == currently_chosen_domain_doc.get_id)))[-1]
+            else:
+                raise NotImplementedError()
+
+            other_domain_docs = [d for d in all_domain_docs if d.get_id != chosen_domain_doc.get_id]
+
 
             self.stdout.write(f'Found duplicate docs for domain: {domain}\n')
-            self.stdout.write(f'Chosen\t{"_id":32}\t{"name":16}\tis_active\t{"date_created":26}\t{"_rev":32}\n')
+            self.stdout.write(f'Chosen\t{"_id":32}\t{"name":16}\tis_active\t{"date_created":26}\t{"_rev":32}\tscore\n')
 
             for domain_doc in all_domain_docs:
-                chosen = domain_doc._id == currently_chosen_domain_doc._id
+                chosen = domain_doc._id == chosen_domain_doc._id
                 chosen_str = '-->' if chosen else ''
-                self.stdout.write(f'{chosen_str}\t{domain_doc._id}\t{domain_doc.name:16}\t{str(domain_doc.is_active):9}\t{domain_doc.date_created}\t{domain_doc._rev}\n')
+                self.stdout.write(f'{chosen_str}\t{domain_doc._id}\t{domain_doc.name:16}\t{str(domain_doc.is_active):9}\t{domain_doc.date_created}\t{domain_doc._rev}\t{score_domain_doc(domain_doc, is_currently_chosen=chosen)}\n')
 
             if not dry_run:
                 for dom in other_domain_docs:
                     dom.doc_type = 'Domain-DUPLICATE'
                     dom.save()
+
+
+@memoized
+def score_domain_doc(domain_doc, *, is_currently_chosen):
+    """
+    Score a domain doc's worthiness as the "real" domain doc
+
+    The score is based on three factors:
+    - Is it the one that is currently returned by Domain.get_by_name?
+      This is a strong prior, since it's what is currently being served
+    - Has the doc been updated many times?
+      This could mean that somehow in the past it was being treated as the real doc, even if not presently
+    - Is the domain active? If only one of the many domain docs is active, we probably want that one
+    """
+    score = 0
+    if is_currently_chosen:
+        score += 1
+    if domain_doc.is_active:
+        score += 1
+    # add to the score the square root of the number of times the doc has been updated
+    score += float(domain_doc._rev.split('-')[0])**(.5)
+    return score

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -31,7 +31,8 @@ class Command(BaseCommand):
 
         for domain in sorted(dups):
             currently_chosen_domain_doc = Domain.get_by_name(domain)
-            all_domain_docs = Domain.view("domain/domains",
+            all_domain_docs = Domain.view(
+                "domain/domains",
                 key=domain,
                 reduce=False,
                 include_docs=True,
@@ -40,7 +41,13 @@ class Command(BaseCommand):
             if selection_method == 'default':
                 chosen_domain_doc = currently_chosen_domain_doc
             elif selection_method == 'smart':
-                chosen_domain_doc = sorted(all_domain_docs, key=lambda d: score_domain_doc(d, is_currently_chosen=(d.get_id == currently_chosen_domain_doc.get_id)))[-1]
+                chosen_domain_doc = sorted(
+                    all_domain_docs,
+                    key=lambda d: score_domain_doc(
+                        d,
+                        is_currently_chosen=(d.get_id == currently_chosen_domain_doc.get_id)
+                    )
+                )[-1]
             else:
                 raise NotImplementedError()
 

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -48,12 +48,29 @@ class Command(BaseCommand):
 
 
             self.stdout.write(f'Found duplicate docs for domain: {domain}\n')
-            self.stdout.write(f'Chosen\t{"_id":32}\t{"name":16}\tis_active\t{"date_created":26}\t{"_rev":32}\tscore\n')
+            self.stdout.write(
+                f'Chosen\t'
+                f'{"_id":32}\t'
+                f'{"name":16}\t'
+                f'is_active\t'
+                f'{"date_created":26}\t'
+                f'{"_rev":32}\t'
+                f'score'
+                f'\n'
+            )
 
             for domain_doc in all_domain_docs:
                 chosen = domain_doc._id == chosen_domain_doc._id
                 chosen_str = '-->' if chosen else ''
-                self.stdout.write(f'{chosen_str}\t{domain_doc._id}\t{domain_doc.name:16}\t{str(domain_doc.is_active):9}\t{domain_doc.date_created}\t{domain_doc._rev}\t{score_domain_doc(domain_doc, is_currently_chosen=chosen)}\n')
+                self.stdout.write(
+                    f'{chosen_str}\t'
+                    f'{domain_doc._id}\t'
+                    f'{domain_doc.name:16}\t'
+                    f'{str(domain_doc.is_active):9}\t'
+                    f'{domain_doc.date_created}\t'
+                    f'{domain_doc._rev}\t'
+                    f'{score_domain_doc(domain_doc, is_currently_chosen=chosen):.2f}'
+                    f'\n')
 
             if not dry_run:
                 for dom in other_domain_docs:

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -105,6 +105,7 @@ def score_domain_doc(domain_doc, *, is_currently_chosen):
     if domain_doc.is_active:
         score += 3
     # add to the score the square root of the number of times the doc has been updated (since initial creation)
+    # and give this just a tad more importance so that a rev of 5 beats being currently chosen
     rev_count = float(domain_doc._rev.split('-')[0])
-    score += (rev_count - 1) ** .5
+    score += ((rev_count - 1) ** .5) * 1.01
     return score / 5

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -20,18 +20,18 @@ class Command(BaseCommand):
             self.stdout.write('Found no duplicate domains\n')
 
         for domain in list(dups):
-            real_dom = Domain.get_by_name(domain)
-            total_doms = Domain.view("domain/domains",
+            currently_chosen_domain_doc = Domain.get_by_name(domain)
+            all_domain_docs = Domain.view("domain/domains",
                 key=domain,
                 reduce=False,
                 include_docs=True,
             ).all()
-            fake_doms = [d for d in total_doms if d.get_id != real_dom.get_id]
+            other_domain_docs = [d for d in all_domain_docs if d.get_id != currently_chosen_domain_doc.get_id]
 
             self.stdout.write('Found Dup: %s\n' % domain)
-            self.stdout.write(" -- _id of correct domain: %s\n" % real_dom.get_id)
-            self.stdout.write(" -- ids of duplicate domains: %s\n" % [d.get_id for d in fake_doms])
+            self.stdout.write(" -- _id of correct domain: %s\n" % currently_chosen_domain_doc.get_id)
+            self.stdout.write(" -- ids of duplicate domains: %s\n" % [d.get_id for d in other_domain_docs])
 
-            for dom in fake_doms:
+            for dom in other_domain_docs:
                 dom.doc_type = 'Domain-DUPLICATE'
                 dom.save()

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         if not dups:
             self.stdout.write('Found no duplicate domains')
 
-        for domain in list(dups):
+        for domain in sorted(dups):
             currently_chosen_domain_doc = Domain.get_by_name(domain)
             all_domain_docs = Domain.view("domain/domains",
                 key=domain,

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -92,9 +92,9 @@ def score_domain_doc(domain_doc, *, is_currently_chosen):
     """
     score = 0
     if is_currently_chosen:
-        score += 1
+        score += 2
     if domain_doc.is_active:
-        score += 1
+        score += 3
     # add to the score the square root of the number of times the doc has been updated
     score += float(domain_doc._rev.split('-')[0])**(.5)
-    return score
+    return score / 6

--- a/corehq/apps/domain/management/commands/remove_duplicate_domains.py
+++ b/corehq/apps/domain/management/commands/remove_duplicate_domains.py
@@ -31,9 +31,13 @@ class Command(BaseCommand):
             ).all()
             other_domain_docs = [d for d in all_domain_docs if d.get_id != currently_chosen_domain_doc.get_id]
 
-            self.stdout.write('Found Dup: %s\n' % domain)
-            self.stdout.write(" -- _id of correct domain: %s\n" % currently_chosen_domain_doc.get_id)
-            self.stdout.write(" -- ids of duplicate domains: %s\n" % [d.get_id for d in other_domain_docs])
+            self.stdout.write(f'Found duplicate docs for domain: {domain}\n')
+            self.stdout.write(f'Chosen\t{"_id":32}\t{"name":16}\tis_active\t{"date_created":26}\t{"_rev":32}\n')
+
+            for domain_doc in all_domain_docs:
+                chosen = domain_doc._id == currently_chosen_domain_doc._id
+                chosen_str = '-->' if chosen else ''
+                self.stdout.write(f'{chosen_str}\t{domain_doc._id}\t{domain_doc.name:16}\t{str(domain_doc.is_active):9}\t{domain_doc.date_created}\t{domain_doc._rev}\n')
 
             if not dry_run:
                 for dom in other_domain_docs:

--- a/corehq/apps/domain/tests/test_remove_duplicate_domains.py
+++ b/corehq/apps/domain/tests/test_remove_duplicate_domains.py
@@ -1,0 +1,29 @@
+from corehq.apps.domain.management.commands.remove_duplicate_domains import score_domain_doc
+from corehq.apps.domain.models import Domain
+
+
+def test_score_domain_doc():
+    # ceteris paribus, choose the current one
+    score_1 = score_domain_doc(Domain(is_active=True, _rev='1-xxx'), is_currently_chosen=True)
+    score_2 = score_domain_doc(Domain(is_active=True, _rev='1-xxx'), is_currently_chosen=False)
+    assert score_1 > score_2
+
+    # Choose a non-current one if it's better on both is_active and rev_count
+    score_1 = score_domain_doc(Domain(is_active=False, _rev='1-xxx'), is_currently_chosen=True)
+    score_2 = score_domain_doc(Domain(is_active=True, _rev='6-xxx'), is_currently_chosen=False)
+    assert score_2 > score_1
+
+    # Obviously choose the current one if it's better on all three fronts
+    score_1 = score_domain_doc(Domain(is_active=True, _rev='12-xxx'), is_currently_chosen=True)
+    score_2 = score_domain_doc(Domain(is_active=False, _rev='2-xxx'), is_currently_chosen=False)
+    assert score_1 > score_2
+
+    # If they're both active but one has rev_count 5, pick that one
+    score_1 = score_domain_doc(Domain(is_active=True, _rev='1-xxx'), is_currently_chosen=True)
+    score_2 = score_domain_doc(Domain(is_active=True, _rev='5-xxx'), is_currently_chosen=False)
+    assert score_2 > score_1, (score_1, score_2)
+
+    # But just 4 isn't enough to overcome "default advantage"
+    score_1 = score_domain_doc(Domain(is_active=True, _rev='1-xxx'), is_currently_chosen=True)
+    score_2 = score_domain_doc(Domain(is_active=True, _rev='4-xxx'), is_currently_chosen=False)
+    assert score_1 > score_2, (score_1, score_2)


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-14909

Best reviewed commit-by-commit. Adds a 'smart' option that uses multiple signals to select the "right" domain doc, namely the number of times the doc has been updated and whether the doc has `is_active` set to `true`. This is designed specifically to select the most likely correct doc in the case of this ticket.

## Safety Assurance

### Safety story
I've added a dry run mode to this command, which all commands like this should have. It gives very clear output that can be reviewed before choosing to apply it. Also the process by which it's applied does not actually _delete_ the doc, it merely hides it by changing its `doc_type`; this means that if need be it can be reverted (manually or with a different script).

This has already been tested (in --dry-run mode on staging).

Upon approval I will run it in --dry-run mode on production and review the output. Depending on what I find, I may make further updates.

### Automated test coverage

Added some tests for the scoring system

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
