### PR TITLE
Custom Case Tile Layout Index Bug Fix

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -93,7 +93,9 @@ class CaseTileHelper(object):
                 style = None
                 if any(field is not None for field in [column_info.column.grid_x, column_info.column.grid_y,
                                                        column_info.column.height, column_info.column.width]):
-                    style = Style(grid_x=column_info.column.grid_x, grid_y=column_info.column.grid_y,
+                    zero_based_grid_x = column_info.column.grid_x - 1
+                    zero_based_grid_y = column_info.column.grid_y - 1
+                    style = Style(grid_x=zero_based_grid_x, grid_y=zero_based_grid_y,
                                   grid_height=column_info.column.height, grid_width=column_info.column.width,
                                   horz_align=column_info.column.horizontal_align,
                                   vert_align=column_info.column.vertical_align,

--- a/corehq/apps/app_manager/tests/test_suite_custom_case_tiles.py
+++ b/corehq/apps/app_manager/tests/test_suite_custom_case_tiles.py
@@ -42,7 +42,7 @@ class SuiteCustomCaseTilesTest(SimpleTestCase, SuiteMixin):
             <partial>
                 <field>
                     <style>
-                        <grid grid-height="1" grid-width="3" grid-x="1" grid-y="1"/>
+                        <grid grid-height="1" grid-width="3" grid-x="0" grid-y="0"/>
                     </style>
                     <header>
                         <text>
@@ -74,7 +74,7 @@ class SuiteCustomCaseTilesTest(SimpleTestCase, SuiteMixin):
             <partial>
                 <field>
                     <style>
-                        <grid grid-height="1" grid-width="3" grid-x="1" grid-y="1"/>
+                        <grid grid-height="1" grid-width="3" grid-x="0" grid-y="0"/>
                     </style>
                     <header>
                         <text>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When using grouped tiles with custom case tile layout, the configured value for grouped tiles `Case tile header rows` maps correctly to the rows.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira Ticket
](https://dimagi-dev.atlassian.net/browse/USH-3733)

Context:
This PR addresses a bug related to the handling of grid coordinates (`grid_x` and `grid_y`) in the suite, particularly when using grouped subcase tiles with custom tile layouts.

Summary of Current State:
In the suite's XML template files, `grid_x = 0` and `grid_y = 0` are historically defined as the first row, first column. And, for compatibility with CSS grid-area styles, which use one-based indexing, we convert `grid_x` and `grid_y` values accordingly.

When using grouped subcase tiles,`Case tile header rows` is set to 1, so the fields in the first row (grid_y=0) are used as the header.

Bug Description:
With custom tile layouts, `tileRowStart` uses one-based indexing to align with grid-area. This value was directly used in the suite, resulting in the first row being defined as `grid_y = 1`, instead of the expected `grid_y = 0`. This led to a discrepancy in the historic logic when using `grid_x` and `grid_y` values from the suite. Consequently, with grouped subcase tiles and Case tile header rows set to 1, the `grid_y = 1` fields were incorrectly displayed as part of the children instead of the header.

 PR Change:
This PR converts the x, y values back to 0-based when creating the suite. I considered making the `tileRowStart` and `tileColumnStart` 0-based on the backend but keeping it 1-based when displayed on the UI. But that seemed unintuitive since it would no longer map to `grid-area`. However, with this change, the suite `grid_x` and `grid_y` value won't map to `DetailColumn`'s `grid_x` and grid_y` value which can also be a source of confusion.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
https://www.commcarehq.org/hq/flags/edit/case_list_tile_custom/

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested. This change only affects case tiles configured via custom layout. This currently has no users.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
