### PR TITLE
Only try to bind lazy load fields if they are present

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -166,9 +166,13 @@ hqDefine("app_manager/js/modules/module_view", function () {
             });
         }
 
-        $('#lazy-load-case-list-fields').koApplyBindings({
-            lazy_load_case_list_fields: ko.observable(initial_page_data('lazy_load_case_list_fields')),
-        });
+        var lazyloadCaseListFields = $('#lazy-load-case-list-fields')
+        if (lazyloadCaseListFields.length > 0) {
+           lazyloadCaseListFields.koApplyBindings({
+                lazy_load_case_list_fields: ko.observable(initial_page_data('lazy_load_case_list_fields')),
+            });
+        }
+
 
         // Registration in case list
         if ($('#case-list-form').length) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_lazy_loading.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_lazy_loading.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
-<label class="control-label col-sm-2">
+<label class="control-label col-xs-12 col-sm-4 col-md-4 col-lg-2">
   {% trans "Lazy load Case List fields" %}
   <span class="hq-help-template"
         data-title="{% trans "Incrementally load case list fields" %}"


### PR DESCRIPTION
## Product Description

An error caused by a missing tag in the config causes the settings tab to not load completely. This causes some drop downs to not be filled and the saving to not work on some settings because the observable do not get updated.

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-3949

## Feature Flag

None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations, but it will reintroduce the bug.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
