### PR TITLE
Standardize minio docker ports; use stable healthcheck solution

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -166,7 +166,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 if settingshelper.is_testing():
     S3_BLOB_DB_SETTINGS = {
-        "url": "http://localhost:9980",
+        "url": "http://localhost:9000",
         "access_key": "admin-key",
         "secret_key": "admin-secret",
         "config": {

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -125,7 +125,7 @@ so you can connect to them directly.
 * Redis (6397)
 * Zookeeper (2181)
 * Kafka (9092)
-* MinIO (9980)
+* MinIO (9000 (API)  & 9001 (Console))
 
 CommCare HQ and the services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -76,5 +76,5 @@ services:
       file: hq-compose.yml
       service: minio
     ports:
-      - "9980:9980"
-      - "9981:9981"
+      - "9000:9000"
+      - "9001:9001"

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -180,17 +180,12 @@ services:
 
   minio:
     image: minio/minio
-    command: server --address :9980 --console-address :9981 /data
+    command: server --console-address :9001 /data
     expose:
-      - "9980"
-      - "9981"
+      - "9000"
+      - "9001"
     healthcheck:
-      # https://min.io/docs/minio/linux/operations/monitoring/healthcheck-probe.html#node-liveness
-      # test: curl -I http://minio:9980/minio/health/live
-      # Recent official minio images have shipped without 'curl'. Below is a temporary fix until this issue is corrected
-      # The environment variables are not set immediatley and will generate errors during startup
-      # It is also unclear if this command will generate the same results as curl
-      test: mc alias set test http://minio:9980 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" && mc ready test
+      test: mc ready local
       start_period: 15s
       interval: 10s
       retries: 10

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -105,7 +105,7 @@ ELASTICSEARCH_PORT = 9200  # ES 5 port
 ELASTICSEARCH_MAJOR_VERSION = 5
 
 S3_BLOB_DB_SETTINGS = {
-    "url": "http://minio:9980/",
+    "url": "http://minio:9000/",
     "access_key": "admin-key",
     "secret_key": "admin-secret",
     "config": {

--- a/docker/min_settings.py
+++ b/docker/min_settings.py
@@ -64,7 +64,7 @@ if os.environ.get('ELASTICSEARCH_MAJOR_VERSION'):
     ELASTICSEARCH_MAJOR_VERSION = int(os.environ.get('ELASTICSEARCH_MAJOR_VERSION'))
 
 S3_BLOB_DB_SETTINGS = {
-    "url": "http://minio:9980/",
+    "url": "http://minio:9000/",
     "access_key": "admin-key",
     "secret_key": "admin-secret",
     "config": {


### PR DESCRIPTION
## Technical Summary
Created a more stable solution for minio's healthcheck, following advice from https://github.com/minio/minio/issues/18371#issuecomment-1789259651.

I don't think the timeout needs to be tweaked -- when I attempted to run `mc ready` against my own local instance that was offline, the command failed immediately.

For reviewers: are _docker/localsettings_ and _docker/minsettings_ still used?

Some other considerations:
1) I was tempted to only change the internal ports while keeping the external ports we use now the same (the benefit of using default internal ports means we can use the builtin `local` alias). The problem with modified external ports is that the API port (9000) auto-redirects to the console port when accessed through a web browser. If the console port is mapped to a different port, that redirect will not respect the external port, and so the console will redirect incorrectly.

2) I've left the port references in [test_s3db](https://github.com/dimagi/commcare-hq/blob/d09c5492d98a7f218ac3b026a11570b882caf4ce/corehq/blobs/tests/test_s3db.py#L17) unchanged. My guess was that minio doesn't expose a prod vs test schema, and so these instructions provided a way to set up a non-prod minio instance.

## Safety Assurance

### Safety story
Tested locally. We no longer get the environment warning messages, the service is listed as healthy, and the tests referenced above still pass.

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
