### PR TITLE
Customize text of “Clear” button for file uploads in Web Apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -504,6 +504,19 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             });
         };
 
+        self.getTranslation = function (translationKey, defaultTranslation) {
+            // Find the root level element which contains the translations.
+            var translations = self.translations;
+
+            if (translations) {
+                var translationText = ko.toJS(translations[translationKey]);
+                if (translationText) {
+                    return translationText;
+                }
+            }
+            return defaultTranslation;
+        };
+
         self.afterRender = function () {
             $(document).on("click", ".help-text-trigger", function (event) {
                 event.preventDefault();
@@ -669,20 +682,6 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             $.publish('formplayer.' + constants.NEW_REPEAT, self);
             $.publish('formplayer.dirty');
             $('.add').trigger('blur');
-        };
-
-        self.getTranslation = function (translationKey, defaultTranslation) {
-            // Find the root level element which contains the translations.
-            var curParent = getParentForm(self);
-            var translations = curParent.translations;
-
-            if (translations) {
-                var addNewRepeatTranslation = ko.toJS(translations[translationKey]);
-                if (addNewRepeatTranslation) {
-                    return addNewRepeatTranslation;
-                }
-            }
-            return defaultTranslation;
         };
     }
     Repeat.prototype = Object.create(Container.prototype);

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -438,8 +438,10 @@
             accept: accept,
         },
     "/>
-  <button class="btn btn-default btn-xs pull-right" data-bind="click: onClear">
-    {% trans "Clear" %}
+  <button class="btn btn-default btn-xs pull-right" data-bind="
+    click: onClear,
+    text: $root.getTranslation('upload.clear.title', '{% trans_html_attr 'Clear' %}'),
+  ">
   </button>
 </script>
 

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -333,7 +333,7 @@
               data-bind="click: newRepeat"
               id="repeat-add-new">
               <i class="fa fa-plus"></i>
-              <!-- ko text: getTranslation('repeat.dialog.add.new', '{% trans_html_attr 'Add new repeat' %}') --><!-- /ko -->
+              <!-- ko text: $root.getTranslation('repeat.dialog.add.new', '{% trans_html_attr 'Add new repeat' %}') --><!-- /ko -->
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-3867

Allows customization of the "Clear" button at the application level, similarly to how other button text in forms can be configured, such as the button to add a new repeat.

Depends on https://github.com/dimagi/formplayer/pull/1503 and relates to https://github.com/dimagi/commcare-translations/pull/80

## Safety Assurance

### Safety story
Pretty limited footprint.

### Automated test coverage

None

### QA Plan

I'm leaning against requesting QA, but could be pretty easily be persuaded to do so.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
