### PR TITLE
Add match_all query function

### DIFF
--- a/corehq/apps/case_search/tests/test_case_search_filters.py
+++ b/corehq/apps/case_search/tests/test_case_search_filters.py
@@ -202,3 +202,22 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             'indices.host': ['c1'],
         }).get_ids()
         self.assertItemsEqual(actual, ['c4'])
+
+    def test_match_all(self):
+        self._create_case_search_config()
+        cases = [
+            {'_id': 'c1', 'case_type': 'song', 'description': 'New York'},
+            {'_id': 'c2', 'case_type': 'song', 'description': 'Manchester'},
+            {'_id': 'c3', 'case_type': 'song', 'description': 'Manchester Boston'},
+        ]
+        self._assert_query_runs_correctly(
+            self.domain,
+            cases,
+            get_case_search_query(
+                self.domain,
+                ['song'],
+                {'_xpath_query': "match-all()"},
+            ),
+            None,
+            ['c1', 'c2', 'c3']
+        )

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -738,6 +738,14 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         built_filter = build_filter_from_ast(parsed, context)
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
+    def test_match_all_error(self):
+        parsed = parse_xpath("match-all()")
+        expected_filter = {
+            "match_all": {}
+        }
+        built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
 
 @es_test(requires=[case_search_adapter], setup_class=True)
 class TestFilterDslLookups(ElasticTestMixin, TestCase):

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -738,7 +738,7 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         built_filter = build_filter_from_ast(parsed, context)
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
-    def test_match_all_error(self):
+    def test_match_all(self):
         parsed = parse_xpath("match-all()")
         expected_filter = {
             "match_all": {}

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -5,7 +5,8 @@ from .query_functions import (
     selected_any,
     within_distance,
     phonetic_match,
-    starts_with
+    starts_with,
+    match_all
 )
 from .subcase_functions import subcase
 from .ancestor_functions import ancestor_exists
@@ -32,4 +33,5 @@ XPATH_QUERY_FUNCTIONS = {
     'phonetic-match': phonetic_match,
     'starts-with': starts_with,
     'ancestor-exists': ancestor_exists,
+    'match-all': match_all
 }

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -105,3 +105,12 @@ def _property_name_to_string(value, node):
         _(f"The first argument to '{node.name}' must be a valid case property name"),
         serialize(node)
     )
+
+
+def match_all(node, context):
+    if len(node.args):
+        raise XPathFunctionException(
+            _("'match-all()' does not take any arguments"),
+            serialize(node)
+        )
+    return filters.match_all()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Jira: [USH-4084](https://dimagi-dev.atlassian.net/browse/USH-4084)

Adds a new query function `match_all()` to CSQL, which returns all cases. This eliminates the need for app builders to write inefficient queries such as `@case_id != 'all'` to get all cases.

![Screenshot 2024-01-15 at 2 47 57 PM](https://github.com/dimagi/commcare-hq/assets/6729291/00fe0d10-81be-4b47-a5ba-ebbae7e329a9)

Gives an error if you try to pass arguments:

![Screenshot 2024-01-15 at 2 51 34 PM](https://github.com/dimagi/commcare-hq/assets/6729291/3b52e26f-a9d2-4a86-844e-a69d11f399d1)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The query function simply returns a [match_all ES query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html).

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Impact should be limited to projects that opt to use `match_all` in their queries
- Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Tests added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None right now--might ask QA to do some testing once all the new queries are added, but I might just let projects play with these on their own and provide feedback.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change

Giving this the "invisible" label since it is an opt-in feature.


[USH-4084]: https://dimagi-dev.atlassian.net/browse/USH-4084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ