### PR TITLE
[SMS] Specify 'pk' parameter when fetching by object id

### DIFF
--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -3,7 +3,7 @@ import math
 from datetime import datetime, timedelta
 
 from django.conf import settings
-from django.db import DataError, transaction
+from django.db import transaction
 
 from celery.schedules import crontab
 
@@ -137,9 +137,11 @@ def time_within_windows(domain_now, windows):
     time = domain_now.time()
 
     for window in windows:
-        if (window.day in [weekday, -1] and
-            (window.start_time is None or time >= window.start_time) and
-            (window.end_time is None or time <= window.end_time)):
+        if (
+            window.day in [weekday, -1]
+            and (window.start_time is None or time >= window.start_time)
+            and (window.end_time is None or time <= window.end_time)
+        ):
             return True
 
     return False
@@ -282,7 +284,7 @@ def handle_incoming(msg):
         handle_successful_processing_attempt(msg)
     except DelayProcessing:
         raise
-    except:
+    except Exception:
         log_sms_exception(msg)
         handle_unsuccessful_processing_attempt(msg)
 
@@ -407,10 +409,10 @@ def process_sms(queued_sms_pk):
         # can cause us to miss sending the message the first time and
         # result in an unnecessary delay.
         if (
-            isinstance(msg.processed, bool) and
-            not msg.processed and
-            not msg.error and
-            msg.datetime_to_process < (utcnow + timedelta(seconds=10))
+            isinstance(msg.processed, bool)
+            and not msg.processed
+            and not msg.error
+            and msg.datetime_to_process < (utcnow + timedelta(seconds=10))
         ):
             if recipient_block:
                 recipient_lock = get_lock(
@@ -419,10 +421,10 @@ def process_sms(queued_sms_pk):
 
             if msg.direction == OUTGOING:
                 if (
-                    msg.domain and
-                    msg.couch_recipient_doc_type and
-                    msg.couch_recipient and
-                    not is_contact_active(msg.domain, msg.couch_recipient_doc_type, msg.couch_recipient)
+                    msg.domain
+                    and msg.couch_recipient_doc_type
+                    and msg.couch_recipient
+                    and not is_contact_active(msg.domain, msg.couch_recipient_doc_type, msg.couch_recipient)
                 ):
                     msg.set_system_error(SMS.ERROR_CONTACT_IS_INACTIVE)
                     remove_from_queue(msg)
@@ -517,9 +519,9 @@ def sync_case_phone_number(contact_case):
             phone_number = None
 
         if (
-            phone_number and
-            phone_number.contact_last_modified and
-            phone_number.contact_last_modified >= contact_case.server_modified_on
+            phone_number
+            and phone_number.contact_last_modified
+            and phone_number.contact_last_modified >= contact_case.server_modified_on
         ):
             return
 

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -601,7 +601,7 @@ def _sync_user_phone_numbers(couch_user_id):
 @no_result_task(queue='background_queue', acks_late=True,
                 default_retry_delay=5 * 60, max_retries=10, bind=True)
 def publish_sms_change(self, sms_id):
-    sms = SMS.objects.get(sms_id)
+    sms = SMS.objects.get(pk=sms_id)
     try:
         publish_sms_saved(sms)
     except Exception as e:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[This error](https://dimagi.sentry.io/issues/3579847252/?environment=production&project=136860&query=is%3Aunresolved+publish_sms_change&referrer=issue-stream&statsPeriod=24h&stream_index=0) has been happening for awhile, and causing [publish_sms_change](https://app.datadoghq.com/dashboard/bdu-k5b-bz5/celery-overview?refresh_mode=sliding&tpl_var_celery_task%5B0%5D=corehq.apps.sms.tasks.publish_sms_change&from_ts=1686584681000&to_ts=1702399481000&live=true) to fail consistently.

The elephant in the room is that this has been failing for over a year. Worth fixing, but this is only triggered if `publish_sms_saved` raises an exception, and then it just calls back into `publish_sms_saved` anyway. So my read is this is basically a retry mechanism for `publish_sms_saved`, and has been invoked infrequently enough that it hasn't been noticeable.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I tested this in a shell with the `sms_id` value in sentry and it behaves as expected.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
