### PR TITLE
Border for question groups appearance attribute

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -42,6 +42,7 @@ hqDefine("cloudcare/js/form_entry/const", function () {
         SHORT: 'short',
         MEDIUM: 'medium',
         STRIPE_REPEATS: 'stripe-repeats',
+        GROUP_BORDER: 'group-border',
 
         // Note it's important to differentiate these two
         NO_PENDING_ANSWER: undefined,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -608,6 +608,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         var styles = _.has(json, 'style') && json.style && json.style.raw ? json.style.raw.split(/\s+/) : [];
         self.stripeRepeats = _.contains(styles, constants.STRIPE_REPEATS);
         self.collapsible = _.contains(styles, constants.COLLAPSIBLE);
+        self.groupBorder = _.contains(styles, constants.GROUP_BORDER);
         self.showChildren = ko.observable(!self.collapsible || _.contains(styles, constants.COLLAPSIBLE_OPEN));
         self.toggleChildren = function () {
             if (self.collapsible) {

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -11,6 +11,7 @@
           'repetition': isRepetition,
           'required-group': !showChildren() && childrenRequired(),
           'stripe-repeats': stripeRepeats,
+          'group-border': groupBorder,
         }">
     <fieldset class="gr-header" data-bind="
         css: {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -81,7 +81,7 @@
   }
 
   .group-border {
-    border: solid 1px #685c53;
+    border: solid 1px @cc-neutral-mid;
     border-radius: 8px;
     margin: 2px;
     padding-top: 5px;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -81,8 +81,8 @@
   }
 
   .group-border {
-    border: solid 1px black;
-    border-radius: 10px;
+    border: solid 1px #685c53;
+    border-radius: 8px;
     margin: 2px;
     padding-top: 5px;
     padding-bottom: 5px;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -80,6 +80,14 @@
     }
   }
 
+  .group-border {
+    border: solid 1px black;
+    border-radius: 10px;
+    margin: 2px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+
   .info {
     overflow-x: auto;
   }


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Jira: [USH-3986](https://dimagi-dev.atlassian.net/browse/USH-3986?atlOrigin=eyJpIjoiYmE0MWYyMDg1OWViNDNlN2E4NzI3MjQyMTA3NTE3MTgiLCJwIjoiaiJ9)

Adds an appearance attribute for question groups that puts a border around it.

![Screenshot 2024-01-04 at 11 59 10 AM](https://github.com/dimagi/commcare-hq/assets/6729291/6604c39c-0ff3-4c72-bb05-309bdd3d077d)

See the ticket for what this looks like on a client's production app. It looks better when the group content takes up the width of the container.

The appearance attribute for the question group is "group-border":
![Screenshot 2024-01-11 at 4 20 10 PM](https://github.com/dimagi/commcare-hq/assets/6729291/77606164-0d67-4b70-a003-b175f18982b9)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

- Inspired by Evan's PR #33844
- The margin CSS prevents the border from being too close to other elements, and makes everything just a bit more snug
- The padding CSS is more important, it gives some room between the group content itself and the border

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested locally so far
- Impact should be limited to projects that opt to use the appearance attribute

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None exist that I'm aware of.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Probably no QA needed for this one since it's a appearance attribute and functionality is purely opt-in.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3986]: https://dimagi-dev.atlassian.net/browse/USH-3986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ