### PR TITLE
Case search: geocoder widget value maintain value between searches

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -81,6 +81,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 kissmetrics.track.event("Accessibility Tracking - Geocoder Interaction in Case Search");
                 model.set('value', item.place_name);
                 initMapboxWidget(model);
+                let geocoderValues = JSON.parse(sessionStorage.geocoderValues);
+                geocoderValues[model.id] = item.place_name;
+                sessionStorage.geocoderValues = JSON.stringify(geocoderValues);
                 var broadcastObj = formEntryUtils.getBroadcastObject(item);
                 $.publish(addressTopic, broadcastObj);
                 return item.place_name;
@@ -149,6 +152,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             $(function () {
                 kissmetrics.track.event("Accessibility Tracking - Geocoder Seen in Case Search");
             });
+            if (!sessionStorage.geocoderValues) {
+                sessionStorage.geocoderValues = JSON.stringify({});
+            }
             if ($field.find('.mapboxgl-ctrl-geocoder--input').length === 0) {
                 if (!initialPageData.get("has_geocoder_privs")) {
                     $("#" + inputId).addClass('unsupported alert alert-warning');
@@ -168,8 +174,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 divEl.css("width", "100%");
             }
 
-            if (model.get('value')) {
-                $field.find('.mapboxgl-ctrl-geocoder--input').val(model.get('value'));
+            let geocoderValues = JSON.parse(sessionStorage.geocoderValues);
+            if (geocoderValues[id]) {
+                $field.find('.mapboxgl-ctrl-geocoder--input').val(geocoderValues[id]);
             }
         };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -81,11 +81,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 kissmetrics.track.event("Accessibility Tracking - Geocoder Interaction in Case Search");
                 model.set('value', item.place_name);
                 initMapboxWidget(model);
-                if (toggles.toggleEnabled('PERSISTENT_GEOCODER_SEARCH_FIELDS')) {
-                    let geocoderValues = JSON.parse(sessionStorage.geocoderValues);
-                    geocoderValues[model.id] = item.place_name;
-                    sessionStorage.geocoderValues = JSON.stringify(geocoderValues);
-                }
+                let geocoderValues = JSON.parse(sessionStorage.geocoderValues);
+                geocoderValues[model.id] = item.place_name;
+                sessionStorage.geocoderValues = JSON.stringify(geocoderValues);
                 var broadcastObj = formEntryUtils.getBroadcastObject(item);
                 $.publish(addressTopic, broadcastObj);
                 return item.place_name;
@@ -176,12 +174,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 divEl.css("width", "100%");
             }
 
-
             let geocoderValues = JSON.parse(sessionStorage.geocoderValues);
-            if (geocoderValues[id] && toggles.toggleEnabled('PERSISTENT_GEOCODER_SEARCH_FIELDS')) {
+            if (geocoderValues[id]) {
                 $field.find('.mapboxgl-ctrl-geocoder--input').val(geocoderValues[id]);
-            } else if (model.get('value')) {
-                $field.find('.mapboxgl-ctrl-geocoder--input').val(model.get('value'));
             }
         };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -81,9 +81,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 kissmetrics.track.event("Accessibility Tracking - Geocoder Interaction in Case Search");
                 model.set('value', item.place_name);
                 initMapboxWidget(model);
-                let geocoderValues = JSON.parse(sessionStorage.geocoderValues);
-                geocoderValues[model.id] = item.place_name;
-                sessionStorage.geocoderValues = JSON.stringify(geocoderValues);
+                if (toggles.toggleEnabled('PERSISTENT_GEOCODER_SEARCH_FIELDS')) {
+                    let geocoderValues = JSON.parse(sessionStorage.geocoderValues);
+                    geocoderValues[model.id] = item.place_name;
+                    sessionStorage.geocoderValues = JSON.stringify(geocoderValues);
+                }
                 var broadcastObj = formEntryUtils.getBroadcastObject(item);
                 $.publish(addressTopic, broadcastObj);
                 return item.place_name;
@@ -174,9 +176,12 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 divEl.css("width", "100%");
             }
 
+
             let geocoderValues = JSON.parse(sessionStorage.geocoderValues);
-            if (geocoderValues[id]) {
+            if (geocoderValues[id] && toggles.toggleEnabled('PERSISTENT_GEOCODER_SEARCH_FIELDS')) {
                 $field.find('.mapboxgl-ctrl-geocoder--input').val(geocoderValues[id]);
+            } else if (model.get('value')) {
+                $field.find('.mapboxgl-ctrl-geocoder--input').val(model.get('value'));
             }
         };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -153,8 +153,11 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 kissmetrics.track.event("Accessibility Tracking - Geocoder Seen in Case Search");
             });
             let queryKey = sessionStorage.queryKey;
-            if (!sessionStorage.geocoderValues || sessionStorage.geocoderValues.queryKey !== queryKey) {
-                sessionStorage.geocoderValues = JSON.stringify({ "queryKey": queryKey });
+            let storedGeocoderValues = sessionStorage.geocoderValues;
+            let geoValues = storedGeocoderValues ? JSON.parse(storedGeocoderValues) : {};
+            if (!geoValues.hasOwnProperty("queryKey") || geoValues["queryKey"] !== queryKey) {
+                geoValues["queryKey"] = queryKey;
+                sessionStorage.geocoderValues = JSON.stringify(geoValues);
             }
             if ($field.find('.mapboxgl-ctrl-geocoder--input').length === 0) {
                 if (!initialPageData.get("has_geocoder_privs")) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -153,7 +153,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 kissmetrics.track.event("Accessibility Tracking - Geocoder Seen in Case Search");
             });
             let queryKey = sessionStorage.queryKey;
-            if (!sessionStorage.geocoderValues || !sessionStorage.geocoderValues.queryKey) {
+            if (!sessionStorage.geocoderValues || sessionStorage.geocoderValues.queryKey !== queryKey) {
                 sessionStorage.geocoderValues = JSON.stringify({ "queryKey": queryKey });
             }
             if ($field.find('.mapboxgl-ctrl-geocoder--input').length === 0) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -314,6 +314,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             self.model.set('error', null);
             self.errorMessage = null;
             self.model.set('searchForBlank', false);
+            sessionStorage.removeItem('geocoderValues');
             if (self.ui.date.length) {
                 self.ui.date.data("DateTimePicker").clear();
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -155,7 +155,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             let queryKey = sessionStorage.queryKey;
             let storedGeocoderValues = sessionStorage.geocoderValues;
             let geoValues = storedGeocoderValues ? JSON.parse(storedGeocoderValues) : {};
-            if (!geoValues.hasOwnProperty("queryKey") || geoValues["queryKey"] !== queryKey) {
+            if (!("queryKey" in geoValues) || geoValues["queryKey"] !== queryKey) {
                 geoValues["queryKey"] = queryKey;
                 sessionStorage.geocoderValues = JSON.stringify(geoValues);
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -81,7 +81,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 kissmetrics.track.event("Accessibility Tracking - Geocoder Interaction in Case Search");
                 model.set('value', item.place_name);
                 initMapboxWidget(model);
-                let geocoderValues = JSON.parse(sessionStorage.geocoderValues);
+                const geocoderValues = JSON.parse(sessionStorage.geocoderValues);
                 geocoderValues[model.id] = item.place_name;
                 sessionStorage.geocoderValues = JSON.stringify(geocoderValues);
                 var broadcastObj = formEntryUtils.getBroadcastObject(item);
@@ -152,9 +152,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             $(function () {
                 kissmetrics.track.event("Accessibility Tracking - Geocoder Seen in Case Search");
             });
-            let queryKey = sessionStorage.queryKey;
-            let storedGeocoderValues = sessionStorage.geocoderValues;
-            let geoValues = storedGeocoderValues ? JSON.parse(storedGeocoderValues) : {};
+            const queryKey = sessionStorage.queryKey;
+            const storedGeocoderValues = sessionStorage.geocoderValues;
+            const geoValues = storedGeocoderValues ? JSON.parse(storedGeocoderValues) : {};
             if (!("queryKey" in geoValues) || geoValues["queryKey"] !== queryKey) {
                 geoValues["queryKey"] = queryKey;
                 sessionStorage.geocoderValues = JSON.stringify(geoValues);
@@ -178,7 +178,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 divEl.css("width", "100%");
             }
 
-            let geocoderValues = JSON.parse(sessionStorage.geocoderValues);
+            const geocoderValues = JSON.parse(sessionStorage.geocoderValues);
             if (geocoderValues[id]) {
                 $field.find('.mapboxgl-ctrl-geocoder--input').val(geocoderValues[id]);
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -152,8 +152,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             $(function () {
                 kissmetrics.track.event("Accessibility Tracking - Geocoder Seen in Case Search");
             });
-            if (!sessionStorage.geocoderValues) {
-                sessionStorage.geocoderValues = JSON.stringify({});
+            let queryKey = sessionStorage.queryKey;
+            if (!sessionStorage.geocoderValues || !sessionStorage.geocoderValues.queryKey) {
+                sessionStorage.geocoderValues = JSON.stringify({ "queryKey": queryKey });
             }
             if ($field.find('.mapboxgl-ctrl-geocoder--input').length === 0) {
                 if (!initialPageData.get("has_geocoder_privs")) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -300,6 +300,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
 
         this.onSubmit = function () {
             sessionStorage.removeItem('selectedValues');
+            sessionStorage.removeItem('geocoderValues');
             this.page = null;
             this.sortIndex = null;
             this.search = null;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -295,6 +295,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             this.queryData = null;
             this.sessionId = null;
             sessionStorage.removeItem('submitPerformed');
+            sessionStorage.removeItem('geocoderValues');
         };
 
         this.onSubmit = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -328,6 +328,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             this.search = null;
             this.sortIndex = null;
             sessionStorage.removeItem('selectedValues');
+            sessionStorage.removeItem('geocoderValues');
             this.sessionId = null;
         };
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2665,3 +2665,12 @@ CUSTOM_DOMAIN_BANNER_ALERTS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
     description='Allow projects to add banners visible to their users on HQ on every login',
 )
+
+PERSISTENT_GEOCODER_SEARCH_FIELDS = StaticToggle(
+    slug='persistent_geocoder_search_fields',
+    label='Allows case search fields configured with geocoder widgets to maintain their value between searches',
+    tag=TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+    description='Allows case search fields configured with geocoder widgets to maintain their value '
+                'between searches',
+)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2665,12 +2665,3 @@ CUSTOM_DOMAIN_BANNER_ALERTS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
     description='Allow projects to add banners visible to their users on HQ on every login',
 )
-
-PERSISTENT_GEOCODER_SEARCH_FIELDS = StaticToggle(
-    slug='persistent_geocoder_search_fields',
-    label='Allows case search fields configured with geocoder widgets to maintain their value between searches',
-    tag=TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-    description='Allows case search fields configured with geocoder widgets to maintain their value '
-                'between searches',
-)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Ticket: [USH-3647](https://dimagi-dev.atlassian.net/browse/USH-3647)
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This problem was found during testing of dynamic search, but I found to be an existing issue with the geocoder widget that the value was not properly saved to the field and therefore would disappear after each search. This is because the value is not sent to formplayer like the rest and therefore I decided to rely on `sessionStorage` to save the value between searches

https://github.com/dimagi/commcare-hq/assets/36681924/c6692a70-867b-4271-9e2a-2e6a6855834c


## Feature Flag
All FFs required for the [geocoder widget](https://confluence.dimagi.com/display/USH/Geocoder+Widget)
<!-- If this is specific to a feature flag, which one? -->
[GEOCODER_MY_LOCATION_BUTTON](https://www.commcarehq.org/hq/flags/edit/geocoder_my_location_button/?__hstc=240960668.08b7bcb6f5d7888333e8e857981fec39.1693345886279.1693851335436.1693864648201.16&__hssc=240960668.1.1693864648201&__hsfp=671759818)
[GEOCODER_AUTOLOAD_USER_LOCATION](https://www.commcarehq.org/hq/flags/edit/geocoder_autoload_user_location/?__hstc=240960668.08b7bcb6f5d7888333e8e857981fec39.1693345886279.1693851335436.1693864648201.16&__hssc=240960668.1.1693864648201&__hsfp=671759818)
[GEOCODER_USER_PROXIMITY](https://www.commcarehq.org/hq/flags/edit/geocoder_user_proximity/?__hstc=240960668.08b7bcb6f5d7888333e8e857981fec39.1693345886279.1693851335436.1693864648201.16&__hssc=240960668.1.1693864648201&__hsfp=671759818)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This has been tested on staging including with all field types and multiple geocoder widgets within the searche
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests cove this area
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3647]: https://dimagi-dev.atlassian.net/browse/USH-3647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ