### PR TITLE
Apply repeat striping with stripe-repeats appearance attribute

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -41,6 +41,7 @@ hqDefine("cloudcare/js/form_entry/const", function () {
         BUTTON_SELECT: 'button-select',
         SHORT: 'short',
         MEDIUM: 'medium',
+        STRIPE_REPEATS: 'stripe-repeats',
 
         // Note it's important to differentiate these two
         NO_PENDING_ANSWER: undefined,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -587,6 +587,17 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         };
 
         var styles = _.has(json, 'style') && json.style && json.style.raw ? json.style.raw.split(/\s+/) : [];
+        self.stripeRepeats = _.contains(styles, constants.STRIPE_REPEATS);
+        self.styleClass = function () {
+            let classStr = '';
+            if (self.isRepetition) {
+                classStr = 'repetition';
+            } else if (self.stripeRepeats) {
+                classStr = 'stripe-repeats';
+            }
+            return classStr;
+        };
+
         self.collapsible = _.contains(styles, constants.COLLAPSIBLE);
         self.showChildren = ko.observable(!self.collapsible || _.contains(styles, constants.COLLAPSIBLE_OPEN));
         self.toggleChildren = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -588,16 +588,6 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
 
         var styles = _.has(json, 'style') && json.style && json.style.raw ? json.style.raw.split(/\s+/) : [];
         self.stripeRepeats = _.contains(styles, constants.STRIPE_REPEATS);
-        self.styleClass = function () {
-            let classStr = '';
-            if (self.isRepetition) {
-                classStr = 'repetition';
-            } else if (self.stripeRepeats) {
-                classStr = 'stripe-repeats';
-            }
-            return classStr;
-        };
-
         self.collapsible = _.contains(styles, constants.COLLAPSIBLE);
         self.showChildren = ko.observable(!self.collapsible || _.contains(styles, constants.COLLAPSIBLE_OPEN));
         self.toggleChildren = function () {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -3,13 +3,14 @@
 
 <script type="text/html" id="sub-group-fullform-ko-template">
   <div tabindex="-1" class ="gr" data-bind="
-        class: styleClass(),
         css: {
           'gr-no-children': $data.children().length === 0,
           'gr-has-no-questions': _.all($data.children(), function(d) { return d.type() !== 'grouped-question-tile-row' }),
           'gr-has-no-nested-questions': !$data.hasAnyNestedQuestions(),
           'panel panel-default': collapsible,
+          'repetition': isRepetition,
           'required-group': !showChildren() && childrenRequired(),
+          'stripe-repeats': stripeRepeats,
         }">
     <fieldset class="gr-header" data-bind="
         css: {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -3,7 +3,7 @@
 
 <script type="text/html" id="sub-group-fullform-ko-template">
   <div tabindex="-1" class ="gr" data-bind="
-        class: isRepetition ? 'repetition' : '',
+        class: styleClass(),
         css: {
           'gr-no-children': $data.children().length === 0,
           'gr-has-no-questions': _.all($data.children(), function(d) { return d.type() !== 'grouped-question-tile-row' }),

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -60,6 +60,9 @@
       &:nth-of-type(odd) {
         background-color: @table-bg-accent;
       }
+      &:nth-of-type(even) {
+        background-color: white;
+      }
       &:hover {
         background-color: @table-bg-hover;
       }

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -56,7 +56,7 @@
   }
 
   .stripe-repeats {
-    .gr.repetition {
+    .gr {
       &:nth-of-type(odd) {
         background-color: @table-bg-accent;
       }

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -55,6 +55,17 @@
     }
   }
 
+  .stripe-repeats {
+    .gr.repetition {
+      &:nth-of-type(odd) {
+        background-color: @table-bg-accent;
+      }
+      &:hover {
+        background-color: @table-bg-hover;
+      }
+    }
+  }
+
   .info {
     overflow-x: auto;
   }


### PR DESCRIPTION
## Product Description
Applies table style striping/hover styles to repeat groups -- whether user-controlled, based on a repeat count, or model interation query -- contained in a group having the `stripe-repeats` appearance attribute.

<img width="940" alt="image" src="https://github.com/dimagi/commcare-hq/assets/100609770/7deb4c16-2079-4122-8061-dbfab82e0473">


## Technical Summary
[USH-3916](https://dimagi-dev.atlassian.net/browse/USH-3916)
Since appearance attributes aren't processed by formplayer for repeat groups, this CSS for this attribute applies styling to every `gr` within a `stripe-repeats` group, using the same striped shading and hover styles as tables plus the explicit addition of a white background for even-numbered rows, otherwise nested groups would look improperly shaded.

## Safety Assurance

### Safety story
Styling only, and has an effect only when the particular appearance attribute is used. Tested locally with different kinds of repeat groups, nested groups, etc. to double-check that odd rows are consistently shaded (with even rows their regular white).

### Automated test coverage
n/a

### QA Plan
I don't think QA is needed, but delivery has reviewed and confirmed the approach and styling works in their real-life application.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3916]: https://dimagi-dev.atlassian.net/browse/USH-3916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ