### PR TITLE
Correctly map dedupe user properties to their system equivalents

### DIFF
--- a/corehq/apps/data_interfaces/migrations/0034_case_name_actions.py
+++ b/corehq/apps/data_interfaces/migrations/0034_case_name_actions.py
@@ -13,13 +13,11 @@ def backwards(apps, schema_editor):
 def replace_property_value(old_value, new_value):
     actions = CaseDeduplicationActionDefinition.objects.filter(case_properties__contains=[old_value])
     for action in actions:
-        props = action.case_properties
-        try:
-            value_index = props.index(old_value)
-        except ValueError:
-            # Should never happen, but ignore these errors
-            continue
-        props[value_index] = new_value
+        action.case_properties = [
+            new_value if value == old_value else value
+            for value in action.case_properties
+        ]
+
         action.save()
 
 

--- a/corehq/apps/data_interfaces/migrations/0034_case_name_actions.py
+++ b/corehq/apps/data_interfaces/migrations/0034_case_name_actions.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+from corehq.apps.data_interfaces.models import CaseDeduplicationActionDefinition
+
+
+def forwards(apps, schema_editor):
+    replace_property_value('case_name', 'name')
+
+
+def backwards(apps, schema_editor):
+    replace_property_value('name', 'case_name')
+
+
+def replace_property_value(old_value, new_value):
+    actions = CaseDeduplicationActionDefinition.objects.filter(case_properties__contains=[old_value])
+    for action in actions:
+        props = action.case_properties
+        try:
+            value_index = props.index(old_value)
+        except ValueError:
+            # Should never happen, but ignore these errors
+            continue
+        props[value_index] = new_value
+        action.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('data_interfaces', '0033_automaticupdaterule_deleted_on'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/corehq/apps/data_interfaces/pillow.py
+++ b/corehq/apps/data_interfaces/pillow.py
@@ -43,11 +43,7 @@ class CaseDeduplicationProcessor(PillowProcessor):
         return AutomaticUpdateRule.by_domain_cached(domain, AutomaticUpdateRule.WORKFLOW_DEDUPLICATE)
 
     def _process_case_update(self, domain, case_update):
-        changed_properties = set()
-        if case_update.get_create_action() is not None:
-            changed_properties.update(set(case_update.get_create_action().raw_block.keys()))
-        if case_update.get_update_action() is not None:
-            changed_properties.update(set(case_update.get_update_action().raw_block.keys()))
+        changed_properties = case_update.get_normalized_update_property_names()
 
         for rule in self._get_rules(domain):
             for action in rule.memoized_actions:

--- a/corehq/ex-submodules/casexml/apps/case/tests/xml/test_parser.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/xml/test_parser.py
@@ -1,0 +1,57 @@
+from casexml.apps.case.xml.parser import CaseUpdate
+from casexml.apps.case.xml import V2
+from django.test import SimpleTestCase
+
+
+class CaseUpdateTests(SimpleTestCase):
+    def test_constructor(self):
+        create_block = {
+            'case_name': 'test_case',
+            'owner_id': '12345',
+            'case_type': 'test_case_type'
+        }
+        update_block = {
+            'email': 'test@email.com'
+        }
+        case_block = self._create_case_block(create_block, update_block)
+
+        case_update = CaseUpdate('case_id', V2, case_block)
+
+        self.assertEqual(case_update.id, 'case_id')
+        self.assertEqual(case_update.version, V2)
+        self.assertEqual(case_update.user_id, '')
+        self.assertEqual(case_update.modified_on_str, '')
+
+        self.assertTrue(case_update.creates_case())
+        self.assertTrue(case_update.updates_case())
+        self.assertEqual(case_update.create_block['case_name'], 'test_case')
+        self.assertEqual(case_update.update_block['email'], 'test@email.com')
+
+    def test_get_normalized_updates(self):
+        create_block = {
+            'case_name': 'test_case',
+            'owner_id': '12345',
+            'case_type': 'test_case_type'
+        }
+        case_block = self._create_case_block(create_block)
+
+        case_update = CaseUpdate('case_id', V2, case_block)
+
+        self.assertEqual(case_update.get_normalized_update_property_names(),
+                         {'name', 'owner_id', 'type'})
+
+    def _create_case_block(self, create_block=None, update_block=None):
+        block = {
+            '@case_id': '1111',
+            '@date_modified': '2023-02-09T17:01:15.054000Z',
+            '@user_id': '2222',
+            '@xmlns': 'http://commcarehq.org/case/transaction/v2',
+        }
+
+        if create_block:
+            block['create'] = create_block
+
+        if update_block:
+            block['update'] = update_block
+
+        return block

--- a/corehq/ex-submodules/casexml/apps/case/xml/parser.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/parser.py
@@ -370,9 +370,9 @@ class CaseUpdate(object):
     def get_normalized_update_property_names(self):
         changed_properties = set()
         if self.creates_case():
-            changed_properties.update(set(self.get_create_action().raw_block.keys()))
+            changed_properties.update(self.get_create_action().raw_block.keys())
         if self.updates_case():
-            changed_properties.update(set(self.get_update_action().raw_block.keys()))
+            changed_properties.update(self.get_update_action().raw_block.keys())
 
         property_map = \
             CaseCreateAction.V1_PROPERTY_MAPPING if self.version == V1 else CaseCreateAction.V2_PROPERTY_MAPPING

--- a/migrations.lock
+++ b/migrations.lock
@@ -332,6 +332,7 @@ data_interfaces
  0031_add_domaincaserulerun_status_choices
  0032_bootstrap_audit_events_for_update_rules
  0033_automaticupdaterule_deleted_on
+ 0034_case_name_actions
 dhis2
  0001_initial
  0002_auto_20170322_1323


### PR DESCRIPTION
## Technical Summary
This is the backend/processing portion of https://dimagi-dev.atlassian.net/browse/SAAS-14919 (not the display part). This fix means that deduplication rules that are configured to match on 'name' will now work correctly on initial population and updates. Prior, there was an issue where, because of how 'name' is referred to as 'name' in some contexts or 'case_name' in others, these updates were getting skipped.

## Safety Assurance

### Safety story
I'm shaky on our case properties. I've reached out to Kai and Ethan to try to confirm that the code here will not break how cases are handled elsewhere. These changes should only affect deduplication rules, which limits their impact. It's worth noting that I had to change an existing dedupe test after making these changes, because that existing test relied on 'case_name' rather than 'name' -- any existing customers who have dedupe rules that match on 'case_name' will now no longer work. The included migration handles these rules. The good news is that we have far more customers using 'name' than 'case_name' in production.

In the event of a rollback, the migration would be unapplied. We have existing rules that are using 'name' rather than 'case_name', which means those rules would suddenly change to 'case_name'. I don't consider this too much of an issue, as, due to the bug that this PR is designed to fix, 'name' doesn't work without this PR. In the event of a rollback, we're basically just upgrading the rules to handle updates.

### Automated test coverage

Changes are covered by two test suites. The regression test for the bug I encountered is at:
_data_interfaces.tests.test_case_deduplication:DeduplicationPillowTest.test_pillow_processes_normalized_system_properties_

### QA Plan

I don't mind submitting this to QA for a general purpose smoke test, due to my uncertainty around case properties.


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

The migration will need to be rolled back in addition to this PR (that might happen automatically?)

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
