### PR TITLE
OR and match_none case search query functions

### DIFF
--- a/corehq/apps/case_search/tests/test_case_search_filters.py
+++ b/corehq/apps/case_search/tests/test_case_search_filters.py
@@ -221,3 +221,46 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             None,
             ['c1', 'c2', 'c3']
         )
+
+    def test_OR_two_postiive_conditions(self):
+        self._create_case_search_config()
+        cases = [
+            {'_id': 'c1', 'case_type': 'wizard', 'first_name': 'Harry', 'last_name': 'Potter',
+             'wand_core': 'phoenix_feather'},
+            {'_id': 'c2', 'case_type': 'wizard', 'first_name': 'Tom', 'last_name': 'Riddle',
+             'wand_core': 'phoenix_feather'},
+            {'_id': 'c3', 'case_type': 'wizard', 'first_name': 'Ron', 'last_name': 'Weasley',
+             'wand_core': 'unicorn_hair'},
+        ]
+        self._assert_query_runs_correctly(
+            self.domain,
+            cases,
+            get_case_search_query(
+                self.domain,
+                ['wizard'],
+                {'_xpath_query': "OR(wand_core='phoenix_feather', last_name='Weasley')"},
+            ),
+            None,
+            ['c1', 'c2', 'c3']
+        )
+
+    def test_OR_one_positive_condition(self):
+        cases = [
+            {'_id': 'c1', 'case_type': 'wizard', 'first_name': 'Harry', 'last_name': 'Potter',
+             'wand_core': 'phoenix_feather'},
+            {'_id': 'c2', 'case_type': 'wizard', 'first_name': 'Tom', 'last_name': 'Riddle',
+             'wand_core': 'phoenix_feather'},
+            {'_id': 'c3', 'case_type': 'wizard', 'first_name': 'Ron', 'last_name': 'Weasley',
+             'wand_core': 'unicorn_hair'},
+        ]
+        self._assert_query_runs_correctly(
+            self.domain,
+            cases,
+            get_case_search_query(
+                self.domain,
+                ['wizard'],
+                {'_xpath_query': "OR(wand_core='dragon_heartstring', last_name='Weasley', '')"},
+            ),
+            None,
+            ['c3']
+        )

--- a/corehq/apps/case_search/tests/test_case_search_filters.py
+++ b/corehq/apps/case_search/tests/test_case_search_filters.py
@@ -283,3 +283,11 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             None,
             ['c3']
         )
+
+    def test_OR_no_arg_raises_XPath_Exception(self):
+        with self.assertRaises(XPathFunctionException):
+            get_case_search_query(
+                self.domain,
+                ['song'],
+                {'_xpath_query': "OR()"},
+            )

--- a/corehq/apps/case_search/tests/test_case_search_filters.py
+++ b/corehq/apps/case_search/tests/test_case_search_filters.py
@@ -222,7 +222,7 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             ['c1', 'c2', 'c3']
         )
 
-    def test_OR_two_postiive_conditions(self):
+    def test_OR_two_positive_conditions(self):
         self._create_case_search_config()
         cases = [
             {'_id': 'c1', 'case_type': 'wizard', 'first_name': 'Harry', 'last_name': 'Potter',

--- a/corehq/apps/case_search/tests/test_case_search_filters.py
+++ b/corehq/apps/case_search/tests/test_case_search_filters.py
@@ -222,7 +222,7 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             ['c1', 'c2', 'c3']
         )
 
-    def test_OR_two_postiive_conditions(self):
+    def test_OR_two_positive_conditions(self):
         self._create_case_search_config()
         cases = [
             {'_id': 'c1', 'case_type': 'wizard', 'first_name': 'Harry', 'last_name': 'Potter',
@@ -263,4 +263,25 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             ),
             None,
             ['c3']
+        )
+
+    def test_OR_no_positive_condition(self):
+        cases = [
+            {'_id': 'c1', 'case_type': 'wizard', 'first_name': 'Harry', 'last_name': 'Potter',
+             'wand_core': 'phoenix_feather'},
+            {'_id': 'c2', 'case_type': 'wizard', 'first_name': 'Tom', 'last_name': 'Riddle',
+             'wand_core': 'phoenix_feather'},
+            {'_id': 'c3', 'case_type': 'wizard', 'first_name': 'Ron', 'last_name': 'Weasley',
+             'wand_core': 'unicorn_hair'},
+        ]
+        self._assert_query_runs_correctly(
+            self.domain,
+            cases,
+            get_case_search_query(
+                self.domain,
+                ['wizard'],
+                {'_xpath_query': "OR('', '')"},
+            ),
+            None,
+            []
         )

--- a/corehq/apps/case_search/tests/test_case_search_filters.py
+++ b/corehq/apps/case_search/tests/test_case_search_filters.py
@@ -222,7 +222,7 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             ['c1', 'c2', 'c3']
         )
 
-    def test_OR_two_positive_conditions(self):
+    def test_OR_two_postiive_conditions(self):
         self._create_case_search_config()
         cases = [
             {'_id': 'c1', 'case_type': 'wizard', 'first_name': 'Harry', 'last_name': 'Potter',
@@ -263,25 +263,4 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             ),
             None,
             ['c3']
-        )
-
-    def test_OR_no_positive_condition(self):
-        cases = [
-            {'_id': 'c1', 'case_type': 'wizard', 'first_name': 'Harry', 'last_name': 'Potter',
-             'wand_core': 'phoenix_feather'},
-            {'_id': 'c2', 'case_type': 'wizard', 'first_name': 'Tom', 'last_name': 'Riddle',
-             'wand_core': 'phoenix_feather'},
-            {'_id': 'c3', 'case_type': 'wizard', 'first_name': 'Ron', 'last_name': 'Weasley',
-             'wand_core': 'unicorn_hair'},
-        ]
-        self._assert_query_runs_correctly(
-            self.domain,
-            cases,
-            get_case_search_query(
-                self.domain,
-                ['wizard'],
-                {'_xpath_query': "OR('', '')"},
-            ),
-            None,
-            []
         )

--- a/corehq/apps/case_search/tests/test_case_search_filters.py
+++ b/corehq/apps/case_search/tests/test_case_search_filters.py
@@ -222,6 +222,25 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             ['c1', 'c2', 'c3']
         )
 
+    def test_match_none(self):
+        self._create_case_search_config()
+        cases = [
+            {'_id': 'c1', 'case_type': 'song', 'description': 'New York'},
+            {'_id': 'c2', 'case_type': 'song', 'description': 'Manchester'},
+            {'_id': 'c3', 'case_type': 'song', 'description': 'Manchester Boston'},
+        ]
+        self._assert_query_runs_correctly(
+            self.domain,
+            cases,
+            get_case_search_query(
+                self.domain,
+                ['song'],
+                {'_xpath_query': "match-none()"},
+            ),
+            None,
+            []
+        )
+
     def test_OR_two_positive_conditions(self):
         self._create_case_search_config()
         cases = [

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -745,6 +745,14 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
+    def test_match_none(self):
+        parsed = parse_xpath("match-none()")
+        expected_filter = {
+            "match_none": {}
+        }
+        built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
     def test_OR(self):
         parsed = parse_xpath("OR(wand_core='phoenix_feather', '')")
         expected_filter = {

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -229,7 +229,6 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, query, is_raw_query=True)
 
-
     @freeze_time('2021-08-02')
     def test_date_comparison__today(self):
         parsed = parse_xpath("dob >= today()")
@@ -872,7 +871,8 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         }
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
-        self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
+        self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(
+            built_filter).values_list('_id', flat=True))
 
     def test_nested_parent_lookups(self):
         parsed = parse_xpath("father/mother/house = 'Tyrell'")
@@ -909,7 +909,8 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         }
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
-        self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
+        self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(
+            built_filter).values_list('_id', flat=True))
 
     def test_subcase_exists(self):
         parsed = parse_xpath("subcase-exists('father', name='Margaery')")

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -745,6 +745,49 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
+    def test_OR(self):
+        parsed = parse_xpath("OR(wand_core='phoenix_feather', '')")
+        expected_filter = {
+            "bool": {
+                "should": [
+                    [
+                        {
+                            "nested": {
+                                "path": "case_properties",
+                                "query": {
+                                    "bool": {
+                                        "filter": [
+                                            {
+                                                "bool": {
+                                                    "filter": [
+                                                        {
+                                                            "term": {
+                                                                "case_properties.key.exact": "wand_core"
+                                                            }
+                                                        },
+                                                        {
+                                                            "term": {
+                                                                "case_properties.value.exact": "phoenix_feather"
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ],
+                                        "must": {
+                                            "match_all": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    ]
+                ]
+            }
+        }
+        built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
 
 @es_test(requires=[case_search_adapter], setup_class=True)
 class TestFilterDslLookups(ElasticTestMixin, TestCase):

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -6,7 +6,8 @@ from .query_functions import (
     within_distance,
     phonetic_match,
     starts_with,
-    match_all
+    match_all,
+    or_
 )
 from .subcase_functions import subcase
 from .ancestor_functions import ancestor_exists
@@ -33,5 +34,6 @@ XPATH_QUERY_FUNCTIONS = {
     'phonetic-match': phonetic_match,
     'starts-with': starts_with,
     'ancestor-exists': ancestor_exists,
-    'match-all': match_all
+    'match-all': match_all,
+    'OR': or_,
 }

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -7,6 +7,7 @@ from .query_functions import (
     phonetic_match,
     starts_with,
     match_all,
+    match_none,
     or_
 )
 from .subcase_functions import subcase
@@ -35,5 +36,6 @@ XPATH_QUERY_FUNCTIONS = {
     'starts-with': starts_with,
     'ancestor-exists': ancestor_exists,
     'match-all': match_all,
-    'OR': or_,
+    'match-none': match_none,
+    'OR': or_
 }

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -127,4 +127,6 @@ def match_none(node, context):
 
 def or_(node, context):
     from corehq.apps.case_search.filter_dsl import build_filter_from_ast
+    if not node.args:
+        raise XPathFunctionException("OR() requires at least one argument.", serialize(node))
     return filters.OR([build_filter_from_ast(arg, context) for arg in node.args if arg])

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -118,7 +118,4 @@ def match_all(node, context):
 
 def or_(node, context):
     from corehq.apps.case_search.filter_dsl import build_filter_from_ast
-    child_filters = [build_filter_from_ast(arg, context) for arg in node.args if arg]
-    if child_filters:
-        return filters.OR(child_filters)
-    return filters.match_none()
+    return filters.OR([build_filter_from_ast(arg, context) for arg in node.args if arg])

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -114,3 +114,8 @@ def match_all(node, context):
             serialize(node)
         )
     return filters.match_all()
+
+
+def or_(node, context):
+    from corehq.apps.case_search.filter_dsl import build_filter_from_ast
+    return filters.OR([build_filter_from_ast(arg, context) for arg in node.args if arg])

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -118,4 +118,7 @@ def match_all(node, context):
 
 def or_(node, context):
     from corehq.apps.case_search.filter_dsl import build_filter_from_ast
-    return filters.OR([build_filter_from_ast(arg, context) for arg in node.args if arg])
+    child_filters = [build_filter_from_ast(arg, context) for arg in node.args if arg]
+    if child_filters:
+        return filters.OR(child_filters)
+    return filters.match_none()

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -116,6 +116,15 @@ def match_all(node, context):
     return filters.match_all()
 
 
+def match_none(node, context):
+    if len(node.args):
+        raise XPathFunctionException(
+            _("'match-none()' does not take any arguments"),
+            serialize(node)
+        )
+    return filters.match_none()
+
+
 def or_(node, context):
     from corehq.apps.case_search.filter_dsl import build_filter_from_ast
     return filters.OR([build_filter_from_ast(arg, context) for arg in node.args if arg])

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -22,6 +22,10 @@ def match_all():
     return {"match_all": {}}
 
 
+def match_none():
+    return {"match_none": {}}
+
+
 def prefix(field, value):
     return {"prefix": {field: value}}
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

- Jira: [USH-4066](https://dimagi-dev.atlassian.net/browse/USH-4066?atlOrigin=eyJpIjoiNDVhNDdjZWI4NjQwNGM2YzljNTUxYmEwM2Q2OWIxYjIiLCJwIjoiaiJ9) and [USH-4134](https://dimagi-dev.atlassian.net/browse/USH-4134?atlOrigin=eyJpIjoiMjgwYzY3M2RlZWNlNGE1ODk5YzUwZTFkYTRmYWNiZjEiLCJwIjoiaiJ9)
- Sequel to https://github.com/dimagi/commcare-hq/pull/33977

Adds a case search query function called `OR` that does an 'or' operation across all the queries inputted, and a `match-none` CSQL function that returns no results. 

For example, a query such as this:

![Screenshot 2024-01-18 at 11 14 20 AM](https://github.com/dimagi/commcare-hq/assets/6729291/7cbffafb-1bae-4ee9-a91a-b0d71220871d)

Will return all cases who have a property `wand_core` equal to `phoenix_feather` **_or_** a property`last_name` equal to `Weasley`. Empty strings are ignored.

And a query like this:

![Screenshot 2024-01-22 at 11 19 21 AM](https://github.com/dimagi/commcare-hq/assets/6729291/480d40d9-af3c-4885-a547-c9038f72d18c)

Returns no results:

![Screenshot 2024-01-22 at 11 19 45 AM](https://github.com/dimagi/commcare-hq/assets/6729291/e6f81f77-a997-44ec-9881-7ea984fd93c4)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Nothing to add here.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested locally
- Automated tests do a decent job
- Impact should be limited to those who opt to use the functions
- Will be tested by delivery on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Tests added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

https://dimagi-dev.atlassian.net/browse/QA-6034

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change

Giving this the "invisible" label since the functions are purely opt-in:

[USH-4066]: https://dimagi-dev.atlassian.net/browse/USH-4066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[USH-4134]: https://dimagi-dev.atlassian.net/browse/USH-4134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ