### PR TITLE
Ensure formplayer db creation is clear prerequisite for running locally

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -778,7 +778,9 @@ yarn install --frozen-lockfile
 
 ## Running Formplayer and submitting data with Web Apps
 
-Formplayer is a Java service that allows us to use applications on the web  instead of on a mobile device.
+#### Prerequisites
+
+Formplayer is a Java service that allows us to use applications on the web instead of on a mobile device.
 
 In `localsettings.py`:
 
@@ -786,6 +788,14 @@ In `localsettings.py`:
 FORMPLAYER_URL = 'http://localhost:8080'
 FORMPLAYER_INTERNAL_AUTH_KEY = "secretkey"
 LOCAL_APPS += ('django_extensions',)
+```
+
+Before running Formplayer either locally or in a container, you need to [initialize the formplayer database](https://github.com/dimagi/formplayer#building-and-running).
+The password for the "commcarehq" user is in the localsettings.py file in the
+`DATABASES` dictionary.
+
+```sh
+createdb formplayer -U commcarehq -h localhost
 ```
 
 **IMPORTANT:** When running HQ, be sure to use `runserver_plus`
@@ -797,16 +807,6 @@ LOCAL_APPS += ('django_extensions',)
 Then you need to have Formplayer running.
 
 ### Running `formplayer` Outside of Docker
-
-#### Prerequisites
-
-Before running Formplayer, you need to [initialize the formplayer database](https://github.com/dimagi/formplayer#building-and-running).
-The password for the "commcarehq" user is in the localsettings.py file in the
-`DATABASES` dictionary.
-
-```sh
-createdb formplayer -U commcarehq -h localhost
-```
 
 #### Installation
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I'm setting up my new machine and it wasn't clear to me that I would need to create the formplayer db in order to successfully run it via docker. Seems a bit obvious in hindsight (wasn't sure if the docker container managed the db), but I think moving the block up to be agnostic of running via docker or the jar file would be helpful.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just docs.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
