### PR TITLE
Dynamic Clustering + Map for Case Grouping Page

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -11,6 +11,7 @@ hqDefine("geospatial/js/case_grouping_map",[
 ) {
     const MAP_CONTAINER_ID = 'case-grouping-map';
     let map;
+    const clusterStatsInstance = new clusterStatsModel();
 
     function caseModel(caseId, coordiantes, caseLink) {
         'use strict';
@@ -22,6 +23,15 @@ hqDefine("geospatial/js/case_grouping_map",[
         // TODO: Group ID needs to be set
         self.groupId = null;
 
+        return self;
+    }
+
+    function clusterStatsModel() {
+        'use strict';
+        let self = {};
+        self.totalClusters = ko.observable(0);
+        self.clusterMinCount = ko.observable(0);
+        self.clusterMaxCount = ko.observable(0);
         return self;
     }
 

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -85,7 +85,7 @@ hqDefine("geospatial/js/case_grouping_map",[
     function initMap() {
         'use strict';
 
-        mapboxgl.accessToken = initialPageData.get('mapbox_access_token');
+        mapboxgl.accessToken = initialPageData.get('mapbox_access_token'); // eslint-disable-line no-undef
         const centerCoordinates = [2.43333330, 9.750];
 
         const mapboxInstance = new mapboxgl.Map({  // eslint-disable-line no-undef

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -165,7 +165,8 @@ hqDefine("geospatial/js/case_grouping_map",[
 
     function updateClusterStats() {
         const sourceFeatures = map.querySourceFeatures('caseWithGPS', {
-            filter: ['get', 'cluster'],
+            sourceLayer: 'clusters',
+            filter: ['==', 'cluster', true],
         });
 
         // Mapbox clustering creates the same cluster groups with slightly different coordinates.

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -225,6 +225,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             if (isAfterReportLoad) {
                 $("#export-controls").koApplyBindings(exportModelInstance);
                 map = initMap();
+                $("#clusterStats").koApplyBindings(clusterStatsInstance);
                 return;
             }
 

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -152,6 +152,39 @@ hqDefine("geospatial/js/case_grouping_map",[
         return mapboxInstance;
     }
 
+    function loadMapClusters(caseList) {
+        let caseLocationsGeoJson = {
+            "type": "FeatureCollection",
+            "features": [],
+        };
+
+        _.each(caseList, function (caseWithGPS) {
+            const coordinates = caseWithGPS.coordinates;
+            if (coordinates && coordinates.lat && coordinates.lng) {
+                caseLocationsGeoJson["features"].push(
+                    {
+                        "type": "feature",
+                        "properties": {
+                            "id": caseWithGPS.caseId,
+                        },
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [coordinates.lng, coordinates.lat],
+                        },
+                    }
+                );
+            }
+        });
+
+        if (map.getSource('caseWithGPS')) {
+            map.getSource('caseWithGPS').setData(caseLocationsGeoJson);
+        } else {
+            map.on('load', () => {
+                map.getSource('caseWithGPS').setData(caseLocationsGeoJson);
+            });
+        }
+    }
+
     $(function () {
         let caseModels = [];
         const exportModelInstance = new exportModel();
@@ -196,6 +229,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             const caseData = xhr.responseJSON.aaData;
             if (caseData.length) {
                 loadCases(caseData);
+                loadMapClusters(caseModels);
             }
         });
     });

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -24,4 +24,28 @@
       {% endif %}
     {% endblock reporttable %}
 </div>
+
+<div class="row panel" id="clusterStats">
+  <div class="col-sm-6 col-md-6 col-lg-6">
+    <table class="table table-striped table-bordered">
+      <thead>
+        <th colspan="2">{% trans "Summary of Case Grouping" %}</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{% trans "Total number of clusters" %}</td>
+          <td data-bind="text: totalClusters"></td>
+        </tr>
+        <tr>
+          <td>{% trans "Maximum cases per cluster" %}</td>
+          <td data-bind="text: clusterMaxCount"></td>
+        </tr>
+        <tr>
+          <td>{% trans "Minimum cases per cluster" %}</td>
+          <td data-bind="text: clusterMinCount"></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
 {% endblock %}

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -12,6 +12,8 @@
   </div>
 </div>
 
+<div id="case-grouping-map" style="height: 500px"></div>
+
 <div class="panel-body-datatable">
     {% block reporttable %}
       {% if report.needs_filters %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Case grouping page now has a map which implements group clustering of cases:
![Screenshot from 2023-10-19 09-23-48](https://github.com/dimagi/commcare-hq/assets/122617251/c5f2c1ee-7e1b-485c-9697-f7246971e812)

There is also a new table at the bottom of the page which contains various statistics for the map clusters:
![Screenshot from 2023-10-19 09-23-59](https://github.com/dimagi/commcare-hq/assets/122617251/7029cc90-59b9-4fdc-b6b0-003155862f81)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3056).

This PR adds a mapbox map to the "Case Grouping" geospatial page. This map is able to cluster all the cases according into groups according to their relative distance from each other. The user can increase/decrease the number of groups by zooming in/out of the map.

At the bottom of the page there is a table which contains statistics of how many cluster groups there are, the size of the cluster with the largest amount of cases, and the size of the cluster with the least amount of cases. This is calculated for all clusters in the map, regardless whether they are currently visible on the map.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Unused page.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Front-end only change, no related tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Ticket has been marked as requiring QA, however given that no actual case data is being loaded yet (to be addressed in [this](https://dimagi-dev.atlassian.net/browse/SC-3056) ticket) I am not sure how much QA will be able to test yet. QA for this should therefore be held off and done when the mentioned ticket has been completed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
