### PR TITLE
New Metric for CommCareHQ Calculated Properties: 365 Active Mobile Workers

### DIFF
--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -46,7 +46,6 @@ from corehq.apps.users.util import WEIRD_USER_IDS
 from corehq.messaging.scheduling.util import domain_has_reminders
 from corehq.motech.repeaters.models import Repeater
 from corehq.util.dates import iso_string_to_datetime
-from corehq.util.metrics import metrics_histogram_timer
 from corehq.util.quickcache import quickcache
 
 
@@ -62,13 +61,7 @@ DISPLAY_DATE_FORMAT = '%Y/%m/%d %H:%M:%S'
 
 
 def active_mobile_users(domain, days=30):
-    buckets = (0.1, 1, 5, 10, 30, 60, 120, 60 * 5, 60 * 10, 60 * 15, 60 * 30)
-    with metrics_histogram_timer(
-            'commcare.calculated_properties.mobile_users.timing',
-            buckets,
-            tags={'days': days}
-    ):
-        return _mobile_users(domain, int(days), inactive=False)
+    return _mobile_users(domain, int(days), inactive=False)
 
 
 def inactive_mobile_users(domain, days=30):

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -60,13 +60,20 @@ def num_mobile_users(domain, *args):
 DISPLAY_DATE_FORMAT = '%Y/%m/%d %H:%M:%S'
 
 
-def active_mobile_users(domain, *args):
+def active_mobile_users(domain, days=30):
+    return _mobile_users(domain, int(days), inactive=False)
+
+
+def inactive_mobile_users(domain, days=30):
+    return _mobile_users(domain, int(days), inactive=True)
+
+
+def _mobile_users(domain, days=30, inactive=False):
     """
-    Returns the number of mobile users who have submitted a form or SMS in the
-    last 30 days
+    Returns the number of mobile users who have submitted a form or SMS
     """
     now = datetime.utcnow()
-    then = (now - timedelta(days=30))
+    then = (now - timedelta(days=days))
 
     user_ids = get_mobile_users(domain)
 
@@ -94,7 +101,7 @@ def active_mobile_users(domain, *args):
     )
 
     num_users = len(form_users | sms_users)
-    return num_users if 'inactive' not in args else len(user_ids) - num_users
+    return num_users if not inactive else len(user_ids) - num_users
 
 
 def cases(domain, *args):
@@ -243,13 +250,13 @@ def not_implemented(domain, *args):
 
 CALC_ORDER = [
     'num_web_users', 'num_mobile_users', 'forms', 'cases',
-    'mobile_users--active', 'mobile_users--inactive', 'active_cases',
-    'cases_in_last--30', 'cases_in_last--60', 'cases_in_last--90',
-    'cases_in_last--120', 'active', 'first_form_submission',
-    'last_form_submission', 'has_app', 'web_users', 'active_apps',
-    'uses_reminders', 'sms--I', 'sms--O', 'sms_in_last', 'sms_in_last--30',
-    'sms_in_last_bool', 'sms_in_last_bool--30', 'sms_in_in_last--30',
-    'sms_out_in_last--30',
+    'active_mobile_users', 'inactive_mobile_users', 'active_mobile_users--365',
+    'active_cases', 'cases_in_last--30', 'cases_in_last--60',
+    'cases_in_last--90', 'cases_in_last--120', 'active',
+    'first_form_submission', 'last_form_submission', 'has_app', 'web_users',
+    'active_apps', 'uses_reminders', 'sms--I', 'sms--O', 'sms_in_last',
+    'sms_in_last--30', 'sms_in_last_bool', 'sms_in_last_bool--30',
+    'sms_in_in_last--30', 'sms_out_in_last--30',
 ]
 
 CALCS = {
@@ -265,8 +272,9 @@ CALCS = {
     'sms_in_in_last--30': "# incoming SMS in last 30 days",
     'sms_out_in_last--30': "# outgoing SMS in last 30 days",
     'cases': "# cases",
-    'mobile_users--active': "# active mobile users",
-    'mobile_users--inactive': "# inactive mobile users",
+    'active_mobile_users': "# active mobile users in last 30 days",
+    'inactive_mobile_users': "# inactive mobile users in last 30 days",
+    'active_mobile_users--365': "# active mobile users in last 365 days",
     'active_cases': "# active cases",
     'cases_in_last--30': "# cases seen last 30 days",
     'cases_in_last--60': "# cases seen last 60 days",
@@ -278,7 +286,7 @@ CALCS = {
     'has_app': "Has App",
     'web_users': "list of web users",
     'active_apps': "list of active apps",
-    'uses_reminders': "uses reminders"
+    'uses_reminders': "uses reminders",
 }
 
 CALC_FNS = {
@@ -293,7 +301,8 @@ CALC_FNS = {
     "sms_in_in_last": sms_in_in_last,
     "sms_out_in_last": sms_out_in_last,
     "cases": cases,
-    "mobile_users": active_mobile_users,
+    "active_mobile_users": active_mobile_users,
+    "inactive_mobile_users": inactive_mobile_users,
     "active_cases": not_implemented,
     "cases_in_last": cases_in_last,
     "inactive_cases_in_last": inactive_cases_in_last,
@@ -342,7 +351,7 @@ def calced_props(domain_obj, id, all_stats):
     return {
         "_id": id,
         "cp_n_web_users": int(all_stats["web_users"].get(dom, 0)),
-        "cp_n_active_cc_users": int(CALC_FNS["mobile_users"](dom)),
+        "cp_n_active_cc_users": int(CALC_FNS["active_mobile_users"](dom)),
         "cp_n_cc_users": int(all_stats["commcare_users"].get(dom, 0)),
         "cp_n_active_cases": int(CALC_FNS["cases_in_last"](dom, 120)),
         "cp_n_users_submitted_form": total_distinct_users(dom),

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -352,6 +352,7 @@ def calced_props(domain_obj, id, all_stats):
         "_id": id,
         "cp_n_web_users": int(all_stats["web_users"].get(dom, 0)),
         "cp_n_active_cc_users": int(CALC_FNS["active_mobile_users"](dom)),
+        "cp_n_active_cc_users_365_days": int(CALC_FNS["active_mobile_users"](dom, 365)),
         "cp_n_cc_users": int(all_stats["commcare_users"].get(dom, 0)),
         "cp_n_active_cases": int(CALC_FNS["cases_in_last"](dom, 120)),
         "cp_n_users_submitted_form": total_distinct_users(dom),


### PR DESCRIPTION
Duplicated from https://github.com/dimagi/commcare-hq/pull/33852 to get the build working. @dannyroberts can you approve please. Builds don't work on PRs from forked repos.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This adds a new field to the calculated properties page of a domain: "# active mobile users in last 365 days"

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://docs.google.com/document/d/1MhB1ENFOj748ENkNT6zmy27nalZDwfq31En2vw-F6f4/edit
I renamed the `active_mobile_workers` function, as this was actually returning active and inactive users depending on a magic parameter. The argument to the function is now the number of days to calculate the property against.

As was requested, I added a new metric timer `'commcare.calculated_properties.mobile_users.timing',`,  as it was unknown how long this calculation would take. I included the "days" tag in that metric so that a comparison could be made between the previous 30 day calculation and the new 365 day calculation. If this timing is low enough, this property will get added to the salesforce API.

![image(1)](https://github.com/dimagi/commcare-hq/assets/146896/edb33edf-8e9f-4de7-b2a2-8ea015ca868f)


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
 The one issue I can foresee arising is that this metric takes a large amount of time to aggregate on elasticsearch, which is why it is currently limited to a Dimagi-only UI for now.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I added a test for this property, even though there were no tests in this area before. I renamed a few functions --
the `test_calculated_properties_are_serializable` test ensures that I did this correctly.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
This is only Dimagi facing, I don't believe there is a pre-release QA plan

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
