### PR TITLE
Use `in` instead of `get()`

### DIFF
--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -131,12 +131,11 @@ class FormRepeaterForm(GenericRepeaterForm):
     )
 
     def __init__(self, *args, **kwargs):
-        if kwargs.get('data', {}).get('white_listed_form_xmlns'):
+        if 'data' in kwargs and 'white_listed_form_xmlns' in kwargs['data']:
             # `FormRepeater.white_listed_form_xmlns` is a list, but
             # `FormRepeaterForm.white_listed_form_xmlns` takes a string.
-            kwargs['data']['white_listed_form_xmlns'] = ', \n'.join(
-                kwargs['data']['white_listed_form_xmlns']
-            )
+            xmlns_list = kwargs['data']['white_listed_form_xmlns']
+            kwargs['data']['white_listed_form_xmlns'] = ', \n'.join(xmlns_list)
         super().__init__(*args, **kwargs)
 
     @property


### PR DESCRIPTION
## Technical Summary

Fixes a bug when editing a `FormRepeater`.

Jira: https://dimagi-dev.atlassian.net/browse/SC-3168

The bug was caused by getting a falsey value of a key, instead of just checking for the presence of the key.

## Safety Assurance

### Safety story

```python
>>> foo = {'bar': []}
>>> bool(foo.get('bar'))
False
>>> 'bar' in foo
True
```

Oh, and verified locally, of course.

### Automated test coverage

Not covered

### QA Plan

Not planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
