### PR TITLE
Prepare to rename table for maintenance alert model

### DIFF
--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -20,7 +20,6 @@ from corehq.util.bounced_email_manager import BouncedEmailManager
 from corehq.util.email_event_utils import get_bounced_system_emails
 from corehq.util.log import send_HTML_email
 from corehq.util.metrics import metrics_track_errors
-from corehq.util.metrics.const import MPM_MAX
 from corehq.util.models import TransientBounceEmail
 
 

--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -19,7 +19,7 @@ from corehq.apps.celery import periodic_task, task
 from corehq.util.bounced_email_manager import BouncedEmailManager
 from corehq.util.email_event_utils import get_bounced_system_emails
 from corehq.util.log import send_HTML_email
-from corehq.util.metrics import metrics_gauge_task, metrics_track_errors
+from corehq.util.metrics import metrics_track_errors
 from corehq.util.metrics.const import MPM_MAX
 from corehq.util.models import TransientBounceEmail
 
@@ -240,15 +240,6 @@ def clean_expired_transient_emails():
                 'error': e,
             }
         )
-
-
-def get_maintenance_alert_active():
-    from corehq.apps.hqwebapp.models import MaintenanceAlert
-    return 1 if MaintenanceAlert.get_active_alerts() else 0
-
-
-metrics_gauge_task('commcare.maintenance_alerts.active', get_maintenance_alert_active,
-                   run_every=crontab(minute=1), multiprocess_mode=MPM_MAX)
 
 
 @periodic_task(run_every=crontab(minute=0, hour=4))

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 from django import template
 from django.conf import settings
+from django.db import ProgrammingError
 from django.http import QueryDict
 from django.template import NodeList, TemplateSyntaxError, loader_tags
 from django.template.base import (
@@ -390,7 +391,10 @@ def chevron(value):
 
 @register.simple_tag
 def maintenance_alerts(request):
-    active_alerts = MaintenanceAlert.get_active_alerts()
+    try:
+        active_alerts = MaintenanceAlert.get_active_alerts()
+    except ProgrammingError:
+        return []
     domain = getattr(request, 'domain', None)
     return [
         alert for alert in active_alerts


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
None

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR simply preps for deploy for https://github.com/dimagi/commcare-hq/pull/33592 which renames the table for model, `MaintenanceAlert`.
While the deploy is happening, the migrations are applied before the code is switched for web processes.
For the linked PR, during the deploy, the table will get renamed after migrations that would lead to errors on the site till the code switch is done, since alerts are fetched on every page visit. So, this PR avoids errors for that fetch in case there is a 'ProgrammingError` due to missing table and simply show no alerts. The alerts, if any, will start showing up as soon as the deploy gets over. No information will be lost during this interim.
Apart from this there is one datadog metric that is redundant, so that is simply removed.
There is no other user facing usage of the model.
For admin end,
We would not be able to add any alert during this interim in the deploy, which should be okay.
This should unblock the linked PR from getting deployed in a deploy after this PR is deployed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Confirmed with SaaS (Danny) that the metric was redundant and can be removed.
Also, tested that the change here, avoids errors, in case the table name is updated in the background.
As for the change itself, is safe.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
