### PR TITLE
Fix enterprise dashboard mobile form submission data

### DIFF
--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -16,6 +16,7 @@ from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
 from corehq.apps.domain.calculations import sms_in_last
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import forms as form_es
+from corehq.apps.es.users import UserES
 from corehq.apps.export.dbaccessors import ODataExportFetcher
 from corehq.apps.users.dbaccessors import (
     get_all_user_rows,
@@ -24,7 +25,6 @@ from corehq.apps.users.dbaccessors import (
 )
 from corehq.apps.users.models import CouchUser, Invitation
 from corehq.util.quickcache import quickcache
-from corehq.apps.es.users import UserES
 
 
 class EnterpriseReport:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This PR will fix the missing data issue for Enterprise Console > Enterprise Dashboard > Mobile Form Submissions.

Before the fix, the Enterprise Admin can only see the mobile form submission data from the project spaces that they're admin of. Those mobile form submitted by deactivated mobile workers will be excluded.

After the fix, the Enterprise Admin will be able to pull the data from all Project Spaces with a subscription attached to the enterprise billing account. Those mobile form submitted by deactivated mobile workers will be included as long as they're submitted in recent 30 days. Both the number displayed in the report, and the report we sent through email will be affected, (might significantly affected), because the data we now pull changed.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi-dev.atlassian.net/browse/SAAS-15146

In `EnterpriseFormReport`, both `total_for_domain` and `rows_for_domain` use the function `_query` to get all the form submission data in one domain. In the base class `EnterpriseReport`, this class will then aggregate the value returned by `total_for_domain` and generate a total count for enterprise billing account, and aggregate the rows returned by `rows_for_domain` and generate a report for enterprise billing account.

In `_query`, we have to get all the mobile workers in the domain using `EMWF.user_es_query`.

In `EMWF.user_es_query`, we check if the requested user has permission to all locations, [otherwise we will filter the query by the location that the requested user has access to.](https://github.com/dimagi/commcare-hq/blob/0b6496ee87df2766ac15ae55c35e61bd4aee6fa1/corehq/apps/reports/filters/users.py#L387-L397)

But Enterprise Admin should be able to pull all the data no matter whether they have permission or not. So I replace the EMWF.user_es_query with a simple query to `UserES().domain(domain_name).mobile_users().show_inactive()`, and also get the both the active and inactive user.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I have tested locally. Will request QA to test on staging.
I think this change is safe because we only replace a user query with another user query...

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA Ticket: https://dimagi-dev.atlassian.net/browse/QA-6018
QA plan:
- Have an Enterprise Billing Account, in this billing account, have at least two domains. Each domain should have some mobile workers and mobile form submissions data (Mobile device is not required. Can be done using the "log in as" feature).
- A new account should be created and set up as Enterprise Admin, or an existing account can be used as long as it is not superuser. This new account should not have access to all domains under the billing account.
- Go to Enterprise Console, the total number of Mobile Form Submission should be 0. 
- Created some mobile workers and submitted some forms (Mobile device is not required. Can be done using the "log in as" feature) in at least two domains. Make sure the enterprise admin doesn't have access to at least one domain that have mobile form submissions.
- Go to Enterprise Console, the total number of Mobile Form Submission should match the total number of mobile form submitted in recent 30 days. The report should also match the actual form submission data.
- Deactivate one mobile worker who have submitted forms, Mobile Form Submission should remain unchanged.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
