### PR TITLE
Ensure table exists in ConfigurableReportTableManager

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -248,9 +248,10 @@ class ConfigurableReportTableManager(UcrTableManager):
         self.table_adapters_by_domain = defaultdict(list)
 
         for config in configs:
-            self.table_adapters_by_domain[config.domain].append(
-                _get_indicator_adapter_for_pillow(config)
-            )
+            adapter = _get_indicator_adapter_for_pillow(config)
+            # protects against couch returning DataSourceConfiguration-Deleted docs
+            if adapter.table_exists:
+                self.table_adapters_by_domain[config.domain].append(adapter)
 
     @property
     def relevant_domains(self):

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -461,7 +461,9 @@ class ConfigurableReportPillowProcessor(BulkPillowProcessor):
                                     async_configs_by_doc_id[doc['_id']].append(adapter.config._id)
                                 else:
                                     try:
-                                        rows_to_save_by_adapter[adapter].extend(adapter.get_all_values(doc, eval_context))
+                                        rows_to_save_by_adapter[adapter].extend(
+                                            adapter.get_all_values(doc, eval_context)
+                                        )
                                     except Exception as e:
                                         change_exceptions.append((change, e))
                                     eval_context.reset_iteration()
@@ -759,9 +761,10 @@ def get_location_pillow(pillow_id='location-ucr-pillow', include_ucrs=None,
 
 
 def get_kafka_ucr_registry_pillow(
-    pillow_id='kafka-ucr-registry',
-    num_processes=1, process_num=0, dedicated_migration_process=False,
-    processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, ucr_configs=None, **kwargs):
+        pillow_id='kafka-ucr-registry',
+        num_processes=1, process_num=0, dedicated_migration_process=False,
+        processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, ucr_configs=None,
+        **kwargs):
     """UCR pillow that reads from all 'case' Kafka topics and writes data into the UCR database tables
 
     Only UCRs backed by Data Registries are processed in this pillow.


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14990

On staging, we've seen an issue where couch returns a DataSourceConfiguration-Deleted doc in the active_data_sources view which strictly should filter out this doc type. After trying to reindex the view multiple times, I'm resorting to adding a safety check in code to protect against couch being couch.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I see no downside of filtering out tables that do not exist to prevent pillow errors from being raised.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
