### PR TITLE
Fix bug in es doc admin view that shoes duplicate couch/sql docs for one es doc

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
@@ -30,18 +30,12 @@
             <h3>Elasticsearch Doc:</h3>
             <pre>{{ es_doc }}</pre>
           </div>
-          <div class="col-xs-6">
-            <h3>Couch/SQL Doc:</h3>
-            <pre>{{ couch_info.doc|default:"NOT FOUND" }}</pre>
-          </div>
         </div>
       {% endfor %}
-      {% if not es_info.found_indices %}
-        <div class="col-xs-6">
-          <h3>Couch/SQL Doc:</h3>
-          <pre>{{ couch_info.doc|default:"NOT FOUND" }}</pre>
-        </div>
-      {% endif %}
+      <div class="col-xs-6">
+        <h3>Couch/SQL Doc:</h3>
+        <pre>{{ couch_info.doc|default:"NOT FOUND" }}</pre>
+      </div>
     {% endif %}
   </div>
 {% endblock content %}

--- a/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
@@ -36,7 +36,7 @@
           </div>
         </div>
       {% endfor %}
-      {% if not found_indices %}
+      {% if not es_info.found_indices %}
         <div class="col-xs-6">
           <h3>Couch/SQL Doc:</h3>
           <pre>{{ couch_info.doc|default:"NOT FOUND" }}</pre>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Pretty straightforward. Looks like we just need to update the check on `found_indices` to be `es_info.found_indices`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging and looks good. This only impacts the es doc admin view.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
