### PR TITLE
Update prompt in build_requirejs.py

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -5,7 +5,6 @@ import re
 import subprocess
 from collections import defaultdict
 from pathlib import Path
-from uuid import uuid4
 from shutil import copyfile
 from subprocess import call
 

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -122,7 +122,8 @@ def _confirm_or_exit():
         if confirm[0].lower() != 'y':
             exit()
     confirm = input("You are running locally. Have you already run "
-                    "`./manage.py collectstatic --noinput && ./manage.py compilejsi18n` (y/n)? ")
+                    "`./manage.py resource_static && ./manage.py collectstatic "
+                    "--noinput && ./manage.py compilejsi18n` (y/n)? ")
     if confirm[0].lower() != 'y':
         exit()
 


### PR DESCRIPTION
## Technical Summary
As noted [here](https://github.com/dimagi/commcare-hq/blob/63d0980a6d6de75d4438e92f35f708639260f455/corehq/apps/hqwebapp/management/commands/build_requirejs.py#L56), resource_static also needs to be run prior to this command.

## Safety Assurance

### Safety story
Trivial. Ran locally.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
