### PR TITLE
Don't fail usercase task on missing users

### DIFF
--- a/corehq/apps/callcenter/tasks.py
+++ b/corehq/apps/callcenter/tasks.py
@@ -73,4 +73,5 @@ def sync_usercases_if_applicable(user, spawn_task):
 @task(queue='background_queue')
 def sync_usercases_task(user_id, domain):
     user = CouchUser.get_by_user_id(user_id)
-    sync_usercases(user, domain)
+    if user:
+        sync_usercases(user, domain)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2531,7 +2531,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
 
     def save(self, fire_signals=True, **params):
         super().save(fire_signals=fire_signals, **params)
-        if fire_signals:
+        if fire_signals and not self.to_be_deleted():
             from corehq.apps.callcenter.tasks import sync_web_user_usercases_if_applicable
             for domain in self.get_domains():
                 sync_web_user_usercases_if_applicable(self, domain)


### PR DESCRIPTION
## Product Description
no change

## Technical Summary
Sentry flagged this recent PR https://github.com/dimagi/commcare-hq/pull/33545
as being a likely cause for this issue: https://dimagi.sentry.io/issues/4497657227/
Turns out it's a longstanding issue that just changed (https://dimagi.sentry.io/issues/3908070098/)

I can't figure out exactly what the cause is - looks like something QA is doing, as all the events I looked at were on a QA domain.  One likely possibility is that it's just a race condition where users are saved, but then deleted before the task runs.  Given that [we don't run the task when users are deleted](https://github.com/dimagi/commcare-hq/blob/9f09abf6643780b53eb6ffa74eb8f216fa26d559/corehq/apps/users/models.py#L1748-L1749), this seems like an acceptable solution

## Feature Flag


## Safety Assurance

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change