### PR TITLE
Fix incomplete forms breadcrumbs issue

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -80,7 +80,9 @@ hqDefine("cloudcare/js/formplayer/menus/utils", function () {
         });
 
         detailCollection = new Backbone.Collection(breadcrumbModels);
-        detailCollection.last().set('ariaCurrentPage', true);
+        if (detailCollection.length) {
+            detailCollection.last().set('ariaCurrentPage', true);
+        }
         var breadcrumbView = views.BreadcrumbListView({
             collection: detailCollection,
         });


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

[This PR](https://github.com/dimagi/commcare-hq/pull/33843) to make breadcrumbs more accessible caused [an issue with incomplete forms](https://dimagi-dev.atlassian.net/browse/SAAS-15182) (Jira) where the incomplete forms page timed out and resulted in [this Sentry error](https://dimagi.sentry.io/issues/4726689650/?environment=production&project=136860&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=4&utc=true). This PR fixes the issue.


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The issue happens specifically for the incomplete forms page because that page doesn't have any breadcrumbs and `detailCollection` is empty. This PR adds a simple check to only try and add the `ariaCurrent` property if there is anything in the collection. The issue was resolved locally and on staging when testing.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

None. Incomplete forms is behind an app-level setting

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested locally and Support tested on staging
- Tested both incomplete forms page as well as normal app/forms

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None I'm aware of

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Rolling this back will result in the same issue described. If you roll this back, you'd want to roll back the original breadcrumbs PR as well.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
