### PR TITLE
Form submission notification text translation

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -480,8 +480,7 @@ def _create_forms_app_strings(
             )
 
         yield id_strings.form_submit_label_locale(form), form.get_submit_label(lang)
-        yield id_strings.form_notification_submit_label_locale(form), form.get_submit_notification_label(lang)
-
+        yield id_strings.form_submit_notification_label_locale(form), form.get_submit_notification_label(lang)
 
 def _create_case_list_form_app_strings(
     app,

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -480,6 +480,7 @@ def _create_forms_app_strings(
             )
 
         yield id_strings.form_submit_label_locale(form), form.get_submit_label(lang)
+        yield id_strings.form_notification_submit_label_locale(form), form.get_submit_notification_label(lang)
 
 
 def _create_case_list_form_app_strings(

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -422,6 +422,14 @@ def form_submit_label_locale(form):
     )
 
 
+@pattern('forms.m%df%d.submit_notification_label')
+def form_submit_notification_label_locale(form):
+    return "forms.m{module.id}f{form.id}.submit_notification_label".format(
+        module=form.get_module(),
+        form=form
+    )
+
+
 @pattern('case_list_form.m%d.icon')
 def case_list_form_icon_locale(module):
     return "case_list_form.m{module.id}.icon".format(module=module)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1350,7 +1350,7 @@ class FormBase(DocumentSchema):
     def get_submit_notification_label(self, lang):
         if self.submit_notification_label and lang in self.submit_notification_label:
             return self.get_submit_notification_label[lang]
-        return None
+        return 'Successfully saved!'  # TODO: figure our default value since setting to None cause build issues
 
 
 class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1350,7 +1350,7 @@ class FormBase(DocumentSchema):
     def get_submit_notification_label(self, lang):
         if self.submit_notification_label and lang in self.submit_notification_label:
             return self.submit_notification_label[lang]
-        return 'Successfully saved!'  # TODO: figure our default value since setting to None cause build issues
+        return ''
 
 
 class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1349,7 +1349,7 @@ class FormBase(DocumentSchema):
 
     def get_submit_notification_label(self, lang):
         if self.submit_notification_label and lang in self.submit_notification_label:
-            return self.get_submit_notification_label[lang]
+            return self.submit_notification_label[lang]
         return 'Successfully saved!'  # TODO: figure our default value since setting to None cause build issues
 
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1347,6 +1347,11 @@ class FormBase(DocumentSchema):
             return self.submit_label[lang]
         return 'Submit'
 
+    def get_submit_notification_label(self, lang):
+        if lang in self.submit_notification_label:
+            return self.get_submit_notification_label[lang]
+        return None
+
 
 class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1348,7 +1348,7 @@ class FormBase(DocumentSchema):
         return 'Submit'
 
     def get_submit_notification_label(self, lang):
-        if lang in self.submit_notification_label:
+        if self.submit_notification_label and lang in self.submit_notification_label:
             return self.get_submit_notification_label[lang]
         return None
 

--- a/corehq/apps/app_manager/tests/test_app_strings.py
+++ b/corehq/apps/app_manager/tests/test_app_strings.py
@@ -267,11 +267,19 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
             'en': 'Submit Button',
             'es': 'Botón de Enviar',
         }
+        form.submit_notification_label = {
+            'en': 'You submitted the form!',
+            'es': '¡Enviaste el formulario!',
+        }
         en_strings = self._generate_app_strings(factory.app, 'en')
         self.assertEqual(en_strings['forms.m0f0.submit_label'], form.submit_label['en'])
+        self.assertEqual(en_strings['forms.m0f0.submit_notification_label'], form.submit_notification_label['en'])
 
         es_strings = self._generate_app_strings(factory.app, 'es')
         self.assertEqual(es_strings['forms.m0f0.submit_label'], form.submit_label['es'])
+        self.assertEqual(es_strings['forms.m0f0.submit_notification_label'], form.submit_notification_label['es'])
 
         default_strings = self._generate_app_strings(factory.app, 'default')
         self.assertEqual(default_strings['forms.m0f0.submit_label'], form.submit_label['en'])
+        self.assertEqual(default_strings['forms.m0f0.submit_notification_label'],
+                         form.submit_notification_label['en'])

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -460,10 +460,13 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
 
         self.getSubmitTranslation = function () {
             var translations = self.translations;
+            console.log(translations)
             if (translations) {
                 const result = Object.entries(translations).find(([k]) => k.includes("submit_label"));
+                console.log(result)
                 if (result) {
                     const [key, _] = result; // Destructuring the found entry
+                    console.log(ko.toJS(translations[key]))
                     return ko.toJS(translations[key]);
                 }
             }

--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -381,8 +381,10 @@ def get_form_question_label_name_media(langs, form):
                 itext_items[text_id][(lang, value_form)] = value
 
     itext_items['submit_label'] = {}
+    itext_items['submit_notification_label'] = {}
     for lang in langs:
         itext_items['submit_label'][(lang, 'default')] = form.get_submit_label(lang)
+        itext_items['submit_notification_label'][(lang, 'default')] = form.get_submit_notification_label(lang)
 
     app = form.get_app()
     for text_id, values in itext_items.items():

--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -402,5 +402,8 @@ def get_form_question_label_name_media(langs, form):
         # Don't add empty rows:
         if any(row[1:]):
             rows.append(row)
+        # allow empty for submit_notification_label row
+        if row[0] == 'submit_notification_label' and not any(row[1:]):
+            rows.append(row)
 
     return rows

--- a/corehq/apps/translations/app_translations/upload_form.py
+++ b/corehq/apps/translations/app_translations/upload_form.py
@@ -39,7 +39,6 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
         # These attributes get populated by update
         self.markdowns = None
         self.markdown_vetoes = None
-        self.submit_notification_label = None
 
     def _get_xform(self):
         if not isinstance(self.form, ShadowForm) and self.form.source:
@@ -86,9 +85,6 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
         # Skip labels that have no translation provided
         label_ids_to_skip = self._get_label_ids_to_skip(rows)
 
-        if self.submit_notification_label:
-            self._update_translation(self.submit_notification_label, self.form.submit_notification_label)
-
         # Update the translations
         for lang in self.langs:
             translation_node = self.itext.find("./{f}translation[@lang='%s']" % lang)
@@ -100,6 +96,12 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
                 if row['label'] == 'submit_label':
                     try:
                         self.form.submit_label[lang] = row[self._get_col_key('default', lang)]
+                    except KeyError:
+                        pass
+                    continue
+                if row['label'] == 'submit_notification_label':
+                    try:
+                        self.form.submit_notification_label[lang] = row[self._get_col_key('default', lang)]
                     except KeyError:
                         pass
                     continue

--- a/corehq/apps/translations/app_translations/upload_form.py
+++ b/corehq/apps/translations/app_translations/upload_form.py
@@ -100,10 +100,13 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
                         pass
                     continue
                 if row['label'] == 'submit_notification_label':
+                    notification_value = ''
                     try:
-                        self.form.submit_notification_label[lang] = row[self._get_col_key('default', lang)]
+                        notification_value = row[self._get_col_key('default', lang)]
                     except KeyError:
                         pass
+                    if notification_value:
+                        self.form.submit_notification_label[lang] = notification_value
                     continue
                 try:
                     self._add_or_remove_translations(lang, row)

--- a/corehq/apps/translations/app_translations/upload_form.py
+++ b/corehq/apps/translations/app_translations/upload_form.py
@@ -40,6 +40,7 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
         self.markdowns = None
         self.markdown_vetoes = None
         self.submit_label = None
+        self.submit_notification_label = None
 
     def _get_xform(self):
         if not isinstance(self.form, ShadowForm) and self.form.source:
@@ -88,6 +89,9 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
 
         if self.submit_label:
             self._update_translation(self.submit_label, self.form.submit_label)
+
+        if self.submit_notification_label:
+            self._update_translation(self.submit_notification_label, self.form.submit_notification_label)
 
         # Update the translations
         for lang in self.langs:

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -399,6 +399,7 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBaseWithApp):
             ('vetoed_markdown-label', '*i just happen to like stars a lot*', '*i just happen to like stars a lot*',
              '', '', '', '', '', ''),
             ("submit_label", "new submit", "nouveau", "", "", "", "", "", ""),
+            ("submit_notification_label", "new submit notification", "nouveau", "", "", "", "", "", ""),
         ))
     )
 
@@ -793,6 +794,15 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBaseWithApp):
         # note changes on upload with new value
         self.upload_raw_excel_translations(self.multi_sheet_upload_headers, self.multi_sheet_upload_data)
         self.assertEqual(form.submit_label, {'en': 'new submit', 'fra': 'nouveau'})
+
+    def test_submit_notification_label_on_upload(self):
+        form = self.app.get_module(0).get_form(0)
+        form.submit_notification_label = {'en': 'old submission label', 'fra': 'passé'}
+        self.assertEqual(form.submit_notification_label, {'en': 'old submission label', 'fra': 'passé'})
+
+        # note changes on upload with new value
+        self.upload_raw_excel_translations(self.multi_sheet_upload_headers, self.multi_sheet_upload_data)
+        self.assertEqual(form.submit_notification_label, {'en': 'new submit notification', 'fra': 'nouveau'})
 
 
     def test_case_search_labels_on_upload(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
[USH-3861](https://dimagi-dev.atlassian.net/browse/USH-3861) and [USH-3885](https://dimagi-dev.atlassian.net/browse/USH-3885
)
Model changes [here](https://github.com/dimagi/commcare-hq/pull/33881)

<img width="900" alt="image" src="https://github.com/dimagi/commcare-hq/assets/36681924/e5800679-1f7f-4d8e-943d-9b5c2347ca2f">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is just for one of the model changes, the other is in a separate PR
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The field will still not be added if it is blank, and now with no migration it will be blank until the field is manually added and uploaded by someone with access.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There are some in ap strings and I added another one

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3861]: https://dimagi-dev.atlassian.net/browse/USH-3861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-3885]: https://dimagi-dev.atlassian.net/browse/USH-3885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ