### PR TITLE
Cap active banners to 3 max

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/manage_alerts.html
+++ b/corehq/apps/domain/templates/domain/admin/manage_alerts.html
@@ -15,6 +15,9 @@
       <h3>
         {% trans "Available Alerts" %}
       </h3>
+      <p>
+        {% trans "You can only have 3 alerts activated at any one time" %}
+      </p>
       <table class="table">
         <thead>
           <tr>

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -60,6 +60,8 @@ from corehq.apps.users.models import CouchUser
 from corehq.toggles import NAMESPACE_DOMAIN
 from corehq.toggles.models import Toggle
 
+MAX_ACTIVE_ALERTS = 3
+
 
 class BaseProjectSettingsView(BaseDomainView):
     section_name = gettext_lazy("Project Settings")
@@ -611,6 +613,11 @@ def _load_alert(alert_id, domain):
 
 def _apply_update(request, alert):
     command = request.POST.get('command')
+    domain_alerts = Alert.objects.filter(created_by_domain=request.domain)
+    if command == "activate" and len(domain_alerts) >= MAX_ACTIVE_ALERTS:
+        messages.error(request, _("Only 3 active alerts allowed!"))
+        return
+
     if command in ['activate', 'deactivate']:
         _update_alert(alert, command)
         messages.success(request, _("Alert updated!"))


### PR DESCRIPTION
A remnant of https://github.com/dimagi/commcare-hq/pull/33855

## Product Description
Currently any number of banners can be displayed (activated) on the screen in HQ. This PR restricts this to only 3.

## Technical Summary
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-3233)
The number of active banners are considered when updating a new banner to active, restricting it to 3 banners at a time.

## Feature Flag
CUSTOM_DOMAIN_BANNER_ALERTS

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
No automated testes included

### QA Plan
QA not necessary.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
