### PR TITLE
Add dedupe domain privilege

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -109,7 +109,7 @@ pro_v1 = standard_v1 + [
     privileges.REGEX_FIELD_VALIDATION,
     privileges.EXPORT_OWNERSHIP,
     privileges.CASE_LIST_EXPLORER,
-    privileges.DEDUPE,
+    privileges.CASE_DEDUPE,
 ]
 
 

--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -109,6 +109,7 @@ pro_v1 = standard_v1 + [
     privileges.REGEX_FIELD_VALIDATION,
     privileges.EXPORT_OWNERSHIP,
     privileges.CASE_LIST_EXPLORER,
+    privileges.DEDUPE,
 ]
 
 

--- a/corehq/apps/accounting/migrations/0089_dedupe_priv.py
+++ b/corehq/apps/accounting/migrations/0089_dedupe_priv.py
@@ -1,0 +1,46 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.privileges import DEDUPE
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+
+@skip_on_fresh_install
+def _add_dedupe_to_pro_and_above(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        DEDUPE,
+        skip_edition='Paused,Community,Standard',
+        noinput=True,
+    )
+
+
+def _reverse(apps, schema_editor):
+    call_command(
+        'cchq_prbac_revoke_privs',
+        DEDUPE,
+        skip_edition='Paused,Community,Standard',
+        delete_privs=False,
+        check_privs_exist=True,
+        noinput=True,
+    )
+
+    from corehq.apps.hqadmin.management.commands.cchq_prbac_bootstrap import Command
+    Command.OLD_PRIVILEGES.append(DEDUPE)
+    call_command('cchq_prbac_bootstrap')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0088_add_new_softwareplan_visibility'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _add_dedupe_to_pro_and_above,
+            reverse_code=_reverse,
+        ),
+    ]

--- a/corehq/apps/accounting/migrations/0089_dedupe_priv.py
+++ b/corehq/apps/accounting/migrations/0089_dedupe_priv.py
@@ -1,7 +1,7 @@
 from django.core.management import call_command
 from django.db import migrations
 
-from corehq.privileges import DEDUPE
+from corehq.privileges import CASE_DEDUPE
 from corehq.util.django_migrations import skip_on_fresh_install
 
 
@@ -11,7 +11,7 @@ def _add_dedupe_to_pro_and_above(apps, schema_editor):
     call_command('cchq_prbac_bootstrap')
     call_command(
         'cchq_prbac_grandfather_privs',
-        DEDUPE,
+        CASE_DEDUPE,
         skip_edition='Paused,Community,Standard',
         noinput=True,
     )
@@ -20,7 +20,7 @@ def _add_dedupe_to_pro_and_above(apps, schema_editor):
 def _reverse(apps, schema_editor):
     call_command(
         'cchq_prbac_revoke_privs',
-        DEDUPE,
+        CASE_DEDUPE,
         skip_edition='Paused,Community,Standard',
         delete_privs=False,
         check_privs_exist=True,
@@ -28,7 +28,7 @@ def _reverse(apps, schema_editor):
     )
 
     from corehq.apps.hqadmin.management.commands.cchq_prbac_bootstrap import Command
-    Command.OLD_PRIVILEGES.append(DEDUPE)
+    Command.OLD_PRIVILEGES.append(CASE_DEDUPE)
     call_command('cchq_prbac_bootstrap')
 
 

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -232,7 +232,7 @@ class Command(BaseCommand):
         Role(slug=privileges.CASE_COPY,
              name='Allow Case Copy',
              description='Allow case copy from one user to another'),
-        Role(slug=privileges.DEDUPE,
+        Role(slug=privileges.CASE_DEDUPE,
              name='Deduplication Rules',
              description='Support for finding duplicate cases'),
     ]

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -232,6 +232,9 @@ class Command(BaseCommand):
         Role(slug=privileges.CASE_COPY,
              name='Allow Case Copy',
              description='Allow case copy from one user to another'),
+        Role(slug=privileges.DEDUPE,
+             name='Deduplication Rules',
+             description='Support for finding duplicate cases'),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -119,7 +119,7 @@ CASE_LIST_EXPLORER = 'case_list_explorer'
 
 CASE_COPY = 'case_copy'
 
-DEDUPE = 'deduplicate'
+DEDUPE = 'case_deduplicate'
 
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -119,7 +119,7 @@ CASE_LIST_EXPLORER = 'case_list_explorer'
 
 CASE_COPY = 'case_copy'
 
-DEDUPE = 'case_deduplicate'
+CASE_DEDUPE = 'case_deduplicate'
 
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
@@ -183,7 +183,7 @@ MAX_PRIVILEGES = [
     DATA_DICTIONARY,
     CASE_LIST_EXPLORER,
     CASE_COPY,
-    DEDUPE,
+    CASE_DEDUPE,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -261,5 +261,5 @@ class Titles(object):
             DATA_DICTIONARY: _("Project level data dictionary of cases"),
             CASE_LIST_EXPLORER: _("Case List Explorer"),
             CASE_COPY: _("Allow case copy from one user to another"),
-            DEDUPE: _("Deduplication Rules"),
+            CASE_DEDUPE: _("Deduplication Rules"),
         }.get(privilege, privilege)

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -119,6 +119,8 @@ CASE_LIST_EXPLORER = 'case_list_explorer'
 
 CASE_COPY = 'case_copy'
 
+DEDUPE = 'deduplicate'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -181,6 +183,7 @@ MAX_PRIVILEGES = [
     DATA_DICTIONARY,
     CASE_LIST_EXPLORER,
     CASE_COPY,
+    DEDUPE,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -258,4 +261,5 @@ class Titles(object):
             DATA_DICTIONARY: _("Project level data dictionary of cases"),
             CASE_LIST_EXPLORER: _("Case List Explorer"),
             CASE_COPY: _("Allow case copy from one user to another"),
+            DEDUPE: _("Deduplication Rules"),
         }.get(privilege, privilege)

--- a/migrations.lock
+++ b/migrations.lock
@@ -108,6 +108,7 @@ accounting
  0086_add_duplicate_invoice_id_to_invoice_model
  0087_invoice_unique_constraints
  0088_add_new_softwareplan_visibility
+ 0089_dedupe_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Technical Summary
This only adds the new domain privilege for dedupe, but does not gate any access behind the privilege. The intention is to quickly get the privilege into the codebase to avoid merge collisions, and then utilize that privilege to gate access later.

## Feature Flag
N/A

## Safety Assurance

### Safety story
I've performed local testing, verifying that the migration is safe to execute and rollback. While I did not see it in previous privilege migrations, my rollback migration here does remove the privilege from the database, not just remove that privilege from active plans.

### Automated test coverage

No tests

### QA Plan

No QA planned


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
