### PR TITLE
Removed formplayer status icon from Web Apps questions

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -707,9 +707,6 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.dirty = ko.computed(function () {
             return self.pendingAnswer() !== constants.NO_PENDING_ANSWER;
         });
-        self.clean = ko.computed(function () {
-            return !self.dirty() && !self.error() && !self.serverError() && self.hasAnswered;
-        });
         self.hasError = ko.computed(function () {
             return (self.error() || self.serverError()) && !self.dirty();
         });

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -252,11 +252,6 @@
       <!-- /ko -->
     </label>
     <div class="widget-container controls" data-bind="css: controlWidth">
-      <div class="loading">
-        <i class="fa fa-check text-success" data-bind="visible: clean "></i>
-        <i class="fa fa-spin fa-refresh" data-bind="visible: dirty"></i>
-        <i class="fa fa-warning text-danger clickable" data-bind="visible: hasError, click: triggerAnswer"></i>
-      </div>
       <div class="widget" data-bind="
                 template: { name: entryTemplate, data: entry, afterRender: afterRender },
                 css: { 'has-error': hasError }

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -15,9 +15,6 @@
     }
   }
 
-  .loading {
-    right: 20px;
-  }
   .controls {
     padding-right: 25px;
     padding-top: 3px;


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-3866

Marking "don't merge" because this is waiting on cross-divisional communication. Copying the rationale from [that](https://docs.google.com/document/d/1IDYrIh2hIz8fWpG1cKfZoxcVsobvjfwz8iNvKcvhO0Q/edit): 

The issue originally raised by a client is that the green checkmark is weird and unnecessary. This was highlighted on a checkbox question, which is fair - users understand the check largely as a "validation passed" message, but there’s no way for that question type to be invalid.

I'm expanding this request to remove the X and spinner as well as the checkmark, for all question types, because this interaction exposes more of the underlying implementation than necessary and is more likely confusing than useful. Users don't need to pay attention to every single formplayer request.


## Safety Assurance

### Safety story
This is a visible change in a critical UI, but it's a pretty small change.

It's going to be on staging for at least a week due to cross-divisional communication.

I removed the `clean` observable and `loading` class based on grepping.

### Automated test coverage

no

### QA Plan

no



### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
