### PR TITLE
[B5] split widgets.js into bootstrap 3 and 5 versions

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_exchange.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_exchange.js
@@ -2,7 +2,7 @@ hqDefine("app_manager/js/app_exchange", [
     "jquery",
     "knockout",
     'analytix/js/kissmetrix',
-    "hqwebapp/js/widgets",  // hqwebapp-select2 for versions
+    "hqwebapp/js/bootstrap3/widgets",  // hqwebapp-select2 for versions
 ], function (
     $,
     ko,

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -75,7 +75,7 @@ hqDefine("app_manager/js/app_view", function () {
                         success: function (content) {
                             self.load_state('loaded');
                             self.multimedia_page_html(content);
-                            hqImport("hqwebapp/js/widgets").init();
+                            hqImport("hqwebapp/js/bootstrap3/widgets").init();
                         },
                         error: function (data) {
                             if (data.hasOwnProperty('responseJSON')) {

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_location.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_location.js
@@ -5,7 +5,7 @@ hqDefine('app_manager/js/manage_releases_by_location', [
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/assert_properties',
     'locations/js/search',
-    'hqwebapp/js/widgets', // using select2/dist/js/select2.full.min for ko-select2 on location select
+    'hqwebapp/js/bootstrap3/widgets', // using select2/dist/js/select2.full.min for ko-select2 on location select
     'translations/js/app_translations',
 ], function (
     $,

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -17,7 +17,7 @@
     <script src="{% static "jsdiff/diff.js" %}"></script>
     <script src="{% static 'app_manager/js/releases/app_diff.js' %}"></script>
     <script src="{% static 'app_manager/js/releases/update_prompt.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
     <script src="{% static 'app_manager/js/supported_languages.js' %}"></script>
     <script src="{% static 'app_manager/js/settings/translations.js' %}"></script>
     <script src="{% static 'app_manager/js/settings/password_setter.jquery.js' %}"></script>

--- a/corehq/apps/case_importer/static/case_importer/js/main.js
+++ b/corehq/apps/case_importer/static/case_importer/js/main.js
@@ -4,7 +4,7 @@ hqDefine("case_importer/js/main", [
     'hqwebapp/js/initial_page_data',
     'case_importer/js/import_history',
     'case_importer/js/excel_fields',
-    'hqwebapp/js/widgets',
+    'hqwebapp/js/bootstrap3/widgets',
 ], function (
     $,
     _,

--- a/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
+++ b/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
@@ -4,7 +4,7 @@ hqDefine('commtrack/js/products_and_programs_main', [
     'underscore',
     'hqwebapp/js/initial_page_data',
     'commtrack/js/base_list_view_model',
-    'hqwebapp/js/widgets',   // "Additional Information" on product page uses a .hqwebapp-select2
+    'hqwebapp/js/bootstrap3/widgets',   // "Additional Information" on product page uses a .hqwebapp-select2
 ], function (
     $,
     ko,

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -109,7 +109,7 @@ class CustomDataEditor(object):
                                    validators=[validator])
         elif field.choices:
             # If form uses knockout, knockout must have control over the select2.
-            # Otherwise, use .hqwebapp-select2 and hqwebapp/js/widgets to make the select2.
+            # Otherwise, use .hqwebapp-select2 and hqwebapp/js/bootstrap3/widgets to make the select2.
             attrs = {
                 'data-placeholder': _('Select one'),
                 'data-allow-clear': 'true',

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
@@ -5,7 +5,7 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
     'hqwebapp/js/initial_page_data',
     'data_interfaces/js/case_property_input',
     'data_interfaces/js/case_rule_criteria',
-    'hqwebapp/js/widgets',
+    'hqwebapp/js/bootstrap3/widgets',
 ], function (
     $,
     ko,

--- a/corehq/apps/domain/static/domain/js/info_basic.js
+++ b/corehq/apps/domain/static/domain/js/info_basic.js
@@ -2,7 +2,7 @@ hqDefine("domain/js/info_basic", [
     'jquery',
     'hqwebapp/js/select_2_ajax_widget', // for call center case owner
     'select2/dist/js/select2.full.min',
-    'hqwebapp/js/widgets',
+    'hqwebapp/js/bootstrap3/widgets',
 ], function (
     $
 ) {

--- a/corehq/apps/domain/static/domain/js/internal_subscription_management.js
+++ b/corehq/apps/domain/static/domain/js/internal_subscription_management.js
@@ -1,7 +1,7 @@
 hqDefine('domain/js/internal_subscription_management', [
     'jquery',
     'knockout',
-    'hqwebapp/js/widgets',
+    'hqwebapp/js/bootstrap3/widgets',
 ], function (
     $,
     ko

--- a/corehq/apps/enterprise/templates/enterprise/enterprise_permissions.html
+++ b/corehq/apps/enterprise/templates/enterprise/enterprise_permissions.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "hqwebapp/js/widgets" %}
+{% requirejs_main "hqwebapp/js/bootstrap3/widgets" %}
 
 {% block page_content %}
   <p class="lead">

--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -5,7 +5,7 @@ hqDefine("events/js/event_attendees",[
     'hqwebapp/js/initial_page_data',
     'jquery.rmi/jquery.rmi',
     'locations/js/widgets',
-    "hqwebapp/js/widgets",
+    "hqwebapp/js/bootstrap3/widgets",
     "hqwebapp/js/bootstrap3/components.ko", // for pagination
 ], function (
     $,

--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -4,7 +4,7 @@ hqDefine("events/js/new_event", [
     "hqwebapp/js/multiselect_utils",
     "hqwebapp/js/initial_page_data",
     "locations/js/widgets",
-    "hqwebapp/js/widgets",
+    "hqwebapp/js/bootstrap3/widgets",
     "jquery-ui/ui/widgets/datepicker",
 ], function (
     $,

--- a/corehq/apps/hqmedia/templates/hqmedia/audio_translator.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/audio_translator.html
@@ -5,7 +5,7 @@
 
 {% block js %}{{ block.super }}
   {% compress js %}
-    <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
   {% endcompress js %}
 {% endblock js %}
 

--- a/corehq/apps/hqmedia/templates/hqmedia/translations_coverage.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/translations_coverage.html
@@ -5,7 +5,7 @@
 
 {% block js %}{{ block.super }}
   {% compress js %}
-    <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
     <script src="{% static 'app_manager/js/widgets.js' %}"></script>
   {% endcompress js %}
 {% endblock js %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/widgets.js
@@ -1,4 +1,4 @@
-hqDefine("hqwebapp/js/widgets",[
+hqDefine("hqwebapp/js/bootstrap3/widgets",[
         'jquery',
         'underscore',
         '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
@@ -1,0 +1,125 @@
+hqDefine("hqwebapp/js/bootstrap5/widgets",[
+        'jquery',
+        'underscore',
+        '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
+        'hqwebapp/js/initial_page_data',
+        'select2/dist/js/select2.full.min',
+        'jquery-ui/ui/widgets/datepicker',
+    ], function ($, _, MapboxGeocoder, initialPageData) {
+        var init = function () {
+            var MAPBOX_ACCESS_TOKEN = initialPageData.get(
+                "mapbox_access_token"
+            );
+            // .hqwebapp-select2 is a basic select2-based dropdown or multiselect
+            _.each($(".hqwebapp-select2"), function (element) {
+                $(element).select2({
+                    width: '100%',
+                });
+                if (window.USE_BOOTSTRAP5 && $(element).hasClass('is-invalid')) {
+                    $(element).data('select2').$container.addClass('is-invalid');
+                }
+                if (window.USE_BOOTSTRAP5 && $(element).hasClass('is-valid')) {
+                    $(element).data('select2').$container.addClass('is-valid');
+                }
+            });
+
+            // .hqwebapp-autocomplete also allows for free text entry
+            _.each($(".hqwebapp-autocomplete"), function (input) {
+                var $input = $(input);
+                $input.select2({
+                    multiple: true,
+                    tags: true,
+                    width: '100%',
+                });
+            });
+
+            _.each($(".hqwebapp-autocomplete-email"), function (input) {
+                var $input = $(input);
+                $input.select2({
+                    multiple: true,
+                    placeholder: ' ',
+                    tags: true,
+                    tokenSeparators: [','],
+                    width: '100%',
+                    createTag: function (params) {
+                        // Support pasting in comma-separated values
+                        var terms = parseEmails(params.term);
+                        if (terms.length === 1) {
+                            return {
+                                id: terms[0],
+                                text: terms[0],
+                            };
+                        }
+                        $input.select2('close');
+                        var values = $input.val() || [];
+                        if (!_.isArray(values)) {
+                            values = [values];
+                        }
+                        _.each(terms, function (term) {
+                            if (!_.contains(values, term)) {
+                                $input.append(new Option(term, term));
+                                values.push(term);
+                            }
+                        });
+                        $input.val(values).trigger("change");
+
+                        return null;
+                    },
+                });
+            });
+
+            _.each($(".geocoder-proximity"), function (input) {
+                var $input = $(input).find('input');
+
+                function getGeocoderItem(item) {
+                    var inputEl = $input;
+                    var geoObj = {};
+                    geoObj.place_name = item.place_name;
+                    geoObj.coordinates = {
+                        longitude: item.geometry.coordinates[0],
+                        latitude: item.geometry.coordinates[1],
+                    };
+                    inputEl.attr("value", JSON.stringify(geoObj));
+                    return item.place_name;
+                }
+
+                function getGeocoderValue() {
+                    var geocoderValue = $input.val();
+                    if (geocoderValue) {
+                        geocoderValue = JSON.parse(geocoderValue);
+                        return geocoderValue.place_name;
+                    }
+                    return null;
+                }
+
+                var geocoder = new MapboxGeocoder({
+                    accessToken: MAPBOX_ACCESS_TOKEN,
+                    types:
+                        "country,region,place,postcode,locality,neighborhood",
+                    getItemValue: getGeocoderItem,
+                });
+
+                geocoder.addTo(".geocoder-proximity");
+                var geocoderValue = getGeocoderValue();
+                if (geocoderValue) {
+                    geocoder.setInput(getGeocoderValue());
+                }
+            });
+
+            $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
+        };
+
+        var parseEmails = function (input) {
+            return $.trim(input).split(/[, ]\s*/);
+        };
+
+        $(function () {
+            init();
+        });
+
+        return {
+            init: init,
+            parseEmails: parseEmails, // export for testing
+        };
+    }
+);

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/maintenance_alerts.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/maintenance_alerts.js
@@ -2,7 +2,7 @@ hqDefine("hqwebapp/js/maintenance_alerts",[
     'jquery',
     'knockout',
     'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/widgets',
+    'hqwebapp/js/bootstrap3/widgets',
 ], function ($, ko, initialPageData) {
     $(function () {
         var alertFormModel = {

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/widgets_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/widgets_spec.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 hqDefine("hqwebapp/spec/widgets_spec", [
-    'hqwebapp/js/widgets',
+    'hqwebapp/js/bootstrap3/widgets',
 ], function (
     widgets
 ) {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/widgets.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/widgets.js.diff.txt
@@ -1,0 +1,8 @@
+--- 
++++ 
+@@ -1,4 +1,4 @@
+-hqDefine("hqwebapp/js/bootstrap3/widgets",[
++hqDefine("hqwebapp/js/bootstrap5/widgets",[
+         'jquery',
+         'underscore',
+         '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',

--- a/corehq/apps/locations/static/locations/js/location.js
+++ b/corehq/apps/locations/static/locations/js/location.js
@@ -9,7 +9,7 @@ hqDefine("locations/js/location", [
     'locations/js/location_drilldown',
     'locations/js/location_tree',
     'hqwebapp/js/select_2_ajax_widget',
-    'hqwebapp/js/widgets',       // custom data fields use a .hqwebapp-select2
+    'hqwebapp/js/bootstrap3/widgets',       // custom data fields use a .hqwebapp-select2
     'locations/js/widgets',
 ], function (
     $,

--- a/corehq/apps/reminders/static/reminders/js/reminders.keywords.ko.js
+++ b/corehq/apps/reminders/static/reminders/js/reminders.keywords.ko.js
@@ -2,7 +2,7 @@ hqDefine("reminders/js/reminders.keywords.ko", [
     "jquery",
     "knockout",
     "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/widgets",      // .hqwebapp-select2 for survey dropdown
+    "hqwebapp/js/bootstrap3/widgets",      // .hqwebapp-select2 for survey dropdown
 ], function (
     $,
     ko,

--- a/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
@@ -5,7 +5,7 @@ hqDefine("reports/js/edit_scheduled_report", [
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/toggles",
     "hqwebapp/js/multiselect_utils",
-    "hqwebapp/js/widgets",  // autocomplete widget for email recipient list
+    "hqwebapp/js/bootstrap3/widgets",  // autocomplete widget for email recipient list
     "jquery-ui/ui/widgets/datepicker",
     'hqwebapp/js/bootstrap3/components.ko',    // select toggle widget
 ], function (

--- a/corehq/apps/reports/static/reports/js/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/hq_report.js
@@ -5,7 +5,7 @@ hqDefine("reports/js/hq_report", [
     'hqwebapp/js/bootstrap3/alert_user',
     'analytix/js/kissmetrix',
     'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/widgets', //multi-emails
+    'hqwebapp/js/bootstrap3/widgets', //multi-emails
 ], function (
     $,
     ko,

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -37,7 +37,7 @@
     <script src="{% static 'reports/js/project_health_dashboard.js' %}"></script>
     <script src="{% static 'reports/js/aggregate_user_status.js' %}"></script>
     <script src="{% static 'reports/js/user_history.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
   {% endcompress %}
 {% endblock %}
 

--- a/corehq/apps/settings/static/settings/js/user_api_keys.js
+++ b/corehq/apps/settings/static/settings/js/user_api_keys.js
@@ -4,7 +4,7 @@ hqDefine("settings/js/user_api_keys", [
     'underscore',
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap3/crud_paginated_list",
-    'hqwebapp/js/widgets',
+    'hqwebapp/js/bootstrap3/widgets',
 ], function (
     $,
     ko,

--- a/corehq/apps/sms/static/sms/js/gateway_list.js
+++ b/corehq/apps/sms/static/sms/js/gateway_list.js
@@ -1,6 +1,6 @@
 hqDefine("sms/js/gateway_list", [
     "hqwebapp/js/bootstrap3/crud_paginated_list_init",
-    "hqwebapp/js/widgets",
+    "hqwebapp/js/bootstrap3/widgets",
 ], function () {
     // No page-specific logic, just need to collect the dependencies above
 });

--- a/corehq/apps/sms/static/sms/js/settings.js
+++ b/corehq/apps/sms/static/sms/js/settings.js
@@ -5,7 +5,7 @@ hqDefine("sms/js/settings", [
     'hqwebapp/js/select2_handler',
     'hqwebapp/js/bootstrap3/components.ko',    // select toggle widget
     'bootstrap-timepicker/js/bootstrap-timepicker',
-    'hqwebapp/js/widgets', //multi-emails
+    'hqwebapp/js/bootstrap3/widgets', //multi-emails
 ], function(
     $,
     ko,

--- a/corehq/apps/smsbillables/static/smsbillables/js/smsbillables.rate_calc.js
+++ b/corehq/apps/smsbillables/static/smsbillables/js/smsbillables.rate_calc.js
@@ -3,7 +3,7 @@ hqDefine("smsbillables/js/smsbillables.rate_calc", [
     'knockout',
     'underscore',
     'hqwebapp/js/select2_handler',
-    'hqwebapp/js/widgets',  // the public sms page uses a .hqwebapp-select2 for country input
+    'hqwebapp/js/bootstrap3/widgets',  // the public sms page uses a .hqwebapp-select2 for country input
 ], function (
     $,
     ko,

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap3/base.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap3/base.html
@@ -33,7 +33,7 @@
     {% compress js %}
       <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
       <script src="{% static 'hqwebapp/js/select2_knockout_bindings.ko.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
+      <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
       <script src="{% static 'multiselect/js/jquery.multi-select.js' %}"></script>
       <script src="{% static 'quicksearch/dist/jquery.quicksearch.min.js' %}"></script>
       <script src="{% static 'hqwebapp/js/multiselect_utils.js' %}"></script>

--- a/corehq/apps/translations/static/translations/js/app_translations.js
+++ b/corehq/apps/translations/static/translations/js/app_translations.js
@@ -3,7 +3,7 @@ hqDefine("translations/js/app_translations", [
     "underscore",
     "hqwebapp/js/initial_page_data",
     "app_manager/js/widgets",
-    "hqwebapp/js/widgets",   // .hqwebapp-select2
+    "hqwebapp/js/bootstrap3/widgets",   // .hqwebapp-select2
 ], function (
     $,
     _,

--- a/corehq/apps/translations/templates/blacklist_translations.html
+++ b/corehq/apps/translations/templates/blacklist_translations.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main "hqwebapp/js/widgets" %}
+{% requirejs_main "hqwebapp/js/bootstrap3/widgets" %}
 
 {% block page_content %}
   <div id="blacklist-trans-form" class="tab-pane">

--- a/corehq/apps/translations/templates/pull_resource.html
+++ b/corehq/apps/translations/templates/pull_resource.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main "hqwebapp/js/widgets" %}
+{% requirejs_main "hqwebapp/js/bootstrap3/widgets" %}
 
 {% block page_content %}
   {% if not transifex_details_available %}

--- a/corehq/apps/userreports/templates/userreports/ucr_expression.html
+++ b/corehq/apps/userreports/templates/userreports/ucr_expression.html
@@ -8,7 +8,7 @@
     <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
     <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
     <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
     <script src="{% static 'userreports/js/widgets.js' %}"></script>
   {% endcompress %}
 {% endblock %}

--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -10,7 +10,7 @@
     <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
     <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
     <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/widgets.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
     <script src="{% static 'userreports/js/widgets.js' %}"></script>
   {% endcompress %}
 {% endblock %}

--- a/corehq/apps/users/static/users/js/custom_data_fields.js
+++ b/corehq/apps/users/static/users/js/custom_data_fields.js
@@ -6,7 +6,7 @@ hqDefine("users/js/custom_data_fields", [
     'underscore',
     'hqwebapp/js/assert_properties',
     'hqwebapp/js/select2_knockout_bindings.ko',     // selects2 for fields
-    'hqwebapp/js/widgets',      // select2 for user fields profile
+    'hqwebapp/js/bootstrap3/widgets',      // select2 for user fields profile
 ], function (
     ko,
     _,

--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -9,7 +9,7 @@ hqDefine('users/js/edit_commcare_user', [
     'locations/js/widgets',
     'jquery-textchange/jquery.textchange',
     'hqwebapp/js/bootstrap3/knockout_bindings.ko',
-    'hqwebapp/js/widgets',
+    'hqwebapp/js/bootstrap3/widgets',
     'registration/js/password',
     'select2/dist/js/select2.full.min',
     'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min',

--- a/corehq/apps/users/static/users/js/filtered_download.js
+++ b/corehq/apps/users/static/users/js/filtered_download.js
@@ -3,7 +3,7 @@ hqDefine('users/js/filtered_download', [
     'knockout',
     'underscore',
     'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/widgets',      // role selection
+    'hqwebapp/js/bootstrap3/widgets',      // role selection
     'locations/js/widgets',     // location search
     'hqwebapp/js/bootstrap3/components.ko',    // select toggle widget
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // slideVisible binding

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_main.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_main.js
@@ -5,7 +5,7 @@ hqDefine("scheduling/js/conditional_alert_main", [
     'hqwebapp/js/initial_page_data',
     'data_interfaces/js/case_rule_criteria',
     'data_interfaces/js/case_property_input',
-    'hqwebapp/js/widgets',
+    'hqwebapp/js/bootstrap3/widgets',
     'scheduling/js/create_schedule.ko',
     'data_interfaces/js/make_read_only',
 ], function (

--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map.js
@@ -3,7 +3,7 @@ hqDefine("dhis2/js/dataset_map", [
     "underscore",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap3/crud_paginated_list_init",
-    "hqwebapp/js/widgets",
+    "hqwebapp/js/bootstrap3/widgets",
 ], function (
     $,
     _,

--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map_create.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map_create.js
@@ -1,6 +1,6 @@
 hqDefine("dhis2/js/dataset_map_create", [
     "jquery",
-    "hqwebapp/js/widgets",
+    "hqwebapp/js/bootstrap3/widgets",
     'jquery-ui/ui/widgets/datepicker',
 ], function ($) {
     function showCompleteDateColumnInput(shouldShow) {

--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map_update.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map_update.js
@@ -1,7 +1,7 @@
 hqDefine("dhis2/js/dataset_map_update", [
     "jquery",
     "hqwebapp/js/bootstrap3/crud_paginated_list_init",
-    "hqwebapp/js/widgets",
+    "hqwebapp/js/bootstrap3/widgets",
     'jquery-ui/ui/widgets/datepicker',
 ], function ($) {
     function showCompleteDateColumnInput(shouldShow) {

--- a/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
+++ b/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
@@ -2,7 +2,7 @@ hqDefine("repeaters/js/add_form_repeater", [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/base_ace',     // expression repeaters use ace for the json editor
-    'hqwebapp/js/widgets',       // case repeaters ("Forward Cases") use .hqwebapp-select2
+    'hqwebapp/js/bootstrap3/widgets',       // case repeaters ("Forward Cases") use .hqwebapp-select2
     'locations/js/widgets',         // openmrs repeaters use the LocationSelectWidget
 ], function (
     $,

--- a/corehq/motech/static/motech/js/connection_settings.js
+++ b/corehq/motech/static/motech/js/connection_settings.js
@@ -1,6 +1,6 @@
 hqDefine("motech/js/connection_settings", [
     "hqwebapp/js/bootstrap3/crud_paginated_list_init",
-    "hqwebapp/js/widgets",
+    "hqwebapp/js/bootstrap3/widgets",
 ], function () {
     // No page-specific logic, just need to collect the dependencies above
 });

--- a/docs/js-guide/dependencies.rst
+++ b/docs/js-guide/dependencies.rst
@@ -121,7 +121,7 @@ dependencies, like in
 
    hqDefine("sms/js/gateway_list", [
        "hqwebapp/js/crud_paginated_list_init",
-       "hqwebapp/js/widgets",
+       "hqwebapp/js/bootstrap3/widgets",
    ], function () {
        // No page-specific logic, just need to collect the dependencies above
    });


### PR DESCRIPTION
## Technical Summary
This splits `hqwebapp/js/widgets.js` into bootstrap 3 and 5 versions. This involves renaming files and duplicating widgets.js into hqwebapp for later modification

## Safety Assurance

### Safety story
tested locally, deploying to staging and testing there. a staging deploy will find out if any renames were missed

### Automated test coverage
Yes

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
leaving unchecked due to b5 diffs
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
