### PR TITLE
Update GenerationCache subclasses to reflect current state

### DIFF
--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -1,41 +1,6 @@
 from dimagi.utils.couch.cache.cache_core import GenerationCache
 
 
-class DomainGenerationCache(GenerationCache):
-    generation_key = '#gen#domain#'
-    doc_types = ['Domain']
-    views = [
-        "domain/snapshots",
-        "domain/published_snapshots",
-        "domain/not_snapshots",
-        "domain/copied_from_snapshot",
-        "domain/domains",
-    ]
-
-
-class UserGenerationCache(GenerationCache):
-    generation_key = '#gen#couch_user#'
-    doc_types = ['CommCareUser', 'CouchUser', 'WebUser']
-    views = [
-        "users/by_domain",
-        "users/phone_users_by_domain",
-        "users/by_default_phone",
-        "users/by_username",
-        "domain/old_users",
-    ]
-
-
-class GroupGenerationCache(GenerationCache):
-    generation_key = '#gen#group#'
-    doc_types = ['Group']
-    views = [
-        "groups/by_user",
-        "groups/by_name",
-        "groups/all_groups",
-        "users/by_group",
-    ]
-
-
 class ReportGenerationCache(GenerationCache):
     generation_key = '#gen#reports#'
     doc_types = ['ReportConfig', 'ReportNotification']

--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -36,14 +36,6 @@ class GroupGenerationCache(GenerationCache):
     ]
 
 
-class UserRoleGenerationCache(GenerationCache):
-    generation_key = '#gen#user_role#'
-    doc_types = ['UserRole']
-    views = [
-        'users/roles_by_domain'
-    ]
-
-
 class ReportGenerationCache(GenerationCache):
     generation_key = '#gen#reports#'
     doc_types = ['ReportConfig', 'ReportNotification']

--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -20,4 +20,5 @@ class UserReportsDataSourceCache(GenerationCache):
         'userreports/data_sources_by_build_info',
         'userreports/data_sources_by_last_modified',
         'userreports/report_configs_by_data_source',
+        'userreports/report_configs_by_domain',
     ]

--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -59,5 +59,8 @@ class UserReportsDataSourceCache(GenerationCache):
     generation_key = '#gen#userreports#datasource#'
     doc_types = ['DataSourceConfiguration']
     views = [
+        'userreports/active_data_sources',
         'userreports/data_sources_by_build_info',
+        'userreports/data_sources_by_last_modified',
+        'userreports/report_configs_by_data_source',
     ]

--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -48,10 +48,10 @@ class ReportGenerationCache(GenerationCache):
     generation_key = '#gen#reports#'
     doc_types = ['ReportConfig', 'ReportNotification']
     views = [
+        "reportconfig/all_notifications",
         'reportconfig/configs_by_domain',
         'reportconfig/notifications_by_config',
         "reportconfig/user_notifications",
-        "reportconfig/daily_notifications",
     ]
 
 

--- a/settings.py
+++ b/settings.py
@@ -1940,7 +1940,6 @@ COUCH_CACHE_BACKENDS = [
     'corehq.apps.cachehq.cachemodels.DomainGenerationCache',
     'corehq.apps.cachehq.cachemodels.UserGenerationCache',
     'corehq.apps.cachehq.cachemodels.GroupGenerationCache',
-    'corehq.apps.cachehq.cachemodels.UserRoleGenerationCache',
     'corehq.apps.cachehq.cachemodels.ReportGenerationCache',
     'corehq.apps.cachehq.cachemodels.UserReportsDataSourceCache',
     'dimagi.utils.couch.cache.cache_core.gen.GlobalCache',

--- a/settings.py
+++ b/settings.py
@@ -1937,9 +1937,6 @@ for k, v in LOCAL_PILLOWTOPS.items():
     PILLOWTOPS[k] = plist
 
 COUCH_CACHE_BACKENDS = [
-    'corehq.apps.cachehq.cachemodels.DomainGenerationCache',
-    'corehq.apps.cachehq.cachemodels.UserGenerationCache',
-    'corehq.apps.cachehq.cachemodels.GroupGenerationCache',
     'corehq.apps.cachehq.cachemodels.ReportGenerationCache',
     'corehq.apps.cachehq.cachemodels.UserReportsDataSourceCache',
     'dimagi.utils.couch.cache.cache_core.gen.GlobalCache',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-14990

### Problem
It was discovered that if a couch view (e.g., `userreports/active_data_sources`) associated with a document (e.g., `DataSourceConfiguration`) that inherits from `CachedCouchDocumentMixin` is not specified in `couchmodels.py` under its respective cache object (e.g., `UserReportsDataSourceCache`), it defaults to using the GlobalCache instead of generational caching. This effectively means that these views cache results with **no mechanism to invalidate it** short of the default 12 hour timeout.

This primarily impacted DataSourceConfiguration views, may have also impacted the `all_notifications` couch view. If you care to read more about the investigation into the issue, see the ticket.

### Solution

I added the appropriate views to their respective cache object to ensure their cache is invalidated when a document is added, updated, or deleted.

While making these changes, I also noticed that we had `GenerationCache` objects specified for Couch documents that either no longer exist or no longer use the `CachedCouchDocumentMixin` and removed those references.

### How to prevent this in the future
A couple of options:

1. Default to not using a cache instead of the [GlobalCache](https://github.com/dimagi/commcare-hq/blob/579b52f1037d30c8e9184214f7278bb1d6a8b9d2/corehq/ex-submodules/dimagi/utils/couch/cache/cache_core/api.py#L50)
2. Replace `CachedCouchDocumentMixin` with `QuickCachedDocumentMixin` in the remaining objects that inherit it, and create dbaccessor methods that wrap querying these views so that we can use a simple quickcache decorator as needed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Most of these changes involved ripping out code that is no longer used, so those instance are very safe. In the case of _new_ views added to the `ReportGenerationCache` and `UserReportsDataSourceCache`, it is an improvement from current behavior because the cache will be invalidated and we will prevent returning stale results to users. The same caching mechanism has been in use for years, and this change simply enables that caching mechanism on a few more views.


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
