### PR TITLE
Add force_manual_search to request for case search validation

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -808,6 +808,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             urlObject.setQueryData({
                 inputs: self.getAnswers(),
                 execute: false,
+                force_manual_search: true,
+
             });
             var fetchingPrompts = FormplayerFrontend.getChannel().request("app:select:menus", urlObject);
             $.when(fetchingPrompts).done(function (response) {


### PR DESCRIPTION
Support Ticket: [USH-4011](https://dimagi-dev.atlassian.net/browse/USH-4011)
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Help performance for vase search validation (has reached 10+ seconds on production)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Suggested by Shubham, based on the problematic app: "This is because the default_search is set to true for the module (Skip to ES search results) and even though Web Apps passes execute as false , FP perform ES search for modules with default_search set. To override the default_search Web Apps also need to pass the force_manual_search as true for requests where we don’t want to do the search. "

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case Search 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This will be tested on staging to ensure it does not break workflow

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Not too many in this area

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4011]: https://dimagi-dev.atlassian.net/browse/USH-4011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ