### PR TITLE
Add Web Users to "Users" filter default selections

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -267,6 +267,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         defaults = [
             self.utils.user_type_tuple(HQUserType.ACTIVE),
             self.utils.user_type_tuple(HQUserType.DEACTIVATED),
+            self.utils.user_type_tuple(HQUserType.WEB),
         ]
         if self.request.project.commtrack_enabled:
             defaults.append(self.utils.user_type_tuple(HQUserType.COMMTRACK))

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -46,7 +46,7 @@ def all_project_data_filter(domain, mobile_user_and_group_slugs):
         domain=domain,
         admin=HQUserType.ADMIN not in user_types,
         unknown=HQUserType.UNKNOWN not in user_types,
-        web=HQUserType.WEB not in user_types,
+        web=False,  # don't exclude cases owned by web users
         demo=HQUserType.DEMO_USER not in user_types,
         commtrack=False,
     )

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -1,3 +1,4 @@
+from corehq import toggles
 from corehq.apps.es import cases as case_es
 from corehq.apps.es import filters
 from corehq.apps.es import users as user_es
@@ -46,7 +47,7 @@ def all_project_data_filter(domain, mobile_user_and_group_slugs):
         domain=domain,
         admin=HQUserType.ADMIN not in user_types,
         unknown=HQUserType.UNKNOWN not in user_types,
-        web=False,  # don't exclude cases owned by web users
+        web=not toggles.WEB_USERS_IN_REPORTS.enabled(domain),  # don't exclude if flag enabled
         demo=HQUserType.DEMO_USER not in user_types,
         commtrack=False,
     )

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -17,6 +17,7 @@ from dimagi.utils.parsing import json_format_date, string_to_utc_datetime
 
 from corehq import toggles
 from corehq.apps.analytics.tasks import track_workflow
+from corehq.apps.es import UserES
 from corehq.apps.es import cases as case_es
 from corehq.apps.es import filters
 from corehq.apps.es.aggregations import (
@@ -29,7 +30,6 @@ from corehq.apps.locations.permissions import (
     location_safe,
 )
 from corehq.apps.reports import util
-from corehq.apps.reports.const import USER_QUERY_LIMIT
 from corehq.apps.reports.analytics.esaccessors import (
     get_active_case_counts_by_owner,
     get_case_counts_closed_by_user,
@@ -45,6 +45,7 @@ from corehq.apps.reports.analytics.esaccessors import (
     get_submission_counts_by_user,
     get_total_case_counts_by_owner,
 )
+from corehq.apps.reports.const import USER_QUERY_LIMIT
 from corehq.apps.reports.datatables import (
     DataTablesColumn,
     DataTablesColumnGroup,
@@ -1386,8 +1387,8 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
             )
             return util.get_simplified_users(user_query)
         elif not self.group_ids:
-            ret = [util._report_user(u) for u in list(CommCareUser.by_domain(self.domain))]
-            return ret
+            user_query = UserES().domain(self.domain)
+            return util.get_simplified_users(user_query)
         else:
             all_users = flatten_list(list(self.users_by_group.values()))
             all_users.extend([user for user in self.get_users_by_mobile_workers().values()])

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1388,6 +1388,8 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
             return util.get_simplified_users(user_query)
         elif not self.group_ids:
             user_query = UserES().domain(self.domain)
+            if not toggles.WEB_USERS_IN_REPORTS.enabled(self.domain):
+                user_query = user_query.mobile_users()
             return util.get_simplified_users(user_query)
         else:
             all_users = flatten_list(list(self.users_by_group.values()))

--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -89,7 +89,6 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
         base_queryset = MALTRow.objects.filter(
             domain_name=domain,
             month=month,
-            user_type__in=['CommCareUser', 'CommCareUser-Deleted'],
             user_id__in=active_not_deleted_users,
         )
         if selected_users:

--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -11,6 +11,7 @@ from memoized import memoized
 from dimagi.ext import jsonobject
 from dimagi.utils.dates import add_months
 
+from corehq import toggles
 from corehq.apps.data_analytics.models import MALTRow
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.groups import GroupES
@@ -91,6 +92,8 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
             month=month,
             user_id__in=active_not_deleted_users,
         )
+        if not toggles.WEB_USERS_IN_REPORTS.enabled(domain):
+            base_queryset = base_queryset.filter(user_type__in=['CommCareUser', 'CommCareUser-Deleted'])
         if selected_users:
             base_queryset = base_queryset.filter(
                 user_id__in=selected_users,

--- a/corehq/apps/reports/tests/test_case_list_report.py
+++ b/corehq/apps/reports/tests/test_case_list_report.py
@@ -76,7 +76,7 @@ class TestCaseListReport(TestCase):
         q_dict_get.setlist('case_list_filter', report_slugs)
         self.request.GET = q_dict_get
         data = CaseListReport(self.request, domain=self.domain).es_results['hits'].get('hits', [])
-        expected_case_ids = ['id-1', 'id-2', 'id-3', 'id-5']
+        expected_case_ids = ['id-1', 'id-2', 'id-3', 'id-4', 'id-5']
         queried_case_ids = [case['_id'] for case in data]
         self.assertCountEqual(expected_case_ids, queried_case_ids)
 

--- a/corehq/apps/reports/tests/test_case_list_report.py
+++ b/corehq/apps/reports/tests/test_case_list_report.py
@@ -71,63 +71,28 @@ class TestCaseListReport(TestCase):
     def _send_cases_to_es(cls):
         case_adapter.bulk_index(cls.case_list, refresh=True)
 
-    def test_with_project_data_slug(self):
-        report_slugs = ['project_data']
+    def assert_filters_yield_cases(self, report_slugs, expected_case_ids):
         q_dict_get = QueryDict('', mutable=True)
         q_dict_get.setlist('case_list_filter', report_slugs)
         self.request.GET = q_dict_get
         data = CaseListReport(self.request, domain=self.domain).es_results['hits'].get('hits', [])
-        expected_case_ids = ['id-1', 'id-2', 'id-3', 'id-5']
-        queried_case_ids = [case['_id'] for case in data]
-        self.assertCountEqual(expected_case_ids, queried_case_ids)
+        self.assertCountEqual(expected_case_ids, [case['_id'] for case in data])
+
+    def test_with_project_data_slug(self):
+        self.assert_filters_yield_cases(['project_data'], ['id-1', 'id-2', 'id-3', 'id-5'])
 
     @flag_enabled('WEB_USERS_IN_REPORTS')
     def test_with_project_data_slug_web_users_enabled(self):
-        report_slugs = ['project_data']
-        q_dict_get = QueryDict('', mutable=True)
-        q_dict_get.setlist('case_list_filter', report_slugs)
-        self.request.GET = q_dict_get
-        data = CaseListReport(self.request, domain=self.domain).es_results['hits'].get('hits', [])
-        expected_case_ids = ['id-1', 'id-2', 'id-3', 'id-4', 'id-5']
-        queried_case_ids = [case['_id'] for case in data]
-        self.assertCountEqual(expected_case_ids, queried_case_ids)
+        self.assert_filters_yield_cases(['project_data'], ['id-1', 'id-2', 'id-3', 'id-4', 'id-5'])
 
     def test_with_deactivated_slug(self):
-        report_slugs = ['t__5']
-        q_dict_get = QueryDict('', mutable=True)
-        q_dict_get.setlist('case_list_filter', report_slugs)
-        self.request.GET = q_dict_get
-        data = CaseListReport(self.request, domain=self.domain).es_results['hits'].get('hits', [])
-        expected_case_ids = ['id-1']
-        queried_case_ids = [case['_id'] for case in data]
-        self.assertCountEqual(expected_case_ids, queried_case_ids)
+        self.assert_filters_yield_cases(['t__5'], ['id-1'])
 
     def test_with_web_user_slug(self):
-        report_slugs = ['t__6']
-        q_dict_get = QueryDict('', mutable=True)
-        q_dict_get.setlist('case_list_filter', report_slugs)
-        self.request.GET = q_dict_get
-        data = CaseListReport(self.request, domain=self.domain).es_results['hits'].get('hits', [])
-        expected_case_ids = ['id-4']
-        queried_case_ids = [case['_id'] for case in data]
-        self.assertCountEqual(expected_case_ids, queried_case_ids)
+        self.assert_filters_yield_cases(['t__6'], ['id-4'])
 
     def test_with_multiple_slugs(self):
-        report_slugs = ['project_data', 't__6']
-        q_dict_get = QueryDict('', mutable=True)
-        q_dict_get.setlist('case_list_filter', report_slugs)
-        self.request.GET = q_dict_get
-        data = CaseListReport(self.request, domain=self.domain).es_results['hits'].get('hits', [])
-        expected_case_ids = ['id-1', 'id-2', 'id-3', 'id-4', 'id-5']
-        queried_case_ids = [case['_id'] for case in data]
-        self.assertCountEqual(expected_case_ids, queried_case_ids)
+        self.assert_filters_yield_cases(['project_data', 't__6'], ['id-1', 'id-2', 'id-3', 'id-4', 'id-5'])
 
     def test_with_slugs_and_user_ids(self):
-        report_slugs = ['t__5', 'u__active1']
-        q_dict_get = QueryDict('', mutable=True)
-        q_dict_get.setlist('case_list_filter', report_slugs)
-        self.request.GET = q_dict_get
-        data = CaseListReport(self.request, domain=self.domain).es_results['hits'].get('hits', [])
-        expected_case_ids = ['id-1', 'id-2', 'id-3']
-        queried_case_ids = [case['_id'] for case in data]
-        self.assertCountEqual(expected_case_ids, queried_case_ids)
+        self.assert_filters_yield_cases(['t__5', 'u__active1'], ['id-1', 'id-2', 'id-3'])

--- a/corehq/apps/saved_reports/tests/end_to_end/test_scheduled_reports.py
+++ b/corehq/apps/saved_reports/tests/end_to_end/test_scheduled_reports.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.core import mail
 from django.test import TestCase
 
@@ -15,6 +17,8 @@ from corehq.apps.users.models import (
 from ...models import ReportConfig, ReportNotification
 
 
+@patch('corehq.apps.reports.standard.monitoring.util.get_simplified_users',
+       new=lambda q: [])
 @es_test(requires=[case_adapter, form_adapter], setup_class=True)
 class TestScheduledReports(TestCase):
 

--- a/corehq/apps/saved_reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/saved_reports/tests/test_scheduled_reports.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from datetime import datetime, timedelta
 
 from django.test import SimpleTestCase, TestCase
@@ -235,6 +237,8 @@ class ScheduledReportTest(TestCase):
         self._check('monthly', datetime(2014, 10, 31, 12, 0), 1)
 
 
+@patch('corehq.apps.reports.standard.monitoring.util.get_simplified_users',
+       new=lambda q: [])
 @es_test(requires=[case_adapter, form_adapter], setup_class=True)
 class ScheduledReportSendingTest(TestCase):
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2498,6 +2498,15 @@ LOCATION_RESTRICTED_SCHEDULED_REPORTS = StaticToggle(
                 'such as schedule creation and deletion.'
 )
 
+WEB_USERS_IN_REPORTS = StaticToggle(
+    'web_users_in_reports',
+    'Adds web users to standard reports by default',
+    TAG_RELEASE,
+    namespaces=[NAMESPACE_DOMAIN],
+    description='Adds web users to default filter selections, the [Project Data] filter for the '
+                'case list reports, and to the body of the Worker Activity and Project Health reports'
+)
+
 CUSTOM_EMAIL_GATEWAY = StaticToggle(
     'custom_email_gateway',
     'Allows user to define custom email gateway that can be used to send emails from HQ',


### PR DESCRIPTION
## Product Description
Adds web users to the default filter selections for standard reports.  Also adds web users to the definition of [Project Data] in the case list reports where that appears.  Also adds them to the body of the worker activity report and Project Performance report

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3589


## Feature Flag
Changes are gated behind a new feature flag: WEB_USERS_IN_REPORTS

## Safety Assurance

### Safety story
All changes are feature flagged

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change