### PR TITLE
Anchored Submit Bar Visual Fix

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -348,9 +348,10 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.hasSubmitAttempted = ko.observable(false);
         self.isSubmitting = ko.observable(false);
         self.submitClass = constants.FULL_WIDTH + ' text-center';
-        if (hqImport('hqwebapp/js/toggles').toggleEnabled('WEB_APPS_ANCHORED_SUBMIT')) {
-            self.submitClass += ' anchored-submit';
-        }
+        self.isAnchoredSubmitStyle = hqImport('hqwebapp/js/toggles').toggleEnabled('WEB_APPS_ANCHORED_SUBMIT');
+        // if (hqImport('hqwebapp/js/toggles').toggleEnabled('WEB_APPS_ANCHORED_SUBMIT')) {
+        //     self.submitClass += ' anchored-submit';
+        // }
 
         self.currentIndex = ko.observable("0");
         self.atLastIndex = ko.observable(false);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -347,11 +347,9 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         self.blockSubmit = ko.observable(false);
         self.hasSubmitAttempted = ko.observable(false);
         self.isSubmitting = ko.observable(false);
-        self.submitClass = constants.FULL_WIDTH + ' text-center';
         self.isAnchoredSubmitStyle = hqImport('hqwebapp/js/toggles').toggleEnabled('WEB_APPS_ANCHORED_SUBMIT');
-        // if (hqImport('hqwebapp/js/toggles').toggleEnabled('WEB_APPS_ANCHORED_SUBMIT')) {
-        //     self.submitClass += ' anchored-submit';
-        // }
+        self.submitClass = constants.FULL_WIDTH + ' text-center' +
+          (self.isAnchoredSubmitStyle ? ' anchored-submit' : ' nonanchored-submit');
 
         self.currentIndex = ko.observable("0");
         self.atLastIndex = ko.observable(false);

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -151,7 +151,14 @@
             </div>
           {% endif %}
           <div id="submit-button" class="form-actions form-group noprint-sub-container" data-bind="visible: showSubmitButton">
-            <div data-bind="css: submitClass">
+            <div data-bind="
+              css: {
+                [submitClass]: true,
+                'anchored-submit': isAnchoredSubmitStyle,
+              },
+              style: {
+                'bottom':isAnchoredSubmitStyle && {{ request.couch_user.can_edit_data|yesno:'true,false' }} ? '30px' : '' {# data preview bar #}
+              }">
               <button class="submit btn btn-lg btn-primary"
                       type="submit"
                       data-bind="enable: enableSubmitButton">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -152,16 +152,18 @@
           {% endif %}
           <div id="submit-button" class="form-actions form-group noprint-sub-container" data-bind="visible: showSubmitButton">
             <div data-bind="
-              css: {
-                [submitClass]: true,
-                'anchored-submit': isAnchoredSubmitStyle,
-              },
+              css: submitClass,
               style: {
                 'bottom':isAnchoredSubmitStyle && {{ request.couch_user.can_edit_data|yesno:'true,false' }} ? '30px' : '' {# data preview bar #}
               }">
-              <button class="submit btn btn-lg btn-primary"
+              <button class="submit btn btn-primary"
                       type="submit"
-                      data-bind="enable: enableSubmitButton">
+                      data-bind="
+                        enable: enableSubmitButton,
+                        css: {
+                          'btn-lg': !isAnchoredSubmitStyle,
+                          'btn-sm': isAnchoredSubmitStyle,
+                        }">
                 <i class="fa fa-spin fa-refresh"
                    data-bind="visible: !enableSubmitButton(){% if environment == "web-apps" %} && erroredQuestions.length != 0{% endif %}"
                 ></i>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -31,7 +31,7 @@
     padding-top: 10px;
     padding-bottom: 10px;
     position: fixed;
-    bottom: 30px; // data preview bar
+    bottom: 0px; // data preview bar
     left: 0;
     z-index: @zindex-formplayer-anchored-submit;
   }

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -102,7 +102,7 @@
 
 }
 
-.form-container .form-actions.nonanchored-submit .btn {
+.form-container .form-actions .nonanchored-submit .btn {
   font-size: 20px;
   padding: 13px 24px;
   .transition(all .5s);

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -28,8 +28,8 @@
   .anchored-submit {
     background-color: @call-to-action-low;
     width: 100vw;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-top: 5px;
+    padding-bottom: 5px;
     position: fixed;
     bottom: 0px; // data preview bar
     left: 0;
@@ -102,7 +102,7 @@
 
 }
 
-.form-container .form-actions .btn {
+.form-container .form-actions.nonanchored-submit .btn {
   font-size: 20px;
   padding: 13px 24px;
   .transition(all .5s);

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -31,7 +31,7 @@
     padding-top: 5px;
     padding-bottom: 5px;
     position: fixed;
-    bottom: 0px; // data preview bar
+    bottom: 0px;
     left: 0;
     z-index: @zindex-formplayer-anchored-submit;
   }


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Two changes
1. Reduces height of anchored submit bar and button
2. Moves the submit bar to the bottom edge of the window when the data preview bar is not shown. It would previously be 30px from the bottom, leaving an empty space between the submit bar bottom edge and the window's bottom edge.
- The data preview bar is only shown to users who have edit access

Old:
Data Preview Hidden (note the gap between anchored submit bar and bottom of the page)
![Old w:o data preview](https://github.com/dimagi/commcare-hq/assets/88759246/bcba1720-61e1-40a8-a332-6a0b2cbbda67)
Data Preview Visible
![Old Data w: data preview](https://github.com/dimagi/commcare-hq/assets/88759246/483e7c0b-6365-4d77-8410-58f1be59d2f0)



New:
Data Preview Hidden
![new w:o data preview](https://github.com/dimagi/commcare-hq/assets/88759246/5e77d55e-157a-426b-aa46-422e424a958e)

Data Preview Visible (Note the reduced height of the anchored submit bar relative to the data preview bar)
![New w: data preview](https://github.com/dimagi/commcare-hq/assets/88759246/35fe8055-0c84-4699-a706-170713cba006)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi-dev.atlassian.net/browse/USH-4021

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[Web Apps Anchored Submit
](https://www.commcarehq.org/hq/flags/edit/web_apps_anchored_submit/)
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
tested locally. Change is limited to "web apps anchored submit" FF and purely visual

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
