### PR TITLE
Location API - Create & update

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -14,7 +14,6 @@ from memoized import memoized
 
 from dimagi.utils.couch.database import iter_docs
 
-from corehq.apps.commtrack.util import generate_code
 from corehq.apps.custom_data_fields.edit_entity import (
     CUSTOM_DATA_FIELD_PREFIX,
     CustomDataEditor,
@@ -24,7 +23,12 @@ from corehq.apps.es import UserES
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import Select2Ajax, SelectToggle
 from corehq.apps.locations.permissions import LOCATION_ACCESS_DENIED
-from corehq.apps.locations.util import valid_location_site_code
+from corehq.apps.locations.util import (
+    validate_site_code,
+    generate_site_code,
+    has_siblings_with_name,
+    get_location_type
+)
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import user_display_string
 from corehq.util.quickcache import quickcache
@@ -216,16 +220,6 @@ class LocationForm(forms.Form):
         return parent_id
 
     def clean_name(self):
-        def has_siblings_with_name(location, name, parent_location_id):
-            qs = SQLLocation.objects.filter(domain=location.domain,
-                                            name=name)
-            if parent_location_id:
-                qs = qs.filter(parent__location_id=parent_location_id)
-            else:  # Top level
-                qs = qs.filter(parent=None)
-            return (qs.exclude(location_id=self.location.location_id)
-                      .exists())
-
         name = self.cleaned_data['name']
         parent_location_id = self.cleaned_data.get('parent_id', None)
 
@@ -239,32 +233,13 @@ class LocationForm(forms.Form):
 
     def clean_site_code(self):
         site_code = self.cleaned_data['site_code']
-
         if site_code:
-            site_code = site_code.lower()
-            if not valid_location_site_code(site_code):
-                raise forms.ValidationError(_(
-                    'The site code cannot contain spaces or special characters.'
-                ))
-            if (SQLLocation.objects
-                    .filter(domain=self.domain,
-                            site_code__iexact=site_code)
-                    .exclude(location_id=self.location.location_id)
-                    .exists()):
-                raise forms.ValidationError(_(
-                    'another location already uses this site code'
-                ))
-            return site_code
+            return validate_site_code(self.domain, self.location.location_id, site_code, forms.ValidationError)
 
     def clean(self):
         if 'name' in self.cleaned_data and not self.cleaned_data.get('site_code', None):
-            all_codes = [
-                code.lower() for code in
-                (SQLLocation.objects.exclude(location_id=self.location.location_id)
-                                    .filter(domain=self.domain)
-                                    .values_list('site_code', flat=True))
-            ]
-            self.cleaned_data['site_code'] = generate_code(self.cleaned_data['name'], all_codes)
+            self.cleaned_data['site_code'] = generate_site_code(
+                self.domain, self.location.location_id, self.cleaned_data['name'])
 
     @staticmethod
     def get_allowed_types(domain, parent):
@@ -275,34 +250,9 @@ class LocationForm(forms.Form):
                     .all())
 
     def clean_location_type(self):
-        loc_type = self.cleaned_data['location_type']
-        allowed_types = self.get_allowed_types(self.domain, self.cleaned_data.get('parent'))
-        if not allowed_types:
-            raise forms.ValidationError(_('The selected parent location cannot have child locations!'))
-
-        if not loc_type:
-            if len(allowed_types) == 1:
-                loc_type_obj = allowed_types[0]
-            else:
-                raise forms.ValidationError(_('You must select a location type'))
-        else:
-            try:
-                loc_type_obj = (LocationType.objects
-                                .filter(domain=self.domain)
-                                .get(Q(code=loc_type) | Q(name=loc_type)))
-            except LocationType.DoesNotExist:
-                raise forms.ValidationError(_("LocationType '{}' not found").format(loc_type))
-            else:
-                if loc_type_obj not in allowed_types:
-                    raise forms.ValidationError(_('Location type not valid for the selected parent.'))
-
-        _can_change_location_type = (self.is_new_location
-                                     or not self.location.get_descendants().exists())
-        if not _can_change_location_type and loc_type_obj.pk != self.location.location_type.pk:
-            raise forms.ValidationError(_(
-                'You cannot change the location type of a location with children'
-            ))
-
+        loc_type_obj = get_location_type(self.domain, self.location, self.cleaned_data.get('parent'),
+                                         self.cleaned_data['location_type'], forms.ValidationError,
+                                         self.is_new_location)
         self.cleaned_data['location_type_object'] = loc_type_obj
         return loc_type_obj.name
 

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -1,7 +1,6 @@
 import re
 
 from django import forms
-from django.db.models import Q
 from django.template.loader import get_template
 from django.urls import reverse
 from django.utils.translation import gettext as _

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -67,12 +67,6 @@ class LocationResource(v0_5.LocationResource):
 
     def _update(self, bundle, domain, is_new_location=False):
         data = bundle.data
-        # Invalid fields that might be common
-        if data.pop('location_type_name', False):
-            raise BadRequest(_('Location type name is not editable.'))
-        if data.pop('last_modified', False):
-            raise BadRequest(_('\"last_modified\" field is not editable.'))
-
         if 'parent_location_id' in data:
             parent = self._get_parent_location(data.pop('parent_location_id'))
             if not is_new_location and 'location_type_code' not in data:
@@ -103,7 +97,7 @@ class LocationResource(v0_5.LocationResource):
             bundle.obj.longitude = data.pop('longitude')
 
         if len(data):
-            raise BadRequest(_("Invalid fields were included in request."))
+            raise BadRequest(_(f"Invalid fields were included in request: {list(data.keys())}"))
 
         bundle.obj.save()
 

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -1,5 +1,5 @@
 from corehq.apps.api.resources.auth import RequirePermissionAuthentication
-from corehq.apps.locations.models import SQLLocation
+from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.users.models import HqPermissions
 
 from corehq.apps.locations.resources import v0_5
@@ -38,3 +38,17 @@ class LocationResource(v0_5.LocationResource):
         bundle.data['location_type_name'] = bundle.obj.location_type.name
         bundle.data['location_type_code'] = bundle.obj.location_type.code
         return bundle
+
+    def _get_location_type(self, type_code):
+        try:
+            return LocationType.objects.get(
+                code=type_code
+            )
+        except LocationType.DoesNotExist:
+            raise Exception('Could not find location type with the given code.')
+
+    def _get_parent_location(self, id):
+        try:
+            return SQLLocation.objects.get(location_id=id)
+        except SQLLocation.DoesNotExist:
+            raise Exception("Could not find parent location with the given ID.")

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -4,7 +4,7 @@ from corehq.apps.users.models import HqPermissions
 
 from corehq.apps.locations.resources import v0_5
 
-from tastypie.exceptions import BadRequest, NotFound
+from tastypie.exceptions import BadRequest
 
 
 class LocationResource(v0_5.LocationResource):
@@ -54,11 +54,9 @@ class LocationResource(v0_5.LocationResource):
 
     def obj_update(self, bundle, **kwargs):
         try:
-            bundle.obj = SQLLocation.objects.get(location_id=kwargs['location_id'])
+            bundle.obj = SQLLocation.objects.get(location_id=kwargs['location_id'], domain=kwargs['domain'])
         except SQLLocation.DoesNotExist:
-            raise BadRequest("Could not find location with given ID.")
-        if bundle.obj.domain != kwargs.pop('domain'):
-            raise NotFound('Location could not be found.')
+            raise BadRequest("Could not find location with given ID on the domain.")
         self._update(bundle)
         return bundle
 

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -37,6 +37,7 @@ class LocationResource(v0_5.LocationResource):
             bundle.data['parent_location_id'] = ''
         bundle.data['location_type_name'] = bundle.obj.location_type.name
         bundle.data['location_type_code'] = bundle.obj.location_type.code
+        bundle.data['location_data'] = bundle.obj.metadata
         return bundle
 
     def _get_location_type(self, type_code):

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -43,9 +43,9 @@ class LocationResource(v0_5.LocationResource):
         return bundle
 
     def obj_create(self, bundle, **kwargs):
-        if 'domain' not in bundle.data or 'name' not in bundle.data:
-            raise BadRequest("'domain' and 'name' are required fields.")
-        domain = bundle.data.pop('domain')
+        domain = kwargs['domain']
+        if 'name' not in bundle.data:
+            raise BadRequest("'name' is a required field.")
         if SQLLocation.objects.filter(domain=domain, site_code=bundle.data['site_code']).exists():
             raise BadRequest("Location on domain with site code already exists.")
         bundle.obj = SQLLocation(domain=domain)

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -12,7 +12,9 @@ class LocationResource(v0_5.LocationResource):
         queryset = SQLLocation.active_objects.all()
         detail_uri_name = 'location_id'
         authentication = RequirePermissionAuthentication(HqPermissions.edit_locations)
-        allowed_methods = ['get']
+        list_allowed_methods = ['get', 'post']
+        detail_allowed_methods = ['get', 'put']
+        always_return_data = True
         include_resource_uri = False
         fields = {
             'domain',

--- a/corehq/apps/locations/tests/test_api_v6.py
+++ b/corehq/apps/locations/tests/test_api_v6.py
@@ -128,7 +128,6 @@ class LocationV6Test(APIResourceTest):
 
     def test_post(self):
         post_data = {
-            "domain": self.domain.name,
             "latitude": 31.1234,
             "location_data": {
                 "city_pop": "729"

--- a/corehq/apps/locations/tests/test_api_v6.py
+++ b/corehq/apps/locations/tests/test_api_v6.py
@@ -111,3 +111,22 @@ class LocationV6Test(APIResourceTest):
             "parent_location_id": "1",
             "site_code": "denver"
         }, response.json())
+
+    def test_post(self):
+        post_data = {
+            "domain": self.domain.name,
+            "latitude": 31.1234,
+            "location_data": {
+                "city_pop": 729
+            },
+            "location_type_code": "city",
+            "longitude": 32.5678,
+            "name": "Fairplay",
+            "parent_location_id": "1",
+            "site_code": "fairplay"
+        }
+        response = self._assert_auth_post_resource(self.list_endpoint, post_data)
+        self.assertEqual(response.status_code, 201)
+
+        created_location = SQLLocation.objects.get(name="Fairplay")
+        all(key_value_pair in created_location.to_json().items() for key_value_pair in post_data.items())

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -175,8 +175,7 @@ class LocationExporter(object):
     @memoized
     def include_consumption(self):
         if bool(
-            self.include_consumption_flag and
-            self.domain_obj.commtrack_settings.individual_consumption_defaults
+            self.include_consumption_flag and self.domain_obj.commtrack_settings.individual_consumption_defaults
         ):
             # we'll be needing these, so init 'em:
             self.products = Product.by_domain(self.domain)
@@ -192,9 +191,8 @@ class LocationExporter(object):
 
     def get_consumption(self, loc):
         if (
-            not self.include_consumption or
-            loc.location_type_name in self.administrative_types or
-            not self.consumption_dict
+            not self.include_consumption or loc.location_type_name in self.administrative_types
+            or not self.consumption_dict
         ):
             return {}
         if loc.location_id in self.supply_point_map:
@@ -296,8 +294,9 @@ class LocationExporter(object):
 
 def dump_locations(domain, download_id, include_consumption, headers_only,
                    owner_id, root_location_ids=None, task=None, **kwargs):
-    exporter = LocationExporter(domain, include_consumption=include_consumption, root_location_ids=root_location_ids,
-                                headers_only=headers_only, async_task=task, **kwargs)
+    exporter = LocationExporter(domain, include_consumption=include_consumption,
+                                root_location_ids=root_location_ids, headers_only=headers_only,
+                                async_task=task, **kwargs)
 
     fd, path = tempfile.mkstemp()
     os.close(fd)
@@ -400,34 +399,33 @@ def has_siblings_with_name(location, name, parent_location_id):
 
 
 def get_location_type(domain, location, parent, loc_type_string, exception, is_new_location):
-        from corehq.apps.locations.forms import LocationForm
-        allowed_types = LocationForm.get_allowed_types(domain, parent)
-        if not allowed_types:
-            raise exception(_('The selected parent location cannot have child locations!'))
+    from corehq.apps.locations.forms import LocationForm
+    allowed_types = LocationForm.get_allowed_types(domain, parent)
+    if not allowed_types:
+        raise exception(_('The selected parent location cannot have child locations!'))
 
-        if not loc_type_string:
-            if len(allowed_types) == 1:
-                loc_type_obj = allowed_types[0]
-            else:
-                raise exception(_('You must select a location type'))
+    if not loc_type_string:
+        if len(allowed_types) == 1:
+            loc_type_obj = allowed_types[0]
         else:
-            try:
-                loc_type_obj = (LocationType.objects
-                                .filter(domain=domain)
-                                .get(Q(code=loc_type_string) | Q(name=loc_type_string)))
-            except LocationType.DoesNotExist:
-                raise exception(_("LocationType '{}' not found").format(loc_type_string))
-            else:
-                if loc_type_obj not in allowed_types:
-                    raise exception(_('Location type not valid for the selected parent.'))
+            raise exception(_('You must select a location type'))
+    else:
+        try:
+            loc_type_obj = (LocationType.objects
+                            .filter(domain=domain)
+                            .get(Q(code=loc_type_string) | Q(name=loc_type_string)))
+        except LocationType.DoesNotExist:
+            raise exception(_("LocationType '{}' not found").format(loc_type_string))
+        else:
+            if loc_type_obj not in allowed_types:
+                raise exception(_('Location type not valid for the selected parent.'))
 
-        _can_change_location_type = (is_new_location
-                                     or not location.get_descendants().exists())
-        if not _can_change_location_type and loc_type_obj.pk != location.location_type.pk:
-            raise exception(_(
-                'You cannot change the location type of a location with children'
-            ))
+    _can_change_location_type = (is_new_location or not location.get_descendants().exists())
+    if not _can_change_location_type and loc_type_obj.pk != location.location_type.pk:
+        raise exception(_(
+            'You cannot change the location type of a location with children'
+        ))
 
-        return loc_type_obj
+    return loc_type_obj
 
 # ---

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -4,6 +4,7 @@ import tempfile
 from collections import OrderedDict
 
 from django.db.models import Q
+from django.utils.translation import gettext as _
 
 from memoized import memoized
 
@@ -13,6 +14,7 @@ from dimagi.utils.couch.loosechange import map_reduce
 from soil import DownloadBase
 from soil.util import expose_blob_download
 
+from corehq.apps.commtrack.util import generate_code
 from corehq.apps.consumption.shortcuts import (
     build_consumption_dict,
     get_loaded_default_monthly_consumption,
@@ -354,6 +356,78 @@ def get_locations_from_ids(location_ids, domain, base_queryset=None):
     return locations
 
 
-def valid_location_site_code(site_code):
-    slug_regex = re.compile(r'^[-_\w\d]+$')
-    return slug_regex.match(site_code)
+# Validation-related methods ---
+
+def validate_site_code(domain, location_id, site_code, error):
+    def valid_location_site_code(site_code):
+        slug_regex = re.compile(r'^[-_\w\d]+$')
+        return slug_regex.match(site_code)
+
+    site_code = site_code.lower()
+    if not valid_location_site_code(site_code):
+        raise error(_(
+            'The site code cannot contain spaces or special characters.'
+        ))
+    if (SQLLocation.objects
+            .filter(domain=domain,
+                    site_code__iexact=site_code)
+            .exclude(location_id=location_id)
+            .exists()):
+        raise error(_(
+            'another location already uses this site code'
+        ))
+    return site_code
+
+
+def generate_site_code(domain, location_id, name):
+    all_codes = [
+        code.lower() for code in
+        (SQLLocation.objects.exclude(location_id=location_id)
+                            .filter(domain=domain)
+                            .values_list('site_code', flat=True))
+    ]
+    return generate_code(name, all_codes)
+
+
+def has_siblings_with_name(location, name, parent_location_id):
+    qs = SQLLocation.objects.filter(domain=location.domain,
+                                    name=name)
+    if parent_location_id:
+        qs = qs.filter(parent__location_id=parent_location_id)
+    else:  # Top level
+        qs = qs.filter(parent=None)
+    return (qs.exclude(location_id=location.location_id).exists())
+
+
+def get_location_type(domain, location, parent, loc_type_string, exception, is_new_location):
+        from corehq.apps.locations.forms import LocationForm
+        allowed_types = LocationForm.get_allowed_types(domain, parent)
+        if not allowed_types:
+            raise exception(_('The selected parent location cannot have child locations!'))
+
+        if not loc_type_string:
+            if len(allowed_types) == 1:
+                loc_type_obj = allowed_types[0]
+            else:
+                raise exception(_('You must select a location type'))
+        else:
+            try:
+                loc_type_obj = (LocationType.objects
+                                .filter(domain=domain)
+                                .get(Q(code=loc_type_string) | Q(name=loc_type_string)))
+            except LocationType.DoesNotExist:
+                raise exception(_("LocationType '{}' not found").format(loc_type_string))
+            else:
+                if loc_type_obj not in allowed_types:
+                    raise exception(_('Location type not valid for the selected parent.'))
+
+        _can_change_location_type = (is_new_location
+                                     or not location.get_descendants().exists())
+        if not _can_change_location_type and loc_type_obj.pk != location.location_type.pk:
+            raise exception(_(
+                'You cannot change the location type of a location with children'
+            ))
+
+        return loc_type_obj
+
+# ---


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Links:
- Jira: [USH-2355](https://dimagi-dev.atlassian.net/browse/USH-2355?atlOrigin=eyJpIjoiMjNjNjliODk4MjczNGQ4NDg2YjM4NTlhYWU5ZjE0NTEiLCJwIjoiaiJ9)
- [Spec](https://docs.google.com/document/d/1pTi8-kg6CCv5jgUAooZuv7Cs65Z_2sIDNC4PAwygC_8/edit?usp=sharing)
- [The previous PR ](https://github.com/dimagi/commcare-hq/pull/32041)(read)

Adds the ability to create and update locations using the Locations API (expands v6). 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Creating locations is done using a POST to the list endpoint (`.../[domain]/api/v0.6/location`) and updating is done via a PUT to a "detail" endpoint (`.../location/[location_id]`).

Review all at once.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Data security-wise, code practices follow Tastypie and API v5 standards. Please feel free to share any thoughts around this subject.

Functionality-wise:
- Tests should cover main concerns
- Tested robustly locally
- v6 is not officially released yet, so no risk of affecting existing projects

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Tests added!

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

No QA planned. I will probably test myself a little on prod after release. I think we might do QA once if/when we get to an official release.

Edit: The validation code we're adding to this PR touches the locations forms code, so I'm requesting regression testing on locations.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-2355]: https://dimagi-dev.atlassian.net/browse/USH-2355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ