### PR TITLE
Use the domain-table_id hash as the sheet name for data source exports

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -149,3 +149,4 @@ BULK_CASE_EXPORT_CACHE = 'bulk-case-export-task'
 # Max limits allowed for being able to do a bulk case export
 MAX_CASE_TYPE_COUNT = 30
 MAX_APP_COUNT = 20
+EXCEL_MAX_SHEET_NAME_LENGTH = 31

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -3130,13 +3130,13 @@ def datasource_export_instance(config):
             ),
             selected=True,
         )
-
+    unique_hash = table.name.split("_")[-1]
     return DataSourceExportInstance(
         name=config.display_name,
         domain=config.domain,
         tables=[
             TableConfiguration(
-                label=table.name,
+                label=unique_hash,
                 columns=[
                     get_export_column(col)
                     for col in config.columns_by_id.values()

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -69,6 +69,7 @@ from corehq.apps.export.const import (
     CASE_NAME_TRANSFORM,
     DEID_TRANSFORM_FUNCTIONS,
     EMPTY_VALUE,
+    EXCEL_MAX_SHEET_NAME_LENGTH,
     FORM_DATA_SCHEMA_VERSION,
     FORM_EXPORT,
     FORM_ID_TO_LINK,
@@ -3131,12 +3132,11 @@ def datasource_export_instance(config):
             selected=True,
         )
 
-    max_sheet_name_length = 31
     unique_hash = table.name.split("_")[-1]
     sheet_name = adapter.table_id
-    if len(sheet_name) > max_sheet_name_length:
+    if len(sheet_name) > EXCEL_MAX_SHEET_NAME_LENGTH:
         sheet_name = f"{config.domain}_{unique_hash}"
-        if len(sheet_name) > max_sheet_name_length:
+        if len(sheet_name) > EXCEL_MAX_SHEET_NAME_LENGTH:
             sheet_name = unique_hash
 
     return DataSourceExportInstance(

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -3132,6 +3132,7 @@ def datasource_export_instance(config):
             selected=True,
         )
 
+    # table.name follows this format: ucr_{project space}_{table id}_{unique hash}
     unique_hash = table.name.split("_")[-1]
     sheet_name = adapter.table_id
     if len(sheet_name) > EXCEL_MAX_SHEET_NAME_LENGTH:

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -3130,13 +3130,21 @@ def datasource_export_instance(config):
             ),
             selected=True,
         )
+
+    max_sheet_name_length = 31
     unique_hash = table.name.split("_")[-1]
+    sheet_name = adapter.table_id
+    if len(sheet_name) > max_sheet_name_length:
+        sheet_name = f"{config.domain}_{unique_hash}"
+        if len(sheet_name) > max_sheet_name_length:
+            sheet_name = unique_hash
+
     return DataSourceExportInstance(
         name=config.display_name,
         domain=config.domain,
         tables=[
             TableConfiguration(
-                label=unique_hash,
+                label=sheet_name,
                 columns=[
                     get_export_column(col)
                     for col in config.columns_by_id.values()


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-3110)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Context: When the user didn't specify a `Table Name` in the datasource's DET config file, the DET will simply use the sheet name as the table's name. Since the sheet name is in the format `ucr_{project space}_{table id}_{unique hash}`, long table id's tend to lead to truncated sheet names, since excel sheet names can only be 31 characters long.

This update fixes this issue by changing the sheet names to be a unique 8 character hash value, created using the domain and table_id.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
See the Product description. This truncation is caused by excel. This is an issue for all exports with long table id's or sheet names. The docs will be updated to mention the max length of excel sheet names so users can be aware of this.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
EXPORT_DATA_SOURCE_DATA

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing. See the screenshots

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated test coverage

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

### Screenshots
#### Before: See the truncated sheet name
![Screenshot from 2023-09-18 10-46-12](https://github.com/dimagi/commcare-hq/assets/64970009/c9fe10de-788b-4cb3-ad4b-c204a468fc99)

#### Before: The DET defaults to the truncated sheet name (this is an export)
![Screenshot from 2023-09-18 11-10-30](https://github.com/dimagi/commcare-hq/assets/64970009/df6c7d3e-6d1c-472d-8653-8e12d31ef860)

#### After
![image](https://github.com/dimagi/commcare-hq/assets/64970009/a6fa0bdd-6925-4ef1-9782-a742cf88c80b)

##### (New export)
![image](https://github.com/dimagi/commcare-hq/assets/64970009/5b9da1f4-c812-4d1f-8ba5-1b9c3f4e6a15)


