### PR TITLE
Add modified_on field to AutomaticUpdateRule

### DIFF
--- a/corehq/apps/data_interfaces/migrations/0035_automaticupdaterule_modified_on.py
+++ b/corehq/apps/data_interfaces/migrations/0035_automaticupdaterule_modified_on.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_interfaces', '0034_case_name_actions'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='automaticupdaterule',
+            name='modified_on',
+            field=models.DateTimeField(auto_now=True),
+        ),
+    ]

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -109,6 +109,7 @@ class AutomaticUpdateRule(models.Model):
     deleted = models.BooleanField(default=False)
     deleted_on = models.DateTimeField(null=True)
     last_run = models.DateTimeField(null=True)
+    modified_on = models.DateTimeField(auto_now=True)
     filter_on_server_modified = models.BooleanField(default=True)
     workflow = models.CharField(max_length=126, choices=WORKFLOW_CHOICES)
 

--- a/migrations.lock
+++ b/migrations.lock
@@ -337,6 +337,7 @@ data_interfaces
  0032_bootstrap_audit_events_for_update_rules
  0033_automaticupdaterule_deleted_on
  0034_case_name_actions
+ 0035_automaticupdaterule_modified_on
 dhis2
  0001_initial
  0002_auto_20170322_1323


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I believe this is needed in order to move forward with https://github.com/dimagi/commcare-hq/pull/33886, since we need to know when the rule was last modified to determine if it is safe to limit which cases are fetched.

This just adds the `modified_on` field.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Simply adds an unused field.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations
Ensure https://github.com/dimagi/commcare-hq/pull/33886 has not been merged and/or `modified_on` is not in use.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
