### PR TITLE
Upgrade jsonfield from 2.1.1 to 3.1.0

### DIFF
--- a/corehq/blobs/tests/test_metadata.py
+++ b/corehq/blobs/tests/test_metadata.py
@@ -61,7 +61,7 @@ class TestMetaDB(TestCase):
         self.assertEqual(get_meta(meta).properties, {})
         query = BlobMeta.objects.partitioned_query(meta.parent_id)
         results = query.filter(id=meta.id).values_list('id', 'properties')
-        self.assertEqual(list(results), [(meta.id, None)])
+        self.assertEqual(list(results), [(meta.id, {})])
 
     def test_delete(self):
         meta = new_meta()

--- a/corehq/blobs/tests/test_metadata.py
+++ b/corehq/blobs/tests/test_metadata.py
@@ -54,13 +54,11 @@ class TestMetaDB(TestCase):
         self.db.put(BytesIO(b"content"), meta=meta)
         self.assertEqual(get_meta(meta).properties, {"mood": "Vangelis"})
 
-    def test_save_empty_properties_returns_none(self):
+    def test_save_empty_properties(self):
         meta = new_meta()
         self.assertEqual(meta.properties, {})
-
         self.db.put(BytesIO(b"content"), meta=meta)
-        self.assertIsNone(get_meta(meta).properties)
-
+        self.assertEqual(get_meta(meta).properties, {})
         query = BlobMeta.objects.partitioned_query(meta.parent_id)
         results = query.filter(id=meta.id).values_list('id', 'properties')
         self.assertEqual(list(results), [(meta.id, None)])

--- a/corehq/blobs/tests/test_metadata.py
+++ b/corehq/blobs/tests/test_metadata.py
@@ -54,11 +54,13 @@ class TestMetaDB(TestCase):
         self.db.put(BytesIO(b"content"), meta=meta)
         self.assertEqual(get_meta(meta).properties, {"mood": "Vangelis"})
 
-    def test_save_empty_properties(self):
+    def test_save_empty_properties_returns_none(self):
         meta = new_meta()
         self.assertEqual(meta.properties, {})
+
         self.db.put(BytesIO(b"content"), meta=meta)
-        self.assertEqual(get_meta(meta).properties, {})
+        self.assertIsNone(get_meta(meta).properties)
+
         query = BlobMeta.objects.partitioned_query(meta.parent_id)
         results = query.filter(id=meta.id).values_list('id', 'properties')
         self.assertEqual(list(results), [(meta.id, None)])

--- a/corehq/messaging/scheduling/tasks.py
+++ b/corehq/messaging/scheduling/tasks.py
@@ -1,4 +1,3 @@
-import json
 import uuid
 from datetime import datetime, timedelta
 
@@ -549,13 +548,7 @@ def delete_unused_messaging_images():
     present_image_ids = set()
     # There is no easy way of figuring out the domain from EmailContent
     # directly, so we only fetch those EmailContents that have html.
-    email_messages = [
-        json.loads(message)
-        for message in (EmailContent.objects
-                        .values_list("html_message", flat=True)
-                        .filter(html_message__isnull=False))
-    ]
-
+    email_messages = EmailContent.objects.values_list("html_message", flat=True).filter(html_message__isnull=False)
     for messages in email_messages:
         for lang, content in messages.items():
             soup = BeautifulSoup(content, features='lxml')

--- a/corehq/messaging/scheduling/tasks.py
+++ b/corehq/messaging/scheduling/tasks.py
@@ -199,8 +199,8 @@ class TimedScheduleInstanceRefresher(ScheduleInstanceRefresher):
 
     def handle_existing_instance(self, instance):
         if (
-            (self.start_date and self.start_date != instance.start_date) or
-            (instance.schedule_revision != self.schedule_revision)
+            (self.start_date and self.start_date != instance.start_date)
+            or (instance.schedule_revision != self.schedule_revision)
         ):
             new_start_date = self.start_date or instance.start_date
             instance.recalculate_schedule(self.schedule, new_start_date=new_start_date)
@@ -286,8 +286,8 @@ class CaseTimedScheduleInstanceRefresher(ScheduleInstanceRefresher):
                 return True
 
         if (
-            (self.start_date and self.start_date != instance.start_date) or
-            (instance.schedule_revision != self.schedule_revision)
+            (self.start_date and self.start_date != instance.start_date)
+            or (instance.schedule_revision != self.schedule_revision)
         ):
             new_start_date = self.start_date or instance.start_date
             instance.recalculate_schedule(self.schedule, new_start_date=new_start_date)
@@ -441,8 +441,11 @@ def _handle_schedule_instance(instance, save_function):
     :return: True if the event was handled, otherwise False
     """
     if (
-        instance.memoized_schedule.deleted or
-        (isinstance(instance, CaseScheduleInstanceMixin) and (instance.case is None or instance.case.is_deleted))
+        instance.memoized_schedule.deleted
+        or (
+            isinstance(instance, CaseScheduleInstanceMixin)
+            and (instance.case is None or instance.case.is_deleted)
+        )
     ):
         instance.delete()
         return False

--- a/corehq/util/models.py
+++ b/corehq/util/models.py
@@ -243,6 +243,10 @@ class NullJsonField(jsonfield_JSONField):
         value = super().to_python(value)
         return self.get_default() if value is None else value
 
+    def from_db_value(self, value, expression, connection):
+        value = super().from_db_value(value, expression, connection)
+        return self.get_default() if value is None else value
+
     def pre_init(self, value, obj):
         value = super().pre_init(value, obj)
         return self.get_default() if value is None else value

--- a/corehq/util/models.py
+++ b/corehq/util/models.py
@@ -231,20 +231,20 @@ class NullJsonField(jsonfield_JSONField):
 
     def __init__(self, **kw):
         kw.setdefault("null", True)
-        super(NullJsonField, self).__init__(**kw)
+        super().__init__(**kw)
         assert self.null
 
     def get_db_prep_value(self, value, *args, **kw):
         if not value:
             value = None
-        return super(NullJsonField, self).get_db_prep_value(value, *args, **kw)
+        return super().get_db_prep_value(value, *args, **kw)
 
     def to_python(self, value):
-        value = super(NullJsonField, self).to_python(value)
+        value = super().to_python(value)
         return self.get_default() if value is None else value
 
     def pre_init(self, value, obj):
-        value = super(NullJsonField, self).pre_init(value, obj)
+        value = super().pre_init(value, obj)
         return self.get_default() if value is None else value
 
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -368,7 +368,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonfield==2.1.1
+jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
@@ -676,7 +676,6 @@ six==1.16.0
     #   google-auth
     #   google-auth-httplib2
     #   isodate
-    #   jsonfield
     #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -317,7 +317,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonfield==2.1.1
+jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
@@ -560,7 +560,6 @@ six==1.16.0
     #   eulxml
     #   google-auth
     #   google-auth-httplib2
-    #   jsonfield
     #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -321,7 +321,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonfield==2.1.1
+jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
@@ -579,7 +579,6 @@ six==1.16.0
     #   google-auth
     #   google-auth-httplib2
     #   isodate
-    #   jsonfield
     #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -301,7 +301,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonfield==2.1.1
+jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
@@ -530,7 +530,6 @@ six==1.16.0
     #   google-auth
     #   google-auth-httplib2
     #   isodate
-    #   jsonfield
     #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -318,7 +318,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonfield==2.1.1
+jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
@@ -570,7 +570,6 @@ six==1.16.0
     #   google-auth
     #   google-auth-httplib2
     #   isodate
-    #   jsonfield
     #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SAAS-15191

v2.1.1 of jsonfield uses [ugettext_lazy](https://github.com/rpkilby/jsonfield/blob/2.1.1/jsonfield/fields.py#L8) which was removed [v3.0.0](https://github.com/rpkilby/jsonfield/blob/3.0.0/src/jsonfield/fields.py#L6). Django no longer supports this method, and instead expects gettext_lazy to be used in its place (this is a blocking issue for upgrading to django 4.2).

As far as the jsonfield upgrade itself, it's a bit of a strange [changelog](https://github.com/rpkilby/jsonfield/blob/master/CHANGES.rst) since the forked jsonfield2 was brought back into jsonfield as part of the v3 release, but the v2.1.1 changelog was removed. ~After looking over that, it doesn't seem like anything will impact us, but I'm also not 100% sure that is true, especially given how widely used this field is in our code. I'll deploy this to staging to see if anything obvious pops up.~


### TypeError: the JSON object must be str, bytes or bytearray, not dict
The first issue encountered was the failing test `corehq.messaging.scheduling.tests.test_views:MessagingImageUploadTest.test_delete_unused_messaging_images
` raising the error `TypeError: the JSON object must be str, bytes or bytearray, not dict`. The problematic code was
```
    email_messages = [
        json.loads(message)
        for message in (EmailContent.objects
                        .values_list("html_message", flat=True)
                        .filter(html_message__isnull=False))
    ]
```
In v2.1.1, `message` was a dictionary serialized into a string, so `json.loads(message)` did not raise any error.
```
'{"*": "<img src=\\"http://localhost:8000/a/fake/messaging/image/download/7v7BHMcwBLp1SRlEQoionA\\" />"}'
```
In v3.1.0, `message` is returned as a pure dictionary, so `json.loads(message)` is an invalid call. When not annotating the query with `values_list`, `message` is a dictionary in both versions, but `values_list` was causing the difference. Looking closer, this [from_db_value](https://github.com/rpkilby/jsonfield/blob/3.1.0/src/jsonfield/fields.py#L50-L58) method was added to JSONField, which django is aware of and [uses](https://github.com/django/django/blob/3.2.23/django/db/models/sql/compiler.py#L1132-L1138) when returning results. That method relies on [checked_loads](https://github.com/rpkilby/jsonfield/blob/3.1.0/src/jsonfield/json.py) which will deserialize the dictionary, ultimately returning a dictionary instead of a string as it did before.

TL;DR: we no longer need to explicitly call `json.loads(message)` in our code, because `JSONField.from_db_value` handles this for us.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
Once on django 4.2, reverting this would cause a runtime error.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
