### PR TITLE
Custom Case Tile Layout Index Bug Fix

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1844,8 +1844,10 @@ class DetailColumn(IndexedSchema):
     useXpathExpression = BooleanProperty(default=False)
     format = StringProperty(exclude_if_none=True)
 
-    grid_x = IntegerProperty(exclude_if_none=True)
-    grid_y = IntegerProperty(exclude_if_none=True)
+    # Only applies to custom case list tile. grid_x and grid_y are zero-based values
+    # representing the starting row and column.
+    grid_x = IntegerProperty(required=False)
+    grid_y = IntegerProperty(required=False)
     width = IntegerProperty(exclude_if_none=True)
     height = IntegerProperty(exclude_if_none=True)
     horizontal_align = StringProperty(exclude_if_none=True)

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -52,11 +52,11 @@ hqDefine("app_manager/js/details/column", function () {
         self.coordinatesVisible = ko.observable(true);
         self.tileRowMax = ko.observable(7); // set dynamically by screen
         self.tileColumnMax = ko.observable(13);
-        self.tileRowStart = ko.observable(self.original.grid_y || 1);
+        self.tileRowStart = ko.observable(self.original.grid_y + 1|| 1); // converts from 0 to 1-based for UI
         self.tileRowOptions = ko.computed(function () {
             return [""].concat(_.range(1, self.tileRowMax()));
         });
-        self.tileColumnStart = ko.observable(self.original.grid_x || 1);
+        self.tileColumnStart = ko.observable(self.original.grid_x + 1|| 1); // converts from 0 to 1-based for UI
         self.tileColumnOptions = [""].concat(_.range(1, self.tileColumnMax()));
         self.tileWidth = ko.observable(self.original.width || self.tileRowMax() - 1);
         self.tileWidthOptions = ko.computed(function () {
@@ -425,8 +425,8 @@ hqDefine("app_manager/js/details/column", function () {
             column.date_format = self.date_extra.val();
             column.enum = self.enum_extra.getItems();
             column.endpoint_action_id = self.action_form_extra.val() === "-1" ? null : self.action_form_extra.val();
-            column.grid_x = self.tileColumnStart();
-            column.grid_y = self.tileRowStart();
+            column.grid_x = self.tileColumnStart()-1;
+            column.grid_y = self.tileRowStart()-1;
             column.height = self.tileHeight();
             column.width = self.tileWidth();
             column.horizontal_align = self.horizontalAlign();

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -52,11 +52,11 @@ hqDefine("app_manager/js/details/column", function () {
         self.coordinatesVisible = ko.observable(true);
         self.tileRowMax = ko.observable(7); // set dynamically by screen
         self.tileColumnMax = ko.observable(13);
-        self.tileRowStart = ko.observable(self.original.grid_y + 1|| 1); // converts from 0 to 1-based for UI
+        self.tileRowStart = ko.observable(self.original.grid_y + 1 || 1); // converts from 0 to 1-based for UI
         self.tileRowOptions = ko.computed(function () {
             return [""].concat(_.range(1, self.tileRowMax()));
         });
-        self.tileColumnStart = ko.observable(self.original.grid_x + 1|| 1); // converts from 0 to 1-based for UI
+        self.tileColumnStart = ko.observable(self.original.grid_x + 1 || 1); // converts from 0 to 1-based for UI
         self.tileColumnOptions = [""].concat(_.range(1, self.tileColumnMax()));
         self.tileWidth = ko.observable(self.original.width || self.tileRowMax() - 1);
         self.tileWidthOptions = ko.computed(function () {
@@ -425,8 +425,8 @@ hqDefine("app_manager/js/details/column", function () {
             column.date_format = self.date_extra.val();
             column.enum = self.enum_extra.getItems();
             column.endpoint_action_id = self.action_form_extra.val() === "-1" ? null : self.action_form_extra.val();
-            column.grid_x = self.tileColumnStart()-1;
-            column.grid_y = self.tileRowStart()-1;
+            column.grid_x = self.tileColumnStart() - 1;
+            column.grid_y = self.tileRowStart() - 1;
             column.height = self.tileHeight();
             column.width = self.tileWidth();
             column.horizontal_align = self.horizontalAlign();


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When using grouped tiles with custom case tile layout, the configured value for grouped tiles Case tile header rows maps correctly to the rows.

Column = 1 will (correctly) display field on left most edge of grid.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi-dev.atlassian.net/browse/USH-3733)

Context:
This PR addresses a bug related to the handling of grid coordinates (grid_x and grid_y) in the suite, particularly when using grouped subcase tiles with custom tile layouts.

Summary of Current State:
In the suite's XML template files, grid_x = 0 and grid_y = 0 are historically defined as the first row, first column. And, for compatibility with CSS grid-area styles, which use one-based indexing, we convert grid_x and grid_y values accordingly.

When using grouped subcase tiles,Case tile header rows is set to 1, so the fields in the first row (grid_y=0) are used as the header. Additionally, all fields configured with column =1 are not displayed on the left most column.

Bug Description:
With custom tile layouts, tileRowStart uses one-based indexing to align with grid-area. This value was directly used in the suite, resulting in the first row being defined as grid_y = 1, instead of the expected grid_y = 0. This led to a discrepancy in the historic logic when using grid_x and grid_y values from the suite. Consequently, with grouped subcase tiles and Case tile header rows set to 1, the grid_y = 1 fields were incorrectly displayed as part of the children instead of the header. Also, all fields are shifted to the right by 1 when compared to the expected result from the configuration.

PR Change:
This PR converts the x, y values to 0-based when saving the values to `DetailColumn` model and back to 1-based when pulling the value from the model.

https://github.com/dimagi/commcare-hq/pull/33707 is an alternative solution that we are not moving forward with.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
https://www.commcarehq.org/hq/flags/edit/case_list_tile_custom/
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested. This change affects only case tiles configured via custom layout.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
test exists that the defined `DetailColumn` creates the expected suite definition

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
