### PR TITLE
End-of-form navigation manual linking advanced mode

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -1,4 +1,8 @@
-hqDefine('app_manager/js/forms/form_workflow', function () {
+hqDefine('app_manager/js/forms/form_workflow', [
+    "hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list",
+], function (
+    uiElementKeyValueList
+) {
     'use strict';
 
     var FormWorkflow = function (options) {
@@ -192,6 +196,26 @@ hqDefine('app_manager/js/forms/form_workflow', function () {
         self.showLinkDatums = ko.computed(function () {
             return (!self.autoLink() || self.manualDatums());
         });
+
+        if (self.advancedMode) {
+            self.advancedModeDatumsElement = uiElementKeyValueList.new(
+                String(Math.random()).slice(2),  // random id
+                gettext("Manual Linking Datums"),
+                gettext("Set datums required to navigate to the selected form or menu"),
+                {key: gettext("Datum ID"), value: gettext("XPath Expression")},  // placeholders
+            );
+            let datumsDict = {};
+            _.each(datums, function (datum) {
+                datumsDict[datum.name] = datum.xpath;
+            });
+            self.advancedModeDatumsElement.val(datumsDict);
+            self.advancedModeDatumsElement.on("change", function () {
+                self.serializedDatums(JSON.stringify(_.map(this.val(), function (xpath, name) {
+                    return {name: name, xpath: xpath};
+                })));
+                workflow.$changeEl.trigger('change'); // Manually trigger change so Save button activates
+            });
+        }
 
         self.formId.subscribe(function (form_id) {
             let form = self.get_form_by_id(form_id);

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -202,7 +202,7 @@ hqDefine('app_manager/js/forms/form_workflow', [
                 String(Math.random()).slice(2),  // random id
                 gettext("Manual Linking Datums"),
                 gettext("Set datums required to navigate to the selected form or menu"),
-                {key: gettext("Datum ID"), value: gettext("XPath Expression")},  // placeholders
+                {key: gettext("Datum ID"), value: gettext("XPath Expression")}  // placeholders
             );
             let datumsDict = {};
             _.each(datums, function (datum) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -1,9 +1,6 @@
-hqDefine('app_manager/js/forms/form_workflow', [
-    "hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list",
-], function (
-    uiElementKeyValueList
-) {
+hqDefine('app_manager/js/forms/form_workflow', function () {
     'use strict';
+    const uiElementKeyValueList = hqImport("hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list");
 
     var FormWorkflow = function (options) {
         var self = this;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -143,6 +143,7 @@ hqDefine('app_manager/js/forms/form_workflow', function () {
         self.formId = ko.observable(formId);
         self.autoLink = ko.observable();
         self.allowManualLinking = ko.observable();
+        self.advancedMode = hqImport("hqwebapp/js/toggles").toggleEnabled('FORM_LINK_ADVANCED_MODE');
         self.forms = workflow.forms || [];
         self.datums = ko.observableArray();
         self.manualDatums = ko.observable(false);

--- a/corehq/apps/app_manager/static/app_manager/spec/form_workflow_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_workflow_spec.js
@@ -3,6 +3,11 @@ describe('Form Workflow', function () {
     var FormWorkflow = hqImport('app_manager/js/forms/form_workflow').FormWorkflow;
 
     describe('#workflowOptions', function () {
+        const Toggles = hqImport('hqwebapp/js/toggles'),
+            sandbox = sinon.sandbox.create();
+
+        sandbox.stub(Toggles, 'toggleEnabled').withArgs('FORM_LINK_ADVANCED_MODE').returns(true);
+
         beforeEach(function () {
             var labels = {},
                 options = {};

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -405,7 +405,7 @@ class EndOfFormNavigationWorkflow(object):
                 if child not in frame_children:
                     frame_children.append(child)
         else:
-            module_command = id_strings.menu_id(module)
+            module_command = id_strings.menu_id(module, WorkflowHelper._get_id_suffix(module))
             if module_command != id_strings.ROOT:
                 frame_children.append(CommandId(module_command))
 

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -272,16 +272,14 @@ def _get_datums_matched_to_manual_values(target_frame_elements, manual_values, f
     """
     manual_values_by_name = {datum.name: datum.xpath for datum in manual_values}
     for child in target_frame_elements:
-        if not isinstance(child, WorkflowSessionMeta) or not child.requires_selection:
+        if child.id in manual_values_by_name:
+            yield StackDatum(id=child.id, value=manual_values_by_name.get(child.id))
+        elif not isinstance(child, WorkflowSessionMeta) or not child.requires_selection:
             yield child
         else:
-            manual_value = manual_values_by_name.get(child.id)
-            if manual_value:
-                yield StackDatum(id=child.id, value=manual_value)
-            else:
-                raise SuiteValidationError("Unable to link form '{}', missing variable '{}'".format(
-                    form.default_name(), child.id
-                ))
+            raise SuiteValidationError("Unable to link form '{}', missing variable '{}'".format(
+                form.default_name(), child.id
+            ))
 
 
 def _get_datums_matched_to_source(target_frame_elements, source_datums):

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -101,42 +101,44 @@
               {% trans "Disable manual linking" %}
             </span>
           </div>
-          <div class="help-block" data-bind="visible: formLink.showLinkDatums()">
-            <button class="btn btn-default btn-xs" data-bind="click: formLink.fetchDatums">
-              <!-- ko if: formLink.datumsFetched() -->
+          <div>  {# manual linking #}
+            <div class="help-block" data-bind="visible: formLink.showLinkDatums()">
+              <button class="btn btn-default btn-xs" data-bind="click: formLink.fetchDatums">
+                <!-- ko if: formLink.datumsFetched() -->
                 {% trans "Refresh" %}
-              <!-- /ko -->
-              <!-- ko if: !formLink.datumsFetched() -->
+                <!-- /ko -->
+                <!-- ko if: !formLink.datumsFetched() -->
                 {% trans "Continue" %}
-              <!-- /ko -->
-            </button>
-          </div>
-          <div class="help-block" data-bind="visible: formLink.datumsFetched() && formLink.datums().length === 0 && !formLink.autoLink()">
-            {% trans "No additional linking required." %}
-          </div>
-          <div class="text-danger" data-bind="visible: formLink.datumsError()">
-            {% trans "Error fetching link data." %}
-          </div>
-        </div>
-      </div>
-      <div data-bind="foreach: formLink.datums, visible: formLink.datumsFetched() && formLink.datums().length">
-        <div class="form-group">
-          <div class="panel panel-appmanager">
-            <div class="panel-heading">
-              <h4 class="panel-title panel-title-nolink">
-                <span data-bind="text: name"></span>
-                <span class="label label-primary" data-bind="text: caseType"></span>
-              </h4>
+                <!-- /ko -->
+              </button>
             </div>
-            <div class="panel-body">
-              <div class="controls">
-                <textarea name="_xpath"
-                          placeholder="XPath Expression"
-                          rows="1"
-                          data-bind="text: xpath, value: xpath"
-                          class="form-control vertical-resize"
-                          spellcheck="false">
-                </textarea>
+            <div class="help-block" data-bind="visible: formLink.datumsFetched() && formLink.datums().length === 0 && !formLink.autoLink()">
+              {% trans "No additional linking required." %}
+            </div>
+            <div class="text-danger" data-bind="visible: formLink.datumsError()">
+              {% trans "Error fetching link data." %}
+            </div>
+            <div data-bind="foreach: formLink.datums, visible: formLink.datumsFetched() && formLink.datums().length">
+              <div class="form-group">
+                <div class="panel panel-appmanager">
+                  <div class="panel-heading">
+                    <h4 class="panel-title panel-title-nolink">
+                      <span data-bind="text: name"></span>
+                      <span class="label label-primary" data-bind="text: caseType"></span>
+                    </h4>
+                  </div>
+                  <div class="panel-body">
+                    <div class="controls">
+                      <textarea name="_xpath"
+                        placeholder="XPath Expression"
+                        rows="1"
+                        data-bind="text: xpath, value: xpath"
+                        class="form-control vertical-resize"
+                        spellcheck="false">
+                      </textarea>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -101,7 +101,7 @@
               {% trans "Disable manual linking" %}
             </span>
           </div>
-          <div>  {# manual linking #}
+          <!-- ko ifnot: formLink.advancedMode -->
             <div class="help-block" data-bind="visible: formLink.showLinkDatums()">
               <button class="btn btn-default btn-xs" data-bind="click: formLink.fetchDatums">
                 <!-- ko if: formLink.datumsFetched() -->
@@ -141,7 +141,10 @@
                 </div>
               </div>
             </div>
-          </div>
+          <!-- /ko -->
+          <!-- ko if: formLink.advancedMode && formLink.showLinkDatums() -->
+            <h1>Here be dragons</h1>
+          <!-- /ko -->
         </div>
       </div>
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -143,7 +143,7 @@
             </div>
           <!-- /ko -->
           <!-- ko if: formLink.advancedMode && formLink.showLinkDatums() -->
-            <h1>Here be dragons</h1>
+            <div data-bind="jqueryElement: formLink.advancedModeDatumsElement.ui"></div>
           <!-- /ko -->
         </div>
       </div>

--- a/corehq/apps/app_manager/templates/app_manager/spec/mocha.html
+++ b/corehq/apps/app_manager/templates/app_manager/spec/mocha.html
@@ -2,6 +2,8 @@
 {% load hq_shared_tags %}
 
 {% block dependencies %}
+  <script src="{% static 'hqwebapp/js/bootstrap3/main.js' %}"></script>
+  <script src="{% static 'hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list.js' %}"></script>
   <script src="{% static 'app_manager/js/forms/form_workflow.js' %}"></script>
   <script src="{% static 'app_manager/js/download_async_modal.js' %}"></script>
   <script src="{% static 'app_manager/js/releases/releases.js' %}"></script>

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module.xml
@@ -245,7 +245,7 @@
     <stack>
       <create>
         <command value="'m6'"/>
-        <command value="'m7'"/>
+        <command value="'m7.m6'"/>
       </create>
     </stack>
   </entry>

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -103,7 +103,8 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
             FormLink(xpath='true()', form_id=m1f0.unique_id, form_module_id=m1.unique_id)
         ]
 
-        self.assertXmlPartialEqual(self.get_xml('form_link_create_update_case'), factory.app.create_suite(), "./entry[1]")
+        self.assertXmlPartialEqual(self.get_xml('form_link_create_update_case'),
+                                   factory.app.create_suite(), "./entry[1]")
 
     def test_with_case_management_multiple_links(self, *args):
         factory = AppFactory(build_version='2.9.0')
@@ -286,7 +287,8 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         m1f0.form_links = [
             FormLink(xpath="true()", form_id=m2f0.unique_id, form_module_id=m2.unique_id, datums=[
                 FormDatum(name='case_id', xpath="instance('commcaresession')/session/data/case_id"),
-                FormDatum(name='case_id_load_visit_0', xpath="instance('commcaresession')/session/data/case_id_new_visit_0"),
+                FormDatum(name='case_id_load_visit_0',
+                          xpath="instance('commcaresession')/session/data/case_id_new_visit_0"),
             ]),
         ]
 
@@ -371,8 +373,10 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         # so items put into the session in one step aren't available later steps
         #
         #    <datum id="case_id_A" value="instance('commcaresession')/session/data/case_id_new_A"/>
-        # -  <datum id="case_id_B" value="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_A]/index/host"/>
-        # +  <datum id="case_id_B" value="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_new_A]/index/host"/>
+        # -  <datum id="case_id_B" value="instance('casedb')/casedb/case[
+        #       @case_id=instance('commcaresession')/session/data/case_id_A]/index/host"/>
+        # +  <datum id="case_id_B" value="instance('casedb')/casedb/case[
+        #       @case_id=instance('commcaresession')/session/data/case_id_new_A]/index/host"/>
         #
         # in the above example ``case_id_A`` is being added to the session and then
         # later referenced. However since the session doesn't get updated
@@ -398,7 +402,8 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         m1f0.post_form_workflow = WORKFLOW_FORM
         m1f0.form_links = [
             FormLink(xpath="true()", form_id=m2f0.unique_id, form_module_id=m2.unique_id, datums=[
-                FormDatum(name='case_id_load_episode_0', xpath="instance('commcaresession')/session/data/case_id_new_episode_0")
+                FormDatum(name='case_id_load_episode_0',
+                          xpath="instance('commcaresession')/session/data/case_id_new_episode_0")
             ]),
         ]
 
@@ -469,7 +474,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         factory.form_requires_case(m0f0)
         m0f0.post_form_workflow = WORKFLOW_MODULE
 
-        m1 = factory.new_shadow_module('shadow_module', m0, with_form=False)
+        factory.new_shadow_module('shadow_module', m0, with_form=False)
 
         expected = """
         <partial>
@@ -500,7 +505,8 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
             FormLink(xpath="true()", form_id=m1f0.unique_id, form_module_id=m1.unique_id),
         ]
 
-        self.assertXmlPartialEqual(self.get_xml('form_link_child_modules'), factory.app.create_suite(), "./entry[3]")
+        self.assertXmlPartialEqual(self.get_xml('form_link_child_modules'),
+                                   factory.app.create_suite(), "./entry[3]")
 
     def test_form_links_submodule(self, *args):
         # Test that when linking between two forms in a submodule we match up the
@@ -763,8 +769,8 @@ class TestReplaceSessionRefs(SimpleTestCase):
             CommandId('m0'),
             StackDatum(id='a', value=session_var('new_a')),
             StackDatum(id='b', value=session_var('new_b')),
-            StackDatum(id='c', value="instance('casedb')/case/[@case_id = {a}]/index/parent".format(a=session_var('a'))),
-            StackDatum(id='d', value="if({c}, {c}, {a}]".format(a=session_var('a'), c=session_var('c')))
+            StackDatum(id='c', value=f"instance('casedb')/case/[@case_id = {session_var('a')}]/index/parent"),
+            StackDatum(id='d', value=f"if({session_var('c')}, {session_var('c')}, {session_var('a')}]"),
         ]
 
         clean = _replace_session_references_in_stack(children)

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -9,6 +9,7 @@ from corehq.apps.app_manager.const import (
     WORKFLOW_PREVIOUS,
     WORKFLOW_ROOT,
 )
+from corehq.apps.app_manager.exceptions import SuiteValidationError
 from corehq.apps.app_manager.models import FormDatum, FormLink
 from corehq.apps.app_manager.suite_xml.post_process.workflow import (
     CommandId,
@@ -290,6 +291,30 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         ]
 
         self.assertXmlPartialEqual(self.get_xml('form_link_tdh'), factory.app.create_suite(), "./entry")
+
+    def test_manual_form_link_bad_datums(self, *args):
+        factory = AppFactory(build_version='2.9.0')
+
+        m0, m0f0 = factory.new_basic_module('child visit', 'child')
+        factory.form_requires_case(m0f0)
+        factory.form_opens_case(m0f0, case_type='visit', is_subcase=True)
+
+        m1, m1f0 = factory.new_advanced_module('visit history', 'visit', parent_module=m0)
+        factory.form_requires_case(m1f0, 'child')
+        factory.form_requires_case(m1f0, 'visit', parent_case_type='child')
+
+        m0f0.post_form_workflow = WORKFLOW_FORM
+        m0f0.form_links = [
+            FormLink(xpath="true()", form_id=m1f0.unique_id, form_module_id=m1.unique_id, datums=[
+                FormDatum(name='case_id', xpath="instance('commcaresession')/session/data/case_id"),
+                # There should be a case_id_load_visit_0 datum defined here
+            ]),
+        ]
+
+        with self.assertRaises(SuiteValidationError) as e:
+            factory.app.create_suite()
+        self.assertIn("Unable to link form 'child visit form 0', missing "
+                      "variable 'case_id_load_visit_0'", str(e.exception))
 
     def test_manual_form_link_with_fallback(self, *args):
         factory = AppFactory(build_version='2.9.0')

--- a/corehq/apps/app_manager/tests/views/test_get_form_datums.py
+++ b/corehq/apps/app_manager/tests/views/test_get_form_datums.py
@@ -51,6 +51,6 @@ class TestReleaseBuild(TestCase):
         with self.assertRaises(Http404):
             _get_form_link_datums(self.domain_name, self.app._id, f'{self.module_id}.missing')
 
-    def test_get_form_link_datums_missing_bad_form_id(self):
-        with self.assertRaises(Http400):
-            _get_form_link_datums(self.domain_name, self.app._id, 'missing')
+    def test_get_form_link_datums_for_module(self):
+        datums = _get_form_link_datums(self.domain_name, self.app._id, self.module_id)
+        self.assertEqual(datums, [{'name': 'case_id', 'case_type': 'cheeto'}])

--- a/corehq/apps/app_manager/tests/views/test_get_form_datums.py
+++ b/corehq/apps/app_manager/tests/views/test_get_form_datums.py
@@ -5,7 +5,7 @@ from no_exceptions.exceptions import Http400
 
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import get_simple_form
-from corehq.apps.app_manager.views.forms import _get_form_datums
+from corehq.apps.app_manager.views.forms import _get_form_link_datums
 
 
 class TestReleaseBuild(TestCase):
@@ -31,26 +31,26 @@ class TestReleaseBuild(TestCase):
         cls.app.delete()
         super().tearDownClass()
 
-    def test_get_form_datums(self):
-        datums = _get_form_datums(self.domain_name, self.app._id, self.disambiguated_form_id)
+    def test_get_form_link_datums(self):
+        datums = _get_form_link_datums(self.domain_name, self.app._id, self.disambiguated_form_id)
         self.assertEqual(datums, [{'name': 'case_id', 'case_type': 'cheeto'}])
 
-    def test_get_form_datums_wrong_domain(self):
+    def test_get_form_link_datums_wrong_domain(self):
         with self.assertRaises(Http404):
-            _get_form_datums('other', self.app._id, self.disambiguated_form_id)
+            _get_form_link_datums('other', self.app._id, self.disambiguated_form_id)
 
-    def test_get_form_datums_missing_app_id(self):
+    def test_get_form_link_datums_missing_app_id(self):
         with self.assertRaises(Http404):
-            _get_form_datums(self.domain_name, 'missing', self.disambiguated_form_id)
+            _get_form_link_datums(self.domain_name, 'missing', self.disambiguated_form_id)
 
-    def test_get_form_datums_missing_module_id(self):
+    def test_get_form_link_datums_missing_module_id(self):
         with self.assertRaises(Http404):
-            _get_form_datums(self.domain_name, self.app._id, f'missing.{self.form_id}')
+            _get_form_link_datums(self.domain_name, self.app._id, f'missing.{self.form_id}')
 
-    def test_get_form_datums_missing_form_id(self):
+    def test_get_form_link_datums_missing_form_id(self):
         with self.assertRaises(Http404):
-            _get_form_datums(self.domain_name, self.app._id, f'{self.module_id}.missing')
+            _get_form_link_datums(self.domain_name, self.app._id, f'{self.module_id}.missing')
 
-    def test_get_form_datums_missing_bad_form_id(self):
+    def test_get_form_link_datums_missing_bad_form_id(self):
         with self.assertRaises(Http400):
-            _get_form_datums(self.domain_name, self.app._id, 'missing')
+            _get_form_link_datums(self.domain_name, self.app._id, 'missing')

--- a/corehq/apps/app_manager/tests/views/test_get_form_datums.py
+++ b/corehq/apps/app_manager/tests/views/test_get_form_datums.py
@@ -1,8 +1,6 @@
 from django.http import Http404
 from django.test import TestCase
 
-from no_exceptions.exceptions import Http400
-
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import get_simple_form
 from corehq.apps.app_manager.views.forms import _get_form_link_datums

--- a/corehq/apps/app_manager/tests/views/test_get_form_datums.py
+++ b/corehq/apps/app_manager/tests/views/test_get_form_datums.py
@@ -15,14 +15,19 @@ class TestReleaseBuild(TestCase):
 
         cls.domain_name = "fandago"
 
-        factory = AppFactory(cls.domain_name, name="cheeto")
-        m0, f0 = factory.new_basic_module("register", "cheeto")
+        factory = AppFactory(cls.domain_name, name="My App")
+        m0, f0 = factory.new_basic_module("households", "household")
         f0.source = get_simple_form(xmlns=f0.unique_id)
         factory.form_requires_case(f0)
+
+        m1, f1 = factory.new_basic_module("patients", "patient", parent_module=m0)
+        factory.form_requires_case(f1)
+
         cls.app = factory.app
         cls.app.save()
 
         cls.module_id = m0.unique_id
+        cls.child_module_id = m1.unique_id
         cls.form_id = f0.unique_id
         cls.disambiguated_form_id = f"{m0.unique_id}.{f0.unique_id}"
 
@@ -33,7 +38,7 @@ class TestReleaseBuild(TestCase):
 
     def test_get_form_link_datums(self):
         datums = _get_form_link_datums(self.domain_name, self.app._id, self.disambiguated_form_id)
-        self.assertEqual(datums, [{'name': 'case_id', 'case_type': 'cheeto'}])
+        self.assertEqual(datums, [{'name': 'case_id', 'case_type': 'household'}])
 
     def test_get_form_link_datums_wrong_domain(self):
         with self.assertRaises(Http404):
@@ -53,4 +58,8 @@ class TestReleaseBuild(TestCase):
 
     def test_get_form_link_datums_for_module(self):
         datums = _get_form_link_datums(self.domain_name, self.app._id, self.module_id)
-        self.assertEqual(datums, [{'name': 'case_id', 'case_type': 'cheeto'}])
+        self.assertEqual(datums, [{'name': 'case_id', 'case_type': 'household'}])
+
+    def test_get_form_link_datums_for_child_module(self):
+        datums = _get_form_link_datums(self.domain_name, self.app._id, self.child_module_id)
+        self.assertEqual(datums, [{'name': 'case_id', 'case_type': 'patient'}])

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -918,9 +918,16 @@ def _get_linkable_forms_context(module, langs):
         return trans(module.name, langs)
 
     def _form_name(module, form):
-        module_name = _module_name(module)
+        names = [_module_name(m) for m in _module_hierarchy(module)]
+        module_names = " > ".join(names)
         form_name = trans(form.name, langs)
-        return "{} > {}".format(module_name, form_name)
+        return "{} > {}".format(module_names, form_name)
+
+    def _module_hierarchy(module):
+        if not module.root_module_id:
+            return [module]
+        else:
+            return _module_hierarchy(module.root_module) + [module]
 
     linkable_items = []
     is_multi_select = module.is_multi_select()
@@ -936,13 +943,24 @@ def _get_linkable_forms_context(module, langs):
                 and module.root_module_id is not None
                 and module.root_module.case_type == candidate_module.root_module.case_type
             )
+            parent_name = ""
+            if candidate_module.root_module_id:
+                parent_name = _module_name(candidate_module.root_module) + " > "
             if is_top_level or is_child_match:
                 linkable_items.append({
                     'unique_id': candidate_module.unique_id,
-                    'name': _module_name(candidate_module),
+                    'name': parent_name + _module_name(candidate_module),
                     'auto_link': True,
                     'allow_manual_linking': False,
                 })
+            else:
+                linkable_items.append({
+                    'unique_id': candidate_module.unique_id,
+                    'name': parent_name + _module_name(candidate_module),
+                    'auto_link': True,
+                    'allow_manual_linking': True,
+                })
+
         for candidate_form in candidate_module.get_suite_forms():
             # Forms can be linked automatically if their module is the same case type as this module,
             # or if they belong to this module's parent module. All other forms can be linked manually.

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -947,12 +947,13 @@ def _get_linkable_forms_context(module, langs):
             if candidate_module.root_module_id:
                 parent_name = _module_name(candidate_module.root_module) + " > "
             auto_link = is_top_level or is_child_match
-            linkable_items.append({
-                'unique_id': candidate_module.unique_id,
-                'name': parent_name + _module_name(candidate_module),
-                'auto_link': auto_link,
-                'allow_manual_linking': not auto_link,
-            })
+            if auto_link or toggles.FORM_LINK_ADVANCED_MODE.enabled(module.get_app().domain):
+                linkable_items.append({
+                    'unique_id': candidate_module.unique_id,
+                    'name': parent_name + _module_name(candidate_module),
+                    'auto_link': auto_link,
+                    'allow_manual_linking': not auto_link,
+                })
 
         for candidate_form in candidate_module.get_suite_forms():
             # Forms can be linked automatically if their module is the same case type as this module,

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -993,28 +993,28 @@ def get_form_datums(request, domain, app_id):
 def _get_form_link_datums(domain, app_id, form_id):
     from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
     app = get_app(domain, app_id)
+    helper = EntriesHelper(app)
 
     try:
-        module_id, form_id = form_id.split('.')
-    except ValueError:
-        raise Http400
-
-    try:
+        if '.' in form_id:
+            module_id, form_id = form_id.split('.')
+            form = app.get_form(form_id)
+        else:
+            module_id = form_id
+            form = None
         module = app.get_module_by_unique_id(module_id)
-        form = app.get_form(form_id)
     except (ModuleNotFoundException, FormNotFoundException) as e:
         raise Http404(str(e))
 
-    def make_datum(datum):
-        return {'name': datum.id, 'case_type': datum.case_type}
+    if form:
+        datums = helper.get_datums_meta_for_form_generic(form, module)
+    else:
+        datums = helper.get_datum_meta_module(module)
 
-    helper = EntriesHelper(app)
-    datums = [
-        make_datum(datum) for datum in helper.get_datums_meta_for_form_generic(form, module)
-        if datum.requires_selection
+    return [
+        {'name': datum.id, 'case_type': datum.case_type}
+        for datum in datums if datum.requires_selection
     ]
-    return datums
-
 
 @require_GET
 @require_deploy_apps

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -946,20 +946,13 @@ def _get_linkable_forms_context(module, langs):
             parent_name = ""
             if candidate_module.root_module_id:
                 parent_name = _module_name(candidate_module.root_module) + " > "
-            if is_top_level or is_child_match:
-                linkable_items.append({
-                    'unique_id': candidate_module.unique_id,
-                    'name': parent_name + _module_name(candidate_module),
-                    'auto_link': True,
-                    'allow_manual_linking': False,
-                })
-            else:
-                linkable_items.append({
-                    'unique_id': candidate_module.unique_id,
-                    'name': parent_name + _module_name(candidate_module),
-                    'auto_link': True,
-                    'allow_manual_linking': True,
-                })
+            auto_link = is_top_level or is_child_match
+            linkable_items.append({
+                'unique_id': candidate_module.unique_id,
+                'name': parent_name + _module_name(candidate_module),
+                'auto_link': auto_link,
+                'allow_manual_linking': not auto_link,
+            })
 
         for candidate_form in candidate_module.get_suite_forms():
             # Forms can be linked automatically if their module is the same case type as this module,

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -981,7 +981,7 @@ def _get_linkable_forms_context(module, langs):
 def get_form_datums(request, domain, app_id):
     form_id = request.GET.get('form_id')
     try:
-        datums = _get_form_datums(domain, app_id, form_id)
+        datums = _get_form_link_datums(domain, app_id, form_id)
     except Exception:
         notify_exception(request, "Error fetching form datums", details={
             "domain": domain, "app_id": app_id, "form_id": form_id
@@ -990,7 +990,7 @@ def get_form_datums(request, domain, app_id):
     return JsonResponse(datums, safe=False)
 
 
-def _get_form_datums(domain, app_id, form_id):
+def _get_form_link_datums(domain, app_id, form_id):
     from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
     app = get_app(domain, app_id)
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -24,7 +24,6 @@ from lxml import etree
 from text_unidecode import unidecode
 
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
-from corehq.apps.hqwebapp.decorators import waf_allow
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import json_response
 
@@ -38,11 +37,11 @@ from corehq.apps.app_manager.const import (
     USERCASE_PREFIX,
     USERCASE_TYPE,
     WORKFLOW_DEFAULT,
-    WORKFLOW_ROOT,
-    WORKFLOW_PARENT_MODULE,
-    WORKFLOW_MODULE,
-    WORKFLOW_PREVIOUS,
     WORKFLOW_FORM,
+    WORKFLOW_MODULE,
+    WORKFLOW_PARENT_MODULE,
+    WORKFLOW_PREVIOUS,
+    WORKFLOW_ROOT,
 )
 from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain
 from corehq.apps.app_manager.decorators import (
@@ -53,8 +52,8 @@ from corehq.apps.app_manager.decorators import (
 from corehq.apps.app_manager.exceptions import (
     AppMisconfigurationError,
     FormNotFoundException,
-    XFormValidationFailed,
     ModuleNotFoundException,
+    XFormValidationFailed,
 )
 from corehq.apps.app_manager.helpers.validators import load_case_reserved_words
 from corehq.apps.app_manager.models import (
@@ -86,9 +85,9 @@ from corehq.apps.app_manager.util import (
     advanced_actions_use_usercase,
     enable_usercase,
     is_usercase_in_use,
-    save_xform,
     module_loads_registry_case,
     module_uses_inline_search,
+    save_xform,
 )
 from corehq.apps.app_manager.views.media_utils import handle_media_edits
 from corehq.apps.app_manager.views.notifications import notify_form_changed
@@ -101,8 +100,8 @@ from corehq.apps.app_manager.views.utils import (
     form_has_submissions,
     get_langs,
     handle_custom_icon_edits,
-    validate_custom_assertions,
     set_session_endpoint,
+    validate_custom_assertions,
 )
 from corehq.apps.app_manager.xform import (
     CaseError,
@@ -119,11 +118,11 @@ from corehq.apps.domain.decorators import (
     login_or_digest,
     track_domain_request,
 )
+from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.programs.models import Program
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
 from corehq.util.view_utils import set_file_download
-from no_exceptions.exceptions import Http400
 
 
 @no_conflict_require_POST
@@ -1009,6 +1008,7 @@ def _get_form_link_datums(domain, app_id, form_id):
         {'name': datum.id, 'case_type': datum.case_type}
         for datum in datums if datum.requires_selection
     ]
+
 
 @require_GET
 @require_deploy_apps

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -749,7 +749,8 @@ FORM_LINK_ADVANCED_MODE = StaticToggle(
     [NAMESPACE_DOMAIN],
     description=(
         "Switches manual datum configuration for form linking to a UI where app "
-        "builders must specify the datum IDs to provide"
+        "builders must specify the datum IDs to provide. Allows for linking to "
+        "more targets, but is way harder to use."
     ),
 )
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -742,6 +742,17 @@ SHOW_PERSIST_CASE_CONTEXT_SETTING = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+FORM_LINK_ADVANCED_MODE = StaticToggle(
+    'form_link_advanced_mode',
+    'USH: Form linking advanced mode',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+    description=(
+        "Switches manual datum configuration for form linking to a UI where app "
+        "builders must specify the datum IDs to provide"
+    ),
+)
+
 CASE_LIST_LOOKUP = StaticToggle(
     'case_list_lookup',
     'Allow external android callouts to search the case list',


### PR DESCRIPTION
## Product Description
Adds an "advanced mode" feature flag for end of form navigation manual linking.

Without the feature flag:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/23c08a0c-8a13-4c74-af81-35bdb9a2d513)

With the feature flag:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/d03e8453-3d4f-4bdc-9351-4a10d53e9d45)


## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3966
This PR incorporates work @MartinRiese did a bit ago to include a broader set of modules in the set of linkable targets for EoF nav.

EoF navigation involves populating the stack to navigate through the app to the desired target.  Some forms and modules expect certain variables (like case IDs) to be available in the session.  Automatic linking attempts to align existing session variables with those needed to navigate to the target.  Where that isn't possible, the app builder must provide an xpath expression for each of these datum IDs.  This manual linking is also sometimes used when automatic linking doesn't do what's desired.

However, we can't always reliably get the set of datum IDs needed to get to a target without going through the full build process, especially when child and shadow modules are involved, as the datum IDs are modified at various stages in the build process.

This PR introduces an "advanced mode" feature flag for manual linking that essentially gives up trying to predict the IDs needed, and requires the user to specify all sets of IDs and xpath expressions needed to navigate to the endpoint.  This will likely be a pain to use, though build validation should catch errors here.

Depending on how this is used, we may consider an extension of this work where advanced mode is used only on a case-by-case basis, so app builders could decide whether to enable it per module, and otherwise use the existing manual linking UI (we'd need to ensure switching between the two doesn't break anything).

## Feature Flag
This adds a new feature flag: 
FORM_LINK_ADVANCED_MODE - USH: Form linking advanced mode

## Safety Assurance

### Safety story
Testing on staging.  The UI itself is pretty small, it uses an existing widget for specifying key/value pairs.  Everything should be sufficiently hidden behind the feature flag that I'm not too concerned about affecting projects that don't enable the FF.

### Automated test coverage

none

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
none


### Rollback instructions
 
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
