### PR TITLE
Fix subscription form validation error

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -625,10 +625,10 @@ class SubscriptionForm(forms.Form):
             is_most_recent_version = subscription.plan_version.plan.get_version() == subscription.plan_version
             most_recent_version_text = ("is most recent version" if is_most_recent_version
                                         else "not most recent version")
-            self.fields['most_recent_version'].initial = most_recent_version_text
+            self.fields['most_recent_version'].initial = is_most_recent_version
             most_recent_version_field = hqcrispy.B3TextField(
                 'most_recent_version',
-                self.fields['most_recent_version'].initial
+                most_recent_version_text
             )
             self.fields['domain'].choices = [
                 (subscription.subscriber.domain, subscription.subscriber.domain)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Fix a bug that resulted in subscription form being non-valid.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-15040

The initial issue was that the `most_recent_version` field was designed to accept boolean values. However, it was being provided with `most_recent_version_text`. This caused a validation error.
So I corrected the value assigned to `self.fields['most_recent_version'].initial` to be boolean and utilized `hqcrispy.B3TextField` to display `most_recent_version_text`


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.
Will raise QA.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA Ticket: https://dimagi-dev.atlassian.net/browse/QA-5753
-  Test whether we can create new subscription
-  Test whether we can update existing subscription. ( Will see the green top bar that says the subscription has been updated if this is a successful update)


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
