### PR TITLE
prevent multiple calls to clear answer

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -892,7 +892,14 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         };
         self.file = ko.observable();
         self.extensionsMap = initialPageData.get("valid_multimedia_extensions_map");
+        // Tracks whether file entry has already been cleared, preventing an additional failing request to Formplayer
+        self.cleared = false;
+
         self.onClear = function () {
+            if (self.cleared) {
+                return;
+            }
+            self.cleared = true;
             self.file(null);
             self.rawAnswer(constants.NO_ANSWER);
             self.xformAction = constants.CLEAR_ANSWER;
@@ -904,9 +911,10 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
     FileEntry.prototype.onPreProcess = function (newValue) {
         var self = this;
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
-            // input has changed and validation will be checked
+            // Input has changed and validation will be checked
             if (newValue !== self.answer()) {
                 self.question.formplayerProcessed = false;
+                self.cleared = false;
             }
             self.answer(newValue.replace(constants.FILE_PREFIX, ""));
         } else {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This is a bug fix for media clear button. When clearing an entry the changing state was triggering am additional call to Formplayer's `answer-media` which would fail. This prevents that additional call in a similar fashion to the `formplayerProcessed` var.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
followup to https://github.com/dimagi/commcare-hq/pull/33443
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
USH: Support signature, image, audio, and video questions in Web Apps

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Under feature flag
tested on staging and locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
