### PR TITLE
Pagination for the Case Grouping Map

### DIFF
--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -184,3 +184,16 @@ def geo_shape(field, shape, relation='intersects'):
             }
         }
     }
+
+
+def geo_grid(field, geohash):
+    """
+    Filters cases by the geohash grid cell in which they are located.
+    """
+    return {
+        "geo_grid": {
+            field: {
+                "geohash": geohash
+            }
+        }
+    }

--- a/corehq/apps/es/tests/test_filters.py
+++ b/corehq/apps/es/tests/test_filters.py
@@ -259,6 +259,38 @@ class TestFilters(ElasticTestMixin, SimpleTestCase):
             validate_query=False,
         )
 
+    def test_geo_grid(self):
+        query = CaseSearchES().filter(
+            filters.geo_grid('location', 'u0')
+        )
+        json_output = {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "geo_grid": {
+                                "location": {
+                                    "geohash": "u0"
+                                }
+                            }
+                        },
+                        {
+                            "match_all": {}
+                        }
+                    ],
+                    "must": {
+                        "match_all": {}
+                    }
+                }
+            },
+            "size": SIZE_LIMIT
+        }
+        self.checkQuery(
+            query,
+            json_output,
+            validate_query=False,
+        )
+
 
 @es_test
 class TestSourceFiltering(ElasticTestMixin, SimpleTestCase):

--- a/corehq/apps/geospatial/README.md
+++ b/corehq/apps/geospatial/README.md
@@ -1,18 +1,51 @@
-# Case Grouping
+Geospatial Features
+===================
 
-There are various configuration settings available for deciding how case grouping is done. These parameters are saved in the `GeoConfig` model which is linked to a domain.
-It is important to note however, that not all available parameters will be used for case grouping. The parameters that actually get used is determined by the chosen grouping
-method. Mainly, these are:
-1. Min/Max Grouping - Grouping is done by specifying the minimum and maximum number of cases that each group may have.
-2. Target Size Grouping - Grouping is done by specifying how many groups should be created. Cases will then evenly get distributed into groups to meet the target number of groups.
+Geospatial features allow the management of cases and mobile workers
+based on their geographical location. Case location is stored in a
+configurable case property, which defaults to "gps_point". Mobile
+worker location is stored in user data, also with the name "gps_point".
 
 
-# Setup Test Data
+Case Grouping
+-------------
 
-To populate test data for any domain, you could simply do a bulk upload for cases with the following columns
+There are various configuration settings available for deciding how case
+grouping is done. These parameters are saved in the `GeoConfig` model
+which is linked to a domain. It is important to note however, that not
+all available parameters will be used for case grouping. The parameters
+that actually get used is determined by the chosen grouping method.
+Mainly, these are:
+
+1. Min/Max Grouping - Grouping is done by specifying the minimum and
+   maximum number of cases that each group may have.
+
+2. Target Size Grouping - Grouping is done by specifying how many groups
+   should be created. Cases will then evenly get distributed into groups
+   to meet the target number of groups.
+
+
+Setting Up Test Data
+--------------------
+
+To populate test data for any domain, you could simply do a bulk upload
+for cases with the following columns
+
 1. case_id: Blank for new cases
-2. name: (Optional) Add a name for each case. Remove column if not using
-3. gps_point: GPS coordinate for the case that has latitude, longitude, altitude and accuracy separated by an empty space. Example: `9.9999952 3.2859413 393.2 4.36`. This is the case property saved on a case to capture its location and is configurable with default value being `gps_point`, so good to check Geospatial Configuration Settings page for the project to confirm the case property being used before doing the upload. If its different, then this column should use that case property instead of `gps_point`
-4. owner_name: (Optional) To assign case to a mobile worker, simply add worker username here. Remove column if not using
 
-For dimagi devs looking for bulk data, you could use any of the excel sheets available in https://dimagi-dev.atlassian.net/browse/SC-3051
+2. name: (Optional) Add a name for each case. Remove column if not using
+
+3. gps_point: GPS coordinate for the case that has latitude, longitude,
+   altitude and accuracy separated by an empty space. Example:
+   `9.9999952 3.2859413 393.2 4.36`. This is the case property saved on
+   a case to capture its location and is configurable with default
+   value being `gps_point`, so good to check Geospatial Configuration
+   Settings page for the project to confirm the case property being
+   used before doing the upload. If its different, then this column
+   should use that case property instead of `gps_point`
+
+4. owner_name: (Optional) To assign case to a mobile worker, simply add
+   worker username here. Remove column if not using.
+
+For Dimagi devs looking for bulk data, you could use any of the Excel
+sheets available in [SC-3051](https://dimagi-dev.atlassian.net/browse/SC-3051).

--- a/corehq/apps/geospatial/README.md
+++ b/corehq/apps/geospatial/README.md
@@ -25,6 +25,54 @@ Mainly, these are:
    to meet the target number of groups.
 
 
+CaseGroupingReport pagination
+-----------------------------
+
+The `CaseGroupingReport` class uses Elasticsearch
+[GeoHash Grid Aggregation][1] to group cases into buckets.
+
+Elasticsearch [bucket aggregations][2] create buckets of documents,
+where each bucket corresponds to a property that determines whether a
+document falls into that bucket.
+
+The buckets of GeoHash Grid Aggregation are cells in a grid. Each cell
+has a GeoHash, which is like a ZIP code or a postal code, in that it
+represents a geographical area. If a document's GeoPoint is in a
+GeoHash's geographical area, then Elasticsearch places it in the
+corresponding bucket. For more information on GeoHash grid cells, see
+the Elasticsearch docs on [GeoHash cell dimensions][3].
+
+GeoHash Grid Aggregation buckets look like this:
+```
+[
+    {
+        "key": "u17",
+        "doc_count": 3
+    },
+    {
+        "key": "u09",
+        "doc_count": 2
+    },
+    {
+        "key": "u15",
+        "doc_count": 1
+    }
+]
+```
+In this example, "key" is a GeoHash of length 3, and "doc_count" gives
+the number of documents in each bucket, or GeoHash grid cell.
+
+For `CaseGroupingReport`, buckets can have up to 10,000 cases each. But
+they could also have much less than that. If the user requests, say, 50
+rows per page, and the page that the user is looking at has fewer than
+50 cases left in the current bucket, then page will need to include
+cases from the next bucket.
+
+The report uses the GeoHash and document counts from the list of
+buckets, like the example above, to determine the buckets and cases to
+include in each page.
+
+
 Setting Up Test Data
 --------------------
 
@@ -48,4 +96,10 @@ for cases with the following columns
    worker username here. Remove column if not using.
 
 For Dimagi devs looking for bulk data, you could use any of the Excel
-sheets available in [SC-3051](https://dimagi-dev.atlassian.net/browse/SC-3051).
+sheets available in Jira ticket [SC-3051][4].
+
+
+[1]: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-geohashgrid-aggregation.html
+[2]: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket.html
+[3]: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-geohashgrid-aggregation.html#_cell_dimensions_at_the_equator
+[4]: https://dimagi-dev.atlassian.net/browse/SC-3051

--- a/corehq/apps/geospatial/README.md
+++ b/corehq/apps/geospatial/README.md
@@ -62,15 +62,8 @@ GeoHash Grid Aggregation buckets look like this:
 In this example, "key" is a GeoHash of length 3, and "doc_count" gives
 the number of documents in each bucket, or GeoHash grid cell.
 
-For `CaseGroupingReport`, buckets can have up to 10,000 cases each. But
-they could also have much less than that. If the user requests, say, 50
-rows per page, and the page that the user is looking at has fewer than
-50 cases left in the current bucket, then page will need to include
-cases from the next bucket.
-
-The report uses the GeoHash and document counts from the list of
-buckets, like the example above, to determine the buckets and cases to
-include in each page.
+For `CaseGroupingReport`, buckets are pages. So pagination simply flips
+from one bucket to the next.
 
 
 Setting Up Test Data

--- a/corehq/apps/geospatial/es.py
+++ b/corehq/apps/geospatial/es.py
@@ -107,7 +107,7 @@ def apply_geohash_agg(query, case_property, precision):
     )
 
 
-def get_bucket_keys_for_page(es_results, skip, limit):
+def get_bucket_keys_for_page(buckets, skip, limit):
     """
     Returns the keys of the buckets that this page spans, and the number
     of cases to be skipped in the first bucket.
@@ -117,13 +117,6 @@ def get_bucket_keys_for_page(es_results, skip, limit):
     second and third buckets, and we want to skip the first case in the
     second bucket.
     """
-    buckets = (
-        es_results['aggregations']
-        ['case_properties']
-        ['case_property']
-        [AGG_NAME]
-        ['buckets']
-    )
     if not buckets:
         return [], 0
 

--- a/corehq/apps/geospatial/es.py
+++ b/corehq/apps/geospatial/es.py
@@ -107,37 +107,6 @@ def apply_geohash_agg(query, case_property, precision):
     )
 
 
-def get_bucket_keys_for_page(buckets, skip, limit):
-    """
-    Returns the keys of the buckets that this page spans, and the number
-    of cases to be skipped in the first bucket.
-
-    For example, if there are 3 buckets containing 1, 2 and 3 cases
-    respectively, and ``skip`` is 2 and ``limit`` is 2, then we want the
-    second and third buckets, and we want to skip the first case in the
-    second bucket.
-    """
-    if not buckets:
-        return [], 0
-
-    count = 0
-    bucket_keys = []
-    for bucket in buckets:
-        if count == 0 and skip >= bucket['doc_count']:
-            # Skip this bucket
-            skip -= bucket['doc_count']
-            continue
-        if count < limit:
-            bucket_keys.append(bucket['key'])
-            if count == 0:
-                # First bucket. Skip `skip`
-                count = bucket['doc_count'] - skip
-            else:
-                count += bucket['doc_count']
-        if count >= limit:
-            return bucket_keys, skip
-
-
 def mid(lower, upper):
     """
     Returns the integer midpoint between ``lower`` and ``upper``.

--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -17,7 +17,7 @@ from corehq.apps.reports.standard.cases.basic import CaseListMixin
 from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
 
 from .dispatchers import CaseManagementMapDispatcher
-from .es import apply_geohash_agg, find_precision
+from .es import apply_geohash_agg, find_precision, get_bucket_keys_for_page
 from .models import GeoPolygon
 from .utils import get_geo_case_property
 
@@ -54,32 +54,16 @@ class BaseCaseMapReport(ProjectReport, CaseListMixin):
     def _get_geo_point(self, case):
         return NotImplementedError()
 
-    @property
-    def rows(self):
+    def _get_geo_location(self, case):
+        geo_point = self._get_geo_point(case)
+        if not geo_point:
+            return
 
-        def _get_geo_location(case):
-            geo_point = self._get_geo_point(case)
-            if not geo_point:
-                return
-
-            try:
-                geo_point = GeoPoint.from_string(geo_point, flexible=True)
-                return {"lat": geo_point.latitude, "lng": geo_point.longitude}
-            except BadValueError:
-                return None
-
-        cases = []
-        for row in self.es_results['hits'].get('hits', []):
-            display = CaseDisplayES(
-                self.get_case(row), self.timezone, self.individual
-            )
-            coordinates = _get_geo_location(self.get_case(row))
-            cases.append([
-                display.case_id,
-                coordinates,
-                display.case_link
-            ])
-        return cases
+        try:
+            geo_point = GeoPoint.from_string(geo_point, flexible=True)
+            return {"lat": geo_point.latitude, "lng": geo_point.longitude}
+        except BadValueError:
+            return None
 
 
 class CaseManagementMap(BaseCaseMapReport):
@@ -107,6 +91,21 @@ class CaseManagementMap(BaseCaseMapReport):
         })
         return context
 
+    @property
+    def rows(self):
+        cases = []
+        for row in self.es_results['hits'].get('hits', []):
+            display = CaseDisplayES(
+                self.get_case(row), self.timezone, self.individual
+            )
+            coordinates = self._get_geo_location(self.get_case(row))
+            cases.append([
+                display.case_id,
+                coordinates,
+                display.case_link
+            ])
+        return cases
+
 
 class CaseGroupingReport(BaseCaseMapReport):
     name = gettext_noop('Case Grouping')
@@ -116,39 +115,147 @@ class CaseGroupingReport(BaseCaseMapReport):
     base_template = 'geospatial/case_grouping_map_base.html'
     report_template_path = 'case_grouping_map.html'
 
-    def _build_query(self):
-        query = super()._build_query()
-        case_property = get_geo_case_property(self.domain)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-        # NOTE: ASSUMES polygon is available in request.POST['feature']
-        if 'feature' in self.request.POST:
-            # Filter cases by a shape set by the user
-            geojson = json.loads(self.request.POST['feature'])
+        # geohash grid precision, set by self._aggregate_query(), read
+        # by self.shared_pagination_GET_params()
+        self._precision = None
+
+    def _base_query(self):
+        # Overrides super()._base_query() to not implement pagination
+        # here. It is done later, in self.rows()
+        return self.search_class().domain(self.domain)
+
+    def _build_query(self):
+        """
+        Returns a filtered, unaggregated, unpaginated ESQuery.
+
+        This allows it to be used by `total_cases()`.
+        """
+        query = super()._build_query()
+        return self._filter_query(query)
+
+    def _filter_query(self, query, additional_filters=None):
+        """
+        Adds ``additional_filters`` to ``query``. If a user-defined
+        polygon (or other GeoShape) is passed in the "feature" GET
+        param, adds that as a filter to ``query``.
+        """
+        # NOTE: Expects GeoShape in request.GET['feature']
+        if self.request.GET.get('feature'):
+            case_property = get_geo_case_property(self.domain)
+            geojson = json.loads(self.request.GET['feature'])
             shape = geojson_to_es_geoshape(geojson)
             relation = 'within' if shape['type'] == 'polygon' else 'intersects'
-            query.nested(
-                CASE_PROPERTIES_PATH,
-                filters.geo_shape(
+            if additional_filters:
+                additional_filters.append(filters.geo_shape(
                     field=case_property,
                     shape=shape,
                     relation=relation,
+                ))
+            else:
+                query.nested(
+                    CASE_PROPERTIES_PATH,
+                    filters.geo_shape(
+                        field=case_property,
+                        shape=shape,
+                        relation=relation,
+                    )
                 )
+        if additional_filters:
+            query.nested(
+                CASE_PROPERTIES_PATH,
+                additional_filters
             )
-
-        # Apply geohash grid aggregation
-        if 'precision' in self.request.GET:
-            precision = self.request.GET['precision']
-        else:
-            precision = find_precision(query, case_property)
-
-        query = apply_geohash_agg(query, case_property, precision)
         return query
+
+    def _aggregate_query(self, query):
+        """
+        Returns ``query`` with geohash grid aggregation applied.
+
+        Also determines ``self._precision`` if it is not set.
+        """
+        case_property = get_geo_case_property(self.domain)
+
+        if self.request.GET.get('precision'):
+            self._precision = int(self.request.GET['precision'])
+        else:
+            # TODO: What is the best way to send this value to the
+            #       browser, for the browser to pass it back as a GET
+            #       param across page requests?
+            self._precision = find_precision(query, case_property)
+
+        return apply_geohash_agg(query, case_property, self._precision)
 
     def _get_geo_point(self, case):
         case_obj = wrap_case_search_hit(case)
         geo_case_property = get_geo_case_property(case_obj.domain)
         geo_point = case_obj.case_json.get(geo_case_property)
         return geo_point
+
+    @property
+    def rows(self):
+        """
+        Returns paginated cases
+        """
+        # Pagination uses a three-step process:
+        # 1. Cases are filtered by `self._build_query()`
+        # 2. The filtered cases are aggregated into buckets by
+        #    `self._aggregate_query()`.
+        # 3. The cases of the selected page may span buckets. The page's
+        #    buckets are calculated, and their cases are fetched.
+        query = self._build_query()
+        query = self._aggregate_query(query)
+        es_results = query.run().raw
+        if es_results is None:
+            return []
+        bucket_keys, skip = get_bucket_keys_for_page(
+            es_results,
+            self.pagination.start,
+            self.pagination.count,
+        )
+        if not bucket_keys:
+            return []
+
+        # We now have everything we need to build the query that will
+        # return the cases for this page.
+        case_property = get_geo_case_property(self.domain)
+        cases = []
+        for geohash in bucket_keys:
+            # We fetch each bucket separately to maintain case sequence.
+            # TODO: Can we OR the geo_grid filters and sort by geohash?
+            query = super()._build_query()
+            query_filters = [filters.geo_grid(
+                field=case_property,
+                geohash=geohash,
+            )]
+            self._filter_query(query, additional_filters=query_filters)
+            es_results = query.run().raw
+
+            for row in es_results['hits'].get('hits', []):
+                if skip > 0:
+                    skip -= 1
+                    continue
+                display = CaseDisplayES(
+                    self.get_case(row), self.timezone, self.individual
+                )
+                coordinates = self._get_geo_location(self.get_case(row))
+                cases.append([
+                    display.case_id,
+                    coordinates,
+                    display.case_link
+                ])
+        return cases
+
+    @property
+    def shared_pagination_GET_params(self):
+        shared_params = super().shared_pagination_GET_params
+        shared_params.extend([
+            {'name': 'feature', 'value': self.request.GET.get('feature')},
+            {'name': 'precision', 'value': self._precision},
+        ])
+        return shared_params
 
 
 def geojson_to_es_geoshape(geojson):

--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -178,10 +178,7 @@ class CaseGroupingReport(BaseCaseMapReport):
         """
         Returns paginated cases
         """
-        buckets = self._get_buckets(
-            self.domain,
-            self.shared_pagination_GET_params,
-        )
+        buckets = self._get_buckets()
         if not buckets:
             return []
         # Ignore self.pagination.count. It is always treated as 1.
@@ -215,10 +212,7 @@ class CaseGroupingReport(BaseCaseMapReport):
         Pagination count is always treated as 1, so the total number of
         records == the number of pages == the number of buckets.
         """
-        buckets = self._get_buckets(
-            self.domain,
-            self.shared_pagination_GET_params,
-        )
+        buckets = self._get_buckets()
         return len(buckets)
 
     @property

--- a/corehq/apps/geospatial/tests/test_es.py
+++ b/corehq/apps/geospatial/tests/test_es.py
@@ -81,34 +81,13 @@ class TestGetMaxDocCount(TestCase):
 
 
 def test_get_bucket_keys_for_page():
-    es_results = {
-        'aggregations': {
-            'case_properties': {
-                'doc_count': 66,
-                'case_property': {
-                    'doc_count': 6,
-                    'geohashes': {
-                        'buckets': [
-                            {
-                                "key": "u17",
-                                "doc_count": 1
-                            },
-                            {
-                                "key": "u09",
-                                "doc_count": 2
-                            },
-                            {
-                                "key": "u15",
-                                "doc_count": 3
-                            }
-                        ]
-                    }
-                }
-            }
-        }
-    }
+    buckets = [
+        {"key": "u17", "doc_count": 1},
+        {"key": "u09", "doc_count": 2},
+        {"key": "u15", "doc_count": 3}
+    ]
     bucket_keys, skip = get_bucket_keys_for_page(
-        es_results,
+        buckets,
         skip=0,
         limit=2,
     )
@@ -116,7 +95,7 @@ def test_get_bucket_keys_for_page():
     assert_equal(skip, 0)
 
     bucket_keys, skip = get_bucket_keys_for_page(
-        es_results,
+        buckets,
         skip=2,
         limit=2,
     )

--- a/corehq/apps/geospatial/tests/test_es.py
+++ b/corehq/apps/geospatial/tests/test_es.py
@@ -12,11 +12,7 @@ from corehq.apps.es import CaseSearchES
 from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.tests.utils import case_search_es_setup, es_test
 from corehq.apps.geospatial.const import GPS_POINT_CASE_PROPERTY
-from corehq.apps.geospatial.es import (
-    find_precision,
-    get_bucket_keys_for_page,
-    get_max_doc_count,
-)
+from corehq.apps.geospatial.es import find_precision, get_max_doc_count
 from corehq.apps.geospatial.utils import get_geo_case_property
 from corehq.util.test_utils import flag_enabled
 
@@ -78,29 +74,6 @@ class TestGetMaxDocCount(TestCase):
         precision = 3
         max_doc_count = get_max_doc_count(query, case_property, precision)
         self.assertEqual(max_doc_count, 3)
-
-
-def test_get_bucket_keys_for_page():
-    buckets = [
-        {"key": "u17", "doc_count": 1},
-        {"key": "u09", "doc_count": 2},
-        {"key": "u15", "doc_count": 3}
-    ]
-    bucket_keys, skip = get_bucket_keys_for_page(
-        buckets,
-        skip=0,
-        limit=2,
-    )
-    assert_equal(bucket_keys, ['u17', 'u09'])
-    assert_equal(skip, 0)
-
-    bucket_keys, skip = get_bucket_keys_for_page(
-        buckets,
-        skip=2,
-        limit=2,
-    )
-    assert_equal(bucket_keys, ['u09', 'u15'])
-    assert_equal(skip, 1)
 
 
 def test_doctests():

--- a/corehq/apps/geospatial/tests/test_es.py
+++ b/corehq/apps/geospatial/tests/test_es.py
@@ -12,7 +12,11 @@ from corehq.apps.es import CaseSearchES
 from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.tests.utils import case_search_es_setup, es_test
 from corehq.apps.geospatial.const import GPS_POINT_CASE_PROPERTY
-from corehq.apps.geospatial.es import find_precision, get_max_doc_count
+from corehq.apps.geospatial.es import (
+    find_precision,
+    get_bucket_keys_for_page,
+    get_max_doc_count,
+)
 from corehq.apps.geospatial.utils import get_geo_case_property
 from corehq.util.test_utils import flag_enabled
 
@@ -74,6 +78,50 @@ class TestGetMaxDocCount(TestCase):
         precision = 3
         max_doc_count = get_max_doc_count(query, case_property, precision)
         self.assertEqual(max_doc_count, 3)
+
+
+def test_get_bucket_keys_for_page():
+    es_results = {
+        'aggregations': {
+            'case_properties': {
+                'doc_count': 66,
+                'case_property': {
+                    'doc_count': 6,
+                    'geohashes': {
+                        'buckets': [
+                            {
+                                "key": "u17",
+                                "doc_count": 1
+                            },
+                            {
+                                "key": "u09",
+                                "doc_count": 2
+                            },
+                            {
+                                "key": "u15",
+                                "doc_count": 3
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    bucket_keys, skip = get_bucket_keys_for_page(
+        es_results,
+        skip=0,
+        limit=2,
+    )
+    assert_equal(bucket_keys, ['u17', 'u09'])
+    assert_equal(skip, 0)
+
+    bucket_keys, skip = get_bucket_keys_for_page(
+        es_results,
+        skip=2,
+        limit=2,
+    )
+    assert_equal(bucket_keys, ['u09', 'u15'])
+    assert_equal(skip, 1)
 
 
 def test_doctests():

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -20,6 +20,7 @@ from corehq.apps.geospatial.utils import get_geo_case_property
 from corehq.form_processor.backends.sql.dbaccessors import CaseReindexAccessor
 from corehq.pillows.base import is_couch_change_for_sql_domain
 from corehq.toggles import (
+    GEOSPATIAL,
     USH_CASE_CLAIM_UPDATES,
 )
 from corehq.util.doc_processor.sql import SqlDocumentProvider
@@ -83,7 +84,7 @@ def _get_case_properties(doc_dict):
     dynamic_properties = [_format_property(key, value, case_id)
                           for key, value in doc_dict['case_json'].items()]
 
-    if USH_CASE_CLAIM_UPDATES.enabled(domain):
+    if USH_CASE_CLAIM_UPDATES.enabled(domain) or GEOSPATIAL.enabled(domain):
         _add_smart_types(dynamic_properties, domain, doc_dict['type'])
 
     return base_case_properties + dynamic_properties


### PR DESCRIPTION
## Technical Summary

Implements pagination for the Case Grouping Map page.

Context:
* [SC-3055](https://dimagi-dev.atlassian.net/browse/SC-3055)
* [Spec](https://docs.google.com/document/d/1jVFUYxYd6F6M1ONpEPEsG7BxFJDXmeY5Ebgx-TcnI1A/edit#heading=h.db494g9hyctf)

The spec covers grouping using geohash, but different geohash grid cells will contain different numbers of cases. The approach I have taken here uses geohash grid aggregation to return cases by their geohash grid cell, but also respects the case count set by the user. See code comments for more details.

There are also two "TODO"s left in the code:
```
    # TODO: What is the best way to send this value to the
    #       browser, for the browser to pass it back as a GET
    #       param across page requests?
```
and
```
    # We fetch each bucket separately to maintain case sequence.
    # TODO: Can we OR the geo_grid filters and sort by geohash?
```
I'm interested on your thoughts on the first. For the second, I am guessing that it's not possible to sort by geohash, and we will need to stick with the less efficient approach to fetching cases by grid cell, but I'd like to be wrong.

Opening as a draft PR because this has not yet had enough testing locally.

## Feature Flag

GEOSPATIAL

## Safety Assurance

### Safety story

Some local testing

### Automated test coverage

Includes tests

### QA Plan

The geospatial feature will go though QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3055]: https://dimagi-dev.atlassian.net/browse/SC-3055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ