### PR TITLE
Update DD toggle check + documentation

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -72,13 +72,12 @@
     <ul id="deprecated-case-types-list" data-bind="foreach: depCaseTypes">
       <li data-bind="text: $data"></li>
     </ul>
-    <!-- TODO: Remove this comment when following PR has been merged: https://github.com/dimagi/commcare-hq/pull/33113 -->
-    <!-- <p>
+    <p>
       {% blocktrans %}
         For more information on deprecated case types, see the following
-        <a target="_blank" href="https://confluence.dimagi.com/display/commcarepublic/Data+Dictionary">documentation</a>.
+        <a target="_blank" href="https://confluence.dimagi.com/display/commcarepublic/Deprecating+Case+Types+and+Case+Properties+using+Data+Dictionary">documentation</a>.
       {% endblocktrans %}
-    </p> -->
+    </p>
   </div>
 
   <div class="row">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -395,11 +395,10 @@
               <li>Case imports cannot be done for cases with this case type.</li>
               <li>New automatic rules cannot be created with this case type.</li>
             </ul>
-            <!-- TODO: Remove this comment when following PR has been merged: https://github.com/dimagi/commcare-hq/pull/33113 -->
-            <!-- <p>
+            <p>
               For more information on deprecated case types, see the
-              <a target="_blank" href="https://confluence.dimagi.com/display/commcarepublic/Data+Dictionary">following documentation</a>.
-            </p> -->
+              <a target="_blank" href="https://confluence.dimagi.com/display/commcarepublic/Deprecating+Case+Types+and+Case+Properties+using+Data+Dictionary">following documentation</a>.
+            </p>
           {% endblocktrans %}
         </div>
         <div class="modal-footer">

--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -36,10 +36,9 @@
                 <p>
                   {% blocktrans %}
                     This case uses a deprecated case type.
-                    <!-- TODO: Remove this comment when following PR has been merged: https://github.com/dimagi/commcare-hq/pull/33113 -->
-                    <!-- See the
-                    <a target="_blank" href="https://confluence.dimagi.com/display/commcarepublic/Data+Dictionary">help documentation</a>
-                    for more information. -->
+                    See the
+                    <a target="_blank" href="https://confluence.dimagi.com/display/commcarepublic/Deprecating+Case+Types+and+Case+Properties+using+Data+Dictionary">help documentation</a>
+                    for more information.
                   {% endblocktrans %}
                 </p>
               </div>

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -641,7 +641,7 @@ class ProjectDataTab(UITab):
             self.domain,
             get_permission_name(HqPermissions.view_data_dict)
         )
-        return toggles.DATA_DICTIONARY.enabled(self.domain) and has_view_data_dict_permission
+        return domain_has_privilege(self.domain, privileges.DATA_DICTIONARY) and has_view_data_dict_permission
 
     def _get_export_data_views(self):
         export_data_views = []


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The Data Dictionary should now correctly show in the sidebar for the "Data" section.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3114).

This PR is based on the changes from the [Data Dictionary to GA PR](https://github.com/dimagi/commcare-hq/pull/33113).

In the mentioned PR all the DD toggle checks were converted to privilege checks. During this time, [this](https://github.com/dimagi/commcare-hq/pull/33305) PR introduced a new toggle check in `tabclasses.py`. Assuming all the toggle checks have already been converted, the DD to GA PR was merged, and the additional toggle check was never converted. 

This PR fixes the outstanding DD toggle check by converting it into a privilege check. Additionally, also uncommented and updated the documentation links for deprecating case types.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Small UI change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
