### PR TITLE
[B5] Update migration script spec for bootstrap 5 migraiton

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/changes_guide/form-group.txt
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes_guide/form-group.txt
@@ -1,3 +1,7 @@
 `form-group` has been dropped. Use grid utilities instead.
 
-- note that `<label>` elements now require `form-label` class
+Since we are opting for vertical forms (where the label is directly above the field),
+the replacement for `form-group` is most likely just `mb-3` and the child `div` with a column
+class surrounding the `form-control` element can be removed, along with the column class that
+appears with the `<label>` `class` attribute. Most often, the `<label>` `class` only needs to
+contain the `form-label` class now.

--- a/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
@@ -51,7 +51,8 @@
         "btn-danger": "btn-outline-danger",
         "btn-xs": "btn-sm",
         "navbar-default": "navbar-light",
-        "inline-block": "d-inline-block"
+        "inline-block": "d-inline-block",
+        "control-label": "form-label"
     },
     "numbered_css_renames": {
         "col-xl-<num>": "col-xxl-<num>",


### PR DESCRIPTION
## Technical Summary
This makes some minor changes to the bootstrap 5 migration script spec and help text:
- improved suggestions for how to handle `form-group` replacement
- ensures `control-label` is replaced by `form-label`

## Safety Assurance

### Safety story
Makes changes only relevant to the bootstrap 5 migration management command

### Automated test coverage
N/A

### QA Plan
Not needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
