### PR TITLE
Replace PUPPETEER_SKIP_CHROMIUM_DOWNLOAD with PUPPETEER_SKIP_DOWNLOAD in gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,7 +73,7 @@ module.exports = function (grunt) {
             };
 
         // For running in docker/travis
-        if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD) {
+        if (process.env.PUPPETEER_SKIP_DOWNLOAD) {
             runnerOptions.executablePath = 'google-chrome-unstable';
         }
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup to https://github.com/dimagi/commcare-hq/pull/33672. I totally missed the other usage of this variable in our gruntfile.

Saw this error in JS tests:
```
  Running Test 'app_manager'
  http://localhost:8000/mocha/app_managerFatal error: Could not find expected browser (chrome) locally. Run `npm install` to download the correct Chromium revision (982053).
```
which was caused because after updating https://github.com/dimagi/commcare-hq/pull/33672, I didn't update this usage. So the docker build succeeded, but when running the tests, we were now checking for the wrong environment variable, and therefore not setting an executablePath to the browser we use for JS tests. My bad!
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only impacts testing code. If tests pass on this PR, this change is good to go 👍🏻 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
