### PR TITLE
Release Data Dictionary Case Data Page

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/css/proptable.css
+++ b/corehq/apps/hqwebapp/static/hqwebapp/css/proptable.css
@@ -95,12 +95,7 @@
     word-break: break-word;
 }
 
-.case-property-table tbody tr th {
+.case-property-table tbody {
     word-wrap: break-word;
-    word-break: break-all;
-}
-
-.case-property-table tbody tr td {
-    word-wrap: break-word;
-    word-break: break-all;
+    word-break: break-word;
 }

--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -277,7 +277,7 @@ def _get_dd_tables(domain, case_type, dynamic_data, timezone):
     ]
     props_in_dd = set(prop.name for _, prop_group in dd_props_by_group
                       for prop in prop_group)
-    unrecognized = set(dynamic_data.keys()) - props_in_dd
+    unrecognized = set(dynamic_data.keys()) - props_in_dd - {'case_name'}
     if unrecognized:
         tables.append((_('Unrecognized'), _table_definition([
             (p, None, None) for p in unrecognized

--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -296,9 +296,9 @@ def _get_dd_props_by_group(domain, case_type):
             case_type__name=case_type,
             deprecated=False,
     ).select_related('group_obj').order_by('group_obj__index', 'index'):
-        ret[prop.group_name].append(prop)
+        ret[prop.group_name or None].append(prop)
 
-    uncategorized = ret.pop('', None)
+    uncategorized = ret.pop(None, None)
     for group, props in ret.items():
         yield group, props
 

--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -38,10 +38,12 @@ from dimagi.utils.chunked import chunked
 from dimagi.utils.web import json_response
 
 from corehq import privileges, toggles
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.dbaccessors import get_latest_app_ids_and_versions
 from corehq.apps.data_dictionary.models import CaseProperty
+from corehq.apps.data_dictionary.util import is_case_type_deprecated
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.export.const import KNOWN_CASE_PROPERTIES
 from corehq.apps.export.models import CaseExportDataSchema
@@ -87,7 +89,6 @@ from corehq.motech.repeaters.views.repeat_record_display import (
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import absolute_reverse, get_case_or_404, reverse
-from corehq.apps.data_dictionary.util import is_case_type_deprecated
 
 from .basic import CaseListReport
 from .utils import get_user_type
@@ -249,26 +250,20 @@ class CaseDataView(BaseProjectReportSectionView):
             "repeat_records": repeat_records,
         }
         if dynamic_data:
-            if toggles.DD_CASE_DATA.enabled_for_request(self.request):
-                dd_properties_tables = _get_dd_tables(self.domain, self.case_instance.type,
-                                                      dynamic_data, timezone)
-                context['dd_properties_tables'] = dd_properties_tables
-                context['show_expand_collapse_buttons'] = len(
-                    [table.get('name') for table in dd_properties_tables if table.get('name') is not None]) > 1
-            else:
-                definition = {
-                    "layout": list(chunked([
-                        DisplayConfig(expr=prop, has_history=True)
-                        for prop in sorted(dynamic_data.keys())
-                    ], DYNAMIC_CASE_PROPERTIES_COLUMNS))
-                }
-                context['dynamic_properties_table'] = get_table_as_rows(dynamic_data, definition, timezone)
+            dd_properties_tables = _get_dd_tables(self.domain, self.case_instance.type,
+                                                    dynamic_data, timezone)
+            context['dd_properties_tables'] = dd_properties_tables
+            context['show_expand_collapse_buttons'] = len(
+                [table.get('name') for table in dd_properties_tables if table.get('name') is not None]) > 1
         context.update(case_hierarchy_context(self.case_instance, _get_case_url, timezone=timezone))
         return context
 
 
 def _get_dd_tables(domain, case_type, dynamic_data, timezone):
-    dd_props_by_group = list(_get_dd_props_by_group(domain, case_type))
+    if domain_has_privilege(domain, privileges.DATA_DICTIONARY):
+        dd_props_by_group = list(_get_dd_props_by_group(domain, case_type))
+    else:
+        dd_props_by_group = []
     tables = [
         (group, _table_definition([
             (p.name, p.label, p.description) for p in props
@@ -276,10 +271,11 @@ def _get_dd_tables(domain, case_type, dynamic_data, timezone):
         for group, props in dd_props_by_group
     ]
     props_in_dd = set(prop.name for _, prop_group in dd_props_by_group
-                      for prop in prop_group)
+                    for prop in prop_group)
     unrecognized = set(dynamic_data.keys()) - props_in_dd - {'case_name'}
     if unrecognized:
-        tables.append((_('Unrecognized'), _table_definition([
+        header = _('Unrecognized') if tables else None
+        tables.append((header, _table_definition([
             (p, None, None) for p in unrecognized
         ])))
 

--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -250,16 +250,16 @@ class CaseDataView(BaseProjectReportSectionView):
             "repeat_records": repeat_records,
         }
         if dynamic_data:
-            dd_properties_tables = _get_dd_tables(self.domain, self.case_instance.type,
-                                                    dynamic_data, timezone)
-            context['dd_properties_tables'] = dd_properties_tables
+            case_property_tables = _get_case_property_tables(
+                self.domain, self.case_instance.type, dynamic_data, timezone)
+            context['case_property_tables'] = case_property_tables
             context['show_expand_collapse_buttons'] = len(
-                [table.get('name') for table in dd_properties_tables if table.get('name') is not None]) > 1
+                [table.get('name') for table in case_property_tables if table.get('name') is not None]) > 1
         context.update(case_hierarchy_context(self.case_instance, _get_case_url, timezone=timezone))
         return context
 
 
-def _get_dd_tables(domain, case_type, dynamic_data, timezone):
+def _get_case_property_tables(domain, case_type, dynamic_data, timezone):
     if domain_has_privilege(domain, privileges.DATA_DICTIONARY):
         dd_props_by_group = list(_get_dd_props_by_group(domain, case_type))
     else:
@@ -271,7 +271,7 @@ def _get_dd_tables(domain, case_type, dynamic_data, timezone):
         for group, props in dd_props_by_group
     ]
     props_in_dd = set(prop.name for _, prop_group in dd_props_by_group
-                    for prop in prop_group)
+                      for prop in prop_group)
     unrecognized = set(dynamic_data.keys()) - props_in_dd - {'case_name'}
     if unrecognized:
         header = _('Unrecognized') if tables else None

--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -1,6 +1,7 @@
 import copy
 import csv
 import io
+import re
 from collections import defaultdict
 from datetime import datetime
 
@@ -307,12 +308,17 @@ def _table_definition(props):
         "layout": list(chunked([
             DisplayConfig(
                 expr=prop_name,
-                name=label or prop_name,
+                name=_add_line_break_opportunities(label or prop_name),
                 description=description,
                 has_history=True
             ) for prop_name, label, description in props
         ], DYNAMIC_CASE_PROPERTIES_COLUMNS))
     }
+
+
+def _add_line_break_opportunities(name):
+    # Add zero-width space after dashes and underscores for better looking word breaks
+    return re.sub(r"([_-])", "\\1\u200B", name)
 
 
 def form_to_json(domain, form, timezone):

--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -72,9 +72,7 @@
             <div class="tab-content">
               <div class="tab-pane" id="properties">
                 <div class="row-fluid">
-                  {% if dynamic_properties_table %}
-                    {% include "reports/partials/case_property_table.html" with rows=dynamic_properties_table %}
-                  {% elif dd_properties_tables %}
+                  {% if dd_properties_tables %}
                     {% if show_expand_collapse_buttons %}
                       <div class="pull-right btn-grp" role="group">
                         <button class="btn btn-sm btn-default" type="button" id="expand-all-accordion-btn">Expand All</button>

--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -72,7 +72,7 @@
             <div class="tab-content">
               <div class="tab-pane" id="properties">
                 <div class="row-fluid">
-                  {% if dd_properties_tables %}
+                  {% if case_property_tables %}
                     {% if show_expand_collapse_buttons %}
                       <div class="pull-right btn-grp" role="group">
                         <button class="btn btn-sm btn-default" type="button" id="expand-all-accordion-btn">Expand All</button>
@@ -80,7 +80,7 @@
                       </div>
                     {% endif %}
                     <div class="panel-group" id="case-properties-accordion">
-                      {% for table in dd_properties_tables %}
+                      {% for table in case_property_tables %}
                         <div class="panel panel-appmanager" id="property-table-{{ forloop.counter }}-parent">
                           {% if table.name is not None %}
                             <div class="panel-heading">

--- a/corehq/apps/reports/tests/test_case_data.py
+++ b/corehq/apps/reports/tests/test_case_data.py
@@ -1,9 +1,17 @@
+from unittest.mock import patch
 from django.test import TestCase
 
-from corehq.apps.data_dictionary.models import CaseProperty, CaseType, CasePropertyGroup
-from corehq.apps.reports.standard.cases.case_data import _get_dd_tables
+from corehq.apps.data_dictionary.models import (
+    CaseProperty,
+    CasePropertyGroup,
+    CaseType,
+)
+from corehq.apps.reports.standard.cases.case_data import (
+    _get_case_property_tables,
+)
 
 
+@patch('corehq.apps.reports.standard.cases.case_data.domain_has_privilege', lambda _, __: True)
 class TestCaseData(TestCase):
 
     def setUp(self) -> None:
@@ -16,6 +24,11 @@ class TestCaseData(TestCase):
         CasePropertyGroup.objects.all().delete()
         CaseType.objects.all().delete()
 
+    def test_no_data_dictionary(self):
+        dynamic_data = {"prop1": None, "prop2": None}
+        result = _get_case_property_tables(self.domain, self.case_type, dynamic_data, self.timezone)
+        self._assert_grouping_order_tables(result, [{"name": None, "properties": ["prop1", "prop2"]}])
+
     def test_dd_ordering_when_single_group(self):
         """
         Tests that when a data dictionary contains only one user defined group,
@@ -24,7 +37,7 @@ class TestCaseData(TestCase):
         # Create group1 properties
         self._create_case_property("prop1", "group1")
         self._create_case_property("prop2", "group1")
-        result = _get_dd_tables(self.domain, self.case_type, {}, self.timezone)
+        result = _get_case_property_tables(self.domain, self.case_type, {}, self.timezone)
         self._assert_grouping_order_tables(result, [{"name": "group1", "properties": ["prop1", "prop2"]}])
 
     def test_dd_ordering_when_multiple_groups(self):
@@ -37,7 +50,7 @@ class TestCaseData(TestCase):
         self._create_case_property("prop2", "group1")
         self._create_case_property("prop3", "group2")
         self._create_case_property("prop4", "group2")
-        result = _get_dd_tables(self.domain, self.case_type, {}, self.timezone)
+        result = _get_case_property_tables(self.domain, self.case_type, {}, self.timezone)
         self._assert_grouping_order_tables(result, [{"name": "group1", "properties": ["prop1", "prop2"]},
                                                     {"name": "group2", "properties": ["prop3", "prop4"]}])
 
@@ -56,7 +69,7 @@ class TestCaseData(TestCase):
         # Dynamic data with additional property not present in any of the groups
         dynamic_data = {"prop1": None, "prop2": None, "prop3": None, "prop4": None, "prop5": None, "prop6": None}
 
-        result = _get_dd_tables(self.domain, self.case_type, dynamic_data, self.timezone)
+        result = _get_case_property_tables(self.domain, self.case_type, dynamic_data, self.timezone)
         self._assert_grouping_order_tables(result, [{"name": "group1", "properties": ["prop1", "prop2"]},
                                                     {"name": "group2", "properties": ["prop3", "prop4"]},
                                                     {"name": "Unrecognized", "properties": ["prop5", "prop6"]}
@@ -77,7 +90,7 @@ class TestCaseData(TestCase):
             self.assertEqual(group_name_expected, group_name_actual)
             rows_actual = group_data.get("rows")[0]
             props_actual = [prop.get("name") for prop in rows_actual]
-            if group_name_actual == "Unrecognized":
+            if not group_name_actual or group_name_actual == "Unrecognized":
                 # Ordering of properties in unrecognized group is not user defined
                 self.assertEqual(set(expected_group_data.get("properties")), set(props_actual))
             else:

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1591,14 +1591,6 @@ EMWF_WORKER_ACTIVITY_REPORT = StaticToggle(
     ),
 )
 
-DD_CASE_DATA = StaticToggle(
-    'dd_case_data',
-    'Data Dictionary Case Data Page',
-    TAG_INTERNAL,
-    [NAMESPACE_USER],
-    description='Experimental: render the case data page in accordance with the data dictionary',
-)
-
 SORT_CALCULATION_IN_CASE_LIST = StaticToggle(
     'sort_calculation_in_case_list',
     'Configure a custom xpath calculation for Sort Property in Case Lists',


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2553
See above doc for context.  This PR releases the feature flag DD_CASE_DATA to GA (depending on plan).  I'm deploying this to staging now, though of course the FF has been in use for like a year now.

## Technical Summary
There are a couple minor changes, but the big one is that the FF behavior will go live for everyone.  For projects with the DD privilege disabled, this results in a single table with all properties in it.

## Feature Flag
Setting DD_CASE_DATA free into the wild.

## Safety Assurance
See the linked ticket for comms plans

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change