### PR TITLE
Overflowing Tables Small Screen

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -45,6 +45,16 @@
     }
   }
 
+  .info {
+    .panel-body {
+      overflow-x: auto;
+      @media (max-width: @screen-xs-max) {
+        padding-left: @form-text-indent + 5px;
+        padding-right: @form-text-indent + 5px;
+      }
+    }
+  }
+
   .gr-header {
     .collapsible-icon-container {
       float: left;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -39,6 +39,10 @@
   .panel-body {
     padding-left: @form-text-indent + 5px;
     padding-right: @form-text-indent + 5px;
+    @media (max-width: @screen-xs-max) {
+      padding-left: 0px;
+      padding-right: 0px;
+    }
   }
 
   .gr-header {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -39,6 +39,11 @@
   .panel-body {
     padding-left: @form-text-indent + 5px;
     padding-right: @form-text-indent + 5px;
+    // Bootstrap introduces -10px left/right margin for row classes. This causes element to overflow parent.
+    .row {
+      margin-left: 0px;
+      margin-right: 0px;
+    }
     @media (max-width: @screen-xs-max) {
       padding-left: 0px;
       padding-right: 0px;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This change reduces the left and right padding for all items inside a group. It also adds a horizontal scrolling bar for overflowing elements.

Before:
<img width="275" alt="Pre-Change-Table" src="https://github.com/dimagi/commcare-hq/assets/88759246/10805f58-2ca0-46a3-b2ca-a0c3e4b7edeb"> <img width="275" alt="Pre-Change Group" src="https://github.com/dimagi/commcare-hq/assets/88759246/4524f3c2-dc72-437d-b89f-aa9cd7586a25">

After:
<img width="275" alt="Post-Change-Table" src="https://github.com/dimagi/commcare-hq/assets/88759246/c0e7987c-dc49-4ecf-a136-badbcef75174"><img width="275" alt="Post-Change-Group" src="https://github.com/dimagi/commcare-hq/assets/88759246/cbd4c7d9-eb57-41a7-8c1a-dcfd4c9f11b8">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi-dev.atlassian.net/browse/USH-3585

Left and Right padding is introduced in a couple layer of parent elements which makes it tricky to remove padding from only tables without introducing JS. Removing left and right padding inside groups for small screens is a good compromise for a simple improvement. The horizontal scrolling is the main solution, as even with 0 padding, it would only give marginal improvement in the width of table allowed before overflowing

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Web Apps
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Locally tested. Only affects display for Web Apps forms.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No testing

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
