### PR TITLE
endpoint action

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -300,7 +300,7 @@ class FormattedDetailColumn(object):
                 template=self.template,
                 sort_node=self.sort_node,
                 print_id=print_id,
-                action=self.action,
+                endpoint_action=self.action,
             )
         elif self.sort_xpath_function and self.detail.display == 'short':
             yield sx.Field(

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -3,7 +3,6 @@ import re
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml import const
 from corehq.apps.app_manager.suite_xml import xml_models as sx
-from corehq.apps.app_manager.suite_xml.sections.details import DetailContributor
 from corehq.apps.app_manager.xpath import (
     CaseXPath,
     CommCareSession,
@@ -12,7 +11,6 @@ from corehq.apps.app_manager.xpath import (
     LocationXpath,
     UsercaseXPath,
     XPath,
-    session_var,
 )
 from corehq.apps.hqmedia.models import CommCareMultimedia
 
@@ -474,24 +472,8 @@ class EnumImage(Enum):
 
     @property
     def action(self):
-        if self.column.action_form_id and self.app.supports_detail_field_action:
-            action_form = self.app.get_form(self.column.action_form_id)
-            action = sx.Action(stack=sx.Stack(), display=sx.Display(text=sx.Text()))
-            frame = sx.PushFrame()
-            frame.add_command(XPath.string(id_strings.form_command(action_form)))
-
-            def map_source_to_target(source_meta, target_meta):
-                if target_meta.from_parent or target_meta.case_type != self.module.case_type:
-                    return sx.StackDatum(id=target_meta.id, value=session_var(source_meta.id))
-                return sx.StackDatum(id=target_meta.id, value="current()/@case_id")
-
-            datums = DetailContributor.get_datums_for_action(
-                self.entries_helper, self.module, action_form, map_source_to_target
-            )
-            for datum in datums:
-                frame.add_datum(datum)
-            action.stack.add_frame(frame)
-            return action
+        if self.column.endpoint_action_id and self.app.supports_detail_field_action:
+            return sx.EndpointAction(endpoint_id=self.column.endpoint_action_id, background="true")
 
     def _xpath_template(self, type):
         return "if({key_as_condition}, {key_as_var_name}"

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -538,35 +538,15 @@ class ModuleBaseValidator(object):
 
     def validate_case_list_field_actions(self):
         if hasattr(self.module, 'case_details'):
-            columns = [column for column in self.module.case_details.short.columns if column.action_form_id]
+            columns = [column for column in self.module.case_details.short.columns if column.endpoint_action_id]
+            form_endpoints = {
+                form.session_endpoint_id for form in self.app.get_forms() if form.session_endpoint_id
+            }
+
             for column in columns:
-                try:
-                    target_form = self.app.get_form(column.action_form_id)
-                except FormNotFoundException:
-                    return [{
-                        'type': 'case list field action form missing',
-                        'module': self.get_module_info(),
-                        'column': column,
-                    }]
-
-                if not target_form.requires_case():
+                if column.endpoint_action_id not in form_endpoints:
                     yield {
-                        'type': 'case list field action form must require case',
-                        'module': self.get_module_info(),
-                        'column': column,
-                    }
-
-                target_parent_module = target_form.get_module().root_module_id
-                if target_parent_module and target_parent_module != self.module.root_module_id:
-                    yield {
-                        'type': 'case list field action form must have same root module',
-                        'module': self.get_module_info(),
-                        'column': column,
-                    }
-
-                if target_form.get_module().case_type != self.module.case_type:
-                    yield {
-                        'type': 'case list field action form must have same case type',
+                        'type': 'case list field action endpoint missing',
                         'module': self.get_module_info(),
                         'column': column,
                     }

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1862,7 +1862,7 @@ class DetailColumn(IndexedSchema):
     filter_xpath = StringProperty(default="", exclude_if_none=True)
     time_ago_interval = FloatProperty(default=365.25)
     date_format = StringProperty(default="%d/%m/%y")
-    action_endpoint_id = FormIdProperty(default="", exclude_if_none=True)
+    endpoint_action_id = FormIdProperty(default="", exclude_if_none=True)
 
     @property
     def enum_dict(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1862,17 +1862,7 @@ class DetailColumn(IndexedSchema):
     filter_xpath = StringProperty(default="", exclude_if_none=True)
     time_ago_interval = FloatProperty(default=365.25)
     date_format = StringProperty(default="%d/%m/%y")
-    action_form_id = FormIdProperty(
-        # This should only be used by 'module.case_details.short'
-        # but adding in all possible reference here for safety
-        'modules[*].case_details.short.columns[*].action_form_id',
-        'modules[*].case_details.long.columns[*].action_form_id',
-        'modules[*].ref_details.short.columns[*].action_form_id',
-        'modules[*].ref_details.long.columns[*].action_form_id',
-        'modules[*].product_details.short.columns[*].action_form_id',
-        'modules[*].product_details.long.columns[*].action_form_id',
-        default="", exclude_if_none=True
-    )
+    action_endpoint_id = FormIdProperty(default="", exclude_if_none=True)
 
     @property
     def enum_dict(self):

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -261,7 +261,7 @@ hqDefine("app_manager/js/details/column", function () {
         }]).val(self.original.date_format);
         self.date_extra.ui.prepend($('<div/>').text(gettext(' Format ')));
 
-        self.autoSubmittingFormLabel = $('<span>Form to submit on click:</span>');
+        self.endpointActionLabel = $('<span>Form to submit on click:</span>');
         const formEndpointOptions = [{value: "-1", label: 'Select a form endpoint'}];
         let moduleName = "";
         const formEndpoints = Object.entries(initialPageData('form_endpoint_options'));
@@ -348,7 +348,7 @@ hqDefine("app_manager/js/details/column", function () {
             if (self.format.ui.parent().length > 0) {
                 self.date_extra.ui.detach();
                 self.enum_extra.ui.detach();
-                self.autoSubmittingFormLabel.detach();
+                self.endpointActionLabel.detach();
                 self.action_form_extra.ui.detach();
                 self.graph_extra.ui.detach();
                 self.late_flag_extra.ui.detach();
@@ -371,7 +371,7 @@ hqDefine("app_manager/js/details/column", function () {
                     self.enum_extra.values_are_icons(true);
                     self.enum_extra.keys_are_conditions(true);
                     self.format.ui.parent().append(self.enum_extra.ui);
-                    self.format.ui.parent().append(self.autoSubmittingFormLabel);
+                    self.format.ui.parent().append(self.endpointActionLabel);
                     self.format.ui.parent().append(self.action_form_extra.ui);
                     const actionForm = self.action_form_extra.ui.find('select');
                     actionForm.change(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -272,7 +272,7 @@ hqDefine("app_manager/js/details/column", function () {
             }
             formEndpointOptions.push({value: endpoint.id, label: endpoint.form_name});
         });
-        const selectedValue = self.original.endpoint_aciont_id ? self.original.endpoint_aciont_id : "-1";
+        const selectedValue = self.original.endpoint_action_id ? self.original.endpoint_action_id : "-1";
         self.action_form_extra = uiElement.select(formEndpointOptions)
             .val(selectedValue);
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -262,20 +262,18 @@ hqDefine("app_manager/js/details/column", function () {
         self.date_extra.ui.prepend($('<div/>').text(gettext(' Format ')));
 
         self.autoSubmittingFormLabel = $('<span>Form to submit on click:</span>');
-        const autoSubmittingFormOptions = [{value: "-1", label: 'Select a form'}];
+        const formEndpointOptions = [{value: "-1", label: 'Select a form endpoint'}];
         let moduleName = "";
-        const autoSubmittingForms =
-            Object.entries(initialPageData('auto_submitting_form_options'));
-        autoSubmittingForms
-            .forEach(([, form]) => {
-                if (form.module_name !== moduleName) {
-                    moduleName = form.module_name;
-                    autoSubmittingFormOptions.push({groupName: moduleName});
-                }
-                autoSubmittingFormOptions.push({value: form.form_id, label: form.form_name});
-            });
-        const selectedValue = self.original.action_form_id ? self.original.action_form_id : "-1";
-        self.action_form_extra = uiElement.select(autoSubmittingFormOptions)
+        const formEndpoints = Object.entries(initialPageData('form_endpoint_options'));
+        formEndpoints.forEach(([, endpoint]) => {
+            if (endpoint.module_name !== moduleName) {
+                moduleName = endpoint.module_name;
+                formEndpointOptions.push({groupName: moduleName});
+            }
+            formEndpointOptions.push({value: endpoint.id, label: endpoint.form_name});
+        });
+        const selectedValue = self.original.endpoint_aciont_id ? self.original.endpoint_aciont_id : "-1";
+        self.action_form_extra = uiElement.select(formEndpointOptions)
             .val(selectedValue);
 
         self.late_flag_extra = uiElement.input().val(self.original.late_flag.toString());
@@ -424,7 +422,7 @@ hqDefine("app_manager/js/details/column", function () {
             column.format = self.format.val();
             column.date_format = self.date_extra.val();
             column.enum = self.enum_extra.getItems();
-            column.action_form_id = self.action_form_extra.val() === "-1" ? null : self.action_form_extra.val();
+            column.endpoint_action_id = self.action_form_extra.val() === "-1" ? null : self.action_form_extra.val();
             column.grid_x = self.tileColumnStart();
             column.grid_y = self.tileRowStart();
             column.height = self.tileHeight();

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -345,7 +345,7 @@ class DetailContributor(SectionContributor):
         return action
 
     @staticmethod
-    def get_datums_for_action(entries_helper, source_module, target_form, source_target_mapper=None):
+    def get_datums_for_action(entries_helper, source_module, target_form):
         target_form_dm = entries_helper.get_datums_meta_for_form_generic(target_form)
         source_form_dm = []
         if len(source_module.forms):
@@ -361,12 +361,9 @@ class DetailContributor(SectionContributor):
                 except ValueError:
                     pass
                 else:
-                    if source_target_mapper:
-                        yield source_target_mapper(source_dm, target_meta)
-                    else:
-                        yield StackDatum(
-                            id=target_meta.id,
-                            value=session_var(source_dm.id))
+                    yield StackDatum(
+                        id=target_meta.id,
+                        value=session_var(source_dm.id))
             else:
                 s_datum = target_meta.datum
                 yield StackDatum(id=s_datum.id, value=s_datum.function)

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -834,7 +834,7 @@ class EndpointAction(XmlObject):
 
 class Field(OrderedXmlObject):
     ROOT_NAME = 'field'
-    ORDER = ('style', 'header', 'template', 'sort_node')
+    ORDER = ('style', 'header', 'template', 'endpoint_action', 'sort_node')
 
     sort = StringField('@sort')
     print_id = StringField('@print-id')

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -825,6 +825,13 @@ class LocalizedAction(ActionMixin, TextOrDisplay):
     pass
 
 
+class EndpointAction(XmlObject):
+    ROOT_NAME = 'endpoint_action'
+
+    endpoint_id = StringField('@endpoint_id')
+    background = StringField('@background')
+
+
 class Field(OrderedXmlObject):
     ROOT_NAME = 'field'
     ORDER = ('style', 'header', 'template', 'sort_node')

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -843,7 +843,7 @@ class Field(OrderedXmlObject):
     template = NodeField('template', Template)
     sort_node = NodeField('sort', Sort)
     background = NodeField('background/text', Text)
-    action = NodeField('action', Action)
+    endpoint_action = NodeField('endpoint_action', EndpointAction)
 
 
 class Lookup(OrderedXmlObject):

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -72,7 +72,7 @@
   {% initial_page_data 'js_options' js_options %}
   {% initial_page_data 'multimedia_object_map' multimedia.object_map %}
   {% initial_page_data 'case_list_form_options' case_list_form_options %}
-  {% initial_page_data 'auto_submitting_form_options' auto_submitting_form_options %}
+  {% initial_page_data 'form_endpoint_options' form_endpoint_options %}
   {% initial_page_data 'case_list_form_not_allowed_reasons' case_list_form_not_allowed_reasons %}
   {% initial_page_data 'case_type' module.case_type %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -504,25 +504,10 @@
                 <a href="{{ module_url }}">{{ module_name }}</a> has a case search property
                 <code>{{ property }}</code> that references an invalid instance.
               {% endblocktrans %}
-            {% case "case list field action form missing" %}
+            {% case "case list field action endpoint missing" %}
               {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
                 <a href="{{ module_url }}">{{ module_name }}</a> has a case list property
-                that references a missing form: <code>{{ column.header|trans:langs }}</code>.
-              {% endblocktrans %}
-            {% case "case list field action form must require case" %}
-              {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
-                <a href="{{ module_url }}">{{ module_name }}</a> has a case list property
-                that references form with a different case type: <code>{{ column.header|trans:langs }}</code>.
-              {% endblocktrans %}
-            {% case "case list field action form must have same root module" %}
-              {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
-                <a href="{{ module_url }}">{{ module_name }}</a> has a case list property
-                that references form with a different parent module: <code>{{ column.header|trans:langs }}</code>.
-              {% endblocktrans %}
-            {% case "case list field action form must have same case type" %}
-              {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
-                <a href="{{ module_url }}">{{ module_name }}</a> has a case list property
-                that references form with a different case type: <code>{{ column.header|trans:langs }}</code>.
+                that references a missing form endpoint: <code>{{ column.header|trans:langs }}</code>.
               {% endblocktrans %}
             {% case "error" %}
               Details: {{ error.message }}

--- a/corehq/apps/app_manager/tests/test_suite_formats.py
+++ b/corehq/apps/app_manager/tests/test_suite_formats.py
@@ -319,124 +319,20 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
                     MappingItem(key='1', value={'en': 'jr://icons/star-gold.png'}),
                     MappingItem(key='0', value={'en': 'jr://icons/star-grey.png'}),
                 ],
-                action_form_id=f1.unique_id,
+                endpoint_aciont_id="auto_submit_form_endpoint",
             ),
         ]
 
         action_spec = """
         <partial>
-          <action>
-            <display><text/></display>
-            <stack>
-              <push>
-                <command value="'m0-f1'"/>
-                <datum id="case_id" value="current()/@case_id"/>
-              </push>
-            </stack>
-          </action>
+          <endpoint_action endpoint_id="auto_submit_form_endpoint" background="true"/>
         </partial>
         """
         # check correct suite is generated
         self.assertXmlPartialEqual(
             action_spec,
             factory.app.create_suite(),
-            './detail[1]/field/action'
-        )
-
-    @flag_enabled('CASE_LIST_CLICKABLE_ICON')
-    def test_case_detail_icon_mapping_with_action_child_module(self, *args):
-        factory = AppFactory(domain='domain', name='Case list field actions', build_version='2.54.0')
-        m0, f0 = factory.new_basic_module("module1", "case")
-        factory.form_requires_case(f0)
-
-        m1, f1 = factory.new_basic_module("module2", "child_case", parent_module=m0)
-        factory.form_requires_case(f1)
-
-        f2 = factory.new_form(m1)
-        factory.form_requires_case(f2)
-
-        m1.case_details.short.columns = [
-            DetailColumn(
-                header={'en': 'Starred'},
-                model='case',
-                field='starred',
-                format='clickable-icon',
-                enum=[
-                    MappingItem(key='1', value={'en': 'jr://icons/star-gold.png'}),
-                    MappingItem(key='0', value={'en': 'jr://icons/star-grey.png'}),
-                ],
-                action_form_id=f2.unique_id,
-            ),
-        ]
-
-        action_spec = """
-            <partial>
-              <action>
-                <display><text/></display>
-                <stack>
-                  <push>
-                    <command value="'m1-f1'"/>
-                    <datum id="case_id_child_case" value="current()/@case_id"/>
-                  </push>
-                </stack>
-              </action>
-            </partial>
-            """
-
-        self.assertXmlPartialEqual(
-            action_spec,
-            factory.app.create_suite(),
-            './detail[3]/field/action'
-        )
-
-    @flag_enabled('CASE_LIST_CLICKABLE_ICON')
-    def test_case_detail_icon_mapping_with_action_parent_select(self, *args):
-        factory = AppFactory(domain='domain', name='Case list field actions', build_version='2.54.0')
-        m0, f0 = factory.new_basic_module("module1", "case")
-        factory.form_requires_case(f0)
-
-        m1, f1 = factory.new_basic_module("module2", "child_case")
-        m1.parent_select.active = True
-        m1.parent_select.module_id = m0.unique_id
-
-        factory.form_requires_case(f1)
-
-        f2 = factory.new_form(m1)
-        factory.form_requires_case(f2)
-
-        m1.case_details.short.columns = [
-            DetailColumn(
-                header={'en': 'Starred'},
-                model='case',
-                field='starred',
-                format='clickable-icon',
-                enum=[
-                    MappingItem(key='1', value={'en': 'jr://icons/star-gold.png'}),
-                    MappingItem(key='0', value={'en': 'jr://icons/star-grey.png'}),
-                ],
-                action_form_id=f2.unique_id,
-            ),
-        ]
-
-        action_spec = """
-                <partial>
-                  <action>
-                    <display><text/></display>
-                    <stack>
-                      <push>
-                        <command value="'m1-f1'"/>
-                        <datum id="parent_id" value="instance('commcaresession')/session/data/parent_id"/>
-                        <datum id="case_id" value="current()/@case_id"/>
-                      </push>
-                    </stack>
-                  </action>
-                </partial>
-                """
-
-        self.assertXmlPartialEqual(
-            action_spec,
-            factory.app.create_suite(),
-            './detail[3]/field/action'
+            './detail[1]/field/endpoint_action'
         )
 
     @flag_enabled('CASE_LIST_CLICKABLE_ICON')
@@ -464,7 +360,7 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
                     MappingItem(key='1', value={'en': 'jr://icons/star-gold.png'}),
                     MappingItem(key='0', value={'en': 'jr://icons/star-grey.png'}),
                 ],
-                action_form_id=f2.unique_id,
+                endpoint_aciont_id="auto_submit_form_endpoint",
             ),
         ]
 

--- a/corehq/apps/app_manager/tests/test_suite_formats.py
+++ b/corehq/apps/app_manager/tests/test_suite_formats.py
@@ -319,7 +319,7 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
                     MappingItem(key='1', value={'en': 'jr://icons/star-gold.png'}),
                     MappingItem(key='0', value={'en': 'jr://icons/star-grey.png'}),
                 ],
-                endpoint_aciont_id="auto_submit_form_endpoint",
+                endpoint_action_id="auto_submit_form_endpoint",
             ),
         ]
 
@@ -332,7 +332,7 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
         self.assertXmlPartialEqual(
             action_spec,
             factory.app.create_suite(),
-            './detail[1]/field/endpoint_action'
+            './detail[@id="m0_case_short"]/field/endpoint_action'
         )
 
     @flag_enabled('CASE_LIST_CLICKABLE_ICON')
@@ -360,7 +360,7 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
                     MappingItem(key='1', value={'en': 'jr://icons/star-gold.png'}),
                     MappingItem(key='0', value={'en': 'jr://icons/star-grey.png'}),
                 ],
-                endpoint_aciont_id="auto_submit_form_endpoint",
+                endpoint_action_id="auto_submit_form_endpoint",
             ),
         ]
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -216,7 +216,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
     context = {
         'details': _get_module_details_context(request, app, module, case_property_builder),
         'case_list_form_options': _case_list_form_options(app, module, lang),
-        'auto_submitting_form_options': _auto_submitting_form_options(app, module, lang),
+        'form_endpoint_options': _form_endpoint_options(app, module, lang),
         'valid_parents_for_child_module': _get_valid_parents_for_child_module(app, module),
         'shadow_parent': _get_shadow_parent(app, module),
         'case_types': {m.case_type for m in app.modules if m.case_type},
@@ -519,16 +519,16 @@ def _case_list_form_options(app, module, lang=None):
     }
 
 
-def _auto_submitting_form_options(app, module, lang=None):
+def _form_endpoint_options(app, module, lang=None):
     langs = None if lang is None else [lang]
     forms = [
         {
-            "form_id": form.unique_id,
+            "id": form.session_endpoint_id,
             "form_name": trans(form.name, langs),
             "module_name": trans(mod.name, langs)
         }
         for mod in app.get_modules()
-        for form in mod.get_forms() if form.is_auto_submitting_form(module.case_type)
+        for form in mod.get_forms() if form.session_endpoint_id and form.is_auto_submitting_form(module.case_type)
     ]
     return forms
 

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -15,6 +15,7 @@ from corehq.apps.app_manager.models import (
     ReportAppConfig,
     ReportModule,
     import_app,
+    FormLink,
 )
 from corehq.apps.app_manager.suite_xml.post_process.resources import (
     ResourceOverride,
@@ -240,11 +241,11 @@ class TestLinkedApps(BaseLinkedAppsTest):
 
     def test_overwrite_app_override_form_unique_ids_references(self):
         m0 = self.master1.get_module(0)
-        f1 = m0.new_form('f1', None, self.get_xml('very_simple_form').decode('utf-8'))
-        m0.case_details.short.columns[0].action_form_id = f1.unique_id
-        m0.case_details.long.columns[0].action_form_id = f1.unique_id
-
         master_form = list(self.master1.get_forms(bare=True))[0]
+        f1 = m0.new_form('f1', None, self.get_xml('very_simple_form').decode('utf-8'))
+        f1.form_links = [
+            FormLink(xpath="true()", form_id=master_form.unique_id, form_module_id=m0.unique_id),
+        ]
 
         add_xform_resource_overrides(self.linked_domain, self.linked_app.get_id, {
             master_form.unique_id: '123',
@@ -264,8 +265,7 @@ class TestLinkedApps(BaseLinkedAppsTest):
             self._get_form_ids_by_xmlns(linked_app)
         )
 
-        self.assertEqual(linked_app.get_module(0).case_details.short.columns[0].action_form_id, '456')
-        self.assertEqual(linked_app.get_module(0).case_details.long.columns[0].action_form_id, '456')
+        self.assertEqual(linked_app.get_module(0).get_form(1).form_links[0].form_id, '123')
 
     def test_multi_master_form_attributes_and_media_versions(self, *args):
         '''

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -726,13 +726,6 @@ CASE_LIST_MAP = StaticToggle(
               'spaceKey=saas&title=Allow+Configuration+of+Case+List+Tiles',
 )
 
-CASE_LIST_CLICKABLE_ICON = StaticToggle(
-    'case_list_clickable_icon',
-    'USH: Allow use of clickable icons in the case list in Web Apps to trigger auto submitting forms',
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN],
-)
-
 SHOW_PERSIST_CASE_CONTEXT_SETTING = StaticToggle(
     'show_persist_case_context_setting',
     'Allow toggling the persistent case context tile',
@@ -1693,6 +1686,14 @@ SESSION_ENDPOINTS = StaticToggle(
     [NAMESPACE_DOMAIN],
     description='Support external Android apps calling in to an endpoint in a '
                 'CommCare app. (Used by the Reminders App)',
+)
+
+CASE_LIST_CLICKABLE_ICON = StaticToggle(
+    'case_list_clickable_icon',
+    'USH: Allow use of clickable icons in the case list in Web Apps to trigger auto submitting forms',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+    parent_toggles=[SESSION_ENDPOINTS]
 )
 
 SUMOLOGIC_LOGS = DynamicallyPredictablyRandomToggle(


### PR DESCRIPTION
## Product Description
Implementation of 'endpoint actions' for case list fields.

Spec: https://docs.google.com/document/d/1coxsFVCYgaQdxE3rgYikRSgEgistrfIUJuoW5KMiM5w/edit#heading=h.13478xeglcy4

## Technical Summary
This is a rework of:
* https://github.com/dimagi/commcare-hq/pull/33528
* https://github.com/dimagi/commcare-hq/pull/33543
* https://github.com/dimagi/commcare-hq/pull/33542

It touches the same code but implements it differently. 

This PR introduces a new Suite XML construct:

```xml
<field>
  ...
  <endpoint_action 
    endpoint_id="auto_submit_form_endpoint" 
    // Id the of the endpoint to trigger on launching this action
    background="true" 
    // Signify that the action should be launched without taking user away from the current screen 
  />
</field>
```

## Feature Flag
Clickable case list icon

## Safety Assurance

### Safety story
Updates to a feature flagged feature. I did test this locally and there are also unit tests for the changes.

### Automated test coverage
Added in this PR

### QA Plan
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
