### PR TITLE
Bump cryptography from 41.0.4 to 41.0.6 in /requirements

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -95,7 +95,7 @@ coverage==7.1.0
     # via -r test-requirements.in
 crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
     # via -r base-requirements.in
-cryptography==41.0.4
+cryptography==41.0.6
     # via
     #   -r sso-requirements.in
     #   jwcrypto

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -77,7 +77,7 @@ contextlib2==21.6.0
     # via schema
 crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
     # via -r base-requirements.in
-cryptography==41.0.4
+cryptography==41.0.6
     # via
     #   jwcrypto
     #   oic

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -79,7 +79,7 @@ contextlib2==21.6.0
     # via schema
 crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
     # via -r base-requirements.in
-cryptography==41.0.4
+cryptography==41.0.6
     # via
     #   -r prod-requirements.in
     #   -r sso-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -73,7 +73,7 @@ contextlib2==21.6.0
     # via schema
 crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
     # via -r base-requirements.in
-cryptography==41.0.4
+cryptography==41.0.6
     # via
     #   -r sso-requirements.in
     #   jwcrypto

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -82,7 +82,7 @@ coverage==7.1.0
     # via -r test-requirements.in
 crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@775b93b8cd8e5312cab4a367409a95b66ce18165
     # via -r base-requirements.in
-cryptography==41.0.4
+cryptography==41.0.6
     # via
     #   -r sso-requirements.in
     #   jwcrypto


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Creating this new PR, because the original PR generated by dependabot failed a test for no strange reason.
Original PR: https://github.com/dimagi/commcare-hq/pull/33809

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Reviewed changelog, nothing suspicious. All tests passed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
