### PR TITLE
Remove success message banner for clickable icons

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -47,13 +47,6 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
 
                 options = {
                     success: function (parsedMenus, response) {
-                        if (params.isClickableIcon && response.submitResponseMessage) {
-                            let message = response.submitResponseMessage;
-                            if (message.indexOf('\n') !== -1) {
-                                message = message.substring(0, message.indexOf('\n'));
-                            }
-                            FormplayerFrontend.trigger('showSuccess', gettext(message));
-                        }
                         if (response.status === 'retry') {
                             FormplayerFrontend.trigger('retry', response, function () {
                                 var newOptionsData = JSON.stringify($.extend(true, { mustRestore: true }, JSON.parse(options.data)));

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -47,7 +47,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
 
                 options = {
                     success: function (parsedMenus, response) {
-                        if (response.submitResponseMessage) {
+                        if (params.isClickableIcon && response.submitResponseMessage) {
                             let message = response.submitResponseMessage;
                             if (message.indexOf('\n') !== -1) {
                                 message = message.substring(0, message.indexOf('\n'));

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -304,6 +304,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             currentUrlToObject.endpointArgs = {[endpointArg]: caseId};
             currentUrlToObject.endpointId = endpointId;
             currentUrlToObject.isBackground = isBackground;
+            currentUrlToObject.isClickableIcon = true;
 
             function resetIcon() {
                 clickedIcon.classList.remove("disabled");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -304,7 +304,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             currentUrlToObject.endpointArgs = {[endpointArg]: caseId};
             currentUrlToObject.endpointId = endpointId;
             currentUrlToObject.isBackground = isBackground;
-            currentUrlToObject.isClickableIcon = true;
 
             function resetIcon() {
                 clickedIcon.classList.remove("disabled");


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is a follow up to this QA ticket https://dimagi-dev.atlassian.net/browse/QA-5774
This eliminates the success banner for mobile workers and web users and the links that are normally presented to web users. The logic is that the changing icon is the correct amount of feedback for the change to the case.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CASE_LIST_CLICKABLE_ICON

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
