### PR TITLE
Profile sessiondetails View

### DIFF
--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -6,6 +6,8 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
+from dimagi.utils.decorators.profile import profile_dump
+
 from corehq import toggles
 from corehq.apps.domain.auth import formplayer_auth
 from corehq.apps.enterprise.models import EnterprisePermissions
@@ -37,6 +39,7 @@ class SessionDetailsView(View):
     urlname = 'session_details'
     http_method_names = ['post']
 
+    @profile_dump('commcare_session_details.prof', probability=1, limit=5)
     def post(self, request, *args, **kwargs):
         start_time = datetime.now()
         try:

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 
+from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views import View
@@ -21,6 +22,9 @@ from corehq.util.metrics import (
     metrics_histogram
 )
 
+PROFILE_LIMIT = settings.COMMCARE_PROFILE_SESSION_DETAILS_LIMIT
+PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
+
 
 @method_decorator(csrf_exempt, name='dispatch')
 @method_decorator(formplayer_auth, name='dispatch')
@@ -39,8 +43,7 @@ class SessionDetailsView(View):
     urlname = 'session_details'
     http_method_names = ['post']
 
-    @profile_dump('commcare_session_details.prof', probability=1, limit=5,
-                cumulative_time_threshold=3000)
+    @profile_dump('commcare_session_details.prof', limit=PROFILE_LIMIT, cumulative_time_threshold=3000)
     def post(self, request, *args, **kwargs):
         start_time = datetime.now()
         try:

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -39,7 +39,8 @@ class SessionDetailsView(View):
     urlname = 'session_details'
     http_method_names = ['post']
 
-    @profile_dump('commcare_session_details.prof', probability=1, limit=5)
+    @profile_dump('commcare_session_details.prof', probability=1, limit=5,
+                cumulative_time_threshold=3000)
     def post(self, request, *args, **kwargs):
         start_time = datetime.now()
         try:

--- a/settings.py
+++ b/settings.py
@@ -1165,6 +1165,8 @@ GOOGLE_SHEETS_API_NAME = "sheets"
 GOOGLE_SHEETS_API_VERSION = "v4"
 DAYS_KEEP_GSHEET_STATUS = 14
 
+COMMCARE_PROFILE_SESSION_DETAILS_LIMIT = None
+
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)


### PR DESCRIPTION
## Product Description
No user facing change

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-4016](https://dimagi-dev.atlassian.net/browse/USH-4016?focusedCommentId=304392&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-304392)

Investigation of slow load times for validating case search inputs found /session_details request as a potential bottleneck. There were a couple Datadog [trace](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20resource_name%3A%22POST%20%2Fnavigate_menu%22%20%40domain%3Aco-carecoordination-test&cols=service%2Cresource_name%2C%40duration%2C%40http.status_code%2C%40_duration.by_service%2C%40domain%2C%40user&graphType=flamegraph&historicalData=false&query_translation_version=v0&saved-view-id=1271135&shouldShowLegend=true&sort=time&spanID=7110734751025576253&spanType=service-entry&spanViewType=metadata&timeHint=1704326482967&trace=60196447845999155917110734751025576253&traceID=6019644784599915591&traceQuery=&view=spans&viz=stream&start=1704325603173&end=1704326503173&paused=false)s that pointed to this. One such example [trace](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20resource_name%3A%22POST%20%2Fnavigate_menu%22%20%40domain%3Aco-carecoordination-test&cols=service%2Cresource_name%2C%40duration%2C%40http.status_code%2C%40_duration.by_service%2C%40domain%2C%40user&graphType=flamegraph&historicalData=false&query_translation_version=v0&saved-view-id=1271135&shouldShowLegend=true&sort=time&spanID=7110734751025576253&spanType=service-entry&spanViewType=metadata&timeHint=1704326482967&trace=60196447845999155917110734751025576253&traceID=6019644784599915591&traceQuery=&view=spans&viz=stream&start=1704325603173&end=1704326503173&paused=false).

This profiling is added to investigate the cause of the bottleneck. It also adds a `cumulative_time_threshold` parameter such that a profile is saved only if the cumulative time (time spent in this and all subfunctions from invocation till exit) exceeds the threshold. This is because not every call to this view is slow and I want to record only the slow invocations.

Based on a couple days of datapoint on staging for this view, I chose 3 seconds as the threshold for "slow".
![image](https://github.com/dimagi/commcare-hq/assets/88759246/ebc2c52a-f31f-4091-ae36-2901c778af73)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No Feature Flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
tested locally - deployed on staging but still figuring out how to verify

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated tests
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4016]: https://dimagi-dev.atlassian.net/browse/USH-4016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ