### PR TITLE
Speed up User API

### DIFF
--- a/corehq/apps/api/query_adapters.py
+++ b/corehq/apps/api/query_adapters.py
@@ -28,9 +28,8 @@ class UserQuerySetAdapter(object):
         if isinstance(item, slice):
             limit = item.stop - item.start
             result = self._query.size(limit).start(item.start).run()
-            users = [WrappedUser.wrap(user) for user in result.hits]
-            prime_user_data_caches(users, self.domain)
-            return users
+            users = (WrappedUser.wrap(user) for user in result.hits)
+            return list(prime_user_data_caches(users, self.domain))
         raise ValueError(
             'Invalid type of argument. Item should be an instance of slice class.')
 

--- a/corehq/apps/api/query_adapters.py
+++ b/corehq/apps/api/query_adapters.py
@@ -1,7 +1,9 @@
+from dimagi.utils.chunked import chunked
+
 from corehq.apps.es import GroupES, UserES
 from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser
-from dimagi.utils.chunked import chunked
+from corehq.apps.users.user_data import prime_user_data_caches
 
 
 class UserQuerySetAdapter(object):
@@ -26,7 +28,9 @@ class UserQuerySetAdapter(object):
         if isinstance(item, slice):
             limit = item.stop - item.start
             result = self._query.size(limit).start(item.start).run()
-            return [WrappedUser.wrap(user) for user in result.hits]
+            users = [WrappedUser.wrap(user) for user in result.hits]
+            prime_user_data_caches(users, self.domain)
+            return users
         raise ValueError(
             'Invalid type of argument. Item should be an instance of slice class.')
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1103,6 +1103,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         self.last_name = ' '.join(data)
 
     def get_user_data(self, domain):
+        # To do this in bulk, try bulk_populate_user_data
         from .user_data import UserData
         if domain not in self._user_data_accessors:
             self._user_data_accessors[domain] = UserData.lazy_init(self, domain)

--- a/corehq/apps/users/tests/test_user_data.py
+++ b/corehq/apps/users/tests/test_user_data.py
@@ -150,7 +150,7 @@ class TestUserData(TestCase):
         for user in users:
             user._user_data_accessors = {}  # wipe cache
         with patch('corehq.apps.users.user_data.UserData.lazy_init') as lazy_init:
-            prime_user_data_caches(users, self.domain)
+            users = prime_user_data_caches(users, self.domain)
             for user in users:
                 user.get_user_data(self.domain)
             self.assertEqual(lazy_init.call_count, 0)

--- a/corehq/apps/users/tests/test_user_data.py
+++ b/corehq/apps/users/tests/test_user_data.py
@@ -10,7 +10,12 @@ from corehq.apps.users.management.commands.populate_sql_user_data import (
     populate_user_data,
 )
 from corehq.apps.users.models import CommCareUser, WebUser
-from corehq.apps.users.user_data import SQLUserData, UserData, UserDataError
+from corehq.apps.users.user_data import (
+    SQLUserData,
+    UserData,
+    UserDataError,
+    prime_user_data_caches,
+)
 
 
 class TestUserData(TestCase):
@@ -128,6 +133,27 @@ class TestUserData(TestCase):
         populate_user_data(user)
         sql_data = SQLUserData.objects.get(domain=self.domain, user_id=user.user_id)
         self.assertEqual(sql_data.data, {})
+
+    def test_prime_user_data_caches(self):
+        users = [
+            self.make_commcare_user(),
+            self.make_commcare_user(),
+            self.make_commcare_user(),
+            self.make_web_user(),
+            self.make_web_user(),
+        ]
+        for user in users:
+            user.get_user_data(self.domain).save()
+        users.append(self.make_web_user())  # add user without data
+        self.assertEqual(SQLUserData.objects.count(), 5)
+
+        for user in users:
+            user._user_data_accessors = {}  # wipe cache
+        with patch('corehq.apps.users.user_data.UserData.lazy_init') as lazy_init:
+            prime_user_data_caches(users, self.domain)
+            for user in users:
+                user.get_user_data(self.domain)
+            self.assertEqual(lazy_init.call_count, 0)
 
 
 def _get_profile(self, profile_id):

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -193,7 +193,11 @@ class SQLUserData(models.Model):
 
 
 def prime_user_data_caches(users, domain):
-    """Lookup and prime caches of user data in chunks"""
+    """
+    Enriches a set of users by looking up and priming user data caches in
+    chunks, for use in bulk workflows.
+    :return: generator that yields the enriched user objects
+    """
     for chunk in chunked(users, 100):
         user_ids = [user.user_id for user in chunk]
         sql_data_by_user_id = {

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -209,3 +209,4 @@ def prime_user_data_caches(users, domain):
                 user_data = UserData({}, user, domain)
             # prime the user.get_user_data cache
             user._user_data_accessors[domain] = user_data
+            yield user

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -3,6 +3,8 @@ from django.db import models
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
+from dimagi.utils.chunked import chunked
+
 from corehq.apps.custom_data_fields.models import (
     COMMCARE_PROJECT,
     PROFILE_SLUG,
@@ -188,3 +190,22 @@ class SQLUserData(models.Model):
     class Meta:
         unique_together = ("user_id", "domain")
         indexes = [models.Index(fields=['user_id', 'domain'])]
+
+
+def prime_user_data_caches(users, domain):
+    """Lookup and prime caches of user data in chunks"""
+    for chunk in chunked(users, 100):
+        user_ids = [user.user_id for user in chunk]
+        sql_data_by_user_id = {
+            ud.user_id: ud for ud in
+            SQLUserData.objects.filter(domain=domain, user_id__in=user_ids)
+        }
+        for user in chunk:
+            if user.user_id in sql_data_by_user_id:
+                sql_data = sql_data_by_user_id[user.user_id]
+                user_data = UserData(sql_data.data, user, domain,
+                                     profile_id=sql_data.profile_id)
+            else:
+                user_data = UserData({}, user, domain)
+            # prime the user.get_user_data cache
+            user._user_data_accessors[domain] = user_data


### PR DESCRIPTION
## Product Description
Speeds up looking up users in bulk via the users API.

Staging doesn't exhibit the same degree of slowness as does prod, but I did observe an appreciable speed-up.  Loading an example set of users before the change took an average of 2.1 seconds, and with the change, that same user set took an average of 1.3 seconds.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3954
https://dimagi-dev.atlassian.net/browse/SAAS-15151
This introduces a utility function which takes an iterable of users, fetches user data in chunks, primes the caches, and returns a generator of those users, but where `get_sql_data` doesn't need to do a DB hit.  It's kinda analogous to `prefetch_related`.  This is then applied to the users API to reduce the DB hits to fetch sql data by a factor of 100 (the chunk size).

I thought this was a pretty nice, clean approach to the issue.  The alternative would probably involve a "memoizer" object that gets passed around, and possibly overriding `get_user_data`.  This utility can be used on a list of users in any context and it should just work as a drop-in optimization, without altering the interface in any way.

## Feature Flag


## Safety Assurance
It's a pretty simple change, and I'm happy with automated testing and a dry run on staging.

### Safety story


### Automated test coverage


### QA Plan
n/a

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
