### PR TITLE
update the pre-commit hook to handle deleted files

### DIFF
--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -50,7 +50,8 @@ fi
 status=0
 git diff-index --check --cached $against --
 if [ $? != 0 ]; then status=1; fi
-pyfiles=($(git diff --staged --name-only | grep "\.py$"))
+# --diff-filter=d ignores deleted files
+pyfiles=($(git diff --staged --name-only --diff-filter=d| grep "\.py$"))
 if [ -n "$pyfiles" ]; then
     flake8 --show-source --config=.flake8 "${pyfiles[@]}"
 	if [ $? != 0 ]; then status=1; fi


### PR DESCRIPTION
## Technical Summary
This fixes a bug with the pre-commit linting process, where deleted files were being fed into the linters -- and then were not found. 

## Safety Assurance

### Safety story
This only affects the linter, and can be skipped with `--no-verify` in the event of problems.
I tested this locally against deleted files, and also made sure that regular modified files as well as renames still functioned as expected.

### Automated test coverage

No tests

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
