### PR TITLE
Anchored Submit Button for Web Apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -348,7 +348,10 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.blockSubmit = ko.observable(false);
         self.hasSubmitAttempted = ko.observable(false);
         self.isSubmitting = ko.observable(false);
-        self.submitClass = constants.LABEL_OFFSET + ' ' + constants.CONTROL_WIDTH;
+        self.submitClass = constants.FULL_WIDTH + ' text-center';
+        if (hqImport('hqwebapp/js/toggles').toggleEnabled('WEB_APPS_ANCHORED_SUBMIT')) {
+            self.submitClass += ' anchored-submit';
+        }
 
         self.currentIndex = ko.observable("0");
         self.atLastIndex = ko.observable(false);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -18,6 +18,7 @@ hqDefine("cloudcare/js/form_entry/spec/entries_spec", function () {
                 "toggles_dict",
                 {
                     WEB_APPS_UPLOAD_QUESTIONS: true,
+                    WEB_APPS_ANCHORED_SUBMIT: false,
                 }
             );
         });

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -151,9 +151,9 @@
           {% endif %}
           <div id="submit-button" class="form-actions form-group noprint-sub-container" data-bind="visible: showSubmitButton">
             <div data-bind="css: submitClass">
-              <button class="submit btn btn-primary"
-                     type="submit"
-                     data-bind="enable: enableSubmitButton">
+              <button class="submit btn btn-lg btn-primary"
+                      type="submit"
+                      data-bind="enable: enableSubmitButton">
                 <i class="fa fa-spin fa-refresh"
                    data-bind="visible: !enableSubmitButton(){% if environment == "web-apps" %} && erroredQuestions.length != 0{% endif %}"
                 ></i>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -33,6 +33,7 @@
     position: fixed;
     bottom: 30px; // data preview bar
     left: 0;
+    z-index: @zindex-formplayer-anchored-submit;
   }
 
   .form-group {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -25,6 +25,16 @@
     .border-bottom-radius(0);
   }
 
+  .anchored-submit {
+    background-color: @call-to-action-low;
+    width: 100vw;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    position: fixed;
+    bottom: 30px; // data preview bar
+    left: 0;
+  }
+
   .form-group {
     padding-left: 25px;
     padding-right: 20px;

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/includes/variables.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/includes/variables.less
@@ -113,7 +113,8 @@
 @zindex-navbar-cloudcare:             995;
 @zindex-formplayer-progress:          990;
 @zindex-cloudcare-debugger:           1005;
-@zindex-formplayer-scroll-to-bottom:     5;
+@zindex-formplayer-scroll-to-bottom:    5;
+@zindex-formplayer-anchored-submit:     2;
 
 
 @input-border-radius-large:       5px;

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables_bootstrap3.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables_bootstrap3.scss
@@ -62,6 +62,7 @@ $zindex-app-preview:                  998;
 $zindex-navbar-cloudcare:             995;
 $zindex-formplayer-progress:          990;
 $zindex-cloudcare-debugger:           1005;
-$zindex-formplayer-scroll-to-bottom:     5;
+$zindex-formplayer-scroll-to-bottom:    5;
+$zindex-formplayer-anchored-submit:     2;
 
 $cursor-disabled: 'not-allowed';

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,121 +1,121 @@
+@@ -1,122 +1,121 @@
 -@import "@{b3-import-variables}";
 +// Grid Containers
 +// we will want to adapt the defaults in a full redesign
@@ -197,7 +197,8 @@
 -@zindex-navbar-cloudcare:             995;
 -@zindex-formplayer-progress:          990;
 -@zindex-cloudcare-debugger:           1005;
--@zindex-formplayer-scroll-to-bottom:     5;
+-@zindex-formplayer-scroll-to-bottom:    5;
+-@zindex-formplayer-anchored-submit:     2;
 +$cc-dark-warm-accent-hi:  #ffe3c2;
 +$cc-dark-warm-accent-mid: #ff8400;
 +$cc-dark-warm-accent-low: #994f00;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,121 +1,194 @@
+@@ -1,122 +1,194 @@
 -@import "@{b3-import-variables}";
 +$prefix: bs;
  
@@ -231,7 +231,8 @@
 -@zindex-navbar-cloudcare:             995;
 -@zindex-formplayer-progress:          990;
 -@zindex-cloudcare-debugger:           1005;
--@zindex-formplayer-scroll-to-bottom:     5;
+-@zindex-formplayer-scroll-to-bottom:    5;
+-@zindex-formplayer-anchored-submit:     2;
 +$body-color: $dark;
 +$link-color: darken($primary, 10);
 +$link-hover-color: darken($primary, 50);

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables_bootstrap3.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables_bootstrap3.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,121 +1,67 @@
+@@ -1,122 +1,68 @@
 -@import "@{b3-import-variables}";
 +/*
 +These are Boostrap 3 variables that were carried over in the
@@ -156,14 +156,16 @@
 -@zindex-navbar-cloudcare:             995;
 -@zindex-formplayer-progress:          990;
 -@zindex-cloudcare-debugger:           1005;
--@zindex-formplayer-scroll-to-bottom:     5;
+-@zindex-formplayer-scroll-to-bottom:    5;
+-@zindex-formplayer-anchored-submit:     2;
 +$zindex-navbar:                       1000;
 +$zindex-report-loading:               100;
 +$zindex-app-preview:                  998;
 +$zindex-navbar-cloudcare:             995;
 +$zindex-formplayer-progress:          990;
 +$zindex-cloudcare-debugger:           1005;
-+$zindex-formplayer-scroll-to-bottom:     5;
++$zindex-formplayer-scroll-to-bottom:    5;
++$zindex-formplayer-anchored-submit:     2;
  
 -
 -@input-border-radius-large:       5px;

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -940,6 +940,13 @@ WEB_APPS_UPLOAD_QUESTIONS = FeatureRelease(
     owner='Jenny Schweers',
 )
 
+WEB_APPS_ANCHORED_SUBMIT = StaticToggle(
+    'web_apps_anchored_submit',
+    'USH: Keep submit button anchored at the bottom of screen for forms in Web Apps',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 SYNC_SEARCH_CASE_CLAIM = StaticToggle(
     'search_claim',
     'Enable synchronous mobile searching and case claiming',


### PR DESCRIPTION
## Product Description
Adds feature flag to always show the submit button onscreen in forms for web apps, as a fullwidth bar at the bottom of screen. Also centers the submit button in all cases.
Old styling:
![image](https://github.com/dimagi/commcare-hq/assets/100609770/5bf04cf0-2992-4c55-acfe-8e55e02b8182)

New with flag disabled:
![image](https://github.com/dimagi/commcare-hq/assets/100609770/e3f200eb-e8d4-41f8-9165-089fc1f5079d)

New with flag enabled:
![image](https://github.com/dimagi/commcare-hq/assets/100609770/2e621285-a915-403a-ad91-7c0f94d083b6)


## Technical Summary
[USH-3645](https://dimagi-dev.atlassian.net/browse/USH-3645)
Adds a new `anchored-submit` class to the form submit button when the associated feature flag is enabled. Styles this to be full width with a dark background, in a fixed position at the bottom of screen. Opted for a feature flag based on LOE and complexity, particularly since I didn't find precedent for passing an app-level setting through Formplayer and back to Web Apps. I'm sure this could be made into an app setting if needed.

Also changes base styling class for submit button to always be centered, hence the `all-users-all-environments` label here.

## Feature Flag
WEB_APPS_ANCHORED_SUBMIT (new)

## Safety Assurance

### Safety story
Modifies UI only and should be very low risk.

### Automated test coverage
n/a

### QA Plan
I don't plan to send this through QA given it's feature flagged and only meaningfully modifies CSS styling.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3645]: https://dimagi-dev.atlassian.net/browse/USH-3645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ