### PR TITLE
Fix stack generation for query datum Endpoints

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/endpoints.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/endpoints.py
@@ -142,7 +142,7 @@ class EndpointsHelper(PostProcessor):
         frame.add_datum(datum)
 
     def _add_query_datum(self, frame, child):
-        frame.add_datum(child.to_stack_datum())
+        frame.add_datum(child.to_stack_datum(True))
 
     def get_frame_children(self, module, form):
         helper = WorkflowHelper(self.suite, self.app, self.app.get_modules())

--- a/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
+++ b/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
@@ -521,7 +521,7 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
                              <command value="'m0'"/>
                              <query id="results:inline" value="http://localhost:8000/a/test-domain/phone/case_fixture/None/">
                                <data key="case_type" ref="'mother'"/>
-                               <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+                               <data key="case_id" ref="$case_id"/>
                              </query>
                             <datum id="case_id" value="$case_id"/>
                         </push>


### PR DESCRIPTION
## Product Description
Bug Fix: https://dimagi-dev.atlassian.net/browse/USH-3928

## Technical Summary

When defining a endpoint to a form with Inline case search enabled, we were generating the endpoint as - 

````
<endpoint id="case_list">
                    <argument id="case_id"/>
                    <stack>
                        <push>
                             <command value="'m0'"/>
                             <query id="results:inline" value="http://localhost:8000/a/test-domain/phone/case_fixture/None/">
                               <data key="case_type" ref="'mother'"/>
                               <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
                             </query>
                            <datum id="case_id" value="$case_id"/>
                        </push>
                    </stack>
                </endpoint>
````

Here `instance('commcaresession')/session/data/case_id` as the `case_id` doesn't make sense for endpoint stack since we don't have the `commcareSession` available for endpoints processing, instead we can just use the value supplied by `$case_id` directly. 

## Feature Flag
Session endpoints

## Safety Assurance

### Safety story

Bug fix, should not make things worse since the smart link to inline case search forms is breaky breaky today

### Automated test coverage

In the PR 
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
