### PR TITLE
Support CLE's Case Search filter in GeoSpatial Reports

### DIFF
--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -28,8 +28,32 @@ from corehq.apps.reports.standard.cases.filters import (
 from corehq.util.metrics import metrics_histogram_timer
 
 
+class XpathCaseSearchFilterMixin(object):
+    """
+    To be mixed in views using XPathCaseSearchFilter to apply the filter
+    """
+    def apply_xpath_case_search_filter(self, query):
+        xpath = XPathCaseSearchFilter.get_value(self.request, self.domain)
+        if xpath:
+            try:
+                query = query.xpath_query(self.domain, xpath)
+            except CaseFilterError as e:
+                track_workflow(self.request.couch_user.username, f"{self.name}: Query Error")
+
+                error = "<p>{}.</p>".format(escape(e))
+                bad_part = "<p>{} <strong>{}</strong></p>".format(
+                    _("The part of your search query that caused this error is: "),
+                    escape(e.filter_part)
+                ) if e.filter_part else ""
+                raise BadRequestError("{}{}".format(error, bad_part))
+
+            if '/' in xpath:
+                track_workflow(self.request.couch_user.username, f"{self.name}: Related case search")
+        return query
+
+
 @location_safe
-class CaseListExplorer(CaseListReport):
+class CaseListExplorer(CaseListReport, XpathCaseSearchFilterMixin):
     name = _('Case List Explorer')
     slug = 'case_list_explorer'
     search_class = CaseSearchES
@@ -67,23 +91,7 @@ class CaseListExplorer(CaseListReport):
     def _build_query(self, sort=True):
         query = super(CaseListExplorer, self)._build_query()
         query = self._populate_sort(query, sort)
-        xpath = XPathCaseSearchFilter.get_value(self.request, self.domain)
-        if xpath:
-            try:
-                query = query.xpath_query(self.domain, xpath)
-            except CaseFilterError as e:
-                track_workflow(self.request.couch_user.username, f"{self.name}: Query Error")
-
-                error = "<p>{}.</p>".format(escape(e))
-                bad_part = "<p>{} <strong>{}</strong></p>".format(
-                    _("The part of your search query that caused this error is: "),
-                    escape(e.filter_part)
-                ) if e.filter_part else ""
-                raise BadRequestError("{}{}".format(error, bad_part))
-
-            if '/' in xpath:
-                track_workflow(self.request.couch_user.username, f"{self.name}: Related case search")
-
+        query = self.apply_xpath_case_search_filter(self, query)
         return query
 
     def _populate_sort(self, query, sort):

--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -91,7 +91,7 @@ class CaseListExplorer(CaseListReport, XpathCaseSearchFilterMixin):
     def _build_query(self, sort=True):
         query = super(CaseListExplorer, self)._build_query()
         query = self._populate_sort(query, sort)
-        query = self.apply_xpath_case_search_filter(self, query)
+        query = self.apply_xpath_case_search_filter(query)
         return query
 
     def _populate_sort(self, query, sort):

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -74,6 +74,9 @@ class DuplicateCaseRuleFilter(BaseSingleOptionFilter):
 
 
 class XPathCaseSearchFilter(BaseSimpleFilter):
+    """
+    For report views use XpathCaseSearchFilterMixin to support this filter
+    """
     slug = 'search_xpath'
     label = gettext_lazy("Search")
     template = "reports/filters/xpath_textarea.html"


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Update reports under GEOSPATIAL to support Case Search filter like on CLE instead of the simple case list like filter.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-3252

Originally, the filters added by CaseListMixin were being used. So 'fields` was overwritten to change filters to have `XPathCaseSearchFilter` instead of `CaseListFilter`. And then the code to implement that filter values, was extracted out and reused in the view modified.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.
The change to extract a mixin out of `CaseListExplorer` should not change anything about it.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
