### PR TITLE
Display mobile UCR count to user

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -154,6 +154,7 @@ from corehq.apps.appstore.models import SnapshotMixin
 from corehq.apps.builds.models import BuildRecord, BuildSpec
 from corehq.apps.builds.utils import get_default_build_spec
 from corehq.apps.cleanup.models import DeletedCouchDoc
+from corehq.apps.cloudcare.utils import get_mobile_ucr_count
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqmedia.models import (
     ApplicationMediaMixin,
@@ -4496,6 +4497,7 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
         get_app_languages.clear(self.domain)
         get_apps_in_domain.clear(self.domain, True)
         get_apps_in_domain.clear(self.domain, False)
+        get_mobile_ucr_count.clear(self.domain)
         self.doc_type += '-Deleted'
         record = DeleteApplicationRecord(
             domain=self.domain,
@@ -4522,6 +4524,7 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
         get_app_languages.clear(self.domain)
         get_apps_in_domain.clear(self.domain, True)
         get_apps_in_domain.clear(self.domain, False)
+        get_mobile_ucr_count.clear(self.domain)
 
         request = view_utils.get_request()
         user = getattr(request, 'couch_user', None)

--- a/corehq/apps/cloudcare/tests/test_utils.py
+++ b/corehq/apps/cloudcare/tests/test_utils.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from corehq.apps.app_manager.models import Application, ReportModule, ReportAppConfig
-from corehq.apps.cloudcare.utils import should_restrict_web_apps_usage
+from corehq.apps.cloudcare.utils import get_mobile_ucr_count, should_restrict_web_apps_usage
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.util.test_utils import flag_disabled, flag_enabled
 
@@ -11,58 +11,87 @@ class TestShouldRestrictWebAppsUsage(TestCase):
     @flag_disabled("ALLOW_WEB_APPS_RESTRICTION")
     @flag_disabled("MOBILE_UCR")
     def test_returns_false_if_domain_ucr_count_is_under_limit_and_neither_toggle_is_enable(self):
-        self._create_app_with_reports(report_count=0)
         with self.settings(MAX_MOBILE_UCR_LIMIT=1):
-            result = should_restrict_web_apps_usage(self.domain.name)
+            result = should_restrict_web_apps_usage(self.domain, 0)
         self.assertFalse(result)
 
     @flag_disabled("ALLOW_WEB_APPS_RESTRICTION")
     @flag_disabled("MOBILE_UCR")
     def test_returns_false_if_domain_ucr_count_exceeds_limit_and_neither_toggle_is_enabled(self):
-        self._create_app_with_reports(report_count=2)
         with self.settings(MAX_MOBILE_UCR_LIMIT=1):
-            result = should_restrict_web_apps_usage(self.domain.name)
+            result = should_restrict_web_apps_usage(self.domain, 2)
         self.assertFalse(result)
 
     @flag_enabled("ALLOW_WEB_APPS_RESTRICTION")
     @flag_disabled("MOBILE_UCR")
     def test_returns_false_if_domain_ucr_count_exceeds_limit_and_ALLOW_WEB_APPS_RESTRICTION_is_enabled(self):
-        self._create_app_with_reports(report_count=2)
         with self.settings(MAX_MOBILE_UCR_LIMIT=1):
-            result = should_restrict_web_apps_usage(self.domain.name)
+            result = should_restrict_web_apps_usage(self.domain, 2)
         self.assertFalse(result)
 
     @flag_disabled("ALLOW_WEB_APPS_RESTRICTION")
     @flag_enabled("MOBILE_UCR")
     def test_returns_false_if_domain_ucr_count_exceeds_limit_and_MOBILE_UCR_is_enabled(self):
-        self._create_app_with_reports(report_count=2)
         with self.settings(MAX_MOBILE_UCR_LIMIT=1):
-            result = should_restrict_web_apps_usage(self.domain.name)
+            result = should_restrict_web_apps_usage(self.domain, 2)
         self.assertFalse(result)
 
     @flag_enabled("ALLOW_WEB_APPS_RESTRICTION")
     @flag_enabled("MOBILE_UCR")
     def test_returns_false_if_domain_ucr_count_is_under_limit_and_both_flags_are_enabled(self):
-        self._create_app_with_reports(report_count=1)
         with self.settings(MAX_MOBILE_UCR_LIMIT=2):
-            result = should_restrict_web_apps_usage(self.domain.name)
+            result = should_restrict_web_apps_usage(self.domain, 1)
         self.assertFalse(result)
 
     @flag_enabled("ALLOW_WEB_APPS_RESTRICTION")
     @flag_enabled("MOBILE_UCR")
     def test_returns_false_if_domain_ucr_count_equals_limit_and_both_flags_are_enabled(self):
-        self._create_app_with_reports(report_count=1)
         with self.settings(MAX_MOBILE_UCR_LIMIT=1):
-            result = should_restrict_web_apps_usage(self.domain.name)
+            result = should_restrict_web_apps_usage(self.domain, 1)
         self.assertFalse(result)
 
     @flag_enabled("ALLOW_WEB_APPS_RESTRICTION")
     @flag_enabled("MOBILE_UCR")
     def test_returns_true_if_domain_ucr_count_exceeds_limit_and_both_flags_are_enabled(self):
-        self._create_app_with_reports(report_count=2)
         with self.settings(MAX_MOBILE_UCR_LIMIT=1):
-            result = should_restrict_web_apps_usage(self.domain.name)
-            self.assertTrue(result)
+            result = should_restrict_web_apps_usage(self.domain, 2)
+        self.assertTrue(result)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'restrict-web-apps-test'
+
+
+class TestGetMobileUCRCount(TestCase):
+
+    @flag_disabled("ALLOW_WEB_APPS_RESTRICTION")
+    @flag_disabled("MOBILE_UCR")
+    def test_returns_zero_if_neither_toggle_is_enable(self):
+        self._create_app_with_reports(report_count=1)
+        count = get_mobile_ucr_count(self.domain.name)
+        self.assertEqual(count, 0)
+
+    @flag_enabled("ALLOW_WEB_APPS_RESTRICTION")
+    @flag_disabled("MOBILE_UCR")
+    def test_returns_zero_if_ALLOW_WEB_APPS_RESTRICTION_is_enabled(self):
+        self._create_app_with_reports(report_count=1)
+        count = get_mobile_ucr_count(self.domain.name)
+        self.assertEqual(count, 0)
+
+    @flag_disabled("ALLOW_WEB_APPS_RESTRICTION")
+    @flag_enabled("MOBILE_UCR")
+    def test_returns_zero_if_MOBILE_UCR_is_enabled(self):
+        self._create_app_with_reports(report_count=1)
+        count = get_mobile_ucr_count(self.domain.name)
+        self.assertEqual(count, 0)
+
+    @flag_enabled("ALLOW_WEB_APPS_RESTRICTION")
+    @flag_enabled("MOBILE_UCR")
+    def test_returns_ucr_count_if_both_flags_are_enabled(self):
+        self._create_app_with_reports(report_count=1)
+        count = get_mobile_ucr_count(self.domain.name)
+        self.assertEqual(count, 1)
 
     def _create_app_with_reports(self, report_count=1):
         configs = []
@@ -76,5 +105,5 @@ class TestShouldRestrictWebAppsUsage(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.domain = create_domain('test-web-apps-restriction')
+        cls.domain = create_domain('mobile-ucr-count-test')
         cls.addClassCleanup(cls.domain.delete)

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -7,6 +7,7 @@ from six.moves.urllib.parse import quote
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
+from corehq.util.quickcache import quickcache
 
 
 def should_show_preview_app(request, app, username):
@@ -37,6 +38,7 @@ def webapps_module(domain, app_id, module_id):
     return _webapps_url(domain, app_id, selections=[module_id])
 
 
+@quickcache(['domain'], timeout=24 * 60 * 60)
 def get_mobile_ucr_count(domain):
     """
     Obtains the count of UCRs referenced across all applications in the specificed domain

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -63,7 +63,7 @@ from corehq.apps.cloudcare.dbaccessors import get_cloudcare_apps, get_applicatio
 from corehq.apps.cloudcare.decorators import require_cloudcare_access
 from corehq.apps.cloudcare.esaccessors import login_as_user_query
 from corehq.apps.cloudcare.models import SQLAppGroup
-from corehq.apps.cloudcare.utils import should_restrict_web_apps_usage
+from corehq.apps.cloudcare.utils import get_mobile_ucr_count, should_restrict_web_apps_usage
 from corehq.apps.domain.decorators import (
     domain_admin_required,
     login_and_domain_required,
@@ -170,7 +170,8 @@ class FormplayerMain(View):
         return request.couch_user, set_cookie
 
     def get(self, request, domain):
-        if should_restrict_web_apps_usage(domain):
+        mobile_ucr_count = get_mobile_ucr_count(domain)
+        if should_restrict_web_apps_usage(domain, mobile_ucr_count):
             return redirect('block_web_apps', domain=domain)
 
         option = request.GET.get('option')
@@ -303,7 +304,8 @@ class PreviewAppView(TemplateView):
     @use_daterangepicker
     @xframe_options_sameorigin
     def get(self, request, *args, **kwargs):
-        if should_restrict_web_apps_usage(request.domain):
+        mobile_ucr_count = get_mobile_ucr_count(request.domain)
+        if should_restrict_web_apps_usage(request.domain, mobile_ucr_count):
             context = get_context_for_ucr_limit_error(request.domain)
             return render(request, 'preview_app/block_app_preview.html', context)
         app = get_app(request.domain, kwargs.pop('app_id'))

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -630,8 +630,8 @@ class BlockWebAppsView(BaseDomainView):
         context = self.get_context_for_ucr_limit_error(request.domain, mobile_ucr_count)
         return render(request, self.template_name, context)
 
-    @classmethod
-    def get_context_for_ucr_limit_error(cls, domain, mobile_ucr_count):
+    @staticmethod
+    def get_context_for_ucr_limit_error(domain, mobile_ucr_count):
         return {
             'domain': domain,
             'ucr_limit': settings.MAX_MOBILE_UCR_LIMIT,

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -12,7 +12,7 @@ from django.http import (
     HttpResponseRedirect,
     JsonResponse,
 )
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -170,8 +170,7 @@ class FormplayerMain(View):
     def get(self, request, domain):
         mobile_ucr_count = get_mobile_ucr_count(domain)
         if should_restrict_web_apps_usage(domain, mobile_ucr_count):
-            context = get_context_for_ucr_limit_error(request.domain, mobile_ucr_count)
-            return render(request, 'block_web_apps.html', context)
+            return redirect('block_web_apps', domain=domain)
 
         option = request.GET.get('option')
         if option == 'apps':
@@ -627,7 +626,8 @@ class BlockWebAppsView(BaseDomainView):
     template_name = 'block_web_apps.html'
 
     def get(self, request, *args, **kwargs):
-        context = get_context_for_ucr_limit_error(request.domain)
+        mobile_ucr_count = get_mobile_ucr_count(request.domain)
+        context = get_context_for_ucr_limit_error(request.domain, mobile_ucr_count)
         return render(request, self.template_name, context)
 
 

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -304,7 +304,7 @@ class PreviewAppView(TemplateView):
     def get(self, request, *args, **kwargs):
         mobile_ucr_count = get_mobile_ucr_count(request.domain)
         if should_restrict_web_apps_usage(request.domain, mobile_ucr_count):
-            context = get_context_for_ucr_limit_error(request.domain, mobile_ucr_count)
+            context = BlockWebAppsView.get_context_for_ucr_limit_error(request.domain, mobile_ucr_count)
             return render(request, 'preview_app/block_app_preview.html', context)
         app = get_app(request.domain, kwargs.pop('app_id'))
         return self.render_to_response({
@@ -627,21 +627,21 @@ class BlockWebAppsView(BaseDomainView):
 
     def get(self, request, *args, **kwargs):
         mobile_ucr_count = get_mobile_ucr_count(request.domain)
-        context = get_context_for_ucr_limit_error(request.domain, mobile_ucr_count)
+        context = self.get_context_for_ucr_limit_error(request.domain, mobile_ucr_count)
         return render(request, self.template_name, context)
 
-
-def get_context_for_ucr_limit_error(domain, mobile_ucr_count):
-    return {
-        'domain': domain,
-        'ucr_limit': settings.MAX_MOBILE_UCR_LIMIT,
-        'error_message': _("""You have the MOBILE_UCR feature flag enabled, and have {ucr_count} mobile UCRs which
-                           exceeds the maximum limit of {ucr_limit} total User Configurable Reports used across
-                           all of your applications. To resolve, you must remove references to UCRs in your
-                           applications until you are under the limit. If you believe this is a mistake, please
-                           reach out to support.
-                           """).format(ucr_count=mobile_ucr_count, ucr_limit=settings.MAX_MOBILE_UCR_LIMIT)
-    }
+    @classmethod
+    def get_context_for_ucr_limit_error(cls, domain, mobile_ucr_count):
+        return {
+            'domain': domain,
+            'ucr_limit': settings.MAX_MOBILE_UCR_LIMIT,
+            'error_message': _("""You have the MOBILE_UCR feature flag enabled, and have {ucr_count} mobile UCRs
+                               which exceeds the maximum limit of {ucr_limit} total User Configurable Reports used
+                               across all of your applications. To resolve, you must remove references to UCRs in
+                               your applications until you are under the limit. If you believe this is a mistake,
+                               please reach out to support.
+                            """).format(ucr_count=mobile_ucr_count, ucr_limit=settings.MAX_MOBILE_UCR_LIMIT)
+        }
 
 
 @login_and_domain_required


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup to https://github.com/dimagi/commcare-hq/pull/33684

The message displayed to the user isn't very helpful if it doesn't tell them how many mobile UCRs they currently have. So I came into this wanting to fix that. I could have returned a tuple (should_restrict, ucr_count) from `should_restrict_web_apps_usage`, but I didn't love that from a cleanliness perspective, so I created a new method `get_mobile_ucr_count` that obtains the count but still maintains checking the feature flags to ensure we don't unnecessarily fetch all referenced mobile UCRs across a domain. This feels like a very safe change that is backed up by tests.

Additionally, I removed the `redirect` I had in place before, since I just wanted to render the view directly with the `mobile_ucr_count` value. There is something funky going on with that and bootstrap5 that I will need to look closer at, and may or may not require an additional commit to resolve.

And lastly, as a direct followup to [Ethan's comment](https://github.com/dimagi/commcare-hq/pull/33684#discussion_r1411078451) on the last PR, I added caching on `get_mobile_ucr_count` that is cleared whenever an application for the relevant domain is saved or deleted.

🐟 Review by commit
 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Existing tests for `should_restrict_web_apps_usage` barely changed and still pass, and newly added tests ensure `get_mobile_ucr_count` behaves as expected.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
TestShouldRestrictWebAppsUsage and TestGetMobileUCRCount in corehq/apps/cloudcare/tests/test_utils.py
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Unsure about QA. It seems prudent given the sensitivity of this area, but I also could do a staging test myself doing exactly what QA just did a week ago.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
