### PR TITLE
Updated messaging for invitations that have been used

### DIFF
--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -66,10 +66,8 @@ class UserInvitationView(object):
                                       "request a project administrator to send you the invitation again."))
             return HttpResponseRedirect(reverse("login"))
 
-        is_invited_user = False
-        if request.user.is_authenticated:
-            if request.couch_user.username.lower() == invitation.email.lower():
-                is_invited_user = True
+        is_invited_user = (request.user.is_authenticated
+            and request.couch_user.username.lower() == invitation.email.lower())
 
         if invitation.is_accepted:
             if request.user.is_authenticated and not is_invited_user:

--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -66,10 +66,16 @@ class UserInvitationView(object):
                                       "request a project administrator to send you the invitation again."))
             return HttpResponseRedirect(reverse("login"))
 
+        is_invited_user = False
+        if request.user.is_authenticated:
+            if request.couch_user.username.lower() == invitation.email.lower():
+                is_invited_user = True
+
         if invitation.is_accepted:
-            messages.error(request, _("Sorry, that invitation has already been used up. "
-                                      "If you feel this is a mistake please ask the inviter for "
-                                      "another invitation."))
+            if request.user.is_authenticated and not is_invited_user:
+                messages.error(request, _("Sorry, that invitation has already been used up. "
+                                          "If you feel this is a mistake, please ask the inviter for "
+                                          "another invitation."))
             return HttpResponseRedirect(reverse("login"))
 
         self.validate_invitation(invitation)
@@ -98,7 +104,6 @@ class UserInvitationView(object):
         else:
             context['current_page'] = {'page_name': _('Project Invitation, Account Required')}
         if request.user.is_authenticated:
-            is_invited_user = request.couch_user.username.lower() == invitation.email.lower()
             if self.is_invited(invitation, request.couch_user) and not request.couch_user.is_superuser:
                 if is_invited_user:
                     # if this invite was actually for this user, just mark it accepted


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-3819

This is to be friendlier to users who click on an invitation they've already accepted, who currently get redirected to the dashboard (reasonable) but with a red error message saying the invitation has been used up (less reasonable). Now, if you click on an accepted invitation, you'll just get redirected onward, *unless* you're logged in as a different user than the one who was invited.

## Safety Assurance

### Safety story
This is a fairly minor change, although it's an important workflow.

I did local testing: inviting a user, then reusing the invitation as both the same user and a different user.

### Automated test coverage

No

### QA Plan

Not planning to request QA, but open to disagreement here.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
