### PR TITLE
Enable 'fail_hard' for Bulk User Uploads

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -1,56 +1,53 @@
 import logging
-import string
 import random
+import string
 from collections import defaultdict, namedtuple
 from datetime import datetime
 
+from django.core.exceptions import ValidationError
 from django.db import DEFAULT_DB_ALIAS
-
-from corehq.apps.enterprise.models import EnterpriseMobileWorkerSettings
-from corehq.apps.users.util import generate_mobile_username
-from dimagi.utils.logging import notify_exception
 from django.utils.translation import gettext as _
 
 from couchdbkit.exceptions import (
     BulkSaveError,
     MultipleResultsFound,
+    ResourceConflict,
     ResourceNotFound,
-    ResourceConflict
 )
 
-from django.core.exceptions import ValidationError
+from dimagi.utils.logging import notify_error, notify_exception
+
 from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.commtrack.util import get_supply_point_and_location
-from corehq.apps.custom_data_fields.models import (
-    CustomDataFieldsDefinition,
-)
+from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
 from corehq.apps.domain.models import Domain
+from corehq.apps.enterprise.models import EnterpriseMobileWorkerSettings
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.models import SQLLocation
+from corehq.apps.sms.util import validate_phone_number
 from corehq.apps.user_importer.exceptions import UserUploadError
-from corehq.apps.user_importer.helpers import (
-    spec_value_to_boolean_or_none,
-)
+from corehq.apps.user_importer.helpers import spec_value_to_boolean_or_none
 from corehq.apps.user_importer.validation import (
     get_user_import_validators,
     is_password,
 )
-from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.account_confirmation import (
     send_account_confirmation_if_necessary,
     send_account_confirmation_sms_if_necessary,
 )
+from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.models import (
     CommCareUser,
     CouchUser,
     Invitation,
+    InvitationStatus,
     UserRole,
-    InvitationStatus
 )
+from corehq.apps.users.util import generate_mobile_username
 from corehq.const import USER_CHANGE_VIA_BULK_IMPORTER
 from corehq.toggles import DOMAIN_PERMISSIONS_MIRROR, TABLEAU_USER_SYNCING
-from corehq.apps.sms.util import validate_phone_number
+from corehq.util.soft_assert.api import soft_assert
 
 required_headers = set(['username'])
 web_required_headers = set(['username', 'role'])
@@ -361,7 +358,9 @@ def get_domain_info(
     group_memoizer=None,
     is_web_upload=False
 ):
-    from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
+    from corehq.apps.users.views.mobile.custom_data_fields import (
+        UserFieldsView,
+    )
     from corehq.apps.users.views.utils import get_editable_role_choices
 
     domain_info = domain_info_by_domain.get(domain)
@@ -469,7 +468,10 @@ def create_or_update_commcare_users_and_groups(upload_domain, user_specs, upload
     # Please remove this flag when this method no longer triggers an 'E' or 'F'
     # classification from the radon code static analysis
 
-    from corehq.apps.user_importer.helpers import CommCareUserImporter, WebUserImporter
+    from corehq.apps.user_importer.helpers import (
+        CommCareUserImporter,
+        WebUserImporter,
+    )
 
     domain_info_by_domain = {}
 


### PR DESCRIPTION
## Technical Summary
We've been seeing duplicate mobile workers created through the bulk user upload. One of those scenarios is detailed in [this ticket](https://dimagi-dev.atlassian.net/browse/SAAS-15061). I was able to reproduce some version of this by shutting off redis midway through the request. If redis goes offline, `CriticalSection`s do not work, and we can get multiple requests trying to create the same user. I am not sure that this is specifically what is happening, but I do think there is something going on with `CriticalSection`s. While the semantics behind a lock that, by default, does not 'fail hard', are odd, I don't know that our code is ready to deal with the errors that would be raised if we set `fail_hard` to True. This is the first attempt at moving to `fail_hard`, restricting it to just the user importer. If a failure occurs, the goal is to alert us so that we at least get confirmation of what is happening and can take better action in the future.

I'm not that familiar with how we generally notify errors. I used `soft_assert`, as I saw that being used elsewhere, but in the event that redis goes down, I'd assume this process would fail many times in quick succession, leading to email spam. I'm open to better ways to accomplish notification.

Intentionally opening as draft to make sure this is a path forward that we want to pursue.

## Safety Assurance

### Safety story
I've tried to be very limited in what is done here. I've verified that, when Redis stays up, imports continue as normal. I've also verified that the import process continues as expected if Redis is taken offline and restored before the entire batch completes.

### Automated test coverage
None

### QA Plan
I don't think this needs explicit QA, but it might make sense to leave on staging just to see if it disrupts anything.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
