### PR TITLE
Add migration to resolve whitelist bug on existing repeaters

### DIFF
--- a/corehq/motech/repeaters/migration_utils.py
+++ b/corehq/motech/repeaters/migration_utils.py
@@ -1,0 +1,23 @@
+from corehq.motech.repeaters.models import Repeater
+
+
+def repair_repeaters_with_whitelist_bug():
+    """
+    Used in 0004_fix_whitelist_bug_repeaters.py
+    The whitelist bug resulted in the white_listed_form_xmlns key in a
+    repeater's option field storing '[]' as a form id it would whitelist.
+    :return: list of repeater ids that were fixed
+    """
+    all_repeaters = Repeater.all_objects.all()
+    broken_repeaters = [r for r in all_repeaters if
+                        'white_listed_form_xmlns' in r.options and r.options.get(
+                            'white_listed_form_xmlns') == ['[]']]
+
+    fixed_repeater_ids = []
+    for repeater in broken_repeaters:
+        # reset back to an empty list
+        repeater.options['white_listed_form_xmlns'] = []
+        repeater.save()
+        fixed_repeater_ids.append(repeater.repeater_id)
+
+    return fixed_repeater_ids

--- a/corehq/motech/repeaters/migration_utils.py
+++ b/corehq/motech/repeaters/migration_utils.py
@@ -1,4 +1,8 @@
+import logging
+
 from corehq.motech.repeaters.models import Repeater
+
+log = logging.getLogger(__name__)
 
 
 def repair_repeaters_with_whitelist_bug():
@@ -19,4 +23,8 @@ def repair_repeaters_with_whitelist_bug():
         repeater.options["white_listed_form_xmlns"] = []
         repeater.save()
         fixed_repeater_ids.append(repeater.repeater_id)
+
+    log.info(
+        f"[repair_repeaters] The following repeaters were fixed:\n{fixed_repeater_ids}"
+    )
     return fixed_repeater_ids

--- a/corehq/motech/repeaters/migration_utils.py
+++ b/corehq/motech/repeaters/migration_utils.py
@@ -13,9 +13,7 @@ def repair_repeaters_with_whitelist_bug():
     :return: list of repeater ids that were fixed
     """
     all_repeaters = Repeater.all_objects.all()
-    broken_repeaters = [
-        r for r in all_repeaters if r.options.get("white_listed_form_xmlns") == ["[]"]
-    ]
+    broken_repeaters = [r for r in all_repeaters if r.options.get("white_listed_form_xmlns") == ["[]"]]
 
     fixed_repeater_ids = []
     for repeater in broken_repeaters:
@@ -24,7 +22,5 @@ def repair_repeaters_with_whitelist_bug():
         repeater.save()
         fixed_repeater_ids.append(repeater.repeater_id)
 
-    log.info(
-        f"[repair_repeaters] The following repeaters were fixed:\n{fixed_repeater_ids}"
-    )
+    log.info(f"[repair_repeaters] The following repeaters were fixed:\n{fixed_repeater_ids}")
     return fixed_repeater_ids

--- a/corehq/motech/repeaters/migration_utils.py
+++ b/corehq/motech/repeaters/migration_utils.py
@@ -9,13 +9,14 @@ def repair_repeaters_with_whitelist_bug():
     :return: list of repeater ids that were fixed
     """
     all_repeaters = Repeater.all_objects.all()
-    broken_repeaters = [r for r in all_repeaters if r.options.get('white_listed_form_xmlns') == ['[]']]
+    broken_repeaters = [
+        r for r in all_repeaters if r.options.get("white_listed_form_xmlns") == ["[]"]
+    ]
 
     fixed_repeater_ids = []
     for repeater in broken_repeaters:
         # reset back to an empty list
-        repeater.options['white_listed_form_xmlns'] = []
+        repeater.options["white_listed_form_xmlns"] = []
         repeater.save()
         fixed_repeater_ids.append(repeater.repeater_id)
-
     return fixed_repeater_ids

--- a/corehq/motech/repeaters/migration_utils.py
+++ b/corehq/motech/repeaters/migration_utils.py
@@ -9,9 +9,7 @@ def repair_repeaters_with_whitelist_bug():
     :return: list of repeater ids that were fixed
     """
     all_repeaters = Repeater.all_objects.all()
-    broken_repeaters = [r for r in all_repeaters if
-                        'white_listed_form_xmlns' in r.options and r.options.get(
-                            'white_listed_form_xmlns') == ['[]']]
+    broken_repeaters = [r for r in all_repeaters if r.options.get('white_listed_form_xmlns') == ['[]']]
 
     fixed_repeater_ids = []
     for repeater in broken_repeaters:

--- a/corehq/motech/repeaters/migrations/0004_fix_whitelist_bug_repeaters.py
+++ b/corehq/motech/repeaters/migrations/0004_fix_whitelist_bug_repeaters.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+from corehq.motech.repeaters.migration_utils import repair_repeaters_with_whitelist_bug
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _fix_broken_repeaters(apps, schema_editor):
+    repair_repeaters_with_whitelist_bug()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('repeaters', '0003_id_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(_fix_broken_repeaters, reverse_code=migrations.RunPython.noop)
+    ]

--- a/corehq/motech/repeaters/tests/test_migration_utils.py
+++ b/corehq/motech/repeaters/tests/test_migration_utils.py
@@ -1,0 +1,67 @@
+from django.test import TestCase
+
+from corehq.motech.models import ConnectionSettings
+from corehq.motech.repeaters.migration_utils import (
+    repair_repeaters_with_whitelist_bug,
+)
+from corehq.motech.repeaters.models import FormRepeater
+
+
+class TestRepairRepeatersWithWhitelistBug(TestCase):
+    """
+    The whitelist bug resulted in the white_listed_form_xmlns key in a
+    repeater's option storing '[]' as a form id it would whitelist.
+    """
+    def test_properly_configured_repeater_is_ignored(self):
+        repeater = FormRepeater.objects.create(
+            domain='test',
+            connection_settings=self.connection_settings,
+            name='properly-configured-repeater',
+            options={'white_listed_form_xmlns': ['abc123']}
+        )
+
+        fixed_ids = repair_repeaters_with_whitelist_bug()
+
+        refetched_repeater = FormRepeater.objects.get(id=repeater.repeater_id)
+        self.assertEqual(refetched_repeater.options['white_listed_form_xmlns'], ['abc123'])
+        self.assertEqual(fixed_ids, [])
+
+    def test_impacted_repeater_is_fixed(self):
+        repeater = FormRepeater.objects.create(
+            domain='test',
+            connection_settings=self.connection_settings,
+            name='repeater-with-bug',
+            options={'white_listed_form_xmlns': ['[]']}
+        )
+
+        fixed_ids = repair_repeaters_with_whitelist_bug()
+
+        refetched_repeater = FormRepeater.objects.get(id=repeater.repeater_id)
+        self.assertEqual(refetched_repeater.options['white_listed_form_xmlns'], [])
+        self.assertEqual(fixed_ids, [repeater.repeater_id])
+
+    def test_impacted_but_deleted_repeater_is_fixed(self):
+        repeater = FormRepeater.objects.create(
+            domain='test',
+            connection_settings=self.connection_settings,
+            name='deletd-repeater-with-bug',
+            options={'white_listed_form_xmlns': ['[]']},
+            is_deleted=True,
+        )
+
+        fixed_ids = repair_repeaters_with_whitelist_bug()
+
+        refetched_repeater = FormRepeater.all_objects.get(id=repeater.repeater_id)
+        self.assertEqual(refetched_repeater.options['white_listed_form_xmlns'], [])
+        self.assertEqual(fixed_ids, [repeater.repeater_id])
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        conn = ConnectionSettings(
+            domain='test',
+            name="repeaters-bug-settings",
+            url="url",
+        )
+        conn.save()
+        cls.connection_settings = conn

--- a/migrations.lock
+++ b/migrations.lock
@@ -778,6 +778,7 @@ repeaters
  0001_adjust_auth_field_format_squashed_0015_drop_connection_settings_fk
  0002_repeaters_db
  0003_id_fields
+ 0004_fix_whitelist_bug_repeaters
 reports
  0001_initial
  0002_auto_20171121_1803


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Recreating this as my last attempt got messier than I prefer. Linking here for reference: https://github.com/dimagi/commcare-hq/pull/33630

https://dimagi-dev.atlassian.net/browse/SAAS-14961

A bug caused a handful of repeaters to be in a broken state, specifically where the white_listed_form_xmlns option in the options property of a repeater was set to '[]'. This means the repeater will only fire for a form id matching '[]', or in other words, it never fires.

The bug has since been resolved, but the remaining step is to run this migration to fix currently broken repeaters.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tests ensure this runs on the relevant repeaters only.


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I've added tests to ensure only relevant repeaters are modified with this migration. I don't love that I had to add a new migration_utilities.py file, but it allows for the simplest testing strategy which is valuable.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
