### PR TITLE
Order alerts by modified timestamp

### DIFF
--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -655,4 +655,4 @@ def _update_alert(alert, command):
         alert.active = True
     elif command == 'deactivate':
         alert.active = False
-    alert.save(update_fields=['active'])
+    alert.save()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Alerts added for projects will order by their modification time with most recently modified on top.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-3230
Alerts are already [order by modified](https://github.com/dimagi/commcare-hq/blob/546d6c934d8a4b2fd075fe8532dddf12f29d96a8/corehq/apps/hqwebapp/models.py#L70) timestamp when listed. This PR just changes to save using the simple save call instead of selected fields. This change then fires the update to "modified" property of `Alert` model which is set to be [updated each time](https://github.com/dimagi/commcare-hq/blob/546d6c934d8a4b2fd075fe8532dddf12f29d96a8/corehq/apps/hqwebapp/models.py#L30) object is saved.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`CUSTOM_DOMAIN_BANNER_ALERTS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
