### PR TITLE
Set ES case_search replicas to 0 for dev envs

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -134,17 +134,29 @@ ELASTICSEARCH_DEBUG_HOSTS = {
     'icds': '100.71.184.7',
 }
 
-# corehq/apps/es/index/settings.py sets the number of replicas for the
-# case_search index to 1. But dev environments only have one node, which
-# is already in use by the primary, and so the replica cannot be
-# assigned. The following overrides those settings. (We can't use the
-# constants defined in that file, because it will cause a circular
-# import.)
+# The default settings for Elasticsearch replicas and shards are managed
+# in `corehq/apps/es/index/settings.py`. These values are not
+# appropriate for dev environments, where there is only one node and so
+# replicas can't be allocated, and where indexed data is unlikely to
+# exceed 20GB, which is the recommended size per shard. The following
+# sets minimum values for all Elasticsearch indices:
 ES_SETTINGS = {
-    'case_search': {
+    'default': {
         'number_of_replicas': 0,
-        'number_of_shards': 5,
-    }
+        'number_of_shards': 1,
+    },
+
+    # If the space used by a shard is more than 20GB then you can
+    # increase the number of shards for a specific index
+    # (e.g. "case_search") by uncommenting and adapting the following:
+    #
+    # 'case_search': {
+    #     'number_of_replicas': 0,
+    #     'number_of_shards': 2,
+    # }
+    #
+    # [elasticsearch-head](https://github.com/mobz/elasticsearch-head)
+    # can show you how much space an index is using.
 }
 
 FORMPLAYER_INTERNAL_AUTH_KEY = "secretkey"

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -134,6 +134,19 @@ ELASTICSEARCH_DEBUG_HOSTS = {
     'icds': '100.71.184.7',
 }
 
+# corehq/apps/es/index/settings.py sets the number of replicas for the
+# case_search index to 1. But dev environments only have one node, which
+# is already in use by the primary, and so the replica cannot be
+# assigned. The following overrides those settings. (We can't use the
+# constants defined in that file, because it will cause a circular
+# import.)
+ES_SETTINGS = {
+    'case_search': {
+        'number_of_replicas': 0,
+        'number_of_shards': 5,
+    }
+}
+
 FORMPLAYER_INTERNAL_AUTH_KEY = "secretkey"
 
 # use console email by default


### PR DESCRIPTION
## Technical Summary

[These settings](https://github.com/dimagi/commcare-hq/blob/b4e53a51d01b44dd654f951dc2e25c5cd770b94a/corehq/apps/es/index/settings.py#L150) in `corehq/apps/es/index/settings.py` cannot work in a dev environment, because (currently) dev environments only have one Elasticsearch node, and so the replica can't be assigned.
```python
    IndexSettingsKey.CASE_SEARCH: {
        IndexTuningKey.REPLICAS: 1,
        IndexTuningKey.SHARDS: 5,
    },
```

This change is to fix that for dev environments by setting the number of case_search replicas to 0, as used by all other indices, and matches the default number of replicas.

Opening as a Draft PR for discussion.

## Feature Flag
Not applicable

## Safety Assurance

### Safety story

* Only affects dev environments.
* If the number of replicas has been manually set, then this change will have no effect on `$ ./manage.py ptop_preindex --reset`.

### Automated test coverage

Not applicable

### QA Plan

Not applicable

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
