### PR TITLE
Web apps responsive design bugfixes (pre-QA)

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -422,7 +422,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             const addressFieldPresent = !!_.find(this.styles, function (style) { return style.displayFormat === constants.FORMAT_ADDRESS; });
 
             self.showMap = addressFieldPresent && !appPreview && !self.hasNoItems && toggles.toggleEnabled('CASE_LIST_MAP');
-            self.smallScreenEnabled = cloudcareUtils.watchSmallScreenEnabled(self.handleSmallScreenChange.bind(self));
+            self.smallScreenListener = cloudcareUtils.smallScreenListener(smallScreenEnabled => {
+                self.handleSmallScreenChange(smallScreenEnabled);
+            });
+            self.smallScreenListener.listen();
         },
 
         ui: CaseListViewUI(),
@@ -707,6 +710,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             self.handleSmallScreenChange(self.smallScreenEnabled);
         },
 
+        onDestroy: function () {
+            this.smallScreenListener.stopListening();
+        },
+
         templateContext: function () {
             const paginateItems = formplayerUtils.paginateOptions(this.options.currentPage, this.options.pageCount);
             const casesPerPage = parseInt($.cookie("cases-per-page-limit")) || (this.smallScreenEnabled ? 5 : 10);
@@ -898,6 +905,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         onDestroy: function () {
+            CaseTileListView.__super__.onDestroy.apply(this, arguments);
             $('#content-container').removeClass('full-width');
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -630,10 +630,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
                 addressMap.on('fullscreenchange', function () {
                     // sticky header interferes with fullscreen map; un-stick it if it exists
-                    if ($('#small-screen-sticky-header')[0]) {
+                    const $stickyHeader = $('#small-screen-sticky-header');
+                    if ($stickyHeader[0]) {
                         addressMap.isFullscreen()
-                            ? $('#small-screen-sticky-header').removeClass('sticky')
-                            : $('#small-screen-sticky-header').addClass('sticky');
+                            ? $stickyHeader.removeClass('sticky')
+                            : $stickyHeader.addClass('sticky');
                     }
                 });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -625,6 +625,15 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     position: 'bottomright',
                 }).addTo(addressMap);
 
+                addressMap.on('fullscreenchange', function () {
+                    // sticky header interferes with fullscreen map; un-stick it if it exists
+                    if ($('#small-screen-sticky-header')[0]) {
+                        addressMap.isFullscreen()
+                            ? $('#small-screen-sticky-header').removeClass('sticky')
+                            : $('#small-screen-sticky-header').addClass('sticky');
+                    }
+                });
+
                 L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=' + token, {
                     id: 'mapbox/streets-v11',
                     attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> ©' +

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -465,8 +465,10 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     break;
                 }
             }
-            this.smallScreenEnabled = cloudcareUtils.watchSmallScreenEnabled(this.handleSmallScreenChange.bind(this));
-            this.handleSmallScreenChange(this.smallScreenEnabled);
+            this.smallScreenListener = cloudcareUtils.smallScreenListener(smallScreenEnabled => {
+                this.handleSmallScreenChange(smallScreenEnabled);
+            });
+            this.smallScreenListener.listen();
         },
 
         templateContext: function () {
@@ -691,6 +693,10 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
         onAttach: function () {
             this.initGeocoders();
+        },
+
+        onDestroy: function () {
+            this.smallScreenListener.stopListening();
         },
 
         initGeocoders: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
@@ -5,27 +5,42 @@ hqDefine("cloudcare/js/spec/utils_spec", function () {
             utils = hqImport("cloudcare/js/utils");
 
         describe('Small Screen Listener', function () {
-            it('should initially enable small screen mode in small window', function () {
-                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX;
-                const smallScreenEnabled = utils.watchSmallScreenEnabled(function () {});
-                assert.isTrue(smallScreenEnabled);
+            const callback = sinon.stub().callsFake(smallScreenEnabled => smallScreenEnabled);
+            const smallScreenListener = utils.smallScreenListener(callback);
+
+            beforeEach(function () {
+                smallScreenListener.listen();
             });
 
-            it('should initially disable small screen mode in large window', function () {
-                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX + 1;
-                const smallScreenEnabled = utils.watchSmallScreenEnabled(function () {});
-                assert.isFalse(smallScreenEnabled);
+            afterEach(function () {
+                smallScreenListener.stopListening();
+                callback.resetHistory();
             });
 
-            it('should update small screen mode on window resize', function () {
-                let smallScreenEnabled = utils.watchSmallScreenEnabled(enabled => smallScreenEnabled = enabled);
-                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX;
+            it('should run callback once on listener initialize', function () {
+                assert.isTrue(callback.calledOnce);
+            });
+
+            it('should run callback with smallScreenEnabled = true in small window', function () {
+                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX - 1;
                 $(window).trigger("resize");
-                assert.isTrue(smallScreenEnabled);
+                assert.isTrue(callback.lastCall.calledWith(true));
+            });
+
+            it('should run callback with smallScreenEnabled = false in large window', function () {
+                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX + 1;
+                $(window).trigger("resize");
+                assert.isTrue(callback.lastCall.calledWith(false));
+            });
+
+            it('should run callback with new smallScreenEnabled value when small screen threshold crossed', function () {
+                window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX - 1;
+                $(window).trigger("resize");
+                assert.isTrue(callback.lastCall.calledWith(true));
 
                 window.innerWidth = constants.SMALL_SCREEN_WIDTH_PX + 1;
                 $(window).trigger("resize");
-                assert.isFalse(smallScreenEnabled);
+                assert.isTrue(callback.lastCall.calledWith(false));
             });
         });
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -345,23 +345,30 @@ hqDefine('cloudcare/js/utils', [
     /**
      *  Listen for screen size changes to enable or disable small screen functionality.
      *  Accepts a callback function that should take in the new value of smallScreenEnabled.
-     *  e.g.,
-     *      watchSmallScreenEnabled(enabled => {
-     *          this.smallScreenEnabled = enabled;
-     *          this.render();
-     *      });
+     *  Callback runs once initially, then every time the small screen threshold is passed.
+     *  Returns an object with two methods:
+     *      listen() initiates a jQuery event listener and runs callback once
+     *      stopListening() removes the jQuery event listener
      */
-    var watchSmallScreenEnabled = function (callback) {
-        var shouldEnableSmallScreen = () => window.innerWidth < constants.SMALL_SCREEN_WIDTH_PX;
-        var smallScreenEnabled = shouldEnableSmallScreen();
-
-        $(window).on("resize", () => {
-            if (smallScreenEnabled !== shouldEnableSmallScreen()) {
-                smallScreenEnabled = shouldEnableSmallScreen();
+    var smallScreenListener = function (callback) {
+        var smallScreenEnabled = window.innerWidth < constants.SMALL_SCREEN_WIDTH_PX;
+        var handleSmallScreenChange = () => {
+            var shouldEnableSmallScreen = window.innerWidth < constants.SMALL_SCREEN_WIDTH_PX;
+            if (smallScreenEnabled !== shouldEnableSmallScreen) {
+                smallScreenEnabled = shouldEnableSmallScreen;
                 callback(smallScreenEnabled);
             }
-        });
-        return smallScreenEnabled;
+        };
+
+        return {
+            listen: function () {
+                $(window).on('resize', handleSmallScreenChange);
+                callback(smallScreenEnabled);
+            },
+            stopListening: function () {
+                $(window).off('resize', handleSmallScreenChange);
+            },
+        };
     };
 
     return {
@@ -382,6 +389,6 @@ hqDefine('cloudcare/js/utils', [
         formplayerLoadingComplete: formplayerLoadingComplete,
         formplayerSyncComplete: formplayerSyncComplete,
         reportFormplayerErrorToHQ: reportFormplayerErrorToHQ,
-        watchSmallScreenEnabled: watchSmallScreenEnabled,
+        smallScreenListener: smallScreenListener,
     };
 });


### PR DESCRIPTION
## Technical Summary
[USH-3484](https://dimagi-dev.atlassian.net/browse/USH-3484)
Fixes two issues:
1. with the new "small screen sticky header" the case list map would inherit this "sticky" property leading to layering issues when the map is fullscreen. This removes the class "sticky" from the small screen header section when the map is fullscreen.
2. screen size listeners were spawned in the `CaseListView` and `QueryListView` but never cleaned up, continually spawning more listeners. This changes the way the util function is structured and its return value, so that it is explicitly initialized with `listen()` and cleaned up with `stopListening()`.

## Feature Flag
CASE_LIST_MAP for issue 1

## Safety Assurance

### Safety story
Bugfixes that came out of local testing of responsive design. Went back through and re-tested design work.

### Automated test coverage
Updated tests for small screen listener util.

### QA Plan
These are pre-QA changes. QA for responsive design work en mass will be requested shortly. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change



[USH-3484]: https://dimagi-dev.atlassian.net/browse/USH-3484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ