### PR TITLE
Jt/form group style adjustment

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -259,12 +259,11 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
             currentNode = currentNode.parent;
         }
 
-        // Colors are ordered from lightest to darkest with the lightest color for the highest level.
-        // Colors are based on Bootstrap provided tint/shades of #5D70D2 (CommCare Cornflower Blue)
-        // shade(#5D70D2, 20%): #4a5aa8
-        // shade(#5D70D2, 40%): #38437e
-        // shade(#5D70D2, 60%); #252d54
-        const repeatColor = ["#4a5aa8", "#38437e", "#252d54"];
+        // Colors are ordered from darkest to lightest with the darkest color for the highest level.
+        // Colors are based on shades of @cc-brand-mid.
+        // shade(#004EBC, 20%) #003e96
+        // shade(#004EBC, 40%) #002f71
+        const repeatColor = ["#002f71", "#003e96", "#004EBC"];
         const repeatColorCount = repeatColor.length;
         const index = (nestedDepthCount - 1) % repeatColorCount;
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
@@ -142,11 +142,11 @@ hqDefine("cloudcare/js/form_entry/spec/form_ui_spec", function () {
             formJSON.tree = [g0];
             let form = formUI.Form(formJSON);
 
-            assert.equal(form.children()[0].headerBackgroundColor(), '#4a5aa8'); //[g0]
+            assert.equal(form.children()[0].headerBackgroundColor(), '#002f71'); //[g0]
             assert.equal(form.children()[0].children()[0].headerBackgroundColor(), ''); //[g0-0]
-            assert.equal(form.children()[0].children()[0].children()[2].headerBackgroundColor(), '#38437e'); //[g1]
-            assert.equal(form.children()[0].children()[0].children()[2].children()[0].headerBackgroundColor(), '#252d54'); //[g1-0]
-            assert.equal(form.children()[0].children()[0].children()[2].children()[0].children()[2].headerBackgroundColor(), '#4a5aa8'); //[r1]
+            assert.equal(form.children()[0].children()[0].children()[2].headerBackgroundColor(), '#003e96'); //[g1]
+            assert.equal(form.children()[0].children()[0].children()[2].children()[0].headerBackgroundColor(), '#004EBC'); //[g1-0]
+            assert.equal(form.children()[0].children()[0].children()[2].children()[0].children()[2].headerBackgroundColor(), '#002f71'); //[r1]
             assert.equal(form.children()[0].children()[0].children()[2].children()[0].children()[2].children()[0].headerBackgroundColor(), ''); //[r1-0]
         });
 

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/breadcrumbs.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/breadcrumbs.less
@@ -8,7 +8,7 @@
   .breadcrumb-text {
     &:before {
       padding: 0 6px 0 12px;
-      color: #cccccc;
+      color: #ffffff;
       font-size: 12px;
       vertical-align: top;
       line-height: 28px;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -42,12 +42,16 @@
   }
 
   .panel-body {
-    padding-left: 0px;
-    padding-right: 0px;
+    padding-left: 5px;
+    padding-right: 5px;
     // Bootstrap introduces -10px left/right margin for row classes. This causes element to overflow parent.
     .row {
       margin-left: 0px;
       margin-right: 0px;
+    }
+    @media (max-width: @screen-xs-max) {
+      padding-left: 0px;
+      padding-right: 0px;
     }
   }
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Follow up to https://github.com/dimagi/commcare-hq/pull/33770
Changes:
- group header nesting background color now goes from darker to lighter and changed to shades of CommCare Blue #004EBC
- breadcrumb text ">" changed to white for contrast
- add small left and right padding to nested groups

BEFORE: 
![Screen Shot 2023-11-30 at 2 29 47 PM](https://github.com/dimagi/commcare-hq/assets/88759246/b5433606-2282-4a83-9d3c-6734b84f3e0f)

AFTER:
![Screen Shot 2023-12-04 at 8 30 18 AM](https://github.com/dimagi/commcare-hq/assets/88759246/7f68dfdf-e6a6-4e10-b0c7-c5199e2feb44)
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
No ticket. Changes prompted by product design feedback. See this [slack thread](https://dimagi.slack.com/archives/C066BHW5N56/p1701259200962399)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Small blast radius changes only to groups with `collapsible` style applied.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test exists for nested group header background colors.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
