### PR TITLE
[USH-3506] Remove references to CaseProperty.group from DD

### DIFF
--- a/corehq/apps/data_dictionary/management/commands/populate_case_prop_groups.py
+++ b/corehq/apps/data_dictionary/management/commands/populate_case_prop_groups.py
@@ -28,7 +28,7 @@ def populate_case_prop_groups(domain):
 
     for case_prop in case_props:
         group, created = CasePropertyGroup.objects.get_or_create(
-            name=case_prop.group_obj.name,
+            name=case_prop.group_name,
             case_type=case_prop.case_type
         )
         case_prop.group_obj = group

--- a/corehq/apps/data_dictionary/management/commands/populate_case_prop_groups.py
+++ b/corehq/apps/data_dictionary/management/commands/populate_case_prop_groups.py
@@ -28,7 +28,7 @@ def populate_case_prop_groups(domain):
 
     for case_prop in case_props:
         group, created = CasePropertyGroup.objects.get_or_create(
-            name=case_prop.group,
+            name=case_prop.group_obj.name,
             case_type=case_prop.case_type
         )
         case_prop.group_obj = group

--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -163,9 +163,7 @@ class CaseProperty(models.Model):
 
     @property
     def group_name(self):
-        if self.group_obj:
-            return self.group_obj.name
-        return self.group
+        return self.group_obj.name
 
 
 class CasePropertyAllowedValue(models.Model):

--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -163,7 +163,8 @@ class CaseProperty(models.Model):
 
     @property
     def group_name(self):
-        return self.group_obj.name
+        if self.group_obj:
+            return self.group_obj.name
 
 
 class CasePropertyAllowedValue(models.Model):

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -42,7 +42,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
                 for (let prop of group.properties) {
                     const isGeoCaseProp = (self.geoCaseProp === prop.name);
-                    var propObj = propertyListItem(prop.name, prop.label, false, prop.group_name, self.name, prop.data_type,
+                    var propObj = propertyListItem(prop.name, prop.label, false, group.name, self.name, prop.data_type,
                         prop.description, prop.allowed_values, prop.fhir_resource_prop_path, prop.deprecated,
                         prop.removeFHIRResourcePropertyPath, isGeoCaseProp);
                     propObj.description.subscribe(changeSaveButton);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -42,7 +42,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
                 for (let prop of group.properties) {
                     const isGeoCaseProp = (self.geoCaseProp === prop.name);
-                    var propObj = propertyListItem(prop.name, prop.label, false, prop.group, self.name, prop.data_type,
+                    var propObj = propertyListItem(prop.name, prop.label, false, prop.group_obj.name, self.name, prop.data_type,
                         prop.description, prop.allowed_values, prop.fhir_resource_prop_path, prop.deprecated,
                         prop.removeFHIRResourcePropertyPath, isGeoCaseProp);
                     propObj.description.subscribe(changeSaveButton);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -42,7 +42,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
                 for (let prop of group.properties) {
                     const isGeoCaseProp = (self.geoCaseProp === prop.name);
-                    var propObj = propertyListItem(prop.name, prop.label, false, prop.group_obj.name, self.name, prop.data_type,
+                    var propObj = propertyListItem(prop.name, prop.label, false, prop.group_obj, self.name, prop.data_type,
                         prop.description, prop.allowed_values, prop.fhir_resource_prop_path, prop.deprecated,
                         prop.removeFHIRResourcePropertyPath, isGeoCaseProp);
                     propObj.description.subscribe(changeSaveButton);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -42,7 +42,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
                 for (let prop of group.properties) {
                     const isGeoCaseProp = (self.geoCaseProp === prop.name);
-                    var propObj = propertyListItem(prop.name, prop.label, false, prop.group_obj, self.name, prop.data_type,
+                    var propObj = propertyListItem(prop.name, prop.label, false, prop.group_name, self.name, prop.data_type,
                         prop.description, prop.allowed_values, prop.fhir_resource_prop_path, prop.deprecated,
                         prop.removeFHIRResourcePropertyPath, isGeoCaseProp);
                     propObj.description.subscribe(changeSaveButton);

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -31,7 +31,10 @@ class UpdateCasePropertyViewTest(TestCase):
         cls.case_type_obj = CaseType(name='caseType', domain=cls.domain_name)
         cls.case_type_obj.save()
         CaseProperty(case_type=cls.case_type_obj, name='property').save()
-        CasePropertyGroup(case_type=cls.case_type_obj, name='group').save()
+
+        group_obj = CasePropertyGroup(case_type=cls.case_type_obj, name='group')
+        group_obj.id = 1
+        group_obj.save()
 
     @classmethod
     def tearDownClass(cls):
@@ -182,7 +185,7 @@ class UpdateCasePropertyViewTest(TestCase):
         response = self.client.post(self.url, post_data)
         self.assertEqual(response.status_code, 200)
         prop = self._get_property()
-        self.assertEqual(prop.group, 'group')
+        self.assertEqual(prop.group_obj.name, 'group')
         self.assertIsNotNone(prop.group_obj)
 
     def test_update_with_no_group_name(self):

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -201,7 +201,6 @@ class UpdateCasePropertyViewTest(TestCase):
         response = self.client.post(self.url, post_data)
         self.assertEqual(response.status_code, 200)
         prop = self._get_property()
-        self.assertEqual(prop.group, '')
         self.assertIsNone(prop.group_obj)
 
 

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -217,13 +217,12 @@ def save_case_property(name, case_type, domain=None, data_type=None,
     prop.data_type = data_type if data_type else ""
     if description is not None:
         prop.description = description
-    if group is not None:
-        prop.group = group
-        # Allow properties to have no group
-        if group:
-            prop.group_obj, created = CasePropertyGroup.objects.get_or_create(name=group, case_type=prop.case_type)
-        else:
-            prop.group_obj = None
+
+    if group:
+        prop.group_obj, created = CasePropertyGroup.objects.get_or_create(name=group, case_type=prop.case_type)
+    else:
+        prop.group_obj = None
+
     if deprecated is not None:
         prop.deprecated = deprecated
     if label is not None:


### PR DESCRIPTION
## Product Description
Remove references to CaseProperty.group from data dictionary module

## Technical Summary
https://docs.google.com/document/d/1lXW2Y4IW_9F_rJKB2zOgPVIqqbWNsCYNJvfuSNeioVQ/edit#heading=h.b4j3gc6nhvyl

https://dimagi-dev.atlassian.net/browse/USH-3506

## Feature Flag
NA

## Safety Assurance

### Safety story
Local testing of import and export of data dictionary


### Automated test coverage
Existing unit tests

### QA Plan
NA


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
