### PR TITLE
SSCS: Disable search button when no change shave been made

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -711,6 +711,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     }
                 }
             });
+            self.updateSubmitButtonStatus(false);
             if (self.dynamicSearchEnabled && useDynamicSearch) {
                 self.updateSearchResults();
             }
@@ -725,12 +726,14 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             if (self.dynamicSearchEnabled) {
                 self.updateSearchResults();
             }
+            self.updateSubmitButtonStatus(false);
         },
 
         submitAction: function (e) {
             var self = this;
             e.preventDefault();
             self.performSubmit();
+            this.updateSubmitButtonStatus(true);
         },
 
         performSubmit: function (initiatedBy) {
@@ -759,6 +762,12 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             });
             if (invalidRequiredFields.length === 0) {
                 self.performSubmit("dynamicSearch");
+            }
+        },
+
+        updateSubmitButtonStatus: function (disabled) {
+            if (this.options.sidebarEnabled) {
+                sessionStorage.submitDisabled = disabled;
             }
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -613,6 +613,23 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             'click @ui.submitButton': 'submitAction',
         },
 
+        onRender: function () {
+            this.submitButtonListener = cloudcareUtils.submitButtonListener(submitButtonDisabled => {
+                this.handleSubmitButtonChange(submitButtonDisabled);
+            });
+            this.submitButtonListener.listen();
+        },
+
+        handleSubmitButtonChange: function (disabled) {
+            var submitButton = this.ui.submitButton;
+            if (disabled === 'true' || disabled == true) {
+                submitButton.prop('disabled', true);
+            } else {
+                submitButton.prop('disabled', false);
+            }
+        },
+
+
         handleSmallScreenChange: function (enabled) {
             this.smallScreenEnabled = enabled;
             if (this.options.sidebarEnabled) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -589,6 +589,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 const groupedCollection = groupDisplays(options.collection, options.groupHeaders);
                 this.collection = new Collection(groupedCollection);
             }
+            sessionStorage.submitDisabled = sessionStorage.submitDisabled ?? true;
         },
 
         templateContext: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -589,7 +589,8 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 const groupedCollection = groupDisplays(options.collection, options.groupHeaders);
                 this.collection = new Collection(groupedCollection);
             }
-            sessionStorage.submitDisabled = sessionStorage.submitDisabled ?? true;
+            sessionStorage.submitDisabled = sessionStorage.submitDisabled === undefined ?
+                true: sessionStorage.submitDisabled;;
         },
 
         templateContext: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -314,6 +314,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             this.sessionId = null;
             sessionStorage.removeItem('submitPerformed');
             sessionStorage.removeItem('geocoderValues');
+            sessionStorage.removeItem('submitDisabled');
         };
 
         this.onSubmit = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -380,6 +380,22 @@ hqDefine('cloudcare/js/utils', [
         };
     };
 
+    var submitButtonListener = function (callback) {
+        var submitButtonDisabled = sessionStorage.submitDisabled;
+        var handleSubmitButtonChange = () => {
+                callback(submitButtonDisabled);
+        };
+        return {
+            listen: function () {
+                $(window).on('load', handleSubmitButtonChange);
+                callback(submitButtonDisabled);
+            },
+            stopListening: function () {
+                $(window).off('load', handleSubmitButtonChange);
+            },
+        };
+    };
+
     return {
         dateFormat: dateFormat,
         convertTwoDigitYear: convertTwoDigitYear,
@@ -400,5 +416,6 @@ hqDefine('cloudcare/js/utils', [
         reportFormplayerErrorToHQ: reportFormplayerErrorToHQ,
         smallScreenIsEnabled: smallScreenIsEnabled,
         smallScreenListener: smallScreenListener,
+        submitButtonListener: submitButtonListener,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -383,7 +383,7 @@ hqDefine('cloudcare/js/utils', [
     var submitButtonListener = function (callback) {
         var submitButtonDisabled = sessionStorage.submitDisabled;
         var handleSubmitButtonChange = () => {
-                callback(submitButtonDisabled);
+            callback(submitButtonDisabled);
         };
         return {
             listen: function () {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
[USH-3989](https://dimagi-dev.atlassian.net/browse/USH-3989)
Disables search button until search results are modified (including cleared) after each search.

https://github.com/dimagi/commcare-hq/assets/36681924/c9aeb183-f71e-4a66-b61d-a96b45670a4a

(ignore weird formatting that's on my local environment and I'll film it again on a staging app)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Listener required to dynamically update the button.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
SSCS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This should disabled the button only whn a search would be unnessary and not when search inputs would cause a change in the search results. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3989]: https://dimagi-dev.atlassian.net/browse/USH-3989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ