### PR TITLE
Disable permenant deletion task

### DIFF
--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -23,13 +23,19 @@ UNDEFINED_XMLNS_LOG_DIR = settings.LOG_HOME
 logger = logging.getLogger(__name__)
 
 
-@periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
+# @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def permanently_delete_eligible_data(dry_run=False):
     """
     Permanently delete database objects that are eligible for hard deletion.
     To be eligible means to have a ``deleted_on`` field with a value less than
     the cutoff date returned from ``get_cutoff_date_for_data_deletion``.
     :param dry_run: if True, no changes will be committed to the database
+    """
+    """
+    NOTE: Do not delete this function! In the interest of keeping deletion records for future reference,
+    data won't be completely hard deleted until the domain is deleted. Instead, they'll be converted
+    into a tombstone after the 90 day safety period. This task will be restructured to do that once a day
+    in a future PR coming soon (Q1 2024).
     """
     dry_run_tag = '[DRY RUN] ' if dry_run else ''
     cutoff_date = get_cutoff_date_for_data_deletion()


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

(No ticket yet)

After some discussion it was pointed out that we should be keeping deletion records for forms and cases. This was originally part of the [main case deletion PR](https://github.com/dimagi/commcare-hq/pull/33831) but since forms are currently set to permanently delete after the 30 day period, this PR is to stop that from happening as soon as possible, in case the main PR doesn't go out next week. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

This just stops a periodic task from running. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

No tests but the existing tests related to this task will eventually be overwritten (RIP)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
