### PR TITLE
Update Countries syntax to accurately use API

### DIFF
--- a/corehq/apps/es/domains.py
+++ b/corehq/apps/es/domains.py
@@ -82,8 +82,9 @@ class ElasticDomain(ElasticDocumentAdapter):
         domain_dict['deployment']['countries'] = []
         if sub:
             domain_dict['subscription'] = sub[0].plan_version.plan.edition
+        countries_map = dict(countries)
         for country in domain_countries:
-            domain_dict['deployment']['countries'].append(dict(countries)[country].upper())
+            domain_dict['deployment']['countries'].append(countries_map[country].upper())
         return super()._from_dict(domain_dict)
 
 

--- a/corehq/apps/es/domains.py
+++ b/corehq/apps/es/domains.py
@@ -83,7 +83,7 @@ class ElasticDomain(ElasticDocumentAdapter):
         if sub:
             domain_dict['subscription'] = sub[0].plan_version.plan.edition
         for country in countries:
-            domain_dict['deployment']['countries'].append(Countries[country].upper())
+            domain_dict['deployment']['countries'].append(Countries().countries[country].upper())
         return super()._from_dict(domain_dict)
 
 

--- a/corehq/apps/es/domains.py
+++ b/corehq/apps/es/domains.py
@@ -12,7 +12,7 @@ DomainES
              .size(0))
 """
 
-from django_countries import Countries
+from django_countries import countries
 
 from . import filters
 from .client import ElasticDocumentAdapter, create_document_adapter
@@ -78,12 +78,12 @@ class ElasticDomain(ElasticDocumentAdapter):
 
         sub = Subscription.visible_objects.filter(subscriber__domain=domain_dict['name'], is_active=True)
         domain_dict['deployment'] = domain_dict.get('deployment') or {}
-        countries = domain_dict['deployment'].get('countries', [])
+        domain_countries = domain_dict['deployment'].get('countries', [])
         domain_dict['deployment']['countries'] = []
         if sub:
             domain_dict['subscription'] = sub[0].plan_version.plan.edition
-        for country in countries:
-            domain_dict['deployment']['countries'].append(Countries().countries[country].upper())
+        for country in domain_countries:
+            domain_dict['deployment']['countries'].append(dict(countries)[country].upper())
         return super()._from_dict(domain_dict)
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
When attempting to send a domain doc to elasticsearch, this error is hit:
```
File ~/www/production/releases/2023-09-11_05.54/corehq/apps/es/domains.py:86, in ElasticDomain._from_dict(self, domain_dict)
     84     domain_dict['subscription'] = sub[0].plan_version.plan.edition
     85 for country in countries:
---> 86     domain_dict['deployment']['countries'].append(Countries[country].upper())
     87 return super()._from_dict(domain_dict)

TypeError: 'type' object is not subscriptable
```
Looking closer at this, it looks like the intention is to use django-countries to fetch a country name based on initials. I think we want to update the syntax to `Countries().countries[country]` to get the desired behavior. Here is an example using 'NP' as the country initials.
```
In [70]: Countries['NP']
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[70], line 1
----> 1 Countries['NP']

TypeError: 'type' object is not subscriptable

In [71]: Countries().countries['NP']
Out[71]: 'Nepal'
```

I'm not sure if this worked at one point, but briefly looking through the django-countries [changelog](https://github.com/SmileyChris/django-countries/blob/main/CHANGES.rst) it didn't seem to be a behavior that has changed.  I reproduced this with my own domain by adding a country in the domain settings, and was unable to send the updated doc to elasticsearch due to the same error.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is only used for sending domains to ES, which is not pivotal to our system functioning, but still impacts some things like calculated properties and other metrics related features. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
