### PR TITLE
Only return active domains for processing calculated properties

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -132,7 +132,6 @@ def get_domains_to_update_es_filter():
     """
     last_week = datetime.utcnow() - timedelta(days=7)
     more_than_a_week_ago = filters.date_range('cp_last_updated', lt=last_week)
-    less_than_a_week_ago = filters.date_range('cp_last_updated', gte=last_week)
     not_updated = filters.missing('cp_last_updated')
     domains_submitted_today = (FormES().submitted(gte=datetime.utcnow() - timedelta(days=1))
         .terms_aggregation('domain.exact', 'domain').size(0).run().aggregations.domain.keys)
@@ -142,8 +141,7 @@ def get_domains_to_update_es_filter():
         filters.OR(
             not_updated,
             more_than_a_week_ago,
-            filters.AND(less_than_a_week_ago,
-                        filters.term('name', domains_submitted_today))
+            filters.term('name', domains_submitted_today)
         )
     )
 

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -124,10 +124,11 @@ def summarize_user_counts(commcare_users_by_domain, n):
 
 def get_domains_to_update_es_filter():
     """
-    Returns ES filter to filter domains that are never updated or
-        domains that haven't been updated since a week or domains that
-        have been updated within last week but have new form submissions
-        in the last day.
+    Returns ES filter to obtain domains that are active, and meet one or more
+    of the following criteria:
+     - never had calculated properties updated
+     - calculated properties was updated over one week ago
+     - new form submissions within the last day
     """
     last_week = datetime.utcnow() - timedelta(days=7)
     more_than_a_week_ago = filters.date_range('cp_last_updated', lt=last_week)
@@ -135,10 +136,15 @@ def get_domains_to_update_es_filter():
     not_updated = filters.missing('cp_last_updated')
     domains_submitted_today = (FormES().submitted(gte=datetime.utcnow() - timedelta(days=1))
         .terms_aggregation('domain.exact', 'domain').size(0).run().aggregations.domain.keys)
-    return filters.OR(
-        not_updated,
-        more_than_a_week_ago,
-        filters.AND(less_than_a_week_ago, filters.term('name', domains_submitted_today))
+    is_domain_active = filters.term('is_active', True)
+    return filters.AND(
+        is_domain_active,
+        filters.OR(
+            not_updated,
+            more_than_a_week_ago,
+            filters.AND(less_than_a_week_ago,
+                        filters.term('name', domains_submitted_today))
+        )
     )
 
 

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -133,6 +133,15 @@ class TestGetDomainsToUpdateESFilter(TestCase):
 
         self.assertEqual(results, [])
 
+    @freeze_time('2020-01-10')
+    def test_inactive_domain_is_excluded(self):
+        self.index_domain('inactive-domain', active=False)
+
+        domains_filter = get_domains_to_update_es_filter()
+        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
+
+        self.assertEqual(results, [])
+
     def index_domain(self, name, active=True, cp_last_updated=None):
         domain = create_domain(name, active)
         if cp_last_updated:

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -144,6 +144,7 @@ class TestGetDomainsToUpdateESFilter(TestCase):
 
     def index_domain(self, name, active=True, cp_last_updated=None):
         domain = create_domain(name, active)
+        self.addCleanup(domain.delete)
         if cp_last_updated:
             domain.cp_last_updated = json_format_datetime(cp_last_updated)
         domain_adapter.index(domain, refresh=True)

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -3,9 +3,9 @@ from unittest.mock import patch
 from uuid import uuid4
 from zipfile import ZipFile
 
-from attrs import define, field
-
 from django.test import SimpleTestCase
+
+from attrs import define, field
 
 from corehq.apps.reports.tasks import (
     _get_question_id_for_attachment,

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -1,17 +1,27 @@
+from datetime import datetime
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 from uuid import uuid4
 from zipfile import ZipFile
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
 from attrs import define, field
+from freezegun import freeze_time
 
+from dimagi.utils.parsing import json_format_datetime
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.es import DomainES, form_adapter
+from corehq.apps.es.domains import domain_adapter
+from corehq.apps.es.tests.utils import es_test
 from corehq.apps.reports.tasks import (
     _get_question_id_for_attachment,
     _make_unique_filename,
     _write_attachments_to_file,
+    get_domains_to_update_es_filter,
 )
+from corehq.form_processor.tests.utils import create_form_for_test
 
 
 class GetQuestionIdTests(SimpleTestCase):
@@ -63,6 +73,79 @@ class GetQuestionIdTests(SimpleTestCase):
 
         result = _get_question_id_for_attachment(form, 'attachment.ext')
         self.assertIsNone(result)
+
+
+@es_test(requires=[domain_adapter, form_adapter], setup_class=True)
+class TestGetDomainsToUpdateESFilter(TestCase):
+    def test_calculated_properties_never_updated_is_included(self):
+        domain = self.index_domain('never-updated')
+        self.assertFalse(hasattr(domain, 'cp_last_updated'))
+
+        domains_filter = get_domains_to_update_es_filter()
+        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
+
+        self.assertEqual(results, [{'_id': domain._id, 'name': domain.name}])
+
+    @freeze_time('2020-01-10')
+    def test_calculated_properties_updated_over_one_week_ago_is_included(self):
+        domain = self.index_domain('cp-over-one-week', cp_last_updated=datetime(2020, 1, 2, 23, 59))
+
+        domains_filter = get_domains_to_update_es_filter()
+        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
+
+        self.assertEqual(results, [{'_id': domain._id, 'name': domain.name}])
+
+    @freeze_time('2020-01-10')
+    def test_calculated_properties_updated_exactly_one_week_ago_is_excluded(self):
+        self.index_domain('cp-one-week', cp_last_updated=datetime(2020, 1, 3))
+
+        domains_filter = get_domains_to_update_es_filter()
+        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
+
+        self.assertEqual(results, [])
+
+    @freeze_time('2020-01-10')
+    def test_calculated_properties_updated_less_than_one_week_ago_is_excluded(self):
+        self.index_domain('cp-less-than-one-week', cp_last_updated=datetime(2020, 1, 4))
+
+        domains_filter = get_domains_to_update_es_filter()
+        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
+
+        self.assertEqual(results, [])
+
+    @freeze_time('2020-01-10')
+    def test_form_submission_in_the_last_day_is_included(self):
+        domain = self.index_domain('form-from-today', cp_last_updated=datetime(2020, 1, 9))
+        self.index_form(domain.name, received_on=datetime(2020, 1, 9, 0, 0))
+
+        domains_filter = get_domains_to_update_es_filter()
+        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
+
+        self.assertEqual(results, [{'_id': domain._id, 'name': domain.name}])
+
+    @freeze_time('2020-01-10')
+    def test_form_submission_over_one_day_ago_is_excluded(self):
+        domain = self.index_domain('form-from-yesterday', cp_last_updated=datetime(2020, 1, 9))
+        self.index_form(domain.name, received_on=datetime(2020, 1, 8, 23, 59))
+
+        domains_filter = get_domains_to_update_es_filter()
+        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
+
+        self.assertEqual(results, [])
+
+    def index_domain(self, name, active=True, cp_last_updated=None):
+        domain = create_domain(name, active)
+        if cp_last_updated:
+            domain.cp_last_updated = json_format_datetime(cp_last_updated)
+        domain_adapter.index(domain, refresh=True)
+        self.addCleanup(domain_adapter.delete, domain._id, refresh=True)
+        return domain
+
+    def index_form(self, domain, received_on):
+        xform = create_form_for_test(domain, received_on=received_on)
+        form_adapter.index(xform, refresh=True)
+        self.addCleanup(form_adapter.delete, xform.form_id, refresh=True)
+        return xform
 
 
 @patch("soil.DownloadBase.set_progress")


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Came up because of work I was doing in https://dimagi-dev.atlassian.net/browse/SAAS-14915, but is a bit of a side quest.

If a domain is not active, there is no need to update calculated properties for it. This PR updates the filter used for obtaining domains to update calculated properties for.

I first wrote tests for the existing code, and then added the active domain filter with a new test. In my last commit (4176923c42132922f0b0afdfe7606f24ff0571ea), I removed the filter that only looked for forms submitted in the last day if the domain had been updated in the last week. I don't think this optimizes the query or anything, and therefore do not think it is necessary. Please correct me if I'm wrong 👍🏻 

Review by commit 🐡 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Calculated properties are used internally, but that doesn't excuse any issues with this code. With the addition of tests, I feel better about this code now than previously.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests for the method being updated.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
