### PR TITLE
[USH-3370] Responsive alignment of case list and map in webapps for different devices

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -34,64 +34,90 @@
     <% } %>
 
     <div id="module-case-list-container__results-container" class="row row-no-gutters">
-      <% if (showMap) { %>
-        <div id="module-case-list-map" class="sticky sticky-map col-md-5 col-md-push-9<% if (useTiles) { %> white-border<% } %> noprint-sub-container"></div>
-      <% } %>
-      <div id="module-case-list" class="col-md<% if (showMap) { %>-7 col-md-pull-5<% } %>">
-        <% if (useTiles) { %>
-          <% if (hasNoItems) { %>
-            {% include 'formplayer/no_items_text.html' %}
-          <% } else { %>
-            <div id="case-list-search-controls">
-              <div>
-                <% if (isMultiSelect) { %>
-                  <input type="checkbox" id="select-all-tile-checkbox"/>
-                  <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
+      <div class="container-md">
+        <% if (window.innerWidth < 992 && showMap) { %>
+          <div class="row" style="margin: auto">
+            <div class="col-md-12">
+              <div id="module-case-list-map" class="sticky sticky-map <% if (useTiles) { %> white-border<% } %> noprint-sub-container"></div>
+            </div>
+          </div>
+        <% } %>
+
+        <% if (window.innerWidth >= 992 && showMap) { %>
+          <div class="row" style="margin: auto">
+          <div id="module-case-list" class="col-md-8">
+        <% } %>
+
+        <% if (!showMap) { %>
+          <div id="module-case-list" class="col-md-12">
+        <% } %>
+
+                <% if (useTiles) { %>
+                  <% if (hasNoItems) { %>
+                    {% include 'formplayer/no_items_text.html' %}
+                  <% } else { %>
+                    <div id="case-list-search-controls">
+                      <div>
+                        <% if (isMultiSelect) { %>
+                          <input type="checkbox" id="select-all-tile-checkbox"/>
+                          <label id="select-all-tile-checkbox-label" for="select-all-tile-checkbox">{% trans "Select All" %}</label>
+                        <% } %>
+                      </div>
+                      <div class="dropdown">
+                        <button class="btn" id="case-list-sort-by-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                          <span> {% trans "Sort By" %} </span><i class="fa fa-sort" aria-hidden="true"></i>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="case-list-sort-by">
+                          <%  _.each(headers, function(header, index) { %>
+                            <% if (columnSortable(index)) { %>
+                            <li tabindex="0" class="header-clickable formplayer-request" data-id="<%- index %>" role="menuitem"><a><%= header %></a></li>
+                            <% } %>
+                          <% }); %>
+                        </ul>
+                      </div>
+                    </div>
+                  <% } %>
+                  <section class="js-case-container clearfix list-cell-container-style"></section>
+                <% } else { %>
+                <div class="module-case-list-table-container">
+                  <table class="table module-table module-table-case-list">
+                      <thead>
+                        <tr>
+                          <% if (isMultiSelect && !hasNoItems) { %>
+                            <th class="module-case-list-header"><input type="checkbox" id="select-all-checkbox"/></th>
+                          <% } %>
+                          <%  _.each(headers, function(header, index) { %>
+                            <% if (columnVisible(index)) { %>
+                              <% if (columnSortable(index)) { %>
+                                <th class="module-case-list-header header-clickable formplayer-request" data-id="<%- index %>"> <%= header %></th>
+                              <% } else { %>
+                                <th class="module-case-list-header" data-id="<%- index %>"> <%= header %></th>
+                              <% } %>
+                            <% } %>
+                          <% }); %>
+                        </tr>
+                      </thead>
+
+                    <% if (hasNoItems) { %>
+                      {% include 'formplayer/no_items_text.html' %}
+                    <% } %>
+                    <tbody class="wrapper js-case-container">
+                    </tbody>
+                  </table>
+                </div>
                 <% } %>
               </div>
-              <div class="dropdown">
-                <button class="btn" id="case-list-sort-by-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  <span> {% trans "Sort By" %} </span><i class="fa fa-sort" aria-hidden="true"></i>
-                </button>
-                <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="case-list-sort-by">
-                  <%  _.each(headers, function(header, index) { %>
-                    <% if (columnSortable(index)) { %>
-                    <li tabindex="0" class="header-clickable formplayer-request" data-id="<%- index %>" role="menuitem"><a><%= header %></a></li>
-                    <% } %>
-                  <% }); %>
-                </ul>
-              </div>
-            </div>
-          <% } %>
-          <section class="js-case-container clearfix list-cell-container-style"></section>
-        <% } else { %>
-        <div class="module-case-list-table-container">
-          <table class="table module-table module-table-case-list">
-              <thead>
-                <tr>
-                  <% if (isMultiSelect && !hasNoItems) { %>
-                    <th class="module-case-list-header"><input type="checkbox" id="select-all-checkbox"/></th>
-                  <% } %>
-                  <%  _.each(headers, function(header, index) { %>
-                    <% if (columnVisible(index)) { %>
-                      <% if (columnSortable(index)) { %>
-                        <th class="module-case-list-header header-clickable formplayer-request" data-id="<%- index %>"> <%= header %></th>
-                      <% } else { %>
-                        <th class="module-case-list-header" data-id="<%- index %>"> <%= header %></th>
-                      <% } %>
-                    <% } %>
-                  <% }); %>
-                </tr>
-              </thead>
 
-            <% if (hasNoItems) { %>
-              {% include 'formplayer/no_items_text.html' %}
-            <% } %>
-            <tbody class="wrapper js-case-container">
-            </tbody>
-          </table>
+
+        <% if (window.innerWidth >= 992 && showMap) { %>
+          <div class="col-md-4">
+              <div id="module-case-list-map" class="sticky sticky-map <% if (useTiles) { %> white-border<% } %> noprint-sub-container"></div>
+          </div>
         </div>
         <% } %>
+
+
+
       </div>
     </div>
     <% if (actions || isMultiSelect) { %>


### PR DESCRIPTION
## Product Description
Positioning of map along with case search table based on the screen size.

![image](https://github.com/dimagi/commcare-hq/assets/14318173/5d77d39b-f9c8-4b72-af9d-d3dc6eca2fa1)


## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3370

Checks for the screen width in pixels and defines the alignment of case search table and map based on that. For small screens, map is stacked on top of the case search table while for larger screens, they are stacked in the same row with a split of 2:1 for table and map.

A screen width of 992px is used to define the type of screen, based on https://dimagi-dev.atlassian.net/browse/USH-3370?focusedCommentId=291757


## Feature Flag
NA

## Safety Assurance

### Safety story
Tested changes on staging for both mobile and desktop device. Used emulator to test on iOS with safari browser.

### Automated test coverage
NA


### QA Plan
NA


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
