### PR TITLE
Only Load Cases/Users with GPS Data on Map

### DIFF
--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -77,9 +77,6 @@ class BaseCaseMapReport(ProjectReport, CaseListMixin, XpathCaseSearchFilterMixin
     def _get_geo_location(self, case):
         geo_case_property = get_geo_case_property(self.domain)
         geo_point = case.get_case_property(geo_case_property)
-        if not geo_point:
-            return
-
         try:
             geo_point = GeoPoint.from_string(geo_point, flexible=True)
             return {"lat": geo_point.latitude, "lng": geo_point.longitude}

--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -15,6 +15,7 @@ from corehq.apps.es.case_search import (
     PROPERTY_GEOPOINT_VALUE,
     PROPERTY_KEY,
     wrap_case_search_hit,
+    case_property_missing,
 )
 from corehq.apps.reports.standard import ProjectReport
 from corehq.apps.reports.standard.cases.basic import CaseListMixin
@@ -68,6 +69,8 @@ class BaseCaseMapReport(ProjectReport, CaseListMixin, XpathCaseSearchFilterMixin
 
     def _build_query(self):
         query = super()._build_query()
+        geo_case_property = get_geo_case_property(self.domain)
+        query = query.NOT(case_property_missing(geo_case_property))
         query = self.apply_xpath_case_search_filter(query)
         return query
 

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -30,7 +30,6 @@ hqDefine("geospatial/js/geospatial_map", [
 
     var mapModel;
     var polygonFilterModel;
-    var missingGPSModelInstance;
 
     function showMapControls(state) {
         $("#geospatial-map").toggle(state);
@@ -327,7 +326,6 @@ hqDefine("geospatial/js/geospatial_map", [
             self.hasErrors(false);
             if (!self.shouldShowUsers()) {
                 self.hasFiltersChanged(false);
-                missingGPSModelInstance.usersWithoutGPS([]);
                 return;
             }
 
@@ -339,16 +337,7 @@ hqDefine("geospatial/js/geospatial_map", [
                     self.hasFiltersChanged(false);
 
                     // TODO: There is a lot of indexing happening here. This should be replaced with a mapping to make reading it more explicit
-                    const usersWithoutGPS = data.user_data.filter(function (item) {
-                        return item.gps_point === null || !item.gps_point.length;
-                    });
-                    missingGPSModelInstance.usersWithoutGPS(usersWithoutGPS);
-
-                    const usersWithGPS = data.user_data.filter(function (item) {
-                        return item.gps_point !== null && item.gps_point.length;
-                    });
-
-                    const userData = _.object(_.map(usersWithGPS, function (userData) {
+                    const userData = _.object(_.map(data.user_data, function (userData) {
                         const gpsData = (userData.gps_point) ? userData.gps_point.split(' ') : [];
                         const lat = parseFloat(gpsData[0]);
                         const lng = parseFloat(gpsData[1]);
@@ -427,19 +416,6 @@ hqDefine("geospatial/js/geospatial_map", [
         }));
         const caseMapItems = mapModel.addMarkersToMap(casesById, caseMarkerColors);
         mapModel.caseMapItems(caseMapItems);
-
-        var $missingCasesDiv = $("#missing-gps-cases");
-        var casesWithoutGPS = caseData.filter(function (item) {
-            return item[1] === null;
-        });
-        casesWithoutGPS = _.map(casesWithoutGPS, function (item) {return {"link": item[2]};});
-        // Don't re-apply if this is the next page of the pagination
-        if (ko.dataFor($missingCasesDiv[0]) === undefined) {
-            $missingCasesDiv.koApplyBindings(missingGPSModelInstance);
-            missingGPSModelInstance.casesWithoutGPS(casesWithoutGPS);
-        }
-        missingGPSModelInstance.casesWithoutGPS(casesWithoutGPS);
-
         mapModel.fitMapBounds(caseMapItems);
     }
 
@@ -459,7 +435,6 @@ hqDefine("geospatial/js/geospatial_map", [
             initUserFilters();
             // Hide controls until data is displayed
             showMapControls(false);
-            missingGPSModelInstance = new models.MissingGPSModel();
 
             disbursementRunner = new disbursementRunnerModel();
             $("#disbursement-spinner").koApplyBindings(disbursementRunner);

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -120,19 +120,7 @@
   {% endblock reporttable %}
 </div>
 
-<div id="case-buttons" class="col-sm-12 col-md-12 col-lg-12">
-    <div id="missing-gps-cases" style="display: inline;">
-        <a class="btn btn-default" target="_blank" href="{% url 'gps_capture' domain %}"
-                data-bind="visible: casesWithoutGPS().length > 0">
-            <span data-bind="text: casesWithoutGPS().length"></span>
-            &nbsp;{% trans "Cases Missing GPS Data" %}
-        </a>
-        <a class="btn btn-default" target="_blank" href="{% url 'gps_capture' domain %}?data_type=user" data-bind="visible: usersWithoutGPS().length">
-            <span data-bind="text: usersWithoutGPS().length"></span>
-            &nbsp;{% trans "Mobile Workers Missing GPS Data" %}
-        </a>
-    </div>
-
+<div id="case-buttons">
     <div id="user-modals" class="pull-right">
         <button class="btn btn-default" data-toggle="modal" data-target="#selected-user-list" data-bind="enable: selectedUsers().length">
             <span data-bind="text: selectedUsers().length"></span>

--- a/corehq/apps/geospatial/tests/test_views.py
+++ b/corehq/apps/geospatial/tests/test_views.py
@@ -343,11 +343,6 @@ class TestGetUsersWithGPS(BaseGeospatialViewClass):
                     'gps_point': '12.34 45.67',
                 },
                 {
-                    'id': self.user_b.user_id,
-                    'username': self.user_b.raw_username,
-                    'gps_point': '',
-                },
-                {
                     'id': self.user_c.user_id,
                     'username': self.user_c.raw_username,
                     'gps_point': '45.67 12.34',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The buttons for cases/users missing GPS data has been removed:
![missing-gps-btns-removed](https://github.com/dimagi/commcare-hq/assets/122617251/d5c70b95-e372-41d8-9561-33aae5d07459)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3257).

The queries for retrieving cases/users for the "Case Management" page have been tweaked to filter out cases and users that do not contain GPS data. This was done due to the fact that loading in these cases/users provides no real value to the map, and the user can rather go to the "Manage GPS Data" page to manage cases/users that are missing GPS data.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Automated tests exist.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There is test coverage for the relevant views to ensure that the correct filtering is being applied and that valid data gets returned.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
