### PR TITLE
Create Case on GPS Capture Page

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -132,6 +132,8 @@ hqDefine("geospatial/js/gps_capture",[
 
         self.isCreatingCase = ko.observable(false);
         self.hasCreateCaseError = ko.observable(false);
+        self.availableCaseTypes = ko.observableArray([]);
+        self.selectedCaseType = ko.observable('');
 
         self.captureLocationForItem = function (item) {
             self.itemLocationBeingCapturedOnMap(item);
@@ -187,8 +189,7 @@ hqDefine("geospatial/js/gps_capture",[
             self.hasSubmissionError(false);
             let dataItemJson = ko.mapping.toJS(dataItem);
             if (self.isCreatingCase()) {
-                const caseType = $('#report_filter_case_type').val();
-                dataItemJson['case_type'] = caseType;
+                dataItemJson['case_type'] = self.selectedCaseType();
             }
 
             $.ajax({

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -205,7 +205,7 @@ hqDefine("geospatial/js/gps_capture",[
                     dataItem.hasUnsavedChanges(false);
                     self.isSubmissionSuccess(true);
                     resetMap();
-                    self.createCaseEnabled(false);
+                    self.resetCaseCreateFlags();
                 },
                 error: function () {
                     self.hasSubmissionError(true);
@@ -229,9 +229,13 @@ hqDefine("geospatial/js/gps_capture",[
         };
 
         self.cancelCreateCase = function () {
+            self.resetCaseCreateFlags();
+            resetMap();
+        };
+
+        self.resetCaseCreateFlags = function () {
             self.createCaseEnabled(false);
             self.createCaseError(false);
-            resetMap();
         };
 
         return self;

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -185,12 +185,19 @@ hqDefine("geospatial/js/gps_capture",[
         self.saveDataRow = function (dataItem) {
             self.isSubmissionSuccess(false);
             self.hasSubmissionError(false);
+            let dataItemJson = ko.mapping.toJS(dataItem);
+            if (self.createCaseEnabled()) {
+                const caseType = $('#report_filter_case_type').val();
+                dataItemJson['case_type'] = caseType;
+            }
+
             $.ajax({
                 method: 'POST',
                 url: initialPageData.reverse('gps_capture'),
                 data: JSON.stringify({
                     'data_type': self.dataType,
-                    'data_item': ko.mapping.toJS(dataItem),
+                    'data_item': dataItemJson,
+                    'create_case': self.createCaseEnabled(),
                 }),
                 dataType: "json",
                 contentType: "application/json; charset=utf-8",
@@ -198,6 +205,7 @@ hqDefine("geospatial/js/gps_capture",[
                     dataItem.hasUnsavedChanges(false);
                     self.isSubmissionSuccess(true);
                     resetMap();
+                    self.createCaseEnabled(false);
                 },
                 error: function () {
                     self.hasSubmissionError(true);

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -315,8 +315,11 @@ hqDefine("geospatial/js/gps_capture",[
     }
 
     $(function () {
+        const caseDataItemListInstance = dataItemListModel('case');
+        caseDataItemListInstance.setCaseTypeList(initialPageData.get('case_types_with_gps'));
+
         $("#tabs-list").koApplyBindings(TabListViewModel());
-        $("#no-gps-list-case").koApplyBindings(dataItemListModel('case'));
+        $("#no-gps-list-case").koApplyBindings(caseDataItemListInstance);
         $("#no-gps-list-user").koApplyBindings(dataItemListModel('user'));
 
         initMap();

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -220,7 +220,7 @@ hqDefine("geospatial/js/gps_capture",[
         };
 
         self.finishCreateCase = function () {
-            const hasValidName = self.itemLocationBeingCapturedOnMap().name.length > 0;
+            const hasValidName = self.itemLocationBeingCapturedOnMap().name().length > 0;
             self.createCaseError(!hasValidName);
             if (!hasValidName) {
                 return;

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -207,7 +207,7 @@ hqDefine("geospatial/js/gps_capture",[
                     dataItem.hasUnsavedChanges(false);
                     self.isSubmissionSuccess(true);
                     resetMap();
-                    self.resetCaseCreateFlags();
+                    self.resetCaseCreate();
                 },
                 error: function () {
                     self.hasSubmissionError(true);
@@ -232,14 +232,15 @@ hqDefine("geospatial/js/gps_capture",[
         };
 
         self.cancelCreateCase = function () {
-            self.resetCaseCreateFlags();
+            self.resetCaseCreate();
             resetMap();
         };
 
-        self.resetCaseCreateFlags = function () {
+        self.resetCaseCreate = function () {
             self.isCreatingCase(false);
             self.hasCreateCaseError(false);
             self.hasCaseTypeError(false);
+            self.selectedCaseType('');
         };
 
         return self;

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -205,6 +205,27 @@ hqDefine("geospatial/js/gps_capture",[
             });
         };
 
+        self.startCreateCase = function () {
+            self.createCaseEnabled(true);
+            const caseToCreate = new dataItemModel(null, self.dataType);
+            self.captureLocationForItem(caseToCreate);
+        };
+
+        self.finishCreateCase = function () {
+            const hasValidName = self.itemLocationBeingCapturedOnMap().name.length > 0;
+            self.createCaseError(!hasValidName);
+            if (!hasValidName) {
+                return;
+            }
+            self.saveDataRow(self.itemLocationBeingCapturedOnMap());
+        };
+
+        self.cancelCreateCase = function () {
+            self.createCaseEnabled(false);
+            self.createCaseError(false);
+            resetMap();
+        };
+
         return self;
     };
 

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -238,6 +238,20 @@ hqDefine("geospatial/js/gps_capture",[
             self.hasCreateCaseError(false);
         };
 
+        self.setCaseTypeList = function (caseTypeList) {
+            self.availableCaseTypes(caseTypeList);
+            if (!caseTypeList.length) {
+                return;
+            }
+
+            const filteredCaseType = $('#report_filter_case_type').val();
+            if (self.availableCaseTypes().includes(filteredCaseType)) {
+                self.selectedCaseType(filteredCaseType);
+            } else {
+                self.selectedCaseType(self.availableCaseTypes()[0]);
+            }
+        };
+
         return self;
     };
 

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -134,6 +134,7 @@ hqDefine("geospatial/js/gps_capture",[
         self.hasCreateCaseError = ko.observable(false);
         self.availableCaseTypes = ko.observableArray([]);
         self.selectedCaseType = ko.observable('');
+        self.hasCaseTypeError = ko.observable(false);
 
         self.captureLocationForItem = function (item) {
             self.itemLocationBeingCapturedOnMap(item);
@@ -223,7 +224,9 @@ hqDefine("geospatial/js/gps_capture",[
         self.finishCreateCase = function () {
             const hasValidName = self.itemLocationBeingCapturedOnMap().name().length > 0;
             self.hasCreateCaseError(!hasValidName);
-            if (hasValidName) {
+            const hasValidCaseType = self.selectedCaseType() && self.selectedCaseType().length > 0;
+            self.hasCaseTypeError(!hasValidCaseType);
+            if (hasValidName && hasValidCaseType) {
                 self.saveDataRow(self.itemLocationBeingCapturedOnMap());
             }
         };
@@ -236,20 +239,7 @@ hqDefine("geospatial/js/gps_capture",[
         self.resetCaseCreateFlags = function () {
             self.isCreatingCase(false);
             self.hasCreateCaseError(false);
-        };
-
-        self.setCaseTypeList = function (caseTypeList) {
-            self.availableCaseTypes(caseTypeList);
-            if (!caseTypeList.length) {
-                return;
-            }
-
-            const filteredCaseType = $('#report_filter_case_type').val();
-            if (self.availableCaseTypes().includes(filteredCaseType)) {
-                self.selectedCaseType(filteredCaseType);
-            } else {
-                self.selectedCaseType(self.availableCaseTypes()[0]);
-            }
+            self.hasCaseTypeError(false);
         };
 
         return self;
@@ -316,7 +306,7 @@ hqDefine("geospatial/js/gps_capture",[
 
     $(function () {
         const caseDataItemListInstance = dataItemListModel('case');
-        caseDataItemListInstance.setCaseTypeList(initialPageData.get('case_types_with_gps'));
+        caseDataItemListInstance.availableCaseTypes(initialPageData.get('case_types_with_gps'));
 
         $("#tabs-list").koApplyBindings(TabListViewModel());
         $("#no-gps-list-case").koApplyBindings(caseDataItemListInstance);

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -130,6 +130,9 @@ hqDefine("geospatial/js/gps_capture",[
             return !self.showLoadingSpinner() && !self.hasError();
         });
 
+        self.createCaseEnabled = ko.observable(false);
+        self.createCaseError = ko.observable(false);
+
         self.captureLocationForItem = function (item) {
             self.itemLocationBeingCapturedOnMap(item);
             selectedDataListObject = self;

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -130,8 +130,8 @@ hqDefine("geospatial/js/gps_capture",[
             return !self.showLoadingSpinner() && !self.hasError();
         });
 
-        self.createCaseEnabled = ko.observable(false);
-        self.createCaseError = ko.observable(false);
+        self.isCreatingCase = ko.observable(false);
+        self.hasCreateCaseError = ko.observable(false);
 
         self.captureLocationForItem = function (item) {
             self.itemLocationBeingCapturedOnMap(item);
@@ -186,7 +186,7 @@ hqDefine("geospatial/js/gps_capture",[
             self.isSubmissionSuccess(false);
             self.hasSubmissionError(false);
             let dataItemJson = ko.mapping.toJS(dataItem);
-            if (self.createCaseEnabled()) {
+            if (self.isCreatingCase()) {
                 const caseType = $('#report_filter_case_type').val();
                 dataItemJson['case_type'] = caseType;
             }
@@ -197,7 +197,7 @@ hqDefine("geospatial/js/gps_capture",[
                 data: JSON.stringify({
                     'data_type': self.dataType,
                     'data_item': dataItemJson,
-                    'create_case': self.createCaseEnabled(),
+                    'create_case': self.isCreatingCase(),
                 }),
                 dataType: "json",
                 contentType: "application/json; charset=utf-8",
@@ -214,18 +214,17 @@ hqDefine("geospatial/js/gps_capture",[
         };
 
         self.startCreateCase = function () {
-            self.createCaseEnabled(true);
+            self.isCreatingCase(true);
             const caseToCreate = new dataItemModel(null, self.dataType);
             self.captureLocationForItem(caseToCreate);
         };
 
         self.finishCreateCase = function () {
             const hasValidName = self.itemLocationBeingCapturedOnMap().name().length > 0;
-            self.createCaseError(!hasValidName);
-            if (!hasValidName) {
-                return;
+            self.hasCreateCaseError(!hasValidName);
+            if (hasValidName) {
+                self.saveDataRow(self.itemLocationBeingCapturedOnMap());
             }
-            self.saveDataRow(self.itemLocationBeingCapturedOnMap());
         };
 
         self.cancelCreateCase = function () {
@@ -234,8 +233,8 @@ hqDefine("geospatial/js/gps_capture",[
         };
 
         self.resetCaseCreateFlags = function () {
-            self.createCaseEnabled(false);
-            self.createCaseError(false);
+            self.isCreatingCase(false);
+            self.hasCreateCaseError(false);
         };
 
         return self;

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -164,13 +164,16 @@
                         </span>
                     </div>
                 </div>
-                <div class="form-group">
+                <div class="form-group" data-bind="css: { 'has-error': $root.hasCaseTypeError }">
                     <label class="control-label col-sm-2 col-md-2 col-lg-2">
                         {% trans 'Case Type' %}
                     </label>
                     <div class="col-sm-4 col-md-4 col-lg-4">
                         <select class="form-control" data-bind="select2: $root.availableCaseTypes, value: $root.selectedCaseType">
                         </select>
+                        <span class="help-block" data-bind="visible: $root.hasCaseTypeError">
+                            {% trans 'A case type is required' %}
+                        </span>
                     </div>
                 </div>
             </div>

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -146,4 +146,20 @@
             {% trans 'Cancel' %}
         </button>
     {% endif %}
+    <div class="row panel" data-bind="visible: itemLocationBeingCapturedOnMap">
+        <div class="col-sm-5 col-md-5 col-lg-5">
+            <div data-bind="with: itemLocationBeingCapturedOnMap">
+                <h3>
+                    {% trans "Capturing location for:" %}
+                    <span data-bind="text: name"></span>
+                </h3>
+                <div class="form-group" data-bind="css: { 'has-error': $root.createCaseError }">
+                    <input data-bind="value: name, visible: $root.createCaseEnabled" type="text" class="form-control" placeholder="{% trans 'Enter new case name...' %}" />
+                    <span class="help-block" data-bind="visible: $root.createCaseError">
+                        {% trans 'A case name is required' %}
+                    </span>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -147,17 +147,31 @@
         </button>
     {% endif %}
     <div class="row panel" data-bind="visible: itemLocationBeingCapturedOnMap">
-        <div class="col-sm-5 col-md-5 col-lg-5">
-            <div data-bind="with: itemLocationBeingCapturedOnMap">
-                <h3>
-                    {% trans "Capturing location for:" %}
-                    <span data-bind="text: name"></span>
-                </h3>
+        <div class="col-sm-5 col-md-5 col-lg-5" data-bind="with: itemLocationBeingCapturedOnMap">
+            <h3>
+                {% trans "Capturing location for:" %}
+                <span data-bind="text: name"></span>
+            </h3>
+            <div data-bind="visible: $root.isCreatingCase">
                 <div class="form-group" data-bind="css: { 'has-error': $root.hasCreateCaseError }">
-                    <input data-bind="value: name, visible: $root.isCreatingCase" type="text" class="form-control" placeholder="{% trans 'Enter new case name...' %}" />
-                    <span class="help-block" data-bind="visible: $root.hasCreateCaseError">
-                        {% trans 'A case name is required' %}
-                    </span>
+                    <label class="control-label col-sm-2 col-md-2 col-lg-2">
+                        {% trans 'Case Name' %}
+                    </label>
+                    <div class="col-sm-4 col-md-4 col-lg-4" >
+                        <input data-bind="value: name, visible: $root.isCreatingCase" type="text" class="form-control" placeholder="{% trans 'Enter new case name...' %}" />
+                        <span class="help-block" data-bind="visible: $root.hasCreateCaseError">
+                            {% trans 'A case name is required' %}
+                        </span>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="control-label col-sm-2 col-md-2 col-lg-2">
+                        {% trans 'Case Type' %}
+                    </label>
+                    <div class="col-sm-4 col-md-4 col-lg-4">
+                        <select class="form-control" data-bind="select2: $root.availableCaseTypes, value: $root.selectedCaseType">
+                        </select>
+                    </div>
                 </div>
             </div>
         </div>

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -89,7 +89,7 @@
                             </div>
                         </td>
                         <td>
-                            <button type="button" class="btn btn-default" data-bind="event: {click: $root.captureLocationForItem.bind($data)}">
+                            <button type="button" class="btn btn-default" data-bind="event: {click: $root.captureLocationForItem.bind($data)}, disable: $root.createCaseEnabled">
                                 {% trans "Capture on Map" %}
                             </button>
                             <button type="button" class="btn btn-primary" data-bind="enable: canSaveRow, event: {click: $root.saveDataRow.bind($data)}">

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -89,7 +89,7 @@
                             </div>
                         </td>
                         <td>
-                            <button type="button" class="btn btn-default" data-bind="event: {click: $root.captureLocationForItem.bind($data)}, disable: $root.createCaseEnabled">
+                            <button type="button" class="btn btn-default" data-bind="event: {click: $root.captureLocationForItem.bind($data)}, disable: $root.isCreatingCase">
                                 {% trans "Capture on Map" %}
                             </button>
                             <button type="button" class="btn btn-primary" data-bind="enable: canSaveRow, event: {click: $root.saveDataRow.bind($data)}">
@@ -136,13 +136,13 @@
         </div>
     </div>
     {% if data_type == 'case' %}
-        <button class="btn btn-primary" data-bind="click: startCreateCase, hidden: createCaseEnabled, disable: itemLocationBeingCapturedOnMap">
+        <button class="btn btn-primary" data-bind="click: startCreateCase, hidden: isCreatingCase, disable: itemLocationBeingCapturedOnMap">
             {% trans 'Create New Case' %}
         </button>
-        <button class="btn btn-primary" data-bind="click: finishCreateCase, visible: createCaseEnabled">
+        <button class="btn btn-primary" data-bind="click: finishCreateCase, visible: isCreatingCase">
             {% trans 'Confirm Case Location' %}
         </button>
-        <button class="btn btn-default" data-bind="click: cancelCreateCase, visible: createCaseEnabled">
+        <button class="btn btn-default" data-bind="click: cancelCreateCase, visible: isCreatingCase">
             {% trans 'Cancel' %}
         </button>
     {% endif %}
@@ -153,9 +153,9 @@
                     {% trans "Capturing location for:" %}
                     <span data-bind="text: name"></span>
                 </h3>
-                <div class="form-group" data-bind="css: { 'has-error': $root.createCaseError }">
-                    <input data-bind="value: name, visible: $root.createCaseEnabled" type="text" class="form-control" placeholder="{% trans 'Enter new case name...' %}" />
-                    <span class="help-block" data-bind="visible: $root.createCaseError">
+                <div class="form-group" data-bind="css: { 'has-error': $root.hasCreateCaseError }">
+                    <input data-bind="value: name, visible: $root.isCreatingCase" type="text" class="form-control" placeholder="{% trans 'Enter new case name...' %}" />
+                    <span class="help-block" data-bind="visible: $root.hasCreateCaseError">
                         {% trans 'A case name is required' %}
                     </span>
                 </div>

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -135,10 +135,15 @@
                                 showSpinner: showPaginationSpinner"></pagination>
         </div>
     </div>
-    <h3 data-bind="visible: itemLocationBeingCapturedOnMap">
-      <div data-bind="with: itemLocationBeingCapturedOnMap">
-          {% trans "Capturing location for:" %}
-          <span data-bind="text: name"></span>
-      </div>
-    </h3>
+    {% if data_type == 'case' %}
+        <button class="btn btn-primary" data-bind="click: startCreateCase, hidden: createCaseEnabled, disable: itemLocationBeingCapturedOnMap">
+            {% trans 'Create New Case' %}
+        </button>
+        <button class="btn btn-primary" data-bind="click: finishCreateCase, visible: createCaseEnabled">
+            {% trans 'Confirm Case Location' %}
+        </button>
+        <button class="btn btn-default" data-bind="click: cancelCreateCase, visible: createCaseEnabled">
+            {% trans 'Cancel' %}
+        </button>
+    {% endif %}
 </div>

--- a/corehq/apps/geospatial/templates/gps_capture_view.html
+++ b/corehq/apps/geospatial/templates/gps_capture_view.html
@@ -21,6 +21,7 @@
 {% registerurl 'case_data' domain '---' %}
 {% registerurl 'edit_commcare_user' domain '---' %}
 {% registerurl 'gps_capture' domain %}
+{% initial_page_data 'case_types_with_gps' case_types_with_gps %}
 
 <ul id="tabs-list" class="nav nav-tabs">
   <li data-bind="click: onclickAction" class="active"><a data-toggle="tab" href="#tabs-cases">{% trans 'Update Case Data' %}</a></li>

--- a/corehq/apps/geospatial/tests/test_utils.py
+++ b/corehq/apps/geospatial/tests/test_utils.py
@@ -14,6 +14,7 @@ from corehq.apps.geospatial.utils import (
     get_geo_user_property,
     set_case_gps_property,
     set_user_gps_property,
+    create_case_with_gps_property,
 )
 from corehq.apps.geospatial.const import GPS_POINT_CASE_PROPERTY
 
@@ -90,7 +91,7 @@ class TestSetGPSProperty(TestCase):
         case_obj = CommCareCase.objects.get_case(self.case_obj.case_id, self.DOMAIN)
         self.assertEqual(case_obj.case_json[GPS_POINT_CASE_PROPERTY], '1.23 4.56 0.0 0.0')
 
-    def test_create_case_gps_property(self):
+    def test_create_case_with_gps_property(self):
         case_type = 'gps-case'
         submit_data = {
             'name': 'CaseB',
@@ -99,7 +100,7 @@ class TestSetGPSProperty(TestCase):
             'case_type': case_type,
             'owner_id': self.user.user_id,
         }
-        set_case_gps_property(self.DOMAIN, submit_data, create_case=True)
+        create_case_with_gps_property(self.DOMAIN, submit_data)
         case_list = CommCareCase.objects.get_case_ids_in_domain(self.DOMAIN, case_type)
         self.assertEqual(len(case_list), 1)
         case_obj = CommCareCase.objects.get_case(case_list[0], self.DOMAIN)

--- a/corehq/apps/geospatial/tests/test_utils.py
+++ b/corehq/apps/geospatial/tests/test_utils.py
@@ -90,6 +90,20 @@ class TestSetGPSProperty(TestCase):
         case_obj = CommCareCase.objects.get_case(self.case_obj.case_id, self.DOMAIN)
         self.assertEqual(case_obj.case_json[GPS_POINT_CASE_PROPERTY], '1.23 4.56 0.0 0.0')
 
+    def test_create_case_gps_property(self):
+        case_type = 'gps-case'
+        submit_data = {
+            'name': 'CaseB',
+            'lat': '1.23',
+            'lon': '4.56',
+            'case_type': case_type,
+        }
+        set_case_gps_property(self.DOMAIN, submit_data, create_case=True)
+        case_list = CommCareCase.objects.get_case_ids_in_domain(self.DOMAIN, case_type)
+        self.assertEqual(len(case_list), 1)
+        case_obj = CommCareCase.objects.get_case(case_list[0], self.DOMAIN)
+        self.assertEqual(case_obj.case_json[GPS_POINT_CASE_PROPERTY], '1.23 4.56 0.0 0.0')
+
     def test_set_user_gps_property(self):
         submit_data = {
             'id': self.user.user_id,

--- a/corehq/apps/geospatial/tests/test_utils.py
+++ b/corehq/apps/geospatial/tests/test_utils.py
@@ -97,6 +97,7 @@ class TestSetGPSProperty(TestCase):
             'lat': '1.23',
             'lon': '4.56',
             'case_type': case_type,
+            'owner_id': self.user.user_id,
         }
         set_case_gps_property(self.DOMAIN, submit_data, create_case=True)
         case_list = CommCareCase.objects.get_case_ids_in_domain(self.DOMAIN, case_type)

--- a/corehq/apps/geospatial/utils.py
+++ b/corehq/apps/geospatial/utils.py
@@ -31,16 +31,22 @@ def _format_coordinates(lat, lon):
     return f"{lat} {lon} 0.0 0.0"
 
 
-def set_case_gps_property(domain, case_data):
+def set_case_gps_property(domain, case_data, create_case=False):
     location_prop_name = get_geo_case_property(domain)
-    helper = CaseHelper(domain=domain, case_id=case_data['id'])
-    case_data = {
+    data = {
         'properties': {
             location_prop_name: _format_coordinates(case_data['lat'], case_data['lon'])
         }
     }
 
-    helper.update(case_data)
+    if create_case:
+        helper = CaseHelper(domain=domain)
+        data['case_name'] = case_data['name']
+        data['case_type'] = case_data['case_type']
+        helper.create_case(data)
+    else:
+        helper = CaseHelper(domain=domain, case_id=case_data['id'])
+        helper.update(data)
 
 
 def set_user_gps_property(domain, user_data):

--- a/corehq/apps/geospatial/utils.py
+++ b/corehq/apps/geospatial/utils.py
@@ -41,8 +41,11 @@ def set_case_gps_property(domain, case_data, create_case=False):
 
     if create_case:
         helper = CaseHelper(domain=domain)
-        data['case_name'] = case_data['name']
-        data['case_type'] = case_data['case_type']
+        data |= {
+            'case_name': case_data['name'],
+            'case_type': case_data['case_type'],
+            'owner_id': case_data['owner_id'],
+        }
         helper.create_case(data)
     else:
         helper = CaseHelper(domain=domain, case_id=case_data['id'])

--- a/corehq/apps/geospatial/utils.py
+++ b/corehq/apps/geospatial/utils.py
@@ -31,6 +31,20 @@ def _format_coordinates(lat, lon):
     return f"{lat} {lon} 0.0 0.0"
 
 
+def create_case_with_gps_property(domain, case_data):
+    location_prop_name = get_geo_case_property(domain)
+    data = {
+        'properties': {
+            location_prop_name: _format_coordinates(case_data['lat'], case_data['lon'])
+        },
+        'case_name': case_data['name'],
+        'case_type': case_data['case_type'],
+        'owner_id': case_data['owner_id'],
+    }
+    helper = CaseHelper(domain=domain)
+    helper.create_case(data)
+
+
 def set_case_gps_property(domain, case_data, create_case=False):
     location_prop_name = get_geo_case_property(domain)
     data = {
@@ -38,18 +52,8 @@ def set_case_gps_property(domain, case_data, create_case=False):
             location_prop_name: _format_coordinates(case_data['lat'], case_data['lon'])
         }
     }
-
-    if create_case:
-        helper = CaseHelper(domain=domain)
-        data |= {
-            'case_name': case_data['name'],
-            'case_type': case_data['case_type'],
-            'owner_id': case_data['owner_id'],
-        }
-        helper.create_case(data)
-    else:
-        helper = CaseHelper(domain=domain, case_id=case_data['id'])
-        helper.update(data)
+    helper = CaseHelper(domain=domain, case_id=case_data['id'])
+    helper.update(data)
 
 
 def set_user_gps_property(domain, user_data):

--- a/corehq/apps/geospatial/utils.py
+++ b/corehq/apps/geospatial/utils.py
@@ -42,7 +42,7 @@ def create_case_with_gps_property(domain, case_data):
         'owner_id': case_data['owner_id'],
     }
     helper = CaseHelper(domain=domain)
-    helper.create_case(data)
+    helper.create_case(data, user_id=case_data['owner_id'])
 
 
 def set_case_gps_property(domain, case_data, create_case=False):

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -51,6 +51,7 @@ from .utils import (
     get_lat_lon_from_dict,
     set_case_gps_property,
     set_user_gps_property,
+    create_case_with_gps_property,
 )
 
 
@@ -286,11 +287,13 @@ class GPSCaptureView(BaseDomainView):
         data_type = json_data.get('data_type', None)
         data_item = json_data.get('data_item', None)
         create_case = json_data.get('create_case', False)
-        if create_case:
-            data_item['owner_id'] = request.couch_user.user_id
 
         if data_type == 'case':
-            set_case_gps_property(request.domain, data_item, create_case)
+            if create_case:
+                data_item['owner_id'] = request.couch_user.user_id
+                create_case_with_gps_property(request.domain, data_item)
+            else:
+                set_case_gps_property(request.domain, data_item)
         elif data_type == 'user':
             set_user_gps_property(request.domain, data_item)
 

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -280,6 +280,8 @@ class GPSCaptureView(BaseDomainView):
         data_type = json_data.get('data_type', None)
         data_item = json_data.get('data_item', None)
         create_case = json_data.get('create_case', False)
+        if create_case:
+            data_item['owner_id'] = request.couch_user.user_id
 
         if data_type == 'case':
             set_case_gps_property(request.domain, data_item, create_case)

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -248,8 +248,14 @@ class GPSCaptureView(BaseDomainView):
 
     @property
     def page_context(self):
+        case_types = CaseProperty.objects.filter(
+            case_type__domain=self.domain,
+            data_type=CaseProperty.DataType.GPS,
+        ).values_list('case_type__name', flat=True).distinct()
+
         page_context = {
             'mapbox_access_token': settings.MAPBOX_ACCESS_TOKEN,
+            'case_types_with_gps': list(case_types),
         }
         page_context.update(self._case_filters_context())
         return page_context

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -279,9 +279,10 @@ class GPSCaptureView(BaseDomainView):
         json_data = json.loads(request.body)
         data_type = json_data.get('data_type', None)
         data_item = json_data.get('data_item', None)
+        create_case = json_data.get('create_case', False)
 
         if data_type == 'case':
-            set_case_gps_property(request.domain, data_item)
+            set_case_gps_property(request.domain, data_item, create_case)
         elif data_type == 'user':
             set_user_gps_property(request.domain, data_item)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
New "Create Case" button on "Manage GPS Data" page:
![2023-10-26_16-57](https://github.com/dimagi/commcare-hq/assets/122617251/a103489e-d7a8-4bbd-8f59-9262cec41cb3)

After clicking on the above-mentioned button, the map will be shown along with the buttons and inputs for the create case workflow as follows:
![Screenshot from 2023-10-30 11-58-35](https://github.com/dimagi/commcare-hq/assets/122617251/f09857c9-3e36-4c9f-b22f-9262a4156e13)

If the user selects a location on the map and tries to save without first entering a case name, the following error will be shown:
![Screenshot from 2023-10-30 12-17-36](https://github.com/dimagi/commcare-hq/assets/122617251/2228fb34-adcb-46e6-b8db-042047b0baf6)

Similarly, if the user does not first select a case type, the following error will be shown:
![Screenshot from 2023-10-31 17-22-47](https://github.com/dimagi/commcare-hq/assets/122617251/c3183508-5710-4958-a252-e7d674c7373b)


Additionally, while the user is going through the create case workflow, the buttons for capturing GPS data for existing cases will be disabled:
![2023-10-30_12-18](https://github.com/dimagi/commcare-hq/assets/122617251/678b17ae-4822-461f-80a5-2636a2baae34)

Upon successfully saving a case, the user will receive a confirmation alert:
![Screenshot from 2023-10-26 17-06-23](https://github.com/dimagi/commcare-hq/assets/122617251/79b5d146-1db9-4e61-8c0e-1948f8dab0e7)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-2972).

A new workflow has been added on the "Manage GPS Data" page where users are now able to create cases with GPS data.

The case type dropdown list only contains case types from the Data Dictionary that have at least one case property with a GPS data type. This dropdown will be reset every time the user successfully creates a case or cancels the create case workflow. This is to ensure the user explicitely sets what case type they want and prevent the headache of being stuck with a wrong case type.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Added additional unit test

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
A new unit test has been created to test that `set_case_gps_property()` is able to successfully create a case.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
