### PR TITLE
Add tracking header option in AWS

### DIFF
--- a/corehq/messaging/emailbackends/aws/forms.py
+++ b/corehq/messaging/emailbackends/aws/forms.py
@@ -1,13 +1,24 @@
 from crispy_forms import layout as crispy
-from django.utils.translation import gettext as _
+from django.forms.fields import BooleanField
+from django.utils.translation import gettext as _, gettext_noop, gettext_lazy
 
 from corehq.apps.email.forms import BackendForm
 
 
 class AWSBackendForm(BackendForm):
 
+    use_tracking_headers = BooleanField(
+        required=False,
+        label=gettext_noop("Use Tracking Headers"),
+        help_text=gettext_lazy("If selected, headers will be appended in the outgoing mails for tracking. "
+                               "Use key generated in HQ in the AWS SNS settings. Key can be found by selecting "
+                               "the gateway from the list."
+                               )
+    )
+
     @property
     def gateway_specific_fields(self):
         return crispy.Fieldset(
             _("AWS Settings"),
+            'use_tracking_headers',
         )

--- a/corehq/messaging/emailbackends/aws/models.py
+++ b/corehq/messaging/emailbackends/aws/models.py
@@ -1,3 +1,5 @@
+import json
+
 from corehq.apps.email.models import EmailSMTPBackend
 from corehq.messaging.emailbackends.aws.forms import AWSBackendForm
 
@@ -16,7 +18,7 @@ class AWSBackend(EmailSMTPBackend):
 
     @classmethod
     def get_available_extra_fields(cls):
-        return []
+        return ['use_tracking_headers']
 
     @classmethod
     def get_form_class(cls):
@@ -38,3 +40,6 @@ class AWSBackend(EmailSMTPBackend):
             result[k] = v
 
         self.extra_fields = result
+
+    def use_tracking_headers(self):
+        return json.loads(self.extra_fields).get("use_tracking_headers")


### PR DESCRIPTION
## Product Description
Adds an option to include tracking headers for AWS email gateway

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3469

## Feature Flag
new feature flag - custom_email_backend

## Safety Assurance

### Safety story
Local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
