### PR TITLE
Use PUPPETEER_SKIP_DOWNLOAD flag as of v20 of puppeteer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN git config --global url."https://".insteadOf git:// \
 
 # this keeps the image size down, make sure to set in mocha-headless-chrome options
 #   executablePath: 'google-chrome-unstable'
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV PUPPETEER_SKIP_DOWNLOAD true
 
 RUN npm -g install \
     yarn \


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Fixes our commcarehq_base docker image build.

v20 of Puppeteer included a breaking change mentioned here: https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v20.0.0

We just needed to update the flag name used to skip downloading a browser (was previously named PUPPETEER_SKIP_CHROMIUM_DOWNLOAD and is now PUPPETEER_SKIP_DOWNLOAD)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Our docker build image has been broken since May 3rd. I tested building the image locally to confirm this fixes the issue. Worst case, our build is still broken 🤷🏻.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tested locally

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
