### PR TITLE
Geospatial: Reset disbursement on saved area change

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -288,6 +288,7 @@ hqDefine("geospatial/js/geospatial_map", [
 
         var $runDisbursement = $("#btnRunDisbursement");
         $runDisbursement.click(function () {
+            $('#disbursement-clear-message').hide();
             if (mapModel && mapModel.mapInstance && !polygonFilterModel.btnRunDisbursementDisabled()) {
                 let selectedCases = mapModel.caseMapItems();
                 let selectedUsers = mapModel.userMapItems();

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -1,11 +1,13 @@
 hqDefine('geospatial/js/models', [
     'jquery',
     'knockout',
+    'underscore',
     'hqwebapp/js/initial_page_data',
     'geospatial/js/utils',
 ], function (
     $,
     ko,
+    _,
     initialPageData,
     utils
 ) {
@@ -386,12 +388,10 @@ hqDefine('geospatial/js/models', [
 
         self.hasDisbursementLayers = function () {
             const mapLayers = self.mapInstance.getStyle().layers;
-            for (const layer of mapLayers) {
-                if (layer.id.includes(DISBURSEMENT_LAYER_PREFIX)) {
-                    return true;
-                }
-            }
-            return false;
+            return _.any(
+                mapLayers,
+                function(layer) { return layer.id.includes(DISBURSEMENT_LAYER_PREFIX) }
+            )
         };
 
         self.removeDisbursementLayers = function () {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -384,13 +384,26 @@ hqDefine('geospatial/js/models', [
             });
         };
 
-        self.removeDisbursementLayers = function () {
+        self.hasDisbursementLayers = function () {
             const mapLayers = self.mapInstance.getStyle().layers;
             mapLayers.forEach(function (layer) {
                 if (layer.id.includes(DISBURSEMENT_LAYER_PREFIX)) {
-                    self.mapInstance.removeLayer(layer.id);
+                    return true;
                 }
             });
+            return false;
+        };
+
+        self.removeDisbursementLayers = function () {
+            const mapLayers = self.mapInstance.getStyle().layers;
+            let layerRemoved = false;
+            mapLayers.forEach(function (layer) {
+                if (layer.id.includes(DISBURSEMENT_LAYER_PREFIX)) {
+                    self.mapInstance.removeLayer(layer.id);
+                    layerRemoved = true;
+                }
+            });
+            return layerRemoved;
         };
     };
 
@@ -504,7 +517,13 @@ hqDefine('geospatial/js/models', [
                 return;
             }
 
-            mapObj.removeDisbursementLayers();
+            if (mapObj.hasDisbursementLayers()) {
+                if (mapObj.removeDisbursementLayers()) {
+                    $('#disbursement-clear-message').show();
+                }
+            } else {
+                $('#disbursement-clear-message').hide();
+            }
             self.clearActivePolygon();
 
             removeActivePolygonLayer();

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -528,9 +528,9 @@ hqDefine('geospatial/js/models', [
                 let confirmation = confirm(
                     gettext("Warning! This action will clear the current disbursement. " +
                             "Please confirm if you want to proceed.")
-                    );
+                );
                 if (confirmation) {
-                    if(mapObj.removeDisbursementLayers()) {
+                    if (mapObj.removeDisbursementLayers()) {
                         $('#disbursement-clear-message').show();
                     }
                 } else {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -504,6 +504,7 @@ hqDefine('geospatial/js/models', [
                 return;
             }
 
+            mapObj.removeDisbursementLayers();
             self.clearActivePolygon();
 
             removeActivePolygonLayer();

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -390,8 +390,8 @@ hqDefine('geospatial/js/models', [
             const mapLayers = self.mapInstance.getStyle().layers;
             return _.any(
                 mapLayers,
-                function(layer) { return layer.id.includes(DISBURSEMENT_LAYER_PREFIX) }
-            )
+                function (layer) { return layer.id.includes(DISBURSEMENT_LAYER_PREFIX); }
+            );
         };
 
         self.removeDisbursementLayers = function () {
@@ -510,7 +510,7 @@ hqDefine('geospatial/js/models', [
             }
         };
 
-        self.selectedSavedPolygonId.subscribe(function(selectedPolygonID) {
+        self.selectedSavedPolygonId.subscribe(function (selectedPolygonID) {
             self.oldSelectedSavedPolygonId(selectedPolygonID);
         }, null, "beforeChange");
 

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -427,6 +427,7 @@ hqDefine('geospatial/js/models', [
 
         self.savedPolygons = ko.observableArray([]);
         self.selectedSavedPolygonId = ko.observable('');
+        self.oldSelectedSavedPolygonId = ko.observable('');
         self.activeSavedPolygon;
 
         self.addPolygonsToFilterList = function (featureList) {
@@ -508,6 +509,10 @@ hqDefine('geospatial/js/models', [
             }
         };
 
+        self.selectedSavedPolygonId.subscribe(function(selectedPolygonID) {
+            self.oldSelectedSavedPolygonId(selectedPolygonID);
+        }, null, "beforeChange");
+
         self.selectedSavedPolygonId.subscribe(() => {
             const selectedId = parseInt(self.selectedSavedPolygonId());
             const polygonObj = self.savedPolygons().find(
@@ -529,6 +534,7 @@ hqDefine('geospatial/js/models', [
                         $('#disbursement-clear-message').show();
                     }
                 } else {
+                    self.selectedSavedPolygonId(self.oldSelectedSavedPolygonId());
                     return;
                 }
             }

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -428,6 +428,7 @@ hqDefine('geospatial/js/models', [
         self.savedPolygons = ko.observableArray([]);
         self.selectedSavedPolygonId = ko.observable('');
         self.oldSelectedSavedPolygonId = ko.observable('');
+        self.resettingSavedPolygon = false;
         self.activeSavedPolygon;
 
         self.addPolygonsToFilterList = function (featureList) {
@@ -514,6 +515,13 @@ hqDefine('geospatial/js/models', [
         }, null, "beforeChange");
 
         self.selectedSavedPolygonId.subscribe(() => {
+            // avoid running actions expected on user interactions if resetting saved polygon
+            // and update resettingSavedPolygon back to false
+            if (self.resettingSavedPolygon) {
+                self.resettingSavedPolygon = false;
+                return;
+            }
+
             const selectedId = parseInt(self.selectedSavedPolygonId());
             const polygonObj = self.savedPolygons().find(
                 function (o) { return o.id === selectedId; }
@@ -534,6 +542,8 @@ hqDefine('geospatial/js/models', [
                         $('#disbursement-clear-message').show();
                     }
                 } else {
+                    // set flag
+                    self.resettingSavedPolygon = true;
                     self.selectedSavedPolygonId(self.oldSelectedSavedPolygonId());
                     return;
                 }

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -386,11 +386,11 @@ hqDefine('geospatial/js/models', [
 
         self.hasDisbursementLayers = function () {
             const mapLayers = self.mapInstance.getStyle().layers;
-            mapLayers.forEach(function (layer) {
+            for (const layer of mapLayers) {
                 if (layer.id.includes(DISBURSEMENT_LAYER_PREFIX)) {
                     return true;
                 }
-            });
+            }
             return false;
         };
 
@@ -517,12 +517,20 @@ hqDefine('geospatial/js/models', [
                 return;
             }
 
+            // hide it by default and show it only if necessary
+            $('#disbursement-clear-message').hide();
             if (mapObj.hasDisbursementLayers()) {
-                if (mapObj.removeDisbursementLayers()) {
-                    $('#disbursement-clear-message').show();
+                let confirmation = confirm(
+                    gettext("Warning! This action will clear the current disbursement. " +
+                            "Please confirm if you want to proceed.")
+                    );
+                if (confirmation) {
+                    if(mapObj.removeDisbursementLayers()) {
+                        $('#disbursement-clear-message').show();
+                    }
+                } else {
+                    return;
                 }
-            } else {
-                $('#disbursement-clear-message').hide();
             }
             self.clearActivePolygon();
 

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -101,6 +101,11 @@
         attempting to run disbursement.
     {% endblocktrans %}
 </div>
+<div id="disbursement-clear-message" class="alert alert-info" style="display: none">
+    {% blocktrans %}
+        Previous disbursement was cleared.
+    {% endblocktrans %}
+</div>
 <div id="geospatial-map" style="height: 500px"></div>
 
 <!-- For Pagination -->


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Changing saved area after running disbursement caused an error. Changing saved area with disbursement markers on the map isn't supported. So now, if users changes saved area after running disbursement, we warn user that the current disbursement markers on the map will be cleared and once confirmed, we clear the disbursement markers and proceed with area change.

Used a simple browser prompt for now. This might be revisited with a prettier prompt if needed.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-3265

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
