### PR TITLE
Added a temporary workaround to minio images lacking curl

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -186,7 +186,11 @@ services:
       - "9981"
     healthcheck:
       # https://min.io/docs/minio/linux/operations/monitoring/healthcheck-probe.html#node-liveness
-      test: curl -I http://minio:9980/minio/health/live
+      # test: curl -I http://minio:9980/minio/health/live
+      # Recent official minio images have shipped without 'curl'. Below is a temporary fix until this issue is corrected
+      # The environment variables are not set immediatley and will generate errors during startup
+      # It is also unclear if this command will generate the same results as curl
+      test: mc alias set test http://minio:9980 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" && mc ready test
       start_period: 15s
       interval: 10s
       retries: 10


### PR DESCRIPTION
## Technical Summary
Recent MinIO docker images have removed the `curl` command. It is unclear if this was intentional or not, but their official docs still recommend using `curl` in their healthcheck.  This provides a temporary workaround to hopefully mimic the previous healthcheck, until we can determine a more permanent solution.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
MinIO isn't used in production -- this only affects our tests

### Automated test coverage
None

### QA Plan
None

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
