### PR TITLE
Fix check for active alerts

### DIFF
--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -638,10 +638,10 @@ def _load_alert(alert_id, domain):
 
 def _apply_update(request, alert):
     command = request.POST.get('command')
-    domain_alerts = Alert.objects.filter(created_by_domain=request.domain)
-    if command == "activate" and len(domain_alerts) >= MAX_ACTIVE_ALERTS:
-        messages.error(request, _("Only 3 active alerts allowed!"))
-        return
+    if command == "activate":
+        if Alert.objects.filter(created_by_domain=request.domain, active=True).count() >= MAX_ACTIVE_ALERTS:
+            messages.error(request, _("Alert not updated. Only 3 active alerts allowed."))
+            return
 
     if command in ['activate', 'deactivate']:
         _update_alert(alert, command)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Just something I noticed that the check for limiting domain alerts to 3 active alerts was incorrect. We were restricting domain to 3 alerts instead of 3 active alerts. This PR just fixes that check.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Follow up to https://github.com/dimagi/commcare-hq/pull/33863

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`CUSTOM_DOMAIN_BANNER_ALERTS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. Added test.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
`corehq.apps.domain.tests.test_views:TestUpdateDomainAlertStatusView.test_limiting_active_alerts`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
