### PR TITLE
[B5] Bootstrap 5 support for datatables

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/requirejs_config.js
@@ -12,14 +12,16 @@ requirejs.config({
         "knockout": "knockout/build/output/knockout-latest.debug",
         "ko.mapping": "hqwebapp/js/lib/knockout_plugins/knockout_mapping.ko.min",
         "datatables": "datatables.net/js/jquery.dataTables.min",
-        "datatables.fixedColumns": "datatables-fixedcolumns/js/dataTables.fixedColumns",
-        "datatables.bootstrap": "datatables-bootstrap3/BS3/assets/js/datatables",
+        "datatables.fixedColumns": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
+        "datatables.fixedColumns.bootstrap": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
+        "datatables.bootstrap": "datatables.net-bs5/js/dataTables.bootstrap5.min",
     },
     shim: {
         "ace-builds/src-min-noconflict/ace": { exports: "ace" },
         "ko.mapping": { deps: ['knockout'] },
         "hqwebapp/js/bootstrap5/hq.helpers": { deps: ['jquery', 'knockout', 'underscore'] },
         "datatables.bootstrap": { deps: ['datatables'] },
+        "datatables.fixedColumns.bootstrap": { deps: ['datatables.fixedColumns'] },
         "jquery.rmi/jquery.rmi": {
             deps: ['jquery', 'knockout', 'underscore'],
             exports: 'RMI',

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_datatables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_datatables.scss
@@ -1,102 +1,54 @@
-.dataTables_info,
-.dataTables_length {
-  display: inline-block;
-}
-.dataTables_info {
-  padding-top: 24px;
-  padding-right: 5px;
+div.dataTables_wrapper div.dataTables_info {
+  padding-top: 9px !important;
 }
 
-.datatable thead th,
-.dataTable thead th {
-  background-color: desaturate($cc-brand-low, 50%);
-  color: #ffffff;
-  &:nth-child(odd) {
-    background-color: lighten(desaturate($cc-brand-low, 50%), 10%);
-  }
+div.dataTables_wrapper div.dataTables_length label {
+  padding-top: 6px !important;
 }
 
-.datatable tfoot td,
-.datatable tfoot th,
-.dataTable tfoot td,
-.dataTable tfoot th{
-  background-color: lighten(desaturate($cc-brand-low, 60%), 10%);
-  color: #ffffff;
-  padding: 8px;
+table.dataTable.table-hq-report {
+  margin-top: 0 !important;
 }
 
-.datatable .header,
-.dataTable .header {
-  .dt-sort-icon:before{
-    font-family: "Glyphicons Halflings";
-    vertical-align: bottom;
-  }
-  &.headerSort {
-    .dt-sort-icon:before {
-      content: "\e150";
-      opacity: 0.2;
+.table-hq-report {
+  thead th {
+    background-color: $blue-800;
+    color: $white;
+    white-space: nowrap;
+
+    &:nth-child(odd) {
+      background-color: $blue-700;
+    }
+
+    &.dtfc-fixed-left,
+    &.dtfc-fixed-right {
+      background-color: $blue !important;
+    }
+
+    &.sorting_asc::before,
+    &.sorting_desc::after {
+      opacity: 1.0 !important;
+      color: $white !important;
+    }
+
+    &::after,
+    &::before {
+      opacity: 0.3 !important;
     }
   }
-  &.headerSortDesc {
-    .dt-sort-icon:before {
-      content: "\e156";
-    }
-  }
-  &.headerSortAsc {
-    .dt-sort-icon:before {
-      content: "\e155";
-    }
-  }
-  &.headerSortDesc,
-  &.headerSortAsc {
-    background-color: $cc-brand-mid;
-  }
-}
 
-.datatable .sorting_1,
-.dataTable .sorting_1 {
-  background-color: $cc-bg;
-}
-
-.panel-body-datatable {
-  padding: 0;
-  .dataTables_control {
-    padding: 10px 15px;
-    .dataTables_info {
-      padding-top: 0;
+  tbody tr {
+    &.odd td.dtfc-fixed-left,
+    &.odd td.dtfc-fixed-right {
+      background-color: lighten($gray-200, 5%);
     }
-    .dataTables_paginate {
-      .pagination {
-        margin: 0;
-      }
+
+    &.even td.dtfc-fixed-left {
+      background-color: $gray-100;
     }
   }
 }
 
-.dataTable td.text-xs {
-  font-size: .8em;
-}
-
-.dataTable td.text-sm {
-  font-size: .9em;
-}
-
-.dataTable td.text-lg {
-  font-size: 1.1em;
-}
-
-.dataTable td.text-xl {
-  font-size: 1.2em;
-}
-
-.dataTable td.text-bold {
-  font-weight: bold;
-}
-
-.dataTable td.text-red {
-  color: $cc-att-neg-mid;
-}
-
-.dataTable td.text-green {
-  color: $cc-att-pos-mid;
+.dtfc-right-top-blocker:last-child {
+  display: none !important;
 }

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/requirejs_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/requirejs_config.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -2,9 +2,13 @@
+@@ -2,21 +2,26 @@
  requirejs.config({
      baseUrl: '/static/',
      paths: {
@@ -14,7 +14,11 @@
          "knockout": "knockout/build/output/knockout-latest.debug",
          "ko.mapping": "hqwebapp/js/lib/knockout_plugins/knockout_mapping.ko.min",
          "datatables": "datatables.net/js/jquery.dataTables.min",
-@@ -13,9 +17,8 @@
+-        "datatables.fixedColumns": "datatables-fixedcolumns/js/dataTables.fixedColumns",
+-        "datatables.bootstrap": "datatables-bootstrap3/BS3/assets/js/datatables",
++        "datatables.fixedColumns": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
++        "datatables.fixedColumns.bootstrap": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
++        "datatables.bootstrap": "datatables.net-bs5/js/dataTables.bootstrap5.min",
      },
      shim: {
          "ace-builds/src-min-noconflict/ace": { exports: "ace" },
@@ -23,9 +27,11 @@
 -        "hqwebapp/js/bootstrap3/hq.helpers": { deps: ['jquery', 'bootstrap', 'knockout', 'underscore'] },
 +        "hqwebapp/js/bootstrap5/hq.helpers": { deps: ['jquery', 'knockout', 'underscore'] },
          "datatables.bootstrap": { deps: ['datatables'] },
++        "datatables.fixedColumns.bootstrap": { deps: ['datatables.fixedColumns'] },
          "jquery.rmi/jquery.rmi": {
              deps: ['jquery', 'knockout', 'underscore'],
-@@ -44,7 +47,7 @@
+             exports: 'RMI',
+@@ -44,7 +49,7 @@
          },
      },
  

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/datatables._datatables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/datatables._datatables.style.diff.txt
@@ -1,52 +1,144 @@
 --- 
 +++ 
-@@ -9,10 +9,10 @@
+@@ -1,102 +1,54 @@
+-.dataTables_info,
+-.dataTables_length {
+-  display: inline-block;
+-}
+-.dataTables_info {
+-  padding-top: 24px;
+-  padding-right: 5px;
++div.dataTables_wrapper div.dataTables_info {
++  padding-top: 9px !important;
+ }
  
- .datatable thead th,
- .dataTable thead th {
+-.datatable thead th,
+-.dataTable thead th {
 -  background-color: desaturate(@cc-brand-low, 50%);
-+  background-color: desaturate($cc-brand-low, 50%);
-   color: #ffffff;
-   &:nth-child(odd) {
+-  color: #ffffff;
+-  &:nth-child(odd) {
 -    background-color: lighten(desaturate(@cc-brand-low, 50%), 10%);
-+    background-color: lighten(desaturate($cc-brand-low, 50%), 10%);
-   }
+-  }
++div.dataTables_wrapper div.dataTables_length label {
++  padding-top: 6px !important;
  }
  
-@@ -20,7 +20,7 @@
- .datatable tfoot th,
- .dataTable tfoot td,
- .dataTable tfoot th{
+-.datatable tfoot td,
+-.datatable tfoot th,
+-.dataTable tfoot td,
+-.dataTable tfoot th{
 -  background-color: lighten(desaturate(@cc-brand-low, 60%), 10%);
-+  background-color: lighten(desaturate($cc-brand-low, 60%), 10%);
-   color: #ffffff;
-   padding: 8px;
+-  color: #ffffff;
+-  padding: 8px;
++table.dataTable.table-hq-report {
++  margin-top: 0 !important;
  }
-@@ -49,13 +49,13 @@
+ 
+-.datatable .header,
+-.dataTable .header {
+-  .dt-sort-icon:before{
+-    font-family: "Glyphicons Halflings";
+-    vertical-align: bottom;
+-  }
+-  &.headerSort {
+-    .dt-sort-icon:before {
+-      content: "\e150";
+-      opacity: 0.2;
++.table-hq-report {
++  thead th {
++    background-color: $blue-800;
++    color: $white;
++    white-space: nowrap;
++
++    &:nth-child(odd) {
++      background-color: $blue-700;
++    }
++
++    &.dtfc-fixed-left,
++    &.dtfc-fixed-right {
++      background-color: $blue !important;
++    }
++
++    &.sorting_asc::before,
++    &.sorting_desc::after {
++      opacity: 1.0 !important;
++      color: $white !important;
++    }
++
++    &::after,
++    &::before {
++      opacity: 0.3 !important;
+     }
    }
-   &.headerSortDesc,
-   &.headerSortAsc {
+-  &.headerSortDesc {
+-    .dt-sort-icon:before {
+-      content: "\e156";
++
++  tbody tr {
++    &.odd td.dtfc-fixed-left,
++    &.odd td.dtfc-fixed-right {
++      background-color: lighten($gray-200, 5%);
+     }
+-  }
+-  &.headerSortAsc {
+-    .dt-sort-icon:before {
+-      content: "\e155";
+-    }
+-  }
+-  &.headerSortDesc,
+-  &.headerSortAsc {
 -    background-color: @cc-brand-mid;
-+    background-color: $cc-brand-mid;
+-  }
+-}
+ 
+-.datatable .sorting_1,
+-.dataTable .sorting_1 {
+-  background-color: @cc-bg;
+-}
+-
+-.panel-body-datatable {
+-  padding: 0;
+-  .dataTables_control {
+-    padding: 10px 15px;
+-    .dataTables_info {
+-      padding-top: 0;
+-    }
+-    .dataTables_paginate {
+-      .pagination {
+-        margin: 0;
+-      }
++    &.even td.dtfc-fixed-left {
++      background-color: $gray-100;
+     }
    }
  }
  
- .datatable .sorting_1,
- .dataTable .sorting_1 {
--  background-color: @cc-bg;
-+  background-color: $cc-bg;
+-.dataTable td.text-xs {
+-  font-size: .8em;
++.dtfc-right-top-blocker:last-child {
++  display: none !important;
  }
- 
- .panel-body-datatable {
-@@ -94,9 +94,9 @@
- }
- 
- .dataTable td.text-red {
+-
+-.dataTable td.text-sm {
+-  font-size: .9em;
+-}
+-
+-.dataTable td.text-lg {
+-  font-size: 1.1em;
+-}
+-
+-.dataTable td.text-xl {
+-  font-size: 1.2em;
+-}
+-
+-.dataTable td.text-bold {
+-  font-weight: bold;
+-}
+-
+-.dataTable td.text-red {
 -  color: @cc-att-neg-mid;
-+  color: $cc-att-neg-mid;
- }
- 
- .dataTable td.text-green {
+-}
+-
+-.dataTable td.text-green {
 -  color: @cc-att-pos-mid;
-+  color: $cc-att-pos-mid;
- }
+-}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
         "datatables-bootstrap3": "Jowin/Datatables-Bootstrap3",
         "datatables-fixedcolumns": "DataTables/FixedColumns#3.2.0",
         "datatables.net": "1.11.3",
+        "datatables.net-bs5": "1.13.8",
+        "datatables.net-fixedcolumns-bs5": "4.3.0",
         "detectrtc": "1.4.0",
         "eonasdan-bootstrap-datetimepicker": "4.17.49",
         "fast-levenshtein": "2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,10 +1249,42 @@ datatables-fixedcolumns@DataTables/FixedColumns#3.2.0:
   version "0.0.0"
   resolved "https://codeload.github.com/DataTables/FixedColumns/tar.gz/a87428accba62d881e14fa2710bcc035a6efbbb6"
 
+datatables.net-bs5@1.13.8, datatables.net-bs5@>=1.13.4:
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/datatables.net-bs5/-/datatables.net-bs5-1.13.8.tgz#807dca4b95c139fe217ed87bd25f3502b1d873d3"
+  integrity sha512-3B6S8LiKGtUtOsA97SkMddwggrza6JDtubnw1qjFb/mjqDmWO0PC1+QWeUspkLPFQCCbLaSVfXLWMdo44IGEmQ==
+  dependencies:
+    datatables.net "1.13.8"
+    jquery ">=1.7"
+
+datatables.net-fixedcolumns-bs5@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/datatables.net-fixedcolumns-bs5/-/datatables.net-fixedcolumns-bs5-4.3.0.tgz#2a3299d06ec00dbfe1545709cc48cc16a7cbac51"
+  integrity sha512-DvBRTfFlvZAqUErXYgkQLcF70sL5zBSJNsaWLF3in++sYHZDfY3fdVqHu0NQMTE0QuwmYh61AgJUrtWLrp7zwQ==
+  dependencies:
+    datatables.net-bs5 ">=1.13.4"
+    datatables.net-fixedcolumns ">=4.2.2"
+    jquery ">=1.7"
+
+datatables.net-fixedcolumns@>=4.2.2:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/datatables.net-fixedcolumns/-/datatables.net-fixedcolumns-4.3.0.tgz#1c5a0b13d56db46b0f53563f2150fabfcb7ebbd9"
+  integrity sha512-H2otCswJDHufI4A8k7HUDj25HCB3a44KFnBlYEwYFWdrJayLcYB3I79kBjS8rSCu4rFEp0I9nVLKvWgKlZZgCQ==
+  dependencies:
+    datatables.net ">=1.13.4"
+    jquery ">=1.7"
+
 datatables.net@1.11.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.11.3.tgz#80e691036efcd62467558ee64c07dd566cb761b4"
   integrity sha512-VMj5qEaTebpNurySkM6jy6sGpl+s6onPK8xJhYr296R/vUBnz1+id16NVqNf9z5aR076OGcpGHCuiTuy4E05oQ==
+  dependencies:
+    jquery ">=1.7"
+
+datatables.net@1.13.8, datatables.net@>=1.13.4:
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.13.8.tgz#05a2fb5a036b0b65b66d1bb1eae0ba018aaea8a3"
+  integrity sha512-2pDamr+GUwPTby2OgriVB9dR9ftFKD2AQyiuCXzZIiG4d9KkKFQ7gqPfNmG7uj9Tc5kDf+rGj86do4LAb/V71g==
   dependencies:
     jquery ">=1.7"
 


### PR DESCRIPTION
## Technical Summary
This PR introduces two bootstrap5 related datatables javscript dependencies
- `datatables.net-b5`, which is the bootstrap5 related styling for datatables
- `datatables.net-fixedcolumns-b5`, which is the bootstrap 5 version of the `fixedColumns` datatables extension that we use in reports

An overview of this is included in the styleguide work

This PR also introduces style changes to `datatables.scss` needed for bootstrap 5 upgrade and updates to paths in the bootstrap 5 version of `requirejs_config.js`

## Safety Assurance

### Safety story
isolated only to bootstrap 5 changes. none of which is being used in production on critical user workflows at this time. changes can be previewed in the styleguide which is on staging

### Automated test coverage
diffs are covered

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
leaving unchecked due to bootstrap 5 diffs adding rollback complications. it's generally fine to rollback if done immediately, but if a long time has passed only the non-diff commits can be rolled back without causing conflicts.

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
