### PR TITLE
Rearrange "Users" sidebar menu

### DIFF
--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -98,12 +98,6 @@
                 <i class="fa fa-cloud-upload"></i> {% trans "Bulk Upload" %}
               </a>
             {% endif %}
-            {% if can_add_extra_users and can_access_all_locations %}
-              <a class="btn btn-default" href="{% url "user_fields_view" domain %}" id="btn-edit_user_fields">
-                <i class="fa fa-edit"></i>
-                {% trans "Edit User Fields" %}
-              </a>
-            {% endif %}
             {% if request|toggle_enabled:"CLEAR_MOBILE_WORKER_DATA" %}
               <a id="clear-data" class="btn btn-danger" href="{% url "clear_commcare_users" domain %}">
                 <i class="fa fa-eraser"></i>

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -149,7 +149,7 @@ urlpatterns = [
 ] + [
     url(r'^commcare/$', MobileWorkerListView.as_view(), name=MobileWorkerListView.urlname),
     url(r'^commcare/json/$', paginate_mobile_workers, name='paginate_mobile_workers'),
-    url(r'^commcare/fields/$', waf_allow('XSS_BODY')(UserFieldsView.as_view()), name=UserFieldsView.urlname),
+    url(r'^user_data/$', waf_allow('XSS_BODY')(UserFieldsView.as_view()), name=UserFieldsView.urlname),
     url(
         r'^commcare/account/(?P<couch_user_id>[ \w-]+)/$',
         EditCommCareUserView.as_view(),

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1516,8 +1516,6 @@ class ProjectUsersTab(UITab):
                      'urlname': 'delete_commcare_users'},
                     {'title': _('Bulk Lookup'),
                      'urlname': 'commcare_users_lookup'},
-                    {'title': _('Edit User Fields'),
-                     'urlname': 'user_fields_view'},
                     {'title': _('Filter and Download Mobile Workers'),
                      'urlname': 'filter_and_download_commcare_users'},
                     {'title': _(
@@ -1525,6 +1523,13 @@ class ProjectUsersTab(UITab):
                         'urlname': ConfirmBillingAccountForExtraUsersView.urlname},
                 ],
                 'show_in_dropdown': True,
+            }
+
+    def _user_fields(self):
+        if self.can_access_all_locations and self.couch_user.can_edit_commcare_users():
+            return {
+                'title': _("Edit User Fields"),
+                'url': reverse('user_fields_view', args=[self.domain]),
             }
 
     def _groups(self):
@@ -1706,6 +1711,7 @@ class ProjectUsersTab(UITab):
             self._mobile_workers(),
             self._web_users(),
             self._roles_and_permissions(),
+            self._user_fields(),
             self._groups(),
             self._web_apps_permissions(),
         ])

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1477,16 +1477,10 @@ class ProjectUsersTab(UITab):
         )
 
     @property
-    def can_view_cloudcare(self):
-        return (has_privilege(self._request, privileges.CLOUDCARE)
-                and self.couch_user.is_domain_admin())
-
-    @property
     def has_project_access(self):
         return has_privilege(self._request, privileges.PROJECT_ACCESS)
 
-    def _get_mobile_users_menu(self):
-        menu = []
+    def _mobile_workers(self):
         if ((self.couch_user.can_edit_commcare_users()
                 or self.couch_user.can_view_commcare_users())
                 and self.has_project_access):
@@ -1507,7 +1501,7 @@ class ProjectUsersTab(UITab):
                 MobileWorkerListView,
             )
 
-            menu.append({
+            return {
                 'title': _(MobileWorkerListView.page_title),
                 'url': reverse(MobileWorkerListView.urlname,
                                args=[self.domain]),
@@ -1531,13 +1525,14 @@ class ProjectUsersTab(UITab):
                         'urlname': ConfirmBillingAccountForExtraUsersView.urlname},
                 ],
                 'show_in_dropdown': True,
-            })
+            }
 
+    def _groups(self):
         if ((self.couch_user.can_edit_groups() or self.couch_user.can_view_groups())
                 and self.has_project_access):
             is_view_only_subpage = (hasattr(self._request, 'is_view_only')
                                     and self._request.is_view_only)
-            menu.append({
+            return {
                 'title': _('Groups'),
                 'url': reverse('all_groups', args=[self.domain]),
                 'description': _("""Create and manage
@@ -1552,21 +1547,16 @@ class ProjectUsersTab(UITab):
                      'urlname': 'group_membership'}
                 ],
                 'show_in_dropdown': True,
-            })
+            }
 
-        if self.can_view_cloudcare:
-            title = _("Web Apps Permissions")
-            menu.append({
-                'title': title,
-                'url': reverse('cloudcare_app_settings',
-                               args=[self.domain])
-            })
+    def _web_apps_permissions(self):
+        if has_privilege(self._request, privileges.CLOUDCARE) and self.couch_user.is_domain_admin():
+            return {
+                'title': _("Web Apps Permissions"),
+                'url': reverse('cloudcare_app_settings', args=[self.domain]),
+            }
 
-        return menu
-
-    def _get_project_users_menu(self):
-        menu = []
-
+    def _web_users(self):
         if self.couch_user.can_edit_web_users() or self.couch_user.can_view_web_users():
             def _get_web_username(request=None, couch_user=None, **context):
                 if (couch_user.user_id != request.couch_user.user_id
@@ -1578,23 +1568,12 @@ class ProjectUsersTab(UITab):
                 else:
                     return None
 
-            from corehq.apps.users.views import (
-                EditWebUserView,
-                EnterpriseUsersView,
-                ListWebUsersView,
-            )
+            from corehq.apps.users.views import EditWebUserView, ListWebUsersView
             from corehq.apps.users.views.mobile.users import (
                 FilteredWebUserDownload,
             )
 
-            if toggles.ENTERPRISE_USER_MANAGEMENT.enabled_for_request(self._request):
-                menu.append({
-                    'title': _(EnterpriseUsersView.page_title),
-                    'url': reverse(EnterpriseUsersView.urlname, args=[self.domain]),
-                    'show_in_dropdown': True,
-                })
-
-            menu = menu + [{
+            return {
                 'title': _(ListWebUsersView.page_title),
                 'url': reverse(ListWebUsersView.urlname,
                                args=[self.domain]),
@@ -1619,22 +1598,28 @@ class ProjectUsersTab(UITab):
                     },
                 ],
                 'show_in_dropdown': True,
-            }]
+            }
 
+    def _enterprise_users(self):
+        from corehq.apps.users.views import EnterpriseUsersView
+        if toggles.ENTERPRISE_USER_MANAGEMENT.enabled_for_request(self._request):
+            return {
+                'title': _(EnterpriseUsersView.page_title),
+                'url': reverse(EnterpriseUsersView.urlname, args=[self.domain]),
+                'show_in_dropdown': True,
+            }
+
+    def _roles_and_permissions(self):
         if ((self.couch_user.is_domain_admin() or self.couch_user.can_view_roles())
                 and self.has_project_access):
             from corehq.apps.users.views import ListRolesView
-            menu.append({
+            return {
                 'title': _(ListRolesView.page_title),
-                'url': reverse(ListRolesView.urlname,
-                               args=[self.domain]),
-                'description': _(
-                    "View and manage user roles."),
+                'url': reverse(ListRolesView.urlname, args=[self.domain]),
+                'description': _("View and manage user roles."),
                 'subpages': [],
                 'show_in_dropdown': True,
-            })
-
-        return menu
+            }
 
     def _get_locations_menu(self):
         if (not has_privilege(self._request, privileges.LOCATIONS)
@@ -1716,13 +1701,16 @@ class ProjectUsersTab(UITab):
     def sidebar_items(self):
         items = []
 
-        mobile_users_menu = self._get_mobile_users_menu()
-        if mobile_users_menu:
-            items.append((_('Application Users'), mobile_users_menu))
-
-        project_users_menu = self._get_project_users_menu()
-        if project_users_menu:
-            items.append((_('Project Users'), project_users_menu))
+        users_menu = filter(None, [
+            self._enterprise_users(),
+            self._mobile_workers(),
+            self._web_users(),
+            self._roles_and_permissions(),
+            self._groups(),
+            self._web_apps_permissions(),
+        ])
+        if users_menu:
+            items.append((_('Users'), users_menu))
 
         locations_menu = self._get_locations_menu()
         if locations_menu:


### PR DESCRIPTION
## Product Description

All user pages were filed under "Application Users" or "Project Users", but that dichotomy doesn't hold up very well today (not to mention the terminology is unorthodox).  Mobile workers can also have roles, and web users will soon be able to have user data, and in the future likely groups too.  This puts in a single "Users" section with both combined.

It also moves "Edit User Data" out of the mobile workers page and onto the sidebar as a top level item.

#### Before:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/67a2f7bc-9edf-4327-86a8-1be93c71d288)

#### After:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/cae3a573-a6cc-41de-b2d1-86ae8fd07c68)

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-953
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Pretty straightforward change technically.  I'm more concerned with the user-facing aspects of the change.  The URL for the user fields page does change, which is unfortunate, but I think should be fine.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

Technically very straightforward change.  Happy with local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
