### PR TITLE
Replace ortools with pulp

### DIFF
--- a/corehq/apps/geospatial/routing_solvers/pulp.py
+++ b/corehq/apps/geospatial/routing_solvers/pulp.py
@@ -19,15 +19,17 @@ class RadialDistanceSolver:
         self.case_locations = request_json['cases']
 
     def calculate_distance_matrix(self):
-        users = [
-            (float(user['lat']), float(user['lon']))
-            for user in self.user_locations
-        ]
-        cases = [
-            (float(case['lat']), float(case['lon']))
-            for case in self.case_locations
-        ]
-        return haversine.haversine_vector(cases, users, comb=True)
+        distance_matrix = []
+        for user in self.user_locations:
+            user_point = (float(user['lat']), float(user['lon']))
+            user_distances = []
+            for case in self.case_locations:
+                case_point = (float(case['lat']), float(case['lon']))
+                user_distances.append(haversine.haversine(case_point, user_point))
+
+            distance_matrix.append(user_distances)
+
+        return distance_matrix
 
     def solve(self, print_solution=False):
         costs = self.calculate_distance_matrix()

--- a/corehq/apps/geospatial/tests/test_pulp.py
+++ b/corehq/apps/geospatial/tests/test_pulp.py
@@ -1,16 +1,16 @@
 from django.test import SimpleTestCase
 
-from corehq.apps.geospatial.routing_solvers.ortools import (
-    ORToolsRadialDistanceSolver
+from corehq.apps.geospatial.routing_solvers.pulp import (
+    RadialDistanceSolver
 )
 
 
-class TestORToolsRadialDistanceSolver(SimpleTestCase):
+class TestRadialDistanceSolver(SimpleTestCase):
     # Tests the correctness of the code, not the optimumness of the solution
 
     def test(self):
         self.assertEqual(
-            ORToolsRadialDistanceSolver(
+            RadialDistanceSolver(
                 {
                     "users": [
                         {"id": "New York", "lon": -73.9750671, "lat": 40.7638143},

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -67,7 +67,7 @@ looseversion
 lxml
 markdown
 oic
-ortools  # Used in Geospatial features to solve routing problems - SolTech
+pulp  # Used in Geospatial features to solve routing problems - SolTech
 openpyxl
 packaging
 phonenumberslite

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -4,8 +4,6 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-absl-py==1.4.0
-    # via ortools
 alabaster==0.7.12
     # via sphinx
 alembic==1.7.7
@@ -434,8 +432,6 @@ nose==1.3.7
     #   sniffer
 nose-exclude==0.5.0
     # via -r test-requirements.in
-numpy==1.24.3
-    # via ortools
 oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
@@ -448,8 +444,6 @@ openpyxl==3.0.9
     #   commcaretranslationchecker
 opentelemetry-api==1.18.0
     # via ddtrace
-ortools==9.7.2996
-    # via -r base-requirements.in
 packaging==23.0
     # via
     #   -r base-requirements.in
@@ -499,7 +493,6 @@ protobuf==4.24.2
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
-    #   ortools
     #   proto-plus
 psutil==5.8.0
     # via -r dev-requirements.in
@@ -511,6 +504,8 @@ psycopg2==2.9.6
     #   sqlalchemy-postgres-copy
 ptyprocess==0.7.0
     # via pexpect
+pulp==2.7.0
+    # via -r base-requirements.in
 pure-eval==0.2.2
     # via stack-data
 py-kissmetrics==1.1.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -4,8 +4,6 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-absl-py==1.4.0
-    # via ortools
 alabaster==0.7.12
     # via sphinx
 alembic==1.7.7
@@ -364,8 +362,6 @@ msgpack==1.0.5
     # via cachecontrol
 myst-parser==2.0.0
     # via -r docs-requirements.in
-numpy==1.24.3
-    # via ortools
 oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
@@ -378,8 +374,6 @@ openpyxl==3.0.9
     #   commcaretranslationchecker
 opentelemetry-api==1.18.0
     # via ddtrace
-ortools==9.7.2996
-    # via -r base-requirements.in
 packaging==23.0
     # via
     #   -r base-requirements.in
@@ -416,11 +410,12 @@ protobuf==4.24.2
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
-    #   ortools
     #   proto-plus
 psycogreen==1.0.2
     # via -r base-requirements.in
 psycopg2==2.9.6
+    # via -r base-requirements.in
+pulp==2.7.0
     # via -r base-requirements.in
 py-kissmetrics==1.1.0
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -4,8 +4,6 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-absl-py==1.4.0
-    # via ortools
 alembic==1.7.7
     # via -r base-requirements.in
 amqp==5.1.1
@@ -364,8 +362,6 @@ msgpack==1.0.5
     # via cachecontrol
 ndg-httpsclient==0.5.1
     # via -r prod-requirements.in
-numpy==1.24.3
-    # via ortools
 oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
@@ -378,8 +374,6 @@ openpyxl==3.0.9
     #   commcaretranslationchecker
 opentelemetry-api==1.18.0
     # via ddtrace
-ortools==9.7.2996
-    # via -r base-requirements.in
 packaging==23.0
     # via
     #   -r base-requirements.in
@@ -423,7 +417,6 @@ protobuf==4.24.2
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
-    #   ortools
     #   proto-plus
 psycogreen==1.0.2
     # via -r base-requirements.in
@@ -431,6 +424,8 @@ psycopg2==2.9.6
     # via -r base-requirements.in
 ptyprocess==0.7.0
     # via pexpect
+pulp==2.7.0
+    # via -r base-requirements.in
 pure-eval==0.2.2
     # via stack-data
 py-kissmetrics==1.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-absl-py==1.4.0
-    # via ortools
 alembic==1.7.7
     # via -r base-requirements.in
 amqp==5.1.1
@@ -340,8 +338,6 @@ markupsafe==2.1.2
     #   werkzeug
 msgpack==1.0.5
     # via cachecontrol
-numpy==1.24.3
-    # via ortools
 oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
@@ -354,8 +350,6 @@ openpyxl==3.0.9
     #   commcaretranslationchecker
 opentelemetry-api==1.18.0
     # via ddtrace
-ortools==9.7.2996
-    # via -r base-requirements.in
 packaging==23.0
     # via
     #   -r base-requirements.in
@@ -389,11 +383,12 @@ protobuf==4.24.2
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
-    #   ortools
     #   proto-plus
 psycogreen==1.0.2
     # via -r base-requirements.in
 psycopg2==2.9.6
+    # via -r base-requirements.in
+pulp==2.7.0
     # via -r base-requirements.in
 py-kissmetrics==1.1.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -4,8 +4,6 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-absl-py==1.4.0
-    # via ortools
 alembic==1.7.7
     # via -r base-requirements.in
 amqp==5.1.1
@@ -368,8 +366,6 @@ nose==1.3.7
     #   nose-exclude
 nose-exclude==0.5.0
     # via -r test-requirements.in
-numpy==1.24.3
-    # via ortools
 oauthlib==3.1.0
     # via
     #   django-oauth-toolkit
@@ -382,8 +378,6 @@ openpyxl==3.0.9
     #   commcaretranslationchecker
 opentelemetry-api==1.18.0
     # via ddtrace
-ortools==9.7.2996
-    # via -r base-requirements.in
 packaging==23.0
     # via
     #   -r base-requirements.in
@@ -422,7 +416,6 @@ protobuf==4.24.2
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
-    #   ortools
     #   proto-plus
 psycogreen==1.0.2
     # via -r base-requirements.in
@@ -430,6 +423,8 @@ psycopg2==2.9.6
     # via
     #   -r base-requirements.in
     #   sqlalchemy-postgres-copy
+pulp==2.7.0
+    # via -r base-requirements.in
 py-kissmetrics==1.1.0
     # via -r base-requirements.in
 pyasn1==0.4.8


### PR DESCRIPTION
## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-3163)

This PR simply replaces `ortools` with [pulp](https://pypi.org/project/PuLP/). The main reason is because ortools uses NumPy which SaaS seems less optimistic about from a maintenance perspective. This new package does not make use of numpy and is purely written in python. It's also quite a popular and widely used package.

The downside to using pulp instead of ortools is performance for optimizing case distribution amongst CHWs, but I would not too concerned about that since
1. We can simply put a loading screen on the UI if the disbursement is running if it's necessary (it's a feature that could be expected to take a while) 
2. Most users would probably not opt for the disbursement algorithm that does make use of pulp (radial solver), but rather the mapbox route solver (optimize over travel time on a road network)   

The method where we used an ortools solver was replaces by an equivalent solver of pulp.

## Feature Flag
Geospatial

## Safety Assurance

### Safety story
There is an existing unit test that will test the method changed in this PR.

### Automated test coverage
### QA Plan
No QA plan (yet).

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
