### PR TITLE
Prevent Message Blink on Page Load (Geospatial Settings)

### DIFF
--- a/corehq/apps/geospatial/templates/geospatial/settings.html
+++ b/corehq/apps/geospatial/templates/geospatial/settings.html
@@ -11,7 +11,7 @@
 {% initial_page_data 'target_grouping_name' target_grouping_name %}
 {% initial_page_data 'min_max_grouping_name' min_max_grouping_name %}
 
-  <form id="geospatial-config-form" class="form-horizontal disable-on-submit" method="post">
+  <form id="geospatial-config-form" class="form-horizontal disable-on-submit ko-template" method="post">
     {% crispy form %}
   </form>
 {% endblock %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Before:
![blinking-text](https://github.com/dimagi/commcare-hq/assets/122617251/dd5de4a7-8459-4573-aa60-8c85a00df07a)

Now when the page loads, the warning messages are no longer seen.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3274).

One-liner change that adds the `ko-template` class to the form element. This causes the form, including the warnings, to stay hidden until the necessary KO bindings are applied.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Small UI change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
