### PR TITLE
Tiny web apps UI tweaks

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/less/markdown-table.less
+++ b/corehq/apps/cloudcare/static/cloudcare/less/markdown-table.less
@@ -1,23 +1,16 @@
 .webapp-markdown-output {
     table {
         padding: 0;
-        td {
-            border: 1px solid #cccccc;
-            text-align: left;
-            margin: 0;
-            padding: 6px 13px;
-            &:first-child {
-                margin-top: 0;
-            }
-            &:last-child {
-                margin-bottom: 0;
-            }
-        }
         tr {
             border-top: 1px solid #cccccc;
             background-color: white;
             margin: 0;
             padding: 0;
+
+            &:nth-child(2n) {
+                background-color: #f8f8f8;
+            }
+
             th {
                 font-weight: bold;
                 border: 1px solid #cccccc;
@@ -31,8 +24,18 @@
                     margin-bottom: 0;
                 }
             }
-            &:nth-child(2n) {
-                background-color: #f8f8f8;
+
+            td {
+                border: 1px solid #cccccc;
+                text-align: left;
+                margin: 0;
+                padding: 6px 13px;
+                &:first-child {
+                    margin-top: 0;
+                }
+                &:last-child {
+                    margin-bottom: 0;
+                }
             }
         }
     }

--- a/corehq/apps/cloudcare/static/cloudcare/less/markdown-table.less
+++ b/corehq/apps/cloudcare/static/cloudcare/less/markdown-table.less
@@ -2,7 +2,6 @@
     table {
         padding: 0;
         tr {
-            border-top: 1px solid #cccccc;
             background-color: white;
             margin: 0;
             padding: 0;
@@ -11,9 +10,8 @@
                 background-color: #f8f8f8;
             }
 
-            th {
-                font-weight: bold;
-                border: 1px solid #cccccc;
+            th, td {
+                border: 1px solid #ccc;
                 text-align: left;
                 margin: 0;
                 padding: 6px 13px;
@@ -25,17 +23,9 @@
                 }
             }
 
-            td {
-                border: 1px solid #cccccc;
-                text-align: left;
-                margin: 0;
-                padding: 6px 13px;
-                &:first-child {
-                    margin-top: 0;
-                }
-                &:last-child {
-                    margin-bottom: 0;
-                }
+            th {
+                font-weight: bold;
+                background-color: #ddd;     // override tr background color
             }
         }
     }

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -97,7 +97,7 @@
     <% if (actions || isMultiSelect) { %>
     <div class="case-list-actions">
       <% if (isMultiSelect) { %>
-      <button type="button" class="btn btn-success btn-lg formplayer-request" disabled="true" id="multi-select-continue-btn">{% trans "Continue" %} (<span id="multi-select-btn-text"><%- selectedCaseIds.length %></span>)</button>
+      <button type="button" class="btn btn-success btn-lg formplayer-request" disabled="true" id="multi-select-continue-btn">{% trans "Continue" %} <span id="multi-select-btn-text" class="badge"><%- selectedCaseIds.length %></span></button>
       <% } %>
       <% if (actions) { %>
         <% _.each(actions, function(action, index) { %>


### PR DESCRIPTION
## Product Description
Two little things that bugged me while watching a demo.

1. Slightly nicer multi-select count

before
<img width="305" alt="Screen Shot 2023-11-07 at 12 05 06 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/4add575a-770b-42fc-b76d-f24f1708c058">

after
<img width="308" alt="Screen Shot 2023-11-07 at 12 02 22 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/7c9064a6-da9a-4c7a-aa7a-e34f0d944121">


2. Better delineate table headers in markdown in web apps

before
<img width="239" alt="Screen Shot 2023-11-07 at 12 36 33 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/d9cce4fe-9de0-43ca-a2ba-a21b5c1bdb12">

after
<img width="226" alt="Screen Shot 2023-11-07 at 1 17 38 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/90aeaa2b-1eb3-4946-97a6-5353d6e051d7">


## Safety Assurance

### Safety story
These are low risk, surface level changes. Tested locally.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
