### PR TITLE
Added visibility binding for case tile dropdown

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -111,7 +111,7 @@
       {% if request|toggle_enabled:'CASE_LIST_TILE' %}
         {% with app|get_available_modules_for_case_tile_configuration:module as available_modules %}
           {% if available_modules %}
-            <div class="row">
+            <div class="row" data-bind="visible: persistTileOnForms">
               <div class="col-sm-6">
                 <label>
                   {% trans "Use persistent case tile from menu" %}


### PR DESCRIPTION
## Product Description

Minor UI fix: only show the "Use persistent case tile from menu" dropdown when "User this case tile persistently in forms" is checked.

<img width="562" alt="Screen Shot 2023-12-27 at 4 49 50 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/1228171b-e0c6-4806-8389-7fda739e40ad">

## Feature Flag
CASE_LIST_TILE

## Safety Assurance

### Safety story
Trivial app manager UI change

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
