### PR TITLE
Add validation for clickable icons

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -559,6 +559,8 @@ class ModuleDetailValidatorMixin(object):
 
     __invalid_tile_configuration_type: str = "invalid tile configuration"
 
+    __invalid_clickable_icon_configuration: str = "invalid clickable icon configuration"
+
     def _validate_fields_with_format(
         self,
         format_value: str,
@@ -574,6 +576,18 @@ class ModuleDetailValidatorMixin(object):
                 'module': self.get_module_info(),
                 'reason': _('Format "{}" can only be used once but is used by multiple properties: {}'
                             .format(format_display, fields_with_address_format_str))
+            })
+
+    def _validate_clickable_icons(
+        self,
+        columns: list,
+        errors: list
+    ):
+        for field in [c.field for c in columns if c.format == 'clickable-icon' and c.endpoint_action_id == '']:
+            errors.append({
+                'type': self.__invalid_clickable_icon_configuration,
+                'module': self.get_module_info(),
+                'reason': _('Column/Field "{}": Clickable Icons require a form to be configured.'.format(field))
             })
 
     '''
@@ -619,6 +633,7 @@ class ModuleDetailValidatorMixin(object):
                         })
             self._validate_fields_with_format('address', 'Address', detail.columns, errors)
             self._validate_fields_with_format('address-popup', 'Address Popup', detail.columns, errors)
+            self._validate_clickable_icons(detail.columns, errors)
 
             if detail.has_persistent_tile() and self.module.report_context_tile:
                 errors.append({


### PR DESCRIPTION
## Product Description

* Check that the configuration for clickable icons has endpoint_action_id set to a non-empty string.

## Technical Summary

## Feature Flag

* USH: Allow use of clickable icons in the case list in Web Apps to trigger auto submitting forms

## Safety Assurance

Tested locally and in a unit test.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

* Try configuring a case list with a clickable icon and the form unset. Saving should fail.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
