### PR TITLE
Reduce chunksize when importing Applications, LinkedApplications, RemoteApps

### DIFF
--- a/corehq/apps/dump_reload/couch/load.py
+++ b/corehq/apps/dump_reload/couch/load.py
@@ -3,6 +3,7 @@ from collections import Counter
 
 from couchdbkit.exceptions import ResourceNotFound
 
+from corehq.apps.app_manager.models import Application, LinkedApplication, RemoteApp
 from corehq.apps.dump_reload.exceptions import DataExistsException
 from corehq.apps.dump_reload.interface import DataLoader
 from corehq.util.couch import (
@@ -53,7 +54,10 @@ class CouchDataLoader(DataLoader):
             if couch_db is None:
                 raise DocumentClassNotFound('No Document class with name "{}" could be found.'.format(doc_type))
             callback = LoaderCallback(self._success_counter, self.stdout)
-            db = IterDB(couch_db, new_edits=False, callback=callback)
+            chunksize = 100
+            if doc_type in [Application._doc_type, LinkedApplication._doc_type, RemoteApp._doc_type]:
+                chunksize = 1
+            db = IterDB(couch_db, new_edits=False, callback=callback, chunksize=chunksize)
             db.__enter__()
             self._dbs[doc_type] = db
         return self._dbs[doc_type]

--- a/corehq/util/couch.py
+++ b/corehq/util/couch.py
@@ -42,9 +42,8 @@ def _get_document_or_not_found_lite(cls, doc_id):
 def get_document_or_not_found(cls, domain, doc_id, additional_doc_types=None):
     allowed_doc_types = (additional_doc_types or []) + [cls.__name__]
     unwrapped = _get_document_or_not_found_lite(cls, doc_id)
-    if ((unwrapped.get('domain', None) != domain and
-         domain not in unwrapped.get('domains', [])) or
-        unwrapped['doc_type'] not in allowed_doc_types):
+    if ((unwrapped.get('domain', None) != domain and domain not in unwrapped.get('domains', []))
+       or unwrapped['doc_type'] not in allowed_doc_types):
         raise DocumentNotFound("Document {} of class {} not in domain {}!".format(
             doc_id,
             cls.__name__,
@@ -332,8 +331,8 @@ def iter_update(db, fn, ids, max_retries=3, verbose=False, chunksize=100):
         if iter_db.error_ids:
             if try_num >= max_retries:
                 results.error_ids.update(iter_db.error_ids)
-                msg = ("The following documents did not correctly save:\n" +
-                       ", ".join(results.error_ids))
+                msg = ("The following documents did not correctly save:\n"
+                       + ", ".join(results.error_ids))
                 raise IterUpdateError(results, msg)
             else:
                 _iter_update(iter_db.error_ids, try_num + 1)
@@ -342,8 +341,8 @@ def iter_update(db, fn, ids, max_retries=3, verbose=False, chunksize=100):
     if results.error_ids:
         msg = ("The following docs didn't correctly save.  Are you sure fn {} "
                "returned either None or an instance of DocUpdate?  Did you "
-               "change or remove the '_id' field?".format(fn.__name__) +
-               ", ".join(results.error_ids))
+               "change or remove the '_id' field?".format(fn.__name__)
+               + ", ".join(results.error_ids))
         raise IterUpdateError(results, msg)
 
     if verbose:


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

While using the command [load_domain_data](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/dump_reload/management/commands/load_domain_data.py), a customer ran into a `HTTPError: 413 Client Error: Request Entity Too Large for url` error, likely because it was trying to save a few individual docs within the chunk that were too big. This PR reduces the chunksize requirement when attempting to import doc_types Application, LinkedApplication and RemoteApps.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

This would only affect how many docs get saved to couch at once, so it's pretty safe.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
