### PR TITLE
Fix the conflicting IDs for filtering software plan

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -885,7 +885,7 @@ class ChangeSubscriptionForm(forms.Form):
         label=gettext_lazy("Visibility"), initial=SoftwarePlanVisibility.PUBLIC,
         choices=SoftwarePlanVisibility.CHOICES,
     )
-    most_recent_version = forms.ChoiceField(
+    new_plan_most_recent_version = forms.ChoiceField(
         label=gettext_lazy("Version"), initial="True",
         choices=(("True", "Show Most Recent Version"), ("False", "Show All Versions"))
     )
@@ -933,7 +933,7 @@ class ChangeSubscriptionForm(forms.Form):
                             % _("Software Plan"),),
                     'new_plan_edition',
                     'new_plan_visibility',
-                    'most_recent_version',
+                    'new_plan_most_recent_version',
                     crispy.Field(
                         'new_plan_version', css_class="input-xxlarge",
                         placeholder="Search for Software Plan",

--- a/corehq/apps/accounting/static/accounting/js/subscriptions_main.js
+++ b/corehq/apps/accounting/static/accounting/js/subscriptions_main.js
@@ -16,7 +16,7 @@ hqDefine('accounting/js/subscriptions_main', [
             return {
                 'edition': $('#id_new_plan_edition').val(),
                 'visibility': $('#id_new_plan_visibility').val(),
-                'most_recent_version': $('#id_most_recent_version').val(),
+                'most_recent_version': $('#id_new_plan_most_recent_version').val(),
                 'current_version': initialPageData.get('current_version'),
             };
         };
@@ -28,6 +28,6 @@ hqDefine('accounting/js/subscriptions_main', [
         };
         $('#id_new_plan_edition').change(deselectPlanVersion);
         $('#id_new_plan_visibility').change(deselectPlanVersion);
-        $('#id_most_recent_version').change(deselectPlanVersion);
+        $('#id_new_plan_most_recent_version').change(deselectPlanVersion);
     });
 });


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Accounting > Subscriptions > Upgrade/Downgrade > Version*
Before the fix, when change between "Show all versions" and "Show most recent version", the dropdown list won't change.
After the fix, it will change according to the selection.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-15101

In Accounting > Subscriptions, there are two tabs that have this filter box. One is the Subscription Tab, another is the Upgrade/Downgrade Tab.

Subscription Tab and Upgrade/Downgrade Tab is using the same id for Version selection.
Subscription Tab has Subscription Form, this is the [crispy field for Version selection](https://github.com/dimagi/commcare-hq/blob/82e0017824e3c3c158eeb231cf911ccfa98e3ad4/corehq/apps/accounting/forms.py#L522-L525)
Thus, `$("#id_most_recent_version").val()` in Upgrade/Downgrade Tab is always returning the selection of Version in Subscription Tab.

Renaming the id of Version Selection in Upgrade/Downgrade Tab to `new_plan_most_recent_version` will solve the problem. The rename follow the pattern for other filters as well: `edition` vs `new_plan_edition`, `visibility` vs `new_plan_visibility`.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and on staging.
No functional change, just rename the id.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA Ticket: https://dimagi-dev.atlassian.net/browse/QA-5994
QA plan:
Go to Accounting > Subscriptions > Upgrade/Downgrade > Version*
Verify:
- Show all versions will display all versions in dropdown menu
- Show most recent version will only display the most recent version for each software plan

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
