### PR TITLE
Update columns for group export

### DIFF
--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -125,17 +125,27 @@ class CaseGroupingReport(BaseCaseMapReport):
 
     default_rows = 1
     force_page_size = True
+    sortable = False
 
     @property
     def headers(self):
-        headers = []
-        # ToDo: populate headers
-        return headers
+        from corehq.apps.reports.datatables import (
+            DataTablesColumn,
+            DataTablesHeader,
+        )
+        return DataTablesHeader(
+            DataTablesColumn(_("Case ID"), prop_name='case_id'),
+            DataTablesColumn(_("Case Name"), prop_name='case_name'),
+            DataTablesColumn(_("Owner ID"), prop_name='owner_id'),
+            DataTablesColumn(_("Owner Name"), prop_name='owner_name'),
+            DataTablesColumn(_("Case Coordinates"), prop_name='coordinates'),
+            DataTablesColumn(_("Link"), prop_name='link'),
+        )
 
     @property
     def template_context(self):
         context = super().template_context
-        context['case_row_order'] = {val.html: idx for idx, val in enumerate(self.headers)}
+        context['case_row_order'] = {column.prop_name: index for index, column in enumerate(self.headers)}
         return context
 
     def _base_query(self):
@@ -217,8 +227,12 @@ class CaseGroupingReport(BaseCaseMapReport):
             )
             case = wrap_case_search_hit(row)
             coordinates = self._get_geo_location(case)
+            case_owner_type, case_owner = display.owner
             cases.append([
                 display.case_id,
+                display.case_name,
+                display.owner_id,
+                case_owner['name'],
                 coordinates,
                 display.case_link
             ])

--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -51,27 +51,12 @@ class BaseCaseMapReport(ProjectReport, CaseListMixin):
         context = super(BaseCaseMapReport, self).template_context
         context.update({
             'mapbox_access_token': settings.MAPBOX_ACCESS_TOKEN,
-            'case_row_order': {val.html: idx for idx, val in enumerate(self.headers)},
             'saved_polygons': [
                 {'id': p.id, 'name': p.name, 'geo_json': p.geo_json}
                 for p in GeoPolygon.objects.filter(domain=self.domain).all()
             ],
         })
         return context
-
-    @property
-    def headers(self):
-        from corehq.apps.reports.datatables import (
-            DataTablesColumn,
-            DataTablesHeader,
-        )
-        headers = DataTablesHeader(
-            DataTablesColumn(_("case_id"), prop_name="type.exact"),
-            DataTablesColumn(_("gps_point"), prop_name="type.exact"),
-            DataTablesColumn(_("link"), prop_name="name.exact", css_class="case-name-link"),
-        )
-        headers.custom_sort = [[2, 'desc']]
-        return headers
 
     def _get_geo_location(self, case):
         geo_case_property = get_geo_case_property(self.domain)
@@ -101,6 +86,20 @@ class CaseManagementMap(BaseCaseMapReport):
         return reverse('geospatial_default', args=[self.request.project.name])
 
     @property
+    def headers(self):
+        from corehq.apps.reports.datatables import (
+            DataTablesColumn,
+            DataTablesHeader,
+        )
+        headers = DataTablesHeader(
+            DataTablesColumn(_("case_id"), prop_name="type.exact"),
+            DataTablesColumn(_("gps_point"), prop_name="type.exact"),
+            DataTablesColumn(_("link"), prop_name="name.exact", css_class="case-name-link"),
+        )
+        headers.custom_sort = [[2, 'desc']]
+        return headers
+
+    @property
     def rows(self):
         cases = []
         for row in self.es_results['hits'].get('hits', []):
@@ -126,6 +125,18 @@ class CaseGroupingReport(BaseCaseMapReport):
 
     default_rows = 1
     force_page_size = True
+
+    @property
+    def headers(self):
+        headers = []
+        # ToDo: populate headers
+        return headers
+
+    @property
+    def template_context(self):
+        context = super().template_context
+        context['case_row_order'] = {val.html: idx for idx, val in enumerate(self.headers)}
+        return context
 
     def _base_query(self):
         # Override function to skip default pagination

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -521,7 +521,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             const caseRowOrder = initialPageData.get('case_row_order');
             for (const caseItem of rawCaseData) {
                 const caseObj = parseCaseItem(caseItem, caseRowOrder);
-                const caseModelInstance = new models.GroupedCaseMapItem(caseObj.case_id, {coordinates: caseObj.gps_point}, caseObj.link);
+                const caseModelInstance = new models.GroupedCaseMapItem(caseObj.case_id, caseObj, caseObj.link);
                 caseModels.push(caseModelInstance);
             }
             mapModel.caseMapItems(caseModels);

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -38,6 +38,7 @@ hqDefine("geospatial/js/case_grouping_map",[
 
     let mapModel;
     let polygonFilterInstance;
+    let currentPage = 1;
 
     function clusterStatsModel() {
         'use strict';
@@ -72,10 +73,14 @@ hqDefine("geospatial/js/case_grouping_map",[
             });
 
             let csvStr = "";
+            let groupNameByID = _.object(_.map(caseGroupsInstance.generatedGroups, function(group) {
+                return [group.groupId, group.name]
+            }));
 
             // Write headers first
             let headers = [
                 gettext('Group ID'),
+                gettext('Group Name'),
                 gettext('Group Center Coordinates'),
                 gettext('Case Name'),
                 gettext('Case Owner Name'),
@@ -88,6 +93,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             _.forEach(casesToExport, function (caseToExport) {
                 csvStr += [
                     caseToExport.groupId,
+                    groupNameByID[caseToExport.groupId],
                     caseToExport.groupCenterCoordinates,
                     caseToExport.caseName,
                     caseToExport.owner_name,
@@ -456,8 +462,9 @@ hqDefine("geospatial/js/case_grouping_map",[
                 const groupUUID =  utils.uuidv4();
 
                 if (casePoints.length) {
-                    groupName = _.template(gettext("Group <%- groupCount %>"))({
+                    groupName = _.template(gettext("Group <%- pageNumber %>-<%- groupCount %>"))({
                         groupCount: groupCount,
+                        pageNumber: currentPage,
                     });
                     groupCount += 1;
 
@@ -585,6 +592,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             $('.dataTables_scroll').hide();
 
             const caseData = xhr.responseJSON.aaData;
+            currentPage = xhr.responseJSON.sEcho;
             if (caseData.length) {
                 loadCases(caseData);
                 loadMapClusters(caseModels);

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -280,6 +280,11 @@ hqDefine("geospatial/js/case_grouping_map",[
         setMapLayersVisibility(MAPBOX_LAYER_VISIBILITY.None);
         mapMarkers.forEach((marker) => marker.remove());
         mapMarkers = [];
+
+        let groupColorByID = _.object(_.map(caseGroupsInstance.generatedGroups, function(group) {
+            return [group.groupId, group.color]
+        }));
+
         exportModelInstance.casesToExport().forEach(function (caseItem) {
             const coordinates = caseItem.itemData.coordinates;
             if (!coordinates) {
@@ -287,8 +292,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             }
             const caseGroupID = caseItem.groupId;
             if (caseGroupsInstance.groupIDInVisibleGroupIds(caseGroupID)) {
-                let caseGroup = caseGroupsInstance.getGroupByID(caseGroupID);
-                color = caseGroup.color;
+                color = groupColorByID[caseGroupID];
                 const marker = new mapboxgl.Marker({ color: color, draggable: false });  // eslint-disable-line no-undef
                 marker.setLngLat([coordinates.lng, coordinates.lat]);
 

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -85,8 +85,15 @@ hqDefine("geospatial/js/case_grouping_map",[
             csvStr = (headers).join(",");
             csvStr += "\n";
 
-            _.forEach(casesToExport, function (itemRow) {
-                csvStr += Object.keys(itemRow).map(key => itemRow[key]).join(",");
+            _.forEach(casesToExport, function (caseToExport) {
+                csvStr += [
+                    caseToExport.groupId,
+                    caseToExport.groupCenterCoordinates,
+                    caseToExport.caseName,
+                    caseToExport.owner_name,
+                    caseToExport.coordinates,
+                    caseToExport.caseId,
+                ].join(",");
                 csvStr += "\n";
             });
 

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -74,7 +74,15 @@ hqDefine("geospatial/js/case_grouping_map",[
             let csvStr = "";
 
             // Write headers first
-            csvStr = Object.keys(casesToExport[0]).join(",");
+            let headers = [
+                gettext('Group ID'),
+                gettext('Group Center Coordinates'),
+                gettext('Case Name'),
+                gettext('Case Owner Name'),
+                gettext('Case Coordinates'),
+                gettext('Case ID'),
+            ]
+            csvStr = (headers).join(",");
             csvStr += "\n";
 
             _.forEach(casesToExport, function (itemRow) {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -81,6 +81,9 @@ hqDefine('geospatial/js/models', [
                 'groupId': self.groupId,
                 'groupCenterCoordinates': groupCoordinates,
                 'caseId': self.itemId,
+                'caseName': self.itemData.case_name,
+                'owner_id': self.itemData.owner_id,
+                'owner_name': self.itemData.owner_name,
                 'coordinates': coordinates,
             };
         };

--- a/corehq/apps/geospatial/tests/test_reports.py
+++ b/corehq/apps/geospatial/tests/test_reports.py
@@ -71,7 +71,7 @@ class TestCaseGroupingReport(BaseReportTest):
         report_obj = CaseGroupingReport(request, domain=DOMAIN)
         report_obj.rendered_as = 'view'
         context_data = report_obj.template_context
-        expected_columns = ['case_id', 'gps_point', 'link']
+        expected_columns = ['case_id', 'case_name', 'owner_id', 'owner_name', 'coordinates', 'link']
         self.assertEqual(
             list(context_data['case_row_order'].keys()),
             expected_columns

--- a/corehq/apps/geospatial/tests/test_reports.py
+++ b/corehq/apps/geospatial/tests/test_reports.py
@@ -87,13 +87,14 @@ class TestCaseGroupingReport(BaseReportTest):
                 in_testing=True,
             )
             json_data = report.json_dict['aaData']
+
         case_data_by_id = {row[0]: row for row in json_data}
         case_ids = set(case_data_by_id)
 
-        self.assertEqual(len(json_data), 3)
-        self.assertIn(porto_novo.case_id, case_ids)
-        self.assertIn(bohicon.case_id, case_ids)
-        self.assertIn(lagos.case_id, case_ids)
+        self.assertSetEqual(
+            case_ids,
+            {porto_novo.case_id, bohicon.case_id, lagos.case_id}
+        )
 
         case_data = case_data_by_id[porto_novo.case_id]
         self.assertListEqual(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds following columns to groups export on "Case Grouping" Page
1. Group Name
2. Case Name
3. Owner ID of the case
4. Owner Name

Group name was originally just a counter of the number of groups on the page. Now its updated to be page number followed by a dash and then group number to avoid confusion between pages. For example, a group that was earlier named "Group 4" on page 2, will now be "Group 2-4".

Additionally,
Coordinates column was renamed to "Case Coordinates" 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-3225

Apart from the expected changes, did couple of coding changes/improvements:
1. Made csv creation more [predictable/robust](https://github.com/dimagi/commcare-hq/pull/33922/commits/72d45c6df3c90ac3b4e0f5649c28d4cf131a5efc) by not relying on indexing and fetching properties from object. 
The mapping of index to expected properties of case is used only once [when parsing data](https://github.com/dimagi/commcare-hq/blob/5a524a1cc51e68f87f8568d2d3315f29056eeba3/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js#L536-L543) from response json. 
2. Above change also made it possible to add translations for headers.
3. Did a small [performance refactor](https://github.com/dimagi/commcare-hq/pull/33922/commits/5a524a1cc51e68f87f8568d2d3315f29056eeba3) to avoid unnecessary iterations over groups while iterating cases for group color

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. Updated tests
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
`corehq.apps.geospatial.tests.test_reports.TestCaseGroupingReport`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
