### PR TITLE
update DEV_SETUP.md to include SASS installation instructions

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -689,16 +689,30 @@ curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 sudo apt install -y nodejs
 ```
 
-### Step 8: Configure LESS CSS (2 Options)
+### Step 8: Configure CSS Precompilers (2 Options)
 
-#### Option 1: Let Client Side Javascript (less.js) handle it for you
+#### Requirements: Install Dart Sass
+
+At present, we are undergoing a migration from Bootstrap 3 to 5. Bootstrap 3 uses LESS
+as its CSS precompiler, and Bootstrap 5 using SASS / SCSS. You will need both installed.
+
+LESS is already taken care of by `package.json` when you run `yarn install`. In order to
+compile SASS, we need Dart Sass. There is a `sass` npm package that can be installed globally with
+`npm install -g sass`, however this installs the pure javascript version without a binary. For speed in a
+development environment, it is recommended to install `sass` with homebrew:
+
+```shell
+brew install sass/sass/sass
+```
+
+#### Option 1: Compile CSS on page-load without compression
 
 This is the setup most developers use. If you don't know which option to use,
 use this one. It's the simplest to set up and the least painful way to develop:
 just make sure your `localsettings.py` does not contain `COMPRESS_ENABLED` or
 `COMPRESS_OFFLINE` settings (or has them both set to `False`).
 
-The disadvantage is that this is a different setup than production, where LESS
+The disadvantage is that this is a different setup than production, where LESS/SASS
 files are compressed.
 
 #### Option 2: Compress OFFLINE, just like production
@@ -715,7 +729,7 @@ COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 ```
 
-For all STATICFILES changes (primarily LESS and JavaScript), run:
+For all STATICFILES changes (primarily LESS, SASS, and JavaScript), run:
 
 ```sh
 ./manage.py collectstatic

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -705,6 +705,8 @@ development environment, it is recommended to install `sass` with homebrew:
 brew install sass/sass/sass
 ```
 
+You can also view [alternative installation instructions](https://sass-lang.com/install/) if homebrew doesn't work for you.
+
 #### Option 1: Compile CSS on page-load without compression
 
 This is the setup most developers use. If you don't know which option to use,


### PR DESCRIPTION
## Technical Summary
This updates `DEV_SETUP.md` with instructions on how to set up your local environment to compile `sass` files into `css`. This will be required to compile the stylesheet for all Bootstrap 5 pages moving forward and as more pages move to Bootstrap 5 this will be necessary for all devs to do on their local environment, not just developers working on the Bootstrap 5 migration

## Safety Assurance

### Safety story
just updating readme. safe change

### Automated test coverage
no

### QA Plan
n/a


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
