### PR TITLE
Remove obsolete backward compatibility flag for case search dropdowns

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -161,7 +161,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     divId: inputId,
                     itemCallback: geocoderItemCallback(id, model),
                     clearCallBack: geocoderOnClearCallback(id),
-                    responseDataTypes: 'address,region,place,postcode'
+                    responseDataTypes: 'address,region,place,postcode',
                 });
                 var divEl = $field.find('.mapboxgl-ctrl-geocoder');
                 divEl.css("max-width", "none");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -231,17 +231,14 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
         _setItemset: function (itemsetChoices, itemsetChoicesKey) {
             itemsetChoices = itemsetChoices || [];
+            itemsetChoicesKey = itemsetChoicesKey || [];
             let itemsetChoicesDict = {};
 
-            if (this.parentView.selectValuesByKeys) {
-                itemsetChoicesKey = itemsetChoicesKey || [];
-                itemsetChoicesKey.forEach((key,i) => itemsetChoicesDict[key] = itemsetChoices[i]);
-                this.model.set({
-                    itemsetChoicesKey: itemsetChoicesKey,
-                });
-            } else {
-                itemsetChoices.forEach((value,i) => itemsetChoicesDict[i] = value);
-            }
+            itemsetChoicesKey.forEach((key,i) => itemsetChoicesDict[key] = itemsetChoices[i]);
+            this.model.set({
+                itemsetChoicesKey: itemsetChoicesKey,
+            });
+
             this.model.set({
                 itemsetChoices: itemsetChoices,
                 itemsetChoicesDict: itemsetChoicesDict,
@@ -463,19 +460,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         initialize: function (options) {
             this.parentModel = options.collection.models || [];
 
-            // whether the select prompt selection is passed as itemset keys
-            // only here to maintain backward compatibility and can be removed
-            // once web apps fully transition using keys to convey select prompt selection.
-            this.selectValuesByKeys = false;
             this.dynamicSearchEnabled = options.disableDynamicSearch ? false :
                 (toggles.toggleEnabled('DYNAMICALLY_UPDATE_SEARCH_RESULTS') && this.options.sidebarEnabled);
 
-            for (let model of this.parentModel) {
-                if ("itemsetChoicesKey" in model.attributes) {
-                    this.selectValuesByKeys = true;
-                    break;
-                }
-            }
             this.smallScreenListener = cloudcareUtils.smallScreenListener(smallScreenEnabled => {
                 this.handleSmallScreenChange(smallScreenEnabled);
             });
@@ -584,7 +571,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 FormplayerFrontend.trigger(
                     "menu:query",
                     self.getAnswers(),
-                    self.selectValuesByKeys,
                     self.options.sidebarEnabled
                 );
                 if (self.smallScreenEnabled && self.options.sidebarEnabled) {
@@ -669,7 +655,6 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             urlObject.setQueryData({
                 inputs: self.getAnswers(),
                 execute: false,
-                selectValuesByKeys: self.selectValuesByKeys,
             });
             var fetchingPrompts = FormplayerFrontend.getChannel().request("app:select:menus", urlObject);
             $.when(fetchingPrompts).done(function (response) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -199,13 +199,12 @@ hqDefine("cloudcare/js/formplayer/router", function () {
         API.listMenus();
     });
 
-    FormplayerFrontend.on("menu:query", function (queryDict, selectValuesByKeys = false, sidebarEnabled) {
+    FormplayerFrontend.on("menu:query", function (queryDict, sidebarEnabled) {
         var urlObject = utils.currentUrlToObject();
         var queryObject = _.extend(
             {
                 inputs: queryDict,
                 execute: true,
-                selectValuesByKeys,
             },
             // force manual search in split screen case search for workflow compatibility
             sidebarEnabled ? { forceManualSearch: true } : {}

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/query_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/query_spec.js
@@ -12,32 +12,17 @@ hqDefine("cloudcare/js/formplayer/spec/query_spec", function () {
                 keyModel = new QueryViewModel({
                     "itemsetChoicesKey": ["CA", "MA", "FL"],
                     "itemsetChoices": ["California", "Massachusetts", "Florida"],
-                }),
-                indexModel = new QueryViewModel({
-                    "itemsetChoices": ["California", "Massachusetts", "Florida"],
                 });
 
-            let keyViewCollection = new QueryViewCollection([keyModel]),
-                indexViewCollection = new QueryViewCollection([indexModel]);
+            let keyViewCollection = new QueryViewCollection([keyModel])
 
             sinon.stub(Utils, 'getStickyQueryInputs').callsFake(function () { return 'fake_value'; });
             let keyQueryListView =  QueryListView({ collection: keyViewCollection}),
-                keyQueryView = new keyQueryListView.childView({ parentView: keyQueryListView, model: keyModel}),
-                indexQueryListView =  QueryListView({ collection: indexViewCollection}),
-                indexQueryView = new keyQueryListView.childView({ parentView: indexQueryListView, model: indexModel});
+                keyQueryView = new keyQueryListView.childView({ parentView: keyQueryListView, model: keyModel})
 
-            it('should flag if options contains keys for itemset', function () {
-                assert.isTrue(keyQueryListView.selectValuesByKeys);
-                assert.isFalse(indexQueryListView.selectValuesByKeys);
-            });
-
-            it('should create dictionary with either keys if provided. Otherwise, with index as the key', function () {
+            it('should create dictionary with either keys', function () {
                 let expectedKeyItemsetChoicesDict = { "CA": "California", "MA": "Massachusetts", "FL": "Florida"};
                 assert.deepEqual(expectedKeyItemsetChoicesDict, keyQueryView.model.get("itemsetChoicesDict"));
-
-                let expectedIndexItemsetChoicesDict = {"0": "California", "1": "Massachusetts", "2": "Florida"};
-                assert.deepEqual(expectedIndexItemsetChoicesDict, indexQueryView.model.get("itemsetChoicesDict"));
-
             });
         });
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/query_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/query_spec.js
@@ -14,11 +14,11 @@ hqDefine("cloudcare/js/formplayer/spec/query_spec", function () {
                     "itemsetChoices": ["California", "Massachusetts", "Florida"],
                 });
 
-            let keyViewCollection = new QueryViewCollection([keyModel])
+            let keyViewCollection = new QueryViewCollection([keyModel]);
 
             sinon.stub(Utils, 'getStickyQueryInputs').callsFake(function () { return 'fake_value'; });
             let keyQueryListView =  QueryListView({ collection: keyViewCollection}),
-                keyQueryView = new keyQueryListView.childView({ parentView: keyQueryListView, model: keyModel})
+                keyQueryView = new keyQueryListView.childView({ parentView: keyQueryListView, model: keyModel});
 
             it('should create dictionary with either keys', function () {
                 let expectedKeyItemsetChoicesDict = { "CA": "California", "MA": "Massachusetts", "FL": "Florida"};

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -264,14 +264,11 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             this.sortIndex = null;
         };
 
-        this.setQueryData = function ({ inputs, execute, forceManualSearch, selectValuesByKeys = false }) {
+        this.setQueryData = function ({ inputs, execute, forceManualSearch}) {
             var selections = Utils.currentUrlToObject().selections;
             this.queryData = this.queryData || {};
             this.queryData[sessionStorage.queryKey] = _.defaults({
                 inputs: inputs,
-                // only here to maintain backward compatibility and can be removed
-                // once web apps fully transition using keys to convey select prompt selection.
-                select_values_by_key: selectValuesByKeys,
                 execute: execute,
                 force_manual_search: forceManualSearch,
                 selections: selections,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No user facing effects.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
remove backward compatibility flag introduced as part of the [spec](https://docs.google.com/document/d/1Xtly4YfrdaB1w1Ozwlwy9LQ4JIrVRmhvg-44-Rl-z6A/edit) and implemented in this PR https://github.com/dimagi/commcare-hq/pull/32883. The flag can be removed as all response to FP should be using `itemsetChoicesKey`

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Removes an obsolete flag. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test exists for using `itemsetChoicesKey`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
