### PR TITLE
Select Owner on Case Create

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -228,8 +228,9 @@ hqDefine("geospatial/js/gps_capture",[
             const caseToCreate = new dataItemModel(null, self.dataType);
             self.captureLocationForItem(caseToCreate);
 
+            const placeholderStr = `${initialPageData.get('couch_user_username')} (${gettext("current user")})`;
             $("#owner-select").select2({
-                placeholder: gettext('Current User'),
+                placeholder: placeholderStr,
                 cache: true,
                 allowClear: true,
                 delay: 250,

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -4,6 +4,7 @@ hqDefine("geospatial/js/gps_capture",[
     'underscore',
     'hqwebapp/js/initial_page_data',
     "hqwebapp/js/bootstrap3/components.ko", // for pagination
+    'select2/dist/js/select2.full.min',
 ], function (
     $,
     ko,
@@ -12,6 +13,7 @@ hqDefine("geospatial/js/gps_capture",[
 ) {
     'use strict';
     const MAP_CONTAINER_ID = "geospatial-map";
+    const USER_LIMIT = 10;
 
     var map;
     var selectedDataListObject;
@@ -219,6 +221,42 @@ hqDefine("geospatial/js/gps_capture",[
             self.isCreatingCase(true);
             const caseToCreate = new dataItemModel(null, self.dataType);
             self.captureLocationForItem(caseToCreate);
+
+            $("#owner-select").select2({
+                placeholder: gettext('Current User'),
+                cache: true,
+                allowClear: true,
+                delay: 250,
+                ajax: {
+                    url: initialPageData.reverse('paginate_mobile_workers'),
+                    dataType: 'json',
+                    data: function (params) {
+                        return {
+                            query: params.term,
+                            page_limit: USER_LIMIT,
+                            page: params.page,
+                        };
+                    },
+                    processResults: function (data, params) {
+                        params.page = params.page || 1;
+
+                        const hasMore = (params.page * USER_LIMIT) < data.total;
+                        const dataResults = $.map(data.users, function (user) {
+                            return {
+                                text: user.username,
+                                id: user.user_id,
+                            };
+                        });
+
+                        return {
+                            results: dataResults,
+                            pagination: {
+                                more: hasMore,
+                            },
+                        };
+                    },
+                },
+            });
         };
 
         self.finishCreateCase = function () {

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -13,7 +13,7 @@ hqDefine("geospatial/js/gps_capture",[
 ) {
     'use strict';
     const MAP_CONTAINER_ID = "geospatial-map";
-    const USER_LIMIT = 10;
+    const USERS_PER_PAGE = 10;
 
     var map;
     var selectedDataListObject;
@@ -240,14 +240,14 @@ hqDefine("geospatial/js/gps_capture",[
                     data: function (params) {
                         return {
                             query: params.term,
-                            page_limit: USER_LIMIT,
+                            page_limit: USERS_PER_PAGE,
                             page: params.page,
                         };
                     },
                     processResults: function (data, params) {
                         params.page = params.page || 1;
 
-                        const hasMore = (params.page * USER_LIMIT) < data.total;
+                        const hasMore = (params.page * USERS_PER_PAGE) < data.total;
                         const dataResults = $.map(data.users, function (user) {
                             return {
                                 text: user.username,

--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -137,6 +137,7 @@ hqDefine("geospatial/js/gps_capture",[
         self.availableCaseTypes = ko.observableArray([]);
         self.selectedCaseType = ko.observable('');
         self.hasCaseTypeError = ko.observable(false);
+        self.selectedOwnerId = ko.observable(null);
 
         self.captureLocationForItem = function (item) {
             self.itemLocationBeingCapturedOnMap(item);
@@ -187,12 +188,17 @@ hqDefine("geospatial/js/gps_capture",[
             self.goToPage(1);
         };
 
+        self.onOwnerIdChange = function (_, e) {
+            self.selectedOwnerId($(e.currentTarget).select2('val'));
+        };
+
         self.saveDataRow = function (dataItem) {
             self.isSubmissionSuccess(false);
             self.hasSubmissionError(false);
             let dataItemJson = ko.mapping.toJS(dataItem);
             if (self.isCreatingCase()) {
                 dataItemJson['case_type'] = self.selectedCaseType();
+                dataItemJson['owner_id'] = self.selectedOwnerId();
             }
 
             $.ajax({
@@ -279,6 +285,7 @@ hqDefine("geospatial/js/gps_capture",[
             self.hasCreateCaseError(false);
             self.hasCaseTypeError(false);
             self.selectedCaseType('');
+            self.selectedOwnerId(null);
         };
 
         return self;

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -176,6 +176,21 @@
                         </span>
                     </div>
                 </div>
+                <div class="col">
+                    <label class="control-label col-sm-1 col-md-1 col-lg-1">
+                        {% trans 'Owner' %}
+                    </label>
+                    <div class="col-sm-2 col-md-2 col-lg-2">
+                        <select class="form-control"
+                                type="text"
+                                id="owner-select"
+                                data-bind="select2: {},
+                                           optionsText: 'text',
+                                           optionsValue: 'id',
+                                           event: {change: $root.onOwnerIdChange}">
+                        </select>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -146,29 +146,29 @@
             {% trans 'Cancel' %}
         </button>
     {% endif %}
-    <div class="row panel" data-bind="visible: itemLocationBeingCapturedOnMap">
-        <div class="col-sm-5 col-md-5 col-lg-5" data-bind="with: itemLocationBeingCapturedOnMap">
-            <h3>
+    <div class="panel" data-bind="visible: itemLocationBeingCapturedOnMap">
+        <div data-bind="with: itemLocationBeingCapturedOnMap" class="row">
+            <h3 class="col">
                 {% trans "Capturing location for:" %}
                 <span data-bind="text: name"></span>
             </h3>
-            <div data-bind="visible: $root.isCreatingCase">
-                <div class="form-group" data-bind="css: { 'has-error': $root.hasCreateCaseError }">
-                    <label class="control-label col-sm-2 col-md-2 col-lg-2">
+            <div data-bind="visible: $root.isCreatingCase" class="form-row">
+                <div class="col" data-bind="css: { 'has-error': $root.hasCreateCaseError }">
+                    <label class="control-label col-sm-1 col-md-1 col-lg-1">
                         {% trans 'Case Name' %}
                     </label>
-                    <div class="col-sm-4 col-md-4 col-lg-4" >
+                    <div class="col-sm-2 col-md-2 col-lg-2" >
                         <input data-bind="value: name, visible: $root.isCreatingCase" type="text" class="form-control" placeholder="{% trans 'Enter new case name...' %}" />
                         <span class="help-block" data-bind="visible: $root.hasCreateCaseError">
                             {% trans 'A case name is required' %}
                         </span>
                     </div>
                 </div>
-                <div class="form-group" data-bind="css: { 'has-error': $root.hasCaseTypeError }">
-                    <label class="control-label col-sm-2 col-md-2 col-lg-2">
+                <div class="col" data-bind="css: { 'has-error': $root.hasCaseTypeError }">
+                    <label class="control-label col-sm-1 col-md-1 col-lg-1">
                         {% trans 'Case Type' %}
                     </label>
-                    <div class="col-sm-4 col-md-4 col-lg-4">
+                    <div class="col-sm-2 col-md-2 col-lg-2">
                         <select class="form-control" data-bind="select2: $root.availableCaseTypes, value: $root.selectedCaseType">
                         </select>
                         <span class="help-block" data-bind="visible: $root.hasCaseTypeError">

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -180,7 +180,7 @@
                     <label class="control-label col-sm-1 col-md-1 col-lg-1">
                         {% trans 'Owner' %}
                     </label>
-                    <div class="col-sm-2 col-md-2 col-lg-2">
+                    <div class="col-sm-3 col-md-3 col-lg-3">
                         <select class="form-control"
                                 type="text"
                                 id="owner-select"

--- a/corehq/apps/geospatial/templates/gps_capture_view.html
+++ b/corehq/apps/geospatial/templates/gps_capture_view.html
@@ -21,6 +21,7 @@
 {% registerurl 'case_data' domain '---' %}
 {% registerurl 'edit_commcare_user' domain '---' %}
 {% registerurl 'gps_capture' domain %}
+{% registerurl 'paginate_mobile_workers' domain %}
 {% initial_page_data 'case_types_with_gps' case_types_with_gps %}
 
 <ul id="tabs-list" class="nav nav-tabs">

--- a/corehq/apps/geospatial/templates/gps_capture_view.html
+++ b/corehq/apps/geospatial/templates/gps_capture_view.html
@@ -23,6 +23,7 @@
 {% registerurl 'gps_capture' domain %}
 {% registerurl 'paginate_mobile_workers' domain %}
 {% initial_page_data 'case_types_with_gps' case_types_with_gps %}
+{% initial_page_data 'couch_user_username' couch_user_username %}
 
 <ul id="tabs-list" class="nav nav-tabs">
   <li data-bind="click: onclickAction" class="active"><a data-toggle="tab" href="#tabs-cases">{% trans 'Update Case Data' %}</a></li>

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -313,7 +313,7 @@ class GPSCaptureView(BaseDomainView):
 
         if data_type == 'case':
             if create_case:
-                data_item['owner_id'] = request.couch_user.user_id
+                data_item['owner_id'] = data_item['owner_id'] or request.couch_user.user_id
                 create_case_with_gps_property(request.domain, data_item)
             else:
                 set_case_gps_property(request.domain, data_item)

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -280,6 +280,7 @@ class GPSCaptureView(BaseDomainView):
         page_context = {
             'mapbox_access_token': settings.MAPBOX_ACCESS_TOKEN,
             'case_types_with_gps': list(case_types),
+            'couch_user_username': self.request.couch_user.raw_username,
         }
         page_context.update(self._case_filters_context())
         return page_context


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A new "Owner" input field has been added to the create case workflow:
![Screenshot from 2023-11-24 08-22-42](https://github.com/dimagi/commcare-hq/assets/122617251/07bd52eb-824e-4ab3-b6b4-f27e5eae1612)

This dropdown will list the project's mobile workers, and supports a searching functionality:
![Screenshot from 2023-11-23 16-20-06](https://github.com/dimagi/commcare-hq/assets/122617251/612c2027-f25f-47a3-94ca-5e0976899064)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3208).

Currently, when creating a new case on the "Manage GPS Data" page, the owner of the new case will default to the web user that created the case. This PR adds a new dropdown that allows the user to select a mobile worker to be the owner instead. This list is location-safe, and will only show the mobile workers that the user has access to. If the user does not select a mobile worker, then the dropdown defaults to "Current User" in which the web user will be the owner of the case.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Automated tests.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests do exist for the public-facing viewpoint that gets used with the changes from this PR.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
