### PR TITLE
DHIS2: Add lastUpdatedByUserInfo and createdByUserInfo to enrollments

### DIFF
--- a/corehq/motech/dhis2/schema.py
+++ b/corehq/motech/dhis2/schema.py
@@ -168,6 +168,8 @@ def get_tracked_entity_schema() -> dict:
             SchemaOptional("storedBy"): str,
             SchemaOptional("trackedEntityInstance"): id_schema,
             SchemaOptional("trackedEntityType"): id_schema,
+            SchemaOptional("lastUpdatedByUserInfo"): user_info_schema,
+            SchemaOptional("createdByUserInfo"): user_info_schema
         }],
         SchemaOptional("featureType"): str,
         SchemaOptional("geometry"): geometry_schema,

--- a/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
+++ b/corehq/motech/dhis2/tests/data/tracked_entity_instance_1.json
@@ -116,7 +116,19 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "lastUpdatedByUserInfo": {
+                "uid": "aKQIBMcRlZF",
+                "firstName": "Testy",
+                "surname": "Tester",
+                "username": "testy_tester"
+              },
+            "createdByUserInfo": {
+                "firstName": "LLAA",
+                "surname": "Commcare",
+                "uid": "aKQIBMcRlZF",
+                "username": "hmhb_commcare"
+            }
         }
     ],
     "relationships": [


### PR DESCRIPTION

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Relating to [this PR](https://github.com/dimagi/commcare-hq/pull/33500). I missed adding `lastUpdatedByUserInfo` and `createdByUserInfo` to the `enrollments` field. Previously I just eye balled the difference in fields and updated the tests. This time around I took [the actual response](https://www.commcarehq.org/a/hmhb-prod/motech/logs/279029253/) and ran the this aganist the Schema to check if it's valid (before and after updating the schema). Had I done this in the first place, this PR would not have been necessary.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing. The new key is optional, so it's backwards compatible

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
