### PR TITLE
DRY up case tile previews

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -93,34 +93,6 @@ hqDefine("app_manager/js/details/screen", function () {
 
             return self.columns();
         });
-        self.caseTilePreviewForTemplate = ko.computed(function () {
-            const grid = (self.caseTileTemplateConfigs[self.caseTileTemplate()] || {}).grid;
-            if (!grid) {
-                return "";
-            }
-            return "<div class='case-tile-preview'>" + _.map(grid, (values, fieldName) => {
-                return _.template(`<div class='case-tile-preview-mapping'
-                                        style='
-                                            grid-area: <%= rowStart %> / <%= columnStart %> / <%= rowEnd %> / <%= columnEnd %>;
-                                        '>
-                                          <div style='
-                                            justify-self: <%= horzAlign %>;
-                                            text-align: <%= horzAlign %>;
-                                            align-self: <%= vertAlign %>;
-                                          '>
-                                            <%= field %>
-                                          </div>
-                                        </div>`)({
-                    rowStart: values.y + 1,
-                    columnStart: values.x + 1,
-                    rowEnd: values.y + values.height + 1,
-                    columnEnd: values.x + values.width + 1,
-                    horzAlign: values["horz-align"],
-                    vertAlign: values["vert-align"],
-                    field: fieldName,
-                });
-            }).join("") + "</div>";
-        });
         self.showCaseTileConfigColumns = ko.computed(function () {
             const featureFlag = hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_TILE_CUSTOM');
             const template = self.caseTileTemplate();

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -80,6 +80,8 @@ hqDefine("app_manager/js/details/screen", function () {
                 return _.map(grid, function (value, key) {
                     return {
                         showInTilePreview: true,
+                        horizontalAlign: value["horz-align"],
+                        verticalAlign: value["vert-align"],
                         tileRowStart: value.y + 1,
                         tileRowEnd: value.y + value.height + 1,
                         tileColumnStart: value.x + 1,

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -74,6 +74,23 @@ hqDefine("app_manager/js/details/screen", function () {
         self.caseTileFieldsForTemplate = ko.computed(function () {
             return (self.caseTileTemplateConfigs[self.caseTileTemplate()] || {}).fields;
         });
+        self.caseTilePreviewColumns = ko.computed(function () {
+            const grid = (self.caseTileTemplateConfigs[self.caseTileTemplate()] || {}).grid;
+            if (grid) {
+                return _.map(grid, function (value, key) {
+                    return {
+                        showInTilePreview: true,
+                        tileRowStart: value.y + 1,
+                        tileRowEnd: value.y + value.height + 1,
+                        tileColumnStart: value.x + 1,
+                        tileColumnEnd: value.x + value.width + 1,
+                        tileContent: key,
+                    };
+                });
+            }
+
+            return self.columns();
+        });
         self.caseTilePreviewForTemplate = ko.computed(function () {
             const grid = (self.caseTileTemplateConfigs[self.caseTileTemplate()] || {}).grid;
             if (!grid) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_tile_preview.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_tile_preview.html
@@ -14,11 +14,15 @@
           'grid-column-start': tileColumnStart,
           'grid-column-end': tileColumnEnd,
       }">
-      <div class="content">
+      <div class="content" data-bind="style: {
+        'justify-self': horizontalAlign,
+        'text-align': horizontalAlign,
+        'align-self': verticalAlign,
+      }">
         <!-- ko if: $data.original -->
           #<span data-bind="text: $index()"></span>:
         <!-- /ko -->
-        <span data-bind="text: tileContent"></span>
+        <!-- ko text: tileContent --><!-- /ko -->
       </div>
       <!-- TODO: align less terribly, this gets messed up as screen/tiles resize -->
       <div class="controls" data-bind="if: $data.original">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_tile_preview.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_tile_preview.html
@@ -6,8 +6,8 @@
   {% trans "Reset Grid" %}
 </button>
 
-<div data-bind="visible: showCaseTileConfigColumns()" id="preview-box">
-  <div id="case-tile-preview" data-bind="foreach: columns">
+<div data-bind="visible: caseTileTemplate()">
+  <div id="case-tile-preview" data-bind="foreach: caseTilePreviewColumns">
     <div class="cell" data-bind="visible: showInTilePreview, style: {
           'grid-row-start': tileRowStart,
           'grid-row-end': tileRowEnd,
@@ -15,11 +15,13 @@
           'grid-column-end': tileColumnEnd,
       }">
       <div class="content">
-        #<span data-bind="text: $index()"></span>:
+        <!-- ko if: $data.original -->
+          #<span data-bind="text: $index()"></span>:
+        <!-- /ko -->
         <span data-bind="text: tileContent"></span>
       </div>
       <!-- TODO: align less terribly, this gets messed up as screen/tiles resize -->
-      <div class="controls">
+      <div class="controls" data-bind="if: $data.original">
         <table style="width: 100%;"><tbody><tr><td style="text-align: center;">
           <div class="btn-group" role="group">
             <button type="button" class="btn btn-xs btn-default"

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_tile_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_tile_templates.html
@@ -10,10 +10,4 @@
       <select data-bind="options:caseTileTemplateOptions, optionsText: 'templateName', optionsValue: 'templateValue', value:caseTileTemplate" class="form-control"></select>
     </div>
   </div>
-  <div class="row">
-    <div class="col-sm-12" data-bind="visible: caseTilePreviewForTemplate">
-      <label></label>
-      <div data-bind="html: caseTilePreviewForTemplate"></div>
-    </div>
-  </div>
 {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/style_configuration_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/style_configuration_modal.html
@@ -20,7 +20,7 @@
               </select>
             </div>
             <div class="form-group">
-              <label for="verticalAlign" class="control-label">{% trans "Vertial Align" %}</label>
+              <label for="verticalAlign" class="control-label">{% trans "Vertical Align" %}</label>
               <select
                 id="verticalAlign"
                 class="form-control"

--- a/corehq/apps/hqwebapp/static/app_manager/less/case_tile_preview.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/case_tile_preview.less
@@ -3,10 +3,9 @@
     grid-template-columns: repeat(12, 8%) min-content 5px;  // TODO: maybe don't hard code the grid dimensions (here and everywhere)
     grid-template-rows: repeat(3, 35px);
     width: 100%;
-    margin: 10px;
-    padding: 5px;
 
     .cell {
+        display: grid;
         margin: 2px;
         border: 1px @cc-light-cool-accent-low dotted;
         position: relative;

--- a/corehq/apps/hqwebapp/static/app_manager/less/case_tile_preview.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/case_tile_preview.less
@@ -1,7 +1,7 @@
 #case-tile-preview {
     display: grid;
-    grid-template-columns: repeat(12, 8%) min-content 5px;  // TODO: maybe don't hard code the grid dimensions (here and everywhere)
-    grid-template-rows: repeat(3, 35px);
+    grid-template-columns: repeat(12, 1fr) min-content 5px;
+    grid-template-rows: repeat(9, auto) min-content 5px;
     width: 100%;
 
     .cell {

--- a/corehq/apps/hqwebapp/static/app_manager/less/content.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/content.less
@@ -271,16 +271,3 @@
   margin-top: 10px;
   margin-bottom: -10px;
 }
-
-.case-tile-preview {
-    display: grid;
-    grid-template-columns: repeat(12, 1fr) min-content 5px;
-    grid-template-rows: repeat(9, auto) min-content 5px;
-
-    .case-tile-preview-mapping {
-        border: 1px @cc-light-cool-accent-low dotted;
-        padding: 3px;
-        margin: 2px;
-        display: grid;
-    }
-}


### PR DESCRIPTION
## Technical Summary
We have two different case tile previews: one used for standard templates that are in the code base, one for templates built using the UI. This PR combines them.

Bonus: This means that improved overflow handling and support for the alignment attributes are now fully supported. Previously, these were only part of the preview for standard templates.

## Feature Flag
Case tiles

## Safety Assurance

### Safety story
Problems should be limited to this flag, which is used by relatively few projects, and the changed code is UI-only.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
