### PR TITLE
Form submit button: Add check for document.visibilityState

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -488,6 +488,11 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         });
 
         self.submitForm = function () {
+            $(document).onvisibilitychange = () => {
+                if (document.visibilityState === "hidden") {
+                    self.showSubmitButton = false;
+                }
+             };
             self.hasSubmitAttempted(true);
             $.publish('formplayer.' + constants.SUBMIT, self);
         };


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
raised in support ticket [USH-3972](https://dimagi-dev.atlassian.net/browse/USH-3972)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This ticket is for sticky submit, but the same issue exists with the non-sticky submit button. When pressing the back button while the form is submitting the submit button would then be shown in the case list because the HTML is not cleared. To fix, I added a check after submit if the `visibilityState` of the document changes to hidden to hide the submit button (as would happen if the back button was pressed during submit) 

I tried different logic for the `visible` of `hidden` for the button, but was unsuccessful beyond this.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging and verified by support and delivery

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA
However with the last potential fix a QA ticket was raised and they verified this new fix does not have the same issue with followup forms: [QA-5942](https://dimagi-dev.atlassian.net/browse/QA-5942?focusedCommentId=302307)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3972]: https://dimagi-dev.atlassian.net/browse/USH-3972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[QA-5942]: https://dimagi-dev.atlassian.net/browse/QA-5942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ