### PR TITLE
Validate Data Dictionary Case types

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -442,6 +442,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 return prop.name === value;
             });
             self.nameUnique(!existing);
+            self.nameValid(isNameValid(self.name()));
             self.nameChecked(true);
         });
 

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -336,6 +336,12 @@ hqDefine("data_dictionary/js/data_dictionary", [
             self.saveButton.setState('saved');
         };
 
+        function isNameValid(nameStr) {
+            // First character must be a letter, and the entire name can only contain letters, numbers, '-', and '_'
+            const pattern = /^[a-zA-Z][a-zA-Z0-9-_]*$/;
+            return pattern.test(nameStr);
+        }
+
         self.newPropertyNameUnique = ko.computed(function () {
             if (!self.newPropertyName()) {
                 return true;

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -432,6 +432,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         });
 
         self.nameValid = ko.observable(false);
+        self.nameUnique = ko.observable(false);
         self.nameChecked = ko.observable(false);
         self.name.subscribe((value) => {
             if (!value) {
@@ -440,7 +441,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
             let existing = _.find(self.caseTypes(), function (prop) {
                 return prop.name === value;
             });
-            self.nameValid(!existing);
+            self.nameUnique(!existing);
             self.nameChecked(true);
         });
 
@@ -454,6 +455,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
             $("#create-case-type-form").trigger("reset");
             self.name("");
             self.nameValid(false);
+            self.nameUnique(false);
             self.nameChecked(false);
             return true;
         };

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -436,6 +436,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.nameChecked = ko.observable(false);
         self.name.subscribe((value) => {
             if (!value) {
+                self.nameChecked(false);
                 return;
             }
             let existing = _.find(self.caseTypes(), function (prop) {

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -54,23 +54,26 @@
             {% csrf_token %}
             <div class="modal-body">
               <fieldset>
-                <div class="form-group" data-bind="css: {'has-error': nameChecked() && !nameValid()}">
+                <div class="form-group" data-bind="css: {'has-error': nameChecked() && (!nameValid() || !nameUnique())}">
                   <label for="name" class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label">
                     {% trans "Name" %}
                   </label>
                   <i class="fa" data-bind="
                      visible: nameChecked(),
                      css: {
-                         'fa-check': nameValid(),
-                         'text-success': nameValid(),
-                         'fa-remove': !nameValid(),
-                         'text-danger': !nameValid(),
+                         'fa-check': nameValid() && nameUnique(),
+                         'text-success': nameValid() && nameUnique(),
+                         'fa-remove': !nameValid() || !nameUnique(),
+                         'text-danger': !nameValid() || !nameUnique(),
                      }
                   "></i>
                   <div class="col-xs-12 col-sm-6 col-md-6 col-lg-8 controls">
                     <input type="text" name="name" class="form-control" required data-bind="textInput: name"/>
-                    <span class='help-block' data-bind="visible: nameChecked() && !nameValid()">
+                    <span class='help-block' data-bind="visible: nameChecked() && !nameUnique()">
                       {% trans "A case type with this name already exists." %}
+                    </span>
+                    <span class="help-block" data-bind="visible: nameChecked() && !nameValid()">
+                      {% trans "Invalid case type name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
                     </span>
                   </div>
                 </div>
@@ -90,8 +93,8 @@
                 attr: {disabled: formCreateCaseTypeSent()}
               ">{% trans 'Cancel' %}</a>
               <button type="submit" class="btn btn-primary" data-bind="
-                css: {disabled: formCreateCaseTypeSent() || !nameValid()},
-                attr: {disabled: formCreateCaseTypeSent() || !nameValid()}
+                css: {disabled: formCreateCaseTypeSent() || !nameValid() || !nameUnique()},
+                attr: {disabled: formCreateCaseTypeSent() || !nameValid() || !nameUnique()}
               ">
                 <i class="fa fa-plus" data-bind="
                    css: {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
If a new case type name has unsupported characters, the following error will be shown:
![Screenshot from 2023-11-13 16-39-33](https://github.com/dimagi/commcare-hq/assets/122617251/5cc7656b-2eca-41a0-a6d8-09448dd0b51f)

While the above error is present, the user will be unable to save the new case type.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3075).

Small PR which simply adds some additional validation when creating a new case type in the Data Dictionary. The validation is similar to that used in applications, where the first character has to be a letter followed by only letters, numbers, '-', or '_'.

Commit [ab46eb6](https://github.com/dimagi/commcare-hq/commit/6a3333404ebbc784dbcea404c86e0b48855b656d) was cherry picked from [this PR](https://github.com/dimagi/commcare-hq/pull/33740).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Will test on staging.
- Will undergo user acceptance testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
