### PR TITLE
Add 365 days option to auto-deactivation Inactivity Period

### DIFF
--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -249,6 +249,7 @@ class EnterpriseManageMobileWorkersForm(forms.Form):
             (120, gettext_lazy("120 days")),
             (150, gettext_lazy("150 days")),
             (180, gettext_lazy("180 days")),
+            (365, gettext_lazy("365 days")),
         ),
         help_text=gettext_lazy(
             "Mobile workers who have not submitted a form after these many "


### PR DESCRIPTION
## Product Description
This adds another Inactivity Period option to the auto-deactivation feature, which is under a feature flag and not used by many.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SUPPORT-17766

## Feature Flag
`AUTO_DEACTIVATE_MOBILE_WORKERS`

## Safety Assurance

### Safety story
I mean, how could this break anything? And in the worst case if it did, it's on a page that is only available to a handful of project spaces, and even by then is not accessed frequently as part of day-to-day operations.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
