### PR TITLE
add username filter to link query

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -356,11 +356,10 @@ class ConnectIDAuthBackend:
             return None
         link = ConnectIDUserLink.objects.get(
             connectid_username=connect_username,
-            domain=couch_user.domain
+            domain=couch_user.domain,
+            commcare_user__username=couch_user.username
         )
 
-        if (couch_user.username != link.commcare_user.username):
-            return None
         return link.commcare_user
 
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Some (internal) people testing connect apps have multiple users in the same project space that they use for testing connect apps. That was not something I had foreseen, since it is not possible for "real" connect users. As such, this function was throwing an error because it was not finding a unique matching record. This adds an additional username filter to be find the correct link and to better match the `get_or_create` [statement](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/views/mobile/users.py#L1675)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`COMMCARE_CONNECT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This changes no code accessed outside the custom connect APKs.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
