### PR TITLE
Question Tile 1 per row adjustment

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -829,15 +829,16 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
 
     Question.prototype.setWidths = function () {
         const columnWidth = Question.calculateColumnWidthForPerRowStyle(this.style);
+        const perRowPattern = new RegExp(`\\d+${constants.PER_ROW}(\\s|$)`);
 
-        if (columnWidth === constants.GRID_COLUMNS) {
-            this.controlWidth = constants.CONTROL_WIDTH;
-            this.labelWidth = constants.LABEL_WIDTH;
-            this.questionTileWidth = constants.FULL_WIDTH;
-        } else {
+        if (this.stylesContains(perRowPattern)) {
             this.controlWidth = constants.FULL_WIDTH;
             this.labelWidth = constants.FULL_WIDTH;
             this.questionTileWidth = `col-sm-${columnWidth}`;
+        } else {
+            this.controlWidth = constants.CONTROL_WIDTH;
+            this.labelWidth = constants.LABEL_WIDTH;
+            this.questionTileWidth = constants.FULL_WIDTH;
         }
     };
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Previously, when using appearance attribute "1-per-row", the input and label within the container would default to the `col-sm-4` for the label and `col-sm-8` for the input. Resulting in a side by side display. With this change, the input and label will take up the whole width of the container whenever n `n-per-row` appearance attribute is used.

Current:
![Screen Shot 2023-11-14 at 9 12 33 AM](https://github.com/dimagi/commcare-hq/assets/88759246/8cc77347-685f-45a9-824c-9b7b36f91851)


New:
![Screen Shot 2023-11-14 at 9 09 03 AM](https://github.com/dimagi/commcare-hq/assets/88759246/82206723-3236-4aaf-9730-9444dbc35b0e)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi-dev.atlassian.net/browse/USH-3862?focusedCommentId=297121&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None - only for web apps

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests exist that entries in form are in the order as expected for the "Form" object and questions are grouped correctly when nested within the children of a "Form" Object

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
