### PR TITLE
Do not set style if it is not configured

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -88,8 +88,8 @@ class CaseTileHelper(object):
             for column_info in self.detail_column_infos:
                 # column_info is an instance of DetailColumnInfo named tuple.
                 style = None
-                if column_info.column.grid_x is not None or column_info.column.grid_y is not None \
-                        or column_info.column.height is not None or column_info.column.width is not None:
+                if any(field is not None for field in [column_info.column.grid_x, column_info.column.grid_y,
+                                                       column_info.column.height, column_info.column.width]):
                     style = Style(grid_x=column_info.column.grid_x, grid_y=column_info.column.grid_y,
                                   grid_height=column_info.column.height, grid_width=column_info.column.width,
                                   horz_align=column_info.column.horizontal_align,

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -88,8 +88,8 @@ class CaseTileHelper(object):
             for column_info in self.detail_column_infos:
                 # column_info is an instance of DetailColumnInfo named tuple.
                 style = None
-                if column_info.column.grid_x or column_info.column.grid_y \
-                        or column_info.column.height or column_info.column.width:
+                if column_info.column.grid_x is not None or column_info.column.grid_y is not None \
+                        or column_info.column.height is not None or column_info.column.width is not None:
                     style = Style(grid_x=column_info.column.grid_x, grid_y=column_info.column.grid_y,
                                   grid_height=column_info.column.height, grid_width=column_info.column.width,
                                   horz_align=column_info.column.horizontal_align,

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -16,7 +16,6 @@ from corehq.apps.app_manager.util import (
     module_uses_inline_search,
 )
 
-
 TILE_DIR = Path(__file__).parent.parent / "case_tile_templates"
 
 
@@ -27,7 +26,7 @@ class CaseTileTemplates(models.TextChoices):
     ONE_TWO_ONE_ONE = ("one_two_one_one", _("Title row, second row with two cells, third and "
                                             "fourth rows, and map"))
     ONE_3X_TWO_4X_ONE_2X = ("one_3X_two_4X_one_2X", _("Three upper rows, four rows with two cells, two lower rows "
-                                                    "and map"))
+                                                      "and map"))
     ONE_TWO_TWO = ("one_two_two", _("Title row, second row with two cells, third row with two cells"))
     ICON_TEXT_GRID = ("icon_text_grid", _("2 x 3 grid of image and text"))
 
@@ -88,11 +87,14 @@ class CaseTileHelper(object):
 
             for column_info in self.detail_column_infos:
                 # column_info is an instance of DetailColumnInfo named tuple.
-                style = Style(grid_x=column_info.column.grid_x, grid_y=column_info.column.grid_y,
-                              grid_height=column_info.column.height, grid_width=column_info.column.width,
-                              horz_align=column_info.column.horizontal_align,
-                              vert_align=column_info.column.vertical_align,
-                              font_size=column_info.column.font_size)
+                style = None
+                if column_info.column.grid_x or column_info.column.grid_y \
+                        or column_info.column.height or column_info.column.width:
+                    style = Style(grid_x=column_info.column.grid_x, grid_y=column_info.column.grid_y,
+                                  grid_height=column_info.column.height, grid_width=column_info.column.width,
+                                  horz_align=column_info.column.horizontal_align,
+                                  vert_align=column_info.column.vertical_align,
+                                  font_size=column_info.column.font_size)
                 fields = get_column_generator(
                     self.app, self.module, self.detail,
                     detail_type=self.detail_type,

--- a/corehq/apps/app_manager/tests/test_suite_custom_case_tiles.py
+++ b/corehq/apps/app_manager/tests/test_suite_custom_case_tiles.py
@@ -92,3 +92,39 @@ class SuiteCustomCaseTilesTest(SimpleTestCase, SuiteMixin):
             app.create_suite(),
             "./detail[@id='m0_case_short']/field[1]"
         )
+
+    def test_custom_case_tile_empty_style(self, *args):
+        app = Application.new_app('domain', 'Untitled Application')
+
+        module = app.add_module(Module.new_module('Untitled Module', None))
+        module.case_type = 'patient'
+        module.case_details.short.case_tile_template = "custom"
+        module.case_details.short.columns = [
+            DetailColumn(
+                header={'en': 'a'},
+                model='case',
+                field='a',
+                format='plain'
+            ),
+        ]
+
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+                <field>
+                    <header>
+                        <text>
+                            <locale id="m0.case_short.case_a_1.header"/>
+                        </text>
+                    </header>
+                    <template>
+                        <text>
+                          <xpath function="a"/>
+                        </text>
+                    </template>
+                </field>
+            </partial>
+            """,
+            app.create_suite(),
+            "./detail[@id='m0_case_short']/field[1]"
+        )


### PR DESCRIPTION
## Product Description

Search field in case lists with custom case tiles generated empty `style` tags.

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3684
https://dimagi-dev.atlassian.net/browse/SUPPORT-17656

## Feature Flag

USH: Configure custom case list tile

## Safety Assurance

### Safety story

Tested locally with app that previously caused issues.

### Automated test coverage

Added new test case that covers the case

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
