### PR TITLE
Apply Polygon Filtering Before Disbursement

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -278,8 +278,22 @@ hqDefine("geospatial/js/geospatial_map", [
 
         var $runDisbursement = $("#btnRunDisbursement");
         $runDisbursement.click(function () {
-            if (mapModel && mapModel.mapInstance) {
-                disbursementRunner.runCaseDisbursementAlgorithm(mapModel.caseMapItems(), mapModel.userMapItems());
+            if (mapModel && mapModel.mapInstance && !polygonFilterModel.btnRunDisbursementDisabled()) {
+                let selectedCases = mapModel.caseMapItems();
+                let selectedUsers = mapModel.userMapItems();
+                if (mapModel.mapHasPolygons() || polygonFilterModel.activeSavedPolygon) {
+                    selectedCases = mapModel.caseMapItems().filter(function (caseItem) {
+                        return caseItem.isSelected();
+                    });
+                    selectedUsers = mapModel.userMapItems().filter((userItem) => {
+                        return userItem.isSelected();
+                    });
+                }
+
+                const hasValidData = selectedCases.length && selectedUsers.length;
+                if (hasValidData) {
+                    disbursementRunner.runCaseDisbursementAlgorithm(selectedCases, selectedUsers);
+                }
             }
         });
     }

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -233,20 +233,23 @@ hqDefine("geospatial/js/geospatial_map", [
         ko.applyBindings({'userModels': mapModel.userMapItems, 'selectedUsers': selectedUsers}, $("#user-modals")[0]);
         ko.applyBindings({'caseModels': mapModel.caseMapItems, 'selectedCases': selectedCases}, $("#case-modals")[0]);
 
-        mapModel.mapInstance.on("draw.update", (e) => {
-            mapModel.selectAllMapItems(e.features);
-        });
-        mapModel.mapInstance.on('draw.selectionchange', (e) => {
-            mapModel.selectAllMapItems(e.features);
-        });
+        mapModel.mapInstance.on("draw.update", selectMapItemsInPolygons);
+        mapModel.mapInstance.on('draw.selectionchange', selectMapItemsInPolygons);
         mapModel.mapInstance.on('draw.delete', function () {
-            // TODO: Need to fix this
             polygonFilterModel.btnSaveDisabled(!mapModel.mapHasPolygons());
+            selectMapItemsInPolygons();
         });
         mapModel.mapInstance.on('draw.create', function () {
-            // TODO: Need to fix this
             polygonFilterModel.btnSaveDisabled(!mapModel.mapHasPolygons());
         });
+    }
+
+    function selectMapItemsInPolygons() {
+        let features = mapModel.drawControls.getAll().features;
+        if (polygonFilterModel.activeSavedPolygon) {
+            features = features.concat(polygonFilterModel.activeSavedPolygon.geoJson.features);
+        }
+        mapModel.selectAllMapItems(features);
     }
 
     function initPolygonFilters() {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -85,6 +85,9 @@ hqDefine("geospatial/js/geospatial_map", [
         };
 
         self.handleDisbursementResults = function (result) {
+            // Clean stale disbursement results
+            mapModel.removeDisbursementLayers();
+
             var groupId = 0;
             Object.keys(result).forEach((userId) => {
                 let user = mapModel.userMapItems().find((userModel) => {return userModel.itemId === userId;});

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -74,6 +74,8 @@ hqDefine("geospatial/js/geospatial_map", [
         self.pollUrl = ko.observable('');
         self.isBusy = ko.observable(false);
 
+        self.hasMissingData = ko.observable(false);  // True if the user attemps disbursement with polygon filtering that includes no cases/users.
+
         self.setBusy = function (isBusy) {
             self.isBusy(isBusy);
             $("#hq-content *").prop("disabled", isBusy);
@@ -290,7 +292,10 @@ hqDefine("geospatial/js/geospatial_map", [
                     });
                 }
 
+                // User might do polygon filtering on an area with no cases/users. We should not do
+                // disbursement if this is the case
                 const hasValidData = selectedCases.length && selectedUsers.length;
+                disbursementRunner.hasMissingData(!hasValidData);
                 if (hasValidData) {
                     disbursementRunner.runCaseDisbursementAlgorithm(selectedCases, selectedUsers);
                 }
@@ -449,6 +454,7 @@ hqDefine("geospatial/js/geospatial_map", [
 
             disbursementRunner = new disbursementRunnerModel();
             $("#disbursement-spinner").koApplyBindings(disbursementRunner);
+            $("#disbursement-error").koApplyBindings(disbursementRunner);
 
             return;
         }

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -310,24 +310,26 @@ hqDefine('geospatial/js/models', [
 
         self.selectAllMapItems = function (featuresArr) {
             // See https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/API.md#drawselectionchange
-            if (!featuresArr.length) {
-                return;
+            for (const caseItem of self.caseMapItems()) {
+                self.selectMapItemInPolygons(featuresArr, caseItem);
             }
-
-            for (const feature of featuresArr) {
-                if (feature.geometry.type === 'Polygon') {
-                    self.selectMapItemsInPolygon(feature, self.caseMapItems());
-                    self.selectMapItemsInPolygon(feature, self.userMapItems());
-                }
+            for (const userItem of self.userMapItems()) {
+                self.selectMapItemInPolygons(featuresArr, userItem);
             }
         };
 
-        self.selectMapItemsInPolygon = function (polygonFeature, mapItems) {
-            _.values(mapItems).filter(function (mapItem) {
-                if (mapItem.itemData.coordinates) {
-                    mapItem.isSelected(isMapItemInPolygon(polygonFeature, mapItem.itemData.coordinates));
+        self.selectMapItemInPolygons = function (polygonArr, mapItem) {
+            let isSelected = false;
+            for (const polygon of polygonArr) {
+                if (polygon.geometry.type !== 'Polygon') {
+                    continue;
                 }
-            });
+                if (isMapItemInPolygon(polygon, mapItem.itemData.coordinates)) {
+                    isSelected = true;
+                    break;
+                }
+            }
+            mapItem.isSelected(isSelected);
         };
 
         function isMapItemInPolygon(polygonFeature, coordinates) {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -511,7 +511,8 @@ hqDefine('geospatial/js/models', [
             self.btnExportDisabled(false);
             self.btnSaveDisabled(true);
             if (self.shouldSelectAfterFilter) {
-                self.mapObj.selectAllMapItems(polygonObj.geoJson.features);
+                const features = polygonObj.geoJson.features.concat(mapObj.drawControls.getAll().features);
+                self.mapObj.selectAllMapItems(features);
             }
         });
 

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -13,6 +13,7 @@ hqDefine('geospatial/js/models', [
     const DOWNPLAY_OPACITY = 0.2;
     const FEATURE_QUERY_PARAM = 'features';
     const DEFAULT_CENTER_COORD = [-20.0, -0.0];
+    const DISBURSEMENT_LAYER_PREFIX = 'route-';
 
     var MissingGPSModel = function () {
         this.casesWithoutGPS = ko.observable([]);
@@ -304,7 +305,7 @@ hqDefine('geospatial/js/models', [
         }
 
         self.getLineFeatureId = function (itemId) {
-            return "route-" + itemId;
+            return DISBURSEMENT_LAYER_PREFIX + itemId;
         };
 
         self.selectAllMapItems = function (featuresArr) {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -378,6 +378,15 @@ hqDefine('geospatial/js/models', [
                 maxZoom: 10,  // 0-23
             });
         };
+
+        self.removeDisbursementLayers = function () {
+            const mapLayers = self.mapInstance.getStyle().layers;
+            mapLayers.forEach(function (layer) {
+                if (layer.id.includes(DISBURSEMENT_LAYER_PREFIX)) {
+                    self.mapInstance.removeLayer(layer.id);
+                }
+            });
+        };
     };
 
     var PolygonFilter = function (mapObj, shouldUpdateQueryParam, shouldSelectAfterFilter) {

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -95,6 +95,12 @@
     {% trans "Running disbursement algorithm..." %}
   </h4>
 </div>
+<div id="disbursement-error" class="alert alert-danger" data-bind="visible: hasMissingData()">
+    {% blocktrans %}
+        Please ensure that the filtered area includes both cases and mobile workers before
+        attempting to run disbursement.
+    {% endblocktrans %}
+</div>
 <div id="geospatial-map" style="height: 500px"></div>
 
 <!-- For Pagination -->


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

When there is one or more polygons present on the map, disbursement will only be done to the map items in the polygon(s):
![filtered-disbursement](https://github.com/dimagi/commcare-hq/assets/122617251/3bcd42ed-80a9-4d40-a73e-466454960ca5)

Users can now have map items selected based on multiple polygons (previously only selected map items from a single polygon):
![multi-select](https://github.com/dimagi/commcare-hq/assets/122617251/ba33801b-3067-4d2b-8c02-559a782bc39c)

The disbursement results will now visually update correctly. Previously, the old results were still shown on the map:
![updated-layers](https://github.com/dimagi/commcare-hq/assets/122617251/7405aed8-5976-4d85-a86d-20c18f2bea4c)

There is a new error that will be shown to the user if they have a filtered area that is missing either cases or users:
![Screenshot from 2023-11-27 17-57-17](https://github.com/dimagi/commcare-hq/assets/122617251/93afd990-a2fd-47c5-abbb-5cf3919e01fc)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3199).

This PR adds in the ability for the user to use polygons to filter which map items will be used for disbursement. If no polygons are given, then disbursement will be done for all cases/users on the map.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
