### PR TITLE
[B5] update field, label, and action class template tags to be compatible with bootstrap 5

### DIFF
--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -72,6 +72,11 @@ class ErrorsOnlyField(Field):
     template = 'hqwebapp/crispy/field/errors_only_field.html'
 
 
+def get_form_action_class():
+    """This is only valid for bootstrap 5"""
+    return CSS_LABEL_CLASS_BOOTSTRAP5.replace('col', 'offset') + CSS_FIELD_CLASS_BOOTSTRAP5
+
+
 def _get_offsets(context):
     label_class = context.get('label_class', '')
     use_bootstrap5 = context.get('use_bootstrap5')

--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -74,7 +74,7 @@ class ErrorsOnlyField(Field):
 
 def get_form_action_class():
     """This is only valid for bootstrap 5"""
-    return CSS_LABEL_CLASS_BOOTSTRAP5.replace('col', 'offset') + CSS_FIELD_CLASS_BOOTSTRAP5
+    return CSS_LABEL_CLASS_BOOTSTRAP5.replace('col', 'offset') + ' ' + CSS_FIELD_CLASS_BOOTSTRAP5
 
 
 def _get_offsets(context):

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -237,19 +237,28 @@ def can_use_restore_as(request):
 
 @register.simple_tag
 def css_label_class():
-    from corehq.apps.hqwebapp.crispy import CSS_LABEL_CLASS
+    from corehq.apps.hqwebapp.crispy import CSS_LABEL_CLASS, CSS_LABEL_CLASS_BOOTSTRAP5
+    from corehq.apps.hqwebapp.utils.bootstrap import get_bootstrap_version, BOOTSTRAP_5
+    if get_bootstrap_version() == BOOTSTRAP_5:
+        return CSS_LABEL_CLASS_BOOTSTRAP5
     return CSS_LABEL_CLASS
 
 
 @register.simple_tag
 def css_field_class():
-    from corehq.apps.hqwebapp.crispy import CSS_FIELD_CLASS
+    from corehq.apps.hqwebapp.crispy import CSS_FIELD_CLASS, CSS_FIELD_CLASS_BOOTSTRAP5
+    from corehq.apps.hqwebapp.utils.bootstrap import get_bootstrap_version, BOOTSTRAP_5
+    if get_bootstrap_version() == BOOTSTRAP_5:
+        return CSS_FIELD_CLASS_BOOTSTRAP5
     return CSS_FIELD_CLASS
 
 
 @register.simple_tag
 def css_action_class():
-    from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
+    from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS, get_form_action_class
+    from corehq.apps.hqwebapp.utils.bootstrap import get_bootstrap_version, BOOTSTRAP_5
+    if get_bootstrap_version() == BOOTSTRAP_5:
+        return get_form_action_class()
     return CSS_ACTION_CLASS
 
 


### PR DESCRIPTION
## Technical Summary
Very simple change that returns the bootstrap 5 values for the following template tags:
- `css_label_class`
- `css_field_class`
- `css_action_class`

## Safety Assurance

### Safety story
Small and very safe change isolated to bootstrap 5 pages

### Automated test coverage
N/A

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
