### PR TITLE
Filter CustomerInvoice correctly

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -487,6 +487,9 @@ class InvoiceInterfaceBase(GenericTabularReport):
     exportable = True
     export_format_override = Format.CSV
 
+    def filter_by_subscription(self, subscription):
+        self.subscription = subscription
+
 
 class WireInvoiceInterface(InvoiceInterfaceBase):
     name = "Wire Invoices"
@@ -924,9 +927,6 @@ class InvoiceInterface(InvoiceInterfaceBase):
             'rows': self.rows,
         })
 
-    def filter_by_subscription(self, subscription):
-        self.subscription = subscription
-
 
 class CustomerInvoiceInterface(InvoiceInterfaceBase):
     name = "Customer Invoices"
@@ -1185,9 +1185,6 @@ class CustomerInvoiceInterface(InvoiceInterfaceBase):
             'month': statement_start.strftime("%B"),
             'rows': self.rows,
         })
-
-    def filter_by_subscription(self, subscription):
-        self.subscription = subscription
 
 
 def _get_domain_from_payment_record(payment_record):

--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -1073,6 +1073,9 @@ class CustomerInvoiceInterface(InvoiceInterfaceBase):
     def _invoices(self):
         queryset = CustomerInvoice.objects.all()
 
+        if self.subscription:
+            queryset = queryset.filter(subscriptions=self.subscription)
+
         account_name = NameFilter.get_value(self.request, self.domain)
         if account_name is not None:
             queryset = queryset.filter(
@@ -1183,8 +1186,8 @@ class CustomerInvoiceInterface(InvoiceInterfaceBase):
             'rows': self.rows,
         })
 
-    def filter_by_account(self, account):
-        self.account = account
+    def filter_by_subscription(self, subscription):
+        self.subscription = subscription
 
 
 def _get_domain_from_payment_record(payment_record):

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -442,7 +442,7 @@ class EditSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
 
         if self.subscription.account.is_customer_billing_account:
             invoice_report = CustomerInvoiceInterface(self.request)
-            invoice_report.filter_by_account(self.subscription.account)
+            invoice_report.filter_by_subscription(self.subscription)
         else:
             invoice_report = InvoiceInterface(self.request)
             invoice_report.filter_by_subscription(self.subscription)

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -442,10 +442,9 @@ class EditSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
 
         if self.subscription.account.is_customer_billing_account:
             invoice_report = CustomerInvoiceInterface(self.request)
-            invoice_report.filter_by_subscription(self.subscription)
         else:
             invoice_report = InvoiceInterface(self.request)
-            invoice_report.filter_by_subscription(self.subscription)
+        invoice_report.filter_by_subscription(self.subscription)
         # Tied to InvoiceInterface.
         encoded_params = urlencode({'subscriber': subscriber_domain})
         invoice_report_url = "{}?{}".format(invoice_report.get_url(), encoded_params)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
If we search subscription by account, if the account is an enterprise account, then in the list of subscriptions, if we click on edit on one of the subscriptions, the page would take 45 seconds to load. It's because, the Invoices tab in EditSubscriptionView, will return all invoices, which causing the slowness.

After the fix, the Invoices tab should only return the related invoices.
![image](https://github.com/dimagi/commcare-hq/assets/39149002/32a32d57-7442-41e3-b208-506144908094)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: [SAAS-14989](https://dimagi-dev.atlassian.net/browse/SAAS-14989)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just change how we filter the invoice. 
Tested on staging.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

No
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-14989]: https://dimagi-dev.atlassian.net/browse/SAAS-14989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ