### PR TITLE
Fit Map Bounds to Case Data

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -534,6 +534,34 @@ hqDefine("geospatial/js/geospatial_map", [
                 missingGPSModelInstance.casesWithoutGPS(casesWithoutGPS);
             }
             missingGPSModelInstance.casesWithoutGPS(casesWithoutGPS);
+
+
+        // @param mapItems - Should be an array of mapItemModel type objects
+        function fitMapBounds(mapItems) {
+            const mapInstance = map.getMapboxInstance();
+            if (!mapItems.length) {
+                mapInstance.flyTo({
+                    zoom: 0,
+                    center: DEFAULT_CENTER_COORD,
+                    duration: 500,
+                });
+                return;
+            }
+
+            // See https://stackoverflow.com/questions/62939325/scale-mapbox-gl-map-to-fit-set-of-markers
+            const firstCoord = mapItems[0].itemData.coordinates;
+            const bounds = mapItems.reduce(function (bounds, mapItem) {
+                const coord = mapItem.itemData.coordinates;
+                if (coord) {
+                    return bounds.extend(coord);
+                }
+            }, new mapboxgl.LngLatBounds(firstCoord, firstCoord));  // eslint-disable-line no-undef
+
+            map.getMapboxInstance().fitBounds(bounds, {
+                padding: 50,  // in pixels
+                duration: 500,  // in ms
+                maxZoom: 10,  // 0-23
+            });
         }
 
         $(document).ajaxComplete(function (event, xhr, settings) {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -535,6 +535,8 @@ hqDefine("geospatial/js/geospatial_map", [
             }
             missingGPSModelInstance.casesWithoutGPS(casesWithoutGPS);
 
+            fitMapBounds(caseMapItems);
+        }
 
         // @param mapItems - Should be an array of mapItemModel type objects
         function fitMapBounds(mapItems) {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -110,7 +110,6 @@ hqDefine("geospatial/js/geospatial_map", [
                 container: 'geospatial-map', // container ID
                 style: 'mapbox://styles/mapbox/streets-v12', // style URL
                 center: centerCoordinates, // starting position [lng, lat]
-                zoom: 12,
                 attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> ©' +
                              ' <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
             });

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -17,6 +17,8 @@ hqDefine("geospatial/js/geospatial_map", [
         'selected': "#0b940d", // Dark Green
     };
 
+    const DEFAULT_CENTER_COORD = [-20.0, -0.0];
+
     var saveGeoJSONUrl = initialPageData.reverse('geo_polygon');
 
     function mapItemModel(itemId, itemData, marker, markerColors) {
@@ -101,7 +103,7 @@ hqDefine("geospatial/js/geospatial_map", [
             mapboxgl.accessToken = initialPageData.get('mapbox_access_token');  // eslint-disable-line no-undef
 
             if (!centerCoordinates) {
-                centerCoordinates = [-91.874, 42.76]; // should be domain specific
+                centerCoordinates = DEFAULT_CENTER_COORD; // should be domain specific
             }
 
             const map = new mapboxgl.Map({  // eslint-disable-line no-undef


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The "Case Management Map" page map will now automatically zoom and pan to fit all the loaded cases into view. If there are no cases on the map, then the map will zoom out to a globe view.
![Peek 2023-11-06 17-43](https://github.com/dimagi/commcare-hq/assets/122617251/0f8559a9-a8f1-4bb1-bd27-3a7efcaa5faa)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3177).

A new `fitMapBounds()` helper function has been created which will take an array of data with coordinates and pan/zoom the map to fit all the data elements into view.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
