### PR TITLE
Reduced vertical padding for web apps page header

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/content.less
@@ -34,6 +34,7 @@ body {
     color: @cc-neutral-mid;
     padding-left: 1.5rem;
     font-weight: bold;
+    margin-top: 0px;
   }
 }
 

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -8,7 +8,8 @@
   font-size: @font-size-base;   // Don't overshadow inputs
 
   .page-header {
-    padding-bottom: 30px;
+    padding-top: 0px;
+    padding-bottom: 0px;
 
     h1 {
       padding-left: @form-text-indent - 5px;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -8,8 +8,7 @@
   font-size: @font-size-base;   // Don't overshadow inputs
 
   .page-header {
-    padding-top: 0px;
-    padding-bottom: 0px;
+    padding-bottom: 30px;
 
     h1 {
       padding-left: @form-text-indent - 5px;


### PR DESCRIPTION
## Product Description
Something of a followup for https://github.com/dimagi/commcare-hq/pull/33747 : reduce the whitespace above and below the page header (e.g., the form name).

## Safety Assurance

### Safety story
Minor styling change. I clicked through the various web apps screens - form, menu, case list, case search, settings, Login As, incomplete forms - and they all look reasonable.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
