### PR TITLE
Add pagination for Case Grouping Page

### DIFF
--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -586,6 +586,22 @@ class GeohashGridAggregation(Aggregation):
         }
 
 
+class GeoBoundsAggregation(Aggregation):
+    """
+    A metric aggregation that computes the bounding box containing all
+    geo_point values for a field.
+
+    More info: `Geo Bounds Aggregation <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-metrics-geobounds-aggregation.html>`_
+    """  # noqa: E501
+    type = 'geo_bounds'
+
+    def __init__(self, name, field):
+        self.name = name
+        self.body = {
+            'field': field,
+        }
+
+
 class NestedAggregation(Aggregation):
     """
     A special single bucket aggregation that enables aggregating nested documents.

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -64,6 +64,10 @@ class CaseSearchES(CaseES):
             external_id,
             indexed_on,
             case_property_missing,
+            filters.geo_bounding_box,
+            filters.geo_polygon,
+            filters.geo_shape,  # Available in Elasticsearch 8+
+            filters.geo_grid,  # Available in Elasticsearch 8+
         ] + super(CaseSearchES, self).builtin_filters
 
     def case_property_query(self, case_property_name, value, clause=queries.MUST, fuzzy=False):

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -137,59 +137,94 @@ def regexp(field, regex):
 def geo_bounding_box(field, top_left, bottom_right):
     """
     Only return geopoints stored in ``field`` that are located within
-    the bounding box defined by GeoPoints ``top_left`` and
-    ``bottom_right``.
+    the bounding box defined by ``top_left`` and ``bottom_right``.
 
-    :param field: The field where geopoints are stored
-    :param top_left: The GeoPoint of the top left of the bounding box,
-        a string in the format "latitude longitude" or "latitude
-        longitude altitude accuracy"
-    :param bottom_right: The GeoPoint of the bottom right of the
-        bounding box
-    :return: A filter dict
+    ``top_left`` and ``bottom_right`` accept a range of data types and
+    formats.
+
+    More info: `Geo Bounding Box Query <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-geo-bounding-box-query.html>`_
     """  # noqa: E501
-    from couchforms.geopoint import GeoPoint
+    return {
+        'geo_bounding_box': {
+            field: {
+                'top_left': top_left,
+                'bottom_right': bottom_right,
+            }
+        }
+    }
 
-    top_left_geo = GeoPoint.from_string(top_left, flexible=True)
-    bottom_right_geo = GeoPoint.from_string(bottom_right, flexible=True)
-    points_list = [
-        {"lat": float(top_left_geo.latitude), "lon": float(top_left_geo.longitude)},
-        {"lat": float(bottom_right_geo.latitude), "lon": float(bottom_right_geo.longitude)},
-    ]
-    return geo_shape(field, points_list)
 
-
-def geo_shape(field, points_list):
+def geo_polygon(field, points):
     """
-    Filters cases by case properties indexed using the the geo_point
+    Filters ``geo_point`` values in ``field`` that fall within the
+    polygon described by the list of ``points``.
+
+    More info: `Geo Polygon Query <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-geo-polygon-query.html>`_
+
+    :param field: A field with Elasticsearch data type ``geo_point``.
+    :param points: A list of points that describe a polygon.
+        Elasticsearch supports a range of formats for list items.
+    :return: A filter dict.
+    """  # noqa: E501
+    # NOTE: Deprecated in Elasticsearch 7.12
+    return {
+        'geo_polygon': {
+            field: {
+                'points': points,
+            }
+        }
+    }
+
+
+def geo_shape(field, shape, relation='intersects'):
+    """
+    Filters cases by case properties indexed using the ``geo_point``
     type.
 
-    More info: `The Geoshape query reference <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html>`_
+    More info: `The Geoshape query reference <https://www.elastic.co/guide/en/elasticsearch/reference/8.10/query-dsl-geo-shape-query.html>`_
 
     :param field: The field where geopoints are stored
-    :param points_list: A list of points for the polygon in the format [{lat: x, lon: y},...]
+    :param shape: A shape definition given in GeoJSON geometry format.
+        More info: `The GeoJSON specification (RFC 7946) <https://datatracker.ietf.org/doc/html/rfc7946>`_
+    :param relation: The relation between the shape and the case
+        property values.
     :return: A filter definition
     """  # noqa: E501
-    from corehq.apps.es.case_search import (
-        PROPERTY_GEOPOINT_VALUE,
-        PROPERTY_KEY,
-    )
-    return AND(
-        term(PROPERTY_KEY, field),
-        {
-            "geo_polygon": {
-                PROPERTY_GEOPOINT_VALUE: {
-                    "points": points_list,
-                },
-            },
-        },
-    )
+    # NOTE: Available in Elasticsearch 8+.
+    #
+    # The geoshape query is available in Elasticsearch 5.6, but only
+    # supports the `geo_shape` type (not the `geo_point` type), which
+    # CommCare HQ does not use.
+
+    # TODO: After Elasticsearch is upgraded, switch from geo_polygon to
+    #       geo_shape. (Norman, 2023-11-01)
+    # e.g.
+    #
+    #     geo_polygon(field, points)
+    #
+    # becomes
+    #
+    #     shape = {
+    #         'type': 'polygon',
+    #         'coordinates': points,
+    #     }
+    #     geo_shape(field, shape, relation='within')
+    #
+    return {
+        "geo_shape": {
+            field: {
+                "shape": shape,
+                "relation": relation
+            }
+        }
+    }
 
 
 def geo_grid(field, geohash):
     """
     Filters cases by the geohash grid cell in which they are located.
     """
+    # Available in Elasticsearch 8+
     return {
         "geo_grid": {
             field: {

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -184,3 +184,16 @@ def geo_shape(field, points_list):
             },
         },
     )
+
+
+def geo_grid(field, geohash):
+    """
+    Filters cases by the geohash grid cell in which they are located.
+    """
+    return {
+        "geo_grid": {
+            field: {
+                "geohash": geohash
+            }
+        }
+    }

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import date, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 import pytz
 
 from django.test import TestCase
@@ -8,7 +8,7 @@ from django.test.testcases import SimpleTestCase
 
 from couchforms.geopoint import GeoPoint
 
-from corehq.apps.case_search.const import IS_RELATED_CASE, RELEVANCE_SCORE
+from corehq.apps.case_search.const import RELEVANCE_SCORE
 from corehq.apps.case_search.models import CaseSearchConfig
 from corehq.apps.case_search.xpath_functions.comparison import adjust_input_date_by_timezone
 from corehq.apps.es import queries
@@ -260,7 +260,6 @@ class TestCaseSearchHitConversions(SimpleTestCase):
     def test_wrap_case_search_hit_include_score(self):
         case = wrap_case_search_hit(self.make_hit(), include_score=True)
         self.assertEqual(case.case_json[RELEVANCE_SCORE], "1.095")
-
 
     @staticmethod
     def make_hit():

--- a/corehq/apps/es/tests/test_filters.py
+++ b/corehq/apps/es/tests/test_filters.py
@@ -182,30 +182,11 @@ class TestFilters(ElasticTestMixin, SimpleTestCase):
                             }
                         },
                         {
-                            "bool": {
-                                "filter": [
-                                    {
-                                        "term": {
-                                            "case_properties.key.exact": "location"
-                                        }
-                                    },
-                                    {
-                                        "geo_polygon": {
-                                            "case_properties.geopoint_value": {
-                                                "points": [
-                                                    {
-                                                        "lat": 40.73,
-                                                        "lon": -74.1
-                                                    },
-                                                    {
-                                                        "lat": 40.01,
-                                                        "lon": -71.12
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                ]
+                            "geo_bounding_box": {
+                                "location": {
+                                    "top_left": "40.73 -74.1",
+                                    "bottom_right": "40.01 -71.12",
+                                }
                             }
                         },
                         {
@@ -242,30 +223,20 @@ class TestFilters(ElasticTestMixin, SimpleTestCase):
                 "bool": {
                     "filter": [
                         {
-                            "bool": {
-                                "filter": [
-                                    {
-                                        "term": {
-                                            "case_properties.key.exact": "case_gps"
+                            "geo_shape": {
+                                "case_gps": {
+                                    "shape": [
+                                        {
+                                            "lat": 40.73,
+                                            "lon": -74.1
+                                        },
+                                        {
+                                            "lat": 40.01,
+                                            "lon": -71.12
                                         }
-                                    },
-                                    {
-                                        "geo_polygon": {
-                                            "case_properties.geopoint_value": {
-                                                "points": [
-                                                    {
-                                                        "lat": 40.73,
-                                                        "lon": -74.1
-                                                    },
-                                                    {
-                                                        "lat": 40.01,
-                                                        "lon": -71.12
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                ]
+                                    ],
+                                    "relation": "intersects"
+                                }
                             }
                         },
                         {

--- a/corehq/apps/es/tests/test_filters.py
+++ b/corehq/apps/es/tests/test_filters.py
@@ -285,6 +285,38 @@ class TestFilters(ElasticTestMixin, SimpleTestCase):
             validate_query=False,
         )
 
+    def test_geo_grid(self):
+        query = CaseSearchES().filter(
+            filters.geo_grid('location', 'u0')
+        )
+        json_output = {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "geo_grid": {
+                                "location": {
+                                    "geohash": "u0"
+                                }
+                            }
+                        },
+                        {
+                            "match_all": {}
+                        }
+                    ],
+                    "must": {
+                        "match_all": {}
+                    }
+                }
+            },
+            "size": SIZE_LIMIT
+        }
+        self.checkQuery(
+            query,
+            json_output,
+            validate_query=False,
+        )
+
 
 @es_test
 class TestSourceFiltering(ElasticTestMixin, SimpleTestCase):

--- a/corehq/apps/geospatial/README.md
+++ b/corehq/apps/geospatial/README.md
@@ -1,18 +1,51 @@
-# Case Grouping
+Geospatial Features
+===================
 
-There are various configuration settings available for deciding how case grouping is done. These parameters are saved in the `GeoConfig` model which is linked to a domain.
-It is important to note however, that not all available parameters will be used for case grouping. The parameters that actually get used is determined by the chosen grouping
-method. Mainly, these are:
-1. Min/Max Grouping - Grouping is done by specifying the minimum and maximum number of cases that each group may have.
-2. Target Size Grouping - Grouping is done by specifying how many groups should be created. Cases will then evenly get distributed into groups to meet the target number of groups.
+Geospatial features allow the management of cases and mobile workers
+based on their geographical location. Case location is stored in a
+configurable case property, which defaults to "gps_point". Mobile
+worker location is stored in user data, also with the name "gps_point".
 
 
-# Setup Test Data
+Case Grouping
+-------------
 
-To populate test data for any domain, you could simply do a bulk upload for cases with the following columns
+There are various configuration settings available for deciding how case
+grouping is done. These parameters are saved in the `GeoConfig` model
+which is linked to a domain. It is important to note however, that not
+all available parameters will be used for case grouping. The parameters
+that actually get used is determined by the chosen grouping method.
+Mainly, these are:
+
+1. Min/Max Grouping - Grouping is done by specifying the minimum and
+   maximum number of cases that each group may have.
+
+2. Target Size Grouping - Grouping is done by specifying how many groups
+   should be created. Cases will then evenly get distributed into groups
+   to meet the target number of groups.
+
+
+Setting Up Test Data
+--------------------
+
+To populate test data for any domain, you could simply do a bulk upload
+for cases with the following columns
+
 1. case_id: Blank for new cases
-2. name: (Optional) Add a name for each case. Remove column if not using
-3. gps_point: GPS coordinate for the case that has latitude, longitude, altitude and accuracy separated by an empty space. Example: `9.9999952 3.2859413 393.2 4.36`. This is the case property saved on a case to capture its location and is configurable with default value being `gps_point`, so good to check Geospatial Configuration Settings page for the project to confirm the case property being used before doing the upload. If its different, then this column should use that case property instead of `gps_point`
-4. owner_name: (Optional) To assign case to a mobile worker, simply add worker username here. Remove column if not using
 
-For dimagi devs looking for bulk data, you could use any of the excel sheets available in https://dimagi-dev.atlassian.net/browse/SC-3051
+2. name: (Optional) Add a name for each case. Remove column if not using
+
+3. gps_point: GPS coordinate for the case that has latitude, longitude,
+   altitude and accuracy separated by an empty space. Example:
+   `9.9999952 3.2859413 393.2 4.36`. This is the case property saved on
+   a case to capture its location and is configurable with default
+   value being `gps_point`, so good to check Geospatial Configuration
+   Settings page for the project to confirm the case property being
+   used before doing the upload. If its different, then this column
+   should use that case property instead of `gps_point`
+
+4. owner_name: (Optional) To assign case to a mobile worker, simply add
+   worker username here. Remove column if not using.
+
+For Dimagi devs looking for bulk data, you could use any of the Excel
+sheets available in [SC-3051](https://dimagi-dev.atlassian.net/browse/SC-3051).

--- a/corehq/apps/geospatial/README.md
+++ b/corehq/apps/geospatial/README.md
@@ -25,6 +25,47 @@ Mainly, these are:
    to meet the target number of groups.
 
 
+CaseGroupingReport pagination
+-----------------------------
+
+The `CaseGroupingReport` class uses Elasticsearch
+[GeoHash Grid Aggregation][1] to group cases into buckets.
+
+Elasticsearch [bucket aggregations][2] create buckets of documents,
+where each bucket corresponds to a property that determines whether a
+document falls into that bucket.
+
+The buckets of GeoHash Grid Aggregation are cells in a grid. Each cell
+has a GeoHash, which is like a ZIP code or a postal code, in that it
+represents a geographical area. If a document's GeoPoint is in a
+GeoHash's geographical area, then Elasticsearch places it in the
+corresponding bucket. For more information on GeoHash grid cells, see
+the Elasticsearch docs on [GeoHash cell dimensions][3].
+
+GeoHash Grid Aggregation buckets look like this:
+```
+[
+    {
+        "key": "u17",
+        "doc_count": 3
+    },
+    {
+        "key": "u09",
+        "doc_count": 2
+    },
+    {
+        "key": "u15",
+        "doc_count": 1
+    }
+]
+```
+In this example, "key" is a GeoHash of length 3, and "doc_count" gives
+the number of documents in each bucket, or GeoHash grid cell.
+
+For `CaseGroupingReport`, buckets are pages. So pagination simply flips
+from one bucket to the next.
+
+
 Setting Up Test Data
 --------------------
 
@@ -48,4 +89,10 @@ for cases with the following columns
    worker username here. Remove column if not using.
 
 For Dimagi devs looking for bulk data, you could use any of the Excel
-sheets available in [SC-3051](https://dimagi-dev.atlassian.net/browse/SC-3051).
+sheets available in Jira ticket [SC-3051][4].
+
+
+[1]: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-geohashgrid-aggregation.html
+[2]: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket.html
+[3]: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-geohashgrid-aggregation.html#_cell_dimensions_at_the_equator
+[4]: https://dimagi-dev.atlassian.net/browse/SC-3051

--- a/corehq/apps/geospatial/es.py
+++ b/corehq/apps/geospatial/es.py
@@ -50,6 +50,7 @@ def get_max_doc_count(query, case_property, precision):
     #
     #     'aggregations': {
     #         'case_properties': {
+    #             'doc_count': 66,
     #             'case_property': {
     #                 'doc_count': 6,
     #                 'geohashes': {
@@ -70,6 +71,11 @@ def get_max_doc_count(query, case_property, precision):
     #                 }
     #             }
     #         }
+    #     },
+    #     'hits': {
+    #         'hits': [],
+    #         'max_score': 0.0,
+    #         'total': 6
     #     }
     buckets = (
         queryset.raw['aggregations']

--- a/corehq/apps/geospatial/es.py
+++ b/corehq/apps/geospatial/es.py
@@ -4,13 +4,17 @@ from corehq.apps.case_search.const import CASE_PROPERTIES_PATH
 from corehq.apps.es import filters
 from corehq.apps.es.aggregations import (
     FilterAggregation,
+    GeoBoundsAggregation,
     GeohashGridAggregation,
     NestedAggregation,
 )
 from corehq.apps.es.case_search import PROPERTY_GEOPOINT_VALUE, PROPERTY_KEY
 from corehq.apps.geospatial.const import MAX_GEOHASH_DOC_COUNT
 
-AGG_NAME = 'geohashes'
+CASE_PROPERTIES_AGG = 'case_properties'
+CASE_PROPERTY_AGG = 'case_property'
+GEOHASHES_AGG = 'geohashes'
+BUCKET_CASES_AGG = 'bucket_cases'
 
 
 def find_precision(query, case_property):
@@ -79,29 +83,38 @@ def get_max_doc_count(query, case_property, precision):
     #     }
     buckets = (
         queryset.raw['aggregations']
-        ['case_properties']
-        ['case_property']
-        [AGG_NAME]
+        [CASE_PROPERTIES_AGG]
+        [CASE_PROPERTY_AGG]
+        [GEOHASHES_AGG]
         ['buckets']
     )
     return max(bucket['doc_count'] for bucket in buckets) if buckets else 0
 
 
 def apply_geohash_agg(query, case_property, precision):
-    nested_agg = NestedAggregation('case_properties', CASE_PROPERTIES_PATH)
+    nested_agg = NestedAggregation(
+        name=CASE_PROPERTIES_AGG,
+        path=CASE_PROPERTIES_PATH,
+    )
     filter_agg = FilterAggregation(
-        'case_property',
-        filters.term(PROPERTY_KEY, case_property),
+        name=CASE_PROPERTY_AGG,
+        filter=filters.term(PROPERTY_KEY, case_property),
     )
     geohash_agg = GeohashGridAggregation(
-        AGG_NAME,
-        PROPERTY_GEOPOINT_VALUE,
-        precision,
+        name=GEOHASHES_AGG,
+        field=PROPERTY_GEOPOINT_VALUE,
+        precision=precision,
+    )
+    geobounds_agg = GeoBoundsAggregation(
+        name=BUCKET_CASES_AGG,
+        field=PROPERTY_GEOPOINT_VALUE,
     )
     return query.aggregation(
         nested_agg.aggregation(
             filter_agg.aggregation(
-                geohash_agg
+                geohash_agg.aggregation(
+                    geobounds_agg
+                )
             )
         )
     )

--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -122,6 +122,9 @@ class CaseGroupingReport(BaseCaseMapReport):
     base_template = 'geospatial/case_grouping_map_base.html'
     report_template_path = 'case_grouping_map.html'
 
+    default_rows = 1
+    force_page_size = True
+
     @property
     def rows(self):
         pass

--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -11,6 +11,7 @@ from couchforms.geopoint import GeoPoint
 
 from corehq.apps.case_search.const import CASE_PROPERTIES_PATH
 from corehq.apps.es import CaseSearchES, filters
+from corehq.apps.es.case_search import wrap_case_search_hit
 from corehq.apps.reports.standard import ProjectReport
 from corehq.apps.reports.standard.cases.basic import CaseListMixin
 from corehq.apps.reports.standard.cases.data_sources import CaseDisplayES
@@ -104,7 +105,8 @@ class CaseManagementMap(BaseCaseMapReport):
             display = CaseDisplayES(
                 self.get_case(row), self.timezone, self.individual
             )
-            coordinates = self._get_geo_location(self.get_case(row))
+            case = wrap_case_search_hit(row)
+            coordinates = self._get_geo_location(case)
             cases.append([
                 display.case_id,
                 coordinates,

--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -178,6 +178,9 @@ class CaseGroupingReport(BaseCaseMapReport):
         #     }
         bounds = bucket[BUCKET_CASES_AGG]['bounds']
 
+        # TODO: If top_left and bottom_right are identical, shift them
+        #       by, say, a metre.
+
         query = super()._build_query()  # `super()` so as not to filter
         filters_ = [filters.geo_bounding_box(
             field=PROPERTY_GEOPOINT_VALUE,

--- a/corehq/apps/geospatial/tests/test_es.py
+++ b/corehq/apps/geospatial/tests/test_es.py
@@ -36,14 +36,19 @@ def test_find_precision():
 
 @es_test(requires=[case_search_adapter], setup_class=True)
 class TestGetMaxDocCount(TestCase):
-    # See https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-geohashgrid-aggregation.html#_simple_low_precision_request
-    # and https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-geohashgrid-aggregation.html#_high_precision_requests
-    # for more context about this test
+    """
+    Verify ``get_max_doc_count()`` using an example pulled from
+    Elasticsearch docs.
+
+    For more context, see
+    https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-geohashgrid-aggregation.html#_simple_low_precision_request
+    and https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-geohashgrid-aggregation.html#_high_precision_requests
+    """  # noqa: E501
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        with flag_enabled('USH_CASE_CLAIM_UPDATES'):
+        with flag_enabled('GEOSPATIAL'):
             case_search_es_setup(DOMAIN, cls._get_case_blocks())
 
     @staticmethod

--- a/corehq/apps/geospatial/tests/test_reports.py
+++ b/corehq/apps/geospatial/tests/test_reports.py
@@ -73,26 +73,6 @@ class TestCaseGroupingReport(BaseReportTest):
         self.assertIn(lagos.case_id, case_ids)
 
     def test_bucket_and_polygon_with_hole(self):
-
-        # AAARGH! top_left and bottom_right are the same!
-
-        #   {
-        #       'key': 's1',
-        #       'doc_count': 1,
-        #       'bucket_cases': {
-        #           'bounds': {
-        #               'top_left': {
-        #                   'lat': 6.497221975587308,
-        #                   'lon': 2.604999952018261
-        #               },
-        #               'bottom_right': {
-        #                   'lat': 6.497221975587308,
-        #                   'lon': 2.604999952018261
-        #               }
-        #           }
-        #       }
-        #   }
-
         with self.get_cases() as (porto_novo, bohicon, lagos):
             request = self._get_request(data={
                 'features': json.dumps(polygon_with_hole)
@@ -126,13 +106,21 @@ class TestCaseGroupingReport(BaseReportTest):
         porto_novo = create_case('Porto-Novo', '6.497222 2.605')
         bohicon = create_case('Bohicon', '7.2 2.066667')
         lagos = create_case('Lagos', '6.455027 3.384082')
-        case_search_adapter.bulk_index(
-            [porto_novo, bohicon, lagos],
-            refresh=True,
-        )
+        case_search_adapter.bulk_index([
+            porto_novo,
+            bohicon,
+            lagos
+        ], refresh=True)
+
         try:
             yield porto_novo, bohicon, lagos
+
         finally:
+            case_search_adapter.bulk_delete([
+                porto_novo.case_id,
+                bohicon.case_id,
+                lagos.case_id
+            ], refresh=True)
             porto_novo.delete()
             bohicon.delete()
             lagos.delete()

--- a/corehq/apps/geospatial/tests/test_reports.py
+++ b/corehq/apps/geospatial/tests/test_reports.py
@@ -1,16 +1,19 @@
 import doctest
+import json
+from contextlib import contextmanager
 
 from nose.tools import assert_equal
 
-from django.test import TestCase
-from django.test.client import RequestFactory
-
-from corehq.apps.users.models import WebUser
-
+from corehq.apps.es import case_search_adapter
+from corehq.apps.es.tests.utils import es_test
 from corehq.apps.geospatial.reports import (
-    geojson_to_es_geoshape,
     CaseGroupingReport,
+    geojson_to_es_geoshape,
 )
+from corehq.apps.geospatial.utils import get_geo_case_property
+from corehq.apps.hqcase.case_helper import CaseHelper
+from corehq.apps.reports.tests.test_sql_reports import DOMAIN, BaseReportTest
+from corehq.util.test_utils import flag_enabled
 
 
 def test_geojson_to_es_geoshape():
@@ -31,30 +34,20 @@ def test_geojson_to_es_geoshape():
     })
 
 
-class TestCaseGroupingReport(TestCase):
-    domain = 'test-domain'
+@flag_enabled('GEOSPATIAL')
+@es_test(requires=[case_search_adapter], setup_class=True)
+class TestCaseGroupingReport(BaseReportTest):
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.user = WebUser(username='test@cchq.com', domain=cls.domain)
-        cls.user.save()
-        cls.request_factory = RequestFactory()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete(cls.domain, deleted_by=None)
-        super().tearDownClass()
-
-    def _create_dummy_request(self):
-        request = self.request_factory.get('/some/url')
-        request.couch_user = self.user
-        request.domain = self.domain
+    def _get_request(self, **kwargs):
+        request = self.factory.get('/some/url', **kwargs)
+        request.couch_user = self.couch_user
+        request.domain = DOMAIN
+        request.can_access_all_locations = True
         return request
 
     def test_case_row_order(self):
-        request = self._create_dummy_request()
-        report_obj = CaseGroupingReport(request, domain=self.domain)
+        request = self._get_request()
+        report_obj = CaseGroupingReport(request, domain=DOMAIN)
         report_obj.rendered_as = 'view'
         context_data = report_obj.template_context
         expected_columns = ['case_id', 'gps_point', 'link']
@@ -63,9 +56,491 @@ class TestCaseGroupingReport(TestCase):
             expected_columns
         )
 
+    def test_bucket_cases(self):
+        with self.get_cases() as (porto_novo, bohicon, lagos):
+            request = self._get_request()
+            report = CaseGroupingReport(
+                request,
+                domain=DOMAIN,
+                in_testing=True,
+            )
+            json_data = report.json_dict['aaData']
+        case_ids = [row[0] for row in json_data]
+
+        self.assertEqual(len(json_data), 3)
+        self.assertIn(porto_novo.case_id, case_ids)
+        self.assertIn(bohicon.case_id, case_ids)
+        self.assertIn(lagos.case_id, case_ids)
+
+    def test_bucket_and_polygon_with_hole(self):
+
+        # AAARGH! top_left and bottom_right are the same!
+
+        #   {
+        #       'key': 's1',
+        #       'doc_count': 1,
+        #       'bucket_cases': {
+        #           'bounds': {
+        #               'top_left': {
+        #                   'lat': 6.497221975587308,
+        #                   'lon': 2.604999952018261
+        #               },
+        #               'bottom_right': {
+        #                   'lat': 6.497221975587308,
+        #                   'lon': 2.604999952018261
+        #               }
+        #           }
+        #       }
+        #   }
+
+        with self.get_cases() as (porto_novo, bohicon, lagos):
+            request = self._get_request(data={
+                'features': json.dumps(polygon_with_hole)
+            })
+            report = CaseGroupingReport(
+                request,
+                domain=DOMAIN,
+                in_testing=True,
+            )
+            json_data = report.json_dict['aaData']
+        case_ids = [row[0] for row in json_data]
+
+        self.assertEqual(len(json_data), 1)
+        self.assertIn(porto_novo.case_id, case_ids)
+
+    @contextmanager
+    def get_cases(self):
+
+        def create_case(name, coordinates):
+            helper = CaseHelper(domain=DOMAIN)
+            helper.create_case({
+                'case_type': 'ville',
+                'case_name': name,
+                'properties': {
+                    geo_property: f'{coordinates} 0 0',
+                }
+            })
+            return helper.case
+
+        geo_property = get_geo_case_property(DOMAIN)
+        porto_novo = create_case('Porto-Novo', '6.497222 2.605')
+        bohicon = create_case('Bohicon', '7.2 2.066667')
+        lagos = create_case('Lagos', '6.455027 3.384082')
+        case_search_adapter.bulk_index(
+            [porto_novo, bohicon, lagos],
+            refresh=True,
+        )
+        try:
+            yield porto_novo, bohicon, lagos
+        finally:
+            porto_novo.delete()
+            bohicon.delete()
+            lagos.delete()
+
 
 def test_doctests():
     import corehq.apps.geospatial.reports as reports
 
     results = doctest.testmod(reports)
     assert results.failed == 0
+
+
+def test_filter_for_two_polygons():
+    two_polygons = {
+        "2a5ea4f248e76d593d1860fd30ff4d7a": {
+            "id": "2a5ea4f248e76d593d1860fd30ff4d7a",
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            3.8611289319507023,
+                            10.678207690092108
+                        ],
+                        [
+                            2.224654018272389,
+                            10.527070203861257
+                        ],
+                        [
+                            2.2356370713843887,
+                            10.062403156135844
+                        ],
+                        [
+                            1.3460097693168223,
+                            9.975878699953796
+                        ],
+                        [
+                            1.3789589286527928,
+                            9.293710611914307
+                        ],
+                        [
+                            1.6645183095633342,
+                            8.957545872249298
+                        ],
+                        [
+                            1.6205860971153925,
+                            6.988931314042162
+                        ],
+                        [
+                            1.8072980000180792,
+                            6.18155446649547
+                        ],
+                        [
+                            2.729874461421531,
+                            6.279818038095172
+                        ],
+                        [
+                            2.8067558332044484,
+                            9.011787334706497
+                        ],
+                        [
+                            3.1032982672269895,
+                            9.098556718238612
+                        ],
+                        [
+                            3.8611289319507023,
+                            10.678207690092108
+                        ]
+                    ]
+                ]
+            }
+        },
+        "f4d8cc04529c256645dd6515f21f5c73": {
+            "id": "f4d8cc04529c256645dd6515f21f5c73",
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            2.554145611629849,
+                            7.023269537230718
+                        ],
+                        [
+                            2.4333320273990466,
+                            7.469976682832254
+                        ],
+                        [
+                            2.2136709651603894,
+                            7.622407688138196
+                        ],
+                        [
+                            1.7084505220112192,
+                            7.644179142046397
+                        ],
+                        [
+                            1.9940099029217606,
+                            6.892443542434833
+                        ],
+                        [
+                            2.554145611629849,
+                            7.023269537230718
+                        ]
+                    ]
+                ]
+            }
+        }
+    }
+    expected_filter = {
+        'bool': {
+            'should': (
+                {
+                    'geo_polygon': {
+                        'case_properties.geopoint_value': {
+                            'points': [
+                                [
+                                    3.8611289319507023,
+                                    10.678207690092108
+                                ],
+                                [
+                                    2.224654018272389,
+                                    10.527070203861257
+                                ],
+                                [
+                                    2.2356370713843887,
+                                    10.062403156135844
+                                ],
+                                [
+                                    1.3460097693168223,
+                                    9.975878699953796
+                                ],
+                                [
+                                    1.3789589286527928,
+                                    9.293710611914307
+                                ],
+                                [
+                                    1.6645183095633342,
+                                    8.957545872249298
+                                ],
+                                [
+                                    1.6205860971153925,
+                                    6.988931314042162
+                                ],
+                                [
+                                    1.8072980000180792,
+                                    6.18155446649547
+                                ],
+                                [
+                                    2.729874461421531,
+                                    6.279818038095172
+                                ],
+                                [
+                                    2.8067558332044484,
+                                    9.011787334706497
+                                ],
+                                [
+                                    3.1032982672269895,
+                                    9.098556718238612
+                                ],
+                                [
+                                    3.8611289319507023,
+                                    10.678207690092108
+                                ]
+                            ]
+                        }
+                    }
+                },
+                {
+                    'geo_polygon': {
+                        'case_properties.geopoint_value': {
+                            'points': [
+                                [
+                                    2.554145611629849,
+                                    7.023269537230718
+                                ],
+                                [
+                                    2.4333320273990466,
+                                    7.469976682832254
+                                ],
+                                [
+                                    2.2136709651603894,
+                                    7.622407688138196
+                                ],
+                                [
+                                    1.7084505220112192,
+                                    7.644179142046397
+                                ],
+                                [
+                                    1.9940099029217606,
+                                    6.892443542434833
+                                ],
+                                [
+                                    2.554145611629849,
+                                    7.023269537230718
+                                ]
+                            ]
+                        }
+                    }
+                }
+            )
+        }
+    }
+    actual_filter = CaseGroupingReport._get_filter_for_features(two_polygons)
+    assert_equal(actual_filter, expected_filter)
+
+
+def test_one_polygon_with_hole():
+    expected_filter = {
+        'bool': {
+            'should': (
+                {
+                    'bool': {
+                        'filter': (
+                            {
+                                'geo_polygon': {
+                                    'case_properties.geopoint_value': {
+                                        'points': [
+                                            [
+                                                3.8611289319507023,
+                                                10.678207690092108
+                                            ],
+                                            [
+                                                2.224654018272389,
+                                                10.527070203861257
+                                            ],
+                                            [
+                                                2.2356370713843887,
+                                                10.062403156135844
+                                            ],
+                                            [
+                                                1.3460097693168223,
+                                                9.975878699953796
+                                            ],
+                                            [
+                                                1.3789589286527928,
+                                                9.293710611914307
+                                            ],
+                                            [
+                                                1.6645183095633342,
+                                                8.957545872249298
+                                            ],
+                                            [
+                                                1.6205860971153925,
+                                                6.988931314042162
+                                            ],
+                                            [
+                                                1.8072980000180792,
+                                                6.18155446649547
+                                            ],
+                                            [
+                                                2.729874461421531,
+                                                6.279818038095172
+                                            ],
+                                            [
+                                                2.8067558332044484,
+                                                9.011787334706497
+                                            ],
+                                            [
+                                                3.1032982672269895,
+                                                9.098556718238612
+                                            ],
+                                            [
+                                                3.8611289319507023,
+                                                10.678207690092108
+                                            ]
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                'bool': {
+                                    'must_not': {
+                                        'geo_polygon': {
+                                            'case_properties.geopoint_value': {
+                                                'points': [
+                                                    [
+                                                        2.554145611629849,
+                                                        7.023269537230718
+                                                    ],
+                                                    [
+                                                        1.9940099029217606,
+                                                        6.892443542434833
+                                                    ],
+                                                    [
+                                                        1.7084505220112192,
+                                                        7.644179142046397
+                                                    ],
+                                                    [
+                                                        2.2136709651603894,
+                                                        7.622407688138196
+                                                    ],
+                                                    [
+                                                        2.4333320273990466,
+                                                        7.469976682832254
+                                                    ],
+                                                    [
+                                                        2.554145611629849,
+                                                        7.023269537230718
+                                                    ]
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        )
+                    }
+                },  # <-- Note the comma: The value of "should" is a tuple.
+            )
+        }
+    }
+    actual_filter = CaseGroupingReport._get_filter_for_features(
+        polygon_with_hole
+    )
+    assert_equal(actual_filter, expected_filter)
+
+
+polygon_with_hole = {
+    "2a5ea4f248e76d593d1860fd30ff4d7a": {
+        "id": "2a5ea4f248e76d593d1860fd30ff4d7a",
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    # External ring. Points listed counterclockwise.
+                    [
+                        3.8611289319507023,
+                        10.678207690092108
+                    ],
+                    [
+                        2.224654018272389,
+                        10.527070203861257
+                    ],
+                    [
+                        2.2356370713843887,
+                        10.062403156135844
+                    ],
+                    [
+                        1.3460097693168223,
+                        9.975878699953796
+                    ],
+                    [
+                        1.3789589286527928,
+                        9.293710611914307
+                    ],
+                    [
+                        1.6645183095633342,
+                        8.957545872249298
+                    ],
+                    [
+                        1.6205860971153925,
+                        6.988931314042162
+                    ],
+                    [
+                        1.8072980000180792,
+                        6.18155446649547
+                    ],
+                    [
+                        2.729874461421531,
+                        6.279818038095172
+                    ],
+                    [
+                        2.8067558332044484,
+                        9.011787334706497
+                    ],
+                    [
+                        3.1032982672269895,
+                        9.098556718238612
+                    ],
+                    [
+                        3.8611289319507023,
+                        10.678207690092108
+                    ]
+                ],
+
+                # Hole. Points listed clockwise.
+                [
+                    [
+                        2.554145611629849,
+                        7.023269537230718
+                    ],
+                    [
+                        1.9940099029217606,
+                        6.892443542434833
+                    ],
+                    [
+                        1.7084505220112192,
+                        7.644179142046397
+                    ],
+                    [
+                        2.2136709651603894,
+                        7.622407688138196
+                    ],
+                    [
+                        2.4333320273990466,
+                        7.469976682832254
+                    ],
+                    [
+                        2.554145611629849,
+                        7.023269537230718
+                    ]
+                ]
+            ]
+        }
+    }
+}

--- a/corehq/apps/geospatial/tests/test_reports.py
+++ b/corehq/apps/geospatial/tests/test_reports.py
@@ -2,7 +2,7 @@ import doctest
 import json
 from contextlib import contextmanager
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_raises
 
 from corehq.apps.es import case_search_adapter
 from corehq.apps.es.tests.utils import es_test
@@ -10,7 +10,10 @@ from corehq.apps.geospatial.reports import (
     CaseGroupingReport,
     geojson_to_es_geoshape,
 )
-from corehq.apps.geospatial.utils import get_geo_case_property
+from corehq.apps.geospatial.utils import (
+    get_geo_case_property,
+    validate_geometry,
+)
 from corehq.apps.hqcase.case_helper import CaseHelper
 from corehq.apps.reports.tests.test_sql_reports import DOMAIN, BaseReportTest
 from corehq.util.test_utils import flag_enabled
@@ -32,6 +35,24 @@ def test_geojson_to_es_geoshape():
         "type": "point",  # NOTE: lowercase Elasticsearch type
         "coordinates": [125.6, 10.1]
     })
+
+
+def test_validate_geometry_type():
+    geojson_geometry = {
+        "type": "Point",
+        "coordinates": [125.6, 10.1]
+    }
+    with assert_raises(ValueError):
+        validate_geometry(geojson_geometry)
+
+
+def test_validate_geometry_schema():
+    geojson_geometry = {
+        "type": "Polygon",
+        "coordinates": [125.6, 10.1]
+    }
+    with assert_raises(ValueError):
+        validate_geometry(geojson_geometry)
 
 
 @flag_enabled('GEOSPATIAL')
@@ -326,7 +347,8 @@ def test_filter_for_two_polygons():
             )
         }
     }
-    actual_filter = CaseGroupingReport._get_filter_for_features(two_polygons)
+    features_json = json.dumps(two_polygons)
+    actual_filter = CaseGroupingReport._get_filter_for_features(features_json)
     assert_equal(actual_filter, expected_filter)
 
 
@@ -435,9 +457,8 @@ def test_one_polygon_with_hole():
             )
         }
     }
-    actual_filter = CaseGroupingReport._get_filter_for_features(
-        polygon_with_hole
-    )
+    features_json = json.dumps(polygon_with_hole)
+    actual_filter = CaseGroupingReport._get_filter_for_features(features_json)
     assert_equal(actual_filter, expected_filter)
 
 

--- a/corehq/apps/geospatial/tests/test_reports.py
+++ b/corehq/apps/geospatial/tests/test_reports.py
@@ -1,3 +1,5 @@
+import doctest
+
 from nose.tools import assert_equal
 
 from django.test import TestCase
@@ -60,3 +62,10 @@ class TestCaseGroupingReport(TestCase):
             list(context_data['case_row_order'].keys()),
             expected_columns
         )
+
+
+def test_doctests():
+    import corehq.apps.geospatial.reports as reports
+
+    results = doctest.testmod(reports)
+    assert results.failed == 0

--- a/corehq/apps/geospatial/tests/test_utils.py
+++ b/corehq/apps/geospatial/tests/test_utils.py
@@ -15,7 +15,6 @@ from corehq.apps.geospatial.utils import (
     set_case_gps_property,
     set_user_gps_property,
     create_case_with_gps_property,
-    features_to_points_list,
 )
 from corehq.apps.geospatial.const import GPS_POINT_CASE_PROPERTY
 
@@ -117,43 +116,3 @@ class TestSetGPSProperty(TestCase):
         set_user_gps_property(self.DOMAIN, submit_data)
         user = CommCareUser.get_by_user_id(self.user.user_id, self.DOMAIN)
         self.assertEqual(user.get_user_data(self.DOMAIN)[GPS_POINT_CASE_PROPERTY], '1.23 4.56 0.0 0.0')
-
-
-class TestFeaturesToPointsList(TestCase):
-
-    def setUp(self):
-        super(TestFeaturesToPointsList, self).setUp()
-        self.features = {
-            '123': {
-                'geometry': {
-                    'coordinates': [
-                        [
-                            [3.4, 1.2],
-                            [7.8, 5.6],
-                        ],
-                        [
-                            [11.12, 9.10],
-                        ],
-                    ],
-                },
-            },
-            '456': {
-                'geometry': {
-                    'coordinates': [
-                        [
-                            [15.16, 13.14],
-                        ],
-                    ],
-                },
-            },
-        }
-
-    def test_features_to_points_list(self):
-        expected_output = [
-            {'lat': 1.2, 'lon': 3.4},
-            {'lat': 5.6, 'lon': 7.8},
-            {'lat': 9.10, 'lon': 11.12},
-            {'lat': 13.14, 'lon': 15.16},
-        ]
-        points_list = features_to_points_list(self.features)
-        self.assertEqual(points_list, expected_output)

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -828,6 +828,7 @@ class GenericTabularReport(GenericReportView):
     # new class properties
     total_row = None
     statistics_rows = None
+    force_page_size = False  # force page size to be as the default rows
     default_rows = 10
     start_at_row = 0
     show_all_rows = False
@@ -1083,6 +1084,7 @@ class GenericTabularReport(GenericReportView):
                 rows=rows,
                 total_row=self.total_row,
                 statistics_rows=self.statistics_rows,
+                force_page_size=self.force_page_size,
                 default_rows=self.default_rows,
                 start_at_row=self.start_at_row,
                 show_all_rows=self.show_all_rows,
@@ -1100,6 +1102,7 @@ class GenericTabularReport(GenericReportView):
         context.update({
             'report_table_js_options': {
                 'datatables': report_table['datatables'],
+                'force_page_size': report_table['force_page_size'],
                 'default_rows': report_table['default_rows'] or 10,
                 'start_at_row': report_table['start_at_row'] or 0,
                 'show_all_rows': report_table['show_all_rows'],

--- a/corehq/apps/reports/static/reports/js/config.dataTables.bootstrap.js
+++ b/corehq/apps/reports/static/reports/js/config.dataTables.bootstrap.js
@@ -12,6 +12,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
         var self = {};
         self.dataTableElem = options.dataTableElem || '.datatable';
         self.paginationType = options.paginationType || 'bs_normal';
+        self.forcePageSize = options.forcePageSize || false;
         self.defaultRows = options.defaultRows || 10;
         self.startAtRowNum = options.startAtRowNum || 0;
         self.showAllRowsOption = options.showAllRowsOption || false;
@@ -207,6 +208,10 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                 if (self.aoColumns)
                     params.aoColumns = self.aoColumns;
 
+                if (self.forcePageSize) {
+                    // limit the page size option to just the default size
+                    params.lengthMenu = [self.defaultRows];
+                }
                 var datatable = $(this).dataTable(params);
                 if (!self.datatable)
                     self.datatable = datatable;

--- a/corehq/apps/reports/static/reports/js/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/hq_report.js
@@ -100,8 +100,13 @@ hqDefine("reports/js/hq_report", [
         self.handleTabularReportCookies = function (reportDatatable) {
             var defaultRowsCookieName = 'hqreport.tabularSetting.defaultRows',
                 savedPath = window.location.pathname;
-            var defaultRowsCookie = '' + $.cookie(defaultRowsCookieName);
-            reportDatatable.defaultRows = parseInt(defaultRowsCookie) || reportDatatable.defaultRows;
+
+            if (!reportDatatable.forcePageSize) {
+                // set the current pagination page size to be equal to page size
+                // used by the user last time for any report on HQ
+                var defaultRowsCookie = '' + $.cookie(defaultRowsCookieName);
+                reportDatatable.defaultRows = parseInt(defaultRowsCookie) || reportDatatable.defaultRows;
+            }
 
             $(reportDatatable.dataTableElem).on('hqreport.tabular.lengthChange', function (event, value) {
                 $.cookie(defaultRowsCookieName, value, {

--- a/corehq/apps/reports/static/reports/js/tabular.js
+++ b/corehq/apps/reports/static/reports/js/tabular.js
@@ -16,6 +16,7 @@ hqDefine("reports/js/tabular", [
             var tableConfig = tableOptions,
                 options = {
                     dataTableElem: '#report_table_' + slug,
+                    forcePageSize: tableConfig.force_page_size,
                     defaultRows: tableConfig.default_rows,
                     startAtRowNum: tableConfig.start_at_row,
                     showAllRowsOption: tableConfig.show_all_rows,

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -20,6 +20,7 @@ from corehq.apps.geospatial.utils import get_geo_case_property
 from corehq.form_processor.backends.sql.dbaccessors import CaseReindexAccessor
 from corehq.pillows.base import is_couch_change_for_sql_domain
 from corehq.toggles import (
+    GEOSPATIAL,
     USH_CASE_CLAIM_UPDATES,
 )
 from corehq.util.doc_processor.sql import SqlDocumentProvider
@@ -83,7 +84,7 @@ def _get_case_properties(doc_dict):
     dynamic_properties = [_format_property(key, value, case_id)
                           for key, value in doc_dict['case_json'].items()]
 
-    if USH_CASE_CLAIM_UPDATES.enabled(domain):
+    if USH_CASE_CLAIM_UPDATES.enabled(domain) or GEOSPATIAL.enabled(domain):
         _add_smart_types(dynamic_properties, domain, doc_dict['type'])
 
     return base_case_properties + dynamic_properties
@@ -92,9 +93,16 @@ def _get_case_properties(doc_dict):
 def _add_smart_types(dynamic_properties, domain, case_type):
     # Properties are stored in a dict like {"key": "dob", "value": "1900-01-01"}
     # `value` is a multi-field property that duck types numeric and date values
-    # We can't do that for geo_points in ES v2, as `ignore_malformed` is broken
-    gps_props = get_gps_properties(domain, case_type)
-    gps_props.add(get_geo_case_property(domain))
+    # We can't do that for properties like geo_points in ES v2, as `ignore_malformed` is broken
+    if USH_CASE_CLAIM_UPDATES.enabled(domain):
+        gps_props = get_gps_properties(domain, case_type)
+        _add_gps_smart_types(dynamic_properties, gps_props)
+    if GEOSPATIAL.enabled(domain):
+        gps_props = [get_geo_case_property(domain)]
+        _add_gps_smart_types(dynamic_properties, gps_props)
+
+
+def _add_gps_smart_types(dynamic_properties, gps_props):
     for prop in dynamic_properties:
         if prop['key'] in gps_props:
             try:


### PR DESCRIPTION
## Technical Summary

Context:
* [SC-3055](https://dimagi-dev.atlassian.net/browse/SC-3055)
* [Spec](https://docs.google.com/document/d/1jVFUYxYd6F6M1ONpEPEsG7BxFJDXmeY5Ebgx-TcnI1A/edit?pli=1#heading=h.db494g9hyctf)

The CaseGroupingMap report will need to deal with large numbers of cases. To do this they are paginated into geographical grid cells. Each cell is analogous to a page.

Probably easier to review :blowfish: by :tropical_fish: commit :fish: as changes build on the work of more than one author, and adapt based on lessons learned (about the differences between Elasticsearch 8+ and 5.6.

Code for Elasticsearch 8+ has not been deleted because hopefully we will be using it soon.


## Feature Flag

`geospatial`

## Safety Assurance

### Safety story

* Local testing
* About to deploy to Staging

### Automated test coverage

Includes tests. (But I would be delighted to add more if you can identify gaps.)

### QA Plan

QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3055]: https://dimagi-dev.atlassian.net/browse/SC-3055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ