### PR TITLE
Moved repeat group button in web apps away from border

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -32,16 +32,22 @@
                 'color': headerBackgroundColor() ? 'white' : '',
         }">
       <div data-bind="ifnot: collapsible">
-        <legend>
-          <span class="caption webapp-markdown-output"
-                data-bind="
-                  html: ko.utils.unwrapObservable($data.caption_markdown) || caption(),
-                "></span>
-          <button class="btn btn-danger del pull-right" href="#" data-bind="
-                      visible: isRepetition,
-                      click: deleteRepeat
-                  "><i class="fa fa-remove"></i></button>
-        </legend>
+        <div class="row">
+          <div class="col-sm-12">
+            <div class="form-group">
+              <legend>
+                <span class="caption webapp-markdown-output"
+                      data-bind="
+                        html: ko.utils.unwrapObservable($data.caption_markdown) || caption(),
+                      "></span>
+                <button class="btn btn-danger del pull-right" href="#" data-bind="
+                            visible: isRepetition,
+                            click: deleteRepeat
+                        "><i class="fa fa-remove"></i></button>
+              </legend>
+            </div>
+          </div>
+        </div>
       </div>
       <div data-bind="if: collapsible">
         <div class="collapsible-icon-container">


### PR DESCRIPTION
## Product Description
Small annoying thing.

before
<img width="1151" alt="Screen Shot 2023-11-30 at 8 11 52 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/5bb30b30-be92-4f7e-8892-4a793d48a469">

after
<img width="1149" alt="Screen Shot 2023-11-30 at 8 11 40 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/3d76a5ca-e3b0-4f7a-a400-fd0a4148ebca">

doesn't affect app preview, which looks like this both before and after

<img width="288" alt="Screen Shot 2023-11-30 at 8 13 33 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/caf97fd6-bee4-4642-b20e-dec7ce558d62">

## Safety Assurance

### Safety story
HTML-only change with a very limited footprint: user-controlled repeat groups in web apps.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
