### PR TITLE
Support web user data update via bulk upload

### DIFF
--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -153,6 +153,23 @@ class BaseUserImporter(object):
         if self.role_updated:
             self.user.set_role(self.user_domain, role_qualified_id)
 
+    def update_user_data(self, data, uncategorized_data, profile_name, profiles_by_name):
+        from corehq.apps.users.user_data import UserDataError
+        user_data = self.user.get_user_data(self.user_domain)
+        old_profile_id = user_data.profile_id
+        if PROFILE_SLUG in data:
+            raise UserUploadError(_("You cannot set {} directly").format(PROFILE_SLUG))
+        if profile_name:
+            profile_id = profiles_by_name[profile_name].pk
+
+        try:
+            user_data.update(data, profile_id=profile_id if profile_name else ...)
+            user_data.update(uncategorized_data)
+        except UserDataError as e:
+            raise UserUploadError(str(e))
+        if user_data.profile_id and user_data.profile_id != old_profile_id:
+            self.logger.add_info(UserChangeMessage.profile_info(user_data.profile_id, profile_name))
+
     def save_log(self):
         # Tracking for role is done post save to have role setup correctly on save
         if self.role_updated:
@@ -187,24 +204,6 @@ class CommCareUserImporter(BaseUserImporter):
     def update_name(self, name):
         self.user.set_full_name(str(name))
         self.logger.add_changes({'first_name': self.user.first_name, 'last_name': self.user.last_name})
-
-    def update_user_data(self, data, uncategorized_data, profile_name, profiles_by_name):
-        from corehq.apps.users.user_data import UserDataError
-        user_data = self.user.get_user_data(self.user_domain)
-        old_profile_id = user_data.profile_id
-        if PROFILE_SLUG in data:
-            raise UserUploadError(_("You cannot set {} directly").format(PROFILE_SLUG))
-        if profile_name:
-            profile_id = profiles_by_name[profile_name].pk
-
-        try:
-            user_data.update(data, profile_id=profile_id if profile_name else ...)
-            user_data.update(uncategorized_data)
-        except UserDataError as e:
-            raise UserUploadError(str(e))
-
-        if user_data.profile_id and user_data.profile_id != old_profile_id:
-            self.logger.add_info(UserChangeMessage.profile_info(user_data.profile_id, profile_name))
 
     def update_language(self, language):
         self.user.language = language

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -35,7 +35,8 @@ def get_user_import_validators(domain_obj, all_specs, is_web_user_import, allowe
         EmailValidator(domain, 'email'),
         RoleValidator(domain, allowed_roles),
         ExistingUserValidator(domain, all_specs),
-        TargetDomainValidator(upload_domain)
+        TargetDomainValidator(upload_domain),
+        ProfileValidator(domain, list(profiles_by_name)),
     ]
     if is_web_user_import:
         return validators + [RequiredWebFieldsValidator(domain), DuplicateValidator(domain, 'email', all_specs),
@@ -52,7 +53,6 @@ def get_user_import_validators(domain_obj, all_specs, is_web_user_import, allowe
             NewUserPasswordValidator(domain),
             PasswordValidator(domain) if validate_passwords else noop,
             GroupValidator(domain, allowed_groups),
-            ProfileValidator(domain, list(profiles_by_name)),
             ConfirmationSmsValidator(domain)
         ]
 

--- a/corehq/apps/users/bulk_download.py
+++ b/corehq/apps/users/bulk_download.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.conf import settings
 from django.utils.translation import gettext
+from memoized import memoized
 
 from couchexport.writers import Excel2007ExportWriter
 from soil import DownloadBase
@@ -88,14 +89,53 @@ def get_phone_numbers(user_data):
     return phone_numbers_dict
 
 
-def make_mobile_user_dict(user, group_names, location_cache, domain, fields_definition, deactivation_triggers):
-    model_data = {}
-    uncategorized_data = {}
-    user_data = user.get_user_data(domain)
-    model_data, uncategorized_data = fields_definition.get_model_and_uncategorized(user_data.to_dict())
-    profile_name = (user_data.profile.name
-                    if user_data.profile and domain_has_privilege(domain, privileges.APP_USER_PROFILES)
-                    else "")
+class UserDataContributor:
+
+    def __init__(self, domain):
+        self.domain = domain
+        self.unrecognized_user_data_keys = set()
+        self.has_profile_privilege = domain_has_privilege(domain, privileges.APP_USER_PROFILES)
+
+    @property
+    @memoized
+    def fields_definition(self):
+        from corehq.apps.users.views.mobile.custom_data_fields import (
+            UserFieldsView,
+        )
+        return CustomDataFieldsDefinition.get_or_create(
+            self.domain,
+            UserFieldsView.field_type
+        )
+
+    def get_headers(self):
+        user_headers = []
+        if self.has_profile_privilege:
+            user_headers += ['user_profile']
+        user_data_fields = [f.slug for f in self.fields_definition.get_fields(include_system=False)]
+        user_headers.extend(build_data_headers(user_data_fields))
+        user_headers.extend(build_data_headers(
+            self.unrecognized_user_data_keys,
+            header_prefix='uncategorized_data'
+        ))
+        return user_headers
+
+    def get_data_dict(self, user):
+        model_data = {}
+        uncategorized_data = {}
+        user_data = user.get_user_data(self.domain)
+        model_data, uncategorized_data = self.fields_definition.get_model_and_uncategorized(user_data.to_dict())
+        profile_name = (user_data.profile.name
+                        if user_data.profile and self.has_profile_privilege
+                        else "")
+        self.unrecognized_user_data_keys.update(uncategorized_data)
+        return {
+            'data': model_data,
+            'uncategorized_data': uncategorized_data,
+            'user_profile': profile_name,
+        }
+
+
+def make_mobile_user_dict(user, group_names, location_cache, domain, deactivation_triggers):
     role = user.get_role(domain)
     activity = user.reporting_metadata
     location_codes = get_location_codes(location_cache, user.location_id, user.assigned_location_ids)
@@ -104,8 +144,6 @@ def make_mobile_user_dict(user, group_names, location_cache, domain, fields_defi
         return date.strftime('%Y-%m-%d %H:%M:%S') if date else ''
 
     user_dict = {
-        'data': model_data,
-        'uncategorized_data': uncategorized_data,
         'group': group_names,
         'name': user.full_name,
         'password': "********",  # dummy display string for passwords
@@ -118,7 +156,6 @@ def make_mobile_user_dict(user, group_names, location_cache, domain, fields_defi
         'location_code': location_codes,
         'role': role.name if role else '',
         'domain': domain,
-        'user_profile': profile_name,
         'registered_on (read only)': _format_date(user.created_on),
         'last_submission (read only)': _format_date(activity.last_submission_for_user.submission_date),
         'last_sync (read only)': activity.last_sync_for_user.sync_date,
@@ -191,19 +228,12 @@ def get_user_rows(user_dicts, user_headers):
 
 
 def parse_mobile_users(domain, user_filters, task=None, total_count=None):
-    from corehq.apps.users.views.mobile.custom_data_fields import (
-        UserFieldsView,
-    )
-    fields_definition = CustomDataFieldsDefinition.get_or_create(
-        domain,
-        UserFieldsView.field_type
-    )
-    unrecognized_user_data_keys = set()
     user_groups_length = 0
     max_location_length = 0
     phone_numbers_length = 0
     user_dicts = []
     (is_cross_domain, domains_list) = get_domains_from_user_filters(domain, user_filters)
+    user_data_contributor = UserDataContributor(domain)
 
     current_user_downloaded_count = 0
     for current_domain in domains_list:
@@ -226,11 +256,10 @@ def parse_mobile_users(domain, user_filters, task=None, total_count=None):
                 group_names,
                 location_cache,
                 current_domain,
-                fields_definition,
                 deactivation_triggers,
             )
+            user_dict.update(user_data_contributor.get_data_dict(user))
             user_dicts.append(user_dict)
-            unrecognized_user_data_keys.update(user_dict['uncategorized_data'])
             user_groups_length = max(user_groups_length, len(group_names))
             max_location_length = max(max_location_length, len(user_dict["location_code"]))
 
@@ -249,17 +278,9 @@ def parse_mobile_users(domain, user_filters, task=None, total_count=None):
         {'phone-number': list(range(1, phone_numbers_length + 1))}
     ))
 
-    if domain_has_privilege(domain, privileges.APP_USER_PROFILES):
-        user_headers += ['user_profile']
-
     if EnterpriseMobileWorkerSettings.is_domain_using_custom_deactivation(domain):
         user_headers += ['deactivate_after']
-    user_data_fields = [f.slug for f in fields_definition.get_fields(include_system=False)]
-    user_headers.extend(build_data_headers(user_data_fields))
-    user_headers.extend(build_data_headers(
-        unrecognized_user_data_keys,
-        header_prefix='uncategorized_data'
-    ))
+    user_headers.extend(user_data_contributor.get_headers())
     user_headers.extend(json_to_headers(
         {'group': list(range(1, user_groups_length + 1))}
     ))
@@ -277,10 +298,12 @@ def parse_web_users(domain, user_filters, task=None, total_count=None):
     max_location_length = 0
     (is_cross_domain, domains_list) = get_domains_from_user_filters(domain, user_filters)
     progress = 0
+    user_data_contributor = UserDataContributor(domain)
     for current_domain in domains_list:
         location_cache = LocationIdToSiteCodeCache(current_domain)
         for user in get_web_users_by_filters(current_domain, user_filters):
             user_dict = make_web_user_dict(user, location_cache, current_domain)
+            user_dict.update(user_data_contributor.get_data_dict(user))
             user_dicts.append(user_dict)
             max_location_length = max(max_location_length, len(user_dict["location_code"]))
             progress += 1
@@ -295,6 +318,7 @@ def parse_web_users(domain, user_filters, task=None, total_count=None):
         'username', 'first_name', 'last_name', 'email', 'role', 'last_access_date (read only)',
         'last_login (read only)', 'status', 'remove'
     ]
+    user_headers.extend(user_data_contributor.get_headers())
     if domain_has_privilege(domain, privileges.LOCATIONS):
         user_headers.extend(json_to_headers(
             {'location_code': list(range(1, max_location_length + 1))}


### PR DESCRIPTION
## Product Description

https://dimagi-dev.atlassian.net/browse/USH-955
- Support web user data update via bulk upload

PRing on https://github.com/dimagi/commcare-hq/pull/33890


## Technical Summary

Dumps user data in bulk download of webusers and supports the same in upload.

## Feature Flag
NA

## Safety Assurance

Added more tests and tested locally

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added more

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
