### PR TITLE
Eliminated inline style

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/case_detail.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_detail.html
@@ -58,8 +58,8 @@
         <div class="js-detail-tabs module-case-detail-tabs"></div>
         <div class="js-detail-content"></div>
       </div>
-      <div class="modal-footer" style="text-align: center">
-        <div class="js-detail-footer-content"></div>
+      <div class="modal-footer">
+        <div class="js-detail-footer-content text-center"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Technical Summary
Minor. This style overrides `.modal-footer`'s right text alignment. Using `text-center` on the same div isn't enough to take precedence, which is probably was this was done as an inline style. But putting `text-center` on the child div works.

## Safety Assurance

### Safety story
Nearly-trivial styling change

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
