### PR TITLE
Removed unsupported kafka depends condition

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -170,9 +170,6 @@ services:
         else
           echo "Wait script download failed"
         fi
-    depends_on:
-      zookeeper:
-        condition: service_healthy
     healthcheck:
       test: bash -c 'exec 6<>/dev/tcp/kafka/9092'
       start_period: 15s


### PR DESCRIPTION
## Technical Summary
This reverts an attempt I made earlier to allow kafka to start more reliably. Podman does not support `depends_on` clauses for services that get extended, so we'll need to find another way to handle this.

## Safety Assurance
This just brings us back to where we were, only now zookeeper at least has a healthcheck

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
None

### QA Plan
None


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
