### PR TITLE
[USH-3711] Updated allowed heights logic in case tile definition UI

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -62,7 +62,7 @@ hqDefine("app_manager/js/details/column", function () {
         });
         self.tileHeight = ko.observable(self.original.height || 1);
         self.tileHeightOptions = ko.computed(function () {
-            return _.range(1, 5 - (self.tileRowStart() || 1));
+            return _.range(1, self.tileRowMax() + 1 - (self.tileRowStart() || 1));
         });
         self.horizontalAlign = ko.observable(self.original.horizontal_align || 'left');
         self.horizontalAlignOptions = ['left', 'center', 'right'];


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-3711

## Technical Summary
I think this is just an oversight. The number of allowed rows was increased during implementation of this UI, but the logic that limits an area's height, based on its row, is still using a hard-coded value that matches the old maximum number of rows.

## Feature Flag
USH: Configure custom case list tile

## Safety Assurance

### Safety story
This is a pretty trivial change in a custom app builder feature flag.

### Automated test coverage

no

### QA Plan

not requesting QA


### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
