### PR TITLE
Do not add extra search fields when using custom case tiles

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -20,6 +20,8 @@ from corehq.apps.app_manager.util import (
 
 TILE_DIR = Path(__file__).parent.parent / "case_tile_templates"
 
+CUSTOM = "custom"
+
 
 class CaseTileTemplates(models.TextChoices):
     PERSON_SIMPLE = ("person_simple", _("Person Simple"))
@@ -83,7 +85,7 @@ class CaseTileHelper(object):
         string.
         """
 
-        if self.detail.case_tile_template == 'custom':
+        if self.detail.case_tile_template == CUSTOM:
             from corehq.apps.app_manager.detail_screen import get_column_generator
             title = Text(locale_id=id_strings.detail_title_locale(self.detail_type))
             detail = Detail(id=self.detail_id, title=title)
@@ -138,7 +140,10 @@ class CaseTileHelper(object):
             )) is not None:
                 detail.actions.append(case_search_action)
 
-        self._populate_sort_elements_in_detail(detail)
+        #  Excludes legacy tile template to preserve behavior of existing apps using this template.
+        if self.detail.case_tile_template not in [CaseTileTemplates.PERSON_SIMPLE.value, CUSTOM]:
+            self._populate_sort_elements_in_detail(detail)
+
         DetailContributor.add_no_items_text_to_detail(detail, self.app, self.detail_type, self.module)
 
         if self.module.has_grouped_tiles():
@@ -243,19 +248,17 @@ class CaseTileHelper(object):
             return f.read()
 
     def _populate_sort_elements_in_detail(self, detail):
-        #  Excludes legacy tile template to preserve behavior of existing apps using this template.
-        if self.detail.case_tile_template != CaseTileTemplates.PERSON_SIMPLE.value:
-            xpath_to_field = self._get_xpath_mapped_to_field_containing_sort()
-            for field in detail.fields:
-                populated_xpath_function = self._escape_xpath_function(field.template.text.xpath_function)
-                if populated_xpath_function in xpath_to_field:
-                    # Adds sort element to the field
-                    field.sort_node = xpath_to_field.pop(populated_xpath_function).sort_node
+        xpath_to_field = self._get_xpath_mapped_to_field_containing_sort()
+        for field in detail.fields:
+            populated_xpath_function = self._escape_xpath_function(field.template.text.xpath_function)
+            if populated_xpath_function in xpath_to_field:
+                # Adds sort element to the field
+                field.sort_node = xpath_to_field.pop(populated_xpath_function).sort_node
 
-            # detail.fields contains only display properties, not sort-only properties.
-            # This adds to detail, hidden fields that contain sort elements.
-            for field in xpath_to_field.values():
-                detail.fields.append(field)
+        # detail.fields contains only display properties, not sort-only properties.
+        # This adds to detail, hidden fields that contain sort elements.
+        for field in xpath_to_field.values():
+            detail.fields.append(field)
 
     def _get_xpath_mapped_to_field_containing_sort(self):
         xpath_to_field = {}

--- a/corehq/apps/app_manager/tests/test_suite_custom_case_tiles.py
+++ b/corehq/apps/app_manager/tests/test_suite_custom_case_tiles.py
@@ -11,19 +11,20 @@ from corehq.apps.app_manager.tests.util import (
 )
 
 
-def add_columns_for_case_details(_module, format='plain'):
+def add_columns_for_case_details(_module, field='a', format='plain', useXpathExpression=False):
+    column = DetailColumn(
+        header={'en': 'a'},
+        model='case',
+        field=field,
+        format=format,
+        grid_x=1,
+        grid_y=1,
+        width=3,
+        height=1,
+        show_border=False)
+    column.useXpathExpression = useXpathExpression
     _module.case_details.short.columns = [
-        DetailColumn(
-            header={'en': 'a'},
-            model='case',
-            field='a',
-            format=format,
-            grid_x=1,
-            grid_y=1,
-            width=3,
-            height=1,
-            show_border=False
-        ),
+        column,
     ]
 
 
@@ -32,12 +33,16 @@ class SuiteCustomCaseTilesTest(SimpleTestCase, SuiteMixin):
 
     def test_custom_case_tile(self, *args):
         app = Application.new_app('domain', 'Untitled Application')
+        from corehq.apps.builds.models import BuildSpec
+        app.build_spec = BuildSpec.from_string('2.7.0/latest')
 
         module = app.add_module(Module.new_module('Untitled Module', None))
         module.case_type = 'patient'
         module.case_details.short.case_tile_template = "custom"
-        add_columns_for_case_details(module)
+        module.case_details.short.display = "short"
+        add_columns_for_case_details(module, "concat('a')", "clickable-icon", True)
 
+        suite = app.create_suite()
         self.assertXmlPartialEqual(
             """
             <partial>
@@ -45,22 +50,37 @@ class SuiteCustomCaseTilesTest(SimpleTestCase, SuiteMixin):
                     <style show-border="false">
                         <grid grid-height="1" grid-width="3" grid-x="1" grid-y="1"/>
                     </style>
-                    <header>
+                    <header width="13%">
                         <text>
-                            <locale id="m0.case_short.case_a_1.header"/>
+                            <locale id="m0.case_short.case_calculated_property_1.header"/>
                         </text>
                     </header>
-                    <template>
+                    <template form="clickable-icon" width="13%">
                         <text>
-                          <xpath function="a"/>
+                            <xpath function="''">
+                                <variable name="calculated_property">
+                                    <xpath function="concat('a')"/>
+                                </variable>
+                            </xpath>
                         </text>
                     </template>
+                    <sort direction="ascending" order="1" type="string">
+                        <text>
+                            <xpath function="''">
+                                <variable name="calculated_property">
+                                    <xpath function="concat('a')"/>
+                                </variable>
+                            </xpath>
+                        </text>
+                    </sort>
                 </field>
             </partial>
             """,
-            app.create_suite(),
+            suite,
             "./detail[@id='m0_case_short']/field[1]"
         )
+
+        self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_case_short']/field[2]")
 
     def test_custom_case_tile_address(self, *args):
         app = Application.new_app('domain', 'Untitled Application')


### PR DESCRIPTION
## Product Description

Calling `_populate_sort_elements_in_detail` caused fields to be added twice, once with coordinates and once without. This caused them to show up multiple times.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3892

## Feature Flag

* USH: Configure custom case list tile

## Safety Assurance

### Safety story

Tested locally and on staging

### Automated test coverage

Added test to cover the bug

### QA Plan

* No more duplicate fields
* Sorting still works as expected

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
