### PR TITLE
Custom Gateway Form Validation for "Host"

### DIFF
--- a/corehq/apps/email/forms.py
+++ b/corehq/apps/email/forms.py
@@ -18,10 +18,10 @@ class EmailSMTPSettingsForm(forms.ModelForm):
         widget=forms.PasswordInput(render_value=True),
     )
 
-    server = forms.URLField(
+    server = forms.CharField(
         label=_('Server'),
         required=True,
-        help_text=_('e.g. "https://smtp.example.com"'),
+        help_text=_('e.g. "smtp.example.com"'),
     )
 
     port = forms.IntegerField(

--- a/corehq/apps/email/tests/test_email_form.py
+++ b/corehq/apps/email/tests/test_email_form.py
@@ -55,19 +55,6 @@ class EmailSMTPSettingsFormTests(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn('from_email', form.errors)
 
-    def test_clean_server(self):
-        form_data = EmailSMTPSettingsFormTests._get_valid_form_data()
-
-        # Valid server format
-        form = EmailSMTPSettingsForm(data=form_data)
-        self.assertTrue(form.is_valid())
-
-        # Invalid server format
-        form_data.update({'server': 'server'})
-        form = EmailSMTPSettingsForm(data=form_data)
-        self.assertFalse(form.is_valid())
-        self.assertIn('server', form.errors)
-
     @staticmethod
     def _get_valid_form_data():
         return {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Allows "host" input to not include `https://` for Email Settings.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The "https://" prefix should not be included because SMTP typically uses plain text or encrypted connections (SSL/TLS or STARTTLS), not HTTP or HTTPS. Including `https://` causes issues for certain email clients, such as for gmail (`smtp.gmail.com`)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
https://www.commcarehq.org/hq/flags/edit/custom_email_gateway/
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
tested locally
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
