### PR TITLE
Gracefully handle exceptions raised in process_reporting_metadata_staging

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -360,9 +360,9 @@ def process_reporting_metadata_staging():
         process_reporting_metadata_staging.delay()
 
 
-def _process_reporting_metadata_staging():
+def _process_reporting_metadata_staging(chunk_size=100):
     from corehq.apps.users.models import CouchUser, UserReportingMetadataStaging
-    for i in range(100):
+    for i in range(chunk_size):
         with transaction.atomic():
             records = (
                 UserReportingMetadataStaging.objects.select_for_update(skip_locked=True).order_by('pk')

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -369,7 +369,7 @@ def _process_reporting_metadata_staging(chunk_size=100):
             try:
                 record.process_record(user)
             except ResourceConflict:
-                # https://sentry.io/organizations/dimagi/issues/1479516073/
+                # if the user was updated before we were able to save the processed metadata, try again
                 user = CouchUser.get_by_user_id(record.user_id, record.domain)
                 try:
                     record.process_record(user)

--- a/corehq/apps/users/tests/test_tasks.py
+++ b/corehq/apps/users/tests/test_tasks.py
@@ -1,13 +1,16 @@
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from unittest import mock
 
 from django.test import TestCase
+
+from couchdbkit import ResourceConflict
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.enterprise.tests.utils import create_enterprise_permissions
 from corehq.apps.users.dbaccessors import delete_all_users
-from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.apps.users.models import CommCareUser, UserReportingMetadataStaging, WebUser
 from corehq.apps.users.tasks import (
     apply_correct_demo_mode_to_loadtest_user,
     update_domain_date,
@@ -15,7 +18,10 @@ from corehq.apps.users.tasks import (
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.es import case_search_adapter
 from corehq.form_processor.models import CommCareCase
-from corehq.apps.users.tasks import remove_users_test_cases
+from corehq.apps.users.tasks import (
+    _process_reporting_metadata_staging,
+    remove_users_test_cases,
+)
 from corehq.apps.reports.util import domain_copied_cases_by_owner
 from corehq.apps.hqcase.case_helper import CaseCopier
 
@@ -176,3 +182,48 @@ class TestRemoveUsersTestCases(TestCase):
 
         case_search_adapter.index(case, refresh=True)
         return case
+
+
+@mock.patch.object(UserReportingMetadataStaging, 'process_record')
+class TestProcessReportingMetadataStaging(TestCase):
+
+    def test_record_is_deleted_if_processed_successfully(self, mock_process_record):
+        record = UserReportingMetadataStaging.objects.create(user_id=self.user._id, domain='test-domain')
+        self.assertTrue(UserReportingMetadataStaging.objects.get(id=record.id))
+
+        _process_reporting_metadata_staging()
+
+        self.assertEqual(mock_process_record.call_count, 1)
+        self.assertEqual(UserReportingMetadataStaging.objects.all().count(), 0)
+
+    def test_record_is_not_deleted_if_not_processed_successfully(self, mock_process_record):
+        record = UserReportingMetadataStaging.objects.create(user_id=self.user._id, domain='test-domain')
+        mock_process_record.side_effect = Exception
+
+        with self.assertRaises(Exception):
+            _process_reporting_metadata_staging()
+
+        self.assertEqual(mock_process_record.call_count, 1)
+        self.assertTrue(UserReportingMetadataStaging.objects.get(id=record.id))
+
+    def test_process_record_is_retried_if_resource_conflict_raised(self, mock_process_record):
+        """
+        I'm not sure why this is necessary, but the original introduction of this links back to
+        https://github.com/dimagi/commcare-hq/pull/27138 which also doesn't have context since
+        all of the related links are no longer accessible. If we are able to remove this, that
+        would be great.
+        """
+        # Simulate the scenario where the first attempt to process a record raises ResourceConflict
+        # but the next attempt succeeds
+        mock_process_record.side_effect = [ResourceConflict, None]
+        UserReportingMetadataStaging.objects.create(user_id=self.user._id, domain='test-domain')
+
+        _process_reporting_metadata_staging()
+
+        self.assertEqual(mock_process_record.call_count, 2)
+        self.assertEqual(UserReportingMetadataStaging.objects.all().count(), 0)
+
+    def setUp(self):
+        super().setUp()
+        self.user = CommCareUser.create('test-domain', 'test-username', 'qwer1234', None, None)
+        self.addCleanup(self.user.delete, 'test-domain', deleted_by=None)

--- a/corehq/apps/users/tests/test_tasks.py
+++ b/corehq/apps/users/tests/test_tasks.py
@@ -207,10 +207,10 @@ class TestProcessReportingMetadataStaging(TestCase):
 
     def test_process_record_is_retried_if_resource_conflict_raised(self, mock_process_record):
         """
-        I'm not sure why this is necessary, but the original introduction of this links back to
-        https://github.com/dimagi/commcare-hq/pull/27138 which also doesn't have context since
-        all of the related links are no longer accessible. If we are able to remove this, that
-        would be great.
+        The original introduction of this links back to https://github.com/dimagi/commcare-hq/pull/27138
+        which doesn't have context since all of the related links are no longer accessible. However this
+        is likely needed in the event that the user object is updated within the time it takes us to process
+        the metadata and save it to the user since couch does not provide a locking mechanism.
         """
         # Simulate the scenario where the first attempt to process a record raises ResourceConflict
         # but the next attempt succeeds

--- a/corehq/apps/users/tests/test_tasks.py
+++ b/corehq/apps/users/tests/test_tasks.py
@@ -223,6 +223,16 @@ class TestProcessReportingMetadataStaging(TestCase):
         self.assertEqual(mock_process_record.call_count, 2)
         self.assertEqual(UserReportingMetadataStaging.objects.all().count(), 0)
 
+    def test_processed_records_are_limited_to_chunk_size(self, mock_process_record):
+        for _ in range(5):
+            UserReportingMetadataStaging.objects.create(user_id=self.user._id, domain='test-domain')
+
+        _process_reporting_metadata_staging(chunk_size=3)
+
+        # 5 records were created, 3 were processed, 2 should be left over
+        self.assertEqual(mock_process_record.call_count, 3)
+        self.assertEqual(UserReportingMetadataStaging.objects.all().count(), 2)
+
     def setUp(self):
         super().setUp()
         self.user = CommCareUser.create('test-domain', 'test-username', 'qwer1234', None, None)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-15077

Followup to the [Application Status Report issue](https://dimagi-dev.atlassian.net/browse/SAAS-15068), which was caused because this task does not handle general exceptions well.

### Problem
At a high level, this task's goal is to process 100 `UserReportingMetadataStaging` records, ensuring a db lock is held on each record while being processed. The existing code has a generic loop to iterate 100 times, and in each iteration, fetches the record with the lowest primary key (equivalent to the oldest record). If an error is encountered when processing this record, other than the ResourceConflict edge case you will see in code, any exception raised is not handled and the task fails early. The next time this task is invoked, the same record is fetched from the db, the same error is encountered, and the task fails early again. The record is only deleted from the database after being successfully processed, so until the error encountered in processing the specific record is resolved, this task consistently fails and the backlog grows.

### Resolution
The first three commits do not change any functionality and are basically prepping for the refactor in the 4th commit (fe701d7f791a62ffa08b42aaa1979b5bed65b1b4). The goal of that change is to handle any exception raised in processing, and move on to subsequent records. Since there is no retry logic associated with processing UserReportingMetadataStaging objects, the same issue described above is still possible, but would require all 100 records (the chunk size) to be consistently failing to completely clog the queue. 

Review by commit 🐟 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I'm relying on automated tests to give me confidence here, though can also deploy this to staging to ensure records are still successfully processed.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
