### PR TITLE
Add `lastUpdatedByUserInfo` to the top-level of tracked entity also

### DIFF
--- a/corehq/motech/dhis2/schema.py
+++ b/corehq/motech/dhis2/schema.py
@@ -1,5 +1,5 @@
 from schema import Optional as SchemaOptional
-from schema import Regex
+from schema import Regex, Schema  # noqa: F401
 
 from corehq.motech.dhis2.const import (
     DHIS2_EVENT_STATUSES,

--- a/corehq/motech/dhis2/schema.py
+++ b/corehq/motech/dhis2/schema.py
@@ -138,6 +138,7 @@ def get_tracked_entity_schema() -> dict:
     note_schema = get_note_schema()
     relationship_schema = get_relationship_schema()
     program_owner_schema = get_program_owner_schema()
+    user_info_schema = get_user_info_schema()
     return {
         SchemaOptional("attributes"): [attribute_schema],
         SchemaOptional("created"): datetime_schema,
@@ -180,7 +181,8 @@ def get_tracked_entity_schema() -> dict:
         SchemaOptional("storedBy"): str,
         SchemaOptional("trackedEntityInstance"): id_schema,
         "trackedEntityType": id_schema,
-        SchemaOptional("lastUpdatedByUserInfo"): get_user_info_schema(),
+        SchemaOptional("lastUpdatedByUserInfo"): user_info_schema,
+        SchemaOptional("createdByUserInfo"): user_info_schema
     }
 
 

--- a/corehq/motech/dhis2/schema.py
+++ b/corehq/motech/dhis2/schema.py
@@ -1,5 +1,5 @@
 from schema import Optional as SchemaOptional
-from schema import Regex, Schema
+from schema import Regex
 
 from corehq.motech.dhis2.const import (
     DHIS2_EVENT_STATUSES,
@@ -180,6 +180,7 @@ def get_tracked_entity_schema() -> dict:
         SchemaOptional("storedBy"): str,
         SchemaOptional("trackedEntityInstance"): id_schema,
         "trackedEntityType": id_schema,
+        SchemaOptional("lastUpdatedByUserInfo"): get_user_info_schema(),
     }
 
 

--- a/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
+++ b/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
@@ -183,5 +183,11 @@
             "attribute": "aKQIBMcRlZF",
             "value": "2021-06-03"
         }
-    ]
+    ],
+    "lastUpdatedByUserInfo": {
+        "uid": "nx8I1YIFu3a",
+        "firstName": "Testy",
+        "surname": "Tester",
+        "username": "testy_tester"
+      }
 }

--- a/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
+++ b/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
@@ -185,9 +185,15 @@
         }
     ],
     "lastUpdatedByUserInfo": {
-        "uid": "nx8I1YIFu3a",
+        "uid": "aKQIBMcRlZF",
         "firstName": "Testy",
         "surname": "Tester",
         "username": "testy_tester"
-      }
+      },
+    "createdByUserInfo": {
+    "firstName": "LLAA",
+    "surname": "Commcare",
+    "uid": "aKQIBMcRlZF",
+    "username": "hmhb_commcare"
+    }
 }

--- a/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
+++ b/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
@@ -191,9 +191,9 @@
         "username": "testy_tester"
       },
     "createdByUserInfo": {
-    "firstName": "LLAA",
-    "surname": "Commcare",
-    "uid": "aKQIBMcRlZF",
-    "username": "hmhb_commcare"
+        "firstName": "LLAA",
+        "surname": "Commcare",
+        "uid": "aKQIBMcRlZF",
+        "username": "hmhb_commcare"
     }
 }


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-3132)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Issue is 
```
Wrong keys 'createdByUserInfo', 'lastUpdatedByUserInfo' in ...{body here}
```

See [this](https://www.commcarehq.org/a/hmhb-prod/motech/logs/278881347/). The `createdByUserInfo` and `lastUpdatedByUserInfo` keys have been added to the toplevel of the schema (following the same local schema as the other `lastUpdatedByUserInfo` fields) we're getting from DHIS2, so I just updated our version of the schema.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing. The new key is optional, so it's backwards compatible
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
