### PR TITLE
Jt/visually segmented query search categories

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -241,3 +241,9 @@ class CommCareFeatureSupportMixin(object):
             toggles.CASE_LIST_CLICKABLE_ICON.enabled(self.domain)
             and self._require_minimum_version('2.54')
         )
+
+    @property
+    def supports_grouped_case_search_properties(self):
+        return (
+            self._require_minimum_version('2.54')
+        )

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -547,7 +547,7 @@ class ModuleBaseValidator(object):
                         yield {
                             "type": "invalid grouping from ungrouped search property",
                             "module": self.get_module_info(),
-                            'property': prop.name,
+                            "property": prop.name,
                         }
 
     def validate_case_list_field_actions(self):

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -539,6 +539,17 @@ class ModuleBaseValidator(object):
                             "details": search_config.get_instance_name()
                         }
 
+            contains_ungrouped_properties = any(not prop.group_key for prop in search_config.properties)
+            contains_grouping_property = any(prop.is_group for prop in search_config.properties)
+            if contains_ungrouped_properties and contains_grouping_property:
+                for prop in search_config.properties:
+                    if not prop.group_key:
+                        yield {
+                            "type": "invalid grouping from ungrouped search property",
+                            "module": self.get_module_info(),
+                            'property': prop.name,
+                        }
+
     def validate_case_list_field_actions(self):
         if hasattr(self.module, 'case_details'):
             columns = [column for column in self.module.case_details.short.columns if column.endpoint_action_id]

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -538,17 +538,15 @@ class ModuleBaseValidator(object):
                             "module": self.get_module_info(),
                             "details": search_config.get_instance_name()
                         }
-
-            contains_ungrouped_properties = any(not prop.group_key for prop in search_config.properties)
-            contains_grouping_property = any(prop.is_group for prop in search_config.properties)
-            if contains_ungrouped_properties and contains_grouping_property:
-                for prop in search_config.properties:
-                    if not prop.group_key:
-                        yield {
-                            "type": "invalid grouping from ungrouped search property",
-                            "module": self.get_module_info(),
-                            "property": prop.name,
-                        }
+            module_contains_grouping_property = any(prop.is_group for prop in search_config.properties)
+            if module_contains_grouping_property:
+                ungrouped_properties = [prop for prop in search_config.properties if not prop.group_key]
+                for prop in ungrouped_properties:
+                    yield {
+                        "type": "invalid grouping from ungrouped search property",
+                        "module": self.get_module_info(),
+                        "property": prop.name,
+                    }
 
     def validate_case_list_field_actions(self):
         if hasattr(self.module, 'case_details'):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2118,6 +2118,7 @@ class CaseSearchProperty(DocumentSchema):
     itemset = SchemaProperty(Itemset)
 
     is_group = BooleanProperty(default=False)
+    group_key = StringProperty(exclude_if_none=True)
 
 
 class DefaultCaseSearchProperty(DocumentSchema):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2117,6 +2117,8 @@ class CaseSearchProperty(DocumentSchema):
     receiver_expression = StringProperty(exclude_if_none=True)
     itemset = SchemaProperty(Itemset)
 
+    is_group = BooleanProperty(default=False)
+
 
 class DefaultCaseSearchProperty(DocumentSchema):
     """Case Properties with fixed value to search on"""

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -91,7 +91,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             validationTest: '',
             validationText: '',
             isGroup: false,
-            groupKey:'',
+            groupKey: '',
         });
         var self = {};
         self.uniqueId = generateSemiRandomId();
@@ -366,16 +366,16 @@ hqDefine("app_manager/js/details/case_claim", function () {
         );
 
         self.search_properties.subscribe(function (newProperties) {
-            let groupKey = ''
+            let groupKey = '';
             ko.utils.arrayForEach(newProperties, function (property, index) {
                 if (property.isGroup) {
-                    groupKey = `group_header_${index}`
-                    if (property.name != groupKey){
-                        property.name(groupKey)
+                    groupKey = `group_header_${index}`;
+                    if (property.name !== groupKey) {
+                        property.name(groupKey);
                     }
                 }
-                if(property.groupKey != groupKey) {
-                    property.groupKey = groupKey
+                if (property.groupKey !== groupKey) {
+                    property.groupKey = groupKey;
                 }
             });
         });
@@ -384,7 +384,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             self.search_properties.push(searchPropertyModel({}, saveButton));
         };
         self.addGroupProperty = function () {
-            self.search_properties.push(searchPropertyModel({isGroup:true}, saveButton));
+            self.search_properties.push(searchPropertyModel({isGroup: true}, saveButton));
         };
         self.removeProperty = function (property) {
             self.search_properties.remove(property);

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -370,6 +370,9 @@ hqDefine("app_manager/js/details/case_claim", function () {
             ko.utils.arrayForEach(newProperties, function (property, index) {
                 if (property.isGroup) {
                     groupKey = `group_header_${index}`
+                    if (property.name != groupKey){
+                        property.name(groupKey)
+                    }
                 }
                 if(property.groupKey != groupKey) {
                     property.groupKey = groupKey

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -365,6 +365,9 @@ hqDefine("app_manager/js/details/case_claim", function () {
         self.addProperty = function () {
             self.search_properties.push(searchPropertyModel({}, saveButton));
         };
+        self.addGroupProperty = function () {
+            self.search_properties.push(searchPropertyModel({isGroup:true}, saveButton));
+        };
         self.removeProperty = function (property) {
             self.search_properties.remove(property);
         };

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -91,6 +91,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             validationTest: '',
             validationText: '',
             isGroup: false,
+            groupKey:'',
         });
         var self = {};
         self.uniqueId = generateSemiRandomId();
@@ -155,6 +156,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         });
         self.itemset = itemsetModel(options.itemsetOptions, saveButton);
         self.isGroup = options.isGroup;
+        self.groupKey = options.groupKey;
 
         subscribeToSave(self, [
             'name', 'label', 'hint', 'appearance', 'defaultValue', 'hidden',
@@ -355,12 +357,25 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 receiverExpression: searchProperty.receiver_expression,
                 itemsetOptions: searchProperty.itemset,
                 isGroup: searchProperty.is_group,
+                groupKey: searchProperty.group_key,
             }, saveButton);
         });
 
         self.search_properties = ko.observableArray(
             wrappedSearchProperties.length > 0 ? wrappedSearchProperties : [searchPropertyModel({}, saveButton)]
         );
+
+        self.search_properties.subscribe(function (newProperties) {
+            let groupKey = ''
+            ko.utils.arrayForEach(newProperties, function (property, index) {
+                if (property.isGroup) {
+                    groupKey = `group_header_${index}`
+                }
+                if(property.groupKey != groupKey) {
+                    property.groupKey = groupKey
+                }
+            });
+        });
 
         self.addProperty = function () {
             self.search_properties.push(searchPropertyModel({}, saveButton));
@@ -376,7 +391,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             return _.map(
                 _.filter(
                     self.search_properties(),
-                    function (p) { return p.name().length > 0; }  // Skip properties where name is blank
+                    function (p) { return p.name().length > 0 || p.isGroup; }  // Skip properties where name is blank
                 ),
                 function (p) {
                     var ifSupportsValidation = function (val) {
@@ -399,6 +414,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                         receiver_expression: p.receiverExpression(),
                         fixture: ko.toJSON(p.itemset),
                         is_group: p.isGroup,
+                        group_key: p.groupKey,
                     };
                 }
             );

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -394,7 +394,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             return _.map(
                 _.filter(
                     self.search_properties(),
-                    function (p) { return p.name().length > 0 || p.isGroup; }  // Skip properties where name is blank
+                    function (p) { return p.name().length > 0;}  // Skip properties where name is blank
                 ),
                 function (p) {
                     var ifSupportsValidation = function (val) {

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -402,7 +402,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     };
                     return {
                         name: p.name(),
-                        label: p.label().length ? p.label() : p.name(),  // If label isn't set, use name
+                        label: (p.label().length || p.isGroup) ? p.label() : p.name(),  // If label isn't set, use name
                         hint: p.hint(),
                         appearance: p.appearanceFinal(),
                         is_multiselect: p.isMultiselect(),

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -90,6 +90,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             requiredText: '',
             validationTest: '',
             validationText: '',
+            isGroup: false,
         });
         var self = {};
         self.uniqueId = generateSemiRandomId();
@@ -153,6 +154,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             );
         });
         self.itemset = itemsetModel(options.itemsetOptions, saveButton);
+        self.isGroup = options.isGroup;
 
         subscribeToSave(self, [
             'name', 'label', 'hint', 'appearance', 'defaultValue', 'hidden',
@@ -352,6 +354,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 hidden: searchProperty.hidden,
                 receiverExpression: searchProperty.receiver_expression,
                 itemsetOptions: searchProperty.itemset,
+                isGroup: searchProperty.is_group,
             }, saveButton);
         });
 
@@ -392,6 +395,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                         hidden: p.hidden(),
                         receiver_expression: p.receiverExpression(),
                         fixture: ko.toJSON(p.itemset),
+                        is_group: p.isGroup,
                     };
                 }
             );

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -211,6 +211,7 @@ class RemoteRequestFactory(object):
                 description=self.build_description() if self.module.search_config.description != {} else None,
                 data=self._remote_request_query_datums,
                 prompts=self.build_query_prompts(),
+                prompt_groups=self.build_query_prompt_groups(),
                 default_search=self.module.search_config.default_search,
                 dynamic_search=self.app.split_screen_dynamic_search and not self.module.is_auto_select(),
             )
@@ -300,16 +301,17 @@ class RemoteRequestFactory(object):
 
     def build_query_prompts(self):
         prompts = []
-        for prop in self.module.search_config.properties:
+        prompt_properties = [prop for prop in self.module.search_config.properties if not prop.is_group]
+        for prop in prompt_properties:
+            text = Text(locale_id=id_strings.search_property_locale(self.module, prop.name))
+
             if prop.is_group:
-                text = Text(locale_id=id_strings.search_property_locale(self.module, prop.group_key))
                 prompts.append(QueryPromptGroup(**{
-                    'key': prop.group_key,
+                    'key': prop.name,
                     'display': Display(text=text)
                 }))
                 continue
 
-            text = Text(locale_id=id_strings.search_property_locale(self.module, prop.name))
             if prop.hint:
                 display = Display(
                     text=text,
@@ -363,6 +365,18 @@ class RemoteRequestFactory(object):
                     for i, validation in enumerate(prop.validations)
                 ]
             prompts.append(QueryPrompt(**kwargs))
+        return prompts
+
+    def build_query_prompt_groups(self):
+        prompts = []
+        prompt_group_properties = [prop for prop in self.module.search_config.properties if prop.is_group]
+        for prop in prompt_group_properties:
+            if prop.is_group:
+                text = Text(locale_id=id_strings.search_property_locale(self.module, prop.group_key))
+                prompts.append(QueryPromptGroup(**{
+                    'key': prop.group_key,
+                    'display': Display(text=text)
+                }))
         return prompts
 
     def build_stack(self):

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -305,13 +305,6 @@ class RemoteRequestFactory(object):
         for prop in prompt_properties:
             text = Text(locale_id=id_strings.search_property_locale(self.module, prop.name))
 
-            if prop.is_group:
-                prompts.append(QueryPromptGroup(**{
-                    'key': prop.name,
-                    'display': Display(text=text)
-                }))
-                continue
-
             if prop.hint:
                 display = Display(
                     text=text,

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -366,12 +366,11 @@ class RemoteRequestFactory(object):
         prompts = []
         prompt_group_properties = [prop for prop in self.module.search_config.properties if prop.is_group]
         for prop in prompt_group_properties:
-            if prop.is_group:
-                text = Text(locale_id=id_strings.search_property_locale(self.module, prop.group_key))
-                prompts.append(QueryPromptGroup(**{
-                    'key': prop.group_key,
-                    'display': Display(text=text)
-                }))
+            text = Text(locale_id=id_strings.search_property_locale(self.module, prop.group_key))
+            prompts.append(QueryPromptGroup(**{
+                'key': prop.group_key,
+                'display': Display(text=text)
+            }))
         return prompts
 
     def build_stack(self):

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -364,6 +364,8 @@ class RemoteRequestFactory(object):
                     )
                     for i, validation in enumerate(prop.validations)
                 ]
+            if prop.group_key:
+                kwargs['group_key'] = prop.group_key
             prompts.append(QueryPrompt(**kwargs))
         return prompts
 

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -44,6 +44,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     PushFrame,
     QueryData,
     QueryPrompt,
+    QueryPromptGroup,
     RemoteRequest,
     RemoteRequestPost,
     RemoteRequestQuery,
@@ -300,6 +301,14 @@ class RemoteRequestFactory(object):
     def build_query_prompts(self):
         prompts = []
         for prop in self.module.search_config.properties:
+            if prop.is_group:
+                text = Text(locale_id=id_strings.search_property_locale(self.module, prop.group_key))
+                prompts.append(QueryPromptGroup(**{
+                    'key': prop.group_key,
+                    'display': Display(text=text)
+                }))
+                continue
+
             text = Text(locale_id=id_strings.search_property_locale(self.module, prop.name))
             if prop.hint:
                 display = Display(

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -571,6 +571,12 @@ class QueryPrompt(DisplayNode):
     itemset = NodeField('itemset', Itemset)
 
 
+class QueryPromptGroup(DisplayNode):
+    ROOT_NAME = 'group'
+
+    key = StringField('@key')
+
+
 class RemoteRequestQuery(OrderedXmlObject, XmlObject):
     ROOT_NAME = 'query'
     ORDER = ('title', 'description', 'data', 'prompts')
@@ -582,6 +588,7 @@ class RemoteRequestQuery(OrderedXmlObject, XmlObject):
     description = NodeField('description', DisplayNode)
     data = NodeListField('data', QueryData)
     prompts = NodeListField('prompt', QueryPrompt)
+    prompt_groups = NodeListField('group', QueryPromptGroup)
     default_search = BooleanField("@default_search")
     dynamic_search = BooleanField("@dynamic_search")
 

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -570,6 +570,8 @@ class QueryPrompt(DisplayNode):
 
     itemset = NodeField('itemset', Itemset)
 
+    group_key = StringField('@group_key', required=False)
+
 
 class QueryPromptGroup(DisplayNode):
     ROOT_NAME = 'group'

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -497,6 +497,11 @@
               {% if not not_actual_build %}The shadow form is {% include "app_manager/partials/form_error_message.html" %}{% endif %}
             {% case "password_format" %}
               {# Do nothing; the full message is contained in error.message #}
+            {% case "invalid grouping from ungrouped search property" %}
+              {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
+                <a href="{{ module_url }}">{{ module_name }}</a> has a case search property
+                <code>{{ property }}</code> that is not assigned to a group.
+              {% endblocktrans %}
             {% case "case search nodeset invalid" %}
               {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
                 <a href="{{ module_url }}">{{ module_name }}</a> has a case search property

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -33,18 +33,19 @@
             {% include "app_manager/partials/modules/case_search_property.html" %}
           </tbody>
         </table>
-        <p>
-          <button type="button"
-                  class="btn btn-default"
-                  data-bind="click: addGroupProperty">
-            <i class="fa fa-plus"></i> {% trans "Add group" %}
-          </button>
+        <div class="btn-group">
           <button type="button"
                   class="btn btn-default"
                   data-bind="click: addProperty">
-            <i class="fa fa-plus"></i> {% trans "Add search property" %}
+            <i class="fa fa-plus"></i> {% trans "Add Search Property" %}
           </button>
-        </p>
+          <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li data-bind="click: addGroupProperty"><a>{% trans "Add Group" %}</a></li>
+          </ul>
+        </div>
       </div>
     </div>
     <div class="panel panel-appmanager">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -36,6 +36,11 @@
         <p>
           <button type="button"
                   class="btn btn-default"
+                  data-bind="click: addGroupProperty">
+            <i class="fa fa-plus"></i> {% trans "Add group" %}
+          </button>
+          <button type="button"
+                  class="btn btn-default"
                   data-bind="click: addProperty">
             <i class="fa fa-plus"></i> {% trans "Add search property" %}
           </button>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -39,12 +39,14 @@
                   data-bind="click: addProperty">
             <i class="fa fa-plus"></i> {% trans "Add Search Property" %}
           </button>
-          <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-            <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu">
-            <li data-bind="click: addGroupProperty"><a>{% trans "Add Group" %}</a></li>
-          </ul>
+          {% if app.supports_grouped_case_search_properties %}
+            <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li data-bind="click: addGroupProperty"><a>{% trans "Add Group" %}</a></li>
+            </ul>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_property.html
@@ -1,10 +1,11 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-<tr>
+<tr data-bind="css: {'info': isGroup}">
   <td class="text-center">
     <i class="grip sortable-handle hq-icon-full fa fa-arrows-v"></i>
   </td>
+  <!--ko if: !isGroup -->
   <td data-bind="css: {'has-error': $parent.isCommon(ko.unwrap(name()))}">
     <input class="form-control" type="text" data-bind="value: name"/>
     <div data-bind="visible: $parent.isCommon(ko.unwrap(name()))" class="help-block">
@@ -243,6 +244,14 @@
     </div>
   </td>
   {% endif %}
+  <!-- /ko -->
+  <!--ko if: isGroup -->
+    <td>
+      <input class="form-control" type="text" placeholder="{% trans "Group Name" %}" data-bind="value: label"/>
+    </td>
+    <td></td>
+    <td></td>
+  <!--/ko-->
   <td>
     <i style="cursor: pointer;" class="fa fa-remove"
        data-bind="click: $parent.removeProperty"></i>

--- a/corehq/apps/app_manager/tests/test_app_strings.py
+++ b/corehq/apps/app_manager/tests/test_app_strings.py
@@ -174,6 +174,8 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
                 label={'en': 'Get them all'}
             ),
             properties=[
+                CaseSearchProperty(is_group=True, name='group_header_0',
+                                   group_key='group_header_0', label={'en': 'Personal Information'}),
                 CaseSearchProperty(name="name", label={'en': 'Name'})
             ]
         )
@@ -201,6 +203,8 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
             self.assertEqual(en_app_strings['case_search.m0.icon'], 'jr://file/commcare/image/1.png')
             self.assertEqual(en_app_strings['case_search.m0.audio'], 'jr://file/commcare/image/2.mp3')
             self.assertEqual(en_app_strings['case_search.m0.again'], 'Get them all')
+            self.assertEqual(en_app_strings['search_property.m0.name'], 'Name')
+            self.assertEqual(en_app_strings['search_property.m0.group_header_0'], 'Personal Information')
 
             # non-default language
             es_app_strings = self._generate_app_strings(app, 'es', build_profile_id='es')

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -989,6 +989,11 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         self.module.search_config.properties = [
             CaseSearchProperty(is_group=True, group_key='group_header_0', label={'en': 'Personal Information'}),
             CaseSearchProperty(name='name', group_key='group_header_0', label={'en': 'Name'}),
+            CaseSearchProperty(name='dob', group_key='group_header_0',
+                               label={'en': 'Date of birth'}, input_="date"),
+            CaseSearchProperty(is_group=True, group_key='group_header_3', label={'en': 'Authorization'}),
+            CaseSearchProperty(name='consent', group_key='group_header_3',
+                               label={'en': 'Consent to search'}, input_="checkbox"),
         ]
         suite = self.app.create_suite()
         expected = """
@@ -1000,10 +1005,17 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                 </text>
               </display>
             </group>
+            <group key="group_header_3">
+              <display>
+                <text>
+                  <locale id="search_property.m0.group_header_3"/>
+                </text>
+              </display>
+            </group>
           </partial>
         """
         self.assertXmlPartialEqual(expected, suite,
-                                  "./remote-request[1]/session/query/group[@key='group_header_0']")
+                                  "./remote-request[1]/session/query/group")
 
         expected = """
           <partial>
@@ -1014,7 +1026,21 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                 </text>
               </display>
             </prompt>
+            <prompt group_key="group_header_0" input="date" key="dob">
+              <display>
+                <text>
+                  <locale id="search_property.m0.dob"/>
+                </text>
+              </display>
+            </prompt>
+            <prompt group_key="group_header_3" input="checkbox" key="consent">
+              <display>
+                <text>
+                  <locale id="search_property.m0.consent"/>
+                </text>
+              </display>
+            </prompt>
           </partial>
         """
         self.assertXmlPartialEqual(expected, suite,
-                                  "./remote-request[1]/session/query/prompt[@key='name']")
+                                  "./remote-request[1]/session/query/prompt")

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -172,7 +172,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
                 CaseSearchProperty(name='dob', label={'en': 'Date of birth'}, input_="date"),
-                CaseSearchProperty(name='consent', label={'en': 'Consent to search'}, input_="checkbox")
+                CaseSearchProperty(name='consent', label={'en': 'Consent to search'}, input_="checkbox"),
             ],
             additional_relevant="instance('groups')/groups/group",
             search_filter="name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name",
@@ -984,3 +984,22 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         </partial>
         """
         self.assertXmlPartialEqual(expected, suite, "./remote-request[1]/session/query/prompt")
+
+    def test_group(self):
+        self.module.search_config.properties = [
+            CaseSearchProperty(is_group=True, name='group_header_1', label={'en': 'Personal Information'}),
+        ]
+        suite = self.app.create_suite()
+        expected = """
+          <partial>
+            <group key="group_header_1">
+              <display>
+                <text>
+                  <locale id="search_property.m0.group_header_1"/>
+                </text>
+              </display>
+            </group>
+          </partial>
+        """
+        self.assertXmlPartialEqual(expected, suite,
+                                  "./remote-request[1]/session/query/group[@key='group_header_1']")

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -1007,7 +1007,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
         expected = """
           <partial>
-            <prompt key="name">
+            <prompt key="name" group_key="group_header_0">
               <display>
                 <text>
                   <locale id="search_property.m0.name"/>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -987,19 +987,34 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
     def test_group(self):
         self.module.search_config.properties = [
-            CaseSearchProperty(is_group=True, name='group_header_1', label={'en': 'Personal Information'}),
+            CaseSearchProperty(is_group=True, group_key='group_header_0', label={'en': 'Personal Information'}),
+            CaseSearchProperty(name='name', group_key='group_header_0', label={'en': 'Name'}),
         ]
         suite = self.app.create_suite()
         expected = """
           <partial>
-            <group key="group_header_1">
+            <group key="group_header_0">
               <display>
                 <text>
-                  <locale id="search_property.m0.group_header_1"/>
+                  <locale id="search_property.m0.group_header_0"/>
                 </text>
               </display>
             </group>
           </partial>
         """
         self.assertXmlPartialEqual(expected, suite,
-                                  "./remote-request[1]/session/query/group[@key='group_header_1']")
+                                  "./remote-request[1]/session/query/group[@key='group_header_0']")
+
+        expected = """
+          <partial>
+            <prompt key="name">
+              <display>
+                <text>
+                  <locale id="search_property.m0.name"/>
+                </text>
+              </display>
+            </prompt>
+          </partial>
+        """
+        self.assertXmlPartialEqual(expected, suite,
+                                  "./remote-request[1]/session/query/prompt[@key='name']")

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1136,6 +1136,8 @@ def _update_search_properties(module, search_properties, lang='en'):
             }]
         if prop.get('is_group'):
             ret['is_group'] = prop['is_group']
+        if prop.get('group_key'):
+            ret['group_key'] = prop['group_key']
         if prop.get('appearance', '') == 'fixture':
             if prop.get('is_multiselect', False):
                 ret['input_'] = 'select'

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1134,6 +1134,8 @@ def _update_search_properties(module, search_properties, lang='en'):
                 'text': _update_translation(current.validations[0] if current and current.validations else None,
                                             prop, "text", "validation_text"),
             }]
+        if prop.get('is_group'):
+            ret['is_group'] = prop['is_group']
         if prop.get('appearance', '') == 'fixture':
             if prop.get('is_multiselect', False):
                 ret['input_'] = 'select'


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This PR adds an "Add Group" button. Fields underneath a "Group" tab (up until the next "Group" or end) will be grouped.

![Screen Shot 2023-12-06 at 6 17 55 PM](https://github.com/dimagi/commcare-hq/assets/88759246/ad21f340-29ea-45e8-b904-ec4f854b82b0)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Tech Spec (App Configuration Frontend)](https://docs.google.com/document/d/1syEA-HC5g1FOjZ6m8DlfBspzKn9hKvq0zbMNbIWzQVE/edit#heading=h.d7s2sycdfk92)
[Jira Ticket](https://dimagi-dev.atlassian.net/browse/USH-3826)
[Research Doc](https://docs.google.com/document/d/1ZkN0_ta8jEjQ5IYHLIduBN6ZFcVEjfSIQrN3AQgBVgw/edit#heading=h.x97repjoa0f2)
[Web Apps PR](https://github.com/dimagi/commcare-hq/pull/33898)
[Formplayer PR 
](https://github.com/dimagi/formplayer/pull/1511)Implementation Details:
[CommcareCore PR
](https://github.com/dimagi/commcare-core/pull/1389)In this change, two new properties have been introduced to the `CaseSearchProperty` model: `is_group` and `group_key`.

- For items categorized as "Group," the `is_group` property is set to `True`, and they are assigned a dynamic `group_key` following the pattern `group_header_<index>`. For instance, in the screenshot provided, the `group_key` for "Group2" would be `group_header_2`. The `group_key` automatically adjusts its index as the fields are rearranged. Additionally, the `name` model property of the "Group" items is dynamically updated to match their `group_key`, which serves as the basis for generating the suite file.

- For `CaseSearchProperty` items where `is_group` is `False`, their `group_key` value corresponds to the Group to which they belong. This value is also dynamically updated to reflect changes in field arrangements.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case Search. Also gated behind min 2.54 app version.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Adds test:
- Group display text is populated in app string file with correct key and value
- Suite is generated with the correct `group` element and attributes as well as `group_key` for `prompt` elment

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will [QA](https://dimagi-dev.atlassian.net/browse/QA-5881)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
This PR will affect app builds. Apps already built will still have this change even if this PR is reverted. Existing apps will not break if this PR is reverted, but existing builds need to be handled.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
