### PR TITLE
Fix Inconsistent Ordering on Geospatial Test

### DIFF
--- a/corehq/apps/geospatial/tests/test_views.py
+++ b/corehq/apps/geospatial/tests/test_views.py
@@ -351,9 +351,8 @@ class TestGetUsersWithGPS(BaseGeospatialViewClass):
         response = self.client.get(self.endpoint)
         response_json = response.json()
         self.assertTrue('user_data' in response_json)
-        for user in response_json['user_data']:
-            user_id = user['id']
-            self.assertEqual(user, expected_results[user_id])
+        user_data = {user['id']: user for user in response_json['user_data']}
+        self.assertEqual(user_data, expected_results)
 
     def test_get_location_filtered_users(self):
         self.client.login(username=self.username, password=self.password)

--- a/corehq/apps/geospatial/tests/test_views.py
+++ b/corehq/apps/geospatial/tests/test_views.py
@@ -335,23 +335,25 @@ class TestGetUsersWithGPS(BaseGeospatialViewClass):
         super().tearDownClass()
 
     def test_get_users_with_gps(self):
-        expected_output = {
-            'user_data': [
-                {
-                    'id': self.user_a.user_id,
-                    'username': self.user_a.raw_username,
-                    'gps_point': '12.34 45.67',
-                },
-                {
-                    'id': self.user_c.user_id,
-                    'username': self.user_c.raw_username,
-                    'gps_point': '45.67 12.34',
-                },
-            ],
+        expected_results = {
+            self.user_a.user_id: {
+                'id': self.user_a.user_id,
+                'username': self.user_a.raw_username,
+                'gps_point': '12.34 45.67',
+            },
+            self.user_c.user_id: {
+                'id': self.user_c.user_id,
+                'username': self.user_c.raw_username,
+                'gps_point': '45.67 12.34',
+            }
         }
         self.client.login(username=self.username, password=self.password)
         response = self.client.get(self.endpoint)
-        self.assertEqual(response.json(), expected_output)
+        response_json = response.json()
+        self.assertTrue('user_data' in response_json)
+        for user in response_json['user_data']:
+            user_id = user['id']
+            self.assertEqual(user, expected_results[user_id])
 
     def test_get_location_filtered_users(self):
         self.client.login(username=self.username, password=self.password)

--- a/corehq/apps/geospatial/tests/test_views.py
+++ b/corehq/apps/geospatial/tests/test_views.py
@@ -350,7 +350,7 @@ class TestGetUsersWithGPS(BaseGeospatialViewClass):
         self.client.login(username=self.username, password=self.password)
         response = self.client.get(self.endpoint)
         response_json = response.json()
-        self.assertTrue('user_data' in response_json)
+        self.assertIn('user_data', response_json)
         user_data = {user['id']: user for user in response_json['user_data']}
         self.assertEqual(user_data, expected_results)
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Currently, the `test_get_users_with_gps()` test for the Geospatial feature has the possibility of sometimes failing. This is because the results of the `get_users_with_gps` view has no ordering applied to it and so the `assertEqual()` can fail. 

This PR fixes the failing test by removing the assumption that the result will be in a specific order.

For reference, the unit test was introduced in [this](https://github.com/dimagi/commcare-hq/pull/33420) PR.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Only touches a unit test, no actual HQ functionality affected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
