### PR TITLE
Refactor loading GPS cases/users

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -454,29 +454,10 @@ hqDefine("geospatial/js/geospatial_map", [
                     url: initialPageData.reverse('get_users_with_gps'),
                     success: function (data) {
                         self.hasFiltersChanged(false);
+                        const userData = partitionUserData(data.user_data);
+                        missingGPSModelInstance.usersWithoutGPS(userData.missingGPS);
 
-                        // TODO: There is a lot of indexing happening here. This should be replaced with a mapping to make reading it more explicit
-                        const usersWithoutGPS = data.user_data.filter(function (item) {
-                            return item.gps_point === null || !item.gps_point.length;
-                        });
-                        missingGPSModelInstance.usersWithoutGPS(usersWithoutGPS);
-
-                        const usersWithGPS = data.user_data.filter(function (item) {
-                            return item.gps_point !== null && item.gps_point.length;
-                        });
-
-                        const userData = _.object(_.map(usersWithGPS, function (userData) {
-                            const gpsData = (userData.gps_point) ? userData.gps_point.split(' ') : [];
-                            const lat = parseFloat(gpsData[0]);
-                            const lng = parseFloat(gpsData[1]);
-
-                            const editUrl = initialPageData.reverse('edit_commcare_user', userData.id);
-                            const link = `<a class="ajax_dialog" href="${editUrl}" target="_blank">${userData.username}</a>`;
-
-                            return [userData.id, {'coordinates': {'lat': lat, 'lng': lng}, 'link': link}];
-                        }));
-
-                        const userMapItems = map.addMarkersToMap(userData, userMarkerColors);
+                        const userMapItems = map.addMarkersToMap(userData.withGPS, userMarkerColors);
                         userModels(userMapItems);
                     },
                     error: function () {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -487,6 +487,36 @@ hqDefine("geospatial/js/geospatial_map", [
             }
         }
 
+        // This function partitions case data into cases with and without GPS data
+        function partitionCaseData(caseData) {
+            const caseItemMapping = {
+                ID: 0,
+                COORDINATES: 1,
+                LINK: 2,
+            };
+
+            let caseDataPartitions = {
+                missingGPS: [],
+                withGPS: {},
+            };
+
+            for (const caseItem of caseData) {
+                const coordinates = caseItem[caseItemMapping.COORDINATES];
+                if (coordinates === null) {
+                    caseDataPartitions.missingGPS.push(
+                        {"link": caseItem[caseItemMapping.LINK]}
+                    );
+                } else {
+                    const caseId = caseItem[caseItemMapping.ID];
+                    caseDataPartitions.withGPS[caseId] = {
+                        'coordinates': coordinates,
+                        'link': caseItem[caseItemMapping.LINK],
+                    };
+                }
+            }
+            return caseDataPartitions;
+        }
+
         function loadCases(caseData) {
             map.removeMarkersFromMap(caseModels());
             caseModels([]);

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -517,32 +517,21 @@ hqDefine("geospatial/js/geospatial_map", [
             return caseDataPartitions;
         }
 
-        function loadCases(caseData) {
+        function loadCases(rawCaseData) {
             map.removeMarkersFromMap(caseModels());
             caseModels([]);
-            var casesWithGPS = caseData.filter(function (item) {
-                return item[1] !== null;
-            });
-            // Index by case_id
-            var casesById = _.object(_.map(casesWithGPS, function (item) {
-                if (item[1]) {
-                    return [item[0], {'coordinates': item[1], 'link': item[2]}];
-                }
-            }));
-            const caseMapItems = map.addMarkersToMap(casesById, caseMarkerColors);
+
+            const caseData = partitionCaseData(rawCaseData);
+            const caseMapItems = map.addMarkersToMap(caseData.withGPS, caseMarkerColors);
             caseModels(caseMapItems);
 
-            var $missingCasesDiv = $("#missing-gps-cases");
-            var casesWithoutGPS = caseData.filter(function (item) {
-                return item[1] === null;
-            });
-            casesWithoutGPS = _.map(casesWithoutGPS, function (item) {return {"link": item[2]};});
+            const $missingCasesDiv = $("#missing-gps-cases");
             // Don't re-apply if this is the next page of the pagination
             if (ko.dataFor($missingCasesDiv[0]) === undefined) {
                 $missingCasesDiv.koApplyBindings(missingGPSModelInstance);
-                missingGPSModelInstance.casesWithoutGPS(casesWithoutGPS);
+                missingGPSModelInstance.casesWithoutGPS(caseData.missingGPS);
             }
-            missingGPSModelInstance.casesWithoutGPS(casesWithoutGPS);
+            missingGPSModelInstance.casesWithoutGPS(caseData.missingGPS);
         }
 
         $(document).ajaxComplete(function (event, xhr, settings) {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -489,7 +489,7 @@ hqDefine("geospatial/js/geospatial_map", [
 
         // This function partitions case data into cases with and without GPS data
         function partitionCaseData(caseData) {
-            const caseItemMapping = {
+            const caseItem = {
                 ID: 0,
                 COORDINATES: 1,
                 LINK: 2,
@@ -500,17 +500,17 @@ hqDefine("geospatial/js/geospatial_map", [
                 withGPS: {},
             };
 
-            for (const caseItem of caseData) {
-                const coordinates = caseItem[caseItemMapping.COORDINATES];
+            for (const currCase of caseData) {
+                const coordinates = currCase[caseItem.COORDINATES];
                 if (coordinates === null) {
                     caseDataPartitions.missingGPS.push(
-                        {"link": caseItem[caseItemMapping.LINK]}
+                        {"link": currCase[caseItem.LINK]}
                     );
                 } else {
-                    const caseId = caseItem[caseItemMapping.ID];
+                    const caseId = currCase[caseItem.ID];
                     caseDataPartitions.withGPS[caseId] = {
                         'coordinates': coordinates,
-                        'link': caseItem[caseItemMapping.LINK],
+                        'link': currCase[caseItem.LINK],
                     };
                 }
             }

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -413,6 +413,32 @@ hqDefine("geospatial/js/geospatial_map", [
             self.showFilterMenu = ko.observable(true);
             self.hasErrors = ko.observable(false);
 
+            // This function partitions user data into users with and without GPS data
+            function partitionUserData(userData) {
+                const userDataPartitions = {
+                    missingGPS: [],
+                    withGPS: {},
+                };
+
+                for (const userItem of userData) {
+                    if (userItem.gps_point === null || !userItem.gps_point.length) {
+                        userDataPartitions.missingGPS.push(userItem);
+                    } else {
+                        const gpsData = userItem.gps_point.split(' ');
+                        const lat = parseFloat(gpsData[0]);
+                        const lng = parseFloat(gpsData[1]);
+
+                        const editUrl = initialPageData.reverse('edit_commcare_user', userItem.id);
+                        const link = `<a class="ajax_dialog" href="${editUrl}" target="_blank">${userItem.username}</a>`;
+                        userDataPartitions.withGPS[userItem.id] = {
+                            'coordinates': {'lat': lat, 'lng': lng},
+                            'link': link,
+                        };
+                    }
+                }
+                return userDataPartitions;
+            }
+
             self.loadUsers = function () {
                 map.removeMarkersFromMap(userModels());
                 userModels([]);


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR addresses a TODO that was put in by [this](https://github.com/dimagi/commcare-hq/pull/33488/commits/998ef185b28dcb9c59953591a0f493e246afe30f) commit.

The front-end code for the Case Management page responsible for loading in cases/users has been refactored to reduce the amount of indexing that happens to split cases/users that do and don't have GPS data. Now, only a single iteration is done to split the case/user data and the code has been abstracted into separate functions.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Small refactor change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
