### PR TITLE
[B5] SCSS updates to button and variables

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_buttons.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_buttons.scss
@@ -31,3 +31,7 @@
     }
   }
 }
+
+.btn-outline-danger:hover {
+  color: #ffffff;
+}

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
@@ -111,7 +111,6 @@ $cc-dark-warm-accent-low: #994f00;
 $primary:   #5c6ac5;
 $success:   $cc-att-pos-mid;
 $info:      $cc-light-cool-accent-mid;
-$warning:   $cc-dark-warm-accent-mid;
 $danger:    $cc-att-neg-mid;
 
 $body-color: $cc-text;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/buttons._buttons.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/buttons._buttons.style.diff.txt
@@ -28,7 +28,7 @@
  }
  
  .btn-full-width {
-@@ -30,25 +9,25 @@
+@@ -30,25 +9,29 @@
  // Separated button groups in toolbars need more space between them,
  // since the buttons within the group have space between them
  .btn-toolbar > .btn-group-separated:not(:first-child) {
@@ -70,3 +70,7 @@
      }
 +  }
  }
++
++.btn-outline-danger:hover {
++  color: #ffffff;
++}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,119 +1,122 @@
+@@ -1,119 +1,121 @@
 -@import "@{b3-import-variables}";
 +// Grid Containers
 +// we will want to adapt the defaults in a full redesign
@@ -208,7 +208,6 @@
 +$primary:   #5c6ac5;
 +$success:   $cc-att-pos-mid;
 +$info:      $cc-light-cool-accent-mid;
-+$warning:   $cc-dark-warm-accent-mid;
 +$danger:    $cc-att-neg-mid;
 +
 +$body-color: $cc-text;


### PR DESCRIPTION
## Technical Summary
Minor scss updates to the bootstrap 5 stylesheet
- ensures hover text on `btn-outline-danger` is white
- removes override of warning color and uses default bootstrap 5 color (looks better)

## Safety Assurance

### Safety story
bootstrap 5 css changes only

### Automated test coverage
Yes

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
