### PR TITLE
Change KO Pagination Component Button Text

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/ko_pagination.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/ko_pagination.html
@@ -21,7 +21,7 @@
         <li>
           <a href="#"
              data-bind="click: previousPage">
-            <span>&laquo;</span>
+            <span>{% trans 'Previous' %}</span>
           </a>
         </li>
         <!-- ko foreach: pagesShown -->
@@ -37,7 +37,7 @@
         <!-- /ko -->
         <li>
           <a href="#" data-bind="click: nextPage">
-            <span>&raquo;</span>
+            <span>{% trans 'Next' %}</span>
           </a>
         </li>
       </ul>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/ko_pagination.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/ko_pagination.html
@@ -22,7 +22,7 @@
                class="page-link"
                aria-label="Previous"
                data-bind="click: previousPage">
-              <span aria-hidden="true">&laquo;</span>
+              <span aria-hidden="true">{% trans 'Previous' %}</span>
             </a>
           </li>
           <!-- ko foreach: pagesShown -->
@@ -43,7 +43,7 @@
                class="page-link"
                aria-label="Next"
                data-bind="click: nextPage">
-              <span aria-hidden="true">&raquo;</span>
+              <span aria-hidden="true">{% trans 'Next' %}</span>
             </a>
           </li>
         </ul>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/ko_pagination.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/ko_pagination.html.diff.txt
@@ -33,7 +33,7 @@
 -        <li>
 -          <a href="#"
 -             data-bind="click: previousPage">
--            <span>&laquo;</span>
+-            <span>{% trans 'Previous' %}</span>
 -          </a>
 -        </li>
 -        <!-- ko foreach: pagesShown -->
@@ -49,7 +49,7 @@
 -        <!-- /ko -->
 -        <li>
 -          <a href="#" data-bind="click: nextPage">
--            <span>&raquo;</span>
+-            <span>{% trans 'Next' %}</span>
 -          </a>
 -        </li>
 -      </ul>
@@ -62,7 +62,7 @@
 +               class="page-link"
 +               aria-label="Previous"
 +               data-bind="click: previousPage">
-+              <span aria-hidden="true">&laquo;</span>
++              <span aria-hidden="true">{% trans 'Previous' %}</span>
 +            </a>
 +          </li>
 +          <!-- ko foreach: pagesShown -->
@@ -83,7 +83,7 @@
 +               class="page-link"
 +               aria-label="Next"
 +               data-bind="click: nextPage">
-+              <span aria-hidden="true">&raquo;</span>
++              <span aria-hidden="true">{% trans 'Next' %}</span>
 +            </a>
 +          </li>
 +        </ul>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The KO pagination component buttons have been changed from:
![Screenshot from 2023-11-24 09-11-47](https://github.com/dimagi/commcare-hq/assets/122617251/57f71606-6107-487a-a0d3-be1e893ee496)

to:
![Screenshot from 2023-11-24 09-11-27](https://github.com/dimagi/commcare-hq/assets/122617251/14808314-a079-4b9c-9743-82677d57ff94)



## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3202).

Small PR that changes the KO pagination component for both bootstrap 3 and 5 to use the text "Previous"/"Next" for the pagination buttons instead of the arrows. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Small, UI only change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
