### PR TITLE
Remove blank option for row and column

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -54,10 +54,10 @@ hqDefine("app_manager/js/details/column", function () {
         self.tileColumnMax = ko.observable(13);
         self.tileRowStart = ko.observable(self.original.grid_y + 1 || 1); // converts from 0 to 1-based for UI
         self.tileRowOptions = ko.computed(function () {
-            return [""].concat(_.range(1, self.tileRowMax()));
+            return _.range(1, self.tileRowMax());
         });
         self.tileColumnStart = ko.observable(self.original.grid_x + 1 || 1); // converts from 0 to 1-based for UI
-        self.tileColumnOptions = [""].concat(_.range(1, self.tileColumnMax()));
+        self.tileColumnOptions = _.range(1, self.tileColumnMax());
         self.tileWidth = ko.observable(self.original.width || self.tileRowMax() - 1);
         self.tileWidthOptions = ko.computed(function () {
             return _.range(1, self.tileColumnMax() + 1 - (self.tileColumnStart() || 1));


### PR DESCRIPTION
## Product Description

When manually configuring case tiles the row and column drop downs currently show "" as an option. This PR removes that option

![Screen Shot 2023-11-13 at 8 28 58 AM](https://github.com/dimagi/commcare-hq/assets/88759246/09cc78e5-da12-401e-9423-5d88d3fa10c8)

## Technical Summary

https://dimagi-dev.atlassian.net/browse/SUPPORT-17925

## Feature Flag

CASE_LIST_TILE_CUSTOM

## Safety Assurance

CASE_LIST_TILE_CUSTOM is still an experimental FF.

### Safety story

Loaded the page. The option is gone.

### Automated test coverage

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
