### PR TITLE
Use table_id to list datasource options on Export Data Source Data page

### DIFF
--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -1115,4 +1115,7 @@ class DatasourceExportDownloadForm(forms.Form):
 
     @staticmethod
     def domain_datasources(domain):
-        return [(ds.data_source_id, ds.display_name) for ds in get_datasources_for_domain(domain)]
+        return [
+            (ds.data_source_id, ds.table_id)
+            for ds in get_datasources_for_domain(domain)
+        ]


### PR DESCRIPTION
## Product Description
This PR addresses an issue where data sources with the same display name makes it hard to know which one to choose when exporting the data sources on the Export Data Source Data page. Instead, now, of using the display name to populate the drop down, the table id is used, ensuring that the items listed are unique, since the table_id is unique on a project. 

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-3107)
Use the table_id instead of the display name when listing data sources in the drop down.

## Feature Flag
Add the Export Data Source Data page to the Data tab

## Safety Assurance

### Safety story
Tested locally.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
