### PR TITLE
Case Search Screen Style

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -25,7 +25,7 @@
         <%= description %>
       </div>
     <% } %>
-    <table class="table table-hover" role="presentation">
+    <table class="table table-hover <%= grouped ? '' : 'table-striped table-bordered' %>" role="presentation">
       <tbody id="query-properties" class="<% if (!sidebarEnabled && grouped) { %>bg-white<%} %>">
       </tbody>
     </table>

--- a/corehq/apps/cloudcare/templates/formplayer/query_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/query_view.html
@@ -26,7 +26,7 @@
       </div>
     <% } %>
     <table class="table table-hover <%= grouped ? '' : 'table-striped table-bordered' %>" role="presentation">
-      <tbody id="query-properties" class="<% if (!sidebarEnabled && grouped) { %>bg-white<%} %>">
+      <tbody id="query-properties">
       </tbody>
     </table>
     <% if (!sidebarEnabled) {%>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -93,7 +93,3 @@
 .search-query-group .table {
   border-collapse: separate; margin-bottom: 0px;
 }
-
-.bg-white {
-  background-color: white;
-}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds back border and alternating row background colors for case search fields.

Before:
![Screen Shot 2023-12-19 at 5 24 00 PM](https://github.com/dimagi/commcare-hq/assets/88759246/5147909b-ee96-4669-9fca-a894d042b430)

After:
![Screen Shot 2023-12-19 at 5 28 43 PM](https://github.com/dimagi/commcare-hq/assets/88759246/bad07937-2734-4edb-ad87-969790d57d87)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
reverting change introduced from https://github.com/dimagi/commcare-hq/pull/33898/files

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case Search 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested, reverts back to original style for case search screen.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated tests
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
