### PR TITLE
Hide locations filter on failed update rule submissions

### DIFF
--- a/corehq/apps/data_interfaces/forms.py
+++ b/corehq/apps/data_interfaces/forms.py
@@ -626,11 +626,9 @@ class CaseRuleCriteriaForm(forms.Form):
             self._json_fail_hard()
 
         if value:
-            location_def = value[0]
-            if not location_def.get('include_child_locations'):
-                location_def['include_child_locations'] = False
-
-            return location_def
+            if not value.get('include_child_locations'):
+                value['include_child_locations'] = False
+            return value
         return ''
 
     def clean_ucr_filter_definitions(self):

--- a/corehq/apps/data_interfaces/forms.py
+++ b/corehq/apps/data_interfaces/forms.py
@@ -430,7 +430,8 @@ class CaseRuleCriteriaForm(forms.Form):
             Fieldset(
                 _("Case Filters") if self.show_fieldset_title else "",
                 HTML(
-                    '<p class="help-block alert alert-info"><i class="fa fa-info-circle"></i> %s</p>' % self.fieldset_help_text
+                    '<p class="help-block alert alert-info"><i class="fa fa-info-circle"></i> %s</p>'
+                    % self.fieldset_help_text
                 ),
                 hidden_bound_field('filter_on_server_modified', 'filterOnServerModified'),
                 hidden_bound_field('server_modified_boundary', 'serverModifiedBoundary'),
@@ -548,9 +549,9 @@ class CaseRuleCriteriaForm(forms.Form):
                 self._json_fail_hard()
 
             if (
-                'property_name' not in obj or
-                'property_value' not in obj or
-                'match_type' not in obj
+                'property_name' not in obj
+                or 'property_value' not in obj
+                or 'match_type' not in obj
             ):
                 self._json_fail_hard()
 
@@ -826,9 +827,9 @@ class CaseRuleActionsForm(forms.Form):
                 self._json_fail_hard()
 
             if (
-                'name' not in obj or
-                'value_type' not in obj or
-                'value' not in obj
+                'name' not in obj
+                or 'value_type' not in obj
+                or 'value' not in obj
             ):
                 self._json_fail_hard()
 
@@ -882,15 +883,15 @@ class CaseRuleActionsForm(forms.Form):
     def clean(self):
         cleaned_data = super(CaseRuleActionsForm, self).clean()
         if (
-            'close_case' in cleaned_data and
-            'properties_to_update' in cleaned_data and
-            'custom_action_definitions' in cleaned_data
+            'close_case' in cleaned_data
+            and 'properties_to_update' in cleaned_data
+            and 'custom_action_definitions' in cleaned_data
         ):
             # All fields passed individual validation
             if (
-                not cleaned_data['close_case'] and
-                not cleaned_data['properties_to_update'] and
-                not cleaned_data['custom_action_definitions']
+                not cleaned_data['close_case']
+                and not cleaned_data['properties_to_update']
+                and not cleaned_data['custom_action_definitions']
             ):
                 raise ValidationError(_("Please specify at least one action."))
 

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_rule_criteria.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_rule_criteria.js
@@ -106,13 +106,14 @@ hqDefine("data_interfaces/js/case_rule_criteria", [
         });
 
         self.locationFilterDefinition = ko.computed(function () {
-            var result = [];
+            var result = undefined;
             $.each(self.criteria(), function (index, value) {
                 if (value.koTemplateId === 'locations-filter') {
-                    result.push({
+                    result = {
                         location_id: value.location_id() || '',
                         include_child_locations: value.include_child_locations() || '',
-                    });
+                    };
+                    return false;  // break -- only a single location is supported
                 }
             });
             return JSON.stringify(result);

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_rule_criteria.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_rule_criteria.js
@@ -76,18 +76,18 @@ hqDefine("data_interfaces/js/case_rule_criteria", [
                         match_type: value.match_type() || '',
                     });
                 } else if (value.koTemplateId === 'advanced-date-case-property-filter') {
-                    var property_value = value.property_value();
-                    if ($.isNumeric(property_value) && value.plus_minus() === '-') {
+                    var propertyValue = value.property_value();
+                    if ($.isNumeric(propertyValue) && value.plus_minus() === '-') {
                         // The value of plus_minus tells us if we should negate the number
                         // given in property_value(). We only attempt to do this if it
                         // actually represents a number. If it doesn't, let the django
                         // validation catch it.
-                        property_value = -1 * Number.parseInt(property_value);
-                        property_value = property_value.toString();
+                        propertyValue = -1 * Number.parseInt(propertyValue);
+                        propertyValue = propertyValue.toString();
                     }
                     result.push({
                         property_name: value.property_name() || '',
-                        property_value: property_value || '',
+                        property_value: propertyValue || '',
                         match_type: value.match_type() || '',
                     });
                 }

--- a/corehq/apps/data_interfaces/tests/test_forms.py
+++ b/corehq/apps/data_interfaces/tests/test_forms.py
@@ -1,0 +1,48 @@
+import json
+from unittest.mock import patch
+from django.test import SimpleTestCase
+from corehq.apps.data_interfaces.forms import CaseRuleCriteriaForm
+from corehq.apps.data_interfaces import forms
+
+
+class CaseRuleCriteriaFormTests(SimpleTestCase):
+    def test_validation_with_fully_specified_location(self):
+        post_data = self._create_form_input(location_filter={
+            'name': 'TestLocation',
+            'location_id': '123',
+            'include_child_locations': 'false',
+        })
+
+        form = CaseRuleCriteriaForm('test-domain', post_data, rule=None)
+        form.is_valid()
+
+    def test_form_is_valid_without_location(self):
+        post_data = self._create_form_input(location_filter='')
+
+        form = CaseRuleCriteriaForm('test-domain', post_data, rule=None)
+        self.assertTrue(form.is_valid())
+
+    def setUp(self):
+        case_types_patcher = patch.object(forms, 'get_case_types_for_domain')
+        self.get_case_types = case_types_patcher.start()
+        self.get_case_types.return_value = ['test-case']
+        self.addCleanup(case_types_patcher.stop)
+
+    def _create_form_input(self, location_filter=None):
+        return {
+            'criteria-case_type': 'test-case',
+            'criteria-property_match_definitions': json.dumps([
+                {
+                    'property_name': 'city',
+                    'property_value': 'Boston',
+                    'match_type': 'EQUAL'
+                }
+            ]),
+            'criteria-custom_match_definitions': json.dumps([]),
+            'criteria-location_filter_definition': json.dumps(location_filter or ''),
+            'criteria-ucr_filter_definitions': json.dumps([]),
+            'criteria-criteria_operator': 'ALL',
+            'criteria-filter_on_server_modified': 'false',
+            'criteria-server_modified_boundary': '',
+            'criteria-filter_on_closed_parent': 'false',
+        }

--- a/corehq/apps/data_interfaces/tests/test_forms.py
+++ b/corehq/apps/data_interfaces/tests/test_forms.py
@@ -10,7 +10,7 @@ class CaseRuleCriteriaFormTests(SimpleTestCase):
         post_data = self._create_form_input(location_filter={
             'name': 'TestLocation',
             'location_id': '123',
-            'include_child_locations': 'false',
+            'include_child_locations': False,
         })
 
         form = CaseRuleCriteriaForm('test-domain', post_data, rule=None)


### PR DESCRIPTION
## Technical Summary
This was discovered as part of https://dimagi-dev.atlassian.net/browse/SAAS-15035, where an invalid automatic update rule would cause an empty locations filter (which isn't part of automatic update rules) to display. The location filter was being interpreted as an array (with a maximum of one value) in one context, and an object in another, so I standardized the representation here.

## Safety Assurance

### Safety story
Local testing was performed. I've verified that the location filter no longer displays on failed update rules, and that the user can still submit automatic update rules and dedupe rules (with and without the location).

### Automated test coverage

A new test suite has been created for form changes: _corehq.apps.data_interfaces.tests.test_forms_

### QA Plan

No QA necessary

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
