### PR TITLE
Add locations fixture for case list filtering

### DIFF
--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -95,3 +95,5 @@ MULTI_SELECT_MAX_SELECT_VALUE = 100
 DEFAULT_PAGE_LIMIT = 10
 
 CALCULATED_SORT_FIELD_RX = r'^_cc_calculated_(\d+)$'
+
+CASE_LIST_FILTER_LOCATIONS_FIXTURE = 'case_list_filter_locations_fixture'

--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -96,4 +96,4 @@ DEFAULT_PAGE_LIMIT = 10
 
 CALCULATED_SORT_FIELD_RX = r'^_cc_calculated_(\d+)$'
 
-CASE_LIST_FILTER_LOCATIONS_FIXTURE = 'case_list_filter_locations_fixture'
+CASE_LIST_FILTER_LOCATIONS_FIXTURE = 'Locations Fixture'

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -194,7 +194,11 @@ class DetailContributor(SectionContributor):
             if len(d.details):
                 helper = EntriesHelper(self.app)
                 datums = helper.get_datum_meta_module(module)
-                d.variables.extend([DetailVariable(name=datum.id, function=datum.datum.value) for datum in datums])
+                d.variables.extend([
+                    DetailVariable(name=datum.id, function=datum.datum.value)
+                    for datum in datums
+                    if datum.action != 'fixture_select'  # FixtureSelect isn't supported under variables
+                ])
                 return d
             else:
                 return None

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -197,7 +197,9 @@ class DetailContributor(SectionContributor):
                 d.variables.extend([
                     DetailVariable(name=datum.id, function=datum.datum.value)
                     for datum in datums
-                    if datum.action != 'fixture_select'  # FixtureSelect isn't supported under variables
+                    # FixtureSelect isn't supported under variables
+                    # More context here: https://github.com/dimagi/commcare-hq/pull/33769#discussion_r1410315708
+                    if datum.action != 'fixture_select'
                 ])
                 return d
             else:

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -27,7 +27,7 @@ import attr
 from memoized import memoized
 
 from corehq.apps.app_manager import id_strings
-from corehq.apps.app_manager.const import USERCASE_ID, USERCASE_TYPE
+from corehq.apps.app_manager.const import CASE_LIST_FILTER_LOCATIONS_FIXTURE, USERCASE_ID, USERCASE_TYPE
 from corehq.apps.app_manager.exceptions import (
     FormNotFoundException,
     ParentModuleReferenceError,
@@ -593,10 +593,14 @@ class EntriesHelper(object):
 
             fixture_select_filter = ''
             if datum['module'].fixture_select.active:
+                if datum['module'].fixture_select.fixture_type == CASE_LIST_FILTER_LOCATIONS_FIXTURE:
+                    nodeset = XPath("instance('locations')/locations")
+                else:
+                    nodeset = ItemListFixtureXpath(datum['module'].fixture_select.fixture_type).instance()
                 datums.append(FormDatumMeta(
                     datum=SessionDatum(
                         id=id_strings.fixture_session_var(datum['module']),
-                        nodeset=ItemListFixtureXpath(datum['module'].fixture_select.fixture_type).instance(),
+                        nodeset=nodeset,
                         value=datum['module'].fixture_select.variable_column,
                         detail_select=id_strings.fixture_detail(detail_module)
                     ),

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -594,7 +594,7 @@ class EntriesHelper(object):
             fixture_select_filter = ''
             if datum['module'].fixture_select.active:
                 if datum['module'].fixture_select.fixture_type == CASE_LIST_FILTER_LOCATIONS_FIXTURE:
-                    nodeset = XPath("instance('locations')/locations")
+                    nodeset = XPath("instance('locations')/locations/location")
                 else:
                     nodeset = ItemListFixtureXpath(datum['module'].fixture_select.fixture_type).instance()
                 datums.append(FormDatumMeta(

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -48,6 +48,7 @@ from corehq.apps.app_manager.xpath import (
     CaseIDXPath,
     ItemListFixtureXpath,
     ProductInstanceXpath,
+    LocationInstanceXpath,
     UsercaseXPath,
     XPath,
     interpolate_xpath,
@@ -594,7 +595,7 @@ class EntriesHelper(object):
             fixture_select_filter = ''
             if datum['module'].fixture_select.active:
                 if datum['module'].fixture_select.fixture_type == CASE_LIST_FILTER_LOCATIONS_FIXTURE:
-                    nodeset = XPath("instance('locations')/locations/location")
+                    nodeset = LocationInstanceXpath().instance()
                 else:
                     nodeset = ItemListFixtureXpath(datum['module'].fixture_select.fixture_type).instance()
                 datums.append(FormDatumMeta(

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -2,7 +2,7 @@ from django.test import SimpleTestCase
 
 from unittest.mock import patch
 
-from corehq.apps.app_manager.const import AUTO_SELECT_USERCASE
+from corehq.apps.app_manager.const import AUTO_SELECT_USERCASE, CASE_LIST_FILTER_LOCATIONS_FIXTURE
 from corehq.apps.app_manager.models import (
     AdvancedModule,
     AdvancedOpenCaseAction,
@@ -21,7 +21,7 @@ from corehq.apps.app_manager.models import (
     ReportModule,
 )
 from corehq.apps.app_manager.views.modules import (
-    _get_fixture_columns_by_type,
+    _get_fixture_columns_options,
     _update_search_properties,
 )
 from corehq.apps.app_manager.util import purge_report_from_mobile_ucr
@@ -106,15 +106,21 @@ class ModuleTests(SimpleTestCase):
             "text": {"en": "you shall not pass"},
         }])
 
-    def test_get_fixture_columns_by_type(self):
+    def test_get_fixture_columns_options(self):
         table = LookupTable(
             domain="module-domain",
             tag="duck",
             fields=[TypeField(name="wing")]
         )
         with patch.object(LookupTable.objects, "by_domain", lambda domain: [table]):
-            result = _get_fixture_columns_by_type("module-domain")
-            self.assertEqual(result, {"duck": ["wing"]})
+            result = _get_fixture_columns_options("module-domain")
+            self.assertDictEqual(
+                result,
+                {
+                    CASE_LIST_FILTER_LOCATIONS_FIXTURE: ['location/@id', 'location/name'],
+                    "duck": ["wing"]
+                }
+            )
 
 
 class AdvancedModuleTests(SimpleTestCase):
@@ -352,7 +358,10 @@ class OverwriteCaseSearchConfigTests(SimpleTestCase):
 
     def test_overwrite_default_properties(self):
         self.dest_module.search_config = CaseSearch()
-        self.dest_module.search_config.overwrite_attrs(self.src_module.search_config, ["search_default_properties"])
+        self.dest_module.search_config.overwrite_attrs(
+            self.src_module.search_config,
+            ["search_default_properties"]
+        )
         self.assertEqual(
             self.src_module.search_config.to_json()["default_properties"],
             self.dest_module.search_config.to_json()["default_properties"]

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -117,7 +117,7 @@ class ModuleTests(SimpleTestCase):
             self.assertDictEqual(
                 result,
                 {
-                    CASE_LIST_FILTER_LOCATIONS_FIXTURE: ['location/@id', 'location/name'],
+                    CASE_LIST_FILTER_LOCATIONS_FIXTURE: ['location/@id', 'location/name', 'location/site_code'],
                     "duck": ["wing"]
                 }
             )

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -117,7 +117,7 @@ class ModuleTests(SimpleTestCase):
             self.assertDictEqual(
                 result,
                 {
-                    CASE_LIST_FILTER_LOCATIONS_FIXTURE: ['location/@id', 'location/name', 'location/site_code'],
+                    CASE_LIST_FILTER_LOCATIONS_FIXTURE: ['@id', 'name', 'site_code'],
                     "duck": ["wing"]
                 }
             )

--- a/corehq/apps/app_manager/tests/test_suite_fixture_to_case_selection.py
+++ b/corehq/apps/app_manager/tests/test_suite_fixture_to_case_selection.py
@@ -32,8 +32,8 @@ class SuiteAssertionsTest(SimpleTestCase, SuiteMixin):
         module, form = factory.new_basic_module('my_module', 'cases')
         module.fixture_select.active = True
         module.fixture_select.fixture_type = CASE_LIST_FILTER_LOCATIONS_FIXTURE
-        module.fixture_select.display_column = 'location/name'
-        module.fixture_select.variable_column = 'location/@id'
+        module.fixture_select.display_column = 'name'
+        module.fixture_select.variable_column = '@id'
         module.fixture_select.xpath = 'case_location_id=$fixture_value'
 
         factory.form_requires_case(form)
@@ -43,7 +43,7 @@ class SuiteAssertionsTest(SimpleTestCase, SuiteMixin):
         expected_xml = """
             <partial>
                 <datum detail-select="m0_fixture_select" id="fixture_value_m0"
-                  nodeset="instance('locations')/locations" value="location/@id"/>
+                  nodeset="instance('locations')/locations/location" value="@id"/>
             </partial>
         """
         self.assertXmlPartialEqual(expected_xml, suite_xml, "./entry/session/datum[1]")

--- a/corehq/apps/app_manager/tests/test_suite_fixture_to_case_selection.py
+++ b/corehq/apps/app_manager/tests/test_suite_fixture_to_case_selection.py
@@ -1,9 +1,9 @@
 from django.test import SimpleTestCase
 
+from corehq.apps.app_manager.const import CASE_LIST_FILTER_LOCATIONS_FIXTURE
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
-    TestXmlMixin,
     patch_get_xform_resource_overrides,
 )
 
@@ -25,6 +25,35 @@ class SuiteAssertionsTest(SimpleTestCase, SuiteMixin):
         factory.form_requires_case(form)
 
         self.assertXmlEqual(self.get_xml('fixture-to-case-selection'), factory.app.create_suite())
+
+    def test_location_fixture_type(self, *args):
+        factory = AppFactory(build_version='2.9.0')
+
+        module, form = factory.new_basic_module('my_module', 'cases')
+        module.fixture_select.active = True
+        module.fixture_select.fixture_type = CASE_LIST_FILTER_LOCATIONS_FIXTURE
+        module.fixture_select.display_column = 'location/name'
+        module.fixture_select.variable_column = 'location/@id'
+        module.fixture_select.xpath = 'case_location_id=$fixture_value'
+
+        factory.form_requires_case(form)
+
+        suite_xml = factory.app.create_suite()
+
+        expected_xml = """
+            <partial>
+                <datum detail-select="m0_fixture_select" id="fixture_value_m0"
+                  nodeset="instance('locations')/locations" value="location/@id"/>
+            </partial>
+        """
+        self.assertXmlPartialEqual(expected_xml, suite_xml, "./entry/session/datum[1]")
+
+        # ensure locations fixture is included
+        self.assertXmlPartialEqual(
+            '<partial><instance id="locations" src="jr://fixture/locations"/></partial>',
+            suite_xml,
+            "./entry/instance[3]"
+        )
 
     def test_fixture_to_case_selection_with_form_filtering(self, *args):
         factory = AppFactory(build_version='2.9.0')

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -216,10 +216,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
         if case_list_map_enabled or not option_to_config[1]['has_map']
     ]
 
-    fixture_column_options = _get_fixture_columns_by_type(app.domain)
-    fixture_column_options[CASE_LIST_FILTER_LOCATIONS_FIXTURE] = [
-        'location/@id', 'location/name'
-    ]
+    fixture_column_options = _get_fixture_columns_options(app.domain)
 
     context = {
         'details': _get_module_details_context(request, app, module, case_property_builder),
@@ -427,6 +424,14 @@ def _get_report_module_context(app, module):
         'uuids_by_instance_id': get_uuids_by_instance_id(app),
     }
     return context
+
+
+def _get_fixture_columns_options(domain):
+    fixture_column_options = _get_fixture_columns_by_type(domain)
+    fixture_column_options[CASE_LIST_FILTER_LOCATIONS_FIXTURE] = [
+        'location/@id', 'location/name'
+    ]
+    return fixture_column_options
 
 
 def _get_fixture_columns_by_type(domain):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -31,6 +31,7 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
     ParentCasePropertyBuilder,
 )
 from corehq.apps.app_manager.const import (
+    CASE_LIST_FILTER_LOCATIONS_FIXTURE,
     MOBILE_UCR_VERSION_1,
     REGISTRY_WORKFLOW_LOAD_CASE,
     REGISTRY_WORKFLOW_SMART_LINK,
@@ -215,6 +216,11 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
         if case_list_map_enabled or not option_to_config[1]['has_map']
     ]
 
+    fixture_column_options = _get_fixture_columns_by_type(app.domain)
+    fixture_column_options[CASE_LIST_FILTER_LOCATIONS_FIXTURE] = [
+        'location/@id', 'location/name'
+    ]
+
     context = {
         'details': _get_module_details_context(request, app, module, case_property_builder),
         'case_list_form_options': _case_list_form_options(app, module, lang),
@@ -230,7 +236,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             (REGISTRY_WORKFLOW_SMART_LINK, _("Smart link to external domain")),
         ),
         'js_options': {
-            'fixture_columns_by_type': _get_fixture_columns_by_type(app.domain),
+            'fixture_columns_by_type': fixture_column_options,
             'is_search_enabled': case_search_enabled_for_domain(app.domain),
             'search_prompt_appearance_enabled': app.enable_search_prompt_appearance,
             'has_geocoder_privs': (

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -429,7 +429,7 @@ def _get_report_module_context(app, module):
 def _get_fixture_columns_options(domain):
     fixture_column_options = _get_fixture_columns_by_type(domain)
     fixture_column_options[CASE_LIST_FILTER_LOCATIONS_FIXTURE] = [
-        'location/@id', 'location/name', 'location/site_code'
+        '@id', 'name', 'site_code'
     ]
     return fixture_column_options
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -429,7 +429,7 @@ def _get_report_module_context(app, module):
 def _get_fixture_columns_options(domain):
     fixture_column_options = _get_fixture_columns_by_type(domain)
     fixture_column_options[CASE_LIST_FILTER_LOCATIONS_FIXTURE] = [
-        'location/@id', 'location/name'
+        'location/@id', 'location/name', 'location/site_code'
     ]
     return fixture_column_options
 

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -426,6 +426,11 @@ class SearchSelectedCasesInstanceXpath(InstanceXpath):
         return self or self.default_id
 
 
+class LocationInstanceXpath(InstanceXpath):
+    id = 'locations'
+    path = 'locations/location'
+
+
 class CommCareSession(object):
     username = SessionInstanceXpath().instance().slash("username")
     userid = SessionInstanceXpath().instance().slash("userid")


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
In order to improve on case list load time for a project we needed a filter before the case list. 
There was a feature flag built for an old (now archived) project, that let app configuration on HQ to choose a Lookup Table and provide data from it as a filter for case list, so that the cases are filtered even before they are shown on the list.

This PR simply extends that existing feature to allow using locations as a filter as well.
Location name, location's ID and site code are available as options for display in the filter and the value to filter the cases on.

One bug was fixed. 
When tabs were used in the Case Detail, the filter datum got added in the variables node, where it broke the app, so the filter's datum was simply skipped.

No changes/updates were made to the implementation of the filter.

Pending: [Non blocking] There should be an update to the feature flag type (Custom for now) and its description. I am trying to understand what that should be. I can take that in a follow up PR as well.

Working example can be found [here](https://staging.commcarehq.org/a/ccqa-mk/apps/view/74879b6ffc577ce07f550305a1668e67/module/02ea0fd7963d494f8dcdf07a41259a83/#case-detail-screen-config-tab)

![Screenshot from 2023-11-30 13-58-19](https://github.com/dimagi/commcare-hq/assets/3864163/8ade57f5-76cf-4cce-b879-0e19319ccf0f)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-3215)
https://docs.google.com/document/d/197IXggjsuNrPOXVKDy4qhrLRNxVzlNYz-qCxPz2D6_Q/edit#heading=h.dc3vdbw2j8z8


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`FIXTURE_CASE_SELECTION`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local Testing.
All changes are limited to the feature flag so this should not impact anything outside the feature flag and even the functionality of the feature should continue to work as expected. I checked on production & india and its hard to tell if there are any live projects using this feature flag, but, even if they are, this change should not break anything for them.
A UAT was also done so QA was not requested.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests for the changes made

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
