### PR TITLE
Collapsible tiles

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -30,5 +30,7 @@ hqDefine("cloudcare/js/formplayer/constants", function () {
 
         BREADCRUMB_HEIGHT_PX: 46.125,
         BREADCRUMB_WIDTH_OFFSET_PX: 106.5, // unavailable breadcrumb space i.e. padding, home and hamburger icons
+
+        COLLAPSIBLE_TILE_MAX_HEIGHT: 150,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -214,6 +214,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         ui: {
             selectRow: ".select-row-checkbox",
+            showMore: ".show-more",
         },
 
         events: {
@@ -221,6 +222,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             "keydown": "rowKeyAction",
             'click @ui.selectRow': 'selectRowAction',
             'keypress @ui.selectRow': 'selectRowAction',
+            'click @ui.showMore': 'showMoreAction',
+            'keypress @ui.showMore': 'showMoreAction',
         },
 
         initialize: function () {
@@ -247,7 +250,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             if (!(
                 e.target.classList.contains('module-case-list-column-checkbox') ||  // multiselect checkbox
                 e.target.classList.contains("select-row-checkbox") ||               // multiselect select all
-                $(e.target).is('a')                                                 // actual link, as in markdown
+                $(e.target).is('a') ||                                              // actual link, as in markdown
+                e.target.classList.contains('show-more') ||
+                e.target.parent.classList.contains('show-more')
             )) {
                 e.preventDefault();
                 let modelId = this.model.get('id');
@@ -275,6 +280,22 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             FormplayerFrontend.trigger("multiSelect:updateCases", action, [this.model.get('id')]);
         },
 
+        showMoreAction: function (e) {
+            console.log("show more");
+            const arrow = $(e.currentTarget).find("i");
+            const tileContent = $(e.currentTarget).prev();
+            if (arrow.hasClass("fa-angle-double-down")) {
+                arrow.removeClass("fa-angle-double-down");
+                arrow.addClass("fa-angle-double-up");
+                tileContent.removeClass("collapsed-tile");
+            } else {
+                arrow.removeClass("fa-angle-double-up");
+                arrow.addClass("fa-angle-double-down");
+                tileContent.addClass("collapsed-tile");
+            }
+
+        },
+
         isChecked: function () {
             return this.ui.selectRow.prop("checked");
         },
@@ -289,7 +310,22 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 resolveUri: function (uri) {
                     return FormplayerFrontend.getChannel().request('resourceMap', uri, appId);
                 },
+                overflows: true,
+                overflowClass: '',
+                // overflowClass: 'collapsed-tile',
             };
+        },
+
+        onAttach: function(e) {
+            const self = this;
+            const height = $(self.el).height()
+            console.log(`attaching tile:  ${height}`);
+            if (height > 150) {
+                const tileContent = $(self.el).find('.tile-content');
+                tileContent.addClass('collapsed-tile');
+                console.log(`added class collapsed-tile`);
+                $(self.el).append(`<div class="show-more"><i class="fa fa-angle-double-down"></i></div>`)
+            }
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -234,6 +234,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     self.ui.selectRow.prop("checked", action === constants.MULTI_SELECT_ADD);
                 }
             });
+            self.smallScreenListener = cloudcareUtils.smallScreenListener(smallScreenEnabled => {
+                self.smallScreenEnabled = smallScreenEnabled;
+            });
+            self.smallScreenListener.listen();
         },
 
         className: "formplayer-request case-row",
@@ -310,21 +314,18 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 resolveUri: function (uri) {
                     return FormplayerFrontend.getChannel().request('resourceMap', uri, appId);
                 },
-                overflows: true,
-                overflowClass: '',
-                // overflowClass: 'collapsed-tile',
             };
         },
 
         onAttach: function(e) {
             const self = this;
-            const height = $(self.el).height()
-            console.log(`attaching tile:  ${height}`);
-            if (height > 150) {
-                const tileContent = $(self.el).find('.tile-content');
-                tileContent.addClass('collapsed-tile');
-                console.log(`added class collapsed-tile`);
-                $(self.el).append(`<div class="show-more"><i class="fa fa-angle-double-down"></i></div>`)
+            if (self.smallScreenEnabled) {
+                const height = $(self.el).height()
+                if (height > 150) {
+                    const tileContent = $(self.el).find('.tile-content');
+                    tileContent.addClass('collapsed-tile');
+                    $(self.el).append(`<div class="show-more"><i class="fa fa-angle-double-down"></i></div>`);
+                }
             }
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -256,7 +256,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 e.target.classList.contains("select-row-checkbox") ||               // multiselect select all
                 $(e.target).is('a') ||                                              // actual link, as in markdown
                 e.target.classList.contains('show-more') ||
-                e.target.parent.classList.contains('show-more')
+                $(e.target).parent().hasClass('show-more')
             )) {
                 e.preventDefault();
                 let modelId = this.model.get('id');
@@ -286,15 +286,15 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         showMoreAction: function (e) {
             const arrow = $(e.currentTarget).find("i");
-            const tileContent = $(e.currentTarget).prev();
+            const tileContent = $(e.currentTarget).siblings('.collapsible-tile-content');
             if (arrow.hasClass("fa-angle-double-down")) {
                 arrow.removeClass("fa-angle-double-down");
                 arrow.addClass("fa-angle-double-up");
-                tileContent.removeClass("collapsed-tile");
+                tileContent.removeClass("collapsed-tile-content");
             } else {
                 arrow.removeClass("fa-angle-double-up");
                 arrow.addClass("fa-angle-double-down");
-                tileContent.addClass("collapsed-tile");
+                tileContent.addClass("collapsed-tile-content");
             }
 
         },
@@ -318,12 +318,15 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         onAttach: function () {
             const self = this;
-            if (self.isMultiSelect && self.smallScreenEnabled) {
+            // if (self.isMultiSelect && self.smallScreenEnabled)
+            {
                 const height = $(self.el).height();
                 if (height > 150) {
-                    const tileContent = $(self.el).find('.tile-content');
-                    tileContent.addClass('collapsed-tile');
-                    $(self.el).append(`<div class="show-more"><i class="fa fa-angle-double-down"></i></div>`);
+                    const tileContent = $(self.el).find('> .collapsible-tile-content');
+                    if (tileContent.length) {
+                        tileContent.addClass('collapsed-tile-content');
+                        $(self.el).append(`<div class="show-more"><i class="fa fa-angle-double-down"></i></div>`);
+                    }
                 }
             }
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -316,10 +316,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             };
         },
 
-        onAttach: function() {
+        onAttach: function () {
             const self = this;
             if (self.isMultiSelect && self.smallScreenEnabled) {
-                const height = $(self.el).height()
+                const height = $(self.el).height();
                 if (height > 150) {
                     const tileContent = $(self.el).find('.tile-content');
                     tileContent.addClass('collapsed-tile');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -208,6 +208,23 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         return caseListLayout;
     };
 
+    const getMapScrollOffset = function (addressMap, smallScreenEnabled) {
+        const $mapEl = $('#module-case-list-map');
+        const $stickyHeader = $('#small-screen-sticky-header');
+        let scrollTopOffset = parseInt(($mapEl).css('top'));
+        if (smallScreenEnabled) {
+            if ($stickyHeader[0]) {
+                scrollTopOffset = parseInt($stickyHeader.css('top')) + $stickyHeader.outerHeight();
+            } else if (addressMap.isFullscreen()) {
+                scrollTopOffset = constants.BREADCRUMB_HEIGHT_PX;
+            } else {
+                scrollTopOffset += $mapEl.outerHeight();
+            }
+        }
+        return scrollTopOffset;
+    };
+
+
     const CaseView = Marionette.View.extend({
         tagName: "tr",
         template: _.template($("#case-view-item-template").html() || ""),
@@ -295,6 +312,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 arrow.removeClass("fa-angle-double-up");
                 arrow.addClass("fa-angle-double-down");
                 tileContent.addClass("collapsed-tile-content");
+                const offset = getMapScrollOffset({isFullscreen: () => false}, this.smallScreenEnabled);
+                $(window).scrollTop($(e.currentTarget).parent().offset().top - offset);
             }
 
         },
@@ -318,7 +337,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         onAttach: function () {
             const self = this;
-            if (self.isMultiSelect && self.smallScreenEnabled) {
+            // if (self.isMultiSelect && self.smallScreenEnabled) {
+            {
                 const height = $(self.el).height();
                 if (height > 150) {
                     const tileContent = $(self.el).find('> .collapsible-tile-content');
@@ -633,22 +653,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             });
         },
 
-        getMapScrollOffset: function (addressMap) {
-            const $mapEl = $('#module-case-list-map');
-            const $stickyHeader = $('#small-screen-sticky-header');
-            let scrollTopOffset = parseInt(($mapEl).css('top'));
-            if (this.smallScreenEnabled) {
-                if ($stickyHeader[0]) {
-                    scrollTopOffset = parseInt($stickyHeader.css('top')) + $stickyHeader.outerHeight();
-                } else if (addressMap.isFullscreen()) {
-                    scrollTopOffset = constants.BREADCRUMB_HEIGHT_PX;
-                } else {
-                    scrollTopOffset += $mapEl.outerHeight();
-                }
-            }
-            return scrollTopOffset;
-        },
-
         loadMap: function () {
             const token = initialPageData.get("mapbox_access_token");
 
@@ -726,7 +730,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                                     marker.setIcon(selectedLocationIcon);
 
                                     $([document.documentElement, document.body]).animate({
-                                        scrollTop: $(`#${rowId}`).offset().top - this.getMapScrollOffset(addressMap),
+                                        scrollTop: $(`#${rowId}`).offset().top - getMapScrollOffset(addressMap, this.smallScreenEnabled),
                                     }, 500);
 
                                     addressMap.panTo(markerCoordinates);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -318,8 +318,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         onAttach: function () {
             const self = this;
-            // if (self.isMultiSelect && self.smallScreenEnabled)
-            {
+            if (self.isMultiSelect && self.smallScreenEnabled) {
                 const height = $(self.el).height();
                 if (height > 150) {
                     const tileContent = $(self.el).find('> .collapsible-tile-content');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -285,7 +285,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         showMoreAction: function (e) {
-            console.log("show more");
             const arrow = $(e.currentTarget).find("i");
             const tileContent = $(e.currentTarget).prev();
             if (arrow.hasClass("fa-angle-double-down")) {
@@ -317,9 +316,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             };
         },
 
-        onAttach: function(e) {
+        onAttach: function() {
             const self = this;
-            if (self.smallScreenEnabled) {
+            if (self.isMultiSelect && self.smallScreenEnabled) {
                 const height = $(self.el).height()
                 if (height > 150) {
                     const tileContent = $(self.el).find('.tile-content');

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -342,6 +342,10 @@ hqDefine('cloudcare/js/utils', [
         $el.on("focusout", $el.data("DateTimePicker").hide);
     };
 
+    var smallScreenIsEnabled = function () {
+        return window.innerWidth < constants.SMALL_SCREEN_WIDTH_PX;
+    };
+
     /**
      *  Listen for screen size changes to enable or disable small screen functionality.
      *  Accepts a callback function that should take in the new value of smallScreenEnabled.
@@ -351,7 +355,7 @@ hqDefine('cloudcare/js/utils', [
      *      stopListening() removes the jQuery event listener
      */
     var smallScreenListener = function (callback) {
-        var smallScreenEnabled = window.innerWidth < constants.SMALL_SCREEN_WIDTH_PX;
+        var smallScreenEnabled = smallScreenIsEnabled();
         var handleSmallScreenChange = () => {
             var shouldEnableSmallScreen = window.innerWidth < constants.SMALL_SCREEN_WIDTH_PX;
             if (smallScreenEnabled !== shouldEnableSmallScreen) {
@@ -389,6 +393,7 @@ hqDefine('cloudcare/js/utils', [
         formplayerLoadingComplete: formplayerLoadingComplete,
         formplayerSyncComplete: formplayerSyncComplete,
         reportFormplayerErrorToHQ: reportFormplayerErrorToHQ,
+        smallScreenIsEnabled: smallScreenIsEnabled,
         smallScreenListener: smallScreenListener,
     };
 });

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -145,7 +145,7 @@
       </div>
     <% } %>
 
-  <div class="<%- prefix %>-cell-grid-style tile-content">
+  <div class="<%- prefix %>-cell-grid-style collapsible-tile-content">
     <% _.each(data, function(datum, index) { %>
     <div class="<%- prefix %>-grid-style-<%- index %> box">
       <% if (styles[index].displayFormat === 'Image') {
@@ -169,7 +169,7 @@
     </div>
   <% } %>
 
-  <div class="group-data">
+  <div class="group-data collapsible-tile-content">
     <div class="<%- prefix %>-cell-grid-style">
       <% for (let [index, datum] of Object.entries(indexedHeaderData)) { %>
         <div class="<%- prefix %>-grid-style-<%- index %> box" >

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -145,7 +145,7 @@
       </div>
     <% } %>
 
-  <div class="<%- prefix %>-cell-grid-style">
+  <div class="<%- prefix %>-cell-grid-style tile-content">
     <% _.each(data, function(datum, index) { %>
     <div class="<%- prefix %>-grid-style-<%- index %> box">
       <% if (styles[index].displayFormat === 'Image') {
@@ -160,6 +160,7 @@
     </div>
     <% }); %>
   </div>
+
 </script>
 
 <script type="text/template" id="case-tile-grouped-view-item-template">

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -160,7 +160,6 @@
     </div>
     <% }); %>
   </div>
-
 </script>
 
 <script type="text/template" id="case-tile-grouped-view-item-template">

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
@@ -121,7 +121,7 @@ body {
   }
 }
 
-.collapsed-tile {
+.collapsed-tile-content {
   height: 100px;
   overflow-y: clip;
   -webkit-mask-image: linear-gradient(180deg, #000 60%, transparent);

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
@@ -120,3 +120,14 @@ body {
     border: 1px solid #ddd;
   }
 }
+
+.collapsed-tile {
+  height: 100px;
+  overflow-y: clip;
+  -webkit-mask-image: linear-gradient(180deg, #000 60%, transparent);
+}
+
+.show-more {
+  text-align: center;
+  font-size: large;
+}


### PR DESCRIPTION
## Product Description

On small screen big case tiles can be quite cumbersome. With these changes tiles of a certain size will be automatically collapsed on small screens and multi select enabled (see spec for reasoning). An arrow at to bottom of the tile lets you expand and re-collapse it.

https://github.com/dimagi/commcare-hq/assets/1946138/d8f1ab10-eb07-4f3b-a0d1-3cbe203d41ea

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3674
https://docs.google.com/document/d/1ZXPXUN5-rr184Sy00e8F3fSQKeCKffKwhvoTLcP0G38

## Feature Flag

None

## Safety Assurance

### Safety story

This is a cosmetic change that only affects the UI. I have tested it locally and on Staging. Kim had a look as well to check if her requirements were met.

### Automated test coverage

None

### QA Plan

Check the following configurations for case lists with big tiles:
* Flat tiles, wide screen => Same behavior as before
* Flat tiles, single select, small screen => Same behavior as before
* Flat tiles, multi select, small screen => Collapsible tiles
* Grouped tiles, wide screen => Same behavior as before
* Grouped tiles, single select, small screen => Same behavior as before
* Grouped tiles, multi select, small screen => Collapsible tiles

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
