### PR TITLE
Move help popovers in small screen SSCS

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -396,7 +396,15 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
         onRender: function () {
             this._initializeSelect2Dropdown();
-            this.ui.hqHelp.hqHelp();
+            this.ui.hqHelp.hqHelp({
+                placement: () => {
+                    if (this.parentView.options.sidebarEnabled && this.parentView.smallScreenEnabled) {
+                        return 'auto bottom';
+                    } else {
+                        return 'auto right';
+                    }
+                },
+            });
             cloudcareUtils.initDatePicker(this.ui.date, this.model.get('value'));
             this.ui.dateRange.daterangepicker({
                 locale: {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js
@@ -72,7 +72,7 @@ hqDefine("hqwebapp/js/bootstrap3/hq.helpers", [
         oldHide.apply(this, arguments);
     };
 
-    $.fn.hqHelp = function () {
+    $.fn.hqHelp = function (opts) {
         var self = this;
         self.each(function (i) {
             var $self = $(self),
@@ -85,6 +85,9 @@ hqDefine("hqwebapp/js/bootstrap3/hq.helpers", [
                 container: 'body',
                 sanitize: false,
             };
+            if (opts) {
+                options = _.extend(options, opts);
+            }
             if (!$link.data('content')) {
                 options.content = function () {
                     return $('#popover_content_wrapper').html();

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
@@ -59,7 +59,7 @@ hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
         return false; // let default handler run
     };
 
-    $.fn.hqHelp = function () {
+    $.fn.hqHelp = function (opts) {
         var self = this;
         self.each(function (i) {
             var $self = $(self),
@@ -72,6 +72,9 @@ hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
                 container: 'body',
                 sanitize: false,
             };
+            if (opts) {
+                options = _.extend(options, opts);
+            }
             if (!$link.data('content')) {
                 options.content = function () {
                     return $('#popover_content_wrapper').html();

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/hq.helpers.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/hq.helpers.js.diff.txt
@@ -23,10 +23,10 @@
 -        oldHide.apply(this, arguments);
 -    };
 -
-     $.fn.hqHelp = function () {
+     $.fn.hqHelp = function (opts) {
          var self = this;
          self.each(function (i) {
-@@ -101,6 +88,11 @@
+@@ -104,6 +91,11 @@
                  event.preventDefault();
              });
          });


### PR DESCRIPTION
## Product Description
Case search help popovers would display offscreen in small windows when using split screen case search, needing a horizontal scroll to view. 

This reorients them to "auto bottom" placement when using split screen case search in a small window -- which will place them below the `?` if possible, or above it if not possible.
![image](https://github.com/dimagi/commcare-hq/assets/100609770/550400bd-df3f-4cf7-8445-36127b9fe9fa) => ![image](https://github.com/dimagi/commcare-hq/assets/100609770/b3afbb08-52a8-4d09-904c-f8d892847854)

## Technical Summary
[QA-5677](https://dimagi-dev.atlassian.net/browse/QA-5677)
This allows our popover implementation through `hqHelp` to accept an `opts` argument, which modifies the default options if provided. A `placement` function is passed in from `QueryView` that determines what placement the popover should get.

## Feature Flag
SPLIT_SCREEN_CASE_SEARCH

## Safety Assurance

### Safety story
Tested locally in split screen and regular case search, large and small screens. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
QA to confirm fix on staging.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[QA-5677]: https://dimagi-dev.atlassian.net/browse/QA-5677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ