### PR TITLE
update outdated github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
       REUSE_DB: true  # do not drop databases on completion to save time
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Docker info
@@ -55,7 +55,7 @@ jobs:
       env:
         TOKEN: ${{ secrets.CODECOV_TOKEN }}
       if: env.TOKEN != ''
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       env:
         TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       if: env.TOKEN != ''
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: dimagi
         password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
@snopoke flagged that we are getting some [deprecation notices](https://github.com/dimagi/commcare-hq/actions/runs/6313476496) on actions, on looking I found that they were coming because of outdated action versions that we are referring to.
This PR updates the outdated github actions that were running on deprecated versions of Node or using deprecated actions APIs. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Only affects CI
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
