### PR TITLE
PEP8 line length for easier reading

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -2,25 +2,33 @@
 DetailContributor
 -----------------
 
-Details represent the configuration for case lists and case details. The reuse of the word "Detail" here is
-unfortunate. Details **can** be used for other purposes, such as the ``referral_detail``, but 99% of the time
-they're used for case list/detail.
+Details represent the configuration for case lists and case details. The
+reuse of the word "Detail" here is unfortunate. Details **can** be used
+for other purposes, such as the ``referral_detail``, but 99% of the
+time they're used for case list/detail.
 
-The case list is the "short" detail and the case detail is the "long" detail. A handful of configurations are only
-supported for one of these, e.g., actions only get added to the short detail.
+The case list is the "short" detail and the case detail is the "long"
+detail. A handful of configurations are only supported for one of
+these, e.g., actions only get added to the short detail.
 
-The detail element can be nested. HQ never nests short details, but it nests long details to produce tabbed case
-details. Each tab has its own ``<detail>`` element.
+The detail element can be nested. HQ never nests short details, but it
+nests long details to produce tabbed case details. Each tab has its own
+``<detail>`` element.
 
-The bulk of detail configuration is in the display properties, called "fields" and sometimes "columns" in the code.
-Each field has a good deal of configuration, and the code transforms them into named tuples while processing them.
-Each field has a format, one of about a dozen options. Formats are typically either UI-based, such as formatting a
-phone number to display as a link, or calculation-based, such as configuring a property to display differently when
-it's "late", i.e., is too far past some reference date.
+The bulk of detail configuration is in the display properties,
+called "fields" and sometimes "columns" in the code. Each field has a
+good deal of configuration, and the code transforms them into named
+tuples while processing them. Each field has a format, one of about a
+dozen options. Formats are typically either UI-based, such as
+formatting a phone number to display as a link, or calculation-based,
+such as configuring a property to display differently when it's "late",
+i.e., is too far past some reference date.
 
-Most fields map to a particular case property, with the exception of calculated properties. These calculated
-properties are identified only by number. A typical field might be called ``case_dob_1`` in the suite, indicating
-both its position and its case property, but a calculation would be called ``case_calculated_property_1``.
+Most fields map to a particular case property, with the exception of
+calculated properties. These calculated properties are identified only
+by number. A typical field might be called ``case_dob_1`` in the suite,
+indicating both its position and its case property, but a calculation
+would be called ``case_calculated_property_1``.
 
 """
 from collections import defaultdict, namedtuple

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -2,15 +2,19 @@
 EntriesContributor
 ------------------
 
-This is the largest and most complex of the suite sections, responsible for generating an ``<entry>``
-element for each form, including the datums required for form entry. The ``EntriesHelper``, which does all of the
-heavy lifting here, is imported into other places in HQ that need to know what datums a form requires,
-such as the session schema generator for form builder and the UI for form linking.
+This is the largest and most complex of the suite sections, responsible
+for generating an ``<entry>`` element for each form, including the
+datums required for form entry. The ``EntriesHelper``, which does all
+of the heavy lifting here, is imported into other places in HQ that
+need to know what datums a form requires, such as the session schema
+generator for form builder and the UI for form linking.
 
-When forms work with multiple datums, they need to be named in a way that is predictable for app builders, who
-reference them inside forms. This is most relevant to the "select parent first" feature and to parent/child
-modules.  See ``update_refs`` and ``rename_other_id``, both inner functions in ``add_parent_datums``, plus
-`this comment`_ on matching parent and child datums.
+When forms work with multiple datums, they need to be named in a way
+that is predictable for app builders, who reference them inside forms.
+This is most relevant to the "select parent first" feature and to
+parent/child modules.  See ``update_refs`` and ``rename_other_id``,
+both inner functions in ``add_parent_datums``, plus `this comment`_ on
+matching parent and child datums.
 
 
 .. _this comment: https://github.com/dimagi/commcare-hq/blob/c9fa01d1ccbb73d8f07fefbe56a0bbe1dbe231f8/corehq/apps/app_manager/suite_xml/sections/entries.py#L966-L971


### PR DESCRIPTION
## Technical Summary

Shortens the line length of two module docstrings to match PEP8, to make reading in an IDE (split-screen) a little easier.

## Safety Assurance

### Safety story

* Tiny
* Documentation-only change. 

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
