### PR TITLE
Disable dynamic search until first search

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -135,7 +135,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
                     title: menuResponse.title,
                     description: menuResponse.description,
                     sidebarEnabled: true,
-                    disableDynamicSearch: sessionStorage.submitPerformed === undefined ? true: !sessionStorage.submitPerformed,
+                    disableDynamicSearch: sessionStorage.submitPerformed === undefined ? true : !sessionStorage.submitPerformed,
                 }).render()
             );
         } else if (sidebarEnabled && menuResponse.type === "query") {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -135,7 +135,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
                     title: menuResponse.title,
                     description: menuResponse.description,
                     sidebarEnabled: true,
-                    disableDynamicSearch: sessionStorage.submitPerformed === undefined ? true : !sessionStorage.submitPerformed,
+                    disableDynamicSearch: !sessionStorage.submitPerformed,
                 }).render()
             );
         } else if (sidebarEnabled && menuResponse.type === "query") {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -135,6 +135,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
                     title: menuResponse.title,
                     description: menuResponse.description,
                     sidebarEnabled: true,
+                    disableDynamicSearch: sessionStorage.submitPerformed === undefined ? true: !sessionStorage.submitPerformed,
                 }).render()
             );
         } else if (sidebarEnabled && menuResponse.type === "query") {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -574,6 +574,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 if (self.smallScreenEnabled && self.options.sidebarEnabled) {
                     $('#sidebar-region').collapse('hide');
                 }
+                sessionStorage.submitPerformed = true;
             });
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -294,6 +294,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             this.search = null;
             this.queryData = null;
             this.sessionId = null;
+            sessionStorage.removeItem('submitPerformed');
         };
 
         this.onSubmit = function () {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
ticket [here](https://dimagi-dev.atlassian.net/browse/USH-3725)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Disables dynamic search until first submit for case search workflows that skip the query request first entirely and go straight to entities (ex. skip to default search results).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`DYNAMICALLY_UPDATE_SEARCH_RESULTS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This only affects logic for dynamic search and does not add functionality but rather restrict functionality. Also, this feature is not live on any non-test production domains

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None for frontend

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
