### PR TITLE
Support mapbox geocoder

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -232,6 +232,18 @@ hqDefine("geospatial/js/gps_capture",[
                          ' <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
         });
 
+        map.addControl(
+            new MapboxGeocoder({
+                accessToken: mapboxgl.accessToken,
+                mapboxgl: mapboxgl,
+                types: 'address',
+                proximity: centerCoordinates.toString(),  // bias results to this point
+                marker: false,
+            }).on('result', function (resultObject) {
+                updateGPSCoordinates(resultObject.result.center[0], resultObject.result.center[1]);
+            })
+        );
+
         map.on('click', (event) => {
             updateGPSCoordinates(event.lngLat.lng, event.lngLat.lat);
         });

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -233,9 +233,9 @@ hqDefine("geospatial/js/gps_capture",[
         });
 
         map.addControl(
-            new MapboxGeocoder({
-                accessToken: mapboxgl.accessToken,
-                mapboxgl: mapboxgl,
+            new MapboxGeocoder({  // eslint-disable-line no-undef
+                accessToken: mapboxgl.accessToken,  // eslint-disable-line no-undef
+                mapboxgl: map,
                 types: 'address',
                 proximity: centerCoordinates.toString(),  // bias results to this point
                 marker: false,

--- a/corehq/apps/geospatial/templates/manage_gps_data.html
+++ b/corehq/apps/geospatial/templates/manage_gps_data.html
@@ -11,6 +11,7 @@
     <!-- Scripts for mapbox -->
     <script src='https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.js'></script>
     <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.0/mapbox-gl-draw.js'></script>
+    <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js"></script>
     {% compress js %}
         <script src="{% static 'geospatial/js/gps_capture.js' %}"></script>
     {% endcompress %}
@@ -20,6 +21,7 @@
  {{ block.super }}
  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.css">
  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.0/mapbox-gl-draw.css" type="text/css">
+ <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.css" type="text/css">
  {% endblock %}
 
 


### PR DESCRIPTION
## Product Description
The GPS capture map now has an address bar where the user can type in the address of the specific mobile worker/case. A marker is placed on the selected address location and the input fields are updated accordingly. Only addresses are supported, so the user won't be able to select countries, regions, postal codes etc...only specific addresses.

What the map looks like with the marker at the selected address location:

![image](https://github.com/dimagi/commcare-hq/assets/44245062/14528888-066d-415b-b4a1-b5c3180d23b9)


## Technical Summary
A simple `MapboxGeocoder` object is added to the map controls for geocoding support.

## Feature Flag
Geospatial FF

## Safety Assurance

### Safety story
Tested locally.

### Automated test coverage
No automated tests.

### QA Plan
No formal QA planned at this stage.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
