### PR TITLE
Cap active banners to 3 on screen

### DIFF
--- a/corehq/apps/domain/static/domain/js/manage_alerts.js
+++ b/corehq/apps/domain/static/domain/js/manage_alerts.js
@@ -13,12 +13,8 @@ hqDefine("domain/js/manage_alerts",[
     var alertsViewModel = function () {
         var self = {};
 
-        var totalActiveAlerts = 0;
-        initialPageData.get('alerts').forEach(function (alert) {
-            if (alert.active) {
-                totalActiveAlerts += 1;
-            }
-        });
+        const activeAlerts = initialPageData.get('alerts').filter((alert) => {return alert.active});
+        var totalActiveAlerts = activeAlerts.length;
 
         var alerts = [];
         initialPageData.get('alerts').forEach(function (alert) {

--- a/corehq/apps/domain/static/domain/js/manage_alerts.js
+++ b/corehq/apps/domain/static/domain/js/manage_alerts.js
@@ -1,10 +1,20 @@
 hqDefine("domain/js/manage_alerts",[
     'jquery',
+    'knockout',
     'hqwebapp/js/initial_page_data',
-], function ($, initialPageData) {
+], function ($, ko, initialPageData) {
+
+    var alertsViewModel = function() {
+        var self = {};
+
+        self.alerts = ko.observable(initialPageData.get('alerts'));
+
+        return self;
+    }
+
     $(function () {
-        $('#ko-alert-container').koApplyBindings({
-            'alerts': initialPageData.get('alerts'),
-        });
+        $('#ko-alert-container').koApplyBindings(
+            alertsViewModel()
+        );
     });
 });

--- a/corehq/apps/domain/static/domain/js/manage_alerts.js
+++ b/corehq/apps/domain/static/domain/js/manage_alerts.js
@@ -13,7 +13,9 @@ hqDefine("domain/js/manage_alerts",[
     var alertsViewModel = function () {
         var self = {};
 
-        const activeAlerts = initialPageData.get('alerts').filter((alert) => {return alert.active});
+        const activeAlerts = initialPageData.get('alerts').filter((alert) => {
+            return alert.active;
+        });
         var totalActiveAlerts = activeAlerts.length;
 
         var alerts = [];

--- a/corehq/apps/domain/static/domain/js/manage_alerts.js
+++ b/corehq/apps/domain/static/domain/js/manage_alerts.js
@@ -8,12 +8,12 @@ hqDefine("domain/js/manage_alerts",[
         var self = alertData;
         self.isDisabled = disabled;
         return self;
-    }
+    };
 
-    var alertsViewModel = function() {
+    var alertsViewModel = function () {
         var self = {};
 
-        var totalActiveAlerts = 0
+        var totalActiveAlerts = 0;
         initialPageData.get('alerts').forEach(function (alert) {
             if (alert.active) {
                 totalActiveAlerts += 1;
@@ -22,7 +22,7 @@ hqDefine("domain/js/manage_alerts",[
 
         var alerts = [];
         initialPageData.get('alerts').forEach(function (alert) {
-            disabled = false;
+            var disabled = false;
             if (totalActiveAlerts >= 3 && !alert.active) {
                 disabled = true;
             }
@@ -32,7 +32,7 @@ hqDefine("domain/js/manage_alerts",[
         });
         self.alerts = ko.observable(alerts);
         return self;
-    }
+    };
 
     $(function () {
         $('#ko-alert-container').koApplyBindings(

--- a/corehq/apps/domain/static/domain/js/manage_alerts.js
+++ b/corehq/apps/domain/static/domain/js/manage_alerts.js
@@ -4,11 +4,33 @@ hqDefine("domain/js/manage_alerts",[
     'hqwebapp/js/initial_page_data',
 ], function ($, ko, initialPageData) {
 
+    var alertModel = function (alertData, disabled) {
+        var self = alertData;
+        self.isDisabled = disabled;
+        return self;
+    }
+
     var alertsViewModel = function() {
         var self = {};
 
-        self.alerts = ko.observable(initialPageData.get('alerts'));
+        var totalActiveAlerts = 0
+        initialPageData.get('alerts').forEach(function (alert) {
+            if (alert.active) {
+                totalActiveAlerts += 1;
+            }
+        });
 
+        var alerts = [];
+        initialPageData.get('alerts').forEach(function (alert) {
+            disabled = false;
+            if (totalActiveAlerts >= 3 && !alert.active) {
+                disabled = true;
+            }
+            alerts.push(
+                alertModel(alert, disabled)
+            );
+        });
+        self.alerts = ko.observable(alerts);
         return self;
     }
 

--- a/corehq/apps/domain/templates/domain/admin/manage_alerts.html
+++ b/corehq/apps/domain/templates/domain/admin/manage_alerts.html
@@ -15,6 +15,9 @@
       <h3>
         {% trans "Available Alerts" %}
       </h3>
+      <p>
+        {% trans "You can only have 3 alerts activated at any one time" %}
+      </p>
       <table class="table">
         <thead>
           <tr>

--- a/corehq/apps/domain/templates/domain/admin/manage_alerts.html
+++ b/corehq/apps/domain/templates/domain/admin/manage_alerts.html
@@ -54,14 +54,14 @@
                         class="btn btn-primary"
                         name="command"
                         value="activate"
-                        data-bind="visible: !active">
+                        data-bind="visible: !active, disable: isDisabled">
                   <span>{% trans "Activate Alert" %}</span>
                 </button>
                 <button type="submit"
                         class="btn btn-outline-danger"
                         name="command"
                         value="deactivate"
-                        data-bind="visible: active">
+                        data-bind="visible: active, disable: isDisabled">
                   {% trans "De-activate Alert" %}
                 </button>
               </form>

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -60,6 +60,8 @@ from corehq.apps.users.models import CouchUser
 from corehq.toggles import NAMESPACE_DOMAIN
 from corehq.toggles.models import Toggle
 
+MAX_ACTIVE_ALERTS = 3
+
 
 class BaseProjectSettingsView(BaseDomainView):
     section_name = gettext_lazy("Project Settings")
@@ -611,6 +613,10 @@ def _load_alert(alert_id, domain):
 
 def _apply_update(request, alert):
     command = request.POST.get('command')
+    if command == "activate" and len(Alert.get_active_alerts()) >= MAX_ACTIVE_ALERTS:
+        messages.error(request, _("Only 3 active alerts allowed!"))
+        return
+
     if command in ['activate', 'deactivate']:
         _update_alert(alert, command)
         messages.success(request, _("Alert updated!"))


### PR DESCRIPTION
## Product Description
Currently any number of banners can be displayed (activated) on the screen in HQ. This PR restricts this to only 3. When at least 3 banners have been activated the other banners' Active action will be disabled.

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-3233)
In addition to disabling the activation action on a banner on the UI, the banner update is also restricted in the backend to disallow more than 3 banners at a time.

## Feature Flag
CUSTOM_DOMAIN_BANNER_ALERTS

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
No automated testes included

### QA Plan
QA not necessary.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
