### PR TITLE
[B5] Updates to validators.ko.js for bootstrap 5 

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/cta_forms.js
+++ b/corehq/apps/analytics/static/analytix/js/cta_forms.js
@@ -4,7 +4,7 @@ hqDefine('analytix/js/cta_forms', [
     'underscore',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/assert_properties',
-    'hqwebapp/js/validators.ko',        // needed for validation of startDate and endDate
+    'hqwebapp/js/bootstrap3/validators.ko',        // needed for validation of startDate and endDate
     'intl-tel-input/build/js/intlTelInput.min',
 ], function (
     $,

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -20,7 +20,7 @@ hqDefine("export/js/export_list", [
     'analytix/js/google',
     'analytix/js/kissmetrix',
     'export/js/utils',
-    'hqwebapp/js/validators.ko',        // needed for validation of startDate and endDate
+    'hqwebapp/js/bootstrap3/validators.ko',        // needed for validation of startDate and endDate
     'hqwebapp/js/bootstrap3/components.ko',        // pagination & feedback widget
     'select2/dist/js/select2.full.min',
 ], function (

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -14,7 +14,7 @@ hqDefine('export/js/models', [
     'analytix/js/kissmetrix',
     'export/js/const',
     'export/js/utils',
-    'hqwebapp/js/validators.ko',        // needed for validation of customPathString
+    'hqwebapp/js/bootstrap3/validators.ko',        // needed for validation of customPathString
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // needed for multirow_sortable binding
 ], function (
     $,

--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -135,6 +135,11 @@ class FormStepNumber(LayoutObject):
 
 
 class ValidationMessage(LayoutObject):
+    """
+    IMPORTANT: DO NOT USE IN BOOTSTRAP 5 VIEWS.
+    See bootstrap5/validators.ko and revisit styleguide in
+    Organisms > Forms for additional help.
+    """
     template = 'hqwebapp/crispy/validation_message.html'
 
     def __init__(self, ko_observable):

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/validators.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/validators.ko.js
@@ -1,4 +1,4 @@
-hqDefine("hqwebapp/js/validators.ko", [
+hqDefine("hqwebapp/js/bootstrap3/validators.ko", [
     'jquery',
     'knockout',
     'knockout-validation/dist/knockout.validation.min', // needed for ko.validation

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/validators.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/validators.ko.js
@@ -6,6 +6,15 @@ hqDefine("hqwebapp/js/bootstrap5/validators.ko", [
     $,
     ko
 ) {
+    'use strict';
+
+    ko.validation.init({
+        errorMessageClass: 'invalid-feedback',
+        errorElementClass: 'is-invalid',
+        decorateElement: true,
+        decorateInputElement: true,
+    }, true);
+
     ko.validation.rules['emailRFC2822'] = {
         validator: function (val) {
             if (val === undefined || val.length === 0) return true;  // do separate validation for required
@@ -19,52 +28,71 @@ hqDefine("hqwebapp/js/bootstrap5/validators.ko", [
 
     /**
      * Use this handler to show bootstrap validation states on a form input when
-     * your input's observable has been extended by KnockoutValidation.
+     * your input's observable has been extended by Knockout Validation
      *
      * Pass in the following:
      * {
-     *      validator: observableWithValidation,
-     *      delayedValidator: rateLimitedObservableWithValidation,
+     *      validator: primary observable with validation,
+     *      delayedValidator: de-coupled rate limited observable with validation (optional),
+     *      successMessage: text (optional),
+     *      checkingMessage: text (optional),
      * }
      *
-     * delayedValidator is optional. Useful if you are doing async validation.
+     * delayedValidator is useful if you are doing async validation and want to decouple async validation from
+     * other validators (perhaps for rate limiting). See Organisms > Forms in styleguide for example.
      *
-     * You can see initial usage of this in registration/js/new_user.ko.js
      */
     ko.bindingHandlers.koValidationStateFeedback = {
-        init: function (element) {
-            $(element).after($('<span />').addClass('fa form-control-feedback'));
+        init: function (element, valueAccessor) {
+            let options = valueAccessor(),
+                successMessage = ko.unwrap(options.successMessage),
+                checkingMessage = ko.unwrap(options.checkingMessage);
+            $(element)
+                .after($('<span />').addClass('valid-feedback').text(successMessage))
+                .after($('<span />').addClass('validating-feedback')
+                    .append($('<i class="fa fa-spin fa-spinner"></i>')).append(" " + (checkingMessage || gettext("Checking..."))))
+                .after($('<span />').addClass('ko-delayed-feedback'));
         },
         update: function (element, valueAccessor) {
-            var options = valueAccessor(),
-                $feedback = $(element).next('.form-control-feedback'),
-                $formGroup = $(element).parent('.form-group');
-
-            var validatorVal = ko.unwrap(options.validator);
-
-            // reset formGroup
-            $formGroup
-                .addClass('has-feedback')
-                .removeClass('has-success has-error has-warning');
-
-            // reset feedback
-            $feedback
-                .removeClass('fa-check fa-remove fa-spin fa-spinner');
+            let options = valueAccessor(),
+                validatorVal = ko.unwrap(options.validator),
+                isValid = false,
+                isValidating = false,
+                isDelayedValid;
 
             if (validatorVal === undefined) {
                 return;
             }
-            var isValid = (
-                (options.validator.isValid() && options.delayedValidator === undefined) ||
-                (options.validator.isValid() && options.delayedValidator !== undefined && options.delayedValidator.isValid())
-            );
 
-            if (isValid) {
-                $feedback.addClass("fa-check");
-                $formGroup.addClass("has-success");
-            } else if (validatorVal !== undefined) {
-                $feedback.addClass("fa-remove");
-                $formGroup.addClass("has-error");
+            if (options.delayedValidator === undefined) {
+                isValid = options.validator.isValid();
+                isValidating = options.validator.isValidating !== undefined && options.validator.isValidating();
+                if (isValid !== undefined && !isValid) $(element).addClass('is-invalid');
+            } else {
+                isValidating = options.validator.isValid() && options.delayedValidator.isValidating();
+
+                isDelayedValid = options.delayedValidator.isValid();
+                if (!isDelayedValid && !isValidating) {
+                    $(element).addClass('is-invalid').removeClass('is-valid is-validating');
+                    $(element).next('.ko-delayed-feedback')
+                        .addClass('invalid-feedback').text(options.delayedValidator.error());
+                } else {
+                    $(element).next('.ko-delayed-feedback').removeClass('invalid-feedback').text("");
+                }
+
+                isValid = options.validator.isValid() && isDelayedValid;
+            }
+
+            if (isValidating) {
+                $(element).removeClass('is-valid is-invalid').addClass('is-validating');
+            } else {
+                $(element).removeClass('is-validating');
+            }
+
+            if (isValid && !isValidating) {
+                $(element).addClass('is-valid').removeClass('is-invalid is-validating');
+            } else if (!isValid) {
+                $(element).removeClass('is-valid');
             }
         },
     };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/validators.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/validators.ko.js
@@ -1,0 +1,71 @@
+hqDefine("hqwebapp/js/bootstrap5/validators.ko", [
+    'jquery',
+    'knockout',
+    'knockout-validation/dist/knockout.validation.min', // needed for ko.validation
+], function (
+    $,
+    ko
+) {
+    ko.validation.rules['emailRFC2822'] = {
+        validator: function (val) {
+            if (val === undefined || val.length === 0) return true;  // do separate validation for required
+            var re = /(?:[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
+            return re.test(val || '') && val.indexOf(' ') < 0;
+        },
+        message: gettext("Not a valid email"),
+    };
+
+    ko.validation.registerExtenders();
+
+    /**
+     * Use this handler to show bootstrap validation states on a form input when
+     * your input's observable has been extended by KnockoutValidation.
+     *
+     * Pass in the following:
+     * {
+     *      validator: observableWithValidation,
+     *      delayedValidator: rateLimitedObservableWithValidation,
+     * }
+     *
+     * delayedValidator is optional. Useful if you are doing async validation.
+     *
+     * You can see initial usage of this in registration/js/new_user.ko.js
+     */
+    ko.bindingHandlers.koValidationStateFeedback = {
+        init: function (element) {
+            $(element).after($('<span />').addClass('fa form-control-feedback'));
+        },
+        update: function (element, valueAccessor) {
+            var options = valueAccessor(),
+                $feedback = $(element).next('.form-control-feedback'),
+                $formGroup = $(element).parent('.form-group');
+
+            var validatorVal = ko.unwrap(options.validator);
+
+            // reset formGroup
+            $formGroup
+                .addClass('has-feedback')
+                .removeClass('has-success has-error has-warning');
+
+            // reset feedback
+            $feedback
+                .removeClass('fa-check fa-remove fa-spin fa-spinner');
+
+            if (validatorVal === undefined) {
+                return;
+            }
+            var isValid = (
+                (options.validator.isValid() && options.delayedValidator === undefined) ||
+                (options.validator.isValid() && options.delayedValidator !== undefined && options.delayedValidator.isValid())
+            );
+
+            if (isValid) {
+                $feedback.addClass("fa-check");
+                $formGroup.addClass("has-success");
+            } else if (validatorVal !== undefined) {
+                $feedback.addClass("fa-remove");
+                $formGroup.addClass("has-error");
+            }
+        },
+    };
+});

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -413,7 +413,7 @@
 
     {% if request.use_ko_validation and not requirejs_main %}
       <script src="{% static 'knockout-validation/dist/knockout.validation.min.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/validators.ko.js' %}"></script>
+      <script src="{% static 'hqwebapp/js/bootstrap3/validators.ko.js' %}"></script>
     {% endif %}
 
     {% if is_demo_visible %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -413,7 +413,11 @@
 
     {% if request.use_ko_validation and not requirejs_main %}
       <script src="{% static 'knockout-validation/dist/knockout.validation.min.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/bootstrap3/validators.ko.js' %}"></script>
+      {% if use_bootstrap5 %}
+        <script src="{% static 'hqwebapp/js/bootstrap5/validators.ko.js' %}"></script>
+      {% else %}
+        <script src="{% static 'hqwebapp/js/bootstrap3/validators.ko.js' %}"></script>
+      {% endif %}
     {% endif %}
 
     {% if is_demo_visible %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/validators.ko.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/validators.ko.js.diff.txt
@@ -1,0 +1,127 @@
+--- 
++++ 
+@@ -1,4 +1,4 @@
+-hqDefine("hqwebapp/js/bootstrap3/validators.ko", [
++hqDefine("hqwebapp/js/bootstrap5/validators.ko", [
+     'jquery',
+     'knockout',
+     'knockout-validation/dist/knockout.validation.min', // needed for ko.validation
+@@ -6,6 +6,15 @@
+     $,
+     ko
+ ) {
++    'use strict';
++
++    ko.validation.init({
++        errorMessageClass: 'invalid-feedback',
++        errorElementClass: 'is-invalid',
++        decorateElement: true,
++        decorateInputElement: true,
++    }, true);
++
+     ko.validation.rules['emailRFC2822'] = {
+         validator: function (val) {
+             if (val === undefined || val.length === 0) return true;  // do separate validation for required
+@@ -19,52 +28,71 @@
+ 
+     /**
+      * Use this handler to show bootstrap validation states on a form input when
+-     * your input's observable has been extended by KnockoutValidation.
++     * your input's observable has been extended by Knockout Validation
+      *
+      * Pass in the following:
+      * {
+-     *      validator: observableWithValidation,
+-     *      delayedValidator: rateLimitedObservableWithValidation,
++     *      validator: primary observable with validation,
++     *      delayedValidator: de-coupled rate limited observable with validation (optional),
++     *      successMessage: text (optional),
++     *      checkingMessage: text (optional),
+      * }
+      *
+-     * delayedValidator is optional. Useful if you are doing async validation.
++     * delayedValidator is useful if you are doing async validation and want to decouple async validation from
++     * other validators (perhaps for rate limiting). See Organisms > Forms in styleguide for example.
+      *
+-     * You can see initial usage of this in registration/js/new_user.ko.js
+      */
+     ko.bindingHandlers.koValidationStateFeedback = {
+-        init: function (element) {
+-            $(element).after($('<span />').addClass('fa form-control-feedback'));
++        init: function (element, valueAccessor) {
++            let options = valueAccessor(),
++                successMessage = ko.unwrap(options.successMessage),
++                checkingMessage = ko.unwrap(options.checkingMessage);
++            $(element)
++                .after($('<span />').addClass('valid-feedback').text(successMessage))
++                .after($('<span />').addClass('validating-feedback')
++                    .append($('<i class="fa fa-spin fa-spinner"></i>')).append(" " + (checkingMessage || gettext("Checking..."))))
++                .after($('<span />').addClass('ko-delayed-feedback'));
+         },
+         update: function (element, valueAccessor) {
+-            var options = valueAccessor(),
+-                $feedback = $(element).next('.form-control-feedback'),
+-                $formGroup = $(element).parent('.form-group');
+-
+-            var validatorVal = ko.unwrap(options.validator);
+-
+-            // reset formGroup
+-            $formGroup
+-                .addClass('has-feedback')
+-                .removeClass('has-success has-error has-warning');
+-
+-            // reset feedback
+-            $feedback
+-                .removeClass('fa-check fa-remove fa-spin fa-spinner');
++            let options = valueAccessor(),
++                validatorVal = ko.unwrap(options.validator),
++                isValid = false,
++                isValidating = false,
++                isDelayedValid;
+ 
+             if (validatorVal === undefined) {
+                 return;
+             }
+-            var isValid = (
+-                (options.validator.isValid() && options.delayedValidator === undefined) ||
+-                (options.validator.isValid() && options.delayedValidator !== undefined && options.delayedValidator.isValid())
+-            );
+ 
+-            if (isValid) {
+-                $feedback.addClass("fa-check");
+-                $formGroup.addClass("has-success");
+-            } else if (validatorVal !== undefined) {
+-                $feedback.addClass("fa-remove");
+-                $formGroup.addClass("has-error");
++            if (options.delayedValidator === undefined) {
++                isValid = options.validator.isValid();
++                isValidating = options.validator.isValidating !== undefined && options.validator.isValidating();
++                if (isValid !== undefined && !isValid) $(element).addClass('is-invalid');
++            } else {
++                isValidating = options.validator.isValid() && options.delayedValidator.isValidating();
++
++                isDelayedValid = options.delayedValidator.isValid();
++                if (!isDelayedValid && !isValidating) {
++                    $(element).addClass('is-invalid').removeClass('is-valid is-validating');
++                    $(element).next('.ko-delayed-feedback')
++                        .addClass('invalid-feedback').text(options.delayedValidator.error());
++                } else {
++                    $(element).next('.ko-delayed-feedback').removeClass('invalid-feedback').text("");
++                }
++
++                isValid = options.validator.isValid() && isDelayedValid;
++            }
++
++            if (isValidating) {
++                $(element).removeClass('is-valid is-invalid').addClass('is-validating');
++            } else {
++                $(element).removeClass('is-validating');
++            }
++
++            if (isValid && !isValidating) {
++                $(element).addClass('is-valid').removeClass('is-invalid is-validating');
++            } else if (!isValid) {
++                $(element).removeClass('is-valid');
+             }
+         },
+     };

--- a/corehq/apps/users/static/users/js/invite_web_user.js
+++ b/corehq/apps/users/static/users/js/invite_web_user.js
@@ -3,7 +3,7 @@ hqDefine('users/js/invite_web_user',[
     'knockout',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
-    'hqwebapp/js/validators.ko',
+    'hqwebapp/js/bootstrap3/validators.ko',
     'locations/js/widgets',
 ], function (
     $,

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -27,7 +27,7 @@ hqDefine("users/js/mobile_workers",[
     'locations/js/widgets',
     'users/js/custom_data_fields',
     'hqwebapp/js/bootstrap3/components.ko', // for pagination
-    'hqwebapp/js/validators.ko', // email address validation
+    'hqwebapp/js/bootstrap3/validators.ko', // email address validation
     'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min',
 ], function (
     $,


### PR DESCRIPTION
## Technical Summary
This splits `hqwebapp/js/validators.ko.js` into `bootstrap3` and `bootstrap5` versions

Additionally, updates are made to the bootstrap 5 javascript of `validators.ko` to accommodate changes from bootstrap 5 as discovered when working on the styleguide.

Lastly i added a note in `hqwebapp.crispy.ValidationMessage` to not use this `LayoutObject` with Bootstrap 5 forms moving forward, as the updates in `boostrap5/validators.ko.js` should take care of what this was trying to accomplish.

## Safety Assurance

### Safety story
Safe change as it does a standard splitting of `validators.ko.js` into Bootstrap 3 and 5 versions, ensuring all references are updated. The Bootstrap 3 version has no functional changes, as the only functional changes are isolated to the Bootstrap 5 version.

### Automated test coverage
Diffs are checked, yes.

### QA Plan
Not needed. I've also put this code up on staging to ensure no 404s are reached with the rename, but this is a fairly standard rename of file paths and the only functional changes are part of code that is not being used by anything in production right now.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
