### PR TITLE
Hide Search and Clear buttons

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -26,6 +26,9 @@ hqDefine("cloudcare/js/formplayer/constants", function () {
         FORMAT_ADDRESS_POPUP: "AddressPopup",
         FORMAT_CLICKABLE_ICON: "ClickableIcon",
 
+        ENTITIES: "entities",
+        QUERY: "query",
+
         SMALL_SCREEN_WIDTH_PX: 992,
 
         BREADCRUMB_HEIGHT_PX: 46.125,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -107,7 +107,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var menuListView = menusUtils.getMenuView(menuResponse);
         var appPreview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
         var queryResponse = menuResponse.queryResponse;
-        var sidebarEnabled = !appPreview && menusUtils.sidebarEnabled(menuResponse);
+        var sidebarEnabled = !appPreview && menusUtils.isSidebarEnabled(menuResponse);
         if (sidebarEnabled && menuResponse.type === constants.QUERY) {
             var menuData = menusUtils.getMenuData(menuResponse);
             menuData["triggerEmptyCaseList"] = true;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -7,7 +7,6 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         formplayerUtils = hqImport("cloudcare/js/formplayer/utils/utils"),
         menusUtils = hqImport("cloudcare/js/formplayer/menus/utils"),
         views = hqImport("cloudcare/js/formplayer/menus/views"),
-        toggles = hqImport("hqwebapp/js/toggles"),
         QueryListView = hqImport("cloudcare/js/formplayer/menus/views/query"),
         initialPageData = hqImport("hqwebapp/js/initial_page_data").get,
         Collection = hqImport("cloudcare/js/formplayer/menus/collections");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -107,8 +107,8 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
     var showMenu = function (menuResponse) {
         var menuListView = menusUtils.getMenuView(menuResponse);
         var appPreview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
-        var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview;
-
+        var queryResponse = menuResponse.queryResponse;
+        var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview && queryResponse && queryResponse.displays.length;
         if (sidebarEnabled && menuResponse.type === "query") {
             var menuData = menusUtils.getMenuData(menuResponse);
             menuData["triggerEmptyCaseList"] = true;
@@ -126,7 +126,6 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             FormplayerFrontend.regions.getRegion('persistentCaseTile').empty();
         }
 
-        var queryResponse = menuResponse.queryResponse;
         if (sidebarEnabled && menuResponse.type === "entities" && queryResponse)  {
             var queryCollection = new Collection(queryResponse.displays);
             FormplayerFrontend.regions.getRegion('sidebar').show(

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -108,7 +108,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var menuListView = menusUtils.getMenuView(menuResponse);
         var appPreview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
         var queryResponse = menuResponse.queryResponse;
-        var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview && menusUtils.sidebarEnabled(menuResponse);
+        var sidebarEnabled = !appPreview && menusUtils.sidebarEnabled(menuResponse);
         if (sidebarEnabled && menuResponse.type === constants.QUERY) {
             var menuData = menusUtils.getMenuData(menuResponse);
             menuData["triggerEmptyCaseList"] = true;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -108,7 +108,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var menuListView = menusUtils.getMenuView(menuResponse);
         var appPreview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
         var queryResponse = menuResponse.queryResponse;
-        const hasSearchInputs = menuResponse.type === "query" ? menuResponse.length > 0 : (menuResponse.queryResponse != null && menuResponse.queryResponse.displays.length > 0);
+        const hasSearchInputs = menuResponse.type === "query" ? menuResponse.models.length > 0 : (menuResponse.queryResponse != null && menuResponse.queryResponse.displays.length > 0);
         var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview && hasSearchInputs;
         if (sidebarEnabled && menuResponse.type === "query") {
             var menuData = menusUtils.getMenuData(menuResponse);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -108,7 +108,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var menuListView = menusUtils.getMenuView(menuResponse);
         var appPreview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
         var queryResponse = menuResponse.queryResponse;
-        const hasSearchInputs = menuResponse.type === "query" ? menuResponse.models.length > 0 : (menuResponse.queryResponse !== null && menuResponse.queryResponse.displays.length > 0);
+        const hasSearchInputs = menuResponse.type === "query" ? menuResponse.models.length > 0 : (queryResponse !== null && queryResponse.displays.length > 0);
         var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview && hasSearchInputs;
         if (sidebarEnabled && menuResponse.type === "query") {
             var menuData = menusUtils.getMenuData(menuResponse);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -108,7 +108,8 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var menuListView = menusUtils.getMenuView(menuResponse);
         var appPreview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
         var queryResponse = menuResponse.queryResponse;
-        var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview && queryResponse && queryResponse.displays.length;
+        const hasSearchInputs = menuResponse.type === "query" ? menuResponse.length > 0 : (menuResponse.queryResponse != null && menuResponse.queryResponse.displays.length > 0);
+        var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview && hasSearchInputs;
         if (sidebarEnabled && menuResponse.type === "query") {
             var menuData = menusUtils.getMenuData(menuResponse);
             menuData["triggerEmptyCaseList"] = true;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -108,7 +108,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var menuListView = menusUtils.getMenuView(menuResponse);
         var appPreview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
         var queryResponse = menuResponse.queryResponse;
-        const hasSearchInputs = menuResponse.type === "query" ? menuResponse.models.length > 0 : (queryResponse !== null && queryResponse.displays.length > 0);
+        const hasSearchInputs = menuResponse.type === "query" ? (menuResponse.models && menuResponse.models.length > 0) : (queryResponse && queryResponse.displays.length > 0);
         var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview && hasSearchInputs;
         if (sidebarEnabled && menuResponse.type === "query") {
             var menuData = menusUtils.getMenuData(menuResponse);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -108,9 +108,8 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var menuListView = menusUtils.getMenuView(menuResponse);
         var appPreview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
         var queryResponse = menuResponse.queryResponse;
-        const hasSearchInputs = menuResponse.type === "query" ? (menuResponse.models && menuResponse.models.length > 0) : (queryResponse && queryResponse.displays.length > 0);
-        var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview && hasSearchInputs;
-        if (sidebarEnabled && menuResponse.type === "query") {
+        var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview && menusUtils.sidebarEnabled(menuResponse);
+        if (sidebarEnabled && menuResponse.type === constants.QUERY) {
             var menuData = menusUtils.getMenuData(menuResponse);
             menuData["triggerEmptyCaseList"] = true;
             menuData["sidebarEnabled"] = true;
@@ -127,7 +126,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             FormplayerFrontend.regions.getRegion('persistentCaseTile').empty();
         }
 
-        if (sidebarEnabled && menuResponse.type === "entities" && queryResponse)  {
+        if (sidebarEnabled && menuResponse.type === constants.ENTITIES && queryResponse)  {
             var queryCollection = new Collection(queryResponse.displays);
             FormplayerFrontend.regions.getRegion('sidebar').show(
                 QueryListView({
@@ -139,7 +138,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
                     disableDynamicSearch: !sessionStorage.submitPerformed,
                 }).render()
             );
-        } else if (sidebarEnabled && menuResponse.type === "query") {
+        } else if (sidebarEnabled && menuResponse.type === constants.QUERY) {
             FormplayerFrontend.regions.getRegion('sidebar').show(
                 QueryListView({
                     collection: menuResponse,
@@ -161,7 +160,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
                 if (isFormEntry) {
                     menusUtils.showMenuDropdown(menuResponse.langs, initialPageData('lang_code_name_mapping'));
                 }
-                if (menuResponse.type === "entities") {
+                if (menuResponse.type === constants.ENTITIES) {
                     menusUtils.showMenuDropdown();
                 }
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -108,7 +108,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         var menuListView = menusUtils.getMenuView(menuResponse);
         var appPreview = FormplayerFrontend.currentUser.displayOptions.singleAppMode;
         var queryResponse = menuResponse.queryResponse;
-        const hasSearchInputs = menuResponse.type === "query" ? menuResponse.models.length > 0 : (menuResponse.queryResponse != null && menuResponse.queryResponse.displays.length > 0);
+        const hasSearchInputs = menuResponse.type === "query" ? menuResponse.models.length > 0 : (menuResponse.queryResponse !== null && menuResponse.queryResponse.displays.length > 0);
         var sidebarEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH') && !appPreview && hasSearchInputs;
         if (sidebarEnabled && menuResponse.type === "query") {
             var menuData = menusUtils.getMenuData(menuResponse);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -95,11 +95,11 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
 
         if (langs && langs.length > 1) {
             langModels = _.map(langs, function (lang) {
-            let matchingLanguage = langCodeNameMapping[lang];
-            return {
-                lang_code: lang,
-                lang_label: matchingLanguage ? matchingLanguage : lang,
-            };
+                let matchingLanguage = langCodeNameMapping[lang];
+                return {
+                    lang_code: lang,
+                    lang_label: matchingLanguage ? matchingLanguage : lang,
+                };
             });
             langCollection = new Backbone.Collection(langModels);
         } else {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -157,10 +157,11 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
     };
 
     var sidebarEnabled = function (menuResponse) {
+        const splitScreenCaseSearchEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH');
         if (menuResponse.type === constants.QUERY) {
-            return menuResponse.models && menuResponse.models.length > 0;
+            return splitScreenCaseSearchEnabled && menuResponse.models && menuResponse.models.length > 0;
         } else if (menuResponse.type === constants.ENTITIES) {
-            return menuResponse.queryResponse && menuResponse.queryResponse.displays.length > 0;
+            return splitScreenCaseSearchEnabled && menuResponse.queryResponse && menuResponse.queryResponse.displays.length > 0;
         }
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -162,7 +162,7 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
         } else if (menuResponse.type === constants.ENTITIES) {
             return menuResponse.queryResponse && menuResponse.queryResponse.displays.length > 0;
         }
-    }
+    };
 
     var getMenuView = function (menuResponse) {
         var menuData = getMenuData(menuResponse);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -7,7 +7,8 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
         QueryView = hqImport("cloudcare/js/formplayer/menus/views/query"),
         toggles = hqImport("hqwebapp/js/toggles"),
         utils = hqImport("cloudcare/js/formplayer/utils/utils"),
-        views = hqImport("cloudcare/js/formplayer/menus/views");
+        views = hqImport("cloudcare/js/formplayer/menus/views"),
+        constants = hqImport("cloudcare/js/formplayer/constants");
 
     var recordPosition = function (position) {
         sessionStorage.locationLat = position.coords.latitude;
@@ -155,6 +156,14 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
         }
     };
 
+    var sidebarEnabled = function (menuResponse) {
+        if (menuResponse.type === constants.QUERY) {
+            return menuResponse.models && menuResponse.models.length > 0;
+        } else if (menuResponse.type === constants.ENTITIES) {
+            return menuResponse.queryResponse && menuResponse.queryResponse.displays.length > 0;
+        }
+    }
+
     var getMenuView = function (menuResponse) {
         var menuData = getMenuData(menuResponse);
         var urlObject = utils.currentUrlToObject();
@@ -162,7 +171,7 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
         sessionStorage.queryKey = menuResponse.queryKey;
         if (menuResponse.type === "commands") {
             return views.MenuListView(menuData);
-        } else if (menuResponse.type === "query") {
+        } else if (menuResponse.type === constants.QUERY) {
             var props = {
                 domain: FormplayerFrontend.getChannel().request('currentUser').domain,
             };
@@ -176,13 +185,13 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
                 forceManualSearch: false,
             });
             return QueryView(menuData);
-        } else if (menuResponse.type === "entities") {
+        } else if (menuResponse.type === constants.ENTITIES) {
             var searchText = urlObject.search;
             var event = "Viewed Case List";
             if (searchText) {
                 event = "Searched Case List";
             }
-            if (menuResponse.queryResponse && menuResponse.queryResponse.displays.length) {
+            if (sidebarEnabled(menuResponse)) {
                 menuData.sidebarEnabled = true;
             }
             var eventData = {
@@ -212,5 +221,6 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
         showBreadcrumbs: showBreadcrumbs,
         showMenuDropdown: showMenuDropdown,
         startOrStopLocationWatching: startOrStopLocationWatching,
+        sidebarEnabled: sidebarEnabled,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -156,7 +156,7 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
         }
     };
 
-    var sidebarEnabled = function (menuResponse) {
+    var isSidebarEnabled = function (menuResponse) {
         const splitScreenCaseSearchEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH');
         if (menuResponse.type === constants.QUERY) {
             return splitScreenCaseSearchEnabled && menuResponse.models && menuResponse.models.length > 0;
@@ -192,7 +192,7 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
             if (searchText) {
                 event = "Searched Case List";
             }
-            if (sidebarEnabled(menuResponse)) {
+            if (isSidebarEnabled(menuResponse)) {
                 menuData.sidebarEnabled = true;
             }
             var eventData = {
@@ -222,6 +222,6 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
         showBreadcrumbs: showBreadcrumbs,
         showMenuDropdown: showMenuDropdown,
         startOrStopLocationWatching: startOrStopLocationWatching,
-        sidebarEnabled: sidebarEnabled,
+        isSidebarEnabled: isSidebarEnabled,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -182,7 +182,7 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
             if (searchText) {
                 event = "Searched Case List";
             }
-            if (menuResponse.queryResponse) {
+            if (menuResponse.queryResponse && menuResponse.queryResponse.displays.length) {
                 menuData.sidebarEnabled = true;
             }
             var eventData = {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -83,6 +83,22 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
                 assert.isTrue(showMain.args[0].options.triggerEmptyCaseList);
             });
 
+            it('should hide sidebar if there are no search inputs in query response', function () {
+                const responseWithTypeQuery = _.extend({}, splitScreenCaseListResponse, { 'type': 'query'});
+                Controller.showMenu(responseWithTypeQuery);
+
+                assert.isTrue(stubs.regions['sidebar'].empty.called);
+            })
+
+            it('should hide sidebar if there are no search inputs in entities response', function () {
+                let queryResponse = splitScreenCaseListResponse.queryResponse;
+                queryResponse = _.extend({}, queryResponse, {'displays': {}});
+                const responseWithTypeQuery = _.extend({}, splitScreenCaseListResponse, {'queryResponse': queryResponse});
+                Controller.showMenu(responseWithTypeQuery);
+
+                assert.isTrue(stubs.regions['sidebar'].empty.called);
+            })
+
             it('should empty sidebar if in app preview', function () {
                 FormplayerFrontend.currentUser.displayOptions.singleAppMode = true;
                 Controller.showMenu(splitScreenCaseListResponse);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -88,7 +88,7 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
                 Controller.showMenu(responseWithTypeQuery);
 
                 assert.isTrue(stubs.regions['sidebar'].empty.called);
-            })
+            });
 
             it('should hide sidebar if there are no search inputs in entities response', function () {
                 let queryResponse = splitScreenCaseListResponse.queryResponse;
@@ -97,7 +97,7 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
                 Controller.showMenu(responseWithTypeQuery);
 
                 assert.isTrue(stubs.regions['sidebar'].empty.called);
-            })
+            });
 
             it('should empty sidebar if in app preview', function () {
                 FormplayerFrontend.currentUser.displayOptions.singleAppMode = true;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -66,7 +66,7 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
             });
 
             it('should show sidebar and main regions with query type split screen case search', function () {
-                const responseWithTypeQuery = _.extend({}, splitScreenCaseListResponse, { 'type': 'query' });
+                const responseWithTypeQuery = _.extend({}, splitScreenCaseListResponse, { 'type': 'query' , 'models': [{}]});
                 Controller.showMenu(responseWithTypeQuery);
 
                 assert.isTrue(stubs.regions['sidebar'].show.called);
@@ -74,7 +74,7 @@ hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function 
             });
 
             it('should explicitly set sidebarEnabled and triggerEmptyCaseList with query type split screen case search', function () {
-                const responseWithTypeQuery = _.extend({}, splitScreenCaseListResponse, { 'type': 'query' });
+                const responseWithTypeQuery = _.extend({}, splitScreenCaseListResponse, { 'type': 'query', 'models': [{}] });
                 Controller.showMenu(responseWithTypeQuery);
 
                 assert.isTrue(stubs.regions['main'].show.called);


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This removes the the `Search` and `Clear` buttons when there is no search input present. This is done by adding additional logic when setting `sideBarEnabled`.
Before:
<img width="1372" alt="Screenshot 2023-12-13 at 2 44 13 PM" src="https://github.com/dimagi/commcare-hq/assets/42388648/b5731199-823b-4aff-b307-e38ec4c7ded9">

After:
<img width="1373" alt="Screenshot 2023-12-13 at 2 43 49 PM" src="https://github.com/dimagi/commcare-hq/assets/42388648/84ce9339-f9ba-433d-87d1-0c1493de00e1">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
jira ticket: https://dimagi-dev.atlassian.net/browse/USH-3924

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
SPLIT_SCREEN_CASE_SEARCH

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
tested locally and on staging. 
will have QA take a pass as well.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
