### PR TITLE
Upgrade asgiref from 3.5.0 to 3.7.2

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -12,7 +12,7 @@ amqp==5.1.1
     # via kombu
 architect==0.6.0
     # via -r base-requirements.in
-asgiref==3.5.0
+asgiref==3.7.2
     # via django
 asttokens==2.0.5
     # via stack-data
@@ -769,6 +769,7 @@ twilio==7.12.0
     # via -r base-requirements.in
 typing-extensions==4.1.1
     # via
+    #   asgiref
     #   bytecode
     #   cattrs
     #   ddtrace

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -12,7 +12,7 @@ amqp==5.1.1
     # via kombu
 architect==0.6.0
     # via -r base-requirements.in
-asgiref==3.5.0
+asgiref==3.7.2
     # via django
 async-timeout==4.0.2
     # via redis
@@ -631,6 +631,7 @@ twilio==7.12.0
     # via -r base-requirements.in
 typing-extensions==4.1.1
     # via
+    #   asgiref
     #   bytecode
     #   cattrs
     #   ddtrace

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -10,7 +10,7 @@ amqp==5.1.1
     # via kombu
 architect==0.6.0
     # via -r base-requirements.in
-asgiref==3.5.0
+asgiref==3.7.2
     # via django
 asttokens==2.0.5
     # via stack-data
@@ -631,6 +631,7 @@ twilio==7.12.0
     # via -r base-requirements.in
 typing-extensions==4.1.1
     # via
+    #   asgiref
     #   bytecode
     #   cattrs
     #   ddtrace

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,7 +10,7 @@ amqp==5.1.1
     # via kombu
 architect==0.6.0
     # via -r base-requirements.in
-asgiref==3.5.0
+asgiref==3.7.2
     # via django
 async-timeout==4.0.2
     # via redis
@@ -574,6 +574,7 @@ twilio==7.12.0
     # via -r base-requirements.in
 typing-extensions==4.1.1
     # via
+    #   asgiref
     #   bytecode
     #   cattrs
     #   ddtrace

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -10,7 +10,7 @@ amqp==5.1.1
     # via kombu
 architect==0.6.0
     # via -r base-requirements.in
-asgiref==3.5.0
+asgiref==3.7.2
     # via django
 async-timeout==4.0.2
     # via redis
@@ -628,6 +628,7 @@ twilio==7.12.0
     # via -r base-requirements.in
 typing-extensions==4.1.1
     # via
+    #   asgiref
     #   bytecode
     #   cattrs
     #   ddtrace


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I know we don't typically directly update sub-dependencies (we never explicitly include asgiref, it is included by django), but this is in preparation for upgrading django. On django 3.2.x, any version of asgiref [between 3.3.2 and less than 4](https://github.com/django/django/blob/stable/3.2.x/setup.cfg#L45) is compatible. On django 4.2.x, that changes to any version  [between 3.6.0 and less than 4](https://github.com/django/django/blob/stable/4.2.x/setup.cfg#L43). Rather than throw this into what will be a large PR to upgrade django to 4.2.x, I figured it'd be nice to do this separately, and it is very safe given django 3.2.x supports this version.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Django 3.2.x explicitly supports any version of asgiref between 3.3.2 and 4, so this is very safe.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
