### PR TITLE
Upgrade gevent sub-dependencies

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -822,7 +822,7 @@ zipp==3.7.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==5.4.0
+zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -820,7 +820,7 @@ yapf==0.31.0
     # via -r dev-requirements.in
 zipp==3.7.0
     # via importlib-metadata
-zope-event==4.5.0
+zope-event==5.0
     # via gevent
 zope-interface==5.4.0
     # via gevent

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -670,7 +670,7 @@ zipp==3.7.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==5.4.0
+zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -668,7 +668,7 @@ xmltodict==0.13.0
     # via ddtrace
 zipp==3.7.0
     # via importlib-metadata
-zope-event==4.5.0
+zope-event==5.0
     # via gevent
 zope-interface==5.4.0
     # via gevent

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -673,7 +673,7 @@ zipp==3.7.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==5.4.0
+zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -671,7 +671,7 @@ xmltodict==0.13.0
     # via ddtrace
 zipp==3.7.0
     # via importlib-metadata
-zope-event==4.5.0
+zope-event==5.0
     # via gevent
 zope-interface==5.4.0
     # via gevent

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -612,7 +612,7 @@ xmltodict==0.13.0
     # via ddtrace
 zipp==3.7.0
     # via importlib-metadata
-zope-event==4.5.0
+zope-event==5.0
     # via gevent
 zope-interface==5.4.0
     # via gevent

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -614,7 +614,7 @@ zipp==3.7.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==5.4.0
+zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -676,7 +676,7 @@ zipp==3.7.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==5.4.0
+zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -674,7 +674,7 @@ xmltodict==0.13.0
     # via ddtrace
 zipp==3.7.0
     # via importlib-metadata
-zope-event==4.5.0
+zope-event==5.0
     # via gevent
 zope-interface==5.4.0
     # via gevent


### PR DESCRIPTION
## Safety Assurance

### Safety story

Reviewed change logs. The only changes were bug fixes, documentation updates, and adding/dropping support for new/old Python versions.

Deploying to staging and tested by clicking around there a bit. Gevent is used by gunicorn.

### Automated test coverage

Probably not.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations