### PR TITLE
Access queryData on `this` from debugger

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -174,7 +174,7 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
             this.options.baseUrl,
             {
                 selections: this.options.selections,
-                query_data: self.options.queryData,
+                query_data: this.options.queryData,
                 username: this.options.username,
                 restoreAs: this.options.restoreAs,
                 domain: this.options.domain,


### PR DESCRIPTION
## Product Description
Debugger will load fully in more contexts through web apps, which from local testing means that "Recent Queries" will more often be populated under "evaluate xpath".

## Technical Summary
No ticket, stumbled across this in review for #33946 . Resolves a TypeError resulting from accessing `self.queryData` where `self` is undefined.

## Safety Assurance

### Safety story
Small bugfix to pull a piece of data from the same location as the others around it.

### Automated test coverage
n/a

### QA Plan
QA doesn't seem necessary, but could be requested.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
