### PR TITLE
Fix jsonattrs conformance to the model deserialization protocol

### DIFF
--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -735,26 +735,21 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
         self._dump_and_load(Counter({CreateCaseRepeater: 1, ConnectionSettings: 1, ZapierSubscription: 1}))
 
     def test_lookup_table(self):
-        from corehq.apps.fixtures.models import LookupTable, LookupTableRow, LookupTableRowOwner, OwnerType
+        from corehq.apps.fixtures.models import (
+            Field,
+            LookupTable,
+            LookupTableRow,
+            LookupTableRowOwner,
+            OwnerType,
+            TypeField,
+        )
         table = LookupTable.objects.create(
             domain=self.domain_name,
             tag="dump-load",
             fields=[
-                {
-                    "name": "country",
-                    "properties": [],
-                    "is_indexed": True,
-                },
-                {
-                    "name": "state_name",
-                    "properties": ["lang"],
-                    "is_indexed": False,
-                },
-                {
-                    "name": "state_id",
-                    "properties": [],
-                    "is_indexed": False,
-                },
+                TypeField("country", is_indexed=True),
+                TypeField("state_name", properties=["lang"]),
+                TypeField("state_id"),
             ]
         )
         row = LookupTableRow.objects.create(
@@ -762,14 +757,14 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
             table_id=table.id,
             fields={
                 "country": [
-                    {"value": "India", "properties": {}},
+                    Field("India"),
                 ],
                 "state_name": [
-                    {"value": "Delhi_IN_ENG", "properties": {"lang": "eng"}},
-                    {"value": "Delhi_IN_HIN", "properties": {"lang": "hin"}},
+                    Field("Delhi_IN_ENG", properties={"lang": "eng"}),
+                    Field("Delhi_IN_HIN", properties={"lang": "hin"}),
                 ],
                 "state_id": [
-                    {"value": "DEL", "properties": {}}
+                    Field("DEL"),
                 ],
             },
             sort_key=0,

--- a/corehq/util/tests/test_jsonattrs.py
+++ b/corehq/util/tests/test_jsonattrs.py
@@ -3,6 +3,7 @@ from datetime import date
 
 from attrs import asdict, define, field
 from attrs.exceptions import NotAnAttrsClassError
+from django.core.exceptions import ValidationError
 from django.db import models
 from testil import assert_raises, eq
 
@@ -26,6 +27,15 @@ def test_attrsdict():
     assert check.points is not xydict, xydict
     eq(check.points, {"north": Point(0, 1)})
 
+    with assert_raises(ValidationError, msg=(
+        '["'
+        "'points' field value has an invalid format: "
+        "Cannot construct Point with {} -> "
+        "TypeError: __init__() missing 2 required positional arguments: 'x' and 'y'"
+        '"]'
+    )):
+        set_json_value(check, "points", {"north": {}})
+
 
 def test_attrsdict_list_of():
     @unregistered_django_model
@@ -47,6 +57,15 @@ def test_attrsdict_list_of():
     with assert_raises(ValueError, msg="expected list of Point, got None"):
         get_json_value(check, "point_lists")
 
+    with assert_raises(ValidationError, msg=(
+        '["'
+        "'point_lists' field value has an invalid format: "
+        "Cannot construct list_of(Point) with 500 -> "
+        "TypeError: 'int' object is not iterable"
+        '"]'
+    )):
+        set_json_value(check, "point_lists", {"north": 500})
+
 
 def test_attrslist():
     @unregistered_django_model
@@ -63,6 +82,16 @@ def test_attrslist():
     set_json_value(check, "values", [{"name": "abby"}])
     assert check.values is not abbylist, abbylist
     eq(check.values, [Value("abby")])
+
+    with assert_raises(ValidationError, msg=(
+        '["'
+        "'values' field value has an invalid format: "
+        "Cannot construct Value with 'bad value' -> "
+        "TypeError: corehq.util.tests.test_jsonattrs.Value() "
+        "argument after ** must be a mapping, not str"
+        '"]'
+    )):
+        set_json_value(check, "values", ["bad value"])
 
 
 def test_attrslist_dict_of():
@@ -84,6 +113,15 @@ def test_attrslist_dict_of():
     check.value_items = [None]
     with assert_raises(ValueError, msg="expected dict with Value values, got None"):
         get_json_value(check, "value_items")
+
+    with assert_raises(ValidationError, msg=(
+        '["'
+        "'value_items' field value has an invalid format: "
+        "Cannot construct dict_of(Value) with 'bad' -> "
+        "AttributeError: 'str' object has no attribute 'items'"
+        '"]'
+    )):
+        set_json_value(check, "value_items", {"bad": "value"})
 
 
 def test_jsonattrs_to_json():

--- a/corehq/util/tests/test_jsonattrs.py
+++ b/corehq/util/tests/test_jsonattrs.py
@@ -2,6 +2,7 @@ import json
 from datetime import date
 
 from attrs import asdict, define, field
+from attrs.exceptions import NotAnAttrsClassError
 from django.db import models
 from testil import assert_raises, eq
 
@@ -114,6 +115,18 @@ def test_value_to_string_returns_json_serializable():
         Check._meta.get_field("events").value_to_string(check),
         [{"day": "2022-07-19"}],
     )
+
+
+def test_invalid_value_does_not_save():
+    @unregistered_django_model
+    class Check(models.Model):
+        events = AttrsList(Event)
+
+    check = Check(events=[{"monday": "2022-07-20"}])
+    with assert_raises(NotAnAttrsClassError, msg=(
+        "<class 'dict'> is not an attrs-decorated class."
+    )):
+        get_json_value(check, "events")
 
 
 def get_json_value(model, field_name):


### PR DESCRIPTION
## Technical Summary

Previously jsonattrs fields did not implement `to_python`, which is part of the model object deserialization protocol. The default `Field.to_python` implementation passes the value as-is, which is what caused the error in [SC-3306](https://dimagi-dev.atlassian.net/browse/SC-3306).

## Safety Assurance

### Safety story

### Automated test coverage

Changes in this PR are covered by automated tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

[SC-3306]: https://dimagi-dev.atlassian.net/browse/SC-3306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ