### PR TITLE
Fixed Improper Method Call: Replaced `mktemp` 

### DIFF
--- a/corehq/apps/export/management/commands/process_skipped_pages.py
+++ b/corehq/apps/export/management/commands/process_skipped_pages.py
@@ -105,6 +105,7 @@ class Command(BaseCommand):
         final_dir, orig_name = os.path.split(export_archive_path)
         if not error_pages:
             fd, final_path = tempfile.mkstemp()
+            os.close(fd)
         else:
             final_name = 'INCOMPLETE_{}_{}.zip'.format(orig_name, datetime.utcnow().isoformat())
             final_path = os.path.join(final_dir, final_name)

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -155,6 +155,7 @@ def _get_file_path(app, include_multimedia_files, include_index_files, build_pro
             fpath += '-targeted'
     else:
         dummy, fpath = tempfile.mkstemp()
+        os.close(dummy)
     return fpath
 
 

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -1,4 +1,5 @@
 import re
+import os
 import tempfile
 from collections import OrderedDict
 
@@ -297,6 +298,7 @@ def dump_locations(domain, download_id, include_consumption, headers_only,
                                 headers_only=headers_only, async_task=task, **kwargs)
 
     fd, path = tempfile.mkstemp()
+    os.close(fd)
     writer = Excel2007ExportWriter()
     writer.open(header_table=exporter.get_headers(), file=path)
     with writer:

--- a/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py
+++ b/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py
@@ -36,7 +36,8 @@ class ProfileMiddleware(MiddlewareMixin):
     """
     def process_request(self, request):
         if (settings.DEBUG or request.user.is_superuser) and 'prof' in request.GET:
-            self.tmpfile = tempfile.mktemp()
+            fd, self.tmpfile = tempfile.mkstemp()
+            os.close(fd)
             self.prof = hotshot.Profile(self.tmpfile)
 
     def process_view(self, request, callback, callback_args, callback_kwargs):

--- a/corehq/ex-submodules/soil/util.py
+++ b/corehq/ex-submodules/soil/util.py
@@ -143,7 +143,8 @@ def get_download_file_path(use_transfer, filename):
     if use_transfer:
         fpath = os.path.join(settings.SHARED_DRIVE_CONF.transfer_dir, filename)
     else:
-        _, fpath = tempfile.mkstemp()
+        fd, fpath = tempfile.mkstemp()
+        os.close(fd)
 
     return fpath
 

--- a/docs/nfs.rst
+++ b/docs/nfs.rst
@@ -25,7 +25,8 @@ Using apache / nginx to handle downloads
     if transfer_enabled:
         path = os.path.join(settings.SHARED_DRIVE_CONF.transfer_dir, uuid.uuid4().hex)
     else:
-        _, path = tempfile.mkstemp()
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
 
     make_file(path)
 
@@ -46,7 +47,8 @@ This also works for files that are generated asynchronously::
         if use_transfer:
             path = os.path.join(settings.SHARED_DRIVE_CONF.transfer_dir, uuid.uuid4().hex)
         else:
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
 
         generate_file(path)
 


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [profiling_middleware.py](https://github.com/dimagi/commcare-hq/blob/master/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py#L39), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.


Also, we found several usage of `mkstemp()` method in your codebase. However, some of the file-descriptors associated with it weren't being closed. This can lead to a [file descriptor leak](https://cwe.mitre.org/data/definitions/775.html) which should be prevented. It is suggested that file descriptors should be closed after use.


## Changes
- Replaced `mktemp()` method with `mkstemp()`
- Closed file-descriptors associated with `mkstemp`
- Updated `docs` showing correct usage of `mkstemp`


## Previously Found & Fixed
- https://www.github.com/invesalius/invesalius3/pull/679
- https://www.github.com/Azure/azure-linux-extensions/pull/1816
- https://www.github.com/celery/billiard/pull/394


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.


