### PR TITLE
Load Mobile Worker GPS Data in Map (Back-end)

### DIFF
--- a/corehq/apps/geospatial/tests/test_views.py
+++ b/corehq/apps/geospatial/tests/test_views.py
@@ -243,3 +243,53 @@ class TestGetPaginatedCasesOrUsers(BaseGeospatialViewClass):
         self.client.login(username=self.username, password=self.password)
         response = self.client.get(self.endpoint, data={'data_type': 'user', 'limit': 5, 'page': 1})
         self.assertEqual(response.json(), expected_output)
+
+
+class TestGetUsersWithGPS(BaseGeospatialViewClass):
+
+    urlname = 'get_users_with_gps'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user_a = CommCareUser.create(
+            cls.domain,
+            username='UserA',
+            password='1234',
+            created_by=None,
+            created_via=None,
+            metadata={GPS_POINT_CASE_PROPERTY: '12.34 45.67'}
+        )
+        cls.user_b = CommCareUser.create(
+            cls.domain,
+            username='UserB',
+            password='1234',
+            created_by=None,
+            created_via=None
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user_a.delete(cls.domain, None)
+        cls.user_b.delete(cls.domain, None)
+        super().tearDownClass()
+
+    def test_get_users_with_gps(self):
+        expected_output = {
+            'user_data': [
+                {
+                    'id': self.user_a.user_id,
+                    'username': self.user_a.raw_username,
+                    'gps_point': '12.34 45.67',
+                },
+                {
+                    'id': self.user_b.user_id,
+                    'username': self.user_b.raw_username,
+                    'gps_point': None,
+                },
+            ],
+        }
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get(self.endpoint)
+        self.assertEqual(response.json(), expected_output)

--- a/corehq/apps/geospatial/urls.py
+++ b/corehq/apps/geospatial/urls.py
@@ -8,7 +8,8 @@ from .views import (
     get_paginated_cases_or_users_without_gps,
     MapboxOptimizationV2,
     mapbox_routing_status,
-    GeospatialConfigPage
+    GeospatialConfigPage,
+    get_users_with_gps,
 )
 
 
@@ -25,6 +26,7 @@ urlpatterns = [
     url(r'^gps_capture/json/$', get_paginated_cases_or_users_without_gps,
         name='get_paginated_cases_or_users_without_gps'),
     url(r'^gps_capture/$', GPSCaptureView.as_view(), name=GPSCaptureView.urlname),
+    url(r'^get_gps_users/$', get_users_with_gps, name='get_users_with_gps'),
     url(r'^$', geospatial_default, name='geospatial_default'),
     CaseManagementMapDispatcher.url_pattern(),
 ]

--- a/corehq/apps/geospatial/urls.py
+++ b/corehq/apps/geospatial/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
     url(r'^gps_capture/json/$', get_paginated_cases_or_users_without_gps,
         name='get_paginated_cases_or_users_without_gps'),
     url(r'^gps_capture/$', GPSCaptureView.as_view(), name=GPSCaptureView.urlname),
-    url(r'^get_gps_users/$', get_users_with_gps, name='get_users_with_gps'),
+    url(r'^users/json/$', get_users_with_gps, name='get_users_with_gps'),
     url(r'^$', geospatial_default, name='geospatial_default'),
     CaseManagementMapDispatcher.url_pattern(),
 ]

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -308,3 +308,17 @@ def _get_paginated_users_without_gps(domain, page, limit, query):
         'items': user_data,
         'total': paginator.count,
     }
+
+
+def get_users_with_gps(request, domain):
+    location_prop_name = get_geo_user_property(domain)
+    users = CommCareUser.by_domain(domain)
+    user_data = [
+        {
+            'id': user.user_id,
+            'username': user.raw_username,
+            'gps_point': user.pop_metadata(key=location_prop_name),
+        } for user in users
+    ]
+
+    return json_response({'user_data': user_data})

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -310,6 +310,8 @@ def _get_paginated_users_without_gps(domain, page, limit, query):
     }
 
 
+@require_GET
+@login_and_domain_required
 def get_users_with_gps(request, domain):
     location_prop_name = get_geo_user_property(domain)
     users = CommCareUser.by_domain(domain)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2872).

This PR adds the necessary back-end changes required for showing mobile workers on the geospatial "Case Management" page. Essentially, a new view has been created to retrieve all mobile workers that have GPS data.

In the future, this will be further filtered by campagin and location drilldown filters.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Only adds a new view which is unused.
- Unit test.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
- Unit test has been created for new view.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

This PR implements the back-end changes required by [another](https://github.com/dimagi/commcare-hq/pull/33488) PR. If this PR needs to be reverted, then the other mentioned PR should also be reverted to avoid the front-end calling on non-existent code.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
