### PR TITLE
Remove redundant metric

### DIFF
--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -20,8 +20,7 @@ from corehq.apps.celery import periodic_task, task
 from corehq.util.bounced_email_manager import BouncedEmailManager
 from corehq.util.email_event_utils import get_bounced_system_emails
 from corehq.util.log import send_HTML_email
-from corehq.util.metrics import metrics_gauge_task, metrics_track_errors
-from corehq.util.metrics.const import MPM_MAX
+from corehq.util.metrics import metrics_track_errors
 from corehq.util.models import TransientBounceEmail
 
 
@@ -243,15 +242,6 @@ def clean_expired_transient_emails():
                 'error': e,
             }
         )
-
-
-def get_maintenance_alert_active():
-    from corehq.apps.hqwebapp.models import MaintenanceAlert
-    return 1 if MaintenanceAlert.get_active_alerts() else 0
-
-
-metrics_gauge_task('commcare.maintenance_alerts.active', get_maintenance_alert_active,
-                   run_every=crontab(minute=1), multiprocess_mode=MPM_MAX)
 
 
 @periodic_task(run_every=crontab(minute=0, hour=4))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No user facing effects

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Simply removes a metric that isn't being used by the team anymore

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Confirmed with SaaS (through Danny) that this was not being used anymore.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
