### PR TITLE
Polygon Filtering Support for Case Grouping Page

### DIFF
--- a/corehq/apps/es/tests/test_filters.py
+++ b/corehq/apps/es/tests/test_filters.py
@@ -182,17 +182,30 @@ class TestFilters(ElasticTestMixin, SimpleTestCase):
                             }
                         },
                         {
-                            "geo_shape": {
-                                "location": {
-                                    "shape": {
-                                        "type": "envelope",
-                                        "coordinates": [
-                                            [-74.1, 40.73],
-                                            [-71.12, 40.01]
-                                        ]
+                            "bool": {
+                                "filter": [
+                                    {
+                                        "term": {
+                                            "case_properties.key.exact": "location"
+                                        }
                                     },
-                                    "relation": "within"
-                                }
+                                    {
+                                        "geo_polygon": {
+                                            "case_properties.geopoint_value": {
+                                                "points": [
+                                                    {
+                                                        "lat": 40.73,
+                                                        "lon": -74.1
+                                                    },
+                                                    {
+                                                        "lat": 40.01,
+                                                        "lon": -71.12
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -216,30 +229,43 @@ class TestFilters(ElasticTestMixin, SimpleTestCase):
         )
 
     def test_geo_shape(self):
-        shape = {
-            'type': 'envelope',
-            # NOTE: coordinate order is longitude, latitude (X, Y)
-            'coordinates': [[-74.1, 40.73], [-71.12, 40.01]]
-        }
+        points_list = [
+            {"lat": 40.73, "lon": -74.1},
+            {"lat": 40.01, "lon": -71.12},
+        ]
+
         query = CaseSearchES().filter(
-            filters.geo_shape('case_gps', shape)
+            filters.geo_shape('case_gps', points_list)
         )
         json_output = {
             "query": {
                 "bool": {
                     "filter": [
                         {
-                            "geo_shape": {
-                                "case_gps": {
-                                    "shape": {
-                                        "type": "envelope",
-                                        "coordinates": [
-                                            [-74.1, 40.73],
-                                            [-71.12, 40.01]
-                                        ]
+                            "bool": {
+                                "filter": [
+                                    {
+                                        "term": {
+                                            "case_properties.key.exact": "case_gps"
+                                        }
                                     },
-                                    "relation": "intersects"
-                                }
+                                    {
+                                        "geo_polygon": {
+                                            "case_properties.geopoint_value": {
+                                                "points": [
+                                                    {
+                                                        "lat": 40.73,
+                                                        "lon": -74.1
+                                                    },
+                                                    {
+                                                        "lat": 40.01,
+                                                        "lon": -71.12
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -36,6 +36,10 @@ class BaseCaseMapReport(ProjectReport, CaseListMixin):
         context.update({
             'mapbox_access_token': settings.MAPBOX_ACCESS_TOKEN,
             'case_row_order': {val.html: idx for idx, val in enumerate(self.headers)},
+            'saved_polygons': [
+                {'id': p.id, 'name': p.name, 'geo_json': p.geo_json}
+                for p in GeoPolygon.objects.filter(domain=self.domain).all()
+            ],
         })
         return context
 
@@ -92,17 +96,6 @@ class CaseManagementMap(BaseCaseMapReport):
 
     def default_report_url(self):
         return reverse('geospatial_default', args=[self.request.project.name])
-
-    @property
-    def template_context(self):
-        context = super(CaseManagementMap, self).template_context
-        context.update({
-            'saved_polygons': [
-                {'id': p.id, 'name': p.name, 'geo_json': p.geo_json}
-                for p in GeoPolygon.objects.filter(domain=self.domain).all()
-            ]
-        })
-        return context
 
 
 class CaseGroupingReport(BaseCaseMapReport):

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -19,7 +19,7 @@ hqDefine("geospatial/js/case_grouping_map",[
 
     const DEFAULT_MARKER_COLOR = "rgba(128,128,128,0.25)";
     const MAP_CONTAINER_ID = 'case-grouping-map';
-    let map;
+    let mapDrawControls;
     const clusterStatsInstance = new clusterStatsModel();
     let exportModelInstance;
     let mapMarkers = [];
@@ -192,6 +192,18 @@ hqDefine("geospatial/js/case_grouping_map",[
                 },
             });
         });
+
+        mapDrawControls = new MapboxDraw({  // eslint-disable-line no-undef
+            // API: https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/API.md
+            displayControlsDefault: false,
+            boxSelect: true,
+            controls: {
+                polygon: true,
+                trash: true,
+            },
+        });
+        mapboxInstance.addControl(mapDrawControls);
+
         mapboxInstance.on('moveend', updateClusterStats);
 
         return mapboxInstance;

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -126,6 +126,37 @@ hqDefine("geospatial/js/case_grouping_map",[
 
         self.savedPolygons = ko.observableArray();
         self.selectedSavedPolygonId = ko.observable('');
+        self.activeSavedPolygon;
+
+        function removeActivePolygonLayer() {
+            if (self.activeSavedPolygon) {
+                map.removeLayer(self.activeSavedPolygon.id);
+                map.removeSource(self.activeSavedPolygon.id);
+            }
+        }
+
+        function createActivePolygonLayer(polygonObj) {
+            map.addSource(
+                String(polygonObj.id),
+                {'type': 'geojson', 'data': polygonObj.geoJson}
+            );
+            map.addLayer({
+                'id': String(polygonObj.id),
+                'type': 'fill',
+                'source': String(polygonObj.id),
+                'layout': {},
+                'paint': {
+                    'fill-color': '#0080ff',
+                    'fill-opacity': 0.5,
+                },
+            });
+        }
+
+        self.clearActivePolygon = function () {
+            self.selectedSavedPolygonId('');
+            removeActivePolygonLayer();
+            self.activeSavedPolygon = null;
+        };
 
         self.loadPolygons = function (polygonArr) {
             self.savedPolygons([]);

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -127,6 +127,17 @@ hqDefine("geospatial/js/case_grouping_map",[
         self.savedPolygons = ko.observableArray();
         self.selectedSavedPolygonId = ko.observable('');
 
+        self.loadPolygons = function (polygonArr) {
+            self.savedPolygons([]);
+            _.each(polygonArr, (polygon) => {
+                // Saved features don't have IDs, so we need to give them to uniquely identify them for polygon filtering
+                for (const feature of polygon.geo_json.features) {
+                    feature.id = uuidv4();
+                }
+                self.savedPolygons.push(polygonModel(polygon));
+            });
+        };
+
         return self;
     }
 
@@ -465,6 +476,7 @@ hqDefine("geospatial/js/case_grouping_map",[
                 map = initMap();
                 $("#clusterStats").koApplyBindings(clusterStatsInstance);
                 polygonFilterInstance = new polygonFilterModel();
+                polygonFilterInstance.loadPolygons(initialPageData.get('saved_polygons'));
                 $("#polygon-filters").koApplyBindings(polygonFilterInstance);
 
                 return;

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -125,6 +125,7 @@ hqDefine("geospatial/js/case_grouping_map",[
     function polygonFilterModel() {
         let self = {};
         self.polygons = {};
+        self.shouldRefreshPage = ko.observable(false);
 
         self.savedPolygons = ko.observableArray();
         self.selectedSavedPolygonId = ko.observable('');
@@ -154,6 +155,7 @@ hqDefine("geospatial/js/case_grouping_map",[
                 url.searchParams.delete(FEATURE_QUERY_PARAM);
             }
             window.history.replaceState({ path: url.href }, '', url.href);
+            self.shouldRefreshPage(true);
         }
 
         function removeActivePolygonLayer() {

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -158,6 +158,19 @@ hqDefine("geospatial/js/case_grouping_map",[
             self.shouldRefreshPage(true);
         }
 
+        self.loadPolygonFromQueryParam = function () {
+            const url = new URL(window.location.href);
+            const featureParam = url.searchParams.get(FEATURE_QUERY_PARAM);
+            if (featureParam) {
+                const features = JSON.parse(featureParam);
+                for (const featureId in features) {
+                    const feature = features[featureId];
+                    mapDrawControls.add(feature);
+                    self.polygons[featureId] = feature;
+                }
+            }
+        };
+
         function removeActivePolygonLayer() {
             if (self.activeSavedPolygon) {
                 map.removeLayer(self.activeSavedPolygon.id);
@@ -210,6 +223,7 @@ hqDefine("geospatial/js/case_grouping_map",[
         });
 
         self.loadPolygons = function (polygonArr) {
+            self.loadPolygonFromQueryParam();
             self.savedPolygons([]);
             _.each(polygonArr, (polygon) => {
                 // Saved features don't have IDs, so we need to give them to uniquely identify them for polygon filtering

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -113,6 +113,14 @@ hqDefine("geospatial/js/case_grouping_map",[
         return self;
     }
 
+    function polygonModel(polygon) {
+        let self = {};
+        self.text = polygon.name;
+        self.id = polygon.id;
+        self.geoJson = polygon.geo_json;
+        return self;
+    }
+
     function polygonFilterModel() {
         let self = {};
 

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -25,6 +25,7 @@ hqDefine("geospatial/js/case_grouping_map",[
     let mapMarkers = [];
 
     let polygonFilterInstance;
+    const FEATURE_QUERY_PARAM = 'features';
 
     function caseModel(caseId, coordinates, caseLink) {
         'use strict';
@@ -133,6 +134,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             for (const feature of featureList) {
                 self.polygons[feature.id] = feature;
             }
+            updatePolygonQueryParam();
         };
 
         self.removePolygonsFromFilterList = function (featureList) {
@@ -141,7 +143,18 @@ hqDefine("geospatial/js/case_grouping_map",[
                     delete self.polygons[feature.id];
                 }
             }
+            updatePolygonQueryParam();
         };
+
+        function updatePolygonQueryParam() {
+            const url = new URL(window.location.href);
+            if (Object.keys(self.polygons).length) {
+                url.searchParams.set(FEATURE_QUERY_PARAM, JSON.stringify(self.polygons));
+            } else {
+                url.searchParams.delete(FEATURE_QUERY_PARAM);
+            }
+            window.history.replaceState({ path: url.href }, '', url.href);
+        }
 
         function removeActivePolygonLayer() {
             if (self.activeSavedPolygon) {

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -158,6 +158,25 @@ hqDefine("geospatial/js/case_grouping_map",[
             self.activeSavedPolygon = null;
         };
 
+        self.selectedSavedPolygonId.subscribe(() => {
+            const selectedId = parseInt(self.selectedSavedPolygonId());
+            const polygonObj = self.savedPolygons().find(
+                function (o) { return o.id === selectedId; }
+            );
+            if (!polygonObj) {
+                return;
+            }
+
+            if (self.activeSavedPolygon) {
+                self.clearActivePolygon();
+            }
+
+            removeActivePolygonLayer();
+            createActivePolygonLayer(polygonObj);
+
+            self.activeSavedPolygon = polygonObj;
+        });
+
         self.loadPolygons = function (polygonArr) {
             self.savedPolygons([]);
             _.each(polygonArr, (polygon) => {

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -24,6 +24,8 @@ hqDefine("geospatial/js/case_grouping_map",[
     let exportModelInstance;
     let mapMarkers = [];
 
+    let polygonFilterInstance;
+
     function caseModel(caseId, coordinates, caseLink) {
         'use strict';
         var self = {};
@@ -108,6 +110,15 @@ hqDefine("geospatial/js/case_grouping_map",[
                 }
             });
         }
+        return self;
+    }
+
+    function polygonFilterModel() {
+        let self = {};
+
+        self.savedPolygons = ko.observableArray();
+        self.selectedSavedPolygonId = ko.observable('');
+
         return self;
     }
 
@@ -445,6 +456,9 @@ hqDefine("geospatial/js/case_grouping_map",[
                 $("#lock-groups-controls").koApplyBindings(new groupLockModel());
                 map = initMap();
                 $("#clusterStats").koApplyBindings(clusterStatsInstance);
+                polygonFilterInstance = new polygonFilterModel();
+                $("#polygon-filters").koApplyBindings(polygonFilterInstance);
+
                 return;
             }
 

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -19,6 +19,7 @@ hqDefine("geospatial/js/case_grouping_map",[
 
     const DEFAULT_MARKER_COLOR = "rgba(128,128,128,0.25)";
     const MAP_CONTAINER_ID = 'case-grouping-map';
+    let map;  // TODO: Map and related functions should be moved to a model
     let mapDrawControls;
     const clusterStatsInstance = new clusterStatsModel();
     let exportModelInstance;
@@ -394,7 +395,7 @@ hqDefine("geospatial/js/case_grouping_map",[
                             "type": "Point",
                             "coordinates": [coordinates.lng, coordinates.lat],
                         },
-                    },
+                    }
                 );
             }
         });
@@ -464,7 +465,7 @@ hqDefine("geospatial/js/case_grouping_map",[
     function uuidv4() {
         // https://stackoverflow.com/questions/105034/how-do-i-create-a-guid-uuid/2117523#2117523
         return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
-            (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16),
+            (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
         );
     }
 

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -42,6 +42,13 @@
       {% trans 'Clear' %}
     </button>
   </div>
+  <div class="alert alert-info" data-bind="visible: shouldRefreshPage">
+    {% blocktrans %}
+      Please
+      <a href="">refresh the page</a>
+      to apply the polygon filtering changes.
+    {% endblocktrans %}
+  </div>
 </div>
 <div id="case-grouping-map" style="height: 500px"></div>
 

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -38,6 +38,9 @@
                         ">
         </select>
     </div>
+    <button class="btn btn-default" data-bind="click: clearActivePolygon, enable: selectedSavedPolygonId">
+      {% trans 'Clear' %}
+    </button>
   </div>
 </div>
 <div id="case-grouping-map" style="height: 500px"></div>

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -26,6 +26,20 @@
   </span>
 </div>
 
+<div class="panel" id="polygon-filters">
+  <div class="row">
+    <label for="saved-polygons" class="control-label col-sm-2 col-md-2 col-lg-2">
+    {% trans "Filter by Saved Area" %}</label>
+    <div class="controls col-sm-2 col-md-2 col-lg-2">
+        <select id="saved-polygons"
+                class="form-control"
+                data-bind="select2: savedPolygons,
+                        value: selectedSavedPolygonId,
+                        ">
+        </select>
+    </div>
+  </div>
+</div>
 <div id="case-grouping-map" style="height: 500px"></div>
 
 <div class="panel-body-datatable">

--- a/corehq/apps/geospatial/templates/geospatial/case_grouping_map_base.html
+++ b/corehq/apps/geospatial/templates/geospatial/case_grouping_map_base.html
@@ -15,4 +15,5 @@
 
 {% block additional_initial_page_data %}{{ block.super }}
     {% initial_page_data 'case_row_order' case_row_order %}
+    {% initial_page_data "saved_polygons" saved_polygons %}
 {% endblock %}

--- a/corehq/apps/geospatial/tests/test_utils.py
+++ b/corehq/apps/geospatial/tests/test_utils.py
@@ -15,6 +15,7 @@ from corehq.apps.geospatial.utils import (
     set_case_gps_property,
     set_user_gps_property,
     create_case_with_gps_property,
+    features_to_points_list,
 )
 from corehq.apps.geospatial.const import GPS_POINT_CASE_PROPERTY
 
@@ -116,3 +117,43 @@ class TestSetGPSProperty(TestCase):
         set_user_gps_property(self.DOMAIN, submit_data)
         user = CommCareUser.get_by_user_id(self.user.user_id, self.DOMAIN)
         self.assertEqual(user.get_user_data(self.DOMAIN)[GPS_POINT_CASE_PROPERTY], '1.23 4.56 0.0 0.0')
+
+
+class TestFeaturesToPointsList(TestCase):
+
+    def setUp(self):
+        super(TestFeaturesToPointsList, self).setUp()
+        self.features = {
+            '123': {
+                'geometry': {
+                    'coordinates': [
+                        [
+                            [3.4, 1.2],
+                            [7.8, 5.6],
+                        ],
+                        [
+                            [11.12, 9.10],
+                        ],
+                    ],
+                },
+            },
+            '456': {
+                'geometry': {
+                    'coordinates': [
+                        [
+                            [15.16, 13.14],
+                        ],
+                    ],
+                },
+            },
+        }
+
+    def test_features_to_points_list(self):
+        expected_output = [
+            {'lat': 1.2, 'lon': 3.4},
+            {'lat': 5.6, 'lon': 7.8},
+            {'lat': 9.10, 'lon': 11.12},
+            {'lat': 13.14, 'lon': 15.16},
+        ]
+        points_list = features_to_points_list(self.features)
+        self.assertEqual(points_list, expected_output)

--- a/corehq/apps/geospatial/utils.py
+++ b/corehq/apps/geospatial/utils.py
@@ -71,3 +71,33 @@ def get_lat_lon_from_dict(data, key):
     except (KeyError, BadValueError):
         lat, lon = ('', '')
     return lat, lon
+
+
+def features_to_points_list(features):
+    """
+    `features` should be in the following format:
+    {
+        feature_id: {
+            geometry: {
+                coordinates: [
+                    [
+                        [lon, lat]
+                        ...
+                    ],
+                    ...
+                ]
+            }
+        }
+    }
+    Each list in `coordinates` is a separate polygon of the feature. This will usually only be a single polygon,
+    but there may be more if a multi-polygon is given.
+    """
+    points_list = []
+    for feature in features.values():
+        feature_coords = feature['geometry']['coordinates']
+        for poly_coords in feature_coords:
+            points_list += [
+                {'lat': coords[1], 'lon': coords[0]}
+                for coords in poly_coords
+            ]
+    return points_list


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Map polygon drawing controls have been added to the "Case Grouping" page:
![Screenshot from 2023-11-03 11-45-48](https://github.com/dimagi/commcare-hq/assets/122617251/c0f99037-54bc-4366-a755-fc334e29f5ae)

A new saved filter section is also added, where the user may add saved polygons that were created on the "Case Management" page. After adding a saved polygon, the user can remove it by clicking on "Clear":
![Screenshot from 2023-11-03 11-46-01](https://github.com/dimagi/commcare-hq/assets/122617251/6f9f3337-15e6-4a93-aeae-f7b7b8c630f9)

If the user draws a polygon, edits it, or loads a saved polygon then they will see an alert requesting them to refresh the page. This is so that the polygon filtering can be done on the back-end:
![Screenshot from 2023-11-03 11-46-18](https://github.com/dimagi/commcare-hq/assets/122617251/c148751a-4522-493e-b0f7-986b11aac33e)

When the user refreshes the page, all the polygons that were on the map will be loaded in again.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3155).

The "Case Grouping" page has been expanded to support polygon filtering. This can be done through a combination of drawing new polygons and/or loading in saved polygons. Whenever a polygon is drawn, edited, or removed the URL will be updated with a `features` query param containing the list of polygons in the map in a JSON format.

The back-end implementation for building the query has also been refactored to allow for filtering cases by one or more polygons based on the case's `geopoint_location` case property. This refactor was done to support the [polygon filtering that our version (5.6) of ES supports](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-geo-polygon-query.html).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Automated tests.
- Have tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
An automated test was created for the `features_to_points_list()` helper function. Additionally, the tests for the `geo_shape` and `geo_bounding_box` filters have been updated as part of the refactor.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned. This feature is still pending work from the [pagination implementation](https://dimagi-dev.atlassian.net/browse/SC-3055) to be done before meaningful QA can be done.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
