### PR TITLE
Remove unused datatables extension libraries and dt style library

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
         "datatables-fixedheader": "DataTables/FixedHeader#^3.1.3",
         "datatables-scroller": "DataTables/Scroller#^1.5.1",
         "datatables.net": "1.11.3",
-        "datatables.net-dt": "1.11.3",
         "detectrtc": "1.4.0",
         "eonasdan-bootstrap-datetimepicker": "4.17.49",
         "fast-levenshtein": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "datatables-bootstrap3": "Jowin/Datatables-Bootstrap3",
         "datatables-colreorder": "DataTables/ColReorder#^1.5.1",
         "datatables-fixedcolumns": "DataTables/FixedColumns#3.2.0",
-        "datatables-fixedheader": "DataTables/FixedHeader#^3.1.3",
         "datatables-scroller": "DataTables/Scroller#^1.5.1",
         "datatables.net": "1.11.3",
         "detectrtc": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
         "d3": "3.5.17",
         "datamaps": "0.5.9",
         "datatables-bootstrap3": "Jowin/Datatables-Bootstrap3",
-        "datatables-buttons": "DataTables/Buttons#^1.5.6",
         "datatables-colreorder": "DataTables/ColReorder#^1.5.1",
         "datatables-fixedcolumns": "DataTables/FixedColumns#3.2.0",
         "datatables-fixedheader": "DataTables/FixedHeader#^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,10 +1364,6 @@ datatables-bootstrap3@Jowin/Datatables-Bootstrap3:
   version "0.0.0"
   resolved "https://codeload.github.com/Jowin/Datatables-Bootstrap3/tar.gz/45802ec4d337bdba6750f03b6472ddbb1d34608c"
 
-datatables-buttons@DataTables/Buttons#^1.5.6:
-  version "0.0.0"
-  resolved "https://codeload.github.com/DataTables/Buttons/tar.gz/5e51cec85d3b3ffc467c8d213592927a590a80ae"
-
 datatables-colreorder@DataTables/ColReorder#^1.5.1:
   version "0.0.0"
   resolved "https://codeload.github.com/DataTables/ColReorder/tar.gz/f0e558a1f38919fa95d82700aeea7ce3ca6fbfd5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,10 +1372,6 @@ datatables-fixedcolumns@DataTables/FixedColumns#3.2.0:
   version "0.0.0"
   resolved "https://codeload.github.com/DataTables/FixedColumns/tar.gz/a87428accba62d881e14fa2710bcc035a6efbbb6"
 
-datatables-fixedheader@DataTables/FixedHeader#^3.1.3:
-  version "0.0.0"
-  resolved "https://codeload.github.com/DataTables/FixedHeader/tar.gz/314b2ee32502c1ecc82c7a37e7bfa0f1eea92a23"
-
 datatables-scroller@DataTables/Scroller#^1.5.1:
   version "0.0.0"
   resolved "https://codeload.github.com/DataTables/Scroller/tar.gz/7dc5c7a56c7797677b224cff4be0a3a18604cc75"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,15 +1384,7 @@ datatables-scroller@DataTables/Scroller#^1.5.1:
   version "0.0.0"
   resolved "https://codeload.github.com/DataTables/Scroller/tar.gz/7dc5c7a56c7797677b224cff4be0a3a18604cc75"
 
-datatables.net-dt@1.11.3:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/datatables.net-dt/-/datatables.net-dt-1.11.3.tgz#242556a490585b457b7d2b9f5fd8fb10761d621b"
-  integrity sha512-EX/thRwXpQRj8hZSb+ZMDNQ4uW1zLZa9BoAhhw1b5HIDH1nJ9WRTkERsoxE+3WISeX8bDiaEydf8TTQBSqxXVw==
-  dependencies:
-    datatables.net ">=1.10.25"
-    jquery ">=1.7"
-
-datatables.net@1.11.3, datatables.net@>=1.10.25:
+datatables.net@1.11.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.11.3.tgz#80e691036efcd62467558ee64c07dd566cb761b4"
   integrity sha512-VMj5qEaTebpNurySkM6jy6sGpl+s6onPK8xJhYr296R/vUBnz1+id16NVqNf9z5aR076OGcpGHCuiTuy4E05oQ==


### PR DESCRIPTION
## Technical Summary
This removes the following datatables extensions that are not referenced anywhere in the codebase:
- `FixedHeader`
- `Button`

It's likely they were being used for custom reports in the past, but after those reports were decommissioned we forgot to delete any supporting dependencies that were no longer referenced. By the way, all of these are the bootstrap 3 versions and super old bower repos so...very happy to have them out of `package.json`!

Additionally, this PR removes the unused `datatables.net-dt` **style only** library which is not referenced anywhere in the codebase. The bootstrap 5 upgrade requires the b5 version, as this library is the default datatables style.

## Safety Assurance

### Safety story
Feels like a very safe change as I searched for references to the paths to these dependencies and found none, apart from `package.json`. I'm also putting this on staging as a way of double-checking this finding.

### Automated test coverage
No

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
