### PR TITLE
Do not use force rerun with migration

### DIFF
--- a/corehq/apps/app_manager/migrations/0029_delete_case_list_custom_variable_xml.py
+++ b/corehq/apps/app_manager/migrations/0029_delete_case_list_custom_variable_xml.py
@@ -6,7 +6,7 @@ from corehq.util.django_migrations import skip_on_fresh_install
 
 @skip_on_fresh_install
 def _delete_xml(apps, schema_editor):
-    call_command("delete_case_list_custom_variables_xml", "--start-from-scratch", "--failfast", "--force-run-again")
+    call_command("delete_case_list_custom_variables_xml", "--start-from-scratch", "--failfast")
 
 
 @skip_on_fresh_install


### PR DESCRIPTION
## Product Description

Force will cause the migration to check all application again. So remove it

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3512

## Feature Flag

None

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Migration command it self is covered by tests.

### QA Plan

1. Run script
2. Run migration
  * Migration will skip over all domains already covered by the scripts


### Migrations

See https://github.com/dimagi/commcare-hq/pull/33551

### Rollback instructions

See https://github.com/dimagi/commcare-hq/pull/33551

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
