### PR TITLE
Updated label question styling in web apps

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -285,9 +285,9 @@
                     }">{% trans 'Sorry, this response is required!' %}</div>
   <!-- /ko -->
   <!-- ko if: datatype() === 'info' -->
-  <div class="info panel panel-default">
+  <div class="form-group">
     {# appearance attributes TEXT_ALIGN_CENTER TEXT_ALIGN_RIGHT #}
-    <div class="panel-body" data-bind="css: {
+    <div class="info col-sm-12" data-bind="css: {
         'text-center': stylesContains('text-align-center'),
         'text-right': stylesContains('text-align-right'),
       }">

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -51,13 +51,21 @@
   }
 
   .info {
-    .panel-body {
-      overflow-x: auto;
-      @media (max-width: @screen-xs-max) {
-        padding-left: @form-text-indent + 5px;
-        padding-right: @form-text-indent + 5px;
-      }
-    }
+    // Use similar border styling to .panel-default
+    border: solid 1px #ddd;
+    border-radius: 4px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+
+    // Add padding to give space between content and border
+    padding-top: 15px;
+    padding-bottom: 15px;
+
+    // Give enough padding between border and content, while
+    // keeping text aligned with regular questions above/below
+    margin-left: -10px;
+    padding-left: 20px;
+
+    overflow-x: auto;
   }
 
   .gr-header {
@@ -133,19 +141,6 @@
     border: none;
   }
 
-}
-
-
-.question-container .gr .children {
-  .info.panel-default {
-    border: none;
-    background-color: transparent;
-    .box-shadow(none);
-
-    .panel-body {
-      padding-top: 6px;
-    }
-  }
 }
 
 @media print {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -51,20 +51,6 @@
   }
 
   .info {
-    // Use similar border styling to .panel-default
-    border: solid 1px #ddd;
-    border-radius: 4px;
-    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
-
-    // Add padding to give space between content and border
-    padding-top: 15px;
-    padding-bottom: 15px;
-
-    // Give enough padding between border and content, while
-    // keeping text aligned with regular questions above/below
-    margin-left: -10px;
-    padding-left: 20px;
-
     overflow-x: auto;
   }
 


### PR DESCRIPTION
## Product Description

Prior to this change, labels at the top level of the form were displayed within a border, while those in any kind of group had no border, and in collapsible sections, label text would be misaligned with other question text.

The border inconsistency was intentional, to match the mobile UI for a particular project (see https://github.com/dimagi/commcare-hq/pull/24041), but it's now more important for forms to be internally visually consistent on Web Apps than it is for them to match mobile.

<img width="1193" alt="Screen Shot 2023-11-16 at 10 11 38 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/1c5d5314-58e3-47b9-bf2c-1960c81aa825">
<img width="1195" alt="Screen Shot 2023-11-16 at 10 12 05 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/b4b10632-5a53-4f2a-99db-086b1672c771">

Now, labels at the top level of the form no longer have borders, and labels within collapsible sections have their text properly aligned with other question labels.
<img width="1195" alt="Screen Shot 2023-11-20 at 1 56 32 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/2993bb4b-d423-4a41-802e-180ba60c5d97">
<img width="1189" alt="Screen Shot 2023-11-20 at 1 57 02 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/c454e2ca-1579-41c1-97d2-f63039892285">

## Safety Assurance

### Safety story
Highly visible UI, but just a styling change. Styling changes are limited to label questions.

### Automated test coverage

no

### QA Plan

Not requesting QA, but deploying to staging today and not anticipating merging for another week, and there's app building happening on staging.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
