### PR TITLE
Add lower boundary when fetching cases to process for case update rules

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -124,10 +124,7 @@ class AutomaticUpdateRule(models.Model):
         default='ALL',
     )
 
-    # For performance reasons, the server_modified_boundary is a
-    # required part of the criteria and should be set to the minimum
-    # number of days old that a case's server_modified_on date must be
-    # before we run the rule against it.
+    # Minimum number of days old a case must be before the rule processes it
     server_modified_boundary = models.IntegerField(null=True)
 
     upstream_id = models.CharField(max_length=32, null=True)
@@ -224,9 +221,12 @@ class AutomaticUpdateRule(models.Model):
                 rules_by_case_type[rule.case_type].append(rule)
         return rules_by_case_type
 
-    # returns None if any of the rules do not filter on server modified
-    @classmethod
-    def get_boundary_date(cls, rules, now):
+    @staticmethod
+    def get_boundary_date(rules, now):
+        """
+        :returns: ``datetime`` based on smallest server_modified_boundary value or None if any rule does not filter
+        on server modified
+        """
         min_boundary = None
         for rule in rules:
             if not rule.filter_on_server_modified:
@@ -235,27 +235,17 @@ class AutomaticUpdateRule(models.Model):
                 min_boundary = rule.server_modified_boundary
             elif rule.server_modified_boundary < min_boundary:
                 min_boundary = rule.server_modified_boundary
-        date = now - timedelta(days=min_boundary)
-        return date
+        return now - timedelta(days=min_boundary)
 
     @classmethod
-    def iter_cases(cls, domain, case_type, boundary_date=None, db=None, include_closed=False):
-        return cls._iter_cases_from_postgres(
-            domain, case_type, boundary_date=boundary_date, db=db, include_closed=include_closed
-        )
+    def iter_cases(cls, domain, case_type, db=None, modified_lte=None, include_closed=False):
+        q_expression = Q(domain=domain, type=case_type, deleted=False)
 
-    @classmethod
-    def _iter_cases_from_postgres(cls, domain, case_type, boundary_date=None, db=None, include_closed=False):
-        q_expression = Q(
-            domain=domain,
-            type=case_type,
-            deleted=False,
-        )
         if not include_closed:
             q_expression = q_expression & Q(closed=False)
 
-        if boundary_date:
-            q_expression = q_expression & Q(server_modified_on__lte=boundary_date)
+        if modified_lte:
+            q_expression = q_expression & Q(server_modified_on__lte=modified_lte)
 
         if db:
             return paginate_query(db, CommCareCase, q_expression, load_source='auto_update_rule')

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -167,11 +167,12 @@ def run_case_update_rules_for_domain(domain, now=None):
     serializer='pickle',
 )
 def run_case_update_rules_for_domain_and_db(domain, now, run_id, case_type, db=None):
-    all_rules = AutomaticUpdateRule.by_domain(domain, AutomaticUpdateRule.WORKFLOW_CASE_UPDATE)
-    rules = list(all_rules.filter(case_type=case_type))
+    rules = list(
+        AutomaticUpdateRule.by_domain(domain, AutomaticUpdateRule.WORKFLOW_CASE_UPDATE).filter(case_type=case_type)
+    )
 
-    boundary_date = AutomaticUpdateRule.get_boundary_date(rules, now)
-    iterator = AutomaticUpdateRule.iter_cases(domain, case_type, boundary_date, db=db)
+    modified_before = AutomaticUpdateRule.get_boundary_date(rules, now)
+    iterator = AutomaticUpdateRule.iter_cases(domain, case_type, db=db, modified_lte=modified_before)
     run = iter_cases_and_run_rules(domain, iterator, rules, now, run_id, case_type, db)
 
     if run.status == DomainCaseRuleRun.STATUS_FINISHED:

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -172,7 +172,11 @@ def run_case_update_rules_for_domain_and_db(domain, now, run_id, case_type, db=N
     )
 
     modified_before = AutomaticUpdateRule.get_boundary_date(rules, now)
-    iterator = AutomaticUpdateRule.iter_cases(domain, case_type, db=db, modified_lte=modified_before)
+    modified_after = AutomaticUpdateRule.get_oldest_rule_run(rules)
+    iterator = AutomaticUpdateRule.iter_cases(domain, case_type, db=db,
+                                              modified_lte=modified_before,
+                                              modified_gte=modified_after)
+
     run = iter_cases_and_run_rules(domain, iterator, rules, now, run_id, case_type, db)
 
     if run.status == DomainCaseRuleRun.STATUS_FINISHED:

--- a/corehq/apps/data_interfaces/tests/test_models.py
+++ b/corehq/apps/data_interfaces/tests/test_models.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, TestCase
@@ -339,6 +339,29 @@ class AutomaticUpdateRuleTests(SimpleTestCase):
             'criteria': ['criteria1', 'criteria2'],
             'actions': ['action1', 'action2'],
         })
+
+    def test_get_boundary_date_returns_none_if_any_rule_does_not_filter_on_server_modified(self):
+        now = datetime(2020, 6, 1, 0, 0)
+        rules = [
+            AutomaticUpdateRule(filter_on_server_modified=True),
+            AutomaticUpdateRule(filter_on_server_modified=False),
+        ]
+
+        result = AutomaticUpdateRule.get_boundary_date(rules, now)
+
+        self.assertIsNone(result)
+
+    def test_get_boundary_date_returns_most_recent_date_if_all_rules_filter_on_server_modified(self):
+        now = datetime(2020, 6, 1, 0, 0)
+        rules = [
+            # filter_on_server_modified is True by default
+            AutomaticUpdateRule(server_modified_boundary=30),
+            AutomaticUpdateRule(server_modified_boundary=1),
+        ]
+
+        result = AutomaticUpdateRule.get_boundary_date(rules, now)
+
+        self.assertEqual(result, datetime(2020, 5, 31, 0, 0))
 
     def setUp(self):
         self.actions = []

--- a/corehq/apps/data_interfaces/tests/test_models.py
+++ b/corehq/apps/data_interfaces/tests/test_models.py
@@ -363,6 +363,26 @@ class AutomaticUpdateRuleTests(SimpleTestCase):
 
         self.assertEqual(result, datetime(2020, 5, 31, 0, 0))
 
+    def test_get_oldest_rule_run_returns_none_if_rule_has_never_been_run(self):
+        rules = [
+            AutomaticUpdateRule(last_run=datetime(2020, 1, 1, 0, 0)),
+            AutomaticUpdateRule(),  # last_run defaults to None
+        ]
+
+        result = AutomaticUpdateRule.get_oldest_rule_run(rules)
+
+        self.assertIsNone(result)
+
+    def test_get_oldest_rule_run_returns_oldest_last_run_if_all_rules_have_been_run(self):
+        rules = [
+            AutomaticUpdateRule(last_run=datetime(2020, 1, 1, 0, 0)),
+            AutomaticUpdateRule(last_run=datetime(2010, 12, 1, 0, 0)),
+        ]
+
+        result = AutomaticUpdateRule.get_oldest_rule_run(rules)
+
+        self.assertEqual(result, datetime(2010, 12, 1, 0, 0))
+
     def setUp(self):
         self.actions = []
         self.criteria = []


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Currently, case update rule runs iterate through all cases in a domain up until the `sever_modified_boundary` if applicable and process any cases that match the criteria. Given that case update rules run daily, we should limit the cases we iterate over to only include cases that have been modified since the last rule run. There are a number of tasks that take [at least over an hour to process cases for all rules in a domain](https://app.datadoghq.com/dashboard/bdu-k5b-bz5/celery-overview?fullscreen_end_ts=1702687345000&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1702600945000&fullscreen_widget=4822372153813112&refresh_mode=sliding&tpl_var_celery_queue%5B0%5D=case_rule_queue&tpl_var_celery_task%5B0%5D=corehq.apps.data_interfaces.tasks.run_case_update_rules_for_domain_and_db&from_ts=1702585276000&to_ts=1702671676000&live=true), so this is an attempt to help optimize this task. I think this is a good change to make, but there are a couple of concerns we may need to address before moving forward.

### Concerns
#### User Edits a Rule
If a rule is edited, it is possible cases that did not fit the criteria previously now do, and the logic implemented in this PR does not account for this. I think I need to add a `modified_on` property to `AutomaticUpdateRule` and use that in conjunction with `last_run` to determine the safest date. Basically, if `modified_on` > `last_run`, run for all cases.

#### Missed Updates
@dannyroberts flagged that the current case pagination sorts by primary key in ascending order, effectively processing the oldest cases first, and the newest cases last. The concern is that a few domains have had their [daily update tasks halted](https://dimagi.sentry.io/issues/?environment=production&query=is%3Aunresolved+Halting+rule+run&referrer=issue-list&statsPeriod=7d) due to the task [potentially exceeding 23 hours of runtime](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_interfaces/utils.py#L238-L242). The alternative is that the number of allowed updates was exceeded, which would make this moot. However assuming some of these tasks have exceeded the runtime limit, this implies they never actually processed the newest cases. This also means that if I were to rollout this PR, the newest cases would have a modified time older than the last rule run, and would never get processed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
