### PR TITLE
Modify ChangeMeta to support dynamic properties

### DIFF
--- a/corehq/ex-submodules/pillowtop/feed/interface.py
+++ b/corehq/ex-submodules/pillowtop/feed/interface.py
@@ -13,7 +13,9 @@ class ChangeMeta(jsonobject.JsonObject):
 
     This is only used in kafka-based pillows.
     """
-    _allow_dynamic_properties = False
+    # Allow dynamic properties, so that if a new property needs to be rolled back,
+    # changes pushed with that property do not create errors
+    _allow_dynamic_properties = True
 
     document_id = DefaultProperty(required=True)
 


### PR DESCRIPTION
## Technical Summary
This change helps roll out new fields to `ChangeMeta` in the future, as if one of these new fields were to need to be rolled  back, the previous strict implementation would throw errors on all changes still in Kafka.  Allowing dynamic properties allows us to continue to process changes with unknown properties in the event of a rollback.

## Safety Assurance

### Safety story
I verified locally that rolling back a new property would cause changes with additional properties to fail. I then verified that setting `_allow_dynamic_properties` to `True` allowed these records to process successfully. I also discussed this with @snopoke [on this comment](https://github.com/dimagi/commcare-hq/pull/33807#issuecomment-1838513633), where we didn't see the need to enforce the strictness here.

### Automated test coverage

No tests created

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
