### PR TITLE
Fix datetime user data

### DIFF
--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -169,7 +169,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(user_back.email, "jdoe@example.org")
         self.assertEqual(user_back.language, "en")
         self.assertEqual(user_back.get_group_ids()[0], group._id)
-        self.assertEqual(user_back.user_data["chw_id"], "13/43/DFA")
+        self.assertEqual(user_back.get_user_data(self.domain.name)["chw_id"], "13/43/DFA")
         self.assertEqual(user_back.default_phone_number, "50253311399")
 
     @flag_enabled('COMMCARE_CONNECT')

--- a/corehq/apps/users/tests/test_user_data.py
+++ b/corehq/apps/users/tests/test_user_data.py
@@ -38,19 +38,8 @@ class TestUserData(TestCase):
             'cruise': 'control',
             'this': 'road',
         })
-        # Normally you shouldn't use `user.user_data` directly - I'm demonstrating that it's updated
-        self.assertEqual(user.user_data, {
-            'cruise': 'control',
-            'this': 'road',
-        })
-        del user_data['cruise']
-        self.assertEqual(user.user_data, {
-            'this': 'road',
-        })
-        user_data.update({'this': 'field'})
-        self.assertEqual(user.user_data, {
-            'this': 'field',
-        })
+        # Normally you shouldn't use `user.user_data` directly - I'm demonstrating that it's not updated
+        self.assertEqual(user.user_data, {})
 
     def test_web_users(self):
         # This behavior is bad - data isn't fully scoped to domain
@@ -67,33 +56,18 @@ class TestUserData(TestCase):
             'commcare_profile': '',
             'start': 'sometimes',
         })
+        # Only the original domain was modified
         self.assertEqual(web_user.get_user_data('ANOTHER_DOMAIN').to_dict(), {
             'commcare_project': 'ANOTHER_DOMAIN',
             'commcare_profile': '',
-            'start': 'sometimes',  # whoops, domain 1 affects other domains!
-        })
-        web_user.save()
-        # at this point, user data has been initialized for each domain, and
-        # will no longer share a namespace
-        web_user = WebUser.get_by_user_id(web_user.user_id)
-        user_data = web_user.get_user_data(self.domain)['new_field'] = 'not_cross_domain'
-        self.assertEqual(web_user.get_user_data(self.domain).to_dict(), {
-            'commcare_project': self.domain,
-            'commcare_profile': '',
-            'start': 'sometimes',
-            'new_field': 'not_cross_domain',
-        })
-        self.assertEqual(web_user.get_user_data('ANOTHER_DOMAIN').to_dict(), {
-            'commcare_project': 'ANOTHER_DOMAIN',
-            'commcare_profile': '',
-            'start': 'sometimes',
         })
 
     def test_lazy_init_and_save(self):
         # Mimic user created the old way, with data stored in couch
         user = CommCareUser.create(self.domain, 'riggan', '***', None, None)
         self.addCleanup(user.delete, self.domain, deleted_by=None)
-        user['user_data'] = {'favorite_color': 'purple'}
+        user['user_data'] = {'favorite_color': 'purple',
+                             'start_date': '2023-01-01T00:00:00.000000Z'}
         user.save()
         with self.assertRaises(SQLUserData.DoesNotExist):
             SQLUserData.objects.get(domain=self.domain, user_id=user.user_id)
@@ -102,6 +76,7 @@ class TestUserData(TestCase):
         self.assertEqual(user.get_user_data(self.domain)['favorite_color'], 'purple')
         sql_data = SQLUserData.objects.get(domain=self.domain, user_id=user.user_id)
         self.assertEqual(sql_data.data['favorite_color'], 'purple')
+        self.assertEqual(sql_data.data['start_date'], '2023-01-01T00:00:00.000000Z')
 
         # Making a modification works immediately, but isn't persisted until user save
         user.get_user_data(self.domain)['favorite_color'] = 'blue'
@@ -111,10 +86,6 @@ class TestUserData(TestCase):
         user.save()
         sql_data.refresh_from_db()
         self.assertEqual(sql_data.data['favorite_color'], 'blue')
-
-        # The modification is also propagated back to couch for now
-        user_doc = CommCareUser.get_db().get(user.user_id)
-        self.assertEqual(user_doc['user_data']['favorite_color'], 'blue')
 
     def test_get_users_without_user_data(self):
         users_without_data = [

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -26,14 +26,14 @@ class UserData:
     def lazy_init(cls, couch_user, domain):
         # To be used during initial rollout - lazily create user_data objs from
         # existing couch data
-        raw_user_data = couch_user.user_data.copy()
+        raw_user_data = couch_user.to_json().get('user_data', {}).copy()
         raw_user_data.pop(COMMCARE_PROJECT, None)
         profile_id = raw_user_data.pop(PROFILE_SLUG, None)
         sql_data, _ = SQLUserData.objects.get_or_create(
             user_id=couch_user.user_id,
             domain=domain,
             defaults={
-                'data': couch_user.user_data,
+                'data': raw_user_data,
                 'django_user': couch_user.get_django_user(),
                 'profile_id': profile_id,
             }


### PR DESCRIPTION
## Product Description
Fixes a bug where the thing that copies user data to SQL choked on data that looked like a datetime stamp, causing 500s

## Technical Summary
https://dimagi-dev.atlassian.net/browse/SUPPORT-18199

Introduced in https://github.com/dimagi/commcare-hq/pull/33688

If user data contains a datetime string, jsonobject parses it into a date object, which we can't send directly to a SQL json field.  To address this, I use the json-compatible version of the user object and extract the user_data from that, using jsonobject's serialization.

A side effect of this change is that I cannot pass the object by reference, meaning updates to it are not passed back to couch.  I think this is actually an improvement, as the prior behavior was inconsistent anyways (it'd only pass back when first initialized, and not thereafter).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

Local testing, will deploy to staging first.


### Automated test coverage

included

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations


### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
