### PR TITLE
[B5] change button style from btn-outline-secondary to btn-outline-primary in 500 template

### DIFF
--- a/corehq/apps/hqwebapp/templates/500.html
+++ b/corehq/apps/hqwebapp/templates/500.html
@@ -27,7 +27,7 @@
             {% endblocktrans %}
           </p>
           <p class="mb-0">
-            <button id="refresh" type="button" class="btn btn-outline-secondary">{% trans "Refresh Page" %}</button>
+            <button id="refresh" type="button" class="btn btn-outline-primary">{% trans "Refresh Page" %}</button>
           </p>
         </div>
       </div>
@@ -44,7 +44,7 @@
               {% endblocktrans %}
             </p>
             <p class="mb-0">
-              <a href="https://status.commcarehq.org/" class="btn btn-outline-secondary">{% trans "View Status Page" %}</a>
+              <a href="https://status.commcarehq.org/" class="btn btn-outline-primary">{% trans "View Status Page" %}</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Technical Summary
When working on the styleguide, I realized that the secondary action on the 500 template page had the incorrect styling class as per our current styleguide cues. Contrary to the current name Bootstrap 5 gives it, `btn-outline-primary` should be used for "secondary" actions or where previously `btn-default` was used.

## Safety Assurance

### Safety story
very safe change. just changing a css class

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
