### PR TITLE
Add Geospatial Case Grouping Page

### DIFF
--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -32,6 +32,7 @@ class BaseCaseMap(ProjectReport, CaseListMixin):
         context = super(BaseCaseMap, self).template_context
         context.update({
             'mapbox_access_token': settings.MAPBOX_ACCESS_TOKEN,
+            'case_row_order': {val.html: idx for idx, val in enumerate(self.headers)},
         })
         return context
 
@@ -43,8 +44,8 @@ class BaseCaseMap(ProjectReport, CaseListMixin):
         )
         headers = DataTablesHeader(
             DataTablesColumn(_("case_id"), prop_name="type.exact"),
-            DataTablesColumn(_("GPS"), prop_name="type.exact"),
-            DataTablesColumn(_("Name"), prop_name="name.exact", css_class="case-name-link"),
+            DataTablesColumn(_("gps_point"), prop_name="type.exact"),
+            DataTablesColumn(_("link"), prop_name="name.exact", css_class="case-name-link"),
         )
         headers.custom_sort = [[2, 'desc']]
         return headers

--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -105,8 +105,7 @@ class CaseGroupingReport(BaseCaseMap):
     slug = 'case_grouping_map'
     search_class = CaseSearchES
 
-    # TODO: We need a separate base template
-    base_template = 'geospatial/map_visualization_base.html'
+    base_template = 'geospatial/case_grouping_map_base.html'
     report_template_path = 'case_grouping_map.html'
 
     def _build_query(self):

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -3,7 +3,6 @@ hqDefine("geospatial/js/case_grouping_map",[
     "knockout",
     'underscore',
     'hqwebapp/js/initial_page_data',
-    "hqwebapp/js/bootstrap3/components.ko", // for pagination
 ], function (
     $,
     ko,

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -22,6 +22,15 @@ hqDefine("geospatial/js/case_grouping_map",[
     }
 
     $(function () {
+        // Parses a case row (which is an array of column values) to an object, using caseRowOrder as the order of the columns
+        function parseCaseItem(caseItem, caseRowOrder) {
+            let caseObj = {};
+            for (const propKey in caseRowOrder) {
+                const propIndex = caseRowOrder[propKey];
+                caseObj[propKey] = caseItem[propIndex];
+            }
+            return caseObj;
+        }
         $(document).ajaxComplete(function (event, xhr, settings) {
             const isAfterReportLoad = settings.url.includes('geospatial/async/case_grouping_map/');
             if (isAfterReportLoad) {

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -22,6 +22,8 @@ hqDefine("geospatial/js/case_grouping_map",[
     }
 
     $(function () {
+        let caseModels = [];
+
         // Parses a case row (which is an array of column values) to an object, using caseRowOrder as the order of the columns
         function parseCaseItem(caseItem, caseRowOrder) {
             let caseObj = {};
@@ -31,19 +33,30 @@ hqDefine("geospatial/js/case_grouping_map",[
             }
             return caseObj;
         }
-        $(document).ajaxComplete(function (event, xhr, settings) {
-            const isAfterReportLoad = settings.url.includes('geospatial/async/case_grouping_map/');
-            if (isAfterReportLoad) {
-                return;
-            }
 
+        function loadCases(rawCaseData) {
+            caseModels = [];
+            const caseRowOrder = initialPageData.get('case_row_order');
+            for (const caseItem of rawCaseData) {
+                const caseObj = parseCaseItem(caseItem, caseRowOrder);
+                const caseModelInstance = new caseModel(caseObj.case_id, caseObj.gps_point, caseObj.link);
+                caseModels.push(caseModelInstance);
+            }
+        }
+
+        $(document).ajaxComplete(function (event, xhr, settings) {
             const isAfterDataLoad = settings.url.includes('geospatial/json/case_grouping_map/');
             if (!isAfterDataLoad) {
                 return;
             }
 
+            // Hide the datatable rows but not the pagination bar
+            $('.dataTables_scroll').hide();
 
+            const caseData = xhr.responseJSON.aaData;
+            if (caseData.length) {
+                loadCases(caseData);
+            }
         });
     });
-
 });

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -10,7 +10,16 @@ hqDefine("geospatial/js/case_grouping_map",[
     _,
     initialPageData
 ) {
-    'use strict';
+
+    function caseModel(caseId, coordiantes, caseLink) {
+        'use strict';
+        var self = {};
+        self.caseId = caseId;
+        self.coordinates = coordiantes;
+        self.caseLink = caseLink;
+
+        return self;
+    }
 
     $(function () {
         $(document).ajaxComplete(function (event, xhr, settings) {

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -4,4 +4,14 @@
 {% load hq_shared_tags %}
 
 {% block reportcontent %}
+<div class="panel-body-datatable">
+    {% block reporttable %}
+      {% if report.needs_filters %}
+        {% include 'reports/partials/description.html' %}
+      {% else %}
+        <table id="report_table_{{ report.slug }}" class="table table-striped datatable" width="100%" {% if pagination.filter %} data-filter="true"{% endif %}>
+        </table>
+      {% endif %}
+    {% endblock reporttable %}
+</div>
 {% endblock %}

--- a/corehq/apps/geospatial/templates/geospatial/case_grouping_map_base.html
+++ b/corehq/apps/geospatial/templates/geospatial/case_grouping_map_base.html
@@ -1,0 +1,18 @@
+{% extends "base_template.html" %}
+
+{% load hq_shared_tags %}
+{% load compress %}
+
+{% block page_title %}
+{{ current_page.title }}
+{% endblock %}
+
+{% block js %}{{ block.super }}
+    {% compress js %}
+        <script src="{% static 'geospatial/js/case_grouping_map.js' %}"></script>
+    {% endcompress %}
+{% endblock %}
+
+{% block additional_initial_page_data %}{{ block.super }}
+    {% initial_page_data 'case_row_order' case_row_order %}
+{% endblock %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The Case Grouping page:
![Screenshot from 2023-10-09 14-49-03](https://github.com/dimagi/commcare-hq/assets/122617251/1948595d-2ad1-4312-87fb-184f36411623)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3054).

The case grouping page was originally implemented by [this](https://dimagi-dev.atlassian.net/browse/SC-3052) ticket. This PR is to slightly more flesh out the existing boilerplate page to handle loading in cases on the JS front-end. Currently, it will only be an empty list however, as the implementation for loading paginated geohashes will be done in [this](https://dimagi-dev.atlassian.net/browse/SC-3055) ticket.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Unused page.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
A unit test has been created to ensure that the report columns are the same as what we expect on the front-end.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
