### PR TITLE
Lazily fetch django user only on first load

### DIFF
--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -34,7 +34,7 @@ class UserData:
             domain=domain,
             defaults={
                 'data': raw_user_data,
-                'django_user': couch_user.get_django_user(),
+                'django_user': couch_user.get_django_user,
                 'profile_id': profile_id,
             }
         )
@@ -46,7 +46,7 @@ class UserData:
             domain=self.domain,
             defaults={
                 'data': self._local_to_user,
-                'django_user': self._couch_user.get_django_user(),
+                'django_user': self._couch_user.get_django_user,
                 'profile_id': self.profile_id,
             },
         )


### PR DESCRIPTION
## Product Description
This is a performance improvement

## Technical Summary

That call to `user.get_django_user()` takes something like 2.5 seconds on prod, since it does an inexact match:

```python
        return queryset.get(username__iexact=self.username)
```
@gherceg is investigating whether it would be possible to switch to an exact match, which is much much faster.  Meanwhile, it'd be better to skip the lookup regardless, and it turns out that's easy to do.  From [the docs](https://docs.djangoproject.com/en/4.2/ref/models/querysets/#get-or-create):

> If there are any callables in `defaults`, evaluate them

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

This is a trivially simple change, and I believe test coverage is sufficient (though I'm verifying the performance improvement on staging)

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
