### PR TITLE
Fixed minio healthcheck warnings

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -185,12 +185,10 @@ services:
       - "9980"
       - "9981"
     healthcheck:
-      # https://min.io/docs/minio/linux/operations/monitoring/healthcheck-probe.html#node-liveness
-      # test: curl -I http://minio:9980/minio/health/live
-      # Recent official minio images have shipped without 'curl'. Below is a temporary fix until this issue is corrected
-      # The environment variables are not set immediatley and will generate errors during startup
-      # It is also unclear if this command will generate the same results as curl
-      test: mc alias set test http://minio:9980 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" && mc ready test
+      # The docker image ships with the expectation that minio runs on port 9000.
+      # If we ran on port 9000, we wouldn't need to update the local alias,
+      # but we felt it was less disruptive to use this workaround
+      test: mc alias set local http://localhost:9980 "" "" >/dev/null && mc ready local
       start_period: 15s
       interval: 10s
       retries: 10


### PR DESCRIPTION
## Technical Summary
Per the discussion in https://github.com/dimagi/commcare-hq/pull/33703, we've opted to modify the existing `local` alias to work with our modified port, rather than switch to using the default minio port.

## Safety Assurance

### Safety story
Tested locally. Again, minio does not run in production.

### Automated test coverage
None

### QA Plan
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
