### PR TITLE
Mobile worker GPS data in map (front-end)

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -443,6 +443,7 @@ hqDefine("geospatial/js/geospatial_map", [
                 self.hasErrors(false);
                 if (!self.shouldShowUsers()) {
                     self.hasFiltersChanged(false);
+                    missingGPSModelInstance.usersWithoutGPS([]);
                     return;
                 }
 

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -83,8 +83,8 @@ hqDefine("geospatial/js/geospatial_map", [
                 return false;
             }
             const coordinatesArr = [coordinates.lng, coordinates.lat];
-            const point = turf.point(coordinatesArr);
-            return turf.booleanPointInPolygon(point, polygonFeature.geometry);
+            const point = turf.point(coordinatesArr);  // eslint-disable-line no-undef
+            return turf.booleanPointInPolygon(point, polygonFeature.geometry);  // eslint-disable-line no-undef
         }
 
         var loadMapBox = function (centerCoordinates) {
@@ -98,7 +98,7 @@ hqDefine("geospatial/js/geospatial_map", [
                 centerCoordinates = [-91.874, 42.76]; // should be domain specific
             }
 
-            const map = new mapboxgl.Map({
+            const map = new mapboxgl.Map({  // eslint-disable-line no-undef
                 container: 'geospatial-map', // container ID
                 style: 'mapbox://styles/mapbox/streets-v12', // style URL
                 center: centerCoordinates, // starting position [lng, lat]
@@ -107,7 +107,7 @@ hqDefine("geospatial/js/geospatial_map", [
                              ' <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
             });
 
-            const draw = new MapboxDraw({
+            const draw = new MapboxDraw({  // eslint-disable-line no-undef
                 // API: https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/API.md
                 displayControlsDefault: false,
                 boxSelect: true, // enables box selection
@@ -155,7 +155,7 @@ hqDefine("geospatial/js/geospatial_map", [
             }
 
             // We should consider refactoring and splitting the below out to a new JS file
-            function moveMarkerToClickedCoordinate(coordinates) {
+            function moveMarkerToClickedCoordinate(coordinates) {  // eslint-disable-line no-unused-vars
                 if (clickedMarker !== null) {
                     clickedMarker.remove();
                 }
@@ -163,7 +163,7 @@ hqDefine("geospatial/js/geospatial_map", [
                     // It's weird moving the marker around with the ploygon
                     return;
                 }
-                clickedMarker = new mapboxgl.Marker({color: "FF0000", draggable: true});
+                clickedMarker = new mapboxgl.Marker({color: "FF0000", draggable: true});  // eslint-disable-line no-undef
                 clickedMarker.setLngLat(coordinates);
                 clickedMarker.addTo(map);
             }
@@ -227,7 +227,7 @@ hqDefine("geospatial/js/geospatial_map", [
             self.addMarker = function (dataId, dataItem, colors) {
                 const coordinates = dataItem.coordinates;
                 // Create the marker
-                const marker = new mapboxgl.Marker({ color: colors.default, draggable: false });
+                const marker = new mapboxgl.Marker({ color: colors.default, draggable: false });  // eslint-disable-line no-undef
                 marker.setLngLat(coordinates);
 
                 // Add the marker to the map
@@ -236,7 +236,7 @@ hqDefine("geospatial/js/geospatial_map", [
                 let popupDiv = document.createElement("div");
                 popupDiv.setAttribute("data-bind", "template: 'select-case'");
 
-                let popup = new mapboxgl.Popup({ offset: 25, anchor: "bottom" })
+                let popup = new mapboxgl.Popup({ offset: 25, anchor: "bottom" })  // eslint-disable-line no-undef
                     .setLngLat(coordinates)
                     .setDOMContent(popupDiv);
 
@@ -270,7 +270,7 @@ hqDefine("geospatial/js/geospatial_map", [
             ko.applyBindings({'caseModels': caseModels, 'selectedCases': selectedCases}, $("#case-modals")[0]);
             // Handle click events here
             map.on('click', (event) => {
-                let coordinates = getCoordinates(event);
+                let coordinates = getCoordinates(event);  // eslint-disable-line no-unused-vars
             });
             return self;
         };
@@ -296,12 +296,12 @@ hqDefine("geospatial/js/geospatial_map", [
                             savedPolygon({
                                 name: name,
                                 id: ret.id,
-                                geo_json: data
+                                geo_json: data,
                             })
                         );
                         // redraw using mapControlsModelInstance
                         mapControlsModelInstance.selectedPolygon(ret.id);
-                    }
+                    },
                 });
             }
         };
@@ -334,7 +334,7 @@ hqDefine("geospatial/js/geospatial_map", [
             // On selection, add the polygon to the map
             self.selectedPolygon.subscribe(function (value) {
                 var polygonObj = self.savedPolygons().find(
-                    function (o) { return o.id == self.selectedPolygon(); }
+                    function (o) { return o.id === self.selectedPolygon(); }
                 );
                 // Clear existing polygon
                 if (self.activePolygon()) {
@@ -345,7 +345,7 @@ hqDefine("geospatial/js/geospatial_map", [
                     // Add selected polygon
                     mapboxinstance.addSource(
                         String(polygonObj.id),
-                        {'type': 'geojson', 'data':polygonObj.geoJson}
+                        {'type': 'geojson', 'data': polygonObj.geoJson}
                     );
                     mapboxinstance.addLayer({
                         'id': String(polygonObj.id),
@@ -354,8 +354,8 @@ hqDefine("geospatial/js/geospatial_map", [
                         'layout': {},
                         'paint': {
                             'fill-color': '#0080ff',
-                            'fill-opacity': 0.5
-                        }
+                            'fill-opacity': 0.5,
+                        },
                     });
                     polygonObj.geoJson.features.forEach(
                         filterMapItemsInPolygon
@@ -385,17 +385,17 @@ hqDefine("geospatial/js/geospatial_map", [
                 self.btnSaveDisabled(!mapHasPolygons());
             });
 
-            self.exportGeoJson = function(){
+            self.exportGeoJson = function () {
                 var exportButton = $("#btnExportDrawnArea");
                 var selectedPolygon = self.savedPolygons().find(
-                    function (o) { return o.id == self.selectedPolygon(); }
+                    function (o) { return o.id === self.selectedPolygon(); }
                 );
                 if (selectedPolygon) {
                     var convertedData = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(selectedPolygon.geoJson));
                     exportButton.attr('href', 'data:' + convertedData);
                     exportButton.attr('download','data.geojson');
                 }
-            }
+            };
 
             return self;
         };
@@ -410,19 +410,19 @@ hqDefine("geospatial/js/geospatial_map", [
             }
 
             var $saveDrawnArea = $("#btnSaveDrawnArea");
-            $saveDrawnArea.click(function(e) {
+            $saveDrawnArea.click(function () {
                 if (map) {
                     saveGeoJson(map.getMapboxDrawInstance(), mapControlsModelInstance);
                 }
             });
 
             var $exportDrawnArea = $("#btnExportDrawnArea");
-            $exportDrawnArea.click(function(e) {
+            $exportDrawnArea.click(function () {
                 if (map) {
-                    mapControlsModelInstance.exportGeoJson()
+                    mapControlsModelInstance.exportGeoJson();
                 }
             });
-        };
+        }
 
         var missingGPSModel = function (cases, users) {
             this.casesWithoutGPS = ko.observable(cases);
@@ -549,7 +549,7 @@ hqDefine("geospatial/js/geospatial_map", [
             if (!isAfterDataLoad) {
                 return;
             }
-            isDataNeverFetched = true;
+
             showMapControls(true);
             // Hide the datatable rows but not the pagination bar
             $('.dataTables_scroll').hide();

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -10,7 +10,9 @@ hqDefine("geospatial/js/geospatial_map", [
     alert_user
 ) {
     const defaultMarkerColor = "#808080"; // Gray
+    const defaultUserMarkerColor = "#0e00ff"; // Blue
     const selectedMarkerColor = "#00FF00"; // Green
+    const selectedUserMarkerColor = "#0b940d"; // Dark Green
     var saveGeoJSONUrl = initialPageData.reverse('geo_polygon');
 
     function mapItemModel(dataId, dataItem, marker, markerColors) {
@@ -49,9 +51,15 @@ hqDefine("geospatial/js/geospatial_map", [
         var map;
 
         var caseModels = ko.observableArray([]);
+        var userModels = ko.observableArray([]);
         var selectedCases = ko.computed(function () {
             return caseModels().filter(function (currCase) {
                 return currCase.isSelected();
+            });
+        });
+        var selectedUsers = ko.computed(function () {
+            return userModels().filter(function (currUser) {
+                return currUser.isSelected();
             });
         });
 
@@ -61,6 +69,13 @@ hqDefine("geospatial/js/geospatial_map", [
                     currCase.isSelected(isMapItemInPolygon(polygonFeature, currCase.dataItem.coordinates));
                 }
             });
+            _.values(userModels()).filter(function (currUser) {
+                if (currUser.dataItem.coordinates) {
+                    currUser.isSelected(isMapItemInPolygon(polygonFeature, currUser.dataItem.coordinates));
+                }
+            });
+        }
+
         function isMapItemInPolygon(polygonFeature, coordinates) {
             // Might be 0 if a user deletes a point from a three-point polygon
             if (!polygonFeature.geometry.coordinates.length) {
@@ -169,6 +184,15 @@ hqDefine("geospatial/js/geospatial_map", [
                 caseModels([]);
             };
 
+            self.removeUserMarkers = function () {
+                _.each(userModels(), function (currUser) {
+                    if (currUser.marker) {
+                        currUser.marker.remove();
+                    }
+                });
+                userModels([]);
+            };
+
             self.addCaseMarkersToMap = function (rawCases) {
                 const caseColors = {
                     'default': defaultMarkerColor,
@@ -180,6 +204,21 @@ hqDefine("geospatial/js/geospatial_map", [
                     if (coordinates && coordinates.lat && coordinates.lng) {
                         const mapItemInstance = self.addMarker(caseId, element, caseColors);
                         caseModels.push(mapItemInstance);
+                    }
+                });
+            };
+
+            self.addUserMarkersToMap = function (rawUsers) {
+                const userColors = {
+                    'default': defaultUserMarkerColor,
+                    'selected': selectedUserMarkerColor,
+                };
+
+                _.forEach(rawUsers, function (element, userId) {
+                    const coordinates = element.coordinates;
+                    if (coordinates && coordinates.lat && coordinates.lng) {
+                        const mapItemInstance = self.addMarker(userId, element, userColors);
+                        userModels.push(mapItemInstance);
                     }
                 });
             };

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -7,9 +7,9 @@ hqDefine("geospatial/js/geospatial_map", [
     initialPageData,
     ko
 ) {
-    const defaultMarkerColor = "#808080"; // Gray
+    const defaultCaseMarkerColor = "#808080"; // Gray
     const defaultUserMarkerColor = "#0e00ff"; // Blue
-    const selectedMarkerColor = "#00FF00"; // Green
+    const selectedCaseMarkerColor = "#00FF00"; // Green
     const selectedUserMarkerColor = "#0b940d"; // Dark Green
     var saveGeoJSONUrl = initialPageData.reverse('geo_polygon');
 
@@ -194,8 +194,8 @@ hqDefine("geospatial/js/geospatial_map", [
 
             self.addCaseMarkersToMap = function (rawCases) {
                 const caseColors = {
-                    'default': defaultMarkerColor,
-                    'selected': selectedMarkerColor,
+                    'default': defaultCaseMarkerColor,
+                    'selected': selectedCaseMarkerColor,
                 };
 
                 _.forEach(rawCases, function (element, caseId) {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -450,6 +450,7 @@ hqDefine("geospatial/js/geospatial_map", [
                     success: function (data) {
                         self.hasFiltersChanged(false);
 
+                        // TODO: There is a lot of indexing happening here. This should be replaced with a mapping to make reading it more explicit
                         const usersWithoutGPS = data.user_data.filter(function (item) {
                             return item.gps_point === null || !item.gps_point.length;
                         });

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -470,7 +470,7 @@ hqDefine("geospatial/js/geospatial_map", [
                             return [dataItem.id, {'coordinates': {'lat': lat, 'lng': lng}, 'link': link}];
                         }));
 
-                        map.addUserMarkersToMap(userData, defaultUserMarkerColor);
+                        map.addUserMarkersToMap(userData);
                     },
                     error: function () {
                         self.hasErrors(true);
@@ -510,7 +510,7 @@ hqDefine("geospatial/js/geospatial_map", [
                     return [item[0], {'coordinates': item[1], 'link': item[2]}];
                 }
             }));
-            map.addCaseMarkersToMap(casesById, defaultMarkerColor);
+            map.addCaseMarkersToMap(casesById);
 
             var $missingCasesDiv = $("#missing-gps-cases");
             var casesWithoutGPS = caseData.filter(function (item) {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -18,13 +18,13 @@ hqDefine("geospatial/js/geospatial_map", [
 
     var saveGeoJSONUrl = initialPageData.reverse('geo_polygon');
 
-    function mapItemModel(dataId, dataItem, marker, markerColors) {
+    function mapItemModel(itemId, itemData, marker, markerColors) {
         'use strict';
         var self = {};
-        self.dataId = dataId;
-        self.dataItem = dataItem;
+        self.itemId = itemId;
+        self.itemData = itemData;
         self.marker = marker;
-        self.selectCssId = "select" + dataId;
+        self.selectCssId = "select" + itemId;
         self.isSelected = ko.observable(false);
         self.markerColors = markerColors;
 
@@ -69,13 +69,13 @@ hqDefine("geospatial/js/geospatial_map", [
 
         function filterMapItemsInPolygon(polygonFeature) {
             _.values(caseModels()).filter(function (currCase) {
-                if (currCase.dataItem.coordinates) {
-                    currCase.isSelected(isMapItemInPolygon(polygonFeature, currCase.dataItem.coordinates));
+                if (currCase.itemData.coordinates) {
+                    currCase.isSelected(isMapItemInPolygon(polygonFeature, currCase.itemData.coordinates));
                 }
             });
             _.values(userModels()).filter(function (currUser) {
-                if (currUser.dataItem.coordinates) {
-                    currUser.isSelected(isMapItemInPolygon(polygonFeature, currUser.dataItem.coordinates));
+                if (currUser.itemData.coordinates) {
+                    currUser.isSelected(isMapItemInPolygon(polygonFeature, currUser.itemData.coordinates));
                 }
             });
         }
@@ -199,8 +199,8 @@ hqDefine("geospatial/js/geospatial_map", [
                 return outArr;
             };
 
-            self.addMarker = function (dataId, dataItem, colors) {
-                const coordinates = dataItem.coordinates;
+            self.addMarker = function (itemId, itemData, colors) {
+                const coordinates = itemData.coordinates;
                 // Create the marker
                 const marker = new mapboxgl.Marker({ color: colors.default, draggable: false });  // eslint-disable-line no-undef
                 marker.setLngLat(coordinates);
@@ -235,7 +235,7 @@ hqDefine("geospatial/js/geospatial_map", [
                 addLeaveEvent(markerDiv, popupDiv);
                 addLeaveEvent(popupDiv, markerDiv);
 
-                const mapItemInstance = new mapItemModel(dataId, dataItem, marker, colors);
+                const mapItemInstance = new mapItemModel(itemId, itemData, marker, colors);
                 $(popupDiv).koApplyBindings(mapItemInstance);
 
                 return mapItemInstance;
@@ -439,15 +439,15 @@ hqDefine("geospatial/js/geospatial_map", [
                             return item.gps_point !== null && item.gps_point.length;
                         });
 
-                        const userData = _.object(_.map(usersWithGPS, function (dataItem) {
-                            const gpsData = (dataItem.gps_point) ? dataItem.gps_point.split(' ') : [];
+                        const userData = _.object(_.map(usersWithGPS, function (userData) {
+                            const gpsData = (userData.gps_point) ? userData.gps_point.split(' ') : [];
                             const lat = parseFloat(gpsData[0]);
                             const lng = parseFloat(gpsData[1]);
 
-                            const editUrl = initialPageData.reverse('edit_commcare_user', dataItem.id);
-                            const link = `<a class="ajax_dialog" href="${editUrl}" target="_blank">${dataItem.username}</a>`;
+                            const editUrl = initialPageData.reverse('edit_commcare_user', userData.id);
+                            const link = `<a class="ajax_dialog" href="${editUrl}" target="_blank">${userData.username}</a>`;
 
-                            return [dataItem.id, {'coordinates': {'lat': lat, 'lng': lng}, 'link': link}];
+                            return [userData.id, {'coordinates': {'lat': lat, 'lng': lng}, 'link': link}];
                         }));
 
                         const userMapItems = map.addMarkersToMap(userData, userMarkerColors);

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -76,7 +76,9 @@ hqDefine("geospatial/js/geospatial_map", [
         }
 
         function isMapItemInPolygon(polygonFeature, coordinates) {
-            // Might be 0 if a user deletes a point from a three-point polygon
+            // Will be 0 if a user deletes a point from a three-point polygon,
+            // since mapbox will delete the entire polygon. turf.booleanPointInPolygon()
+            // does not expect this, and will raise a 'TypeError' exception.
             if (!polygonFeature.geometry.coordinates.length) {
                 return false;
             }

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -266,6 +266,7 @@ hqDefine("geospatial/js/geospatial_map", [
                 return mapItemInstance;
             };
 
+            ko.applyBindings({'userModels': userModels, 'selectedUsers': selectedUsers}, $("#user-modals")[0]);
             ko.applyBindings({'caseModels': caseModels, 'selectedCases': selectedCases}, $("#case-modals")[0]);
             // Handle click events here
             map.on('click', (event) => {
@@ -423,8 +424,12 @@ hqDefine("geospatial/js/geospatial_map", [
             });
         };
 
-        var missingGPSModel = function(cases) {
+        var missingGPSModel = function (cases, users) {
             this.casesWithoutGPS = ko.observable(cases);
+            this.usersWithoutGPS = ko.observable(users);
+        };
+        var missingGPSModelInstance = new missingGPSModel([], []);
+
         var userFiltersModel = function () {
             var self = {};
 

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -2,12 +2,10 @@ hqDefine("geospatial/js/geospatial_map", [
     "jquery",
     "hqwebapp/js/initial_page_data",
     "knockout",
-    "hqwebapp/js/bootstrap3/alert_user",
 ], function (
     $,
     initialPageData,
-    ko,
-    alert_user
+    ko
 ) {
     const defaultMarkerColor = "#808080"; // Gray
     const defaultUserMarkerColor = "#0e00ff"; // Blue
@@ -92,7 +90,7 @@ hqDefine("geospatial/js/geospatial_map", [
 
             var self = {};
             let clickedMarker;
-            mapboxgl.accessToken = initialPageData.get('mapbox_access_token');
+            mapboxgl.accessToken = initialPageData.get('mapbox_access_token');  // eslint-disable-line no-undef
 
             if (!centerCoordinates) {
                 centerCoordinates = [-91.874, 42.76]; // should be domain specific

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -399,11 +399,11 @@ hqDefine("geospatial/js/geospatial_map", [
             });
         }
 
-        var missingGPSModel = function (cases, users) {
-            this.casesWithoutGPS = ko.observable(cases);
-            this.usersWithoutGPS = ko.observable(users);
+        var missingGPSModel = function () {
+            this.casesWithoutGPS = ko.observable([]);
+            this.usersWithoutGPS = ko.observable([]);
         };
-        var missingGPSModelInstance = new missingGPSModel([], []);
+        var missingGPSModelInstance = new missingGPSModel();
 
         var userFiltersModel = function () {
             var self = {};
@@ -509,6 +509,8 @@ hqDefine("geospatial/js/geospatial_map", [
         }
 
         $(document).ajaxComplete(function (event, xhr, settings) {
+            // When mobile workers are loaded from the user filtering menu, ajaxComplete will be called again.
+            // We don't want to reload the map or cases when this happens, so simply return.
             const isAfterUserLoad = settings.url.includes('geospatial/get_users_with_gps/');
             if (isAfterUserLoad) {
                 return;

--- a/corehq/apps/geospatial/templates/geospatial/map_visualization_base.html
+++ b/corehq/apps/geospatial/templates/geospatial/map_visualization_base.html
@@ -29,4 +29,6 @@
     {% initial_page_data "mapbox_access_token" mapbox_access_token %}
     {% initial_page_data "saved_polygons" saved_polygons %}
     {% registerurl 'geo_polygon' domain %}
+    {% registerurl 'get_users_with_gps' domain %}
+    {% registerurl 'edit_commcare_user' domain '---' %}
 {% endblock %}

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -81,6 +81,59 @@
             <span data-bind="text: casesWithoutGPS().length"></span>
             &nbsp;{% trans "Cases Missing GPS Data" %}
         </a>
+        <a class="btn btn-default" target="_blank" href="{% url 'gps_capture' domain %}?data_type=user" data-bind="visible: usersWithoutGPS().length">
+            <span data-bind="text: usersWithoutGPS().length"></span>
+            &nbsp;{% trans "Users Missing GPS Data" %}
+        </a>
+    </div>
+
+    <div id="user-modals" class="pull-right">
+        <button class="btn btn-default" data-toggle="modal" data-target="#selected-user-list" data-bind="enable: selectedUsers().length">
+            <span data-bind="text: selectedUsers().length"></span>
+            &nbsp;{% trans "Selected Mobile Workers" %}
+        </button>
+        <div class="modal fade" id="selected-user-list">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span>
+                    <span class="sr-only">{% trans "Close" %}</span></button>
+                    <h4 class="modal-title">{% trans "Selected Mobile Workers" %}</h4>
+                </div>
+                <div class="modal-body">
+                    <table class="table table-striped table-responsive">
+                        <thead><th>{% trans "Username" %}</th></thead>
+                        <tbody data-bind="foreach: selectedUsers">
+                            <tr><td data-bind="html: $data.dataItem.link"></td></tr>
+                        </tbody>
+                    </table>
+                </div>
+                </div>
+            </div>
+        </div>
+        <button class="btn btn-default" data-toggle="modal" data-target="#all-user-list">
+            <span data-bind="text: userModels().length"></span>
+            &nbsp;{% trans "Mobile Workers on Map" %}
+        </button>
+        <div class="modal fade" id="all-user-list">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span>
+                        <span class="sr-only">{% trans "Close" %}</span></button>
+                        <h4 class="modal-title">{% trans "All Mobile Workers on Map" %}</h4>
+                    </div>
+                    <div class="modal-body">
+                        <table class="table table-striped table-responsive">
+                            <thead><th>{% trans "Username" %}</th></thead>
+                            <tbody data-bind="foreach: userModels">
+                                <tr><td data-bind="html: $data.dataItem.link"></td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
     <div id="case-modals"  class="pull-right">
         <button class="btn btn-default" data-toggle="modal" data-target="#selected-case-list"

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -3,6 +3,45 @@
 {% load i18n %}
 
 {% block reportcontent %}
+<div class="panel panel-default" id="user-filters-panel">
+    <div class="panel-body collapse in" aria-expanded="true">
+        <legend>
+            {% trans "Mobile Worker Filters" %}
+        </legend>
+        <div class="alert alert-danger" data-bind="visible: hasErrors()">
+            <i class="fa fa-exclamation-triangle"></i>
+            {% blocktrans %}
+                <strong>There was an issue retrieving mobile workers from the server.</strong>
+                If this problem continues, please
+                <a href="#modalReportIssue" data-toggle="modal">report an issue</a>.
+            {% endblocktrans %}
+        </div>
+        <div class="form-group">
+            <label class="col-sm-3">
+                {% trans "Show mobile workers on the map" %}
+            </label>
+            <div class="checkbox">
+                <input type="checkbox" data-bind="checked: $root.shouldShowUsers, event: {change: onFiltersChange}" />
+            </div>
+        </div>
+        <div class="spacer"></div>
+        <div class="form-actions">
+            <button type="button" class="btn btn-primary" style="float:left; margin-left:1em" data-bind="event: {click: loadUsers}, enable: hasFiltersChanged()">
+                {% trans "Apply" %}
+            </button>
+        </div>
+    </div>
+    <div class="panel-footer">
+        <button class="btn btn-default" data-bind="event: {click: toggleFilterMenu}">
+            <span data-bind="visible: showFilterMenu()">
+                {% trans "Hide Filter Options" %}
+            </span>
+            <span data-bind="visible: !showFilterMenu()">
+                {% trans "Show Filter Options" %}
+            </span>
+        </button>
+    </div>
+</div>
 <div class="row panel" id="mapControls">
     <label for="saved-polygons" class="control-label col-sm-2 col-md-2 col-lg-2">
     {% trans "Filter by Saved Area" %}</label>

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -61,7 +61,7 @@
                     <table class="table table-striped table-responsive">
                         <thead><th>{% trans "Case Name" %}</th></thead>
                         <tbody data-bind="foreach: selectedCases">
-                            <tr><td data-bind="html: $data.case.link"></td></tr>
+                            <tr><td data-bind="html: $data.dataItem.link"></td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -84,7 +84,7 @@
                         <table class="table table-striped table-responsive">
                             <thead><th>{% trans "Case Name" %}</th></thead>
                             <tbody data-bind="foreach: caseModels">
-                                <tr><td data-bind="html: $data.case.link"></td></tr>
+                                <tr><td data-bind="html: $data.dataItem.link"></td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -97,7 +97,7 @@
 <script type="text/html" id="select-case">
     <div class="form-check">
       <input type="checkbox" class="form-check-input" data-bind="checked: isSelected, attr: {id: selectCssId}">
-      <label class="form-check-label" data-bind="html: $data.case.link, attr: {for: selectCssId}"></label>
+      <label class="form-check-label" data-bind="html: $data.dataItem.link, attr: {for: selectCssId}"></label>
     </div>
 </script>
 {% endblock %}

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -104,7 +104,7 @@
                     <table class="table table-striped table-responsive">
                         <thead><th>{% trans "Username" %}</th></thead>
                         <tbody data-bind="foreach: selectedUsers">
-                            <tr><td data-bind="html: $data.dataItem.link"></td></tr>
+                            <tr><td data-bind="html: $data.itemData.link"></td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -127,7 +127,7 @@
                         <table class="table table-striped table-responsive">
                             <thead><th>{% trans "Username" %}</th></thead>
                             <tbody data-bind="foreach: userModels">
-                                <tr><td data-bind="html: $data.dataItem.link"></td></tr>
+                                <tr><td data-bind="html: $data.itemData.link"></td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -153,7 +153,7 @@
                     <table class="table table-striped table-responsive">
                         <thead><th>{% trans "Case Name" %}</th></thead>
                         <tbody data-bind="foreach: selectedCases">
-                            <tr><td data-bind="html: $data.dataItem.link"></td></tr>
+                            <tr><td data-bind="html: $data.itemData.link"></td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -176,7 +176,7 @@
                         <table class="table table-striped table-responsive">
                             <thead><th>{% trans "Case Name" %}</th></thead>
                             <tbody data-bind="foreach: caseModels">
-                                <tr><td data-bind="html: $data.dataItem.link"></td></tr>
+                                <tr><td data-bind="html: $data.itemData.link"></td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -189,7 +189,7 @@
 <script type="text/html" id="select-case">
     <div class="form-check">
       <input type="checkbox" class="form-check-input" data-bind="checked: isSelected, attr: {id: selectCssId}">
-      <label class="form-check-label" data-bind="html: $data.dataItem.link, attr: {for: selectCssId}"></label>
+      <label class="form-check-label" data-bind="html: $data.itemData.link, attr: {for: selectCssId}"></label>
     </div>
 </script>
 {% endblock %}

--- a/corehq/apps/geospatial/tests/test_views.py
+++ b/corehq/apps/geospatial/tests/test_views.py
@@ -286,7 +286,7 @@ class TestGetUsersWithGPS(BaseGeospatialViewClass):
                 {
                     'id': self.user_b.user_id,
                     'username': self.user_b.raw_username,
-                    'gps_point': None,
+                    'gps_point': '',
                 },
             ],
         }

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -321,7 +321,7 @@ def get_users_with_gps(request, domain):
         {
             'id': user.user_id,
             'username': user.raw_username,
-            'gps_point': user.pop_metadata(key=location_prop_name),
+            'gps_point': user.metadata.get(location_prop_name, ''),
         } for user in users
     ]
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A new mobile worker filter section is added to the "Case Management" page:
![Screenshot from 2023-09-18 08-47-25](https://github.com/dimagi/commcare-hq/assets/122617251/212b8ceb-5003-47c3-ba1e-b5885e7b5eda)

When mobile workers are loaded on the map, they will have a different default/selected colour to cases to help differentiate the two:
![Screenshot from 2023-09-18 08-48-16](https://github.com/dimagi/commcare-hq/assets/122617251/b3dc1e37-93b1-4e28-bfbe-0a8b15f71ec5)

![Screenshot from 2023-09-18 08-48-37](https://github.com/dimagi/commcare-hq/assets/122617251/b3d0dbc4-e47a-4697-86dd-34af74952f99)

New pop-up modals have been added that function similar to the currently existing ones for cases:
![2023-09-18_08-53](https://github.com/dimagi/commcare-hq/assets/122617251/1dd4bfcb-aee8-4845-9b8a-9844b04ecd4e)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2872).

This PR includes the required front-end changes for the ticket, with the back-end changes having been done in [this](https://github.com/dimagi/commcare-hq/pull/33471) PR. A small back-end change is done in this PR, however this is simply changing how the user custom location property is retrieved.

A new mobile workers filtering section UI has been implemented, which allows the user to enable/disable showing users on the map alongside cases. In the future, this section will be expanded to include other user filters such as campagin selection and location drilldown filters.

To accommodate loading mobile workers into the map, the knockout `caseModel` in the case management JS file has been made more generic to be usable for both cases and mobile workers. Additionally separate functions for the ones that already exist for cases have been created to support adding/removing users from the map.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
