### PR TITLE
handle no refresh token

### DIFF
--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -210,7 +210,7 @@ class OAuth2ClientGrantManager(AuthManager):
             # Used by OAuth2Session
             self.last_token = token
 
-        if not self.last_token:
+        if not self.last_token or self.last_token.get('refresh_token') is None:
             client = BackendApplicationClient(client_id=self.client_id)
             session = OAuth2Session(client=client)
             self.last_token = session.fetch_token(
@@ -281,7 +281,7 @@ class OAuth2PasswordGrantManager(AuthManager):
             # Used by OAuth2Session
             self.last_token = token
 
-        if not self.last_token:
+        if not self.last_token or self.last_token.get('refresh_token') is None:
             client = LegacyApplicationClient(client_id=self.client_id)
             session = OAuth2Session(client=client)
             if self.pass_credentials_in_header:

--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -210,6 +210,10 @@ class OAuth2ClientGrantManager(AuthManager):
             # Used by OAuth2Session
             self.last_token = token
 
+        # This adds an extra round trip for all access tokens without refresh tokens.
+        # That is not ideal, but is the only way to ensure that we are able to guarantee
+        # the token will work without error, or refactoring the way sessions are used across
+        # all repeaters.            
         if not self.last_token or self.last_token.get('refresh_token') is None:
             client = BackendApplicationClient(client_id=self.client_id)
             session = OAuth2Session(client=client)
@@ -281,6 +285,10 @@ class OAuth2PasswordGrantManager(AuthManager):
             # Used by OAuth2Session
             self.last_token = token
 
+        # This adds an extra round trip for all access tokens without refresh tokens.
+        # That is not ideal, but is the only way to ensure that we are able to guarantee
+        # the token will work without error, or refactoring the way sessions are used across
+        # all repeaters.
         if not self.last_token or self.last_token.get('refresh_token') is None:
             client = LegacyApplicationClient(client_id=self.client_id)
             session = OAuth2Session(client=client)

--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -213,7 +213,7 @@ class OAuth2ClientGrantManager(AuthManager):
         # This adds an extra round trip for all access tokens without refresh tokens.
         # That is not ideal, but is the only way to ensure that we are able to guarantee
         # the token will work without error, or refactoring the way sessions are used across
-        # all repeaters.            
+        # all repeaters.
         if not self.last_token or self.last_token.get('refresh_token') is None:
             client = BackendApplicationClient(client_id=self.client_id)
             session = OAuth2Session(client=client)


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Standards compliant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3) oauth providers do not send refresh tokens with the client credentials grant. Our code assumed there would always be a refresh token and that was causing [errors](https://dimagi.sentry.io/issues/4441621140/?environment=staging&project=136860&query=is%3Aunresolved+refresh&referrer=issue-stream&statsPeriod=90d&stream_index=0). I also updated the password grant to handle this better because refresh tokens are optional there.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This does not change the underlying token requests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
