### PR TITLE
Case search custom ES sort

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2122,6 +2122,13 @@ class DefaultCaseSearchProperty(DocumentSchema):
     defaultValue = StringProperty(exclude_if_none=True)
 
 
+class CaseSearchCustomSortProperty(DocumentSchema):
+    """Sort properties to be applied to search before results are filtered"""
+    property_name = StringProperty()
+    sort_type = StringProperty()
+    direction = StringProperty()
+
+
 class BaseCaseSearchLabel(NavMenuItemMediaMixin):
     def get_app(self):
         return self._module.get_app()
@@ -2150,6 +2157,7 @@ class CaseSearch(DocumentSchema):
     search_filter = StringProperty(exclude_if_none=True)
     search_button_display_condition = StringProperty(exclude_if_none=True)
     default_properties = SchemaListProperty(DefaultCaseSearchProperty)
+    custom_sort_properties = SchemaListProperty(CaseSearchCustomSortProperty)
     blacklisted_owner_ids_expression = StringProperty(exclude_if_none=True)
     additional_case_types = StringListProperty()
     data_registry = StringProperty(exclude_if_none=True)

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -32,8 +32,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             write: function (value) {
                 if (value === undefined) {
                     self.nodeset(null);
-                }
-                else {
+                } else {
                     self.instance_id(value);
                     var itemList = _.filter(get('js_options').item_lists, function (item) {
                         return item.id === value;
@@ -305,8 +304,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
         // init with blank string to avoid triggering save button
         var appearance = searchProperty.appearance || "";
         if (searchProperty.input_ === "select1" || searchProperty.input_ === "select") {
-            var instance_id = searchProperty.itemset.instance_id;
-            if (instance_id !== null && instance_id.includes("commcare-reports")) {
+            var instanceId = searchProperty.itemset.instance_id;
+            if (instanceId !== null && instanceId.includes("commcare-reports")) {
                 appearance = "report_fixture";
             } else {
                 appearance = "lookup_table_fixture";

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -1,8 +1,7 @@
-/* global Uint8Array */
 hqDefine("app_manager/js/details/case_claim", function () {
     var get = hqImport('hqwebapp/js/initial_page_data').get,
         generateSemiRandomId = function () {
-        // https://stackoverflow.com/a/2117523
+            // https://stackoverflow.com/a/2117523
             return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, function (c) {
                 return (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16);
             });
@@ -41,8 +40,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     });
                     if (itemList && itemList.length === 1) {
                         self.nodeset(itemsetValue(itemList[0]));
-                    }
-                    else {
+                    } else {
                         self.nodeset(null);
                     }
                 }
@@ -56,8 +54,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 return true;
             }
             var itemLists = _.map(get('js_options').item_lists, function (item) {
-                    return itemsetValue(item);
-                });
+                return itemsetValue(item);
+            });
             if (self.nodeset().split("/").length === 0) {
                 return false;
             }
@@ -113,8 +111,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             var appearance = self.appearance();
             if (appearance === 'report_fixture' || appearance === 'lookup_table_fixture') {
                 return 'fixture';
-            }
-            else {
+            } else {
                 return appearance;
             }
         });
@@ -127,8 +124,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     'tableLabel': gettext("Mobile UCR Report"),
                     'selectLabel': gettext("Select a Report..."),
                 };
-            }
-            else {
+            } else {
                 return {
                     'labelPlaceholder': 'name',
                     'valuePlaceholder': 'id',
@@ -214,7 +210,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         options.description = options.description[lang] || "";
         var mapping = {
             'additional_registry_cases': {
-                create: function(options) {
+                create: function (options) {
                     return additionalRegistryCaseModel(options.data, saveButton);
                 },
             },
@@ -290,7 +286,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
 
         self.serialize = function () {
             var data = ko.mapping.toJS(self);
-            data.additional_registry_cases = data.data_registry_workflow === "load_case" ?  _.pluck(data.additional_registry_cases, 'caseIdXpath') : [];
+            data.additional_registry_cases = data.data_registry_workflow === "load_case" ? _.pluck(data.additional_registry_cases, 'caseIdXpath') : [];
             _.each(['search_label', 'search_again_label'], function (label) {
                 _.each(['image', 'audio'], function (media) {
                     var key = label + "_" + media,

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -176,6 +176,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
             self.search = caseClaimModels.searchViewModel(
                 spec.search_properties || [],
                 spec.default_properties,
+                spec.custom_sort_properties,
                 _.pick(spec, caseClaimModels.searchConfigKeys),
                 spec.lang,
                 self.shortScreen.saveButton,

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -80,8 +80,8 @@ from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY,
     CASE_SEARCH_REGISTRY_ID_KEY,
-    CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY
-
+    CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY,
+    CASE_SEARCH_SORT_KEY,
 )
 from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
@@ -279,6 +279,18 @@ class RemoteRequestFactory(object):
                 QueryData(
                     key=CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY,
                     ref="'true'",
+                )
+            )
+        if self.module.search_config.custom_sort_properties:
+            refs = []
+            for sort_property in self.module.search_config.custom_sort_properties:
+                direction = '-' if sort_property.direction == 'descending' else '+'
+                sort_type = sort_property.sort_type or 'exact'
+                refs.append(f"{direction}{sort_property.property_name}:{sort_type}")
+            datums.append(
+                QueryData(
+                    key=CASE_SEARCH_SORT_KEY,
+                    ref=f"'{','.join(refs)}'",
                 )
             )
         return datums

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -89,6 +89,71 @@
         </p>
       </div>
     </div>
+    <div class="panel panel-appmanager">
+      <div class="panel-heading">
+        <h4 class="panel-title panel-title-nolink">
+          {% trans "Custom Sort Properties" %}
+        </h4>
+      </div>
+      <div class="panel-body">
+        <p>{% trans "Sort search results by case property before filtering. These will affect the priority in which results are returned and are hidden from the user." %}</p>
+        <table class="table table-condensed">
+          <thead data-bind="visible: custom_sort_properties().length > 0">
+            <tr>
+              <th></th>
+              <th>{% trans "Case Property" %}</th>
+              <th>{% trans "Format" %}</th>
+              <th>{% trans "Direction" %}</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody data-bind="foreach: custom_sort_properties, sortableList: custom_sort_properties" class="ui-sortable">
+            <tr>
+              <td>
+                <i class="grip fa fa-arrows-v icon-blue"></i>
+              </td>
+              <td class="form-group">
+                <input class="form-control" type="text" data-bind="value: property_name"/>
+              </td>
+              <td>
+                <select class="form-control" data-bind="value: sort_type">
+                  <option value="exact">
+                    {% trans "Exact" %}
+                  </option>
+                  <option value="date">
+                    {% trans "Date" %}
+                  </option>
+                  <option value="numeric">
+                    {% trans "Numeric" %}
+                  </option>
+                </select>
+              </td>
+              <td>
+                <select class="form-control" data-bind="value: direction">
+                  <option value="ascending">
+                    {% trans "Ascending" %}
+                  </option>
+                  <option value="descending">
+                    {% trans "Descending" %}
+                  </option>
+                </select>
+              </td>
+              <td>
+                <a data-bind="click: $parent.removeCustomSortProperty">
+                  <i class="fa fa-remove icon-blue"></i>
+                </a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="form-group">
+          <button class="btn btn-default" data-bind="click: addCustomSortProperty">
+            <i class="fa fa-plus"></i>
+            {% trans "Add custom sort property" %}
+          </button>
+        </div>
+      </div>
+    </div>
     <div class="panel panel-appmanager" data-bind="visible: isEnabled">
       <div class="panel-heading">
         <h4 class="panel-title panel-title-nolink">{% trans "Search and Claim Options" %}</h4>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -241,7 +241,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
     @flag_enabled('USH_SEARCH_FILTER')
-    @patch('corehq.apps.app_manager.suite_xml.post_process.resources.ResourceOverrideHelper.update_suite', lambda _: None)
+    @patch('corehq.apps.app_manager.suite_xml.post_process.resources.ResourceOverrideHelper.update_suite',
+           lambda _: None)
     def test_duplicate_remote_request(self):
         """
         Adding a second search config should not affect the initial one.

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -51,6 +51,7 @@ from corehq.apps.app_manager.models import (
     AdvancedModule,
     CaseListForm,
     CaseSearch,
+    CaseSearchCustomSortProperty,
     CaseSearchProperty,
     DefaultCaseSearchProperty,
     DeleteModuleRecord,
@@ -249,6 +250,8 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
                     module.search_config.properties if module_offers_search(module) else [],
                 'default_properties':
                     module.search_config.default_properties if module_offers_search(module) else [],
+                'custom_sort_properties':
+                    module.search_config.custom_sort_properties if module_offers_search(module) else [],
                 'auto_launch': module.search_config.auto_launch if module_offers_search(module) else False,
                 'default_search': module.search_config.default_search if module_offers_search(module) else False,
                 'search_filter': module.search_config.search_filter if module_offers_search(module) else "",
@@ -1347,6 +1350,10 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 default_properties=[
                     DefaultCaseSearchProperty.wrap(p)
                     for p in search_properties.get('default_properties')
+                ],
+                custom_sort_properties=[
+                    CaseSearchCustomSortProperty.wrap(p)
+                    for p in search_properties.get('custom_sort_properties')
                 ],
                 data_registry=data_registry_slug,
                 data_registry_workflow=data_registry_workflow,

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -30,6 +30,7 @@ CONFIG_KEYS_MAPPING = {
     CASE_SEARCH_REGISTRY_ID_KEY: "data_registry",
     CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY: "custom_related_case_property",
     CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY: "include_all_related_cases",
+    CASE_SEARCH_SORT_KEY: "commcare_sort",
 }
 UNSEARCHABLE_KEYS = (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
@@ -142,6 +143,27 @@ def criteria_dict_to_criteria_list(criteria_dict):
     return criteria
 
 
+@attr.dataclass
+class CommcareSortProperty:
+    property_name: str = ''
+    sort_type: str = ''
+    is_descending: bool = False
+
+
+def _parse_commcare_sort_properties(values):
+    parsed_sort_properties = []
+    flattened_values = [sort_property for value in values for sort_property in value.split(',')]
+    for sort_property in flattened_values:
+        parts = sort_property.lstrip('+-').split(':')
+        parsed_sort_properties.append(
+            CommcareSortProperty(
+                property_name=parts[0],
+                sort_type=parts[1] if len(parts) > 1 else 'exact',
+                is_descending=sort_property.startswith('-')
+            ))
+    return parsed_sort_properties
+
+
 @attr.s(frozen=True)
 class CaseSearchRequestConfig:
     criteria = attr.ib(kw_only=True)
@@ -149,6 +171,7 @@ class CaseSearchRequestConfig:
     data_registry = attr.ib(kw_only=True, default=None, converter=_flatten_singleton_list)
     custom_related_case_property = attr.ib(kw_only=True, default=None, converter=_flatten_singleton_list)
     include_all_related_cases = attr.ib(kw_only=True, default=None, converter=_flatten_singleton_list)
+    commcare_sort = attr.ib(kw_only=True, default=None, converter=_parse_commcare_sort_properties)
 
     @case_types.validator
     def _require_case_type(self, attribute, value):

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -151,6 +151,9 @@ class CommcareSortProperty:
 
 
 def _parse_commcare_sort_properties(values):
+    if values is None:
+        return
+
     parsed_sort_properties = []
     flattened_values = [sort_property for value in values for sort_property in value.split(',')]
     for sort_property in flattened_values:

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -17,6 +17,7 @@ CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY = 'commcare_blacklisted_owner_ids'
 CASE_SEARCH_XPATH_QUERY_KEY = '_xpath_query'
 CASE_SEARCH_CASE_TYPE_KEY = "case_type"
 CASE_SEARCH_INDEX_KEY_PREFIX = "indices."
+CASE_SEARCH_SORT_KEY = "commcare_sort"
 
 # These use the `x_commcare_` prefix to distinguish them from 'filter' keys
 # This is a purely aesthetic distinction and not functional
@@ -118,7 +119,6 @@ class SearchCriteria:
                 _("Multiple values are only supported for simple text and range searches"),
                 self.key
             )
-
 
     def _validate_daterange(self):
         if not self.is_daterange:

--- a/corehq/apps/case_search/tests/test_case_search_es_queries.py
+++ b/corehq/apps/case_search/tests/test_case_search_es_queries.py
@@ -429,6 +429,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
             "sort": [
                 {
                     "case_properties.value.exact": {
+                        "missing": "_first",
                         "order": "asc",
                         "nested_path": "case_properties",
                         "nested_filter": {
@@ -440,6 +441,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                 },
                 {
                     "case_properties.value.date": {
+                        "missing": "_last",
                         "order": "desc",
                         "nested_path": "case_properties",
                         "nested_filter": {

--- a/corehq/apps/case_search/tests/test_case_search_es_queries.py
+++ b/corehq/apps/case_search/tests/test_case_search_es_queries.py
@@ -190,7 +190,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                                                                 },
                                                                 {
                                                                     "term": {
-                                                                        "case_properties.value.exact": "this should be"
+                                                                        "case_properties.value.exact": "this should be"  # noqa: E501
                                                                     }
                                                                 }
                                                             ]
@@ -220,7 +220,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                                                                 },
                                                                 {
                                                                     "term": {
-                                                                        "case_properties.value.exact": "this word should not be gone"
+                                                                        "case_properties.value.exact": "this word should not be gone"  # noqa: E501
                                                                     }
                                                                 }
                                                             ]
@@ -256,87 +256,87 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
             ('_xpath_query', ["name='Frodo Baggins'", "home='Hobbiton'"]),
         ])
         expected = {
-                    "query": {
-                        "bool": {
-                            "filter": [
-                                {"terms": {"domain.exact": [DOMAIN]}},
-                                {"terms": {"type.exact": ["case_type"]}},
-                                {"term": {"closed": False}},
-                                {
-                                    "nested": {
-                                        "path": "case_properties",
-                                        "query": {
-                                            "bool": {
-                                                "filter": [
-                                                    {
-                                                        "bool": {
-                                                            "filter": [
-                                                                {
-                                                                    "term": {
-                                                                        "case_properties.key.exact": "name"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "term": {
-                                                                        "case_properties.value.exact": "Frodo Baggins"
-                                                                    }
-                                                                }
-                                                            ]
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"terms": {"domain.exact": [DOMAIN]}},
+                        {"terms": {"type.exact": ["case_type"]}},
+                        {"term": {"closed": False}},
+                        {
+                            "nested": {
+                                "path": "case_properties",
+                                "query": {
+                                    "bool": {
+                                        "filter": [
+                                            {
+                                                "bool": {
+                                                    "filter": [
+                                                        {
+                                                            "term": {
+                                                                "case_properties.key.exact": "name"
+                                                            }
+                                                        },
+                                                        {
+                                                            "term": {
+                                                                "case_properties.value.exact": "Frodo Baggins"
+                                                            }
                                                         }
-                                                    }
-                                                ],
-                                                "must": {
-                                                    "match_all": {}
+                                                    ]
                                                 }
                                             }
+                                        ],
+                                        "must": {
+                                            "match_all": {}
                                         }
                                     }
-                                },
-                                {
-                                    "nested": {
-                                        "path": "case_properties",
-                                        "query": {
-                                            "bool": {
-                                                "filter": [
-                                                    {
-                                                        "bool": {
-                                                            "filter": [
-                                                                {
-                                                                    "term": {
-                                                                        "case_properties.key.exact": "home"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "term": {
-                                                                        "case_properties.value.exact": "Hobbiton"
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    }
-                                                ],
-                                                "must": {
-                                                    "match_all": {}
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                {
-                                    "match_all": {}
                                 }
-                            ],
-                            "must": {
-                                "match_all": {}
                             }
+                        },
+                        {
+                            "nested": {
+                                "path": "case_properties",
+                                "query": {
+                                    "bool": {
+                                        "filter": [
+                                            {
+                                                "bool": {
+                                                    "filter": [
+                                                        {
+                                                            "term": {
+                                                                "case_properties.key.exact": "home"
+                                                            }
+                                                        },
+                                                        {
+                                                            "term": {
+                                                                "case_properties.value.exact": "Hobbiton"
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ],
+                                        "must": {
+                                            "match_all": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "match_all": {}
                         }
-                    },
-                    "sort": [
-                        "_score",
-                        "_doc"
                     ],
-                    "size": CASE_SEARCH_MAX_RESULTS
+                    "must": {
+                        "match_all": {}
+                    }
                 }
+            },
+            "sort": [
+                "_score",
+                "_doc"
+            ],
+            "size": CASE_SEARCH_MAX_RESULTS
+        }
         self.checkQuery(
             get_case_search_query(DOMAIN, ['case_type'], criteria),
             expected,
@@ -427,30 +427,30 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
                     }
                 }
             },
-        "sort": [
-            {
-                "case_properties.value.exact": {
-                    "order": "asc",
-                    "nested_path": "case_properties",
-                    "nested_filter": {
-                        "term": {
-                            "case_properties.key.exact": "name"
+            "sort": [
+                {
+                    "case_properties.value.exact": {
+                        "order": "asc",
+                        "nested_path": "case_properties",
+                        "nested_filter": {
+                            "term": {
+                                "case_properties.key.exact": "name"
+                            }
+                        }
+                    }
+                },
+                {
+                    "case_properties.value.date": {
+                        "order": "desc",
+                        "nested_path": "case_properties",
+                        "nested_filter": {
+                            "term": {
+                                "case_properties.key.exact": "date_of_birth"
+                            }
                         }
                     }
                 }
-            },
-            {
-                "case_properties.value.date": {
-                    "order": "desc",
-                    "nested_path": "case_properties",
-                    "nested_filter": {
-                        "term": {
-                            "case_properties.key.exact": "date_of_birth"
-                        }
-                    }
-                }
-            }
-        ],
+            ],
             "size": CASE_SEARCH_MAX_RESULTS
         }
 

--- a/corehq/apps/case_search/tests/test_case_search_es_queries.py
+++ b/corehq/apps/case_search/tests/test_case_search_es_queries.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from django.test import TestCase
 
 from corehq.apps.case_search.const import CASE_SEARCH_MAX_RESULTS
-from corehq.apps.case_search.models import CaseSearchConfig, IgnorePatterns
+from corehq.apps.case_search.models import CaseSearchConfig, IgnorePatterns, _parse_commcare_sort_properties
 from corehq.apps.case_search.tests.utils import get_case_search_query
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
 
@@ -410,9 +410,8 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
         )
 
     def test_add_custom_sort_properties(self):
-        criteria = {
-            "commcare_sort": "name,-date_of_birth:date"
-        }
+        criteria = {}
+        commcare_sort = _parse_commcare_sort_properties(["name,-date_of_birth:date"])
         expected = {
             "query": {
                 "bool": {
@@ -455,6 +454,6 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
         }
 
         self.checkQuery(
-            get_case_search_query(DOMAIN, ['case_type'], criteria),
+            get_case_search_query(DOMAIN, ['case_type'], criteria, commcare_sort=commcare_sort),
             expected
         )

--- a/corehq/apps/case_search/tests/test_models.py
+++ b/corehq/apps/case_search/tests/test_models.py
@@ -11,11 +11,12 @@ from corehq.apps.case_search.models import (
     CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY,
     CASE_SEARCH_REGISTRY_ID_KEY,
     CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY,
+    CASE_SEARCH_SORT_KEY,
     CaseSearchRequestConfig,
     disable_case_search,
     enable_case_search,
     extract_search_request_config,
-    CASE_SEARCH_CASE_TYPE_KEY, SearchCriteria, CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY, CASE_SEARCH_XPATH_QUERY_KEY,
+    CASE_SEARCH_CASE_TYPE_KEY, SearchCriteria, CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
 )
 from corehq.util.test_utils import generate_cases
 
@@ -46,22 +47,24 @@ class TestCaseSearch(TestCase):
 
 
 @generate_cases([
-    ("jelly", None, None, True, False),
-    (["jelly", "tots"], None, None, True, False),
-    (None, None, None, True, True),  # required case type
-    ("jelly", "reg1", "dupe_id", False, False),
+    ("jelly", None, None, True, None, False),
+    (["jelly", "tots"], None, None, True, None, False),
+    (None, None, None, True, None, True),  # required case type
+    ("jelly", "reg1", "dupe_id", False, None, False),
+    ("jelly", None, None, False, ["name,-date_of_birth:date"], False),
     # disallow lists
-    ("jelly", None, ["dupe_id1", "dupe_id2"], False, True),
-    ("jelly", ["reg1", "reg2"], None, False, True),
+    ("jelly", None, ["dupe_id1", "dupe_id2"], False, None, True),
+    ("jelly", ["reg1", "reg2"], None, False, None, True),
 ])
 def test_extract_criteria_config(self, case_type, data_registry, custom_related_case_property,
-                            include_all_related_cases, expect_exception):
+                            include_all_related_cases, commcare_sort, expect_exception):
     with assert_raises(None if not expect_exception else CaseSearchUserError):
         request_dict = _make_request_dict({
             CASE_SEARCH_CASE_TYPE_KEY: case_type,
             CASE_SEARCH_REGISTRY_ID_KEY: data_registry,
             CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY: custom_related_case_property,
             CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY: include_all_related_cases,
+            CASE_SEARCH_SORT_KEY: commcare_sort,
             "other_key": "jim",
         })
         config = extract_search_request_config(request_dict)
@@ -73,6 +76,7 @@ def test_extract_criteria_config(self, case_type, data_registry, custom_related_
             case_types=expected_case_types, data_registry=data_registry,
             custom_related_case_property=custom_related_case_property,
             include_all_related_cases=include_all_related_cases,
+            commcare_sort=commcare_sort,
         ))
 
 

--- a/corehq/apps/case_search/tests/utils.py
+++ b/corehq/apps/case_search/tests/utils.py
@@ -2,7 +2,7 @@ from corehq.apps.case_search.models import criteria_dict_to_criteria_list
 from corehq.apps.case_search.utils import CaseSearchQueryBuilder
 
 
-def get_case_search_query(domain, case_types, criteria_dict):
+def get_case_search_query(domain, case_types, criteria_dict, commcare_sort=None):
     """Helper function for tests"""
     criteria = criteria_dict_to_criteria_list(criteria_dict)
-    return CaseSearchQueryBuilder(domain, case_types).build_query(criteria)
+    return CaseSearchQueryBuilder(domain, case_types).build_query(criteria, commcare_sort=commcare_sort)

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -190,8 +190,17 @@ class CaseSearchQueryBuilder:
 
     def _apply_sort(self, search_es, commcare_sort=None):
         if commcare_sort:
-            return search_es.sort_by_case_properties(commcare_sort)
+            return self._sort_by_case_properties(search_es, commcare_sort)
         return search_es.set_sorting_block(['_score', '_doc'])
+
+    def _sort_by_case_properties(self, search_es, commcare_sort_properties):
+        for sort_property in commcare_sort_properties:
+            search_es = search_es.sort_by_case_property(
+                sort_property.property_name,
+                desc=sort_property.is_descending,
+                sort_type=sort_property.sort_type
+            )
+        return search_es
 
     def _apply_filter(self, search_es, criteria):
         if criteria.key == CASE_SEARCH_XPATH_QUERY_KEY:

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -128,8 +128,16 @@ class CaseSearchES(CaseES):
             queries.MUST,
         )
 
-    def sort_by_case_property(self, case_property_name, desc=False):
+    def sort_by_case_property(self, case_property_name, desc=False, sort_type=None, reset_sort=False):
         sort_filter = filters.term(PROPERTY_KEY, case_property_name)
+        if sort_type:
+            return self.nested_sort(
+                CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, sort_type),
+                sort_filter,
+                desc,
+                reset_sort
+            )
+
         return self.nested_sort(
             CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, 'numeric'),
             sort_filter,
@@ -146,16 +154,6 @@ class CaseSearchES(CaseES):
             desc,
             reset_sort=False
         )
-
-    def sort_by_case_properties(self, sort_properties):
-        for sort_property in sort_properties:
-            self = self.nested_sort(
-                CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, sort_property.sort_type),
-                filters.term(PROPERTY_KEY, sort_property.property_name),
-                desc=sort_property.is_descending,
-                reset_sort=False
-            )
-        return self
 
 
 class ElasticCaseSearch(ElasticDocumentAdapter):

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -147,6 +147,17 @@ class CaseSearchES(CaseES):
             reset_sort=False
         )
 
+    def sort_by_case_properties(self, sort_properties):
+        for sort_property in sort_properties:
+            reset_sort = sort_property is sort_properties[0]
+            self = self.nested_sort(
+                CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, sort_property['sort_type']),
+                filters.term(PROPERTY_KEY, sort_property['property_name']),
+                desc=sort_property['is_descending'],
+                reset_sort=reset_sort
+            )
+        return self
+
 
 class ElasticCaseSearch(ElasticDocumentAdapter):
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -128,7 +128,7 @@ class CaseSearchES(CaseES):
             queries.MUST,
         )
 
-    def sort_by_case_property(self, case_property_name, desc=False, sort_type=None, reset_sort=False):
+    def sort_by_case_property(self, case_property_name, desc=False, sort_type=None):
         sort_filter = filters.term(PROPERTY_KEY, case_property_name)
         if sort_type:
             sort_missing = '_last' if desc else '_first'
@@ -136,8 +136,8 @@ class CaseSearchES(CaseES):
                 CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, sort_type),
                 sort_filter,
                 desc,
-                reset_sort,
-                sort_missing
+                reset_sort=False,
+                sort_missing=sort_missing
             )
 
         return self.nested_sort(

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -131,11 +131,13 @@ class CaseSearchES(CaseES):
     def sort_by_case_property(self, case_property_name, desc=False, sort_type=None, reset_sort=False):
         sort_filter = filters.term(PROPERTY_KEY, case_property_name)
         if sort_type:
+            sort_missing = '_last' if desc else '_first'
             return self.nested_sort(
                 CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, sort_type),
                 sort_filter,
                 desc,
-                reset_sort
+                reset_sort,
+                sort_missing
             )
 
         return self.nested_sort(

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -149,12 +149,11 @@ class CaseSearchES(CaseES):
 
     def sort_by_case_properties(self, sort_properties):
         for sort_property in sort_properties:
-            reset_sort = sort_property is sort_properties[0]
             self = self.nested_sort(
-                CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, sort_property['sort_type']),
-                filters.term(PROPERTY_KEY, sort_property['property_name']),
-                desc=sort_property['is_descending'],
-                reset_sort=reset_sort
+                CASE_PROPERTIES_PATH, "{}.{}".format(VALUE, sort_property.sort_type),
+                filters.term(PROPERTY_KEY, sort_property.property_name),
+                desc=sort_property.is_descending,
+                reset_sort=False
             )
         return self
 

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -418,7 +418,7 @@ class ESQuery(object):
         }
         return self._sort(sort_field, reset_sort)
 
-    def nested_sort(self, path, field_name, nested_filter, desc=False, reset_sort=True):
+    def nested_sort(self, path, field_name, nested_filter, desc=False, reset_sort=True, sort_missing=None):
         """Order results by the value of a nested field
         """
         sort_field = {
@@ -426,6 +426,7 @@ class ESQuery(object):
                 'order': 'desc' if desc else 'asc',
                 'nested_path': path,
                 'nested_filter': nested_filter,
+                'missing': sort_missing,
             }
         }
         return self._sort(sort_field, reset_sort)

--- a/corehq/apps/es/tests/test_sorting.py
+++ b/corehq/apps/es/tests/test_sorting.py
@@ -24,6 +24,7 @@ class TestESSort(SimpleTestCase):
 
         expected = [{
             "case_properties.value": {
+                "missing": None,
                 "order": "asc",
                 "nested_path": path,
                 "nested_filter": sort_filter


### PR DESCRIPTION
## Product Description
Adds UI in app builder under _Case Search and Claim_ for _Custom Sort Properties_.
![image](https://github.com/dimagi/commcare-hq/assets/100609770/e6134cb2-2afa-4173-8a05-69578c4b3e71)

Through these properties, allows sorting of case search results as they are pulled from ElasticSearch, for example: sorting cases by date so that the most recent cases appear first in the search return, and if there were >500 cases, the cases over 500 that would be left out of the search return would be the older cases. It could be more accurate from a user's perspective to think of this as "priority" than "sorting" as it doesn't affect the order in which search results are displayed.

## Technical Summary
[USH-3673](https://dimagi-dev.atlassian.net/browse/USH-3673), [Spec](https://docs.google.com/document/d/1Cpvy4qN4Qy0YF7u8GT4BDzB8_kEOehOIIB-OrBy0Qwc/edit?pli=1)

Per spec, uses a `commcare_sort` key to add custom sort properties in a `<data>` element which is added to the suite. This is read back and parsed during a case search to apply sorting to the ES query in the order provided.

Can be reviewed commit-by-commit.

## Feature Flag
SYNC_SEARCH_CASE_CLAIM

## Safety Assurance

### Safety story
Tested locally with different properties, sort types and directions and reviewed results as returned from ElasticSearch for accurate sorting. Tested on staging with ~600 cases to see that results are returned differently in web apps based on custom sort properties (e.g., custom sort on `person` cases by age descending leaves out the youngest cases).

### Automated test coverage
Added automated tests for suite generation and ES query:
`corehq.apps.app_manager.tests.test_suite_remote_request.test_custom_sort_properties`
`corehq.apps.case_search.tests.test_case_search_es_queries.test_add_custom_sort_properties`


### QA Plan
QA should at least test that UI component works and saves correctly. Unsure about testing search results since this change is mostly invisible in web apps.

### Rollback instructions
If a case list had Custom Sort Properties added and this PR was reverted, case search would be broken on that case list until the next app build.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3673]: https://dimagi-dev.atlassian.net/browse/USH-3673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ