### PR TITLE
Improve UI for Deprecating Case Types in Data Dictionary

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -244,7 +244,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         };
 
         self.init = function (callback) {
-            $.getJSON(dataUrl)
+            $.getJSON(dataUrl, {load_deprecated_case_types: self.showDeprecatedCaseTypes()})
                 .done(function (data) {
                     _.each(data.case_types, function (caseTypeData) {
                         var caseTypeObj = caseType(

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -179,6 +179,11 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
         const params = new URLSearchParams(document.location.search);
         self.showDeprecatedCaseTypes = ko.observable(params.get("load_deprecated_case_types") !== null);
+
+        // Elements with this class have a hidden class to hide them on page load. If we don't do this, then the elements
+        // will flash on the page for a bit while the KO bindings are being applied.
+        $(".deprecate-case-type").removeClass('hidden');
+
         self.saveButton = hqMain.initSaveButton({
             unsavedMessage: gettext("You have unsaved changes to your data dictionary."),
             save: function () {

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -423,6 +423,17 @@ hqDefine("data_dictionary/js/data_dictionary", [
             self.removefhirResourceType(false);
         };
 
+        self.toggleShowDeprecatedCaseTypes = function () {
+            self.showDeprecatedCaseTypes(!self.showDeprecatedCaseTypes());
+            const pageUrl = new URL(window.location.href);
+            if (self.showDeprecatedCaseTypes()) {
+                pageUrl.searchParams.append('load_deprecated_case_types', true);
+            } else {
+                pageUrl.searchParams.delete('load_deprecated_case_types');
+            }
+            window.location.href = pageUrl;
+        };
+
         // CREATE workflow
         self.name = ko.observable("").extend({
             rateLimit: { method: "notifyWhenChangesStop", timeout: 400 },

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -176,6 +176,9 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.showAll = ko.observable(false);
         self.availableDataTypes = typeChoices;
         self.fhirResourceTypes = ko.observableArray(fhirResourceTypes);
+
+        const params = new URLSearchParams(document.location.search);
+        self.showDeprecatedCaseTypes = ko.observable(params.get("load_deprecated_case_types") !== null);
         self.saveButton = hqMain.initSaveButton({
             unsavedMessage: gettext("You have unsaved changes to your data dictionary."),
             save: function () {

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -17,6 +17,18 @@
 {% block page_navigation %}
   <h2 class="text-hq-nav-header">{% trans "Data Dictionary" %}</h2>
   <ul class="nav nav-hq-sidebar">
+    <li>
+      <a class="hidden deprecate-case-type" data-bind="click: $root.toggleShowDeprecatedCaseTypes">
+        <div data-bind="hidden: $root.showDeprecatedCaseTypes">
+          <i class="fa fa-eye"></i>
+          {% trans 'Show Deprecated Case Types' %}
+        </div>
+        <div data-bind="visible: $root.showDeprecatedCaseTypes">
+          <i class="fa fa-eye-slash"></i>
+          {% trans 'Hide Deprecated Case Types' %}
+        </div>
+      </a>
+    </li>
     <!-- ko foreach: caseTypes -->
     <li data-bind="css: { active: $data.name == $root.activeCaseType() }">
       {# navigation handle by URL hash #}

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -34,7 +34,7 @@
       {# navigation handle by URL hash #}
       <a data-bind="attr: {href: $data.url}">
         <span data-bind="text: $data.name" style="display: inline-block"></span>
-        <span data-bind="visible: $data.deprecated" class="label label-warning">{% trans "deprecated" %}</span>
+        <span data-bind="visible: $data.deprecated" class="hidden deprecate-case-type label label-warning">{% trans "deprecated" %}</span>
       </a>
     </li>
     <!-- /ko -->
@@ -143,7 +143,7 @@
     <div class="col-md-12">
       <div>
         <h3 data-bind="text: $root.activeCaseType()" style="display: inline-block;"></h3>
-        <span data-bind="visible: $root.isActiveCaseTypeDeprecated()" class="label label-warning" style="display: inline-block;">{% trans "deprecated" %}</span>
+        <span data-bind="visible: $root.isActiveCaseTypeDeprecated()" class="deprecate-case-type hidden label label-warning" style="display: inline-block;">{% trans "deprecated" %}</span>
       </div>
       {% if fhir_integration_enabled %}
         <div id="fhir-resource-type-form" class="form-inline" data-bind="visible: fhirResourceTypes().length">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -35,14 +35,13 @@
       </li>
       <li>
         <a class="hidden deprecate-case-type" data-bind="click: $root.toggleShowDeprecatedCaseTypes">
-          <div data-bind="hidden: $root.showDeprecatedCaseTypes">
-            <i class="fa fa-eye"></i>
-            {% trans 'Show Deprecated Case Types' %}
-          </div>
-          <div data-bind="visible: $root.showDeprecatedCaseTypes">
-            <i class="fa fa-eye-slash"></i>
-            {% trans 'Hide Deprecated Case Types' %}
-          </div>
+            <i class="fa fa-archive"></i>
+            <span data-bind="hidden: $root.showDeprecatedCaseTypes">
+              {% trans 'Show Deprecated Case Types' %}
+            </span>
+            <span data-bind="visible: $root.showDeprecatedCaseTypes">
+              {% trans 'Hide Deprecated Case Types' %}
+            </span>
         </a>
       </li>
     {% endif %}

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -17,18 +17,6 @@
 {% block page_navigation %}
   <h2 class="text-hq-nav-header">{% trans "Data Dictionary" %}</h2>
   <ul class="nav nav-hq-sidebar">
-    <li>
-      <a class="hidden deprecate-case-type" data-bind="click: $root.toggleShowDeprecatedCaseTypes">
-        <div data-bind="hidden: $root.showDeprecatedCaseTypes">
-          <i class="fa fa-eye"></i>
-          {% trans 'Show Deprecated Case Types' %}
-        </div>
-        <div data-bind="visible: $root.showDeprecatedCaseTypes">
-          <i class="fa fa-eye-slash"></i>
-          {% trans 'Hide Deprecated Case Types' %}
-        </div>
-      </a>
-    </li>
     <!-- ko foreach: caseTypes -->
     <li data-bind="css: { active: $data.name == $root.activeCaseType() }">
       {# navigation handle by URL hash #}
@@ -43,6 +31,18 @@
         <a href="#" data-bind="openModal: 'create-case-type'">
           <i class="fa fa-plus"></i>
           {% trans "Add Case Type" %}
+        </a>
+      </li>
+      <li>
+        <a class="hidden deprecate-case-type" data-bind="click: $root.toggleShowDeprecatedCaseTypes">
+          <div data-bind="hidden: $root.showDeprecatedCaseTypes">
+            <i class="fa fa-eye"></i>
+            {% trans 'Show Deprecated Case Types' %}
+          </div>
+          <div data-bind="visible: $root.showDeprecatedCaseTypes">
+            <i class="fa fa-eye-slash"></i>
+            {% trans 'Hide Deprecated Case Types' %}
+          </div>
         </a>
       </li>
     {% endif %}

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -339,11 +339,14 @@ class DataDictionaryJsonTest(TestCase):
             group=cls.case_prop_group
         )
         cls.case_prop_obj.save()
+        cls.deprecated_case_type_obj = CaseType(name='depCaseType', domain=cls.domain_name, is_deprecated=True)
+        cls.deprecated_case_type_obj.save()
         cls.client = Client()
 
     @classmethod
     def tearDownClass(cls):
         cls.case_type_obj.delete()
+        cls.deprecated_case_type_obj.delete()
         cls.couch_user.delete(cls.domain_name, deleted_by=None)
         cls.domain.delete()
         super(DataDictionaryJsonTest, cls).tearDownClass()
@@ -351,16 +354,9 @@ class DataDictionaryJsonTest(TestCase):
     def setUp(self):
         self.endpoint = reverse('data_dictionary_json', args=[self.domain_name])
 
-    def test_no_access(self):
-        response = self.client.get(self.endpoint)
-        self.assertEqual(response.status_code, 302)
-
-    @patch('corehq.apps.data_dictionary.views.get_case_type_app_module_count', return_value={})
-    def test_get_json_success(self, *args):
-        self.client.login(username='test', password='foobar')
-        response = self.client.get(self.endpoint)
-        self.assertEqual(response.status_code, 200)
-        expected_response = {
+    @classmethod
+    def _get_case_type_json(self, with_deprecated=False):
+        expected_output = {
             "case_types": [
                 {
                     "name": "caseType",
@@ -388,8 +384,37 @@ class DataDictionaryJsonTest(TestCase):
                     "is_deprecated": False,
                     "module_count": 0,
                     "properties": [],
-                }
+                },
             ],
             "geo_case_property": GPS_POINT_CASE_PROPERTY,
         }
+        if with_deprecated:
+            expected_output['case_types'].append(
+                {
+                    "name": "depCaseType",
+                    "fhir_resource_type": None,
+                    "groups": [
+                        {
+                            "name": '',
+                            "properties": []
+                        },
+                    ],
+                    "is_deprecated": True,
+                    "module_count": 0,
+                    "properties": [],
+                }
+            )
+        return expected_output
+
+    def test_no_access(self):
+        response = self.client.get(self.endpoint)
+        self.assertEqual(response.status_code, 302)
+
+    @patch('corehq.apps.data_dictionary.views.get_case_type_app_module_count', return_value={})
+    def test_get_json_success(self, *args):
+        self.client.login(username='test', password='foobar')
+        response = self.client.get(self.endpoint)
+        self.assertEqual(response.status_code, 200)
+        expected_response = self._get_case_type_json()
+        self.assertEqual(response.json(), expected_response)
         self.assertEqual(response.json(), expected_response)

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -417,4 +417,10 @@ class DataDictionaryJsonTest(TestCase):
         self.assertEqual(response.status_code, 200)
         expected_response = self._get_case_type_json()
         self.assertEqual(response.json(), expected_response)
+
+    @patch('corehq.apps.data_dictionary.views.get_case_type_app_module_count', return_value={})
+    def test_get_json_success_with_deprecated_case_types(self, *args):
+        self.client.login(username='test', password='foobar')
+        response = self.client.get(self.endpoint, data={'load_deprecated_case_types': 'true'})
+        expected_response = self._get_case_type_json(with_deprecated=True)
         self.assertEqual(response.json(), expected_response)

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -58,7 +58,10 @@ def data_dictionary_json(request, domain, case_type_name=None):
     props = []
     fhir_resource_type_name_by_case_type = {}
     fhir_resource_prop_by_case_prop = {}
-    queryset = CaseType.objects.filter(domain=domain).prefetch_related(
+    queryset = CaseType.objects.filter(domain=domain)
+    if not request.GET.get('load_deprecated_case_types', False) == 'true':
+        queryset = queryset.filter(is_deprecated=False)
+    queryset = queryset.prefetch_related(
         Prefetch('groups', queryset=CasePropertyGroup.objects.order_by('index')),
         Prefetch('properties', queryset=CaseProperty.objects.order_by('group_id', 'index')),
         Prefetch('properties__allowed_values', queryset=CasePropertyAllowedValue.objects.order_by('allowed_value'))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A new toggle button has been added to the case type list in the Data Dictionary page:
![dd-new-button](https://github.com/dimagi/commcare-hq/assets/122617251/4b1e745c-8b8f-44ab-803f-461eab957d2f)

Once the button has been clicked, a `load_deprecated_case_types=true` query param will be put in the URL and the button will switch to the following:
![toggle-show-deprecated-dd](https://github.com/dimagi/commcare-hq/assets/122617251/3cd7a04f-bd9b-4235-9450-a15f1b88ef10)


By default, deprecated case types will not be loaded/shown in the Data Dictionary.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3240).

A new UI button has been added to the sidebar of the Data Dictionary which gives the user the ability to toggle showing deprecated case types. This also has a potential performance benefit as domains with a lot of deprecated case types will now have faster loading times since deprecated case types are not loaded/processed by default.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Unit test.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit test has been created to ensure that deprecated case types are only added to the response JSON if the relevant query param has been given.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
