### PR TITLE
[B5] This adds bootstrap 5 support to the multiselect widget

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -40,9 +40,10 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     };
 
     var _renderSearch = function (inputId, placeholder) {
-        var input = _.template(
+        var inputGroupTextClass = (window.USE_BOOTSTRAP5) ? "input-group-text" : "input-group-addon",
+            input = _.template(
             '<div class="input-group ms-input-group">' +
-                '<span class="input-group-addon">' +
+                '<span class="' + inputGroupTextClass + '">' +
                     '<i class="fa fa-search"></i>' +
                 '</span>' +
                 '<input type="search" class="form-control search-input" id="<%- searchInputId %>" autocomplete="off" placeholder="<%- searchInputPlaceholder %>" />' +
@@ -76,17 +77,18 @@ hqDefine('hqwebapp/js/multiselect_utils', [
             selectAllId = baseId + '-select-all',
             removeAllId = baseId + '-remove-all',
             searchSelectableId = baseId + '-search-selectable',
-            searchSelectedId = baseId + '-search-selected';
+            searchSelectedId = baseId + '-search-selected',
+            defaultBtnClass = (window.USE_BOOTSTRAP5) ? 'btn-outline-primary btn-sm' : 'btn-default';
 
         $element.multiSelect({
             selectableHeader: _renderHeader(
                 selectableHeaderTitle,
-                _renderAction(selectAllId, 'btn-default', 'fa fa-plus', gettext("Add All"), disableModifyAllActions),
+                _renderAction(selectAllId, defaultBtnClass, 'fa fa-plus', gettext("Add All"), disableModifyAllActions),
                 _renderSearch(searchSelectableId, searchItemTitle)
             ),
             selectionHeader: _renderHeader(
                 selectedHeaderTitle,
-                _renderAction(removeAllId, 'btn-default', 'fa fa-remove', gettext("Remove All"), disableModifyAllActions),
+                _renderAction(removeAllId, defaultBtnClass, 'fa fa-remove', gettext("Remove All"), disableModifyAllActions),
                 _renderSearch(searchSelectedId, searchItemTitle)
             ),
             afterInit: function () {

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_forms.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_forms.scss
@@ -43,3 +43,7 @@ legend {
     padding-left: 6px;
   }
 }
+
+.ms-header .btn {
+  margin-top: -3px;
+}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/forms._forms.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/forms._forms.style.diff.txt
@@ -354,7 +354,7 @@
  }
  
  .form-hide-actions .form-actions {
-@@ -355,15 +12,34 @@
+@@ -355,15 +12,38 @@
    .validationMessage {
      display: block;
      padding-top: 8px;
@@ -395,4 +395,8 @@
 +  div {
 +    padding-left: 6px;
 +  }
++}
++
++.ms-header .btn {
++  margin-top: -3px;
 +}


### PR DESCRIPTION
## Technical Summary
The classes for `default-btn` and `input-group-addon` have changed to `btn-outline-primary` and `input-group-text` respectively. This ensures that on bootstrap 5 pages, this change is made. I've also added the `btn-sm` class to the "add all" button in the multiselect widget so that the UI looks a little nicer. A preview of this can be seen in the new styleguide.

This also adds some minor `scss` changes for multiselect.

## Safety Assurance

### Safety story
very safe small change. tested on staging

### Automated test coverage
diffs are covered

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
leaving unchecked due to bootstrap 5 diffs adding rollback complications. it's generally fine to rollback if done immediately, but if a long time has passed only the non-diff commits can be rolled back without causing conflicts.
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
