### PR TITLE
Replace comment with soft assert

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -41,10 +41,17 @@ from corehq.apps.reports.tasks import export_all_rows_task
 from corehq.apps.reports.util import DatatablesParams
 from corehq.apps.saved_reports.models import ReportConfig
 from corehq.apps.users.models import CouchUser
+from corehq.util.soft_assert import soft_assert
 from corehq.util.timezones.utils import get_timezone
 from corehq.util.view_utils import absolute_reverse, request_as_dict, reverse
 
 CHART_SPAN_MAP = {1: '10', 2: '6', 3: '4', 4: '3', 5: '2', 6: '2'}
+
+
+_soft_assert_html_safe = soft_assert(
+    to='@'.join(('nhooper', 'dimagi.com')),
+    exponential_backoff=True,
+)
 
 
 def _sanitize_rows(rows):
@@ -59,8 +66,10 @@ def _sanitize_col(col):
     if isinstance(col, str):
         return conditional_escape(col)
 
-    # HACK: dictionaries make it here. The dictionaries I've seen have an 'html' key
-    # which I expect to be sanitized already, but there is no guaranteee
+    _soft_assert_html_safe(
+        isinstance(col, dict) and 'html' in col,
+        f'Potentially passing HTML-unsafe value {col!r} in report',
+    )
     return col
 
 

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -13,14 +13,13 @@ from django.http import (
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch
+from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
-from django.utils.html import conditional_escape
 
 from celery.utils.log import get_task_logger
 from memoized import memoized
 
-from corehq.util.timezones.utils import get_timezone
 from couchexport.export import export_from_tables, get_writer
 from couchexport.shortcuts import export_response
 from dimagi.utils.modules import to_function
@@ -42,6 +41,7 @@ from corehq.apps.reports.tasks import export_all_rows_task
 from corehq.apps.reports.util import DatatablesParams
 from corehq.apps.saved_reports.models import ReportConfig
 from corehq.apps.users.models import CouchUser
+from corehq.util.timezones.utils import get_timezone
 from corehq.util.view_utils import absolute_reverse, request_as_dict, reverse
 
 CHART_SPAN_MAP = {1: '10', 2: '6', 3: '4', 4: '3', 5: '2', 6: '2'}

--- a/corehq/apps/reports/tests/test_generic.py
+++ b/corehq/apps/reports/tests/test_generic.py
@@ -74,3 +74,25 @@ class SanitizeRowTests(SimpleTestCase):
         self.assertEqual(result[0], ['One', 'Two'])
         self.assertEqual(result[1], ['Three', 'Four'])
         self.assertEqual(result[2], ['Five', 'Six'])
+
+    def test_handles_safe_dict(self):
+        rows = [[{'text': '**One**', 'html': '<b>One</b>'}]]
+
+        result = _sanitize_rows(rows)
+        self.assertEqual(
+            result[0],
+            [{'text': '**One**', 'html': '<b>One</b>'}],
+        )
+
+    def test_soft_asserts_unsafe_dict(self):
+        rows = [[{'text': '<b>One</b>'}]]
+
+        with self.assertRaises(AssertionError):
+            _sanitize_rows(rows)
+
+    def test_soft_asserts_unexpected_type(self):
+        one = object()
+        rows = [[one]]
+
+        with self.assertRaises(AssertionError):
+            _sanitize_rows(rows)


### PR DESCRIPTION
## Technical Summary

I found this comment while working on a report. Curious to hear your thoughts on replacing it with a soft_assert.

## Safety Assurance

### Safety story

* Unit tests with and without `softer_assert()` convinced me that the change behaves as expected.
* Marking as medium risk anyway, because this code is used a lot.

### Automated test coverage

Includes tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
