### PR TITLE
Revert "delay call to get_details"

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -312,10 +312,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             }
 
             $.when(FormplayerFrontend.getChannel().request("icon:click", currentUrlToObject)).done(function () {
-                setTimeout(() => {
-                    self.reloadCase(self.model.get('id'));
-                    resetIcon();
-                }, 500);
+                self.reloadCase(self.model.get('id'));
+                resetIcon();
             }).fail(function () {
                 resetIcon();
             });


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This removes the delay to get_details after clickable icons form submission. Having projects that use clickable icons turn on [synchronous ES updates](https://confluence.dimagi.com/display/saas/Project+Case+Search+Configuration#ProjectCaseSearchConfiguration-ConfigureSynchronousWebAppsSubmissions) should take care of the issue of stale case data causing icons to not update.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CASE_LIST_CLICKABLE_ICON
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
