### PR TITLE
Disable changing used geolocation property

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -41,7 +41,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 groupObj.toBeDeprecated.subscribe(changeSaveButton);
 
                 for (let prop of group.properties) {
-                    const isGeoCaseProp = (self.geoCaseProp === prop.name);
+                    const isGeoCaseProp = (self.geoCaseProp === prop.name && prop.data_type === 'gps');
                     var propObj = propertyListItem(prop.name, prop.label, false, group.name, self.name, prop.data_type,
                         prop.description, prop.allowed_values, prop.fhir_resource_prop_path, prop.deprecated,
                         prop.removeFHIRResourcePropertyPath, isGeoCaseProp);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -102,7 +102,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.fhirResourcePropPath = ko.observable(fhirResourcePropPath);
         self.originalResourcePropPath = fhirResourcePropPath;
         self.deprecated = ko.observable(deprecated || false);
-        self.isGeoCaseProp = isGeoCaseProp;
+        self.isGeoCaseProp = ko.observable(isGeoCaseProp);
         self.removeFHIRResourcePropertyPath = ko.observable(removeFHIRResourcePropertyPath || false);
         let subTitle;
         if (toggles.toggleEnabled("CASE_IMPORT_DATA_DICTIONARY_VALIDATION")) {
@@ -128,7 +128,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         };
 
         self.deprecateProperty = function () {
-            if (toggles.toggleEnabled('GEOSPATIAL') && self.isGeoCaseProp) {
+            if (toggles.toggleEnabled('GEOSPATIAL') && self.isGeoCaseProp()) {
                 self.confirmGeospatialDeprecation();
             } else {
                 self.deprecated(true);

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -278,6 +278,14 @@
                             value: dataType,
                             disable: isGeoCaseProp,">
                   </select>
+                  <span class="hq-help" style="height: fit-content"
+                        data-bind="
+                          popover: {
+                            content: '{% blocktrans %}This GPS case property is currently being used to store the geolocation for cases, and so the data type cannot be changed.{% endblocktrans %}',
+                            trigger: 'hover' },
+                          visible: isGeoCaseProp">
+                    <i class="fa fa-question-circle icon-question-sign"></i>
+                  </span>
                 </div>
               {% endif %}
               <div class="row-item main-form">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -269,14 +269,15 @@
               </div>
               {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
                 <div class="row-item main-form">
-                <select class="form-control"
-                        data-bind="
-                                    options: $root.availableDataTypes,
-                                    optionsCaption: 'Select a data type',
-                                    optionsText: 'display',
-                                    optionsValue: 'value',
-                                    value: dataType,
-                                "></select>
+                  <select class="form-control"
+                          data-bind="
+                            options: $root.availableDataTypes,
+                            optionsCaption: 'Select a data type',
+                            optionsText: 'display',
+                            optionsValue: 'value',
+                            value: dataType,
+                            disable: isGeoCaseProp,">
+                  </select>
                 </div>
               {% endif %}
               <div class="row-item main-form">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -281,7 +281,7 @@
                   <span class="hq-help" style="height: fit-content"
                         data-bind="
                           popover: {
-                            content: '{% blocktrans %}This GPS case property is currently being used to store the geolocation for cases, and so the data type cannot be changed.{% endblocktrans %}',
+                            content: '{% blocktrans %}This GPS case property is currently being used to store the geolocation for cases, so the data type cannot be changed.{% endblocktrans %}',
                             trigger: 'hover' },
                           visible: isGeoCaseProp">
                     <i class="fa fa-question-circle icon-question-sign"></i>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
If a Data Dictionary case property is being used as the gelocation case property for the geospatial feature, then the user will be unable to change the property's data type whilst it is being used. Additionally, there is a popover help button where the user can see why this field is disabled.
![Screenshot from 2023-10-25 11-27-01](https://github.com/dimagi/commcare-hq/assets/122617251/307be5c4-8b20-4d62-9272-6bcca2ff46c2)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3106).

When the user selects a case property from the Data Dictionary to use as the GPS case property in the geospatial feature, then the ability to change the data type of this property will now be disabled. This will remain disabled until the user switches the current GPS case property for the domain to another case property.

The above mentioned changes will apply to case properties across all case types. For example, a user has the same case property name that is used in two different case types. If the user chooses this to be their GPS case property, then the data type for both case properties will be set as disabled.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`CASE_IMPORT_DATA_DICTIONARY_VALIDATION`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
