### PR TITLE
Inline case search for child modules 

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -530,13 +530,13 @@ class ModuleBaseValidator(object):
             if self.module.root_module_id:
                 root_module = self.app.get_module_by_unique_id(self.module.root_module_id)
                 if root_module and module_uses_inline_search(root_module):
-                    root_module_instance_name = root_module.search_config.instance_name
-                    if search_config.instance_name == root_module_instance_name:
+                    root_module_instance_name = root_module.search_config.get_instance_name()
+                    if search_config.get_instance_name() == root_module_instance_name:
                         yield {
                             "type": "non-unique instance name with parent module",
-                            "message": f'The instance "{search_config.instance_name}" is not unique',
+                            "message": f'The instance "{search_config.get_instance_name()}" is not unique',
                             "module": self.get_module_info(),
-                            "details": search_config.instance_name
+                            "details": search_config.get_instance_name()
                         }
 
     def validate_case_list_field_actions(self):

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -342,14 +342,6 @@ class ModuleBaseValidator(object):
 
         errors.extend(self.validate_case_list_field_actions())
 
-        if self.module.root_module_id:
-            root_module = self.app.get_module_by_unique_id(self.module.root_module_id)
-            if root_module and module_uses_inline_search(root_module):
-                errors.append({
-                    'type': 'inline search as parent module',
-                    'module': self.get_module_info(),
-                })
-
         for form in self.module.get_suite_forms():
             errors.extend(form.validator.validate_for_module(self.module))
 
@@ -534,6 +526,17 @@ class ModuleBaseValidator(object):
                             'module': self.get_module_info(),
                             'property': prop.name,
                             'message': _('This feature is compatible with only version 2 of Mobile UCR'),
+                        }
+            if self.module.root_module_id:
+                root_module = self.app.get_module_by_unique_id(self.module.root_module_id)
+                if root_module and module_uses_inline_search(root_module):
+                    root_module_instance_name = root_module.search_config.instance_name
+                    if search_config.instance_name == root_module_instance_name:
+                        yield {
+                            "type": "non-unique instance name with parent module",
+                            "message": f'The instance "{search_config.instance_name}" is not unique',
+                            "module": self.get_module_info(),
+                            "details": search_config.instance_name
                         }
 
     def validate_case_list_field_actions(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2173,6 +2173,7 @@ class CaseSearch(DocumentSchema):
     custom_related_case_property = StringProperty(exclude_if_none=True)
 
     inline_search = BooleanProperty(default=False)
+    instance_name = StringProperty(exclude_if_none=True)  # only applicable to inline_search
 
     @property
     def case_session_var(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2021,10 +2021,7 @@ class Detail(IndexedSchema, CaseListLookupMixin):
         value_is_the_default = self.instance_name == 'casedb'
         if value_is_the_default:
             if module_uses_inline_search(module):
-                if module.search_config.instance_name:
-                    return f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
-                else:
-                    return RESULTS_INSTANCE_INLINE
+                return module.search_config.get_instance_name()
             elif module_loads_registry_case(module):
                 return RESULTS_INSTANCE
         return self.instance_name
@@ -2182,6 +2179,12 @@ class CaseSearch(DocumentSchema):
     @property
     def case_session_var(self):
         return "search_case_id"
+
+    def get_instance_name(self):
+        if self.instance_name:
+            return f'{RESULTS_INSTANCE_BASE}{self.instance_name}'
+        else:
+            return RESULTS_INSTANCE_INLINE
 
     def get_relevant(self, case_session_var, multi_select=False):
         xpath = CaseClaimXpath(case_session_var)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -115,6 +115,7 @@ from corehq.apps.app_manager.suite_xml.generator import (
 )
 from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
     RESULTS_INSTANCE,
+    RESULTS_INSTANCE_BASE,
     RESULTS_INSTANCE_INLINE,
 )
 from corehq.apps.app_manager.suite_xml.utils import get_select_chain
@@ -2020,7 +2021,10 @@ class Detail(IndexedSchema, CaseListLookupMixin):
         value_is_the_default = self.instance_name == 'casedb'
         if value_is_the_default:
             if module_uses_inline_search(module):
-                return RESULTS_INSTANCE_INLINE
+                if module.search_config.instance_name:
+                    return f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
+                else:
+                    return RESULTS_INSTANCE_INLINE
             elif module_loads_registry_case(module):
                 return RESULTS_INSTANCE
         return self.instance_name

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -33,16 +33,14 @@ hqDefine("app_manager/js/details/case_claim", function () {
             write: function (value) {
                 if (value === undefined) {
                     self.nodeset(null);
-                }
-                else {
+                } else {
                     self.instance_id(value);
                     var itemList = _.filter(get('js_options').item_lists, function (item) {
                         return item.id === value;
                     });
                     if (itemList && itemList.length === 1) {
                         self.nodeset(itemsetValue(itemList[0]));
-                    }
-                    else {
+                    } else {
                         self.nodeset(null);
                     }
                 }
@@ -56,8 +54,8 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 return true;
             }
             var itemLists = _.map(get('js_options').item_lists, function (item) {
-                    return itemsetValue(item);
-                });
+                return itemsetValue(item);
+            });
             if (self.nodeset().split("/").length === 0) {
                 return false;
             }
@@ -113,8 +111,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             var appearance = self.appearance();
             if (appearance === 'report_fixture' || appearance === 'lookup_table_fixture') {
                 return 'fixture';
-            }
-            else {
+            } else {
                 return appearance;
             }
         });
@@ -127,8 +124,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     'tableLabel': gettext("Mobile UCR Report"),
                     'selectLabel': gettext("Select a Report..."),
                 };
-            }
-            else {
+            } else {
                 return {
                     'labelPlaceholder': 'name',
                     'valuePlaceholder': 'id',
@@ -202,7 +198,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         options.description = options.description[lang] || "";
         var mapping = {
             'additional_registry_cases': {
-                create: function(options) {
+                create: function (options) {
                     return additionalRegistryCaseModel(options.data, saveButton);
                 },
             },

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -242,6 +242,11 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.inlineSearchActive = ko.computed(() => {
             return self.inlineSearchVisible() && self.inline_search();
         });
+        self.exampleInstance = ko.computed(() => {
+            let name = self.instance_name() || 'inline';
+            return "instance('results:" + name + "')/results/case";
+        });
+
 
         // Allow search filter to be copied from another part of the page
         self.setSearchFilterVisible = ko.computed(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -191,7 +191,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         'auto_launch', 'blacklisted_owner_ids_expression', 'default_search', 'search_again_label',
         'title_label', 'description', 'search_button_display_condition', 'search_label', 'search_filter',
         'additional_relevant', 'data_registry', 'data_registry_workflow', 'additional_registry_cases',
-        'custom_related_case_property', 'inline_search', 'include_all_related_cases',
+        'custom_related_case_property', 'inline_search', 'instance_name', 'include_all_related_cases',
     ];
     var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
         hqImport("hqwebapp/js/assert_properties").assertRequired(options, searchConfigKeys);

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -74,12 +74,8 @@ from corehq.apps.app_manager.exceptions import (
     UnknownInstanceError,
 )
 from corehq.apps.app_manager.suite_xml.contributors import PostProcessor
-from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
-    RESULTS_INSTANCE,
-    RESULTS_INSTANCE_INLINE,
-    RESULTS_INSTANCE_BASE
-)
 from corehq.apps.app_manager.suite_xml.xml_models import Instance
+from corehq.apps.app_manager.suite_xml.utils import is_valid_results_instance_name
 from corehq.apps.app_manager.util import (
     module_offers_search,
     module_uses_inline_search,
@@ -362,11 +358,7 @@ def search_input_instances(app, instance_name):
         src = f'jr://instance/search-input/{query_datum_id}'
     except ValueError:
         src = 'jr://instance/search-input'  # legacy instance
-
-    valid_query_datum_id = {RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE}
-    valid_query_datum_id.update(f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
-                                for module in app.get_modules())
-    if query_datum_id in valid_query_datum_id:
+    if is_valid_results_instance_name(app, query_datum_id):
         return Instance(id=instance_name, src=src)
     return None
 
@@ -378,11 +370,7 @@ def selected_cases_instances(app, instance_name):
 
 @register_factory('results')
 def remote_instances(app, instance_name):
-    valid_instance_names = {RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE}
-    valid_instance_names.update(f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
-                                for module in app.get_modules())
-
-    if instance_name in valid_instance_names:
+    if is_valid_results_instance_name(app, instance_name):
         return Instance(id=instance_name, src=f'jr://instance/remote/{instance_name}')
     return None
 

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -356,9 +356,11 @@ def search_input_instances(app, instance_name):
     try:
         _, query_datum_id = instance_name.split(':', 1)
         src = f'jr://instance/search-input/{query_datum_id}'
+        is_valid_instance_name = is_valid_results_instance_name(app, query_datum_id)
     except ValueError:
         src = 'jr://instance/search-input'  # legacy instance
-    if is_valid_results_instance_name(app, query_datum_id):
+        is_valid_instance_name = True
+    if is_valid_instance_name:
         return Instance(id=instance_name, src=src)
     return None
 

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -74,11 +74,17 @@ from corehq.apps.app_manager.exceptions import (
     UnknownInstanceError,
 )
 from corehq.apps.app_manager.suite_xml.contributors import PostProcessor
+from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
+    RESULTS_INSTANCE,
+    RESULTS_INSTANCE_INLINE,
+    RESULTS_INSTANCE_BASE
+)
 from corehq.apps.app_manager.suite_xml.xml_models import Instance
 from corehq.apps.app_manager.util import (
     module_offers_search,
     module_uses_inline_search,
 )
+
 from corehq.util.timer import time_method
 
 
@@ -356,7 +362,13 @@ def search_input_instances(app, instance_name):
         src = f'jr://instance/search-input/{query_datum_id}'
     except ValueError:
         src = 'jr://instance/search-input'  # legacy instance
-    return Instance(id=instance_name, src=src)
+
+    valid_query_datum_id = {RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE}
+    valid_query_datum_id.update(f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
+                                for module in app.get_modules())
+    if query_datum_id in valid_query_datum_id:
+        return Instance(id=instance_name, src=src)
+    return None
 
 
 @register_factory('selected_cases')
@@ -366,7 +378,13 @@ def selected_cases_instances(app, instance_name):
 
 @register_factory('results')
 def remote_instances(app, instance_name):
-    return Instance(id=instance_name, src=f'jr://instance/remote/{instance_name}')
+    valid_instance_names = {RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE}
+    valid_instance_names.update(f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
+                                for module in app.get_modules())
+
+    if instance_name in valid_instance_names:
+        return Instance(id=instance_name, src=f'jr://instance/remote/{instance_name}')
+    return None
 
 
 @register_factory('commcare')

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -353,14 +353,12 @@ def generic_fixture_instances(app, instance_name):
 
 @register_factory('search-input')
 def search_input_instances(app, instance_name):
-    try:
-        _, query_datum_id = instance_name.split(':', 1)
+    if ":" not in instance_name:
+        return Instance(id=instance_name, src='jr://instance/search-input')  # legacy instance
+
+    _, query_datum_id = instance_name.split(':', 1)
+    if is_valid_results_instance_name(app, query_datum_id):
         src = f'jr://instance/search-input/{query_datum_id}'
-        is_valid_instance_name = is_valid_results_instance_name(app, query_datum_id)
-    except ValueError:
-        src = 'jr://instance/search-input'  # legacy instance
-        is_valid_instance_name = True
-    if is_valid_instance_name:
         return Instance(id=instance_name, src=src)
     return None
 

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -88,6 +88,7 @@ from corehq.util.view_utils import absolute_reverse
 
 # The name of the instance where search results are stored
 RESULTS_INSTANCE = 'results'
+RESULTS_INSTANCE_BASE = f'{RESULTS_INSTANCE}:'
 RESULTS_INSTANCE_INLINE = 'results:inline'
 
 # The name of the instance where search results are stored when querying a data registry

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -656,10 +656,13 @@ class EntriesHelper(object):
         """
         from ..post_process.remote_requests import (
             RESULTS_INSTANCE,
+            RESULTS_INSTANCE_BASE,
             RESULTS_INSTANCE_INLINE,
             RemoteRequestFactory,
         )
         storage_instance = RESULTS_INSTANCE_INLINE if uses_inline_search else RESULTS_INSTANCE
+        if module.search_config.instance_name:
+            storage_instance = f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
         factory = RemoteRequestFactory(None, module, [], storage_instance=storage_instance)
         query = factory.build_remote_request_queries()[0]
         return FormDatumMeta(datum=query, case_type=None, requires_selection=False, action=None)

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -16,6 +16,7 @@ modules.  See ``update_refs`` and ``rename_other_id``, both inner functions in `
 .. _this comment: https://github.com/dimagi/commcare-hq/blob/c9fa01d1ccbb73d8f07fefbe56a0bbe1dbe231f8/corehq/apps/app_manager/suite_xml/sections/entries.py#L966-L971
 """  # noqa
 from collections import defaultdict
+import re
 
 from django.utils.translation import gettext as _
 
@@ -535,8 +536,10 @@ class EntriesHelper(object):
                 loads_registry_case = module_loads_registry_case(module)
                 uses_inline_search = module_uses_inline_search(module)
                 if loads_registry_case or uses_inline_search:
-                    result.append(self.get_query_datums(module, uses_inline_search))
-                    result.append(datum)
+                    query_datum = self.get_query_datums(module, uses_inline_search)
+                    result.append(query_datum)
+                    renamed_datum = self.rename_datum_nodeset_for_query(datum, query_datum)
+                    result.append(renamed_datum)
                     if loads_registry_case:
                         result.append(self.get_data_registry_case_datums(datum, module))
                 else:
@@ -544,6 +547,18 @@ class EntriesHelper(object):
             else:
                 result.append(datum)
         return result
+
+    def rename_datum_nodeset_for_query(self, datum, query_datum):
+        """Rename the instance in the case datum to match the instance used by the query datum
+        """
+        instance_name = query_datum.datum.storage_instance
+        if instance_name == "results":
+            return datum
+        instance_pattern = r"""instance\(['"]results:(.*?)['"]\)"""
+        new_instance = f"instance('{instance_name}')"
+        renamed = re.sub(instance_pattern, new_instance, datum.datum.nodeset)
+        datum.datum.nodeset = renamed
+        return datum
 
     def get_datum_meta_module(self, module, use_filter=False):
         datums = []

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -245,16 +245,10 @@ class EntriesHelper(object):
     def add_post_to_entry(self, form, module, e):
         from ..post_process.remote_requests import (
             RemoteRequestFactory,
-            RESULTS_INSTANCE_INLINE,
-            RESULTS_INSTANCE_BASE
         )
         case_session_var = self.get_case_session_var_for_form(form)
-        if module_uses_inline_search(module):
-            storage_instance = RESULTS_INSTANCE_INLINE
-            if module.search_config.instance_name:
-                storage_instance = f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
-        else:
-            storage_instance = 'casedb'
+        storage_instance = module.search_config.get_instance_name() if module_uses_inline_search(module) \
+            else 'casedb'
         remote_request_factory = RemoteRequestFactory(
             None, module, [], case_session_var=case_session_var, storage_instance=storage_instance,
             exclude_relevant=case_search_sync_cases_on_form_entry_enabled_for_domain(self.app.domain))
@@ -679,13 +673,9 @@ class EntriesHelper(object):
         """
         from ..post_process.remote_requests import (
             RESULTS_INSTANCE,
-            RESULTS_INSTANCE_BASE,
-            RESULTS_INSTANCE_INLINE,
             RemoteRequestFactory,
         )
-        storage_instance = RESULTS_INSTANCE_INLINE if uses_inline_search else RESULTS_INSTANCE
-        if module.search_config.instance_name:
-            storage_instance = f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
+        storage_instance = module.search_config.get_instance_name() if uses_inline_search else RESULTS_INSTANCE
         factory = RemoteRequestFactory(None, module, [], storage_instance=storage_instance)
         query = factory.build_remote_request_queries()[0]
         return FormDatumMeta(datum=query, case_type=None, requires_selection=False, action=None)

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -245,11 +245,16 @@ class EntriesHelper(object):
     def add_post_to_entry(self, form, module, e):
         from ..post_process.remote_requests import (
             RemoteRequestFactory,
-            RESULTS_INSTANCE_INLINE
+            RESULTS_INSTANCE_INLINE,
+            RESULTS_INSTANCE_BASE
         )
         case_session_var = self.get_case_session_var_for_form(form)
-        storage_instance = RESULTS_INSTANCE_INLINE if module_uses_inline_search(module) \
-            else 'casedb'
+        if module_uses_inline_search(module):
+            storage_instance = RESULTS_INSTANCE_INLINE
+            if module.search_config.instance_name:
+                storage_instance = f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
+        else:
+            storage_instance = 'casedb'
         remote_request_factory = RemoteRequestFactory(
             None, module, [], case_session_var=case_session_var, storage_instance=storage_instance,
             exclude_relevant=case_search_sync_cases_on_form_entry_enabled_for_domain(self.app.domain))

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -81,7 +81,7 @@ def validate_suite(suite):
         suite = etree.fromstring(suite)
     if isinstance(suite, etree._Element):
         suite = Suite(suite)
-    assert isinstance(suite, Suite),\
+    assert isinstance(suite, Suite), \
         'Could not convert suite to a Suite XmlObject: %r' % suite
 
     def is_unique_list(things):

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -130,6 +130,6 @@ def is_valid_results_instance_name(app, instance_name):
     )
 
     valid_instance_names = {RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE}
-    valid_instance_names.update(f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
+    valid_instance_names.update(f'{RESULTS_INSTANCE_BASE}{module.search_config.get_instance_name()}'
                                 for module in app.get_modules() if hasattr(module, 'search_config'))
     return instance_name in valid_instance_names

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -129,6 +129,6 @@ def is_valid_results_instance_name(app, instance_name):
     )
 
     valid_instance_names = {RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE}
-    valid_instance_names.update(f'{module.search_config.get_instance_name()}'
+    valid_instance_names.update(module.search_config.get_instance_name()
                                 for module in app.get_modules() if hasattr(module, 'search_config'))
     return instance_name in valid_instance_names

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -131,5 +131,5 @@ def is_valid_results_instance_name(app, instance_name):
 
     valid_instance_names = {RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE}
     valid_instance_names.update(f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
-                                for module in app.get_modules())
+                                for module in app.get_modules() if hasattr(module, 'search_config'))
     return instance_name in valid_instance_names

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -6,6 +6,12 @@ from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.exceptions import SuiteValidationError
 from corehq.apps.app_manager.suite_xml.xml_models import Suite
 
+from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
+    RESULTS_INSTANCE,
+    RESULTS_INSTANCE_INLINE,
+    RESULTS_INSTANCE_BASE
+)
+
 
 def get_select_chain(app, module, include_self=True):
     return [
@@ -119,3 +125,10 @@ def get_ordered_case_types(case_type, additional_case_types=None):
     additional_case_types = additional_case_types or []
     additional_types = set(additional_case_types) - {case_type}
     return [case_type] + sorted(additional_types)
+
+
+def is_valid_results_instance_name(app, instance_name):
+    valid_instance_names = {RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE}
+    valid_instance_names.update(f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
+                                for module in app.get_modules())
+    return instance_name in valid_instance_names

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -6,12 +6,6 @@ from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.exceptions import SuiteValidationError
 from corehq.apps.app_manager.suite_xml.xml_models import Suite
 
-from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
-    RESULTS_INSTANCE,
-    RESULTS_INSTANCE_INLINE,
-    RESULTS_INSTANCE_BASE
-)
-
 
 def get_select_chain(app, module, include_self=True):
     return [
@@ -128,6 +122,13 @@ def get_ordered_case_types(case_type, additional_case_types=None):
 
 
 def is_valid_results_instance_name(app, instance_name):
+    # avoid circular import
+    from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
+        RESULTS_INSTANCE,
+        RESULTS_INSTANCE_INLINE,
+        RESULTS_INSTANCE_BASE
+    )
+
     valid_instance_names = {RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE}
     valid_instance_names.update(f'{RESULTS_INSTANCE_BASE}{module.search_config.instance_name}'
                                 for module in app.get_modules())

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -126,10 +126,9 @@ def is_valid_results_instance_name(app, instance_name):
     from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
         RESULTS_INSTANCE,
         RESULTS_INSTANCE_INLINE,
-        RESULTS_INSTANCE_BASE
     )
 
     valid_instance_names = {RESULTS_INSTANCE, RESULTS_INSTANCE_INLINE}
-    valid_instance_names.update(f'{RESULTS_INSTANCE_BASE}{module.search_config.get_instance_name()}'
+    valid_instance_names.update(f'{module.search_config.get_instance_name()}'
                                 for module in app.get_modules() if hasattr(module, 'search_config'))
     return instance_name in valid_instance_names

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -187,11 +187,9 @@
                 uses smart links and is configured to make search input available after search.
                 These two features are not compatible.
               {% endblocktrans %}
-            {% case "inline search as parent module" %}
+            {% case "non-unique instance name with parent module" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                has a Parent Menu configured with "make search input available after search",
-                This workflow is unsupported.
+              The case list in <a href="{{ module_url }}">{{ module_name }}</a> can not use the same "search input instance name" as its Parent Menu.
               {% endblocktrans %}
             {% case "inline search to display only forms" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -134,13 +134,16 @@
                 <input type="checkbox" data-bind="checked: inline_search" />
                 <input type="hidden" name="search-input" data-bind="value: inline_search"/>
               </label>
+              <p class="help-block" data-bind="visible: inlineSearchActive">
+                Example: <span data-bind="text: exampleInstance" ></span>
+              </p>
             </div>
           </div>
           <div class="form-group" data-bind="visible: inlineSearchActive">
             <label class="control-label {% css_label_class %}">
               {% trans "Search Input Instance Name" %}
               <span class="hq-help-template" data-title="{% trans "Search Input Instance Name" %}"
-                    data-content="{% trans_html_attr "Customize the name used to reference the search input values." %}">
+                    data-content="{% trans_html_attr "Customize the name used to reference the search input values.  If modified, you'll need to update any existing references to it." %}">
               </span>
             </label>
             <div class="{% css_field_class %}">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -136,6 +136,17 @@
               </label>
             </div>
           </div>
+          <div class="form-group" data-bind="visible: inlineSearchActive">
+            <label class="control-label {% css_label_class %}">
+              {% trans "Search Input Instance Name" %}
+              <span class="hq-help-template" data-title="{% trans "Search Input Instance Name" %}"
+                    data-content="{% trans_html_attr "Customize the name used to reference the search input values." %}">
+              </span>
+            </label>
+            <div class="{% css_field_class %}">
+              <input type="text" name="instance_name" class="form-control" data-bind="value: instance_name"/>
+            </div>
+          </div>
           {% endif %}
           {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
           <div class="form-group" data-bind="hidden: inlineSearchActive">

--- a/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
@@ -19,7 +19,7 @@ from corehq.util.test_utils import flag_enabled
 class BuildErrorsInlineSearchTest(SimpleTestCase):
 
     def test_inline_search_as_parent(self, *args):
-        """an inline search module can't be a parent module"""
+        """a parent module and its submodule can not have the same instance_name"""
         factory = AppFactory(build_version='2.51.0')
         m0, _ = factory.new_basic_module('first', 'case')
         m1, _ = factory.new_basic_module('second', 'case', parent_module=m0)
@@ -29,9 +29,14 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
             properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
             auto_launch=True,
             inline_search=True,
+            instance_name="instance_name"
         )
 
-        self.assertIn("inline search as parent module", _get_error_types(factory.app))
+        m1.search_config = CaseSearch(
+            inline_search=True,
+            instance_name="instance_name"
+        )
+        self.assertIn("non-unique instance name with parent module", _get_error_types(factory.app))
 
     @flag_enabled('DATA_REGISTRY')
     @patch.object(Application, 'supports_data_registry', lambda: True)

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -644,8 +644,8 @@ class InlineSearchCustomInstanceName(SimpleTestCase, SuiteMixin):
 
     def test_inline_search_custom_instance_name(self):
         suite = self.app.create_suite()
-        custom_instance0 = f'{RESULTS_INSTANCE_BASE}{self.m0.search_config.instance_name}'
-        custom_instance1 = f'{RESULTS_INSTANCE_BASE}{self.m1.search_config.instance_name}'
+        custom_instance0 = f'{RESULTS_INSTANCE_BASE}{self.m0.search_config.get_instance_name()}'
+        custom_instance1 = f'{RESULTS_INSTANCE_BASE}{self.m1.search_config.get_instance_name()}'
 
         self.assertXmlPartialEqual(self._expected_entry_query('m0', custom_instance0), suite, "./entry[1]")
         self.assertXmlPartialEqual(self._expected_entry_query('m1', custom_instance1), suite, "./entry[2]")

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -643,8 +643,8 @@ class InlineSearchCustomInstanceName(SimpleTestCase, SuiteMixin):
 
     def test_inline_search_custom_instance_name(self):
         suite = self.app.create_suite()
-        custom_instance0 = f'{self.m0.search_config.get_instance_name()}'
-        custom_instance1 = f'{self.m1.search_config.get_instance_name()}'
+        custom_instance0 = self.m0.search_config.get_instance_name()
+        custom_instance1 = self.m1.search_config.get_instance_name()
 
         self.assertXmlPartialEqual(self._expected_entry_query('m0', custom_instance0), suite, "./entry[1]")
         self.assertXmlPartialEqual(self._expected_entry_query('m1', custom_instance1), suite, "./entry[2]")

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -17,7 +17,6 @@ from corehq.apps.app_manager.models import (
 )
 from corehq.apps.app_manager.suite_xml.post_process.remote_requests import (
     RESULTS_INSTANCE_INLINE,
-    RESULTS_INSTANCE_BASE,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
@@ -644,8 +643,8 @@ class InlineSearchCustomInstanceName(SimpleTestCase, SuiteMixin):
 
     def test_inline_search_custom_instance_name(self):
         suite = self.app.create_suite()
-        custom_instance0 = f'{RESULTS_INSTANCE_BASE}{self.m0.search_config.get_instance_name()}'
-        custom_instance1 = f'{RESULTS_INSTANCE_BASE}{self.m1.search_config.get_instance_name()}'
+        custom_instance0 = f'{self.m0.search_config.get_instance_name()}'
+        custom_instance1 = f'{self.m1.search_config.get_instance_name()}'
 
         self.assertXmlPartialEqual(self._expected_entry_query('m0', custom_instance0), suite, "./entry[1]")
         self.assertXmlPartialEqual(self._expected_entry_query('m1', custom_instance1), suite, "./entry[2]")

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -272,6 +272,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
                 'additional_registry_cases': module.search_config.additional_registry_cases,
                 'custom_related_case_property': module.search_config.custom_related_case_property,
                 'inline_search': module.search_config.inline_search,
+                'instance_name': module.search_config.instance_name or "",
                 'include_all_related_cases': module.search_config.include_all_related_cases,
             },
         },
@@ -1353,6 +1354,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 additional_registry_cases=additional_registry_cases,
                 custom_related_case_property=search_properties.get('custom_related_case_property', ""),
                 inline_search=search_properties.get('inline_search', False),
+                instance_name=search_properties.get('instance_name', ""),
                 include_all_related_cases=search_properties.get('include_all_related_cases', False)
             )
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from dataclasses import asdict
 from collections import OrderedDict
 from functools import partial
@@ -1332,6 +1333,12 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
             # force auto launch when data registry load case workflow selected
             force_auto_launch = data_registry_slug and data_registry_workflow == REGISTRY_WORKFLOW_LOAD_CASE
 
+            instance_name = search_properties.get('instance_name', "")
+            if instance_name and not re.match(r"^[a-zA-Z]\w*$", instance_name):
+                return HttpResponseBadRequest(_(
+                    "'{}' is an invalid instance name. It can contain only letters, numbers, and underscores."
+                ).format(instance_name))
+
             module.search_config = CaseSearch(
                 search_label=search_label,
                 search_again_label=search_again_label,
@@ -1354,7 +1361,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
                 additional_registry_cases=additional_registry_cases,
                 custom_related_case_property=search_properties.get('custom_related_case_property', ""),
                 inline_search=search_properties.get('inline_search', False),
-                instance_name=search_properties.get('instance_name', ""),
+                instance_name=instance_name,
                 include_all_related_cases=search_properties.get('include_all_related_cases', False)
             )
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds compatibility using sub-modules with parent menu configured with inline case search.

Adds app builder input for custom instance name that will be applied to the `results` and `search-input:results` instances. 

<img width="706" alt="Screen Shot 2023-10-20 at 3 21 47 PM" src="https://github.com/dimagi/commcare-hq/assets/88759246/cc14b029-e61f-4697-88fb-8f14078c6b4b">
 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Tech Spec](https://docs.google.com/document/d/1hp6b3ilLFDF6YYwLLgcr18v4SNR089lOBlLrYDZMOBw/edit)

Jira Ticket [USH-3712](https://dimagi-dev.atlassian.net/browse/USH-3712)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[Inline Case Search](https://www.commcarehq.org/hq/flags/edit/inline_case_search/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The blast radius is limited to the inline case search FF.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test added for conflicting instance name app build validation.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3712]: https://dimagi-dev.atlassian.net/browse/USH-3712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ