### PR TITLE
Fully qualify docker images

### DIFF
--- a/docker/files/Dockerfile.couch
+++ b/docker/files/Dockerfile.couch
@@ -1,3 +1,3 @@
-FROM apache/couchdb:3.3.1
+FROM docker.io/apache/couchdb:3.3.1
 
 RUN echo '-name node1@127.0.0.1' >> /opt/couchdb/etc/vm.args

--- a/docker/files/Dockerfile.es.2
+++ b/docker/files/Dockerfile.es.2
@@ -1,3 +1,3 @@
-FROM  elasticsearch:2.4.6
+FROM docker.io/elasticsearch:2.4.6
 
 RUN bin/plugin install analysis-phonetic

--- a/docker/files/Dockerfile.es.5
+++ b/docker/files/Dockerfile.es.5
@@ -1,3 +1,3 @@
-FROM elasticsearch:5.6.16
+FROM docker.io/elasticsearch:5.6.16
 
 RUN bin/elasticsearch-plugin install analysis-phonetic

--- a/docker/hq-compose-os-default.yml
+++ b/docker/hq-compose-os-default.yml
@@ -4,4 +4,4 @@ version: '2.3'
 
 services:
   postgres:
-    image: dimagi/docker-postgresql:${DOCKER_HQ_POSTGRES_VERSION}
+    image: docker.io/dimagi/docker-postgresql:${DOCKER_HQ_POSTGRES_VERSION}

--- a/docker/hq-compose-os-macos-m1-11.yml
+++ b/docker/hq-compose-os-macos-m1-11.yml
@@ -5,4 +5,4 @@ version: '2.3'
 services:
   postgres:
     # TODO: enumerate differences with 'dimagi/docker-postgresql' image
-    image: arm64v8/postgres
+    image: docker.io/arm64v8/postgres

--- a/docker/hq-compose-os-macos-m1-12.yml
+++ b/docker/hq-compose-os-macos-m1-12.yml
@@ -4,7 +4,7 @@ version: '2.3'
 
 services:
   postgres:
-    image: dimagi/docker-postgresql:${DOCKER_HQ_POSTGRES_VERSION}
+    image: docker.io/dimagi/docker-postgresql:${DOCKER_HQ_POSTGRES_VERSION}
     platform: linux/amd64
   couch:
     platform: linux/amd64

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -51,7 +51,7 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-lib:}/mnt/lib
 
   formplayer:
-    image: dimagi/formplayer
+    image: docker.io/dimagi/formplayer
     environment:
       COMMCARE_HOST: "http://host.docker.internal:8000"
       COMMCARE_ALTERNATE_ORIGINS: "http://localhost:8000,http://127.0.0.1:8000"
@@ -95,7 +95,7 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-couchdb2:}/opt/couchdb/data
 
   redis:
-    image: redis:7
+    image: docker.io/redis:7
     expose:
       - "6379"
     healthcheck:
@@ -138,7 +138,7 @@ services:
       - ./files/elasticsearch_5.yml:/usr/share/elasticsearch/config/elasticsearch.yml:rw
 
   zookeeper:
-    image: zookeeper:3.7
+    image: docker.io/zookeeper:3.7
     expose:
       - "2181"
     # No healthcheck:
@@ -151,7 +151,7 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/opt/zookeeper-3.7/data
 
   kafka:
-    image: confluentinc/cp-kafka:7.2.2 # kafka v3.2.2
+    image: docker.io/confluentinc/cp-kafka:7.2.2 # kafka v3.2.2
     expose:
       - "9092"
     environment:
@@ -179,7 +179,7 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-kafka:}/kafka/kafka-logs-1
 
   minio:
-    image: minio/minio
+    image: docker.io/minio/minio
     command: server --address :9980 --console-address :9981 /data
     expose:
       - "9980"

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -139,14 +139,15 @@ services:
 
   zookeeper:
     image: docker.io/zookeeper:3.7
+    environment:
+      ZOO_4LW_COMMANDS_WHITELIST: "ruok"
     expose:
       - "2181"
-    # No healthcheck:
-    #   * Polling the port causes "EndOfStreamException: Unable to read
-    #     additional data from client, it probably closed the socket"
-    #   * Using the "ruok" command returns "ruok is not executed because it is
-    #     not in the whitelist."
-    #     See https://zookeeper.apache.org/doc/r3.7.1/zookeeperAdmin.html#sc_4lw
+    healthcheck:
+      test: echo ruok | nc localhost 2181
+      start_period: 15s
+      interval: 10s
+      retries: 10
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/opt/zookeeper-3.7/data
 
@@ -169,6 +170,9 @@ services:
         else
           echo "Wait script download failed"
         fi
+    depends_on:
+      zookeeper:
+        condition: service_healthy
     healthcheck:
       test: bash -c 'exec 6<>/dev/tcp/kafka/9092'
       start_period: 15s


### PR DESCRIPTION
## Technical Summary
I think this is a fix aimed primarily at supporting Podman installations. Because some Podman installations default to querying multiple registries for requested packages, unqualified package names either generate a prompt or, worse, just error out due to the ambiguity. Specifying short image names is convenient for human interaction, but, as our scripts are meant to automate this process, it seems fully-specified image names are more appropriate.

Because I was trying to correct docker issues, there is an unrelated change here to prevent kafka startup errors by placing a dependency on zookeeper.

One interesting thing to note -- the initial healthcheck I tried for zookeeper involved a `curl` command on the admin server.  I reverted to `nc` after realizing that this is another situation where `curl` was only recently added to the docker image. Because both the latest image and the curl-less images both seem to share the `3.7` tag, I felt it was safer to use the `nc` test, as I think it's compatible with both images.

## Safety Assurance

### Safety story
I've verified that these changes do not affect my local docker configuration -- I was able to reuse my existing containers, as well as delete, recreate, and re-pull them from docker.io without issue. I did brief testing on podman on linux to test that the "docker.io" prefix eliminated ambiguity.

The zookeeper/kafka dependency was checked the same way, and I was able to start both locally.

### Automated test coverage

No tests

### QA Plan

No QA necessary

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
