### PR TITLE
Expire cache on alert delete

### DIFF
--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -52,6 +52,11 @@ class Alert(models.Model):
         cls.get_active_alerts.clear(cls)
         super().save(*args, **kwargs)
 
+    def delete(self, *args, **kwargs):
+        cls = type(self)
+        cls.get_active_alerts.clear(cls)
+        super().delete(*args, **kwargs)
+
     @classmethod
     @quickcache([], timeout=1 * 60)
     def get_active_alerts(cls):


### PR DESCRIPTION
## Product Description
When an active banner is currently deleted without being deactivated it stays on the UI for at least 1min (when the cache expires). This PR changes that in that, once an active banner (alert) is deleted the banner instantly disappears from the UI. 

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-3231)
When an Alert is deleted the cache is also cleared as is the case on a save.

Another approach could have been disabling the `Delete` action while a banner is active, hence the user would first need to disable a banner before the user can delete it.

## Feature Flag
Although this has to do with the CUSTOM_DOMAIN_BANNER_ALERTS feature flag, the change is affecting all alert banners. 

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
No automated test

### QA Plan
No QA planned.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
