### PR TITLE
Improve property selection for deduplication

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
@@ -123,7 +123,7 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
         return self;
     };
 
-    var CaseProperty = function (name, propertyManager) {
+    const CaseProperty = function (name, propertyManager) {
         var self = {};
         self.name = ko.observable();
         let prevValue = '';
@@ -139,7 +139,7 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
         return self;
     };
 
-    var PropertyToUpdate = function (name, valueType, value, propertyManager) {
+    const PropertyToUpdate = function (name, valueType, value, propertyManager) {
         var self = {};
         self.name = ko.observable();
         self.valueType = ko.observable(valueType);
@@ -158,7 +158,7 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
         return self;
     };
 
-    var CaseDedupe = function (
+    const CaseDedupe = function (
         initialName,
         initialCaseType,
         caseTypeOptions,
@@ -175,17 +175,14 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
         self.caseTypeOptions = caseTypeOptions;
         self.matchType = ko.observable(initialMatchType);
         self.matchTypeText = ko.computed(function () {
-            if (self.matchType() === "ANY") {
-                return gettext("OR");
-            }
-            return gettext("AND");
+            return (self.matchType() === 'ANY') ? gettext('OR') : gettext('AND');
         });
-        self.matchTypeOptions = ["ALL", "ANY"];
+        self.matchTypeOptions = ['ALL', 'ANY'];
         self.matchTypeOptionsText = function (item) {
-            if (item === "ANY") {
-                return gettext("True when ANY of the case properties match");
+            if (item === 'ANY') {
+                return gettext('True when ANY of the case properties match');
             }
-            return gettext("True when ALL of the case properties match");
+            return gettext('True when ALL of the case properties match');
         };
 
         /* Case Properties */
@@ -243,10 +240,10 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
 
         // This is a little hacky; it prevents the "multiple bindings to same
         // element" error.
-        var caseFilterElement = $("#caseFiltersForm");
+        const caseFilterElement = $("#caseFiltersForm");
         caseFilterElement.detach();
 
-        var caseDedupe = CaseDedupe(
+        const caseDedupe = CaseDedupe(
             initialPageData.get('name'),
             initialPageData.get('case_type'),
             initialPageData.get('case_types'),

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
@@ -14,6 +14,131 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
     casePropertyInput,
     CaseRuleCriteria
 ) {
+
+    /*
+    PropertyManager exists to make sure that available properties are updated and unique.
+    For example, if a case type contains A, B, and C properties, this class ensures
+    that if C is selected, further options will only show A and B.
+    */
+    const PropertyManager = function (caseType, selectedProperties, initialPropertyMap) {
+        const self = {};
+        self.caseType = caseType;
+        self.selectedProperties = selectedProperties;
+        self.availablePropertyMap = ko.observable(clonePropertyMap(initialPropertyMap));
+
+        self.addProperty = function (property) {
+            self.selectedProperties.push(property);
+
+            if (property.name()) {
+                let currentProperties = self.availablePropertyMap()[self.caseType()];
+                currentProperties = reserveProperties([property.name()], currentProperties);
+                rebuildPropertyMap(currentProperties);
+            }
+        };
+
+        self.removeProperty = function (property) {
+            self.selectedProperties.remove(property);
+
+            let currentProperties = self.availablePropertyMap()[self.caseType()];
+            currentProperties = restoreProperty(property.name(), currentProperties);
+
+            rebuildPropertyMap(currentProperties);
+        };
+
+        self.updatePropertyValue = function (oldValue, newValue) {
+            let currentProperties = self.availablePropertyMap()[self.caseType()];
+            currentProperties = reserveProperties([oldValue], currentProperties);
+            currentProperties = restoreProperty(newValue, currentProperties);
+
+            rebuildPropertyMap(currentProperties);
+        };
+
+        self.caseType.subscribe(handleCaseTypeChange);
+        function handleCaseTypeChange(caseType) {
+            if (!caseType) {
+                return;
+            }
+
+            resetAvailableProperties();
+
+            const selectedNames = self.selectedProperties().map(function (prop) {
+                return prop.name();
+            });
+
+            let currentProperties = self.availablePropertyMap()[caseType];
+            currentProperties = reserveProperties(selectedNames, currentProperties);
+            rebuildPropertyMap(currentProperties);
+        }
+
+        function resetAvailableProperties() {
+            const originalPropertyMap = clonePropertyMap(initialPropertyMap);
+            self.availablePropertyMap(originalPropertyMap);
+        }
+
+        function clonePropertyMap(originalMap) {
+            const clone = {};
+            for (const key in originalMap) {
+                clone[key] = originalMap[key].slice();
+            }
+
+            return clone;
+        }
+
+        function propertyExistsInOriginalMap(propName) {
+            const originalProperties = initialPropertyMap[self.caseType()];
+
+            return (originalProperties.indexOf(propName) !== -1);
+        }
+
+        function rebuildPropertyMap(changedCategory) {
+            const caseType = self.caseType();
+            const existingMap = self.availablePropertyMap();
+            changedCategory.sort();
+            existingMap[caseType] = changedCategory;
+            self.availablePropertyMap(existingMap);
+        }
+
+        function restoreProperty(propName, currentProperties) {
+            if (!propName || !propertyExistsInOriginalMap(propName)) {
+                // do not put custom properties back into the map
+                return currentProperties;
+            }
+
+            currentProperties.push(propName);
+
+            return currentProperties;
+        }
+
+        function reserveProperties(propertyNames, currentProperties) {
+            propertyNames.forEach(function (propName) {
+                const foundIndex = currentProperties.indexOf(propName);
+                if (foundIndex !== -1) {
+                    currentProperties.splice(foundIndex, 1);
+                }
+            });
+
+            return currentProperties;
+        }
+
+        return self;
+    };
+
+    var CaseProperty = function (name, propertyManager) {
+        var self = {};
+        self.name = ko.observable();
+        let prevValue = '';
+        self.name.subscribe(function (newValue) {
+            if (!newValue) {
+                return;
+            }
+
+            propertyManager.updatePropertyValue(newValue, prevValue);
+            prevValue = newValue;
+        });
+        self.name(name);
+        return self;
+    };
+
     var CaseDedupe = function (
         initialName,
         initialCaseType,
@@ -21,12 +146,24 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
         initialMatchType,
         initialCaseProperties,
         initialIncludeClosed,
-        initialPropertiesToUpdate
+        initialPropertiesToUpdate,
+        allCaseProperties
     ) {
         var self = {};
         self.name = ko.observable(initialName);
+        self.caseType = ko.observable();
+        self.caseProperties = ko.observableArray();
+        self.includeClosed = ko.observable(initialIncludeClosed);
+        self.propertyManager = PropertyManager(self.caseType, self.caseProperties, allCaseProperties);
 
-        self.caseType = ko.observable(initialCaseType);
+        // Create a separate property for this so that outside callers do not need
+        // to be aware of this class's structure. Also functions as making the variable read-only
+        self.availablePropertyMap = ko.pureComputed(function () {
+            return self.propertyManager.availablePropertyMap();
+        });
+
+        self.caseType(initialCaseType);
+
         self.caseTypeOptions = caseTypeOptions;
 
         self.matchType = ko.observable(initialMatchType);
@@ -44,28 +181,22 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
             return gettext("True when ALL of the case properties match");
         };
 
-        var caseProperty = function (name) {
-            var self = {};
-            self.name = ko.observable(name);
-            return self;
-        };
-        self.caseProperties = ko.observableArray(_.map(initialCaseProperties, function (name) {
-            return caseProperty(name);
+        self.caseProperties(_.map(initialCaseProperties, function (name) {
+            return CaseProperty(name, self.propertyManager);
         }));
         self.removeCaseProperty = function (item) {
-            self.caseProperties.remove(item);
+            self.propertyManager.removeProperty(item);
         };
         self.addCaseProperty = function () {
-            self.caseProperties.push(caseProperty(''));
+            self.propertyManager.addProperty(CaseProperty('', self.propertyManager));
         };
+
         if (self.caseProperties().length === 0) {
             self.addCaseProperty();
         }
         self.serializedCaseProperties = ko.computed(function () {
             return ko.toJSON(self.caseProperties);
         });
-
-        self.includeClosed = ko.observable(initialIncludeClosed);
 
         var propertyToUpdate = function (name, valueType, value) {
             var self = {};
@@ -105,7 +236,8 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
             initialPageData.get('match_type'),
             initialPageData.get('case_properties'),
             initialPageData.get('include_closed'),
-            initialPageData.get('properties_to_update')
+            initialPageData.get('properties_to_update'),
+            initialPageData.get("all_case_properties")
         );
         $("#case-dedupe-rule-definition").koApplyBindings(caseDedupe);
 

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
@@ -19,7 +19,7 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
     PropertyManager exists to make sure that available properties are updated and unique.
     For example, if a case type contains A, B, and C properties, this class ensures
     that if C is selected, further options will only show A and B.
-    caseType is expectted to be an observable.
+    caseType is expected to be an observable.
     selectedProperties is expected to be an observableArray.
     */
     const PropertyManager = function (caseType, selectedProperties, initialPropertyMap) {
@@ -112,14 +112,8 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
         }
 
         function reserveProperties(propertyNames, currentProperties) {
-            propertyNames.forEach(function (propName) {
-                const foundIndex = currentProperties.indexOf(propName);
-                if (foundIndex !== -1) {
-                    currentProperties.splice(foundIndex, 1);
-                }
-            });
-
-            return currentProperties;
+            // make the specified propertyNames unavailable for future selection
+            return _.difference(currentProperties, propertyNames);
         }
 
         return self;
@@ -253,7 +247,7 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
             initialPageData.get('case_properties'),
             initialPageData.get('include_closed'),
             initialPageData.get('properties_to_update'),
-            initialPageData.get("all_case_properties")
+            initialPageData.get('all_case_properties')
         );
         $("#case-dedupe-rule-definition").koApplyBindings(caseDedupe);
 

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
@@ -47,10 +47,10 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
             rebuildPropertyMap(currentProperties);
         };
 
-        self.updatePropertyValue = function (oldValue, newValue) {
+        self.updatePropertyValue = function (newValue, oldValue) {
             let currentProperties = self.availablePropertyMap()[self.caseType()];
-            currentProperties = reserveProperties([oldValue], currentProperties);
-            currentProperties = restoreProperty(newValue, currentProperties);
+            currentProperties = reserveProperties([newValue], currentProperties);
+            currentProperties = restoreProperty(oldValue, currentProperties);
 
             rebuildPropertyMap(currentProperties);
         };

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
@@ -19,6 +19,8 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
     PropertyManager exists to make sure that available properties are updated and unique.
     For example, if a case type contains A, B, and C properties, this class ensures
     that if C is selected, further options will only show A and B.
+    caseType is expectted to be an observable.
+    selectedProperties is expected to be an observableArray.
     */
     const PropertyManager = function (caseType, selectedProperties, initialPropertyMap) {
         const self = {};

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_property_input.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_property_input.js
@@ -45,12 +45,16 @@ hqDefine('data_interfaces/js/case_property_input', [
             self.valueObservable = params.valueObservable;
             self.disabled = initialPageData.get('read_only_mode') || false;
 
-            self.allCaseProperties = initialPageData.get("all_case_properties");
+            if ('allCaseProperties' in params) {
+                self.allCaseProperties = params.allCaseProperties;
+            } else {
+                self.allCaseProperties = ko.observable(initialPageData.get("all_case_properties"));
+            }
             self.casePropertyNames = ko.computed(function () {
-                if (!self.allCaseProperties) {
+                if (!self.allCaseProperties()) {
                     return [];
                 }
-                return self.allCaseProperties[self.caseTypeObservable()] || [];
+                return self.allCaseProperties()[self.caseTypeObservable()] || [];
             });
 
             self.showDropdown = privileges.hasPrivilege('data_dictionary');

--- a/corehq/apps/data_interfaces/templates/data_interfaces/edit_deduplication_rule.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/edit_deduplication_rule.html
@@ -130,6 +130,7 @@
         <case-property-input params="
          valueObservable: caseProperty.name,
          caseTypeObservable: $root.caseType,
+         allCaseProperties: $root.availablePropertyMap
         "></case-property-input>
       </div>
     </div>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/edit_deduplication_rule.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/edit_deduplication_rule.html
@@ -130,7 +130,7 @@
         <case-property-input params="
          valueObservable: caseProperty.name,
          caseTypeObservable: $root.caseType,
-         allCaseProperties: $root.availablePropertyMap
+         allCaseProperties: $root.availablePropertyMap,
         "></case-property-input>
       </div>
     </div>
@@ -146,7 +146,7 @@
         <case-property-input params="
          valueObservable: name,
          caseTypeObservable: $root.caseType,
-         allCaseProperties: $root.availableActionPropertyMap
+         allCaseProperties: $root.availableActionPropertyMap,
         "></case-property-input>
       </div>
       <div class="controls col-xs-2">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/edit_deduplication_rule.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/edit_deduplication_rule.html
@@ -146,6 +146,7 @@
         <case-property-input params="
          valueObservable: name,
          caseTypeObservable: $root.caseType,
+         allCaseProperties: $root.availableActionPropertyMap
         "></case-property-input>
       </div>
       <div class="controls col-xs-2">


### PR DESCRIPTION
## Technical Summary
Associated Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-14927

Dedupe had two areas of its javascript functionality where it would want you to select exclusive property options, but then not enforce that exclusivity. So, you could insist that you wanted to match only cases with matching 'name', 'name', and 'name' properties -- that didn't feel polished. This fix enforces the exclusivity and hopefully is modular enough to port to similar pages.

## Safety Assurance

### Safety story
I've locally tested all the combinations of properties that I could think of.

### Automated test coverage

Unfortunately, no front-end tests for this.

### QA Plan
I've requested QA to verify that this doesn't break the existing dropdown behavior

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
