### PR TITLE
Add another retry for _process_record_with_retry

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -371,7 +371,7 @@ def _process_reporting_metadata_staging():
                 record.delete()
 
 
-@retry_on(ResourceConflict, delays=[0])
+@retry_on(ResourceConflict, delays=[0, 0.5])
 def _process_record_with_retry(record):
     """
     It is possible that an unrelated user update is saved to the db while we are processing the record

--- a/corehq/apps/users/tests/test_tasks.py
+++ b/corehq/apps/users/tests/test_tasks.py
@@ -209,7 +209,7 @@ class TestProcessReportingMetadataStaging(TestCase):
         self.assertEqual(mock_process_record.call_count, 1)
         self.assertTrue(UserReportingMetadataStaging.objects.get(id=record.id))
 
-    def test_process_record_is_retried_if_resource_conflict_raised(self, mock_process_record):
+    def test_process_record_is_retried_successfully_after_resource_conflict_raised(self, mock_process_record):
         # Simulate the scenario where the first attempt to process a record raises ResourceConflict
         # but the next attempt succeeds
         mock_process_record.side_effect = [ResourceConflict, None]
@@ -219,6 +219,17 @@ class TestProcessReportingMetadataStaging(TestCase):
 
         self.assertEqual(mock_process_record.call_count, 2)
         self.assertEqual(UserReportingMetadataStaging.objects.all().count(), 0)
+
+    def test_process_record_raises_resource_conflict_after_three_tries(self, mock_process_record):
+        # ResourceConflict will always be raised when calling mock_process_record
+        mock_process_record.side_effect = ResourceConflict
+        UserReportingMetadataStaging.objects.create(user_id=self.user._id, domain='test-domain')
+
+        with self.assertRaises(ResourceConflict):
+            _process_reporting_metadata_staging()
+
+        self.assertEqual(mock_process_record.call_count, 3)
+        self.assertEqual(UserReportingMetadataStaging.objects.all().count(), 1)
 
     def test_subsequent_records_are_not_processed_if_exception_raised(self, mock_process_record):
         mock_process_record.side_effect = [Exception, None]


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup to https://github.com/dimagi/commcare-hq/pull/33745

Sentry flagged that new `ResourceConflict` errors appeared after that PR was rolled out, but when looking closer it was just because the method where the `ResourceConflict` was raised from changed in that PR. I did a search in Sentry on this task and saw these [four resource conflicts](https://dimagi.sentry.io/issues/?environment=production&project=136860&query=is%3Aunresolved+process_reporting_metadata_staging&referrer=issue-list&statsPeriod=90d), two of which seemingly stopped when the other two started, which coincided with the deploy of that PR.

All that to say, `ResourceConflict`s are expected to be raised from time to time in this task, but do result in the task failing hard/exiting. This can be seen in [the datadog graph for this task](https://app.datadoghq.com/dashboard/bdu-k5b-bz5/celery-overview?fullscreen_end_ts=1701270660168&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1700665860168&fullscreen_widget=1285677644544988&refresh_mode=sliding&tpl_var_celery_task%5B0%5D=corehq.apps.users.tasks.process_reporting_metadata_staging&from_ts=1700665857000&to_ts=1701270657000&live=true). It is a pretty minor issue, but now that playing around with the number of retries, and the delays associated with each retry is straightforward thanks to the `retry_on` decorator, this PR intends to add an additional retry with a delay of 0.5 seconds.

If reviewers have any strong opinions about what the delay value should be, I'm open to it. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Automated tests exist for this method, though in making this change I realized I had a gap in my tests from the last PR. Nothing confirmed that after X retries where a `ResourceConflict` was encountered each time, a `ResourceConflict` would be raised. That test now exists as well.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
users/tests/test_tasks.py:TestProcessReportingMetadataStaging
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
