### PR TITLE
Update Geospatial Map Button + Saved Polygon Fix

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -530,9 +530,14 @@ hqDefine("geospatial/js/geospatial_map", [
 
             // On selection, add the polygon to the map
             self.selectedPolygon.subscribe(function (value) {
+                const polygonId = parseInt(self.selectedPolygon());
                 var polygonObj = self.savedPolygons().find(
-                    function (o) { return o.id === self.selectedPolygon(); }
+                    function (o) { return o.id === polygonId; }
                 );
+                if (!polygonObj) {
+                    return;
+                }
+
                 // Clear existing polygon
                 if (self.activePolygon()) {
                     mapboxinstance.removeLayer(self.activePolygon());

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -118,7 +118,7 @@
         </a>
         <a class="btn btn-default" target="_blank" href="{% url 'gps_capture' domain %}?data_type=user" data-bind="visible: usersWithoutGPS().length">
             <span data-bind="text: usersWithoutGPS().length"></span>
-            &nbsp;{% trans "Users Missing GPS Data" %}
+            &nbsp;{% trans "Mobile Workers Missing GPS Data" %}
         </a>
     </div>
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Button on "Case Management" page has been updated to say mobile workers instead of users:
![Screenshot from 2023-11-07 10-38-41](https://github.com/dimagi/commcare-hq/assets/122617251/c35a9337-58ec-4d50-9145-215d5d500e07)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3178).

This PR updates the text on a button to make it correctly say "Mobile Workers" instead of "Users".

Additionally, a small fix has also been implemented where the "Case Management" page was unable to load saved polygons due to trying to filter through an array using a string ID. This has been changed so that the ID is correctly parsed to a number before doing the filter.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- UI change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
