### PR TITLE
Dynamically set case tile row options based on number of properties

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -53,7 +53,9 @@ hqDefine("app_manager/js/details/column", function () {
         self.tileRowMax = ko.observable(7);
         self.tileColumnMax = ko.observable(13);
         self.tileRowStart = ko.observable(self.original.grid_y || 1);
-        self.tileRowOptions = [""].concat(_.range(1, self.tileRowMax()));
+        self.tileRowOptions = ko.computed(function () {
+            return [""].concat(_.range(1, self.tileRowMax()));
+        });
         self.tileColumnStart = ko.observable(self.original.grid_x || 1);
         self.tileColumnOptions = [""].concat(_.range(1, self.tileColumnMax()));
         self.tileWidth = ko.observable(self.original.width || self.tileRowMax() - 1);

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -50,7 +50,7 @@ hqDefine("app_manager/js/details/column", function () {
         self.case_tile_field = ko.observable(self.original.case_tile_field);
 
         self.coordinatesVisible = ko.observable(true);
-        self.tileRowMax = ko.observable(7);
+        self.tileRowMax = ko.observable(7); // set dynamically by screen
         self.tileColumnMax = ko.observable(13);
         self.tileRowStart = ko.observable(self.original.grid_y || 1);
         self.tileRowOptions = ko.computed(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -413,6 +413,18 @@ hqDefine("app_manager/js/details/screen", function () {
             self.initColumnAsColumn(self.columns()[i]);
         }
 
+        self.caseTileRowMax = ko.computed(() => _.max([self.columns().length + 1, 7]));
+        self.caseTileRowMax.subscribe(function (newValue) {
+            self.updateTileRowMaxForColumns(newValue);
+        });
+
+        self.updateTileRowMaxForColumns = function (newValue) {
+            _.each(self.columns(), function (column) {
+                column.tileRowMax(newValue);
+            });
+        };
+        self.updateTileRowMaxForColumns(self.caseTileRowMax());
+
         self.saveButton = hqImport("hqwebapp/js/bootstrap3/main").initSaveButton({
             unsavedMessage: gettext('You have unsaved detail screen configurations.'),
             save: function () {


### PR DESCRIPTION
## Product Description
Sets the number of available rows in the case tile config UI to the greater of: the current number of properties on the tile, or 6.

## Technical Summary
[USH-3748](https://dimagi-dev.atlassian.net/browse/USH-3748)
Sets each property's `tileRowMax` based on a computed `caseTileRowMax` added to the `screen`. Updates the list of "row" options to be computed based on the `tileRowMax`.

## Feature Flag
CASE_LIST_TILE_CUSTOM

## Safety Assurance

### Safety story
This is a fairly small change to logic in the case tile config UI, and I've tested with/without case tiles enabled, with Row values saved greater than the default 1-6, and confirmed it doesn't seem to cause any regression with the case tile feature flags turned off.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
I don't think this needs QA as a small change to a so far lightly-used, feature flagged UI component.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3748]: https://dimagi-dev.atlassian.net/browse/USH-3748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ