### PR TITLE
Cs/sc 3057 lock case grouping

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -7,13 +7,13 @@ hqDefine("geospatial/js/case_grouping_map",[
     $,
     ko,
     _,
-    initialPageData
+    initialPageData,
 ) {
 
-    MAPBOX_LAYER_VISIBILITY = {
+    const MAPBOX_LAYER_VISIBILITY = {
         None: 'none',
         Visible: 'visible',
-    }
+    };
 
     const MAP_CONTAINER_ID = 'case-grouping-map';
     let map;
@@ -228,7 +228,7 @@ hqDefine("geospatial/js/case_grouping_map",[
                             "type": "Point",
                             "coordinates": [coordinates.lng, coordinates.lat],
                         },
-                    }
+                    },
                 );
             }
         });
@@ -280,7 +280,7 @@ hqDefine("geospatial/js/case_grouping_map",[
     }
 
     function getRandomColor() {
-        const randomColor = Math.floor(Math.random()*16777215).toString(16);
+        const randomColor = Math.floor(Math.random() * 16777215).toString(16);
         return `#${randomColor}`;
     }
 
@@ -288,7 +288,7 @@ hqDefine("geospatial/js/case_grouping_map",[
         setMapLayersVisibility(MAPBOX_LAYER_VISIBILITY.None);
         var groupColors = {};
 
-        exportModelInstance.casesToExport().forEach(function(caseItem) {
+        exportModelInstance.casesToExport().forEach(function (caseItem) {
             const groupId = caseItem.groupId;
             if (groupId) {
                 if (groupColors[groupId] === undefined) {
@@ -309,7 +309,7 @@ hqDefine("geospatial/js/case_grouping_map",[
     function uuidv4() {
         // https://stackoverflow.com/questions/105034/how-do-i-create-a-guid-uuid/2117523#2117523
         return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
-            (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+            (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16),
         );
     }
 
@@ -335,7 +335,7 @@ hqDefine("geospatial/js/case_grouping_map",[
                         groupCoordinates: {
                             lng: cluster.geometry.coordinates[0],
                             lat: cluster.geometry.coordinates[1],
-                        }
+                        },
                     };
                 }
             } catch (error) {
@@ -348,7 +348,7 @@ hqDefine("geospatial/js/case_grouping_map",[
 
     function clearCaseGroups() {
         setMapLayersVisibility(MAPBOX_LAYER_VISIBILITY.Visible);
-        mapMarkers.forEach((marker) => marker.remove())
+        mapMarkers.forEach((marker) => marker.remove());
         mapMarkers = [];
         clearCaseGroupsInExport();
     }
@@ -376,7 +376,7 @@ hqDefine("geospatial/js/case_grouping_map",[
                 map.scrollZoom.disable();
                 setCaseGroups();
             }
-        }
+        };
         return self;
     }
 

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -233,6 +233,29 @@ hqDefine("geospatial/js/case_grouping_map",[
         }
     }
 
+    function groupLockModel() {
+        'use strict';
+        var self = {};
+
+        self.groupsLocked = ko.observable(false);
+
+        self.showLockButton = ko.computed(function () {
+            return !self.groupsLocked();
+        });
+        self.showUnLockButton = ko.computed(function () {
+            return self.groupsLocked();
+        });
+
+        self.triggerGroupLock = function () {
+            if (self.groupsLocked()) {
+                self.groupsLocked(false);
+            } else {
+                self.groupsLocked(true);
+            }
+        }
+        return self;
+    }
+
     $(function () {
         let caseModels = [];
         const exportModelInstance = new exportModel();
@@ -262,6 +285,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             const isAfterReportLoad = settings.url.includes('geospatial/async/case_grouping_map/');
             if (isAfterReportLoad) {
                 $("#export-controls").koApplyBindings(exportModelInstance);
+                $("#lock-groups-controls").koApplyBindings(new groupLockModel());
                 map = initMap();
                 $("#clusterStats").koApplyBindings(clusterStatsInstance);
                 return;

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -282,9 +282,12 @@ hqDefine("geospatial/js/case_grouping_map",[
         map.setLayoutProperty('unclustered-point', 'visibility', visibility);
     }
 
-    function getRandomColor() {
-        const randomColor = Math.floor(Math.random() * 16777215).toString(16);
-        return `#${randomColor}`;
+    function getRandomRGBColor() {
+        var r = Math.floor(Math.random() * 256); // Random value between 0 and 255 for red
+        var g = Math.floor(Math.random() * 256); // Random value between 0 and 255 for green
+        var b = Math.floor(Math.random() * 256); // Random value between 0 and 255 for blue
+
+        return `rgba(${r},${g},${b},1)`;
     }
 
     function collapseGroupsOnMap() {
@@ -292,20 +295,25 @@ hqDefine("geospatial/js/case_grouping_map",[
         var groupColors = {};
 
         exportModelInstance.casesToExport().forEach(function (caseItem) {
+            if (!caseItem.coordinates) {
+                return;
+            }
+
             const groupId = caseItem.groupId;
+            let color = "rgba(128,128,128,0.25)";
+
             if (groupId) {
                 if (groupColors[groupId] === undefined) {
-                    groupColors[groupId] = getRandomColor();
+                    groupColors[groupId] = getRandomRGBColor();
                 }
-                const color = groupColors[groupId];
-
-                const marker = new mapboxgl.Marker({ color: color, draggable: false });  // eslint-disable-line no-undef
-                marker.setLngLat([caseItem.coordinates.lng, caseItem.coordinates.lat]);
-
-                // Add the marker to the map
-                marker.addTo(map);
-                mapMarkers.push(marker);
+                color = groupColors[groupId];
             }
+            const marker = new mapboxgl.Marker({ color: color, draggable: false });  // eslint-disable-line no-undef
+            marker.setLngLat([caseItem.coordinates.lng, caseItem.coordinates.lat]);
+
+            // Add the marker to the map
+            marker.addTo(map);
+            mapMarkers.push(marker);
         });
     }
 

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -305,6 +305,13 @@ hqDefine("geospatial/js/case_grouping_map",[
         });
     }
 
+    function uuidv4() {
+        // https://stackoverflow.com/questions/105034/how-do-i-create-a-guid-uuid/2117523#2117523
+        return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
+            (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+        );
+    }
+
     async function setCaseGroups() {
         const sourceFeatures = map.querySourceFeatures('caseWithGPS', {
             sourceLayer: 'clusters',
@@ -318,19 +325,20 @@ hqDefine("geospatial/js/case_grouping_map",[
             const pointCount = cluster.properties.point_count;
 
             try {
-              const casePoints = await getClusterLeavesAsync(clusterSource, clusterId, pointCount);
-              for (const casePoint of casePoints) {
-                const caseId = casePoint.properties.id;
-                caseGroups[caseId] = {
-                    groupId: clusterId,
-                    groupCoordinates: {
-                        lng: cluster.geometry.coordinates[0],
-                        lat: cluster.geometry.coordinates[1],
-                    }
-                };
-              }
+                const casePoints = await getClusterLeavesAsync(clusterSource, clusterId, pointCount);
+                const groupUUID = uuidv4();
+                for (const casePoint of casePoints) {
+                    const caseId = casePoint.properties.id;
+                    caseGroups[caseId] = {
+                        groupId: groupUUID,
+                        groupCoordinates: {
+                            lng: cluster.geometry.coordinates[0],
+                            lat: cluster.geometry.coordinates[1],
+                        }
+                    };
+                }
             } catch (error) {
-              console.error("Error processing cluster:", error);
+                console.error("Error processing cluster:", error);
             }
         }
         loadCaseGroupsInExport(caseGroups);

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -2,12 +2,14 @@ hqDefine("geospatial/js/case_grouping_map",[
     "jquery",
     "knockout",
     'underscore',
-    'hqwebapp/js/initial_page_data'
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/bootstrap3/alert_user',
 ], function (
     $,
     ko,
     _,
     initialPageData,
+    alertUser
 ) {
 
     const MAPBOX_LAYER_VISIBILITY = {
@@ -350,7 +352,7 @@ hqDefine("geospatial/js/case_grouping_map",[
                     };
                 }
             } catch (error) {
-                console.error("Error processing cluster:", error);
+                alertUser.alert_user(gettext("Something went wrong while processing the cluster."), 'danger');
             }
         }
         exportModelInstance.loadCaseGroups(caseGroups);

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -249,8 +249,10 @@ hqDefine("geospatial/js/case_grouping_map",[
         self.triggerGroupLock = function () {
             if (self.groupsLocked()) {
                 self.groupsLocked(false);
+                map.scrollZoom.enable();
             } else {
                 self.groupsLocked(true);
+                map.scrollZoom.disable();
             }
         }
         return self;

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -256,6 +256,7 @@ hqDefine("geospatial/js/case_grouping_map",[
         exportModelInstance.casesToExport().forEach(caseItem => {
             if (caseItem.groupId) {
                 caseItem.groupId = null;
+                caseItem.groupCoordinates = null;
             }
         });
     }
@@ -365,7 +366,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             return self.groupsLocked();
         });
 
-        self.triggerGroupLock = function () {
+        self.toggleGroupLock = function () {
             if (self.groupsLocked()) {
                 self.groupsLocked(false);
                 map.scrollZoom.enable();

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -30,6 +30,17 @@ hqDefine("geospatial/js/case_grouping_map",[
         self.groupId = null;
         self.groupCoordinates = null;
 
+        self.toJson = function () {
+            const coordinates = (self.coordinates) ? `${self.coordinates.lng} ${self.coordinates.lat}` : "";
+            const groupCoordinates = (self.groupCoordinates) ? `${self.groupCoordinates.lng} ${self.groupCoordinates.lat}` : "";
+            return {
+                'groupId': self.groupId,
+                'groupCenterCoordinates': groupCoordinates,
+                'caseId': self.caseId,
+                'coordinates': coordinates,
+            };
+        }
+
         return self;
     }
 
@@ -53,14 +64,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             }
 
             const casesToExport = _.map(self.casesToExport(), function (caseItem) {
-                const coordinates = (caseItem.coordinates) ? `${caseItem.coordinates.lng} ${caseItem.coordinates.lat}` : "";
-                const groupCoordinates = (caseItem.groupCoordinates) ? `${caseItem.groupCoordinates.lng} ${caseItem.groupCoordinates.lat}` : "";
-                return {
-                    'groupId': caseItem.groupId,
-                    'groupCenterCoordinates': groupCoordinates,
-                    'caseId': caseItem.caseId,
-                    'coordinates': coordinates,
-                };
+                return caseItem.toJson();
             });
 
             let csvStr = "";

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -4,12 +4,26 @@
 {% load hq_shared_tags %}
 
 {% block reportcontent %}
-<div class="row panel" id="export-controls">
-  <div class="controls col-sm-2 col-md-2 col-lg-2">
-    <button class="btn-default form-control" data-bind="click: downloadCSV">
-      {% trans "Export Groups" %}
-    </button>
-  </div>
+<div class="row panel">
+  <span id="lock-groups-controls">
+    <div class="controls col-sm-2 col-md-2 col-lg-2">
+      <button data-bind="visible: showLockButton, click: triggerGroupLock" class="btn-default form-control">
+        <i class="fa fa-lock"></i>
+        {% trans "Lock Case Grouping for Me" %}
+      </button>
+      <button data-bind="visible: showUnLockButton, click: triggerGroupLock" class="btn-primary form-control">
+        <i class="fa fa-unlock"></i>
+        {% trans "Unlock Case Grouping for Me" %}
+      </button>
+    </div>
+  </span>
+  <span id="export-controls">
+    <div class="controls col-sm-2 col-md-2 col-lg-2">
+      <button class="btn-default form-control" data-bind="click: downloadCSV">
+        {% trans "Export Groups" %}
+      </button>
+    </div>
+  </span>
 </div>
 
 <div id="case-grouping-map" style="height: 500px"></div>

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -11,7 +11,7 @@
         <i class="fa fa-lock"></i>
         {% trans "Lock Case Grouping for Me" %}
       </button>
-      <button data-bind="visible: showUnLockButton, click: triggerGroupLock" class="btn-primary form-control">
+      <button data-bind="visible: showUnlockButton, click: triggerGroupLock" class="btn-primary form-control">
         <i class="fa fa-unlock"></i>
         {% trans "Unlock Case Grouping for Me" %}
       </button>

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -7,11 +7,11 @@
 <div class="row panel">
   <span id="lock-groups-controls">
     <div class="controls col-sm-2 col-md-2 col-lg-2">
-      <button data-bind="visible: showLockButton, click: toggleGroupLock" class="btn-default form-control">
+      <button data-bind="visible: !groupsLocked(), click: toggleGroupLock" class="btn-default form-control">
         <i class="fa fa-lock"></i>
         {% trans "Lock Case Grouping for Me" %}
       </button>
-      <button data-bind="visible: showUnlockButton, click: toggleGroupLock" class="btn-primary form-control">
+      <button data-bind="visible: groupsLocked(), click: toggleGroupLock" class="btn-primary form-control">
         <i class="fa fa-unlock"></i>
         {% trans "Unlock Case Grouping for Me" %}
       </button>

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -7,11 +7,11 @@
 <div class="row panel">
   <span id="lock-groups-controls">
     <div class="controls col-sm-2 col-md-2 col-lg-2">
-      <button data-bind="visible: showLockButton, click: triggerGroupLock" class="btn-default form-control">
+      <button data-bind="visible: showLockButton, click: toggleGroupLock" class="btn-default form-control">
         <i class="fa fa-lock"></i>
         {% trans "Lock Case Grouping for Me" %}
       </button>
-      <button data-bind="visible: showUnlockButton, click: triggerGroupLock" class="btn-primary form-control">
+      <button data-bind="visible: showUnlockButton, click: toggleGroupLock" class="btn-primary form-control">
         <i class="fa fa-unlock"></i>
         {% trans "Unlock Case Grouping for Me" %}
       </button>


### PR DESCRIPTION
## Product Description

This PR adds a new button to the Case Grouping page, "Lock Case Grouping for Me", which locks the map such that the user can't zoom in or out anymore. The case groups are also collapsed and all the cases belonging to their respective groups gets the same colour marker on the map. 

Also, when the button is clicked the button text updates to "Unlock Case Grouping for Me" which undo's all the above.

See the quick demo of what the button toggling looks like:

![case_lock_button](https://github.com/dimagi/commcare-hq/assets/44245062/a03c445c-270e-4e48-8001-fc1565a191cc)

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-3057)

When the button mentioned above is clicked, a couple of things happen:
1. The map zoom capability is removed (map is locked at current zoom level)
2. The various clusters are iterated to retrieve the underlying case_ids so that the `exportModelInstance`'s cases can be updated with the cluster/group data.
    - The group data consists of the groupUUID which is generated in javascript (is this strictly necessary?) and the cluster coordinate.
3. The clusters on the map is collapsed. Each cluster will show all the cases contained in that cluster with each cluster of cases having their own colour (which is also generated randomly).  

In addition to the above, a new column is added to the export csv called "groupCenterCoordinate" which contains the case clusters' center coordinates.

**Note**
Currently, when the case groups/clusters are locked on the map, all cases that does not belong to a cluster is ignored.

#### Questions
1. I had to add a javascript function, `uuidv4`, which generates the unique group UUIDs. Is there some other way to do this that we're maybe already doing in other places in javascript?

## Feature Flag
Geospatial

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
No automated tests

### QA Plan
No QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
