### PR TITLE
[B5] fix small issue with bootstrap 5 version of sticky tabs

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/sticky_tabs.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/sticky_tabs.js
@@ -16,14 +16,16 @@ hqDefine("hqwebapp/js/bootstrap5/sticky_tabs", [
         }
         return "";
     };
-
     $(function () {
-        var tabSelector = "a[data-toggle='tab']",
+        var tabSelector = "a[data-bs-toggle='tab']",
             navSelector = ".nav.sticky-tabs",
             hash = getHash(),
             $tabFromUrl = hash ? $("a[href='" + hash + "']") : undefined,
             $altTabSelector = $(navSelector + ' ' + tabSelector).first(),
             tabController;
+
+        // make sure we don't treat all anchor tags as a sticky tab
+        if ($tabFromUrl && $tabFromUrl.parents('.sticky-tabs').length === 0) return;
 
         if ($tabFromUrl && $tabFromUrl.length) {
             tabController = new bootstrap.Tab($tabFromUrl);

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/sticky_tabs.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/sticky_tabs.js.diff.txt
@@ -15,14 +15,23 @@
  ) {
      var getHash = function () {
          if (window.location.hash) {
-@@ -21,16 +21,21 @@
-         var tabSelector = "a[data-toggle='tab']",
+@@ -16,21 +16,28 @@
+         }
+         return "";
+     };
+-
+     $(function () {
+-        var tabSelector = "a[data-toggle='tab']",
++        var tabSelector = "a[data-bs-toggle='tab']",
              navSelector = ".nav.sticky-tabs",
              hash = getHash(),
 -            $tabFromUrl = hash ? $("a[href='" + hash + "']") : undefined;
 +            $tabFromUrl = hash ? $("a[href='" + hash + "']") : undefined,
 +            $altTabSelector = $(navSelector + ' ' + tabSelector).first(),
 +            tabController;
++
++        // make sure we don't treat all anchor tags as a sticky tab
++        if ($tabFromUrl && $tabFromUrl.parents('.sticky-tabs').length === 0) return;
  
          if ($tabFromUrl && $tabFromUrl.length) {
 -            $tabFromUrl.tab('show');
@@ -42,7 +51,7 @@
              if (!$link.closest(navSelector).length) {
                  return true;
              }
-@@ -42,13 +47,18 @@
+@@ -42,13 +49,18 @@
                  window.location.hash = tabName;
              }
  


### PR DESCRIPTION
## Technical Summary
This ensures that the bootstrap 5 version of `sticky_tabs` doesn't throw a javascript error when anchor tabs are present on the page which are not related to bootstrap 5 tabs.

## Safety Assurance

### Safety story
very small change that fixes a bug and is only isolated to the bootstrap 5 version of `sticky_tabs`

### Automated test coverage
yes, diffs are covered

### QA Plan
not needed due to small scope

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
leaving unchecked due to bootstrap 5 diffs adding rollback complications. it's generally fine to rollback if done immediately, but if a long time has passed only the non-diff commits can be rolled back without causing conflicts.
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
