### PR TITLE
Basic Accessibility for Clickable Icons

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -282,6 +282,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
         $("#persistent-cell-grid-style").html(caseTileStyles.cellGridStyle).data("css-polyfilled", false);
         return views.PersistentCaseTileView({
             model: detailModel,
+            headers: detailObject.headers,
             styles: detailObject.styles,
             tiles: detailObject.tiles,
             maxWidth: detailObject.maxWidth,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -416,6 +416,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             return {
                 data: this.options.model.get('data'),
                 styles: this.options.styles,
+                headers: this.model.collection.headers,
                 isMultiSelect: this.options.isMultiSelect,
                 renderMarkdown: markdown.render,
                 resolveUri: function (uri) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -416,7 +416,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             return {
                 data: this.options.model.get('data'),
                 styles: this.options.styles,
-                headers: this.model.collection.headers,
+                headers: this.options.headers,
                 isMultiSelect: this.options.isMultiSelect,
                 renderMarkdown: markdown.render,
                 resolveUri: function (uri) {
@@ -590,6 +590,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
         childViewOptions: function () {
             return {
                 styles: this.options.styles,
+                headers: this.options.headers,
                 endpointActions: this.options.endpointActions,
             };
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -240,6 +240,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
 
         events: {
             "click @ui.clickIcon": "iconClick",
+            "keydown @ui.clickIcon": "iconKeyAction",
             "click": "rowClick",
             "keydown": "rowKeyAction",
             'click @ui.selectRow': 'selectRowAction',
@@ -290,6 +291,12 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             const endpointArg = urlTemplate.substring(urlTemplate.indexOf('?') + 1, urlTemplate.lastIndexOf('='));
             e.target.className += " disabled";
             this.clickableIconRequest(e, endpointId, caseId, endpointArg, isBackground);
+        },
+
+        iconKeyAction: function (e) {
+            if (e.keyCode === 13) {
+                this.iconClick(e);
+            }
         },
 
         getFieldIndexFromEvent: function (e) {

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -140,7 +140,7 @@
         <td class="module-case-list-column"><img class="module-icon" src="<%- resolveUri(datum) %>"/></td>
       <% } else if (styles[index].displayFormat === 'ClickableIcon') { %>
         <td class="module-case-list-column">
-          <img class="module-icon clickable-icon" src="<%- resolveUri(datum) %>"/>
+          <img class="module-icon clickable-icon" role="button" src="<%- resolveUri(datum) %>" tabindex="0"/>
           <i class="fa fa-spin fa-spinner" style="display:none"></i>
         </td>
       <% } else if (styles[index].displayFormat === 'Markdown') { %>
@@ -170,7 +170,7 @@
       <% } %>
       <% } else if (styles[index].displayFormat === 'ClickableIcon') {
       if(resolveUri(datum)) { %>
-        <img class="module-icon clickable-icon" src="<%- resolveUri(datum) %>"/>
+        <img class="module-icon clickable-icon" role="button" src="<%- resolveUri(datum) %>" tabindex="0"/>
         <i class="fa fa-spin fa-spinner" style="display:none"></i>
       <% } %>
       <% } else if(styles[index].widthHint === 0) { %>
@@ -196,7 +196,7 @@
         <div class="<%- prefix %>-grid-style-<%- index %> box" >
           <% if (styles[index].displayFormat === 'ClickableIcon') {
           if(resolveUri(datum)) { %>
-            <img class="module-icon clickable-icon" style="max-width:100%; max-height:100%;" src="<%- resolveUri(datum) %>"/>
+            <img class="module-icon clickable-icon" role="button" style="max-width:100%; max-height:100%;" src="<%- resolveUri(datum) %>" tabindex="0"/>
             <i class="fa fa-spin fa-spinner" style="display:none"></i>
           <% } %>
           <% } else if (styles[index].displayFormat === 'Image') {
@@ -224,7 +224,7 @@
                 <% } %>
               <% } else if (styles[index].displayFormat === 'ClickableIcon') {
                 if(resolveUri(datum)) { %>
-                  <img class="module-icon clickable-icon" style="max-width:100%; max-height:100%;" src="<%- resolveUri(datum) %>"/>
+                  <img class="module-icon clickable-icon" role="button" style="max-width:100%; max-height:100%;" src="<%- resolveUri(datum) %>" tabindex="0"/>
                   <i class="fa fa-spin fa-spinner" style="display:none"></i>
                 <% } %>
               <% } else { %>

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -140,7 +140,7 @@
         <td class="module-case-list-column"><img class="module-icon" src="<%- resolveUri(datum) %>"/></td>
       <% } else if (styles[index].displayFormat === 'ClickableIcon') { %>
         <td class="module-case-list-column">
-          <img class="module-icon clickable-icon" role="button" src="<%- resolveUri(datum) %>" tabindex="0"/>
+          <img alt="<%- headers[index] %>" class="module-icon clickable-icon" role="button" src="<%- resolveUri(datum) %>" tabindex="0"/>
           <i class="fa fa-spin fa-spinner" style="display:none"></i>
         </td>
       <% } else if (styles[index].displayFormat === 'Markdown') { %>
@@ -170,7 +170,7 @@
       <% } %>
       <% } else if (styles[index].displayFormat === 'ClickableIcon') {
       if(resolveUri(datum)) { %>
-        <img class="module-icon clickable-icon" role="button" src="<%- resolveUri(datum) %>" tabindex="0"/>
+        <img alt="<%- headers[index] %>" class="module-icon clickable-icon" role="button" src="<%- resolveUri(datum) %>" tabindex="0"/>
         <i class="fa fa-spin fa-spinner" style="display:none"></i>
       <% } %>
       <% } else if(styles[index].widthHint === 0) { %>
@@ -196,7 +196,7 @@
         <div class="<%- prefix %>-grid-style-<%- index %> box" >
           <% if (styles[index].displayFormat === 'ClickableIcon') {
           if(resolveUri(datum)) { %>
-            <img class="module-icon clickable-icon" role="button" style="max-width:100%; max-height:100%;" src="<%- resolveUri(datum) %>" tabindex="0"/>
+            <img alt="<%- headers[index] %>" class="module-icon clickable-icon" role="button" style="max-width:100%; max-height:100%;" src="<%- resolveUri(datum) %>" tabindex="0"/>
             <i class="fa fa-spin fa-spinner" style="display:none"></i>
           <% } %>
           <% } else if (styles[index].displayFormat === 'Image') {
@@ -224,7 +224,7 @@
                 <% } %>
               <% } else if (styles[index].displayFormat === 'ClickableIcon') {
                 if(resolveUri(datum)) { %>
-                  <img class="module-icon clickable-icon" role="button" style="max-width:100%; max-height:100%;" src="<%- resolveUri(datum) %>" tabindex="0"/>
+                  <img alt="<%- headers[index] %>" class="module-icon clickable-icon" role="button" style="max-width:100%; max-height:100%;" src="<%- resolveUri(datum) %>" tabindex="0"/>
                   <i class="fa fa-spin fa-spinner" style="display:none"></i>
                 <% } %>
               <% } else { %>


### PR DESCRIPTION
## Product Description
Makes clickable icons keyboard navigable and adds a basic alt text taken from the "Display Text" field for the property.
![image](https://github.com/dimagi/commcare-hq/assets/100609770/2eb20ff0-a86a-427d-8697-1d3b070d72da)

![image](https://github.com/dimagi/commcare-hq/assets/100609770/bd8e2811-e063-4b4c-8405-3ffc142da090)


## Technical Summary
[USH-4026](https://dimagi-dev.atlassian.net/browse/USH-4026)
This change can stand alone for basic accessibility, but should also be considered a stepping-stone to _good_ accessibility for clickable icons, that is, a screen reader being able to see _which icon_ is currently shown, not just the general purpose of the icon.

## Feature Flag
CASE_LIST_CLICKABLE_ICON


## Safety Assurance

### Safety story
This change uses the existing display text string from `headers` to label alt text for clickable icons. Tested locally and on staging with clickable icons in different contexts (case list, case tile, grouped tiles, multi-select tiles, and persistent case tile).

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
This should get QA to confirm accessibility/keyboard navigability, and that it doesn't have other unexpected consequences. ~~Not sure yet if that should happen for the changes in this PR alone, or if it should wait for changes allowing more specific alt text on icons.~~

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4026]: https://dimagi-dev.atlassian.net/browse/USH-4026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ