### PR TITLE
First attempt at adding streamlined installation scripts for ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ corehq/apps/hqwebapp/static/hqwebapp/js/lib/modernizr.js
 # direnv
 .envrc
 .direnv
+
+# setup
+.setup_progress
+.setup_container

--- a/setup/database.sh
+++ b/setup/database.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env -S bash -i
+
+# Prompt to run containers
+echo "Please start up the containers if not already started"
+echo "In a separate terminal, please run 'scripts/docker up postgres couch redis elasticsearch5 zookeeper kafka minio'"
+echo "We've copied it to the clipboard to make it easy"
+echo "When the containers are ready, please type 'ready' below"
+echo -n "scripts/docker up postgres couch redis elasticsearch5 zookeeper kafka minio" | xclip -sel clip
+read CONTAINERS_READY
+if [[ $CONTAINERS_READY != "ready" ]]; then
+    echo "Operation terminated. Please re-run when the containers are started"
+    exit 1
+fi
+
+#read -r DB_NAME DB_USER DB_PASS < <(python -c 'import localsettings; db=localsettings.DATABASES["default"]; print("{} {} {}".format(db["NAME"], db["USER"], db["PASSWORD"]))')
+#PGPASSWORD="$DB_PASS" psql -h localhost -p 5432 -U "$DB_USER" -c "CREATE DATABASE commcarehq;"
+
+read -r COUCH_USER COUCH_PASS < <(python -c 'import localsettings; db=localsettings.COUCH_DATABASES["default"]; print("{} {}".format(db["COUCH_USERNAME"], db["COUCH_PASSWORD"]))')
+
+curl -X PUT http://"$COUCH_USER":"$COUCH_PASS"@127.0.0.1:5984/_users
+curl -X PUT http://"$COUCH_USER":"$COUCH_PASS"@127.0.0.1:5984/_replicator
+
+./manage.py sync_couch_views
+./manage.py create_kafka_topics
+env CCHQ_IS_FRESH_INSTALL=1 ./manage.py migrate --noinput
+./manage.py ptop_preindex

--- a/setup/dependencies.sh
+++ b/setup/dependencies.sh
@@ -1,0 +1,28 @@
+if [ -z "$SUDO_USER" ]; then
+    echo "This script is intended to be run as sudo. Exiting"
+    exit 1
+fi
+
+# TODO: detect and toggle between bash and zsh
+
+add-apt-repository -y ppa:deadsnakes/ppa
+apt update
+apt install -y python3.9 python3.9-dev python3-pip python3-venv
+
+# Install pre-requisite libraries
+apt install -y libncurses-dev libxml2-dev libxmlsec1-dev \
+libxmlsec1-openssl libxslt1-dev libpq-dev pkg-config gettext make build-essential \
+libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev
+
+apt install -y curl
+# XClip (optional for scripting)
+apt install -y xclip
+
+# Install JDK
+apt install -y openjdk-17-jre
+
+# Install Postgress Client (optional)
+apt install -y postgresql-client
+
+setup/node.sh

--- a/setup/docker.sh
+++ b/setup/docker.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+if [ -z "$SUDO_USER" ]; then
+    echo "This script is intended to be run as sudo. Exiting"
+    exit 1
+fi
+
+remove_podman () {
+    command -v podman
+    if [[ $? -ne 0 ]]; then
+        return
+    fi
+
+    USER_HOME=$(eval echo ~$SUDO_USER)
+    rm ${USER_HOME}/.local/bin/docker
+
+    # Remove the podman socket configuration
+    sed -i '/podman\.sock/d' ${USER_HOME}/.bashrc
+
+    flatpak uninstall -y io.podman_desktop.PodmanDesktop
+    apt remove -y podman podman-docker docker-compose
+}
+
+remove_podman
+
+# Add Docker's official GPG key:
+apt-get update
+apt-get install ca-certificates curl gnupg
+if [ ! -f /etc/apt/keyrings/docker.gpg ]; then
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    chmod a+r /etc/apt/keyrings/docker.gpg
+fi
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+
+apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+groupadd docker
+usermod -aG docker $SUDO_USER
+# Need to trigger a re-login to get the updated groups.
+# Both options below only apply to the current script. Best solution is a reboot
+#su - $USER
+#newgrp docker
+
+systemctl is-active docker || systemctl start docker
+systemctl enable docker.service
+systemctl enable containerd.service
+
+chmod 0644 docker/files/elasticsearch*.yml

--- a/setup/fake-docker
+++ b/setup/fake-docker
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if [[ "$1" == compose ]]; then
+    shift
+    /usr/bin/docker-compose "$@"
+else
+    podman "$@"
+fi

--- a/setup/frontend.sh
+++ b/setup/frontend.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env -S bash -i
+yarn install --frozen-lockfile
+./manage.py compilejsi18n

--- a/setup/node.sh
+++ b/setup/node.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ -z "$SUDO_USER" ]; then
+    echo "This script is intended to be run as sudo. Exiting"
+    exit 1
+fi
+
+apt-get update
+apt-get install -y ca-certificates curl gnupg
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+
+NODE_MAJOR=20
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+apt-get update
+apt-get install nodejs -y
+
+npm install --global yarn
+npm install --global sass

--- a/setup/podman.sh
+++ b/setup/podman.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+if [ -z "$SUDO_USER" ]; then
+    echo "This script is intended to be run as sudo. Exiting"
+    exit 1
+fi
+
+UBUNTU_MAJOR_VERS=$(lsb_release -rs | cut -c-2)
+
+add_sources () {
+    if [[ "$UBUNTU_MAJOR_VERS" -ge "23" ]]; then
+        # appropriate podman versions are already available
+        return
+    fi
+
+    if [ ! -f /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list ]; then
+        mkdir -p /etc/apt/keyrings
+        curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
+          | gpg --dearmor \
+          | tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+        # NOTE: opensuse seems to be having https difficulties, so switching to http temporarily
+        echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
+            http://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
+          | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
+        apt-get update -qq
+    fi
+}
+
+#add_sources
+
+# Clean previous podman installations, just in case
+apt remove -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+#rm -f /etc/systemd/system/docker.socket
+#rm -f /etc/systemd/system/sockets.target.wants/docker.socket
+#rm -f /etc/systemd/system/multi-user.target.wants/docker.service
+
+# Also might want to take care of /var/lib/docker (containers and images still stored here)
+
+#rm -f /etc/systemd/system/podman.service
+#rm -f /etc/systemd/system/podman-restart.service
+#rm -f /etc/systemd/system/podman-auto-update.service
+#rm -f /etc/systemd/system/podman-auto-update.timer
+
+#rm -f /etc/systemd/user/podman.service
+#rm -f /etc/systemd/user/default.target.wants/podman.service
+#rm -f /etc/systemd/user/sockets.target.wants/podman.socket
+#rm -f /etc/xdg/systemd/user/podman.socket
+#systemctl  --user daemon-reload
+
+#Also look in /usr/lib/systemd/user/podman.socket
+# /usr/lib/systemd/user/podman.service
+
+apt install -y podman podman-docker
+apt install -y systemd-container  # Necessary to load the socket within this script
+
+if [[ "$UBUNTU_MAJOR_VERS" -lt "23" ]]; then
+    # not ignoring recommended packages pulls a normal docker install -- we just need the docker-compose binary
+    #apt install --no-install-recommends -y docker-compose
+
+    # Fix a bug that ships with 22.04
+    curl -O --output-dir "/tmp" http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3_amd64.deb
+    apt install /tmp/containernetworking-plugins_1.1.1+ds1-3_amd64.deb
+    rm /tmp/containernetworking-plugins_1.1.1+ds1-3_amd64.deb
+fi
+
+# Install flatpak
+apt install -y flatpak
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak install -y flathub io.podman_desktop.PodmanDesktop
+
+# Mimic docker-compose support
+USER_HOME=$(eval echo ~$SUDO_USER)
+DOCKER_BIN_FOLDER=${USER_HOME}/.local/bin
+DOCKER_DEST=${DOCKER_BIN_FOLDER}/docker
+
+mkdir -p $DOCKER_BIN_FOLDER
+cp setup/fake-docker $DOCKER_DEST
+chown -R $SUDO_UID:$SUDO_GID $DOCKER_DEST
+
+echo "export DOCKER_HOST=unix://\$XDG_RUNTIME_DIR/podman/podman.sock" >> $USER_HOME/.bashrc
+echo "export DOCKER_SOCK=\$XDG_RUNTIME_DIR/podman/podman.sock" >> $USER_HOME/.bashrc
+
+echo "PATH=\$HOME/.local/bin:\$PATH" >> $USER_HOME/.bashrc
+
+#sudo -u $SUDO_USER systemctl --user enable --now podman.socket
+machinectl shell $SUDO_USER@ $(which systemctl) --user enable --now podman.socket

--- a/setup/pyenv.sh
+++ b/setup/pyenv.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env -S bash -i
+
+# the above shebang causes the script to run in interactive mode.
+# Without interactive mode, the default Ubuntu .bashrc exits immediately, so the below `source` command will fail
+# There is probably a much better way to handle this
+
+curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+
+echo 'export PYENV_ROOT="$HOME/.pyenv"
+command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"' >> $HOME/.bashrc
+echo 'eval "$(pyenv virtualenv-init -)"' >> $HOME/.bashrc
+# reboot shell to read the pyenv configuration
+source $HOME/.bashrc
+
+pyenv install 3.9.18
+pyenv global 3.9.18
+pyenv virtualenv 3.9.18 hq
+pyenv local hq
+
+# configure HQ
+git submodule update --init --recursive
+git-hooks/install.sh
+pip install -r requirements/dev-requirements.txt
+cp localsettings.example.py localsettings.py
+mkdir sharedfiles

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+if [ -z "$SUDO_USER" ]; then
+    echo "This script is intended to be run as sudo. Exiting"
+    exit 1
+fi
+
+run_segment() {
+    case "$1" in
+    1) dependencies ;;
+    2) pyenv ;;
+    3) frontend ;;
+    4) containers ;;
+    5) databases ;;
+    *) echo "Invalid number $1";;
+    esac
+}
+
+MAX_STEPS=5
+
+run_setup () {
+    START="$1"; shift
+    [ -z "$START" ] && START=1
+
+    CONTAINER="$1";  shift
+    [ -z "$CONTAINER" ] && CONTAINER="$(< .setup_container)"
+    CONTAINER="${CONTAINER:-podman}"
+    echo "$CONTAINER" > .setup_container
+
+    for i in $(seq "$START" "$MAX_STEPS"); do
+        echo $i > .setup_progress
+        run_segment $i
+    done
+
+    rm  .setup_progress
+    rm  .setup_container
+
+    echo "Installation and setup complete"
+    echo "Please open a new terminal to access the updated environment"
+    echo "You can then run the server with './manage.py runserver 0.0.0.0:8000'"
+}
+
+dependencies () {
+    echo "setting up dependencies"
+    setup/dependencies.sh
+}
+
+pyenv () {
+    echo "setting up pyenv"
+    sudo -u $SUDO_USER setup/pyenv.sh
+}
+
+frontend () {
+    echo "setting up frontend"
+    sudo -u $SUDO_USER setup/frontend.sh
+}
+
+containers () {
+    CONTAINER=$(< .setup_container)
+    if [[ "$CONTAINER" == "podman" ]]; then
+        echo "setting up podman"
+        setup/podman.sh
+    else
+        echo "setting up docker"
+        setup/docker.sh
+    fi
+}
+
+databases () {
+    echo "setting up databases"
+    sudo -u $SUDO_USER setup/database.sh
+}
+
+touch .setup_progress
+touch .setup_container
+run_setup "$(< .setup_progress)" $@


### PR DESCRIPTION
## Product Description
Our current process for a new developer is a long, error-prone process with many caveats.  This is a first attempt to try to streamline this. On a completely fresh machine, this will allow  a user to get a working HQ setup in ~10 minutes through:
`sudo setup/setup.sh`, starting containers when prompted, and then typing 'ready'

The script has a rudimentary way to select the container runtime.  Leaving out any arguments defaults to podman. Ideally, executing `sudo setup/setup.sh docker` will install docker instead, although anything other than `podman` will do so.  As I found no good way to make the user's environment aware of the new docker group, the docker setup involves a restart. I believe that the script can now resume from where it previously left off, but I have not tested the restart for docker yet.

This workflow is not enforced, although I would like us to eventually migrate to "one right way" for all of our installations.

## Safety Assurance

### Safety story
This isn't required. Hopefully standardization eventually makes things more safe and reliable

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
