### PR TITLE
Web apps case list "skip to bottom" button

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -743,7 +743,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             }
         },
 
-        onDestroy: function () {
+        onBeforeDetach: function () {
             const self = this;
             self.smallScreenListener.stopListening();
             $(window).off('scroll', self.boundHandleScroll);
@@ -939,8 +939,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             }
         },
 
-        onDestroy: function () {
-            CaseTileListView.__super__.onDestroy.apply(this, arguments);
+        onBeforeDetach: function () {
+            CaseTileListView.__super__.onBeforeDetach.apply(this, arguments);
             $('#content-container').removeClass('full-width');
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -371,6 +371,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             paginationGoText: '#goText',
             casesPerPageLimit: '.per-page-limit',
             searchMoreButton: '#search-more',
+            scrollToBottomButton: '#scroll-to-bottom',
         };
     };
 
@@ -382,6 +383,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             'click @ui.paginationGoButton': 'paginationGoAction',
             'click @ui.columnHeader': 'columnSortAction',
             'click @ui.searchMoreButton': 'searchMoreAction',
+            'click @ui.scrollToBottomButton': 'scrollToBottom',
             'keypress @ui.columnHeader': 'columnSortAction',
             'change @ui.casesPerPageLimit': 'onPerPageLimitChange',
             'keypress @ui.searchTextBox': 'searchTextKeyAction',
@@ -477,6 +479,12 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     scrollTop: $('#content-container').offset().top - constants.BREADCRUMB_HEIGHT_PX,
                 }, 350);
             }
+        },
+
+        scrollToBottom: function () {
+            $([document.documentElement, document.body]).animate({
+                scrollTop: $('.container .pagination-container').offset().top,
+            }, 500);
         },
 
         searchTextKeyAction: function (event) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -711,16 +711,42 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             }
         },
 
+        handleScroll: function () {
+            const self = this;
+            if (self.smallScreenEnabled) {
+                const $scrollButton = $('#scroll-to-bottom');
+                if (self.shouldShowScrollButton() && $scrollButton.is(':hidden')) {
+                    $scrollButton.fadeIn();
+                } else if (!self.shouldShowScrollButton() && !$scrollButton.is(':hidden')) {
+                    $scrollButton.fadeOut();
+                }
+            }
+        },
+
+        shouldShowScrollButton: function () {
+            const $pagination = $('.container .pagination-container');
+            const paginationOffscreen = $pagination[0]
+                ? $pagination.offset().top - $(window).scrollTop() > window.innerHeight : false;
+            return paginationOffscreen;
+        },
+
         onAttach() {
             const self = this;
             if (self.showMap) {
                 self.loadMap();
             }
             self.handleSmallScreenChange(self.smallScreenEnabled);
+            self.boundHandleScroll = self.handleScroll.bind(self);
+            $(window).on('scroll', self.boundHandleScroll);
+            if (self.shouldShowScrollButton()) {
+                $('#scroll-to-bottom').show();
+            }
         },
 
         onDestroy: function () {
-            this.smallScreenListener.stopListening();
+            const self = this;
+            self.smallScreenListener.stopListening();
+            $(window).off('scroll', self.boundHandleScroll);
         },
 
         templateContext: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -695,7 +695,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.initGeocoders();
         },
 
-        onDestroy: function () {
+        onBeforeDetach: function () {
             this.smallScreenListener.stopListening();
         },
 

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -3,7 +3,7 @@
 
 <script type="text/template" id="case-view-list-template">
   <div class="module-case-list-container">
-    <button id="scroll-to-bottom" class="btn btn-lg btn-circle btn-primary hidden-md hidden-lg" type="button" aria-label="{% trans 'Scroll to bottom' %}">
+    <button id="scroll-to-bottom" class="btn btn-lg btn-circle btn-primary hidden-md hidden-lg" type="button" aria-label="{% trans 'Scroll to bottom' %}" style="display: none;">
       <i class="fa fa-lg fa-arrow-down" aria-hidden="true"></i>
     </button>
     <div class="page-header menu-header" id="case-list-menu-header">

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -3,7 +3,9 @@
 
 <script type="text/template" id="case-view-list-template">
   <div class="module-case-list-container">
-
+    <button id="scroll-to-bottom" class="btn btn-lg btn-circle btn-primary hidden-md hidden-lg" type="button" aria-label="{% trans 'Scroll to bottom' %}">
+      <i class="fa fa-lg fa-arrow-down" aria-hidden="true"></i>
+    </button>
     <div class="page-header menu-header" id="case-list-menu-header">
       <% if (sidebarEnabled) {%>
         <button id="search-more" class="btn btn-primary visible-xs visible-sm pull-right" type="button"

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/menu.less
@@ -23,6 +23,18 @@
   }
 }
 
+.btn-circle {
+  border-radius: 50%;
+  aspect-ratio: 1;
+}
+
+#scroll-to-bottom {
+  position: fixed;
+  z-index: @zindex-formplayer-scroll-to-bottom;
+  bottom: 45px;
+  left: calc(100vw - 80px);
+}
+
 #menu-region .module-menu-container,
 #menu-region .module-case-list-container {
   background-color: white;

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/includes/variables.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/includes/variables.less
@@ -113,6 +113,7 @@
 @zindex-navbar-cloudcare:             995;
 @zindex-formplayer-progress:          990;
 @zindex-cloudcare-debugger:           1005;
+@zindex-formplayer-scroll-to-bottom:     5;
 
 
 @input-border-radius-large:       5px;


### PR DESCRIPTION
## Product Description
Adds a button to scroll to the bottom of the case list in web apps: when on a small screen and the pagination controls are offscreen. Otherwise, the button is hidden.

https://github.com/dimagi/commcare-hq/assets/100609770/547e3263-4cb3-4fd7-8b7c-81c7e8f1a568


## Technical Summary
[USH-3517](https://dimagi-dev.atlassian.net/browse/USH-3517)
Adds two main elements to the CaseListView - a UI element for the "scroll to bottom" button with an action that performs the scroll when clicked, and an event handler that listens to the scroll event, to determine whether the button should be shown or hidden at that time.

Also changes the function being used for cleanup of a couple of event handlers from `onDestroy` to `onBeforeDetach`, to be more in line with what Marionette recommends in its docs.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Tested locally in different app configs and screen sizes and made sure to add cleanup to the event listener so it doesn't hang around and cause a memory leak.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
QA as part of [USH-3485](https://dimagi-dev.atlassian.net/browse/USH-3485)


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3517]: https://dimagi-dev.atlassian.net/browse/USH-3517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-3485]: https://dimagi-dev.atlassian.net/browse/USH-3485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ