### PR TITLE
Fixes for QA for custom domain banners

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -362,3 +362,24 @@ class ConnectIDAuthBackend:
         if (couch_user.username != link.commcare_user.username):
             return None
         return link.commcare_user
+
+
+def user_can_access_domain_specific_pages(request):
+    # an active logged-in user can access domain specific pages if
+    # domain is active &
+    # they are a member of the domain or
+    # a superuser and domain does not restrict superusers from access
+    from corehq.apps.domain.decorators import active_user_logged_in, _ensure_request_couch_user, _ensure_request_project
+
+    if not active_user_logged_in(request):
+        return False
+
+    project = _ensure_request_project(request)
+    if not (project and project.is_active):
+        return False
+
+    couch_user = _ensure_request_couch_user(request)
+    if not couch_user:
+        return False
+
+    return couch_user.is_member_of(project) or (couch_user.is_superuser and not project.restrict_superusers)

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -371,7 +371,11 @@ def user_can_access_domain_specific_pages(request):
         they are a member of the domain or
         a superuser and domain does not restrict superusers from access
     """
-    from corehq.apps.domain.decorators import active_user_logged_in, _ensure_request_couch_user, _ensure_request_project
+    from corehq.apps.domain.decorators import (
+        _ensure_request_couch_user,
+        _ensure_request_project,
+        active_user_logged_in,
+    )
 
     if not active_user_logged_in(request):
         return False

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -365,10 +365,12 @@ class ConnectIDAuthBackend:
 
 
 def user_can_access_domain_specific_pages(request):
-    # an active logged-in user can access domain specific pages if
-    # domain is active &
-    # they are a member of the domain or
-    # a superuser and domain does not restrict superusers from access
+    """
+        An active logged-in user can access domain specific pages if
+        domain is active &
+        they are a member of the domain or
+        a superuser and domain does not restrict superusers from access
+    """
     from corehq.apps.domain.decorators import active_user_logged_in, _ensure_request_couch_user, _ensure_request_project
 
     if not active_user_logged_in(request):

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -86,7 +86,7 @@ def login_and_domain_required(view_func):
             msg = _('The domain "{domain}" was not found.').format(domain=domain_name)
             raise Http404(msg)
 
-        if not (user.is_authenticated and user.is_active):
+        if not (active_user_logged_in(req)):
             login_url = reverse('domain_login', kwargs={'domain': domain_name})
             return redirect_for_login_or_domain(req, login_url=login_url)
 
@@ -172,6 +172,18 @@ def _ensure_request_couch_user(request):
     if not couch_user and hasattr(request, 'user'):
         request.couch_user = couch_user = CouchUser.from_django_user(request.user)
     return couch_user
+
+
+def _ensure_request_project(request):
+    project = getattr(request, 'project', None)
+    if not project and hasattr(request, 'domain'):
+        domain_name, domain_obj = load_domain(request, request.domain)
+        request.project = domain_obj
+    return project
+
+
+def active_user_logged_in(request):
+    return request.user.is_authenticated and request.user.is_active
 
 
 class LoginAndDomainMixin(object):

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -65,9 +65,13 @@ OTP_AUTH_FAIL_RESPONSE = {"error": "must send X-COMMCAREHQ-OTP header or 'otp' U
 
 def load_domain(req, domain):
     domain_name = normalize_domain_name(domain)
+    _store_project_on_request(req, domain_name)
+    return domain_name, req.project
+
+
+def _store_project_on_request(request, domain_name):
     domain_obj = Domain.get_by_name(domain_name)
-    req.project = domain_obj
-    return domain_name, domain_obj
+    request.project = domain_obj
 
 
 def redirect_for_login_or_domain(request, login_url=None):
@@ -177,8 +181,7 @@ def _ensure_request_couch_user(request):
 def _ensure_request_project(request):
     project = getattr(request, 'project', None)
     if not project and hasattr(request, 'domain'):
-        domain_name, domain_obj = load_domain(request, request.domain)
-        request.project = domain_obj
+        _store_project_on_request(request, request.domain)
     return project
 
 

--- a/corehq/apps/domain/tests/test_auth.py
+++ b/corehq/apps/domain/tests/test_auth.py
@@ -1,0 +1,66 @@
+from django.http.request import HttpRequest
+from django.test import SimpleTestCase
+
+from unittest.mock import patch
+
+from corehq.apps.domain.auth import user_can_access_domain_specific_pages
+from corehq.apps.domain.models import Domain
+from corehq.apps.users.models import CouchUser
+
+
+class TestUserCanAccessDomainSpecificPages(SimpleTestCase):
+    def test_request_with_no_logged_in_user(self, *args):
+        request = HttpRequest()
+
+        with patch('corehq.apps.domain.decorators.active_user_logged_in', return_value=False):
+            self.assertFalse(user_can_access_domain_specific_pages(request))
+
+    @patch('corehq.apps.domain.decorators.active_user_logged_in', return_value=True)
+    def test_request_with_no_project(self, *args):
+        request = HttpRequest()
+
+        with patch('corehq.apps.domain.decorators.ensure_request_project', return_value=None):
+            self.assertFalse(user_can_access_domain_specific_pages(request))
+
+    @patch('corehq.apps.domain.decorators.active_user_logged_in', return_value=True)
+    def test_request_with_inactive_project(self, *args):
+        request = HttpRequest()
+        project = Domain(is_active=False)
+
+        with patch('corehq.apps.domain.decorators.ensure_request_project', return_value=project):
+            self.assertFalse(user_can_access_domain_specific_pages(request))
+
+    @patch('corehq.apps.domain.decorators.active_user_logged_in', return_value=True)
+    @patch('corehq.apps.domain.decorators.ensure_request_project', return_value=Domain(is_active=True))
+    def test_request_with_no_couch_user(self, *args):
+        request = HttpRequest()
+
+        self.assertFalse(user_can_access_domain_specific_pages(request))
+
+    @patch('corehq.apps.domain.decorators.active_user_logged_in', return_value=True)
+    @patch('corehq.apps.domain.decorators.ensure_request_project', return_value=Domain(is_active=True))
+    @patch('corehq.apps.domain.decorators.ensure_request_couch_user', return_value=CouchUser())
+    def test_request_for_missing_domain_membership_for_non_superuser(self, *args):
+        request = HttpRequest()
+
+        self.assertFalse(user_can_access_domain_specific_pages(request))
+
+    @patch('corehq.apps.domain.decorators.active_user_logged_in', return_value=True)
+    @patch('corehq.apps.domain.decorators.ensure_request_project', return_value=Domain(is_active=True))
+    def test_request_for_missing_domain_membership_for_superuser(self, *args):
+        request = HttpRequest()
+
+        couch_user = CouchUser()
+        couch_user.is_superuser = True
+
+        with patch('corehq.apps.domain.decorators.ensure_request_couch_user', return_value=couch_user):
+            self.assertTrue(user_can_access_domain_specific_pages(request))
+
+    @patch('corehq.apps.domain.decorators.active_user_logged_in', return_value=True)
+    @patch('corehq.apps.domain.decorators.ensure_request_project', return_value=Domain(is_active=True))
+    @patch('corehq.apps.domain.decorators.ensure_request_couch_user', return_value=CouchUser())
+    def test_request_for_valid_domain_membership_for_non_superuser(self, *args):
+        request = HttpRequest()
+
+        with patch('corehq.apps.users.models.CouchUser.is_member_of', return_value=True):
+            self.assertTrue(user_can_access_domain_specific_pages(request))

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -390,12 +390,18 @@ def chevron(value):
 
 @register.simple_tag
 def commcarehq_alerts(request):
+    from corehq.apps.domain.auth import user_can_access_domain_specific_pages
+
     active_alerts = Alert.get_active_alerts()
-    domain = getattr(request, 'domain', None)
+    load_alerts_for_domain = None
+
+    if hasattr(request, 'domain') and user_can_access_domain_specific_pages(request):
+        load_alerts_for_domain = request.domain
+
     return [
         alert for alert in active_alerts
         if (not alert.domains
-            or domain in alert.domains)
+            or load_alerts_for_domain in alert.domains)
     ]
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A minor bug noticed during QA for a feature flag to let projects add their own custom alerts.

Currently users can see new domain specific alerts and existing domain specific maintenance alerts on a domain specific page without being logged in like on login page (`http://<HQ>/a/test/login/`) or even when they see a 404 when accessing a domain specific page directly from URL
QA Tickets:
Access without login: https://dimagi-dev.atlassian.net/browse/QA-5724
Alerts shown when domain page accessed directly: https://dimagi-dev.atlassian.net/browse/QA-5723

So, this PR fixes that behavior by showing domain specific alerts to users only when:
1. they have access to the project space
2. they are logged in


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Took inspiration from [login_and_domain_required](https://github.com/dimagi/commcare-hq/blob/70aa77afd66dd0a43f3c037b56ffcb26f44e380a/corehq/apps/domain/decorators.py#L78) for the checks that should be done for user access to domain and added a function that could be used generally to check if user can access domain specific page.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
GA (Maintenance Alerts used by Superuser) & Feature Flag `CUSTOM_DOMAIN_BANNER_ALERTS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested Locally.
Added tests for new code added.
Going through QA as well.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests for new code

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi-dev.atlassian.net/browse/QA-5708

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
