### PR TITLE
Upgrade django-phonenumber-field from 6.4.0 to 7.3.0

### DIFF
--- a/corehq/apps/settings/tests/test_validators.py
+++ b/corehq/apps/settings/tests/test_validators.py
@@ -4,25 +4,33 @@ from django.test import SimpleTestCase
 from corehq.apps.settings.validators import validate_international_phonenumber
 
 
-class GetTempFileTests(SimpleTestCase):
+class ValidateInternationalPhonenumberTests(SimpleTestCase):
 
-    def test_valid_us_number(self):
+    def test_empty_string_raises_error(self):
+        with self.assertRaises(ValidationError):
+            validate_international_phonenumber('')
+
+    def test_valid_us_number_does_not_raise_error(self):
         validate_international_phonenumber('+16175555555')
 
-    def test_invalid_international_number(self):
+    def test_invalid_us_number_raises_error(self):
         with self.assertRaises(ValidationError):
-            validate_international_phonenumber('6175555555')
+            validate_international_phonenumber('+1617555555')
 
-    def test_valid_south_africa_number(self):
+    def test_valid_south_africa_number_does_not_raise_error(self):
         validate_international_phonenumber('+27623555555')
 
-    def test_invalid_south_africa_number(self):
+    def test_invalid_south_africa_number_raises_error(self):
         with self.assertRaises(ValidationError):
             validate_international_phonenumber('+27555555555')
 
-    def test_valid_india_number(self):
+    def test_valid_india_number_does_not_raise_error(self):
         validate_international_phonenumber('+911125555555')
 
-    def test_invalid_india_number(self):
+    def test_invalid_india_number_raises_error(self):
         with self.assertRaises(ValidationError):
             validate_international_phonenumber('+915555555555')
+
+    def test_invalid_international_number_raises_error(self):
+        with self.assertRaises(ValidationError):
+            validate_international_phonenumber('6175555555')

--- a/corehq/apps/settings/validators.py
+++ b/corehq/apps/settings/validators.py
@@ -3,6 +3,12 @@ from django.utils.translation import gettext_lazy as _
 
 from phonenumber_field.phonenumber import to_python
 
+# This is based on the two_factor international phonenumber validator. This is the only place we explicitly depend
+# on django-phonenumber-field, but we need to define our own validator because the HQPhoneNumberForm that relies on
+# this validator sets the phonenumber field to not required, which allows the user to navigate back in the setup
+# process without filling out a valid phonenumber. The back button on that form is of type 'submit' which seems
+# necessary to properly update the underlying 2FA wizard setup provided by django-two-factor-auth.
+
 
 def validate_international_phonenumber(value):
     phone_number = to_python(value)

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -200,7 +200,7 @@ django-otp==1.1.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-phonenumber-field==7.2.0
+django-phonenumber-field==7.3.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -200,7 +200,7 @@ django-otp==1.1.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-phonenumber-field==6.4.0
+django-phonenumber-field==7.2.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -176,7 +176,7 @@ django-otp==1.1.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-phonenumber-field==7.2.0
+django-phonenumber-field==7.3.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -176,7 +176,7 @@ django-otp==1.1.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-phonenumber-field==6.4.0
+django-phonenumber-field==7.2.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -177,7 +177,7 @@ django-otp==1.1.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-phonenumber-field==7.2.0
+django-phonenumber-field==7.3.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -177,7 +177,7 @@ django-otp==1.1.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-phonenumber-field==6.4.0
+django-phonenumber-field==7.2.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -169,7 +169,7 @@ django-otp==1.1.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-phonenumber-field==7.2.0
+django-phonenumber-field==7.3.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -169,7 +169,7 @@ django-otp==1.1.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-phonenumber-field==6.4.0
+django-phonenumber-field==7.2.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -178,7 +178,7 @@ django-otp==1.1.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-phonenumber-field==7.2.0
+django-phonenumber-field==7.3.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -178,7 +178,7 @@ django-otp==1.1.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-phonenumber-field==6.4.0
+django-phonenumber-field==7.2.0
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-15125

[Changelog](https://github.com/stefanfoulis/django-phonenumber-field/releases/)

This is blocked by https://github.com/dimagi/commcare-hq/pull/33918 due to the django-phonenumber-field version restriction in [v1.13.2](https://github.com/jazzband/django-two-factor-auth/blob/1.13.2/setup.py#L18) of django-two-factor-authentication that is resolved in [v1.15.5](https://github.com/jazzband/django-two-factor-auth/blob/1.15.5/setup.py#L18), so this branch is based on that branch for now.

As noted in the comment I've added in this PR, this package is only used to create a phonenumber validator, specifically only using the `to_python` method. There is no mention of updates to this method in the changelog, and looking at the code for this method, no recent changes have been made to it or the methods it depends on which suggests the functionality as remained the same.

I've confirmed this locally by setting up a phone method for 2FA and confirming validation still behaves as expected.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
See above, I've tested this locally and ensured there are no changes to the `to_python` method we depend on.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
corehq.apps.settings.tests.test_validators:ValidateInternationalPhonenumberTests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
