### PR TITLE
Refactor repeaters code and tests

### DIFF
--- a/corehq/apps/accounting/tests/utils.py
+++ b/corehq/apps/accounting/tests/utils.py
@@ -47,7 +47,10 @@ class DomainSubscriptionMixin(object):
 
     @classmethod
     def teardown_subscription(cls, domain):
-        SubscriptionAdjustment.objects.all().delete()
-        Subscription.visible_and_suppressed_objects.all().delete()
-        cls.__subscriptions[domain].delete()
-        cls.__accounts[domain].delete()
+        try:
+            SubscriptionAdjustment.objects.all().delete()
+            Subscription.visible_and_suppressed_objects.all().delete()
+            cls.__subscriptions[domain].delete()
+            cls.__accounts[domain].delete()
+        finally:
+            Subscription._get_active_subscription_by_domain.clear(Subscription, domain)

--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -592,7 +592,8 @@ class CaseRuleCriteriaTest(BaseCaseRuleTest):
         from corehq.apps.domain.shortcuts import create_domain
         from corehq.apps.locations.models import LocationType, SQLLocation
 
-        create_domain(self.domain)
+        domain_obj = create_domain(self.domain)
+        self.addCleanup(domain_obj.delete)
 
         location_type_provice = LocationType(domain=self.domain, name='Province')
         location_type_provice.save()
@@ -1178,11 +1179,7 @@ class CaseRuleEndToEndTests(BaseCaseRuleTest):
         super(CaseRuleEndToEndTests, cls).setUpClass()
         cls.domain_object = Domain(name=cls.domain)
         cls.domain_object.save()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.domain_object.delete()
-        super(CaseRuleEndToEndTests, cls).tearDownClass()
+        cls.addClassCleanup(cls.domain_object.delete)
 
     def test_get_rules_from_domain(self):
         rule1 = _create_empty_rule(self.domain, case_type='person-1')

--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -150,18 +150,6 @@ class SyncCouchToSQLMixin(object):
         if save:
             sql_object.save(sync_to_couch=False)
 
-    @classmethod
-    def _migration_bulk_sync_to_sql(cls, couch_docs, **kw):
-        sql_class = cls._migration_get_sql_model_class()
-        id_name = sql_class._migration_couch_id_name
-        new_sql_docs = []
-        for doc in couch_docs:
-            assert doc._id, doc
-            obj = sql_class(**{id_name: doc._id})
-            doc._migration_sync_to_sql(obj, save=False)
-            new_sql_docs.append(obj)
-        sql_class.objects.bulk_create(new_sql_docs, **kw)
-
     def _migration_sync_submodels_to_sql(self, sql_object):
         """Migrate submodels from the Couch model to the SQL model. This is called
         as part of ``_migration_sync_to_sql``"""

--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -224,7 +224,7 @@ class SyncSQLToCouchMixin(object):
         Should return a list of SubModelSpec tuples, one for each SchemaListProperty
         in the couch class. Should be identical in the couch and sql mixins.
         """
-        return []
+        return cls._migration_get_couch_model_class()._migration_get_submodels()
 
     @classmethod
     def _migration_get_custom_sql_to_couch_functions(cls):

--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -170,8 +170,7 @@ class SyncCouchToSQLMixin(object):
         self._migration_sync_to_sql(sql_object)
         return sql_object
 
-    def save(self, *args, **kwargs):
-        sync_to_sql = kwargs.pop('sync_to_sql', True)
+    def save(self, *args, sync_to_sql=True, **kwargs):
         super(SyncCouchToSQLMixin, self).save(*args, **kwargs)
         if sync_to_sql:
             try:
@@ -185,8 +184,7 @@ class SyncCouchToSQLMixin(object):
                     message='Could not sync %s SQL object from %s %s' % (sql_class_name,
                         couch_class_name, self._id))
 
-    def delete(self, *args, **kwargs):
-        sync_to_sql = kwargs.pop('sync_to_sql', True)
+    def delete(self, sync_to_sql=True, *args, **kwargs):
         if sync_to_sql:
             sql_object = self._migration_get_sql_object()
             if sql_object is not None:
@@ -288,8 +286,7 @@ class SyncSQLToCouchMixin(object):
         couch_object = self._migration_get_or_create_couch_object()
         self._migration_sync_to_couch(couch_object)
 
-    def save(self, *args, **kwargs):
-        sync_to_couch = kwargs.pop('sync_to_couch', True)
+    def save(self, *args, sync_to_couch=True, **kwargs):
         super(SyncSQLToCouchMixin, self).save(*args, **kwargs)
         if sync_to_couch and sync_to_couch_enabled(self.__class__):
             try:
@@ -303,8 +300,7 @@ class SyncSQLToCouchMixin(object):
                     message='Could not sync %s Couch object from %s %s' % (couch_class_name,
                         sql_class_name, self.pk))
 
-    def delete(self, *args, **kwargs):
-        sync_to_couch = kwargs.pop('sync_to_couch', True)
+    def delete(self, *args, sync_to_couch=True, **kwargs):
         if sync_to_couch and sync_to_couch_enabled(self.__class__):
             couch_object = self._migration_get_couch_object()
             if couch_object is not None:

--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -183,9 +183,6 @@ def _iter_repeat_records_by_repeater(domain, repeater_id, chunk_size,
 
 
 def get_repeat_records_by_payload_id(domain, payload_id):
-    repeat_records = get_sql_repeat_records_by_payload_id(domain, payload_id)
-    if repeat_records:
-        return repeat_records
     return get_couch_repeat_records_by_payload_id(domain, payload_id)
 
 

--- a/corehq/motech/repeaters/dbaccessors.py
+++ b/corehq/motech/repeaters/dbaccessors.py
@@ -258,14 +258,13 @@ def get_domains_that_have_repeat_records():
 @unit_testing_only
 def delete_all_repeat_records():
     from .models import RepeatRecord
-    results = RepeatRecord.get_db().view('repeaters/repeat_records', reduce=False).all()
-    for result in results:
-        try:
-            repeat_record = RepeatRecord.get(result['id'])
-        except Exception:
-            pass
-        else:
-            repeat_record.delete()
+    db = RepeatRecord.get_db()
+    results = db.view(
+        'repeaters/repeat_records_by_payload_id',
+        reduce=False,
+        include_docs=True,
+    ).all()
+    db.bulk_delete([r["doc"] for r in results], empty_on_delete=False)
 
 
 @unit_testing_only

--- a/corehq/motech/repeaters/expression/tests.py
+++ b/corehq/motech/repeaters/expression/tests.py
@@ -25,7 +25,10 @@ class CaseExpressionRepeaterTest(TestCase, DomainSubscriptionMixin):
 
         cls.domain = 'test'
         cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(clear_plan_version_cache)
+        cls.addClassCleanup(cls.domain_obj.delete)
         cls.setup_subscription(cls.domain, SoftwarePlanEdition.PRO)
+        cls.addClassCleanup(cls.teardown_subscriptions)
 
         cls.factory = CaseFactory(cls.domain)
 
@@ -80,15 +83,6 @@ class CaseExpressionRepeaterTest(TestCase, DomainSubscriptionMixin):
         )
 
         cls.repeater.save()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.repeater.delete()
-        cls.connection.delete()
-        cls.teardown_subscriptions()
-        cls.domain_obj.delete()
-        clear_plan_version_cache()
-        super().tearDownClass()
 
     def tearDown(self):
         delete_all_repeat_records()

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -935,7 +935,7 @@ class RepeatRecord(Document):
 
     def is_repeater_deleted(self):
         try:
-            return Repeater.all_objects.get(repeater_id=self.repeater_id).is_deleted
+            return Repeater.all_objects.values_list("is_deleted", flat=True).get(repeater_id=self.repeater_id)
         except Repeater.DoesNotExist:
             return True
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -116,7 +116,6 @@ from corehq.motech.requests import simple_request
 from corehq.privileges import DATA_FORWARDING, ZAPIER_INTEGRATION
 from corehq.util.metrics import metrics_counter
 from corehq.util.models import ForeignObject, foreign_init
-from corehq.util.quickcache import quickcache
 from corehq.util.urlvalidate.ip_resolver import CannotResolveHost
 from corehq.util.urlvalidate.urlvalidate import PossibleSSRFAttempt
 
@@ -1446,15 +1445,8 @@ def is_response(duck):
     return hasattr(duck, 'status_code') and hasattr(duck, 'reason')
 
 
-@quickcache(['domain'], timeout=5 * 60)
 def are_repeat_records_migrated(domain) -> bool:
-    """
-    Returns True if ``domain`` has SQLRepeatRecords.
-
-    .. note:: Succeeded and cancelled RepeatRecords may not have been
-              migrated to SQLRepeatRecords.
-    """
-    return SQLRepeatRecord.objects.filter(domain=domain).exists()
+    return False
 
 
 def domain_can_forward(domain):

--- a/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
+++ b/corehq/motech/repeaters/tests/test_data_registry_case_update_repeater.py
@@ -31,9 +31,12 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
     def setUpClass(cls):
         super().setUpClass()
         cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(clear_plan_version_cache)
+        cls.addClassCleanup(cls.domain_obj.delete)
 
         # DATA_FORWARDING is on PRO and above
         cls.setup_subscription(cls.domain, SoftwarePlanEdition.PRO)
+        cls.addClassCleanup(cls.teardown_subscriptions)
 
         cls.connx = ConnectionSettings.objects.create(
             domain=cls.domain,
@@ -63,6 +66,7 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
         ).slug
 
         cls.mobile_user = CommCareUser.create(cls.domain, "user1", "123", None, None, is_admin=True)
+        cls.addClassCleanup(cls.mobile_user.delete, None, None)
 
         cls.target_case_id_1 = uuid.uuid4().hex
         cls.target_case_id_2 = uuid.uuid4().hex
@@ -80,16 +84,6 @@ class DataRegistryCaseUpdateRepeaterTest(TestCase, TestXmlMixin, DomainSubscript
 
     def tearDown(self):
         delete_all_repeat_records()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.repeater.delete()
-        cls.connx.delete()
-        cls.mobile_user.delete(None, None)
-        cls.teardown_subscriptions()
-        cls.domain_obj.delete()
-        clear_plan_version_cache()
-        super().tearDownClass()
 
     def test_update_cases(self):
         builder1 = (

--- a/corehq/motech/repeaters/tests/test_dbaccessors.py
+++ b/corehq/motech/repeaters/tests/test_dbaccessors.py
@@ -101,15 +101,10 @@ class TestRepeatRecordDBAccessors(TestCase):
             empty,
             other_id,
         ]
+        cls.addClassCleanup(RepeatRecord.bulk_delete, cls.records)
 
         for record in cls.records:
             record.save()
-
-    @classmethod
-    def tearDownClass(cls):
-        for record in cls.records:
-            record.delete()
-        super(TestRepeatRecordDBAccessors, cls).tearDownClass()
 
     def test_get_pending_repeat_record_count(self):
         count = get_pending_repeat_record_count(self.domain, self.repeater_id)
@@ -199,11 +194,7 @@ class TestOtherDBAccessors(TestCase):
             RepeatRecord(domain='c'),
         ]
         RepeatRecord.bulk_save(cls.records)
-
-    @classmethod
-    def tearDownClass(cls):
-        RepeatRecord.bulk_delete(cls.records)
-        super(TestOtherDBAccessors, cls).tearDownClass()
+        cls.addClassCleanup(RepeatRecord.bulk_delete, cls.records)
 
     def test_get_domains_that_have_repeat_records(self):
         self.assertEqual(get_domains_that_have_repeat_records(), ['a', 'b', 'c'])

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -28,7 +28,6 @@ from ..models import (
     FormRepeater,
     Repeater,
     RepeatRecord,
-    are_repeat_records_migrated,
     format_response,
     get_all_repeater_types,
     is_response,
@@ -398,22 +397,6 @@ class AddAttemptsTests(RepeaterTestCase):
                          RECORD_CANCELLED_STATE)
         self.assertEqual(self.repeat_record.attempts[0].message, message)
         self.assertEqual(self.repeat_record.attempts[0].traceback, tb_str)
-
-
-class TestAreRepeatRecordsMigrated(RepeaterTestCase):
-
-    def setUp(self):
-        super().setUp()
-        are_repeat_records_migrated.clear(DOMAIN)
-
-    def test_no(self):
-        is_migrated = are_repeat_records_migrated(DOMAIN)
-        self.assertFalse(is_migrated)
-
-    def test_yes(self):
-        with make_repeat_record(self.repeater, RECORD_PENDING_STATE):
-            is_migrated = are_repeat_records_migrated(DOMAIN)
-        self.assertTrue(is_migrated)
 
 
 class TestConnectionSettingsUsedBy(TestCase):

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -114,16 +114,12 @@ class BaseRepeaterTest(TestCase, DomainSubscriptionMixin):
         )
 
         cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(clear_plan_version_cache)
+        cls.addClassCleanup(cls.domain_obj.delete)
 
         # DATA_FORWARDING is on PRO and above
         cls.setup_subscription(cls.domain, SoftwarePlanEdition.PRO)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.teardown_subscriptions()
-        cls.domain_obj.delete()
-        clear_plan_version_cache()
-        super().tearDownClass()
+        cls.addClassCleanup(cls.teardown_subscriptions)
 
     @classmethod
     def post_xml(cls, xml, domain_name):


### PR DESCRIPTION
The code that automatically switches a domain to use SQL if any repeat records exist in SQL is being removed (see [first commit](https://github.com/dimagi/commcare-hq/commit/1fe8e76e5d0f14fc80be2fcab7473581454723df)). No repeat records have ever been written to SQL, so this has never been used, and it would not be safe to leave it in place while the Couch to SQL migration is in progress since some records will not exist in SQL for some time during that period.

These changes are preparation for the Repeat Records Couch to SQL migration. They are mostly cleanup which is not specifically dependent on migration code, and therefore can be done beforehand.

:fish: Review by commit.

## Safety Assurance

### Safety story

Minor refactors to repeaters code plus improvements to existing tests. A few clean up the Couch to SQL migration framework.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations