### PR TITLE
Clear user cache after successful save

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1485,11 +1485,12 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
             if not self.to_be_deleted():
                 self._save_user_data()
-            super(CouchUser, self).save(**params)
+            try:
+                super(CouchUser, self).save(**params)
+            finally:
+                # ensure the cache is cleared even if something goes wrong while saving the user to couch
+                self.clear_quickcache_for_user()
 
-        # wait to clear cache until the user has been successfully saved to couch
-        # otherwise a method could trigger caching the previous value of the user despite the save
-        self.clear_quickcache_for_user()
         if fire_signals:
             self.fire_signals()
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-15176

This aims to address a stale cache issue discovered when saving a user object consecutively. Take the following code:
```
from corehq.apps.users.models import WebUser

user = WebUser.get_by_username(username)
user._rev
>> 1
user.save()  # increments rev by 1
user.save()  # increments rev by 1
WebUser.get_by_username(username)._rev}
>> 2  # expected new rev to be 3 (2 ahead of the initial rev), but it is 2
WebUser.get_by_username.clear(WebUser, username)
WebUser.get_by_username(username)._rev
>> 3  # since the cache was cleared, the latest object is fetched from couch
```

By default calling save on a user will send the signal `couch_user_post_save` and trigger receivers including [this one](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/signals.py#L57-L57) that sends the `sync_user_phone_numbers` task to celery. [This celery task](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/sms/tasks.py#L558-L571) includes a very important call `couch_user = CouchUser.get_by_user_id(couch_user_id)`, which if called when a cached value does not exist, will cache the return value as expected. It also [sets the cached value](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/models.py#L1416) for `WebUser.get_by_username` and [vice versa](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/models.py#L1374-L1374). 

The fun part is that we clear these cached values in `clear_quickcache_for_user` which currently is called in the user `save` method before actually saving the updated user to couch. This means that if some other process (like `sync_user_phone_numbers` running via celery) were to call `WebUser.get_by_user_id` or `WebUser.get_by_username` before the updated couch value is saved but after the cache is cleared, we will cache the old value that we had potentially just cleared from the cache, effectively breaking our cache invalidation logic.

To resolve this, it makes sense to me to only clear the cache once the user has been successfully saved to couch. This actually preserves existing behavior. If another process calls a cached method like `get_by_user_id` before the new user is saved, the old value is returned either way. The difference is that we currently also cache the stale value since we just cleared it to make way for the new value, but now we will just use the cached value if it exists, and then clear the cache once we are sure the new value is saved.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The code I've included above is roughly what I've been running in a django shell to reproduce and test this change. I've tested it locally and it behaves as expected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
~No automated tests. This is a race condition that would be hard to reliably reproduce in a test. I suppose I could write a test to ensure we call the clear cache method after the couch object is saved just to make sure it isn't moved back at some point.~ Added a test in users/tests/test_models.py:CouchUserSaveRaceConditionTests
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
