### PR TITLE
Web apps breadcrumbs improvements

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -79,6 +79,7 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
         });
 
         detailCollection = new Backbone.Collection(breadcrumbModels);
+        detailCollection.last().set('ariaCurrentPage', true);
         var breadcrumbView = views.BreadcrumbListView({
             collection: detailCollection,
         });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1182,11 +1182,15 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         template: _.template($("#breadcrumb-item-template").html() || ""),
         className: "breadcrumb-text",
         attributes: function () {
-            return {
+            let attributes = {
                 "role": "link",
                 "tabindex": "0",
                 "style": this.buildMaxWidth(),
             };
+            if (this.options.model.get('ariaCurrentPage')) {
+                attributes['aria-current'] = 'page';
+            }
+            return attributes;
         },
         events: {
             "click": "crumbClick",

--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -120,13 +120,13 @@
 </script>
 
 <script type="text/template" id="breadcrumb-list-template">
-  <div class="breadcrumb-nav">
+  <nav class="breadcrumb-nav">
     <ol class="breadcrumb">
-      <li class="js-home breadcrumb-text" role="link" tabindex="0" aria-label="{% trans_html_attr 'Home' %}"><i class="fa fa-home"></i></li>
+      <li class="js-home breadcrumb-text" role="link" tabindex="0" style="margin-right: -5px" aria-label="Breadcrumb">{% trans 'Home' %}</li>
     </ol>
     <div class="pull-right dropdown dropdown-menu-right" id="breadcrumb__menu-dropdown">
     </div>
-  </div>
+  </nav>
 </script>
 
 <script type="text/template" id="menu-dropdown-template">

--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -120,9 +120,9 @@
 </script>
 
 <script type="text/template" id="breadcrumb-list-template">
-  <nav class="breadcrumb-nav">
+  <nav class="breadcrumb-nav" aria-label="Breadcrumb">
     <ol class="breadcrumb">
-      <li class="js-home breadcrumb-text" role="link" tabindex="0" style="margin-right: -5px" aria-label="Breadcrumb">{% trans 'Home' %}</li>
+      <li class="js-home breadcrumb-text" role="link" tabindex="0" style="margin-right: -5px">{% trans 'Home' %}</li>
     </ol>
     <div class="pull-right dropdown dropdown-menu-right" id="breadcrumb__menu-dropdown">
     </div>

--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -122,7 +122,7 @@
 <script type="text/template" id="breadcrumb-list-template">
   <nav class="breadcrumb-nav" aria-label="Breadcrumb">
     <ol class="breadcrumb">
-      <li class="js-home breadcrumb-text" role="link" tabindex="0" style="margin-right: -5px">{% trans 'Home' %}</li>
+      <li class="js-home breadcrumb-text" role="link" tabindex="0">{% trans 'Home' %}</li>
     </ol>
     <div class="pull-right dropdown dropdown-menu-right" id="breadcrumb__menu-dropdown">
     </div>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/breadcrumbs.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/breadcrumbs.less
@@ -6,6 +6,9 @@
   padding-bottom: 1rem;
   margin-top: -1px;
   .breadcrumb-text {
+    &.js-home {
+      margin-right: -5px;
+    }
     &:before {
       padding: 0 6px 0 12px;
       color: #cccccc;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Making some changes to breadcrumbs in Web Apps to have us align better with USWDS recommendations. 

Links:
- [JIRA](https://dimagi-dev.atlassian.net/browse/USH-3890?atlOrigin=eyJpIjoiOGZiZjQ3NTVlOGI0NDg5ZDkwOGM3NjJjYjUyMTk0NmEiLCJwIjoiaiJ9)
- [USWDS guidance](https://designsystem.digital.gov/components/breadcrumb/) 

Updated look with "Home" instead of the icon:

![Screenshot 2023-12-05 at 3 40 34 PM](https://github.com/dimagi/commcare-hq/assets/6729291/e334f2ac-4768-4b97-bdfa-8e90d881aac3)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Accessibility guidance around breadcrumbs is that a `nav` element should be used instead of `div`, the `aria-label=Breadcrumb` for the first breadcrumb and `aria-current=page` on the last.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested locally and on staging
- The changes are purely cosmetic. Biggest risk is someone doesn't like the changes or there's some quirkiness about the logic in Marionette

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

No, it's purely UI.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Not sure we usually do QA for this sort of thing.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
