### PR TITLE
Clean up logic in _process_repeat_record

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -424,7 +424,6 @@ class Repeater(RepeaterSuperProxy):
         self.save()
 
     def retire(self):
-        self.is_paused = False
         self.is_deleted = True
         self.save()
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -958,6 +958,11 @@ class RepeatRecord(Document):
             state = RECORD_FAILURE_STATE
         return state
 
+    @property
+    def exceeded_max_retries(self):
+        return (self.state == RECORD_FAILURE_STATE and self.overall_tries
+                >= self.max_possible_tries)
+
     @classmethod
     def all(cls, domain=None, due_before=None, limit=None):
         json_now = json_format_datetime(due_before or datetime.utcnow())

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -165,37 +165,29 @@ def retry_process_repeat_record(repeat_record_id, domain):
 
 
 def _process_repeat_record(repeat_record):
-
-    # A RepeatRecord should ideally never get into this state, as the
-    # domain_has_privilege check is also triggered in the create_repeat_records
-    # in signals.py. But if it gets here, forcefully cancel the RepeatRecord.
-    if not domain_can_forward(repeat_record.domain):
-        repeat_record.cancel()
-        repeat_record.save()
-
-    if repeat_record.exceeded_max_retries:
-        repeat_record.cancel()
-        repeat_record.save()
+    if repeat_record.cancelled:
         return
 
-    if repeat_record.cancelled:
+    if not domain_can_forward(repeat_record.domain) or repeat_record.exceeded_max_retries:
+        # When creating repeat records, we check if a domain can forward so
+        # we should never have a repeat record associated with a domain that
+        # cannot forward, but this is just to be sure
+        repeat_record.cancel()
+        repeat_record.save()
         return
 
     if repeat_record.is_repeater_deleted():
         if not repeat_record.doc_type.endswith(DELETED_SUFFIX):
             repeat_record.doc_type += DELETED_SUFFIX
-            repeat_record.save()
-
-    repeater = repeat_record.repeater
-    if not repeater:
         repeat_record.cancel()
         repeat_record.save()
         return
 
     try:
-        if repeater.is_paused:
-            # postpone repeat record by MAX_RETRY_WAIT so that these don't get picked in each cycle and
-            # thus clogging the queue with repeat records with paused repeater
+        if repeat_record.repeater.is_paused:
+            # postpone repeat record by MAX_RETRY_WAIT so that it is not fetched
+            # in the next check to process repeat records, which helps to avoid
+            # clogging the queue
             repeat_record.postpone_by(MAX_RETRY_WAIT)
         elif repeat_record.state == RECORD_PENDING_STATE or repeat_record.state == RECORD_FAILURE_STATE:
             repeat_record.fire()

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -173,13 +173,11 @@ def _process_repeat_record(repeat_record):
         repeat_record.cancel()
         repeat_record.save()
 
-    if (
-        repeat_record.state == RECORD_FAILURE_STATE and
-        repeat_record.overall_tries >= repeat_record.max_possible_tries
-    ):
+    if repeat_record.exceeded_max_retries:
         repeat_record.cancel()
         repeat_record.save()
         return
+
     if repeat_record.cancelled:
         return
 

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -1,6 +1,6 @@
 import uuid
 from contextlib import contextmanager
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import patch, Mock
 from uuid import uuid4
 
@@ -497,3 +497,62 @@ class TestFormRepeaterAllowedToForward(RepeaterTestCase):
         ]
         payload = Mock(xmlns='http://openrosa.org/formdesigner/def456')
         self.assertFalse(self.repeater.allowed_to_forward(payload))
+
+
+class TestCouchRepeatRecordMethods(TestCase):
+
+    def test_repeater_returns_active_repeater(self):
+        repeater = Repeater.objects.create(
+            domain=self.domain,
+            connection_settings=self.conn_settings,
+            is_deleted=False
+        )
+        repeat_record = RepeatRecord(
+            domain=self.domain,
+            payload_id='abc123',
+            registered_at=datetime.utcnow(),
+            repeater_id=repeater.repeater_id
+        )
+        repeat_record.save()
+        self.addCleanup(repeat_record.delete)
+
+        self.assertIsNotNone(repeat_record.repeater)
+
+    def test_repeater_does_not_return_deleted_repeater(self):
+        repeater = Repeater.objects.create(
+            domain=self.domain,
+            connection_settings=self.conn_settings,
+            is_deleted=True
+        )
+        repeat_record = RepeatRecord(
+            domain=self.domain,
+            payload_id='abc123',
+            registered_at=datetime.utcnow(),
+            repeater_id=repeater.repeater_id
+        )
+        repeat_record.save()
+        self.addCleanup(repeat_record.delete)
+
+        self.assertIsNone(repeat_record.repeater)
+
+    def test_repeater_returns_none_if_not_found(self):
+        repeat_record = RepeatRecord(
+            domain=self.domain,
+            payload_id='abc123',
+            registered_at=datetime.utcnow(),
+            repeater_id='def456'
+        )
+        repeat_record.save()
+        self.addCleanup(repeat_record.delete)
+
+        self.assertIsNone(repeat_record.repeater)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'repeat-record-tests'
+        cls.conn_settings = ConnectionSettings.objects.create(
+            domain=cls.domain,
+            name='To Be Deleted',
+            url="http://localhost/api/"
+        )

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1131,17 +1131,6 @@ class TestRepeaterDeleted(BaseRepeaterTest):
             self.assertEqual(mock_fire.call_count, 0)
             self.assertEqual(self.repeat_record.doc_type, "RepeatRecord-Deleted")
 
-    def test_paused_then_deleted(self):
-        self.repeater.pause()
-        self.repeater.retire()
-
-        with patch.object(RepeatRecord, 'fire') as mock_fire:
-            self.repeat_record = self.repeater.register(CommCareCase.objects.get_case(CASE_ID, self.domain))
-            self.repeat_record = reloaded(self.repeat_record)
-            _process_repeat_record(self.repeat_record)
-            self.assertEqual(mock_fire.call_count, 0)
-            self.assertEqual(self.repeat_record.doc_type, "RepeatRecord-Deleted")
-
 
 def reloaded(couch_doc: Document) -> Document:
     """

--- a/corehq/motech/repeaters/tests/test_tasks.py
+++ b/corehq/motech/repeaters/tests/test_tasks.py
@@ -14,14 +14,13 @@ from corehq.form_processor.utils.xform import (
     TestFormMetadata,
 )
 from corehq.motech.models import ConnectionSettings, RequestLog
-
+from corehq.motech.repeaters.models import FormRepeater, RepeatRecord, Repeater
+from corehq.motech.repeaters.tasks import delete_old_request_logs, process_repeater, _process_repeat_record
 from ..const import (
     RECORD_CANCELLED_STATE,
     RECORD_FAILURE_STATE,
     RECORD_PENDING_STATE,
 )
-from ..models import FormRepeater
-from ..tasks import process_repeater, delete_old_request_logs
 
 DOMAIN = 'gaidhlig'
 PAYLOAD_IDS = ['aon', 'dha', 'trì', 'ceithir', 'coig', 'sia', 'seachd', 'ochd',
@@ -154,3 +153,147 @@ def form_context(form_ids):
         yield
     finally:
         XFormInstance.objects.hard_delete_forms(DOMAIN, form_ids)
+
+
+class TestProcessRepeatRecord(TestCase):
+
+    def test_returns_if_record_is_cancelled(self):
+        repeat_record = RepeatRecord(
+            domain=self.domain,
+            payload_id='abc123',
+            registered_at=datetime.utcnow(),
+            repeater_id=self.repeater.repeater_id,
+            next_check=None,
+            cancelled=True,
+        )
+
+        _process_repeat_record(repeat_record)
+
+        self.assertEqual(self.mock_fire.call_count, 0)
+        self.assertEqual(self.mock_postpone_by.call_count, 0)
+
+    def test_cancels_and_returns_if_domain_cannot_forward(self):
+        self.mock_domain_can_forward.return_value = False
+
+        repeat_record = RepeatRecord(
+            domain=self.domain,
+            payload_id='abc123',
+            registered_at=datetime.utcnow(),
+            repeater_id=self.repeater.repeater_id,
+        )
+
+        _process_repeat_record(repeat_record)
+
+        fetched_repeat_record = RepeatRecord.get(repeat_record._id)
+        self.assertTrue(fetched_repeat_record.cancelled)
+        self.assertEqual(self.mock_fire.call_count, 0)
+        self.assertEqual(self.mock_postpone_by.call_count, 0)
+
+    def test_cancels_and_returns_if_repeat_record_exceeds_max_retries(self):
+        repeat_record = RepeatRecord(
+            domain=self.domain,
+            payload_id='abc123',
+            registered_at=datetime.utcnow(),
+            repeater_id=self.repeater.repeater_id,
+            failure_reason='test',
+            overall_tries=1,
+            max_possible_tries=1
+        )
+
+        _process_repeat_record(repeat_record)
+
+        fetched_repeat_record = RepeatRecord.get(repeat_record._id)
+        self.assertTrue(fetched_repeat_record.cancelled)
+        self.assertEqual(self.mock_fire.call_count, 0)
+        self.assertEqual(self.mock_postpone_by.call_count, 0)
+
+    def test_deletes_repeat_record_cancels_and_returns_if_repeater_deleted(self):
+        deleted_repeater = Repeater.objects.create(
+            domain=self.domain,
+            connection_settings=self.conn_settings,
+            is_deleted=True
+        )
+
+        repeat_record = RepeatRecord(
+            domain=self.domain,
+            payload_id='abc123',
+            registered_at=datetime.utcnow(),
+            repeater_id=deleted_repeater.repeater_id,
+        )
+
+        _process_repeat_record(repeat_record)
+
+        fetched_repeat_record = RepeatRecord.get(repeat_record._id)
+        self.assertEqual(fetched_repeat_record.doc_type, 'RepeatRecord-Deleted')
+        self.assertTrue(fetched_repeat_record.cancelled)
+        self.assertEqual(self.mock_fire.call_count, 0)
+        self.assertEqual(self.mock_postpone_by.call_count, 0)
+
+    def test_postpones_record_if_repeater_is_paused(self):
+        paused_repeater = Repeater.objects.create(
+            domain=self.domain,
+            connection_settings=self.conn_settings,
+            is_paused=True
+        )
+
+        repeat_record = RepeatRecord(
+            domain=self.domain,
+            payload_id='abc123',
+            registered_at=datetime.utcnow(),
+            repeater_id=paused_repeater.repeater_id,
+        )
+
+        _process_repeat_record(repeat_record)
+
+        self.assertEqual(self.mock_fire.call_count, 0)
+        self.assertEqual(self.mock_postpone_by.call_count, 1)
+
+    def test_fires_record_if_repeater_is_not_paused(self):
+        paused_repeater = Repeater.objects.create(
+            domain=self.domain,
+            connection_settings=self.conn_settings,
+            is_paused=False
+        )
+
+        repeat_record = RepeatRecord(
+            domain=self.domain,
+            payload_id='abc123',
+            registered_at=datetime.utcnow(),
+            repeater_id=paused_repeater.repeater_id,
+        )
+
+        _process_repeat_record(repeat_record)
+
+        self.assertEqual(self.mock_fire.call_count, 1)
+        self.assertEqual(self.mock_postpone_by.call_count, 0)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'process-repeat-record-tests'
+        cls.conn_settings = ConnectionSettings.objects.create(
+            domain=cls.domain,
+            name='To Be Deleted',
+            url="http://localhost/api/"
+        )
+        cls.repeater = Repeater.objects.create(
+            domain=cls.domain,
+            connection_settings=cls.conn_settings,
+        )
+
+    def setUp(self):
+        self.patch()
+
+    def patch(self):
+        patch_fire = patch.object(RepeatRecord, 'fire')
+        self.mock_fire = patch_fire.start()
+        self.addCleanup(patch_fire.stop)
+
+        patch_postpone_by = patch.object(RepeatRecord, 'postpone_by')
+        self.mock_postpone_by = patch_postpone_by.start()
+        self.addCleanup(patch_postpone_by.stop)
+
+        patch_domain_can_forward = patch('corehq.motech.repeaters.tasks.domain_can_forward')
+        self.mock_domain_can_forward = patch_domain_can_forward.start()
+        self.mock_domain_can_forward.return_value = True
+        self.addCleanup(patch_domain_can_forward.stop)

--- a/corehq/motech/repeaters/tests/test_tasks.py
+++ b/corehq/motech/repeaters/tests/test_tasks.py
@@ -267,6 +267,26 @@ class TestProcessRepeatRecord(TestCase):
         self.assertEqual(self.mock_fire.call_count, 1)
         self.assertEqual(self.mock_postpone_by.call_count, 0)
 
+    def test_paused_and_deleted_repeater_does_not_fire_or_postpone(self):
+        paused_and_deleted_repeater = Repeater.objects.create(
+            domain=self.domain,
+            connection_settings=self.conn_settings,
+            is_paused=True,
+            is_deleted=True,
+        )
+
+        repeat_record = RepeatRecord(
+            domain=self.domain,
+            payload_id='abc123',
+            registered_at=datetime.utcnow(),
+            repeater_id=paused_and_deleted_repeater.repeater_id,
+        )
+
+        _process_repeat_record(repeat_record)
+
+        self.assertEqual(self.mock_fire.call_count, 0)
+        self.assertEqual(self.mock_postpone_by.call_count, 0)
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Related to https://dimagi-dev.atlassian.net/browse/SAAS-14961

Created https://dimagi-dev.atlassian.net/browse/SAAS-14993 to track this.

During the investigation of the linked ticket, there were some notable improvements that could be made to `_process_repeat_record` to make it easier to understand.

### Deleted Repeater Behavior

First, I added tests to reflect the behavior of `repeat_record.repeater` since as discussed in https://github.com/dimagi/commcare-hq/pull/33557, the behavior of this method changed when migrating from couch to SQL (deleted repeaters are no longer returned). The behavior now is to only return non-deleted repeaters.

This means that once a repeater is deleted, all associated repeat records will be cancelled. This is consistent with past behavior, but I think is implemented in a clearer way. Originally, [we deleted the repeat record](https://github.com/dimagi/commcare-hq/blob/2022-09-15_06.22-production-deploy/corehq/motech/repeaters/tasks.py#L191-L194) instead of postponing or firing it since `repeat_record.repeater` returned a valid object at that point. After the repeater migration to SQL, we moved the deleted check earlier in this method, but since `repeat_record.repeater` now returned None for deleted repeaters, we exited the method before postponing or firing a deleter. 

### Logic Refactor

Both `repeat_record.is_repeater_deleted()` and `repeat_record.repeater` treat a deleted repeater and a repeater that does not exist at all the same. This means that we only need one of these checks, and `repeat_record.is_repeater_deleted()` is easier to understand. If a repeater is deleted, we should delete the record as well, cancel it, and return.

Additionally, I added a helper for `exceeded_max_retries` just to help clean up the readability of the method.

### Unpausing repeaters when deleting them is confusing

[This slack thread](https://dimagi.slack.com/archives/C02QG63MU/p1695825472734379) highlighted that it is unintuitive to unpause a repeater when deleting it, so 1730ec95898ecccbb5d596892c17a85f0cba02d2 addresses this. Now that repeat records associated with deleted repeaters are not processed regardless of if they are paused or not, I removed the line in the repeater's `retire` method to unpause the repeater.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tests were added to ensure behavior stayed the same.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I added tests for `_process_repeat_record` prior to making any changes (08c29ce1e9151ffd49e9d8428d056632aeb4b4d2) to make sure the behavior stayed the same after refactoring.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
