### PR TITLE
Ensure default settings are imported before localsettings import

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1042,6 +1042,8 @@ COMMCARE_NAME = {
     "default": "CommCare",
 }
 
+ALLOW_MAKE_SUPERUSER_COMMAND = True
+
 ENTERPRISE_MODE = False
 
 RESTRICT_DOMAIN_CREATION = False
@@ -1232,8 +1234,6 @@ for database in DATABASES.values():
 _location = lambda x: os.path.join(FILEPATH, x)
 
 IS_SAAS_ENVIRONMENT = SERVER_ENVIRONMENT in ('production', 'staging')
-
-ALLOW_MAKE_SUPERUSER_COMMAND = True
 
 if 'KAFKA_URL' in globals():
     import warnings

--- a/settings.py
+++ b/settings.py
@@ -1151,6 +1151,9 @@ FCM_CREDS = None
 
 CONNECTID_USERINFO_URL = 'http://localhost:8080/o/userinfo'
 
+# used by periodic tasks that delete soft deleted data older than PERMANENT_DELETION_WINDOW days
+PERMANENT_DELETION_WINDOW = 30  # days
+
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)
@@ -2089,5 +2092,3 @@ GOOGLE_SHEETS_API_NAME = "sheets"
 GOOGLE_SHEETS_API_VERSION = "v4"
 
 DAYS_KEEP_GSHEET_STATUS = 14
-
-PERMANENT_DELETION_WINDOW = 30  # days

--- a/settings.py
+++ b/settings.py
@@ -2089,3 +2089,5 @@ os.environ['DD_TRACE_STARTUP_LOGS'] = os.environ.get('DD_TRACE_STARTUP_LOGS', 'F
 
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 
+# NOTE: if you are adding a new setting that you intend to have other environments override,
+# make sure you add it before localsettings are imported (from localsettings import *)

--- a/settings.py
+++ b/settings.py
@@ -1156,6 +1156,13 @@ CONNECTID_USERINFO_URL = 'http://localhost:8080/o/userinfo'
 # used by periodic tasks that delete soft deleted data older than PERMANENT_DELETION_WINDOW days
 PERMANENT_DELETION_WINDOW = 30  # days
 
+# GSheets related work that was dropped, but should be picked up in the near future
+GOOGLE_OATH_CONFIG = {}
+GOOGLE_OAUTH_SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
+GOOGLE_SHEETS_API_NAME = "sheets"
+GOOGLE_SHEETS_API_VERSION = "v4"
+DAYS_KEEP_GSHEET_STATUS = 14
+
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)
@@ -2082,13 +2089,3 @@ os.environ['DD_TRACE_STARTUP_LOGS'] = os.environ.get('DD_TRACE_STARTUP_LOGS', 'F
 
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 
-# Config settings for the google oauth handshake to get a user token
-# Google Cloud Platform secret settings config file
-GOOGLE_OATH_CONFIG = {}
-# Scopes to give read/write access to the code that generates the spreadsheets
-GOOGLE_OAUTH_SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
-
-GOOGLE_SHEETS_API_NAME = "sheets"
-GOOGLE_SHEETS_API_VERSION = "v4"
-
-DAYS_KEEP_GSHEET_STATUS = 14


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
When I first added this setting, I did not realize that adding it at the bottom of the file would be localsettings would not be able to override it. In the event we want to change this depending on the environment, this setting should exist before localsettings are imported.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The setting and value have remained the exact same, but just moved to earlier in the file. I confirmed that commcare-cloud has no mention of this setting, meaning it isn't currently being overridden anywhere which makes this change especially safe.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
