### PR TITLE
switch default value of useDynamicSearch in notifyParentOfFieldChange

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -348,7 +348,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             this.parentView.setStickyQueryInputs();
         },
 
-        notifyParentOfFieldChange: function (e, useDynamicSearch = false) {
+        notifyParentOfFieldChange: function (e, useDynamicSearch = true) {
             if (this.model.get('input') === 'address') {
                 // Geocoder doesn't have a real value, doesn't need to be sent to formplayer
                 return;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -341,9 +341,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
         changeDateQueryField: function (e) {
             this.model.set('value', $(e.currentTarget).val());
-            if (this.dynamicSearchEnabled) {
-                var useDynamicSearch = Date(this.model._previousAttributes.value) !== Date($(e.currentTarget).val());
-            }
+            var useDynamicSearch = Date(this.model._previousAttributes.value) !== Date($(e.currentTarget).val());
             this.notifyParentOfFieldChange(e, useDynamicSearch);
             this.parentView.setStickyQueryInputs();
         },


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
followup to https://github.com/dimagi/commcare-hq/pull/33562

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The default value should be set to `True` for all other uses of notifyParentOfFieldChange because there is another check later on [here](https://github.com/dimagi/commcare-hq/pull/33562/files#diff-97f5c2845f6d9d4044e2040c6775b6882db38cfabf524a74574857605822ccc4R536) if dynamic search is enabled

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DYNAMICALLY_UPDATE_SEARCH_RESULTS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This feature is not yet live on non-test production domains

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None yet for the frontend of dynamic search

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
