### PR TITLE
Continue/select button translation

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -142,7 +142,7 @@ def _create_module_details_app_strings(module, langs):
             clean_trans(module.case_details.short.no_items_text, langs)
         )
 
-    if hasattr(module, 'case_details'):
+    if module.get_app().supports_select_text and hasattr(module, 'case_details'):
         yield (
             id_strings.select_text_detail(module),
             clean_trans(module.case_details.short.select_text, langs)

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -142,10 +142,11 @@ def _create_module_details_app_strings(module, langs):
             clean_trans(module.case_details.short.no_items_text, langs)
         )
 
-    yield (
-        id_strings.select_text_detail(module),
-        clean_trans(module.case_details.short.select_text, langs)
-    )
+    if hasattr(module, 'case_details'):
+        yield (
+            id_strings.select_text_detail(module),
+            clean_trans(module.case_details.short.select_text, langs)
+        )
 
     for detail_type, detail, _ in module.get_details():
         for column in detail.get_columns():

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -142,6 +142,11 @@ def _create_module_details_app_strings(module, langs):
             clean_trans(module.case_details.short.no_items_text, langs)
         )
 
+    yield (
+        id_strings.select_text_detail(module),
+        clean_trans(module.case_details.short.select_text, langs)
+    )
+
     for detail_type, detail, _ in module.get_details():
         for column in detail.get_columns():
             yield (

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -217,6 +217,13 @@ class CommCareFeatureSupportMixin(object):
         )
 
     @property
+    def supports_select_text(self):
+        """
+        Ability to configure select button text through bulk translations
+        """
+        return self._require_minimum_version('2.54')
+
+    @property
     def supports_menu_instances(self):
         return self._require_minimum_version('2.54')
 

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -473,6 +473,11 @@ def no_items_text_detail(module):
     return detail(module, 'no_items_text')
 
 
+@pattern('m%d_select_text')
+def select_text_detail(module):
+    return detail(module, 'select_text')
+
+
 def fixture_detail(module):
     return detail(module, 'fixture_select')
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2024,6 +2024,8 @@ class Detail(IndexedSchema, CaseListLookupMixin):
     #Only applies to 'short' details
     no_items_text = LabelProperty(default={'en': 'List is empty.'})
 
+    select_text = LabelProperty(default={'en': 'Continue'})
+
     def get_instance_name(self, module):
         value_is_the_default = self.instance_name == 'casedb'
         if value_is_the_default:

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -147,6 +147,8 @@ class CaseTileHelper(object):
 
         DetailContributor.add_no_items_text_to_detail(detail, self.app, self.detail_type, self.module)
 
+        DetailContributor.add_select_text_to_detail(detail, self.app, self.detail_type, self.module)
+
         if self.module.has_grouped_tiles():
             detail.tile_group = TileGroup(
                 function=f"string(./index/{self.detail.case_tile_group.index_identifier})",

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -250,6 +250,8 @@ class DetailContributor(SectionContributor):
                         id
                     )) is not None:
                         d.actions.append(case_search_action)
+            # Add select text
+            self.add_select_text_to_detail(d, self.app, detail_type, module)
 
             try:
                 if not self.app.enable_multi_sort:
@@ -552,6 +554,11 @@ class DetailContributor(SectionContributor):
     def add_no_items_text_to_detail(detail, app, detail_type, module):
         if detail_type.endswith('short') and app.supports_empty_case_list_text:
             detail.no_items_text = Text(locale_id=id_strings.no_items_text_detail(module))
+
+    @staticmethod
+    def add_select_text_to_detail(detail, app, detail_type, module):
+        if detail_type.endswith('short'):
+            detail.select_text = Text(locale_id=id_strings.select_text_detail(module))
 
 
 class DetailsHelper(object):

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -557,7 +557,7 @@ class DetailContributor(SectionContributor):
 
     @staticmethod
     def add_select_text_to_detail(detail, app, detail_type, module):
-        if detail_type.endswith('short'):
+        if detail_type.endswith('short') and app.supports_select_text:
             detail.select_text = Text(locale_id=id_strings.select_text_detail(module))
 
 

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -933,6 +933,7 @@ class Detail(OrderedXmlObject, IdNode):
     fields = NodeListField('field', Field)
     actions = NodeListField('action', Action)
     details = NodeListField('detail', "self")
+    select_text = NodeField('select_text/text', Text)
     _variables = NodeField('variables', DetailVariableList)
     relevant = StringField('@relevant')
     tile_group = NodeField('group', TileGroup)

--- a/corehq/apps/app_manager/tests/app_factory.py
+++ b/corehq/apps/app_manager/tests/app_factory.py
@@ -237,9 +237,7 @@ class AppFactory(object):
         case_module.search_config.description = {
             'en': 'More information',
         }
-        case_module.search_config.select_text = {
-            'en': 'Continue with case',
-        }
+
         case_module.search_config.properties = [CaseSearchProperty(
             name='name',
             label={'en': 'Name of Mother'}

--- a/corehq/apps/app_manager/tests/app_factory.py
+++ b/corehq/apps/app_manager/tests/app_factory.py
@@ -173,7 +173,10 @@ class AppFactory(object):
                 if not parent_tag:
                     parent_tag = form.actions.load_update_cases[-1].case_tag
 
-                action.case_indices = [CaseIndex(tag=parent_tag, relationship='extension' if is_extension else 'child')]
+                action.case_indices = [CaseIndex(
+                    tag=parent_tag,
+                    relationship='extension' if is_extension else 'child'
+                )]
 
             form.actions.open_cases.append(action)
 

--- a/corehq/apps/app_manager/tests/app_factory.py
+++ b/corehq/apps/app_manager/tests/app_factory.py
@@ -234,6 +234,9 @@ class AppFactory(object):
         case_module.search_config.description = {
             'en': 'More information',
         }
+        case_module.search_config.select_text = {
+            'en': 'Continue with case',
+        }
         case_module.search_config.properties = [CaseSearchProperty(
             name='name',
             label={'en': 'Name of Mother'}

--- a/corehq/apps/app_manager/tests/test_app_strings.py
+++ b/corehq/apps/app_manager/tests/test_app_strings.py
@@ -287,3 +287,21 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
         self.assertEqual(default_strings['forms.m0f0.submit_label'], form.submit_label['en'])
         self.assertEqual(default_strings['forms.m0f0.submit_notification_label'],
                          form.submit_notification_label['en'])
+
+    def test_select_text_app_strings(self):
+        factory = AppFactory(build_version='2.54.0')
+        factory.app.langs = ['en', 'fra']
+        factory.app.build_profiles = OrderedDict({
+            'en': BuildProfile(langs=['en'], name='en-profile'),
+            'fra': BuildProfile(langs=['fra'], name='fra-profile'),
+        })
+        module, form = factory.new_basic_module('my_module', 'cases')
+        module.case_details.short.select_text = {'en': 'Continue with case', 'fra': 'Continuer avec le cas'}
+
+        app = Application.wrap(factory.app.to_json())
+
+        en_app_strings = self._generate_app_strings(app, 'default', build_profile_id='en')
+        self.assertEqual(en_app_strings['m0_select_text'], 'Continue with case')
+
+        es_app_strings = self._generate_app_strings(app, 'fra', build_profile_id='fra')
+        self.assertEqual(es_app_strings['m0_select_text'], 'Continuer avec le cas')

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -58,6 +58,7 @@ hqDefine("cloudcare/js/formplayer/menus/collections", function () {
             'groupHeaderRows',
             'queryResponse',
             'endpointActions',
+            'selectText',
         ],
 
         commandProperties: [

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -595,6 +595,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             self.styles = options.styles;
             self.hasNoItems = options.collection.length === 0 || options.triggerEmptyCaseList;
             self.noItemsText = options.triggerEmptyCaseList ? sidebarNoItemsText : this.options.collection.noItemsText;
+            self.selectText = this.options.collection.selectText;
             self.headers = options.triggerEmptyCaseList ? [] : this.options.headers;
             self.redoLast = options.redoLast;
             if (sessionStorage.selectedValues !== undefined) {
@@ -950,6 +951,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 startPage: paginateItems.startPage,
                 title: title.trim(),
                 description: description === undefined ? "" : markdown.render(description.trim()),
+                selectText: this.selectText === undefined ? "" : this.selectText.trim(),
                 headers: this.headers,
                 widthHints: this.options.widthHints,
                 actions: this.options.actions,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -951,7 +951,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 startPage: paginateItems.startPage,
                 title: title.trim(),
                 description: description === undefined ? "" : markdown.render(description.trim()),
-                selectText: this.selectText === undefined ? "" : this.selectText.trim(),
+                selectText: this.selectText === undefined ? "" : this.selectText,
                 headers: this.headers,
                 widthHints: this.options.widthHints,
                 actions: this.options.actions,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -595,7 +595,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             self.styles = options.styles;
             self.hasNoItems = options.collection.length === 0 || options.triggerEmptyCaseList;
             self.noItemsText = options.triggerEmptyCaseList ? sidebarNoItemsText : this.options.collection.noItemsText;
-            self.selectText = this.options.collection.selectText;
+            self.selectText = options.collection.selectText;
             self.headers = options.triggerEmptyCaseList ? [] : this.options.headers;
             self.redoLast = options.redoLast;
             if (sessionStorage.selectedValues !== undefined) {

--- a/corehq/apps/cloudcare/templates/formplayer/multi_select_continue_button.html
+++ b/corehq/apps/cloudcare/templates/formplayer/multi_select_continue_button.html
@@ -1,6 +1,10 @@
 {% load i18n %}
 <button type="button" class="btn btn-success btn-lg formplayer-request multi-select-continue-btn" disabled="true">
-  {% trans "Continue" %}
+  <% if (selectText.length > 0) { %>
+    <%= selectText %>
+    <% } else { %>
+      {% trans "Continue" %}
+    <% } %>
   <span id="multi-select-btn-text" class="badge">
     <%- selectedCaseIds.length %>
   </span>

--- a/corehq/apps/cloudcare/templates/formplayer/multi_select_continue_button.html
+++ b/corehq/apps/cloudcare/templates/formplayer/multi_select_continue_button.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <button type="button" class="btn btn-success btn-lg formplayer-request multi-select-continue-btn" disabled="true">
-  <% if (selectText.length > 0) { %>
+  <% if (selectText && selectText.length > 0) { %>
     <%= selectText %>
     <% } else { %>
       {% trans "Continue" %}

--- a/corehq/apps/cloudcare/templates/formplayer/multi_select_continue_button.html
+++ b/corehq/apps/cloudcare/templates/formplayer/multi_select_continue_button.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <button type="button" class="btn btn-success btn-lg formplayer-request multi-select-continue-btn" disabled="true">
   <% if (selectText && selectText.length > 0) { %>
-    <%= selectText %>
+    <%- selectText %>
     <% } else { %>
       {% trans "Continue" %}
     <% } %>

--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -265,7 +265,10 @@ def _get_module_detail_no_items_text(langs, module):
 
 
 def _get_module_detail_select_text(langs, module):
+    app = module.get_app()
     short_detail = module.case_details.short
+    if not (app.supports_select_text):
+        return []
     return [
         ("select_text", "list") + tuple(short_detail.select_text.get(lang, '') for lang in langs)
     ]

--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -244,6 +244,7 @@ def get_case_search_rows(langs, module, domain):
 def get_module_detail_rows(langs, module):
     rows = []
     rows += _get_module_detail_no_items_text(langs, module)
+    rows += _get_module_detail_select_text(langs, module)
     for list_or_detail, detail in [
         ("list", module.case_details.short),
         ("detail", module.case_details.long)
@@ -260,6 +261,13 @@ def _get_module_detail_no_items_text(langs, module):
         return []
     return [
         ("no_items_text", "list") + tuple(short_detail.no_items_text.get(lang, '') for lang in langs)
+    ]
+
+
+def _get_module_detail_select_text(langs, module):
+    short_detail = module.case_details.short
+    return [
+        ("select_text", "list") + tuple(short_detail.select_text.get(lang, '') for lang in langs)
     ]
 
 

--- a/corehq/apps/translations/app_translations/upload_module.py
+++ b/corehq/apps/translations/app_translations/upload_module.py
@@ -31,6 +31,7 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
         self.search_again_label = None
         self.title_label = None
         self.description = None
+        self.select_text = None
         self.tab_headers = None
         self.no_items_text = None
 
@@ -99,6 +100,9 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
 
         if self.description:
             self._update_translation(self.description, self.module.search_config.description)
+
+        if self.select_text:
+            self._update_translation(self.select_text, self.module.case_details.short.select_text)
 
         if self.no_items_text:
             self._update_translation(self.no_items_text, self.module.case_details.short.no_items_text)
@@ -208,6 +212,7 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
         self.search_again_label = None
         self.title_label = None
         self.description = None
+        self.select_text = None
         self.no_items_text = None
         self.tab_headers = [None for i in self.module.case_details.long.tabs]
         index_of_last_enum_in_condensed = -1
@@ -268,6 +273,8 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
                 self.title_label = row
             elif row['case_property'] == 'description':
                 self.description = row
+            elif row['case_property'] == 'select_text':
+                self.select_text = row
 
             # It's the empty case list text. Don't add it to condensed rows
             elif row['case_property'] == 'no_items_text':

--- a/corehq/apps/translations/tests/data/bulk_app_translation/download/app.json
+++ b/corehq/apps/translations/tests/data/bulk_app_translation/download/app.json
@@ -2105,6 +2105,7 @@
           "lookup_field_header": {},
           "custom_variables": null,
           "pull_down_tile": null,
+          "select_text": {"en": "Continue with Case(s)"},
           "columns": [
             {
               "doc_type": "DetailColumn",

--- a/corehq/apps/translations/tests/data/bulk_app_translation/download/app.json
+++ b/corehq/apps/translations/tests/data/bulk_app_translation/download/app.json
@@ -19,7 +19,7 @@
   "admin_password": null,
   "build_spec": {
     "doc_type": "BuildSpec",
-    "version": "2.13.0",
+    "version": "2.54.0",
     "build_number": null,
     "latest": true
   },

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -88,6 +88,7 @@ EXCEL_DATA = (
     ('menu1',
      (('case_list_menu_item_label', 'list', 'Steth List'),
       ('no_items_text', 'list', 'Empty List'),
+      ('select_text', 'list', 'Continue'),
       ('name', 'list', 'Name'),
       ('name', 'detail', 'Name'))),
     ('menu1_form1',
@@ -98,13 +99,18 @@ EXCEL_DATA = (
                          'and "bad" &lt; xml.', '', '', ''),
       ('submit_label', 'Submit', '', '', ''),
       ('submit_notification_label', '', '', '', ''))),
-    ('menu2', (('no_items_text', 'list', 'List is empty.'), ('name', 'list', 'Name'), ('name', 'detail', 'Name'))),
+    ('menu2',
+     (('no_items_text', 'list', 'List is empty.'),
+      ('select_text', 'list', 'Continue'),
+      ('name', 'list', 'Name'),
+      ('name', 'detail', 'Name'))),
     ('menu2_form1',
      (('name_of_series-label', 'Name of series', '', '', ''),
       ('submit_label', 'Submit', '', '', ''),
       ('submit_notification_label', '', '', '', ''))),
     ('menu3',
      (('no_items_text', 'list', 'List is empty.'),
+      ('select_text', 'list', 'Continue'),
       ('name', 'list', 'Name'),
       ('Tab 0', 'detail', 'Name'),
       ('Tab 1', 'detail', 'Graph'),
@@ -123,6 +129,7 @@ EXCEL_DATA = (
       ('submit_notification_label', '', '', '', ''))),
     ('menu4',
      (('no_items_text', 'list', 'List is empty.'),
+      ('select_text', 'list', 'Continue'),
       ('x', 'list', 'X'),
       ('y', 'list', 'Y'),
       ('x (ID Mapping Text)', 'detail', 'X Name'),
@@ -137,7 +144,11 @@ EXCEL_DATA = (
       ('submit_label', 'Submit', '', '', ''),
       ('submit_notification_label', '', '', '', ''))),
     ('menu5', ()),
-    ('menu6', (('no_items_text', 'list', 'List is empty.'), ('name', 'list', 'Name'), ('name', 'detail', 'Name'))),
+    ('menu6',
+     (('no_items_text', 'list', 'List is empty.'),
+      ('select_text', 'list', 'Continue'),
+      ('name', 'list', 'Name'),
+      ('name', 'detail', 'Name'))),
     ('menu6_form1',
      (('this_form_does_nothing-label', 'This form does nothing.', '', '', ''),
       ('submit_label', 'Submit', '', '', ''),
@@ -361,6 +372,7 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBaseWithApp):
             ("search_again_label", "list", "Find Another Mother", "Mère! Encore!"),
             ("title_label", "list", "Find a Mom", "Maman!"),
             ("description", "list", "More information", "Plus d'information"),
+            ("select_text", "list", "Continue with case", "Continuer avec le cas"),
             ("no_items_text", "list", "Empty List", "Lista Vacía"),
             ("name", "list", "Name", "Nom"),
             ("Tab 0", "detail", "Name", "Nom"),
@@ -418,6 +430,7 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBaseWithApp):
             ("menu1", "search_again_label", "list", "", "Find Another Mother", "", "", "", ""),
             ("menu1", "title_label", "list", "Find a Mom", "Maman!", "", "", "", ""),
             ("menu1", "description", "list", "More information", "Plus d'information", "", "", "", ""),
+            ("menu1", "select_text", "list", "Continue with case", "Continuer avec le cas", "", "", "", ""),
             ("menu1", "no_items_text", "list", "Empty List", "Lista Vacía", "", "", "", ""),
             ("menu1", "name", "list", "", "Name", "", "", "", ""),
             ("menu1", "Tab 0", "detail", "", "Name", "", "", "", ""),
@@ -1141,6 +1154,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
     def test_module_detail_rows(self):
         self.assertListEqual(get_module_detail_rows(self.app.langs, self.app.modules[0]), [
             ('no_items_text', 'list', 'Empty List'),
+            ('select_text', 'list', 'Continue'),
             ('name', 'list', 'Name'),
             ('name', 'detail', 'Name'),
         ])
@@ -1226,6 +1240,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
             ['menu1', '', '', '', 'Stethoscope', 'jr://file/commcare/image/module0.png', None, '',
              '58ce5c9cf6eda401526973773ef216e7980bc6cc'],
             ['menu1', 'case_list_menu_item_label', 'list', '', 'Steth List', '', '', '', ''],
+            ['menu1', 'select_text', 'list', '', 'Continue', '', '', '', ''],
             ['menu1', 'name', 'list', '', 'Name', '', '', '', ''],
             ['menu1', 'name', 'detail', '', 'Name', '', '', '', ''],
 
@@ -1241,6 +1256,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
             ['menu1_form1', '', '', 'submit_notification_label', '', '', '', '', ''],
 
             ['menu2', '', '', '', 'Register Series', '', '', '', 'b9c25abe21054632a3623199debd7cfa'],
+            ['menu2', 'select_text', 'list', '', 'Continue', '', '', '', ''],
             ['menu2', 'name', 'list', '', 'Name', '', '', '', ''],
             ['menu2', 'name', 'detail', '', 'Name', '', '', '', ''],
 
@@ -1250,6 +1266,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
             ['menu2_form1', '', '', 'submit_notification_label', '', '', '', '', ''],
 
             ['menu3', '', '', '', 'Followup Series', '', '', '', '217e1c8de3dd46f98c7d2806bc19b580'],
+            ['menu3', 'select_text', 'list', '', 'Continue', '', '', '', ''],
             ['menu3', 'name', 'list', '', 'Name', '', '', '', ''],
             ['menu3', 'Tab 0', 'detail', '', 'Name', '', '', '', ''],
             ['menu3', 'Tab 1', 'detail', '', 'Graph', '', '', '', ''],
@@ -1269,6 +1286,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
             ['menu3_form1', '', '', 'submit_notification_label', '', '', '', '', ''],
 
             ['menu4', '', '', '', 'Remove Point', '', '', '', '17195132472446ed94bd91ba19a2b379'],
+            ['menu4', 'select_text', 'list', '', 'Continue', '', '', '', ''],
             ['menu4', 'x', 'list', '', 'X', '', '', '', ''],
             ['menu4', 'y', 'list', '', 'Y', '', '', '', ''],
             ['menu4', 'x (ID Mapping Text)', 'detail', '', 'X Name', '', '', '', ''],
@@ -1287,6 +1305,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
             ['menu5', '', '', '', 'Empty Reports Module', '', '', '', '703eb807ae584d1ba8bf9457d7ac7590'],
 
             ['menu6', '', '', '', 'Advanced Module', None, None, '', '7f75ed4c15be44509591f41b3d80746e'],
+            ['menu6', 'select_text', 'list', '', 'Continue', '', '', '', ''],
             ['menu6', 'name', 'list', '', 'Name', '', '', '', ''],
             ['menu6', 'name', 'detail', '', 'Name', '', '', '', ''],
 

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -146,7 +146,7 @@ EXCEL_DATA = (
     ('menu5', ()),
     ('menu6',
      (('no_items_text', 'list', 'List is empty.'),
-      ('select_text', 'list', 'Continue'),
+      ('select_text', 'list', 'Continue with Case(s)'),
       ('name', 'list', 'Name'),
       ('name', 'detail', 'Name'))),
     ('menu6_form1',
@@ -1305,7 +1305,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
             ['menu5', '', '', '', 'Empty Reports Module', '', '', '', '703eb807ae584d1ba8bf9457d7ac7590'],
 
             ['menu6', '', '', '', 'Advanced Module', None, None, '', '7f75ed4c15be44509591f41b3d80746e'],
-            ['menu6', 'select_text', 'list', '', 'Continue', '', '', '', ''],
+            ['menu6', 'select_text', 'list', '', 'Continue with Case(s)', '', '', '', ''],
             ['menu6', 'name', 'list', '', 'Name', '', '', '', ''],
             ['menu6', 'name', 'detail', '', 'Name', '', '', '', ''],
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This allows for custom translation text to be added to multi-select case list "Continue" button via bulk translation. Button text defaults to "Continue" if no translation change is made.

<img width="707" alt="Screenshot 2024-01-15 at 1 00 41 PM" src="https://github.com/dimagi/commcare-hq/assets/42388648/b6308ba1-4b8e-455a-a14d-11eee7d147bf">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Jira ticket: https://dimagi-dev.atlassian.net/browse/USH-3859
Related Formplayer PR: https://github.com/dimagi/formplayer/pull/1529
[Bulk Application Translations](https://confluence.dimagi.com/display/commcarepublic/Bulk+Application+Translations)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

tested locally and will test on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
corehq/apps/translations/tests/test_bulk_app_translation.py

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
