### PR TITLE
adds metric for session_details view

### DIFF
--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.utils.decorators import method_decorator
@@ -13,6 +14,7 @@ from corehq.apps.users.models import CouchUser
 from corehq.feature_previews import previews_enabled_for_domain
 from corehq.middleware import TimeoutMiddleware
 from corehq.toggles import toggles_enabled_for_user, toggles_enabled_for_domain
+from corehq.util.metrics import metrics_histogram
 
 
 @method_decorator(csrf_exempt, name='dispatch')
@@ -33,6 +35,7 @@ class SessionDetailsView(View):
     http_method_names = ['post']
 
     def post(self, request, *args, **kwargs):
+        start_time = datetime.now()
         try:
             data = json.loads(request.body.decode('utf-8'))
         except ValueError:
@@ -69,6 +72,13 @@ class SessionDetailsView(View):
             domains.update(EnterprisePermissions.get_domains(member_domain))
 
         enabled_toggles = toggles_enabled_for_user(user.username) | toggles_enabled_for_domain(domain)
+        end_time = datetime.now()
+        metrics_histogram("commcare.session_details.processing_time",
+                      int((end_time - start_time).total_seconds() * 1000),
+                      bucket_tag='duration_bucket',
+                      buckets=(100, 250, 500, 1000, 2000, 3000, 4000),
+                      bucket_unit='ms',
+                      tags={'domain': domain})
         return JsonResponse({
             'username': user.username,
             'djangoUserId': user.pk,

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -72,6 +72,7 @@ class SessionDetailsView(View):
             domains.update(EnterprisePermissions.get_domains(member_domain))
 
         enabled_toggles = toggles_enabled_for_user(user.username) | toggles_enabled_for_domain(domain)
+        enabled_previews = previews_enabled_for_domain(domain)
         end_time = datetime.now()
         metrics_histogram("commcare.session_details.processing_time",
                       int((end_time - start_time).total_seconds() * 1000),
@@ -87,5 +88,5 @@ class SessionDetailsView(View):
             'domains': list(domains),
             'anonymous': False,
             'enabled_toggles': list(enabled_toggles),
-            'enabled_previews': list(previews_enabled_for_domain(domain))
+            'enabled_previews': list(enabled_previews)
         })

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -14,7 +14,10 @@ from corehq.apps.users.models import CouchUser
 from corehq.feature_previews import previews_enabled_for_domain
 from corehq.middleware import TimeoutMiddleware
 from corehq.toggles import toggles_enabled_for_user, toggles_enabled_for_domain
-from corehq.util.metrics import metrics_histogram
+from corehq.util.metrics import (
+    limit_domains,
+    metrics_histogram
+)
 
 
 @method_decorator(csrf_exempt, name='dispatch')
@@ -77,9 +80,9 @@ class SessionDetailsView(View):
         metrics_histogram("commcare.session_details.processing_time",
                       int((end_time - start_time).total_seconds() * 1000),
                       bucket_tag='duration_bucket',
-                      buckets=(100, 250, 500, 1000, 2000, 3000, 4000),
+                      buckets=(250, 1000, 3000),
                       bucket_unit='ms',
-                      tags={'domain': domain})
+                      tags={'domain': limit_domains(domain)})
         return JsonResponse({
             'username': user.username,
             'djangoUserId': user.pk,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds metric for Datadog [widget](https://app.datadoghq.com/dashboard/h78-9qs-7cx/ush-performance-monitoring?fullscreen_end_ts=1704494564189&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1704480164189&fullscreen_widget=3530931766462588&refresh_mode=sliding&tpl_var_environment%5B0%5D=staging&view=spans&from_ts=1704478561648&to_ts=1704492961648&live=true) 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-4016](https://dimagi-dev.atlassian.net/browse/USH-4016?focusedCommentId=304392&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-304392)

Investigation of slow load times for validating case search inputs found `/session_details` request as a potential bottleneck. There were a couple Datadog traces that pointed to this. One such example [trace](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20resource_name%3A%22POST%20%2Fnavigate_menu%22%20%40domain%3Aco-carecoordination-test&cols=service%2Cresource_name%2C%40duration%2C%40http.status_code%2C%40_duration.by_service%2C%40domain%2C%40user&graphType=flamegraph&historicalData=false&query_translation_version=v0&saved-view-id=1271135&shouldShowLegend=true&sort=time&spanID=7110734751025576253&spanType=service-entry&spanViewType=metadata&timeHint=1704326482967&trace=60196447845999155917110734751025576253&traceID=6019644784599915591&traceQuery=&view=spans&viz=stream&start=1704325603173&end=1704326503173&paused=false)
This metric will be used to track request timings for `session_details` request on DD and see if any spikes there correspond to the behavior we are seeing with users.
 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
tested on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4016]: https://dimagi-dev.atlassian.net/browse/USH-4016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ