### PR TITLE
Handle request failure on disbursement runs

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -3,12 +3,14 @@ hqDefine("geospatial/js/geospatial_map", [
     "hqwebapp/js/initial_page_data",
     "knockout",
     'geospatial/js/models',
+    'hqwebapp/js/bootstrap3/alert_user',
     'select2/dist/js/select2.full.min',
 ], function (
     $,
     initialPageData,
     ko,
-    models
+    models,
+    alertUser
 ) {
     const caseMarkerColors = {
         'default': "#808080", // Gray
@@ -146,6 +148,12 @@ hqDefine("geospatial/js/geospatial_map", [
                     } else {
                         self.handleDisbursementResults(ret['result']);
                     }
+                },
+                error: function () {
+                    alertUser.alert_user(
+                        gettext("Oops! Something went wrong! Please contact admin if the problem persists."), 'danger'
+                    );
+                    self.setBusy(false);
                 },
             });
         };


### PR DESCRIPTION
## Product Description
#### Before
When the Road Network disbursement algorithm is run on staging the request fails because the mapbox token does not seem to allow for the specific feature required. This failure was not reported on the UI, so from the user's perspective the algorithm still seems to be computing.   

#### Now
When the request fails the UI is updated to show a somewhat generic error message. 

I'm still to look into either updating the current mapbox token or generating a new token specifically for the disbursement runs (will do in another PR).

## Technical Summary

## Feature Flag
Geospatial

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
No auto-tests

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
