### PR TITLE
Changes Group Header Background Color

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -261,10 +261,10 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
 
         // Colors are ordered from lightest to darkest with the lightest color for the highest level.
         // Colors are based on Bootstrap provided tint/shades of #5D70D2 (CommCare Cornflower Blue)
-        // tint(#5D70D2, 20%): #7d8ddb
         // shade(#5D70D2, 20%): #4a5aa8
         // shade(#5D70D2, 40%): #38437e
-        const repeatColor = ["#7d8ddb", "#4a5aa8", "#38437e"];
+        // shade(#5D70D2, 60%); #252d54
+        const repeatColor = ["#4a5aa8", "#38437e", "#252d54"];
         const repeatColorCount = repeatColor.length;
         const index = (nestedDepthCount - 1) % repeatColorCount;
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
@@ -142,11 +142,11 @@ hqDefine("cloudcare/js/form_entry/spec/form_ui_spec", function () {
             formJSON.tree = [g0];
             let form = formUI.Form(formJSON);
 
-            assert.equal(form.children()[0].headerBackgroundColor(), '#7d8ddb'); //[g0]
+            assert.equal(form.children()[0].headerBackgroundColor(), '#4a5aa8'); //[g0]
             assert.equal(form.children()[0].children()[0].headerBackgroundColor(), ''); //[g0-0]
-            assert.equal(form.children()[0].children()[0].children()[2].headerBackgroundColor(), '#4a5aa8'); //[g1]
-            assert.equal(form.children()[0].children()[0].children()[2].children()[0].headerBackgroundColor(), '#38437e'); //[g1-0]
-            assert.equal(form.children()[0].children()[0].children()[2].children()[0].children()[2].headerBackgroundColor(), '#7d8ddb'); //[r1]
+            assert.equal(form.children()[0].children()[0].children()[2].headerBackgroundColor(), '#38437e'); //[g1]
+            assert.equal(form.children()[0].children()[0].children()[2].children()[0].headerBackgroundColor(), '#252d54'); //[g1-0]
+            assert.equal(form.children()[0].children()[0].children()[2].children()[0].children()[2].headerBackgroundColor(), '#4a5aa8'); //[r1]
             assert.equal(form.children()[0].children()[0].children()[2].children()[0].children()[2].children()[0].headerBackgroundColor(), ''); //[r1-0]
         });
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Changes background color for group header

Before
![image](https://github.com/dimagi/commcare-hq/assets/88759246/7368299b-54f8-43f5-9330-2f49e95138ea)
After

![image](https://github.com/dimagi/commcare-hq/assets/88759246/695c2dc0-8abf-41ab-9efe-c3b0789fca12)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Previous background color with white text did not meet the minimum contrast ratio of 4.5:1 https://www.w3.org/TR/WCAG21/#contrast-minimum
Related to https://github.com/dimagi/commcare-hq/pull/33770
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No Feature Flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Small color change. Locally tested.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests exist that background colors are as expected.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
