### PR TITLE
Populate Appcues id to Enable Appcues for Web Apps

### DIFF
--- a/corehq/apps/analytics/templates/analytics/initial/appcues.html
+++ b/corehq/apps/analytics/templates/analytics/initial/appcues.html
@@ -6,10 +6,11 @@
 {% elif is_saas_environment %}
   {% comment %}
   HACK: project/domain_links is a hacky way for us to ensure appcues is being shown on the ERM/MRM page.
+  /cloudcare/apps/v2/ is a way for us to ensure appcues is being shown on Web Apps.
   If we remove these checks so all users see appcues, we risk going over our appcues user cap
   This is intended to be a short-term fix as we search for tour alternatives.
   {% endcomment %}
-  {% if not request.user.is_authenticated or request.couch_user.days_since_created < 31 or '/project/domain_links/' in request.path %}
+  {% if not request.user.is_authenticated or request.couch_user.days_since_created < 31 or '/project/domain_links/' in request.path or '/cloudcare/apps/v2/' in request.path%}
     {% initial_analytics_data 'appcues.apiId' ANALYTICS_IDS.APPCUES_ID %}
   {% endif %}
 {% endif %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Enables Appcues to be configured for web apps

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Adds the appcue ID to web Apps by checking the path contains `/cloudcare/apps/v2/` 
Related [AppCue Doc](https://studio.appcues.com/settings/installation/guide/script)
[Jira Ticket](https://dimagi-dev.atlassian.net/browse/USH-3551?focusedCommentId=293588&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-293588)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Locally tested, change expands app cues availability which doesn't pose a safety risk.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
