### PR TITLE
[B5] Updates to modal knockout bindings

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
@@ -2,11 +2,13 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
     'jquery',
     'underscore',
     'knockout',
+    "es6!hqwebapp/js/bootstrap5_loader",
     'jquery-ui/ui/widgets/sortable',
 ], function (
     $,
     _,
-    ko
+    ko,
+    bootstrap
 ) {
     // Need this due to https://github.com/knockout/knockout/pull/2324
     // so that ko.bindingHandlers.foreach.update works properly
@@ -344,19 +346,15 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
 
     ko.bindingHandlers.modal = {
         init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-            $(element).addClass('modal fade').modal({
-                show: false,
-            });
-            //        ko.bindingHandlers['if'].init(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext);
+            viewModel.binding_modal = new bootstrap.Modal(element);
         },
         update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
             ko.bindingHandlers.visible.update(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext);
-            var value = ko.utils.unwrapObservable(valueAccessor());
-            //        ko.bindingHandlers['if'].update(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext);
+            let value = ko.utils.unwrapObservable(valueAccessor());
             if (value) {
-                $(element).modal('show');
+                viewModel.binding_modal.show();
             } else {
-                $(element).modal('hide');
+                viewModel.binding_modal.hide();
             }
         },
     };
@@ -383,19 +381,21 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
                 templateID = value.templateId;
                 ifValue = _.has(value, 'if') ? value.if : true;
             }
-            var modal = $('<div></div>').addClass('modal fade').appendTo('body'),
+            let modalElement = $('<div></div>').addClass('modal fade').attr("tabindex", "-1").appendTo('body'),
                 newValueAccessor = function () {
-                    var clickAction = function () {
+                    let clickAction = function () {
                         if (!ifValue) {
                             return;
                         }
-                        ko.bindingHandlers.template.init(modal.get(0), function () {
+                        ko.bindingHandlers.template.init(modalElement.get(0), function () {
                             return templateID;
                         }, allBindingsAccessor, viewModel, bindingContext);
-                        ko.bindingHandlers.template.update(modal.get(0), function () {
+                        ko.bindingHandlers.template.update(modalElement.get(0), function () {
                             return templateID;
                         }, allBindingsAccessor, viewModel, bindingContext);
-                        modal.modal('show');
+
+                        let modal = new bootstrap.Modal(modalElement.get(0));
+                        modal.show();
                     };
                     return clickAction;
                 };
@@ -405,11 +405,13 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
 
     ko.bindingHandlers.openRemoteModal = {
         init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-            var modal = $('<div></div>').addClass('modal fade').appendTo('body'),
+            var modalElement = $('<div></div>').addClass('modal fade').attr("tabindex", "-1").appendTo('body'),
                 newValueAccessor = function () {
                     var clickAction = function () {
-                        modal.load($(element).data('ajaxSource'));
-                        modal.modal('show');
+                        modalElement.load($(element).data('ajaxSource'), function () {
+                            let modal = new bootstrap.Modal(modalElement.get(0));
+                            modal.show();
+                        });
                     };
                     return clickAction;
                 };

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -136,6 +136,10 @@
       {% endcompress %}
     {% endif %}
 
+    <script>
+      window.USE_BOOTSTRAP5 = {{ use_bootstrap5|BOOL }};
+    </script>
+
     {% if not requirejs_main %}
       {% javascript_libraries use_bootstrap5=use_bootstrap5 underscore=True jquery_ui=request.use_jquery_ui ko=True hq=True analytics=True %}
     {% endif %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html
@@ -5,7 +5,6 @@
   // hqModules.js uses `typeof define` and `define.amd` to determine whether or not to use RequireJS, but
   // this fails for form designer, which currently uses RequireJS for vellum but not for the surrounding page.
   window.USE_REQUIREJS = {{ requirejs_main|BOOL }};
-  window.USE_BOOTSTRAP5 = {{ use_bootstrap5|BOOL }};
 </script>
 
 {% if requirejs_main %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/knockout_bindings.ko.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/knockout_bindings.ko.js.diff.txt
@@ -1,8 +1,87 @@
 --- 
 +++ 
-@@ -1,4 +1,4 @@
+@@ -1,12 +1,14 @@
 -hqDefine("hqwebapp/js/bootstrap3/knockout_bindings.ko", [
 +hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
      'jquery',
      'underscore',
      'knockout',
++    "es6!hqwebapp/js/bootstrap5_loader",
+     'jquery-ui/ui/widgets/sortable',
+ ], function (
+     $,
+     _,
+-    ko
++    ko,
++    bootstrap
+ ) {
+     // Need this due to https://github.com/knockout/knockout/pull/2324
+     // so that ko.bindingHandlers.foreach.update works properly
+@@ -344,19 +346,15 @@
+ 
+     ko.bindingHandlers.modal = {
+         init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+-            $(element).addClass('modal fade').modal({
+-                show: false,
+-            });
+-            //        ko.bindingHandlers['if'].init(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext);
++            viewModel.binding_modal = new bootstrap.Modal(element);
+         },
+         update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+             ko.bindingHandlers.visible.update(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext);
+-            var value = ko.utils.unwrapObservable(valueAccessor());
+-            //        ko.bindingHandlers['if'].update(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext);
++            let value = ko.utils.unwrapObservable(valueAccessor());
+             if (value) {
+-                $(element).modal('show');
++                viewModel.binding_modal.show();
+             } else {
+-                $(element).modal('hide');
++                viewModel.binding_modal.hide();
+             }
+         },
+     };
+@@ -383,19 +381,21 @@
+                 templateID = value.templateId;
+                 ifValue = _.has(value, 'if') ? value.if : true;
+             }
+-            var modal = $('<div></div>').addClass('modal fade').appendTo('body'),
++            let modalElement = $('<div></div>').addClass('modal fade').attr("tabindex", "-1").appendTo('body'),
+                 newValueAccessor = function () {
+-                    var clickAction = function () {
++                    let clickAction = function () {
+                         if (!ifValue) {
+                             return;
+                         }
+-                        ko.bindingHandlers.template.init(modal.get(0), function () {
++                        ko.bindingHandlers.template.init(modalElement.get(0), function () {
+                             return templateID;
+                         }, allBindingsAccessor, viewModel, bindingContext);
+-                        ko.bindingHandlers.template.update(modal.get(0), function () {
++                        ko.bindingHandlers.template.update(modalElement.get(0), function () {
+                             return templateID;
+                         }, allBindingsAccessor, viewModel, bindingContext);
+-                        modal.modal('show');
++
++                        let modal = new bootstrap.Modal(modalElement.get(0));
++                        modal.show();
+                     };
+                     return clickAction;
+                 };
+@@ -405,11 +405,13 @@
+ 
+     ko.bindingHandlers.openRemoteModal = {
+         init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+-            var modal = $('<div></div>').addClass('modal fade').appendTo('body'),
++            var modalElement = $('<div></div>').addClass('modal fade').attr("tabindex", "-1").appendTo('body'),
+                 newValueAccessor = function () {
+                     var clickAction = function () {
+-                        modal.load($(element).data('ajaxSource'));
+-                        modal.modal('show');
++                        modalElement.load($(element).data('ajaxSource'), function () {
++                            let modal = new bootstrap.Modal(modalElement.get(0));
++                            modal.show();
++                        });
+                     };
+                     return clickAction;
+                 };


### PR DESCRIPTION
## Technical Summary
While creating the bootstrap 5 styleguide page for modals, I noticed I needed to update the modal javascript usage in the following knockout bindings in `bootstrap5/knockout_bindings.ko.js`:
- `modal`
- `openModal`
- `openRemoteModal`

Note that these changes only have an effect on bootstrap 5 pages, of which none of the migrated pages use the modal bindings above except the styleguide (which i'm still working on in another branch)

## Safety Assurance

### Safety story
Changes only have an effect on bootstrap 5 pages, of which none of the migrated pages use the modal bindings above except the styleguide (which i'm still working on in another branch). Deploying branch to staging just to check it doesn't break build and that the known migrated bootstrap5 pages do not throw errors.

### Automated test coverage
the bootstrap5 diffs are covered

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
