### PR TITLE
`JsonAttrsField.get_pre_value()` to handle native types

### DIFF
--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -777,7 +777,7 @@ class TestSqlLoadWithError(BaseDumpLoadTest):
         self.assertEqual(actual_model_counts['products.sqlproduct'], 3)
 
         loader = SqlDataLoader()
-        with self.assertRaises(IntegrityError),\
+        with self.assertRaises(IntegrityError), \
              mock.patch("corehq.apps.dump_reload.sql.load.CHUNK_SIZE", chunk_size):
             # patch the chunk size so that the queue blocks
             loader.load_objects(dump_lines)

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -736,8 +736,44 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
 
     def test_lookup_table(self):
         from corehq.apps.fixtures.models import LookupTable, LookupTableRow, LookupTableRowOwner, OwnerType
-        table = LookupTable.objects.create(domain=self.domain_name, tag="dump-load")
-        row = LookupTableRow.objects.create(domain=self.domain_name, table_id=table.id, sort_key=0)
+        table = LookupTable.objects.create(
+            domain=self.domain_name,
+            tag="dump-load",
+            fields=[
+                {
+                    "name": "country",
+                    "properties": [],
+                    "is_indexed": True,
+                },
+                {
+                    "name": "state_name",
+                    "properties": ["lang"],
+                    "is_indexed": False,
+                },
+                {
+                    "name": "state_id",
+                    "properties": [],
+                    "is_indexed": False,
+                },
+            ]
+        )
+        row = LookupTableRow.objects.create(
+            domain=self.domain_name,
+            table_id=table.id,
+            fields={
+                "country": [
+                    {"value": "India", "properties": {}},
+                ],
+                "state_name": [
+                    {"value": "Delhi_IN_ENG", "properties": {"lang": "eng"}},
+                    {"value": "Delhi_IN_HIN", "properties": {"lang": "hin"}},
+                ],
+                "state_id": [
+                    {"value": "DEL", "properties": {}}
+                ],
+            },
+            sort_key=0,
+        )
         LookupTableRowOwner.objects.create(
             domain=self.domain_name,
             row_id=row.id,


### PR DESCRIPTION
## Technical Summary

Loading dumped domain data is failing when trying to load `AttrsList` values.

This is because the dumped data is a list of native dictionaries, and not a list of `attrs` subclasses.

This PR reproduces the error in a unit test, and fixes it.

More context: [SC-3306](https://dimagi-dev.atlassian.net/browse/SC-3306)

## Safety Assurance

### Safety story

Reproduced using unit test based on data similar to that confirmed to be in the data dump.

### Automated test coverage

Includes test coverage.

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3306]: https://dimagi-dev.atlassian.net/browse/SC-3306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ