### PR TITLE
Cache `get_geo_(case|user)_property()`

### DIFF
--- a/corehq/apps/geospatial/models.py
+++ b/corehq/apps/geospatial/models.py
@@ -145,3 +145,17 @@ class GeoConfig(models.Model):
     location_data_source = models.CharField(max_length=126, default=CUSTOM_USER_PROPERTY)
     user_location_property_name = models.CharField(max_length=256, default=GPS_POINT_CASE_PROPERTY)
     case_location_property_name = models.CharField(max_length=256, default=GPS_POINT_CASE_PROPERTY)
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self._clear_caches()
+
+    def delete(self, *args, **kwargs):
+        self._clear_caches()
+        return super().delete(*args, **kwargs)
+
+    def _clear_caches(self):
+        from .utils import get_geo_case_property, get_geo_user_property
+
+        get_geo_case_property.clear(self.domain)
+        get_geo_user_property.clear(self.domain)

--- a/corehq/apps/geospatial/tests/test_utils.py
+++ b/corehq/apps/geospatial/tests/test_utils.py
@@ -36,6 +36,7 @@ class TestGetGeoProperty(TestCase):
             user_location_property_name=user_geo_property,
         )
         config.save()
+        self.addCleanup(config.delete)
 
         self.assertEqual(get_geo_case_property(self.DOMAIN), case_geo_property)
         self.assertEqual(get_geo_user_property(self.DOMAIN), user_geo_property)

--- a/corehq/apps/geospatial/utils.py
+++ b/corehq/apps/geospatial/utils.py
@@ -4,10 +4,12 @@ from couchforms.geopoint import GeoPoint
 
 from corehq.apps.hqcase.case_helper import CaseHelper
 from corehq.apps.users.models import CommCareUser
+from corehq.util.quickcache import quickcache
 
 from .models import GeoConfig
 
 
+@quickcache(['domain'], timeout=24 * 60 * 60)
 def get_geo_case_property(domain):
     try:
         config = GeoConfig.objects.get(domain=domain)
@@ -16,6 +18,7 @@ def get_geo_case_property(domain):
     return config.case_location_property_name
 
 
+@quickcache(['domain'], timeout=24 * 60 * 60)
 def get_geo_user_property(domain):
     try:
         config = GeoConfig.objects.get(domain=domain)


### PR DESCRIPTION
## Technical Summary

`get_geo_case_property()` gets called for every row of the `CaseManagementMap` report. Best to cache it.

## Feature Flag

GEOSPATIAL

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Includes tests

### QA Plan

Not applicable.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
