### PR TITLE
Added markdown support to collapsible header sections in Web Apps

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -46,7 +46,7 @@
               css: {'fa-angle-double-right': !showChildren(), 'fa-angle-double-down': showChildren()},
           "></i>
         </div>
-        <span class="caption" data-bind="html: caption(), attr: {id: captionId()}"></span><!-- Markdown interferes with header styling -->
+        <span class="webapp-markdown-output caption" data-bind="html: caption_markdown(), attr: {id: captionId()}"></span>
         <i class="fa fa-warning text-danger pull-right" data-bind="visible: hasError() && !showChildren()"></i>
         <button class="btn btn-danger del pull-right" href="#" data-bind="
                     visible: isRepetition,


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-3888

This was intentionally unsupported (see https://github.com/dimagi/commcare-hq/commit/ec4115f7284162f8612abd5775a204e9c5c7ee4f), I believe primarily because of the way that header margins change the size of the header:

<img width="1182" alt="Screen Shot 2023-11-20 at 7 35 17 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/8c7fa127-b9bf-4a49-bb99-c263a9c96ebb">

However, I'm adding support, because there are plenty of useful ways to apply markdown to section headers, and putting the responsibility on app builders to test their particular content.

## Safety Assurance

### Safety story
Minor UI change.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
