### PR TITLE
Cs/sc 3104 add mobile workers page gps capture page

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -71,7 +71,7 @@ hqDefine("geospatial/js/gps_capture",[
         return self;
     };
 
-    var dataItemListModel = function () {
+    var dataItemListModel = function (dataType) {
         var self = {};
         self.dataItems = ko.observableArray([]);  // Can be cases or users
 
@@ -80,8 +80,7 @@ hqDefine("geospatial/js/gps_capture",[
         self.itemLocationBeingCapturedOnMap = ko.observable();
         self.query = ko.observable('');
 
-        self.dataType = initialPageData.get('data_type');
-
+        self.dataType = dataType
         self.showLoadingSpinner = ko.observable(true);
         self.showPaginationSpinner = ko.observable(false);
         self.hasError = ko.observable(false);

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -38,7 +38,7 @@ hqDefine("geospatial/js/gps_capture",[
         }
     }
 
-    function collapseMap() {
+    function resetMap() {
         setMapVisible(false);
         if (selectedDataListItem) {
             selectedDataListItem.itemLocationBeingCapturedOnMap(null);
@@ -187,7 +187,7 @@ hqDefine("geospatial/js/gps_capture",[
                 success: function () {
                     dataItem.hasUnsavedChanges(false);
                     self.isSubmissionSuccess(true);
-                    collapseMap();
+                    resetMap();
                 },
                 error: function () {
                     self.hasSubmissionError(true);
@@ -246,7 +246,7 @@ hqDefine("geospatial/js/gps_capture",[
     function TabListViewModel() {
         var self = {};
         self.onclickAction = function() {
-            collapseMap();
+            resetMap();
         }
         return self;
     }

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -38,10 +38,15 @@ hqDefine("geospatial/js/gps_capture",[
         }
     }
 
-    function runSaveSuccessCallback() {
+    function collapseMap() {
         setMapVisible(false);
-        selectedDataListItem.itemLocationBeingCapturedOnMap(null);
-        coordinateCaptureMarker = undefined;
+        if (selectedDataListItem) {
+            selectedDataListItem.itemLocationBeingCapturedOnMap(null);
+        }
+        if (coordinateCaptureMarker) {
+            coordinateCaptureMarker.remove();
+            coordinateCaptureMarker = undefined;
+        }
     }
 
     var dataItemModel = function (options, dataType) {
@@ -182,7 +187,7 @@ hqDefine("geospatial/js/gps_capture",[
                 success: function () {
                     dataItem.hasUnsavedChanges(false);
                     self.isSubmissionSuccess(true);
-                    runSaveSuccessCallback();
+                    collapseMap();
                 },
                 error: function () {
                     self.hasSubmissionError(true);
@@ -238,7 +243,16 @@ hqDefine("geospatial/js/gps_capture",[
         return map;
     };
 
+    function TabListViewModel() {
+        var self = {};
+        self.onclickAction = function() {
+            collapseMap();
+        }
+        return self;
+    }
+
     $(function () {
+        $("#tabs-list").koApplyBindings(TabListViewModel());
         $("#no-gps-list-case").koApplyBindings(dataItemListModel('case'));
         $("#no-gps-list-user").koApplyBindings(dataItemListModel('user'));
 

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -14,7 +14,7 @@ hqDefine("geospatial/js/gps_capture",[
     const MAP_CONTAINER_ID = "geospatial-map";
 
     var map;
-    var selectedDataListItem;
+    var selectedDataListObject;
     var mapMarker = new mapboxgl.Marker({  // eslint-disable-line no-undef
         draggable: true,
     });
@@ -23,7 +23,7 @@ hqDefine("geospatial/js/gps_capture",[
         updateSelectedItemLonLat(lngLat.lng, lngLat.lat);
     });
 
-    function setMapVisible(isVisible) {
+    function toggleMapVisible(isVisible) {
         if (isVisible) {
             $("#" + MAP_CONTAINER_ID).show();
             centerMapWithMarker();
@@ -33,8 +33,8 @@ hqDefine("geospatial/js/gps_capture",[
     }
 
     function centerMapWithMarker() {
-        if (selectedDataListItem) {
-            let dataItem = selectedDataListItem.itemLocationBeingCapturedOnMap();
+        if (selectedDataListObject) {
+            let dataItem = selectedDataListObject.itemLocationBeingCapturedOnMap();
             if (dataItem.lon() && dataItem.lat()) {
                 map.setCenter([dataItem.lon(), dataItem.lat()]);
                 setMarkerAtLngLat(dataItem.lon(), dataItem.lat());
@@ -43,9 +43,9 @@ hqDefine("geospatial/js/gps_capture",[
     }
 
     function resetMap() {
-        setMapVisible(false);
-        if (selectedDataListItem) {
-            selectedDataListItem.itemLocationBeingCapturedOnMap(null);
+        toggleMapVisible(false);
+        if (selectedDataListObject) {
+            selectedDataListObject.itemLocationBeingCapturedOnMap(null);
         }
         if (mapMarker) {
             mapMarker.remove();
@@ -132,8 +132,8 @@ hqDefine("geospatial/js/gps_capture",[
 
         self.captureLocationForItem = function (item) {
             self.itemLocationBeingCapturedOnMap(item);
-            selectedDataListItem = self;
-            setMapVisible(true);
+            selectedDataListObject = self;
+            toggleMapVisible(true);
         };
         self.setCoordinates = function (lat, lng) {
             self.itemLocationBeingCapturedOnMap().setCoordinates(lat, lng);
@@ -208,10 +208,10 @@ hqDefine("geospatial/js/gps_capture",[
     }
 
     function updateSelectedItemLonLat(lon, lat) {
-        selectedDataListItem.setCoordinates(lat, lon);
+        selectedDataListObject.setCoordinates(lat, lon);
     }
 
-    function setPointOnMap(lon, lat) {
+    function updateGPSCoordinates(lon, lat) {
         setMarkerAtLngLat(lon, lat);
         updateSelectedItemLonLat(lon, lat);
     }
@@ -233,9 +233,9 @@ hqDefine("geospatial/js/gps_capture",[
         });
 
         map.on('click', (event) => {
-            setPointOnMap(event.lngLat.lng, event.lngLat.lat);
+            updateGPSCoordinates(event.lngLat.lng, event.lngLat.lat);
         });
-        setMapVisible(false);
+        toggleMapVisible(false);
 
         return map;
     };

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -11,12 +11,17 @@ hqDefine("geospatial/js/gps_capture",[
     initialPageData
 ) {
     'use strict';
-    const selectedMarkerColor = "#00FF00"; // Green
+    const MAP_CONTAINER_ID = "geospatial-map";
 
-    var MAP_CONTAINER_ID = "geospatial-map";
     var map;
     var selectedDataListItem;
-    var coordinateCaptureMarker;
+    var mapMarker = new mapboxgl.Marker({  // eslint-disable-line no-undef
+        draggable: true,
+    });
+    mapMarker.on('dragend', function () {
+        let lngLat = mapMarker.getLngLat();
+        updateSelectedItemLonLat(lngLat.lng, lngLat.lat);
+    });
 
     function setMapVisible(isVisible) {
         if (isVisible) {
@@ -42,9 +47,8 @@ hqDefine("geospatial/js/gps_capture",[
         if (selectedDataListItem) {
             selectedDataListItem.itemLocationBeingCapturedOnMap(null);
         }
-        if (coordinateCaptureMarker) {
-            coordinateCaptureMarker.remove();
-            coordinateCaptureMarker = undefined;
+        if (mapMarker) {
+            mapMarker.remove();
         }
     }
 
@@ -197,25 +201,19 @@ hqDefine("geospatial/js/gps_capture",[
         return self;
     };
 
+    function setMarkerAtLngLat(lon, lat) {
+        mapMarker.remove();
+        mapMarker.setLngLat([lon, lat]);
+        mapMarker.addTo(map);
+    }
+
     function updateSelectedItemLonLat(lon, lat) {
         selectedDataListItem.setCoordinates(lat, lon);
     }
 
-    function onMarkerDragEnd() {
-        let lngLat = coordinateCaptureMarker.getLngLat();
-        updateSelectedItemLonLat(lngLat.lng, lngLat.lat);
-    }
-
-    function setMarkerAtLngLat(lon, lat) {
-        if (coordinateCaptureMarker) { coordinateCaptureMarker.remove(); }
-
-        coordinateCaptureMarker = new mapboxgl.Marker({  // eslint-disable-line no-undef
-            color: selectedMarkerColor,
-            draggable: true,
-        });
-        coordinateCaptureMarker.on('dragend', onMarkerDragEnd);
-        coordinateCaptureMarker.setLngLat([lon, lat]);
-        coordinateCaptureMarker.addTo(map);
+    function setPointOnMap(lon, lat) {
+        setMarkerAtLngLat(lon, lat);
+        updateSelectedItemLonLat(lon, lat);
     }
 
     var initMap = function () {
@@ -235,10 +233,10 @@ hqDefine("geospatial/js/gps_capture",[
         });
 
         map.on('click', (event) => {
-            setMarkerAtLngLat(event.lngLat.lng, event.lngLat.lat);
-            updateSelectedItemLonLat(event.lngLat.lng, event.lngLat.lat);
+            setPointOnMap(event.lngLat.lng, event.lngLat.lat);
         });
         setMapVisible(false);
+
         return map;
     };
 

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -22,11 +22,10 @@ hqDefine("geospatial/js/gps_capture",[
         if (isVisible) {
             $("#" + MAP_CONTAINER_ID).show();
             centerMapWithMarker();
-        }
-        else {
+        } else {
             $("#" + MAP_CONTAINER_ID).hide();
         }
-    };
+    }
 
     function centerMapWithMarker() {
         if (selectedDataListItem) {
@@ -207,10 +206,10 @@ hqDefine("geospatial/js/gps_capture",[
         updateSelectedItemLonLat(lngLat.lng, lngLat.lat);
     }
 
-    function setMarkerAtLngLat(lon, lat, centerView) {
+    function setMarkerAtLngLat(lon, lat) {
         if (coordinateCaptureMarker) { coordinateCaptureMarker.remove(); }
 
-        coordinateCaptureMarker = new mapboxgl.Marker({
+        coordinateCaptureMarker = new mapboxgl.Marker({  // eslint-disable-line no-undef
             color: selectedMarkerColor,
             draggable: true,
         });
@@ -245,9 +244,9 @@ hqDefine("geospatial/js/gps_capture",[
 
     function TabListViewModel() {
         var self = {};
-        self.onclickAction = function() {
+        self.onclickAction = function () {
             resetMap();
-        }
+        };
         return self;
     }
 

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -1,40 +1,8 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
 {% load compress %}
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% block page_title %}
-    {{ current_page.page_name }}
-{% endblock page_title %}
-
-{% block js %}{{ block.super }}
-    <!-- Scripts for mapbox -->
-    <script src='https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.js'></script>
-    <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.0/mapbox-gl-draw.js'></script>
-    {% compress js %}
-        <script src="{% static 'geospatial/js/gps_capture.js' %}"></script>
-    {% endcompress %}
-{% endblock %}
-
- {% block stylesheets %}
- {{ block.super }}
- <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.css">
- <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.0/mapbox-gl-draw.css" type="text/css">
- {% endblock %}
-
-
-{% block additional_initial_page_data %}{{ block.super }}
-    {% initial_page_data "mapbox_access_token" mapbox_access_token %}
-{% endblock %}
-
-{% block page_content %}
-{% initial_page_data 'data_type' data_type %}
-{% registerurl 'get_paginated_cases_or_users_without_gps' domain %}
-{% registerurl 'case_data' domain '---' %}
-{% registerurl 'edit_commcare_user' domain '---' %}
-{% registerurl 'gps_capture' domain %}
-
-<div id="no-gps-list" class="ko-template">
+<div id="no-gps-list-{{ data_type }}" class="ko-template">
     <p class="lead">
         <p>
             {% if data_type == 'user' %}
@@ -178,5 +146,3 @@
       </div>
     </h3>
 </div>
-<div id="geospatial-map" style="height: 500px"></div>
-{% endblock %}

--- a/corehq/apps/geospatial/templates/manage_gps_data.html
+++ b/corehq/apps/geospatial/templates/manage_gps_data.html
@@ -34,6 +34,15 @@
 {% registerurl 'edit_commcare_user' domain '---' %}
 {% registerurl 'gps_capture' domain %}
 
+<div>
+  <span>
+    {% blocktrans %}
+      Use this page to manage GPS data associated with Cases or Mobile workers.
+    {% endblocktrans %}
+  </span>
+</div>
+<br>
+
 <ul class="nav nav-tabs">
   <li class="active"><a data-toggle="tab" href="#tabs-cases">{% trans 'Update Case Data' %}</a></li>
   <li><a data-toggle="tab" href="#tabs-users">{% trans 'Update Mobile Worker Data' %}</a></li>

--- a/corehq/apps/geospatial/templates/manage_gps_data.html
+++ b/corehq/apps/geospatial/templates/manage_gps_data.html
@@ -43,9 +43,9 @@
 </div>
 <br>
 
-<ul class="nav nav-tabs">
-  <li class="active"><a data-toggle="tab" href="#tabs-cases">{% trans 'Update Case Data' %}</a></li>
-  <li><a data-toggle="tab" href="#tabs-users">{% trans 'Update Mobile Worker Data' %}</a></li>
+<ul id="tabs-list" class="nav nav-tabs">
+  <li data-bind="click: onclickAction" class="active"><a data-toggle="tab" href="#tabs-cases">{% trans 'Update Case Data' %}</a></li>
+  <li data-bind="click: onclickAction"><a data-toggle="tab" href="#tabs-users">{% trans 'Update Mobile Worker Data' %}</a></li>
 </ul>
 
 <div class="tab-content">

--- a/corehq/apps/geospatial/templates/manage_gps_data.html
+++ b/corehq/apps/geospatial/templates/manage_gps_data.html
@@ -1,0 +1,52 @@
+{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% load compress %}
+{% load i18n %}
+{% load hq_shared_tags %}
+
+{% block page_title %}
+    {{ current_page.page_name }}
+{% endblock page_title %}
+
+{% block js %}{{ block.super }}
+    <!-- Scripts for mapbox -->
+    <script src='https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.js'></script>
+    <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.0/mapbox-gl-draw.js'></script>
+    {% compress js %}
+        <script src="{% static 'geospatial/js/gps_capture.js' %}"></script>
+    {% endcompress %}
+{% endblock %}
+
+ {% block stylesheets %}
+ {{ block.super }}
+ <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.css">
+ <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.0/mapbox-gl-draw.css" type="text/css">
+ {% endblock %}
+
+
+{% block additional_initial_page_data %}{{ block.super }}
+    {% initial_page_data "mapbox_access_token" mapbox_access_token %}
+{% endblock %}
+
+{% block page_content %}
+{% initial_page_data 'data_type' data_type %}
+{% registerurl 'get_paginated_cases_or_users_without_gps' domain %}
+{% registerurl 'case_data' domain '---' %}
+{% registerurl 'edit_commcare_user' domain '---' %}
+{% registerurl 'gps_capture' domain %}
+
+<ul class="nav nav-tabs">
+  <li class="active"><a data-toggle="tab" href="#tabs-cases">{% trans 'Update Case Data' %}</a></li>
+  <li><a data-toggle="tab" href="#tabs-users">{% trans 'Update Mobile Worker Data' %}</a></li>
+</ul>
+
+<div class="tab-content">
+  <div class="tab-pane fade in active" id="tabs-cases">
+    {% include 'gps_capture.html' with data_type='case' %}
+  </div>
+
+  <div class="tab-pane fade" id="tabs-users">
+    {% include 'gps_capture.html' with data_type='user' %}
+  </div>
+</div>
+<div id="geospatial-map" style="height: 500px"></div>
+{% endblock %}

--- a/corehq/apps/geospatial/templates/manage_gps_data.html
+++ b/corehq/apps/geospatial/templates/manage_gps_data.html
@@ -46,6 +46,18 @@
 
   <div class="tab-pane fade" id="tabs-users">
     {% include 'gps_capture.html' with data_type='user' %}
+      <div class="module-banner alert alert-info">
+        <span>
+          {% blocktrans %}
+            To create new Mobile Workers navigate to the Mobile Workers page under the Users tab.
+          {% endblocktrans %}
+          <a href="{% url 'mobile_workers' domain %}">
+            {% blocktrans %}
+            Navigate there.
+            {% endblocktrans %}
+          </a>
+        </span>
+      </div>
   </div>
 </div>
 <div id="geospatial-map" style="height: 500px"></div>

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -194,7 +194,7 @@ class GeospatialConfigPage(BaseDomainView):
 
 class GPSCaptureView(BaseDomainView):
     urlname = 'gps_capture'
-    template_name = 'gps_capture.html'
+    template_name = 'manage_gps_data.html'
 
     page_name = _("Manage GPS Data")
     section_name = _("Geospatial")
@@ -213,9 +213,7 @@ class GPSCaptureView(BaseDomainView):
 
     @property
     def page_context(self):
-        data_type = self.request.GET.get('data_type', 'case')
         return {
-            'data_type': data_type,
             'mapbox_access_token': settings.MAPBOX_ACCESS_TOKEN,
         }
 


### PR DESCRIPTION
## Product Description

This PR alters the GPS capture page for the cases by adding a new tab for capturing mobile worker GPS data. In addition, when the "Capture on Map" button is clicked the map will appear (hidden by default) where the user can select the location of the case/user. Upon selecting a point on the map a marker appears which is draggable. The coordinates of the marker will update the relevant coordinate input fields (lat/lon) of the user/case. 

Also, a banner will show below the table listing the mobile workers indicating that new mobile workers can be created on the mobile workers page. A link to that page is also provided. 

### The new look of the _Manage GPS Data_ page

![image](https://github.com/dimagi/commcare-hq/assets/44245062/080dabed-b861-4809-b17a-c49a1ec6b6ea)


### The _Update Mobile Worker Data_ tab

![image](https://github.com/dimagi/commcare-hq/assets/44245062/37201c28-8d24-41ed-a207-a59238fde43a)
   

### When the user selects "Capture on Map" and click somewhere

![image](https://github.com/dimagi/commcare-hq/assets/44245062/b770c911-2f20-4c6d-ac36-04a6b86f683a)


## Technical Summary
The _gps_capture.html_ page was altered to be reused as a component/partial and a new page `manage_gps_data.html` page was added which serves as the base of the _Manage GPS Data_ page.

Three global variables are [introduced](https://github.com/dimagi/commcare-hq/blob/8bf17cf3808a5dc8975d67b3feecd7d2c5873341/corehq/apps/geospatial/static/geospatial/js/gps_capture.js#L17-L19) to manage the selected item and it's marker on the map for which the GPS coordinates are being captured on the map.  

## Feature Flag
Geospatial feature

## Safety Assurance

### Safety story
Tested this locally

### Automated test coverage
No tests included

### QA Plan
No formal QA planned at this stage.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
