### PR TITLE
Explicitly set line_length in .isort.cfg to match .flake8

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,6 +2,7 @@
 [settings]
 multi_line_output=3
 include_trailing_comma=true
+line_length = 115
 
 known_django=django
 known_third_party=jsonschema


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I would gladly be proven wrong here. When running `isort`, it has never respected the line length set in the flake8 config, and I don't see why it would. Did I miss something in our setup that would have linked the two? This isn't ideal since we hard code the project's line length in multiple places (in `.flake8`), but solved the problem on my end.

Alternatively it is possible we want `isort` to use its default line length of 79 and I'm just not aware of that.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just code formatting related.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
