### PR TITLE
Web apps: hide pagination controls when unnecessary

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -938,7 +938,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         },
 
         templateContext: function () {
-            const paginateItems = formplayerUtils.paginateOptions(this.options.currentPage, this.options.pageCount);
+            const paginateItems = formplayerUtils.paginateOptions(
+                this.options.currentPage,
+                this.options.pageCount,
+                this.options.collection.length
+            );
             const casesPerPage = parseInt($.cookie("cases-per-page-limit")) || (this.smallScreenEnabled ? 5 : 10);
             let description = this.options.description;
             let title = this.options.title;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -946,16 +946,13 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 description = this.options.collection.queryResponse.description;
                 title = this.options.collection.queryResponse.title;
             }
-            return {
-                startPage: paginateItems.startPage,
+            return _.extend(paginateItems, {
                 title: title.trim(),
                 description: description === undefined ? "" : markdown.render(description.trim()),
                 headers: this.headers,
                 widthHints: this.options.widthHints,
                 actions: this.options.actions,
                 currentPage: this.options.currentPage,
-                endPage: paginateItems.endPage,
-                pageCount: paginateItems.pageCount,
                 rowRange: [5, 10, 25, 50, 100],
                 limit: casesPerPage,
                 styles: this.options.styles,
@@ -979,7 +976,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                     return !(this.widthHints && this.widthHints[index] === 0);
                 },
                 pageNumLabel: _.template(gettext("Page <%-num%>")),
-            };
+            });
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -953,7 +953,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 widthHints: this.options.widthHints,
                 actions: this.options.actions,
                 currentPage: this.options.currentPage,
-                rowRange: [5, 10, 25, 50, 100],
                 limit: casesPerPage,
                 styles: this.options.styles,
                 breadcrumbs: this.options.breadcrumbs,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -978,7 +978,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 columnVisible: function (index) {
                     return !(this.widthHints && this.widthHints[index] === 0);
                 },
-                pageNumLabel: _.template(gettext("Page <%-num%>")),
             });
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -133,7 +133,6 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
                 totalPages: this.options.totalPages,
                 currentPage: this.model.get('page') - 1,
                 limit: this.model.get("limit"),
-                pageNumLabel: _.template(gettext("Page <%-num%>")),
                 isPreviewEnv: user.environment === constants.PREVIEW_APP_ENVIRONMENT,
             });
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -124,18 +124,15 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
         templateContext: function () {
             var user = FormplayerFrontend.getChannel().request('currentUser');
             var paginationConfig = utils.paginateOptions(this.options.pageNumber, this.options.totalPages);
-            return {
+            return _.extend(paginationConfig, {
                 total: this.collection.totalSessions,
                 totalPages: this.options.totalPages,
                 currentPage: this.model.get('page') - 1,
-                startPage: paginationConfig.startPage,
-                endPage: paginationConfig.endPage,
-                pageCount: paginationConfig.pageCount,
                 rowRange: [10, 25, 50, 100],
                 limit: this.model.get("limit"),
                 pageNumLabel: _.template(gettext("Page <%-num%>")),
                 isPreviewEnv: user.environment === constants.PREVIEW_APP_ENVIRONMENT,
-            };
+            });
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -123,7 +123,11 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
         },
         templateContext: function () {
             var user = FormplayerFrontend.getChannel().request('currentUser');
-            var paginationConfig = utils.paginateOptions(this.options.pageNumber, this.options.totalPages);
+            var paginationConfig = utils.paginateOptions(
+                this.options.pageNumber,
+                this.options.totalPages,
+                this.collection.totalSessions
+            );
             return _.extend(paginationConfig, {
                 total: this.collection.totalSessions,
                 totalPages: this.options.totalPages,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -128,7 +128,6 @@ hqDefine("cloudcare/js/formplayer/sessions/views", function () {
                 total: this.collection.totalSessions,
                 totalPages: this.options.totalPages,
                 currentPage: this.model.get('page') - 1,
-                rowRange: [10, 25, 50, 100],
                 limit: this.model.get("limit"),
                 pageNumLabel: _.template(gettext("Page <%-num%>")),
                 isPreviewEnv: user.environment === constants.PREVIEW_APP_ENVIRONMENT,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/case_list_pagination_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/case_list_pagination_spec.js
@@ -1,4 +1,4 @@
-hqDefine("cloudcare/js/form_entry/spec/case_list_pagination_spec", function () {
+hqDefine("cloudcare/js/formplayer/spec/case_list_pagination_spec", function () {
     describe('#paginateOptions', function () {
         var paginateItems = hqImport("cloudcare/js/formplayer/utils/utils");
         it('Should return paginateOptions', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/case_list_pagination_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/case_list_pagination_spec.js
@@ -14,11 +14,6 @@ hqDefine("cloudcare/js/formplayer/spec/case_list_pagination_spec", function () {
             assert.equal(case1.endPage, 5);
             assert.equal(case1.pageCount, 15);
 
-            //Asserting not equal
-            assert.notEqual(case1.startPage, 5);
-            assert.notEqual(case1.endPage, 10);
-            assert.notEqual(case1.pageCount, 20);
-
             var case2 = paginateItems.paginateOptions(4, 10, 7);
 
             //Asserting equal
@@ -26,11 +21,6 @@ hqDefine("cloudcare/js/formplayer/spec/case_list_pagination_spec", function () {
             assert.equal(case2.endPage, 6);
             assert.equal(case2.pageCount, 10);
             assert.equal(case2.showPagination, true);
-
-            //Asserting not equal
-            assert.notEqual(case2.startPage, 7);
-            assert.notEqual(case2.endPage, 9);
-            assert.notEqual(case2.pageCount, 3);
 
             var case3 = paginateItems.paginateOptions(-1, 10, 5);
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/case_list_pagination_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/case_list_pagination_spec.js
@@ -2,7 +2,7 @@ hqDefine("cloudcare/js/formplayer/spec/case_list_pagination_spec", function () {
     describe('#paginateOptions', function () {
         var paginateItems = hqImport("cloudcare/js/formplayer/utils/utils");
         it('Should return paginateOptions', function () {
-            var case1 = paginateItems.paginateOptions(0, 15);
+            var case1 = paginateItems.paginateOptions(0, 15, 3);
             /**
              *   result: {startPage:'', endPage:'', pageCount:''}
              *   endPage: max number of pages to display at a time
@@ -19,24 +19,26 @@ hqDefine("cloudcare/js/formplayer/spec/case_list_pagination_spec", function () {
             assert.notEqual(case1.endPage, 10);
             assert.notEqual(case1.pageCount, 20);
 
-            var case2 = paginateItems.paginateOptions(4, 10);
+            var case2 = paginateItems.paginateOptions(4, 10, 7);
 
             //Asserting equal
             assert.equal(case2.startPage, 2);
             assert.equal(case2.endPage, 6);
             assert.equal(case2.pageCount, 10);
+            assert.equal(case2.showPagination, true);
 
             //Asserting not equal
             assert.notEqual(case2.startPage, 7);
             assert.notEqual(case2.endPage, 9);
             assert.notEqual(case2.pageCount, 3);
 
-            var case3 = paginateItems.paginateOptions(-1, 10);
+            var case3 = paginateItems.paginateOptions(-1, 10, 5);
 
             //Asserting equal
             assert.equal(case3.startPage, 1);
             assert.equal(case3.endPage, 5);
             assert.equal(case3.pageCount, 10);
+            assert.equal(case3.showPagination, true);
 
             var case4 = paginateItems.paginateOptions(10, 10);
 
@@ -44,6 +46,9 @@ hqDefine("cloudcare/js/formplayer/spec/case_list_pagination_spec", function () {
             assert.equal(case4.startPage, 6);
             assert.equal(case4.endPage, 10);
             assert.equal(case4.pageCount, 10);
+
+            var case5 = paginateItems.paginateOptions(1, 1, 5);
+            assert.equal(case5.showPagination, false);
         });
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -144,7 +144,6 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
                 total: this.collection.total,
                 totalPages: this.totalPages(),
                 limit: this.limit,
-                rowRange: [10, 25, 50, 100],
                 currentPage: this.model.get('page') - 1,
                 pageNumLabel: _.template(gettext("Page <%- num %>")),
             });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -139,7 +139,11 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
             'keypress @ui.paginationGoTextBox': 'paginationGoKeyAction',
         },
         templateContext: function () {
-            var paginationOptions = formplayerUtils.paginateOptions(this.model.get('page') - 1, this.totalPages());
+            var paginationOptions = formplayerUtils.paginateOptions(
+                this.model.get('page') - 1,
+                this.totalPages(),
+                this.collection.total
+            );
             return _.extend(paginationOptions, {
                 total: this.collection.total,
                 totalPages: this.totalPages(),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -149,7 +149,6 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
                 totalPages: this.totalPages(),
                 limit: this.limit,
                 currentPage: this.model.get('page') - 1,
-                pageNumLabel: _.template(gettext("Page <%- num %>")),
             });
         },
         navigate: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -140,17 +140,14 @@ hqDefine("cloudcare/js/formplayer/users/views", function () {
         },
         templateContext: function () {
             var paginationOptions = formplayerUtils.paginateOptions(this.model.get('page') - 1, this.totalPages());
-            return {
+            return _.extend(paginationOptions, {
                 total: this.collection.total,
                 totalPages: this.totalPages(),
                 limit: this.limit,
                 rowRange: [10, 25, 50, 100],
-                startPage: paginationOptions.startPage,
-                endPage: paginationOptions.endPage,
-                pageCount: paginationOptions.pageCount,
                 currentPage: this.model.get('page') - 1,
                 pageNumLabel: _.template(gettext("Page <%- num %>")),
-            };
+            });
         },
         navigate: function () {
             FormplayerFrontend.navigate(

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -164,6 +164,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             startPage: startPage,
             endPage: endPage,
             pageCount: totalPages,
+            rowRange: [5, 10, 25, 50, 100],
         };
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -162,7 +162,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             }
         }
 
-        let rowRange = [5, 10, 25, 50, 100],
+        const rowRange = [5, 10, 25, 50, 100],
             hasMultiplePages = totalPages > 1,
             hasAtLeastMinimumItemsPerPage = totalItems > rowRange[0],
             showPagination = hasMultiplePages || hasAtLeastMinimumItemsPerPage;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -127,9 +127,10 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
         return defer.promise();
     };
 
-    // this method takes current page number on which user has clicked and total possible pages
+    // This method takes current page number on which user has clicked and total possible pages
     // and calculate the range of page numbers (start and end) that has to be shown on pagination widget.
-    Utils.paginateOptions = function (currentPage, totalPages) {
+    // totalItems can be either the total on the current page or across all pages.
+    Utils.paginateOptions = function (currentPage, totalPages, totalItems) {
         var maxPages = 5;
         // ensure current page isn't out of range
         if (currentPage < 1) {
@@ -160,12 +161,18 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
                 endPage = currentPage + maxPagesAfterCurrentPage;
             }
         }
+
+        let rowRange = [5, 10, 25, 50, 100],
+            hasMultiplePages = totalPages > 1,
+            hasAtLeastMinimumItemsPerPage = totalItems > rowRange[0],
+            showPagination = hasMultiplePages || hasAtLeastMinimumItemsPerPage;
+
         return {
             startPage: startPage,
             endPage: endPage,
             pageCount: totalPages,
-            rowRange: [5, 10, 25, 50, 100],
-            showPagination: false,
+            rowRange: rowRange,
+            showPagination: showPagination,
         };
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -173,6 +173,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             pageCount: totalPages,
             rowRange: rowRange,
             showPagination: showPagination,
+            pageNumLabel: _.template(gettext("Page <%- num %>")),
         };
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -165,6 +165,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             endPage: endPage,
             pageCount: totalPages,
             rowRange: [5, 10, 25, 50, 100],
+            showPagination: false,
         };
     };
 

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/form_entry/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/form_entry/mocha.html
@@ -21,7 +21,6 @@
   <script src="{% static 'cloudcare/js/form_entry/spec/integration_spec.js' %}"></script>
   <script src="{% static 'cloudcare/js/form_entry/spec/utils_spec.js' %}"></script>
   <script src="{% static 'cloudcare/js/form_entry/spec/web_form_session_spec.js' %}"></script>
-  <script src="{% static 'cloudcare/js/form_entry/spec/case_list_pagination_spec.js' %}"></script>
 {% endblock %}
 
 {% block fixtures %}

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
@@ -14,6 +14,7 @@
 
 {% block mocha_tests %}
   <script src="{% static 'cloudcare/js/spec/utils_spec.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/spec/case_list_pagination_spec.js' %}"></script>
   <script src="{% static 'cloudcare/js/formplayer/spec/hq_events_spec.js' %}"></script>
   <script src="{% static 'cloudcare/js/formplayer/spec/menu_list_spec.js' %}"></script>
   <script src="{% static 'cloudcare/js/formplayer/spec/user_spec.js' %}"></script>

--- a/corehq/apps/cloudcare/templates/formplayer/pagination.html
+++ b/corehq/apps/cloudcare/templates/formplayer/pagination.html
@@ -4,103 +4,105 @@
 
 
 {% block pagination_templates %}
-  <div class="container pagination-container">
-    <div class="row">
-      <div class="col-xs-6 col-sm-3 module-per-page-container">
-        <div class="form-inline input-group-lg">
-          <select class="form-control per-page-limit">
-            <% for(var i = 0; i < rowRange.length; i++) { %>
-              <% if (rowRange[i] === limit) { %>
-                <option value="<%- rowRange[i] %>" selected>{% trans "<%- rowRange[i] %> per page" %}</option>
-              <% } else { %>
-                <option value="<%- rowRange[i] %>">{% trans "<%- rowRange[i] %> per page" %}</option>
+  <% if (showPagination) { %>
+    <div class="container pagination-container">
+      <div class="row">
+        <div class="col-xs-6 col-sm-3 module-per-page-container">
+          <div class="form-inline input-group-lg">
+            <select class="form-control per-page-limit">
+              <% for(var i = 0; i < rowRange.length; i++) { %>
+                <% if (rowRange[i] === limit) { %>
+                  <option value="<%- rowRange[i] %>" selected>{% trans "<%- rowRange[i] %> per page" %}</option>
+                <% } else { %>
+                  <option value="<%- rowRange[i] %>">{% trans "<%- rowRange[i] %> per page" %}</option>
+                <% } %>
               <% } %>
-            <% } %>
-          </select>
-        </div>
-      </div>
-      <% if (pageCount > 1) { %>
-        <div class="col-xs-6 col-sm-3 col-sm-push-6 module-go-container">
-          <div class="input-group input-group-lg">
-            <input type="text" class="form-control" placeholder='{% trans_html_attr "Go to page" %}' id="goText">
-            <div class="input-group-btn">
-              <button class="btn btn-default" type="button" id="pagination-go-button">{% trans "Go" %}</button>
-            </div>
+            </select>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-6 col-sm-pull-3 text-center">
-          <nav class="module-pagination-container">
-            <ul class="pagination">
-              <!-- Render Previous button -->
-              <% if (currentPage > 0) { %>
-                <li>
-                  <a class="js-page" aria-label='{% trans_html_attr "First Page" %}' tabindex="0" data-id="0">
-                  <span><i class="fa fa-fast-backward"></i></span>
-                </a>
-                <a class="js-page" aria-label='{% trans_html_attr "Previous" %}' tabindex="0" data-id="<%- currentPage - 1 %>">
-                  <span><i class="fa fa-caret-left"></i></span>
-                </a>
-                </li>
-              <% } else { %>
-                <li class="paginate-disabled">
-                <a class="js-page" data-id="0">
-                  <span><i class="fa fa-fast-backward"></i></span>
-                </a>
-                <a class="js-page" data-id="<%- currentPage - 1 %>">
-                  <span><i class="fa fa-caret-left"></i></span>
-                </a>
-                </li>
-              <% } %>
-              <!-- Render page buttons -->
-              <% if (pageCount <= 5) { %>
-                  <% for (i = startPage-1; i < endPage; i++) { %>
-                    <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current ='page'<% } %> tabindex="0"><%- i + 1 %></a></li>
+        <% if (pageCount > 1) { %>
+          <div class="col-xs-6 col-sm-3 col-sm-push-6 module-go-container">
+            <div class="input-group input-group-lg">
+              <input type="text" class="form-control" placeholder='{% trans_html_attr "Go to page" %}' id="goText">
+              <div class="input-group-btn">
+                <button class="btn btn-default" type="button" id="pagination-go-button">{% trans "Go" %}</button>
+              </div>
+            </div>
+          </div>
+          <div class="col-xs-12 col-sm-6 col-sm-pull-3 text-center">
+            <nav class="module-pagination-container">
+              <ul class="pagination">
+                <!-- Render Previous button -->
+                <% if (currentPage > 0) { %>
+                  <li>
+                    <a class="js-page" aria-label='{% trans_html_attr "First Page" %}' tabindex="0" data-id="0">
+                    <span><i class="fa fa-fast-backward"></i></span>
+                  </a>
+                  <a class="js-page" aria-label='{% trans_html_attr "Previous" %}' tabindex="0" data-id="<%- currentPage - 1 %>">
+                    <span><i class="fa fa-caret-left"></i></span>
+                  </a>
+                  </li>
+                <% } else { %>
+                  <li class="paginate-disabled">
+                  <a class="js-page" data-id="0">
+                    <span><i class="fa fa-fast-backward"></i></span>
+                  </a>
+                  <a class="js-page" data-id="<%- currentPage - 1 %>">
+                    <span><i class="fa fa-caret-left"></i></span>
+                  </a>
+                  </li>
+                <% } %>
+                <!-- Render page buttons -->
+                <% if (pageCount <= 5) { %>
+                    <% for (i = startPage-1; i < endPage; i++) { %>
+                      <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current ='page'<% } %> tabindex="0"><%- i + 1 %></a></li>
+                    <% } %>
+                <% } else { %>
+                  <% if (startPage <= 3) { %>
+                    <% for (i = 0; i < startPage; i++) { %>
+                      <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%- i + 1 %></a></li>
+                    <% } %>
+                  <% } else { %>
+                      <li class="js-page" data-id="0"><a aria-label="<%- pageNumLabel({num: 1}) %>" tabindex="0">{% trans "1" %}</a></li>
+                      <li class="js-page"><a class="paginate-disabled">{% trans "..." %}</a></li>
                   <% } %>
-              <% } else { %>
-                <% if (startPage <= 3) { %>
-                  <% for (i = 0; i < startPage; i++) { %>
+                  <% for (i = startPage; i < endPage; i++) { %>
                     <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%- i + 1 %></a></li>
                   <% } %>
-                <% } else { %>
-                    <li class="js-page" data-id="0"><a aria-label="<%- pageNumLabel({num: 1}) %>" tabindex="0">{% trans "1" %}</a></li>
+                  <% if (endPage >= pageCount - 2) { %>
+                    <% for (i = endPage+1; i <= pageCount; i++) { %>
+                      <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i - 1 %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%- i %></a></li>
+                    <% } %>
+                  <% } else { %>
                     <li class="js-page"><a class="paginate-disabled">{% trans "..." %}</a></li>
-                <% } %>
-                <% for (i = startPage; i < endPage; i++) { %>
-                  <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%- i + 1 %></a></li>
-                <% } %>
-                <% if (endPage >= pageCount - 2) { %>
-                  <% for (i = endPage+1; i <= pageCount; i++) { %>
-                    <li class="js-page<% if (i === currentPage) { %> active<% } %>" data-id="<%- i - 1 %>"><a aria-label="<%- pageNumLabel({num: i + 1}) %>" <% if (i === currentPage ) { %> aria-current='page'<% } %> tabindex="0"><%- i %></a></li>
+                    <li class="js-page" data-id="<%- pageCount - 1 %>"><a aria-label="<%- pageNumLabel({num: pageCount}) %>" tabindex="0"><%- pageCount %></a></li>
                   <% } %>
-                <% } else { %>
-                  <li class="js-page"><a class="paginate-disabled">{% trans "..." %}</a></li>
-                  <li class="js-page" data-id="<%- pageCount - 1 %>"><a aria-label="<%- pageNumLabel({num: pageCount}) %>" tabindex="0"><%- pageCount %></a></li>
                 <% } %>
-              <% } %>
-              <!-- Render Next buttons -->
-              <% if (currentPage >= pageCount - 1) { %>
-                <li class="paginate-disabled">
-                  <a class="js-page" data-id="<%- currentPage + 1 %>">
-                  <span><i class="fa fa-caret-right"></i></span>
-                </a>
-                <a class="js-page" data-id="<%- pageCount - 1 %>">
-                  <span><i class="fa fa-fast-forward"></i></span>
-                </a>
-                </li>
-              <% } else { %>
-                <li>
-                <a class="js-page" aria-label='{% trans_html_attr "Next" %}' tabindex="0" data-id="<%- currentPage + 1 %>">
-                  <span><i class="fa fa-caret-right"></i></span>
-                </a>
-                <a class="js-page" aria-label='{% trans_html_attr "Last Page" %}' tabindex="0" data-id="<%- pageCount - 1 %>">
-                  <span><i class="fa fa-fast-forward"></i></span>
-                </a>
-                </li>
-              <% } %>
-            </ul>
-          </nav>
-        </div>
-      <% } %>
+                <!-- Render Next buttons -->
+                <% if (currentPage >= pageCount - 1) { %>
+                  <li class="paginate-disabled">
+                    <a class="js-page" data-id="<%- currentPage + 1 %>">
+                    <span><i class="fa fa-caret-right"></i></span>
+                  </a>
+                  <a class="js-page" data-id="<%- pageCount - 1 %>">
+                    <span><i class="fa fa-fast-forward"></i></span>
+                  </a>
+                  </li>
+                <% } else { %>
+                  <li>
+                  <a class="js-page" aria-label='{% trans_html_attr "Next" %}' tabindex="0" data-id="<%- currentPage + 1 %>">
+                    <span><i class="fa fa-caret-right"></i></span>
+                  </a>
+                  <a class="js-page" aria-label='{% trans_html_attr "Last Page" %}' tabindex="0" data-id="<%- pageCount - 1 %>">
+                    <span><i class="fa fa-fast-forward"></i></span>
+                  </a>
+                  </li>
+                <% } %>
+              </ul>
+            </nav>
+          </div>
+        <% } %>
+      </div>
     </div>
-  </div>
+  <% } %>
 {% endblock %}


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-3936

## Safety Assurance

### Safety story
Impact should be limited to pagination, though web apps js changes can always break web apps.

### Automated test coverage

in PR

### QA Plan

https://dimagi-dev.atlassian.net/browse/QA-5976

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
