### PR TITLE
Show software plan version in the list of subscriptions

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -370,8 +370,8 @@ class SubscriptionInterface(AddItemInterface):
         filter_created_by = CreatedSubAdjMethodFilter.get_value(
             self.request, self.domain)
         if (
-            filter_created_by is not None and
-            filter_created_by in [s[0] for s in SubscriptionAdjustmentMethod.CHOICES]
+            filter_created_by is not None
+            and filter_created_by in [s[0] for s in SubscriptionAdjustmentMethod.CHOICES]
         ):
             queryset = queryset.filter(
                 subscriptionadjustment__reason=SubscriptionAdjustmentReason.CREATE,
@@ -535,8 +535,8 @@ class WireInvoiceInterface(InvoiceInterfaceBase):
                 WireInvoiceSummaryView, ManageBillingAccountView,
             )
             new_this_month = (
-                invoice.date_created.month == invoice.account.date_created.month and
-                invoice.date_created.year == invoice.account.date_created.year
+                invoice.date_created.month == invoice.account.date_created.month
+                and invoice.date_created.year == invoice.account.date_created.year
             )
             try:
                 contact_info = BillingContactInfo.objects.get(account=invoice.account)
@@ -702,8 +702,8 @@ class InvoiceInterface(InvoiceInterfaceBase):
                 ManageBillingAccountView, EditSubscriptionView,
             )
             new_this_month = (
-                invoice.date_created.month == invoice.subscription.account.date_created.month and
-                invoice.date_created.year == invoice.subscription.account.date_created.year
+                invoice.date_created.month == invoice.subscription.account.date_created.month
+                and invoice.date_created.year == invoice.subscription.account.date_created.year
             )
             try:
                 contact_info = BillingContactInfo.objects.get(
@@ -994,8 +994,8 @@ class CustomerInvoiceInterface(InvoiceInterfaceBase):
         def _invoice_to_row(invoice):
             from corehq.apps.accounting.views import ManageBillingAccountView
             new_this_month = (
-                invoice.date_created.month == invoice.account.date_created.month and
-                invoice.date_created.year == invoice.account.date_created.year
+                invoice.date_created.month == invoice.account.date_created.month
+                and invoice.date_created.year == invoice.account.date_created.year
             )
             try:
                 contact_info = BillingContactInfo.objects.get(
@@ -1486,9 +1486,9 @@ class CreditAdjustmentInterface(GenericTabularReport):
         domain = DomainFilter.get_value(self.request, self.domain)
         if domain is not None:
             queryset = queryset.filter(
-                Q(credit_line__subscription__subscriber__domain=domain) |
-                Q(invoice__subscription__subscriber__domain=domain) |
-                Q(
+                Q(credit_line__subscription__subscriber__domain=domain)
+                | Q(invoice__subscription__subscriber__domain=domain)
+                | Q(
                     credit_line__subscription__isnull=True,
                     invoice__isnull=True,
                     credit_line__account__created_by_domain=domain,

--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -307,7 +307,7 @@ class SubscriptionInterface(AddItemInterface):
                     ),
                     sort_key=subscription.account.name,
                 ),
-                subscription.plan_version.plan.name,
+                subscription.plan_version,
                 subscription.is_active,
                 subscription.salesforce_contract_id,
                 subscription.date_start,
@@ -712,10 +712,7 @@ class InvoiceInterface(InvoiceInterfaceBase):
             except BillingContactInfo.DoesNotExist:
                 contact_info = BillingContactInfo()
 
-            plan_name = "{name} v{version}".format(
-                name=invoice.subscription.plan_version.plan.name,
-                version=invoice.subscription.plan_version.version,
-            )
+            plan_name = invoice.subscription.plan_version
             plan_href = reverse(EditSubscriptionView.urlname, args=[invoice.subscription.id])
             account_name = invoice.subscription.account.name
             account_href = reverse(ManageBillingAccountView.urlname, args=[invoice.subscription.account.id])

--- a/corehq/apps/accounting/templates/accounting/partials/subscriptions_tab.html
+++ b/corehq/apps/accounting/templates/accounting/partials/subscriptions_tab.html
@@ -27,7 +27,7 @@
     {% for subscription, last_due_date in subscription_list %}
       <tr>
         <td>{{ subscription.subscriber.domain }}</td>
-        <td>{{ subscription.plan_version.plan.name }}</td>
+        <td>{{ subscription.plan_version }}</td>
         <td>{{ subscription.date_start }}</td>
         <td>{{ subscription.date_end }}</td>
         <td>{{ subscription.is_active }}</td>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
_The screenshots are taken from my local env and none of the data displayed is real data._

This ticket is to show version number as well in the list of subscriptions. The change will be visible at two reports:

1. Admin > Billing Accounts > Subscription Tab
Before
![image](https://github.com/dimagi/commcare-hq/assets/39149002/e38452fe-f3bd-46e9-9667-5e4755a42271)
After
![image](https://github.com/dimagi/commcare-hq/assets/39149002/c21b7c3b-9fdc-4890-baaa-eaff60bee1dd)

2. Admin > Subscriptions
Before
![image](https://github.com/dimagi/commcare-hq/assets/39149002/d7b0388f-4cbb-4536-9f85-9bff5f4f2059)
After
![image](https://github.com/dimagi/commcare-hq/assets/39149002/8c1a80a4-e334-481a-a95a-6372ac85635f)

3. Admin > Invoice
This report already included software plan version in it. But I still changed how they include software plan version, so we can leverage the `__str__` method. This is kind of just a refactoring.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-14898
Leveraged `__str__` [method](https://github.com/dimagi/commcare-hq/blob/f4c524daffa6e6ce202dc57e063b00bcde7389b5/corehq/apps/accounting/models.py#L878-L882) in SoftwarePlanVersion

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.
Test on Staging.
Will ask QA to test.
The PR is just changing the text.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Ticket: [QA-5613](https://dimagi-dev.atlassian.net/browse/QA-5613)
QA should test if this three report "Admin > Invoice ", "Admin > Subscriptions", "Admin > Billing Accounts > Subscription Tab" still works. And the plan version is now included in the software plan column.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[QA-5613]: https://dimagi-dev.atlassian.net/browse/QA-5613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ