### PR TITLE
Updated collapsible group headers to display plain text, not just markdown

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -49,7 +49,7 @@
               css: {'fa-angle-double-right': !showChildren(), 'fa-angle-double-down': showChildren()},
           "></i>
         </div>
-        <span class="webapp-markdown-output caption" data-bind="html: caption_markdown(), attr: {id: captionId()}"></span>
+        <span class="webapp-markdown-output caption" data-bind="html: caption_markdown() || caption(), attr: {id: captionId()}"></span>
         <i class="fa fa-warning text-danger pull-right" data-bind="visible: hasError() && !showChildren()"></i>
         <button class="btn btn-danger del pull-right" href="#" data-bind="
                     visible: isRepetition,


### PR DESCRIPTION
## Product Description
Followup for https://github.com/dimagi/commcare-hq/pull/33778

https://dimagi-dev.atlassian.net/browse/SUPPORT-18203
<img width="1207" alt="Screen Shot 2023-11-30 at 9 19 54 AM" src="https://github.com/dimagi/commcare-hq/assets/1486591/28d432db-a7aa-4ecb-92ac-9dc7ae9a4480">



## Feature Flag
Not flagged, but behind an appearance attribute.

## Safety Assurance

### Safety story


### Automated test coverage

no

### QA Plan

no, hotfixing


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
