### PR TITLE
Remove case insensitive match when fetching django user

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1170,7 +1170,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         queryset = User.objects
         if use_primary_db:
             queryset = queryset.using(router.db_for_write(User))
-        return queryset.get(username__iexact=self.username)
+        return queryset.get(username=self.username)
 
     def add_phone_number(self, phone_number, default=False, **kwargs):
         """ Don't add phone numbers if they already exist """


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
While investigating various performance issues from today, it became clear that the current implementation of `get_django_user` is shockingly slow due to the case insensitive match.
![Screenshot from 2023-11-30 16-29-04](https://github.com/dimagi/commcare-hq/assets/15785053/ebe36452-acce-4e98-a3cb-6acee1f683ad)
There is also currently no caching of this method, so performance is paramount. The question is, can we safely remove `__iexact` from this query. In order to answer, we need to verify that there aren't any existing usernames with uppercase characters, and that when creating new users, usernames will be lowercase.

### Existing usernames
In a django shell, I iterated over all Django users and Couch users to ensure that all usernames did not contain any uppercase characters. These results prove that.
#### Django Usernames
![Screenshot from 2023-11-30 16-53-15](https://github.com/dimagi/commcare-hq/assets/15785053/899a495b-40c5-4dcc-a2da-fd2f7a0221f4)
#### Couch Usernames
![Screenshot from 2023-11-30 16-59-23](https://github.com/dimagi/commcare-hq/assets/15785053/023dbcfc-c8ac-4c88-bc23-a3e314de0be2)

### New users
https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/models.py#L715-L715 shows that the username field on the DjangoUserMixin is set to a LowercaseStringProperty which [Danny added years ago](https://github.com/dimagi/commcare-hq/commit/7c17abba70e4e3ae6a937059d59d599deeacf1bf) to ensure new usernames were lowercased. Notably, [the addition of __iexact](https://github.com/dimagi/commcare-hq/commit/387bc7131679d74b91820b55135f3b999c442688#diff-72cb8ba3bb5b51c7450986f76285fc191501fc01ba292789849e90d794fb7662R461) in the `get_django_user` method was added around this time as well.

### Better Solutions
It would be cool we linked the CouchUser and DjangoUser via one of their IDs (maybe add the couch user id to the django user), rather than rely on usernames.

 ## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The safety story is outlined above.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Not really applicable here.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
