### PR TITLE
Prevent HTML error on validating empty case property input

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_property_input.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_property_input.js
@@ -63,12 +63,14 @@ hqDefine('data_interfaces/js/case_property_input', [
                     data-bind="value: valueObservable, autocompleteSelect2: casePropertyNames"\
             ></select>\
           <!-- /ko -->\
+          <!-- ko ifnot: showDropdown -->\
           <input type="text"\
                  required\
                  class="textinput form-control"\
-                 data-bind="visible: !showDropdown, value: valueObservable, disable: disabled,\
+                 data-bind="value: valueObservable, disable: disabled,\
                  attr: { placeholder: placeholder }"\
           />\
+          <!-- /ko -->\
         </div>',
     };
 


### PR DESCRIPTION
## Technical Summary
This is the bug likely responsible for https://dimagi-dev.atlassian.net/browse/QA-5665.

Chrome (and possibly most browsers) will do internal validation on any form fields marked as required.  The difference between knockout's `if` and `visible` bindings is that markup that fails the `if` conditional is completely removed from the HTML, whereas `visible` conditionals just hide that HTML. Because form submissions still attempt to validate hidden HTML, this means the console error occurs.

## Safety Assurance

### Safety story
Tested dedupe and automatic update rules locally. For dedupe, I ensured that they still worked with both the `<select>` and `<input>` options. For automatic update rules, I made sure that the criteria and actions were saved correctly on new rules.

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
