### PR TITLE
add back old scope name

### DIFF
--- a/corehq/apps/ota/decorators.py
+++ b/corehq/apps/ota/decorators.py
@@ -66,7 +66,7 @@ def mobile_auth(view_func):
     It supports basic, session, and apikey auth, but not digest.
     Endpoints with this decorator will not enforce two factor authentication.
     """
-    return get_multi_auth_decorator(default=BASIC, oauth_scopes=['mobile_access'])(
+    return get_multi_auth_decorator(default=BASIC, oauth_scopes=['sync'])(
         two_factor_exempt(
             require_mobile_access(view_func)
         )
@@ -78,7 +78,7 @@ def mobile_auth_or_formplayer(view_func):
     This decorator is used only for anonymous web apps and SMS forms.
     Endpoints with this decorator will not enforce two factor authentication.
     """
-    return get_multi_auth_decorator(default=BASIC, allow_formplayer=True, oauth_scopes=['mobile_access'])(
+    return get_multi_auth_decorator(default=BASIC, allow_formplayer=True, oauth_scopes=['sync'])(
         two_factor_exempt(
             require_mobile_access(view_func)
         )

--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -266,7 +266,7 @@ class _AuthTestsBothBackends(object):
         token_model.objects.create(
             user=self.user.get_django_user(),
             token='mytoken',
-            scope='mobile_access',
+            scope='sync',
             expires=one_hour
         )
         expected_auth_context = {

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -368,7 +368,7 @@ def _secure_post_basic(request, domain, app_id=None):
 
 
 @handle_401_response
-@login_or_oauth2_ex(allow_cc_users=True, oauth_scopes=['mobile_access'])
+@login_or_oauth2_ex(allow_cc_users=True, oauth_scopes=['sync'])
 @two_factor_exempt
 @set_request_duration_reporting_threshold(60)
 def _secure_post_oauth2(request, domain, app_id=None):

--- a/settings.py
+++ b/settings.py
@@ -900,7 +900,8 @@ OAUTH2_PROVIDER = {
     'SCOPES': {
         'access_apis': 'Access API data on all your CommCare projects',
         'reports:view': 'Allow users to view and download all report data',
-        'mobile_access': 'Allow access to mobile sync and submit endpoints'
+        'mobile_access': 'Allow access to mobile sync and submit endpoints',
+        'sync': '(Deprecated, do not use) Allow access to mobile endpoints',
     },
     'REFRESH_TOKEN_EXPIRE_SECONDS': 60 * 60 * 24 * 15,  # 15 days
 }


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This has no user visible effects.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR temporarily changes the oauth scope required for mobile operations back to `sync` (the scope name during early testing) to match the released version of the commcare connect application. Future versions of the mobile app will support both scopes, so that this can be renamed as soon as the current cohort ends (roughly 2 weeks).


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This changes a feature only used by the commcare connect mobile application. It will not impact any non-connect users.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There is test coverage for token auth in the form submission tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
