### PR TITLE
Add validation for address popup back in

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -674,8 +674,7 @@ class ModuleDetailValidatorMixin(object):
             self.module.case_details.long.columns,
             errors)
 
-        # Temporarily comment out until migrate_address_popup has been run
-        # self._validate_address_popup_in_long(errors)
+        self._validate_address_popup_in_long(errors)
 
         return errors
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -317,6 +317,18 @@
                 <a href="{{ module_url }}">{{ module_name }}</a>
                 has an invalid case tile configuration. Reason: {{ error_reason }}
               {% endblocktrans %}
+            {% case "deprecated popup configuration" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                The case list in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                has an address popup configuration that should be moved to case detail.
+              {% endblocktrans %}
+            {% case "invalid clickable icon configuration" %}
+              {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
+                The case list in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                has an invalid clickable icon configuration. Reason: {{ error_reason }}
+              {% endblocktrans %}
             {% case "no source module id" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 Shadow module

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -173,25 +173,23 @@ class BuildErrorsTest(TestCase):
         self._clean_unique_id(errors)
         self.assertIn(case_tile_error, errors)
 
-    # Temporarily comment out until migrate_address_popup has been run and
-    # _validate_address_popup_in_long has been added back in
-    # def test_address_popup_defined_in_case_list(self, *args):
-    #     case_tile_error = {
-    #         'type': "invalid tile configuration",
-    #         'module': {'id': 0, 'name': {'en': 'first module'}},
-    #         'reason': 'Format "Address Popup" should be used in the Case Detail not Case List.'
-    #     }
-    #     app, module = self.create_app_with_module()
-    #     module.case_details.short.columns.append(DetailColumn(
-    #         format='address-popup',
-    #         field='field',
-    #         header={'en': 'Column'},
-    #         model='case',
-    #     ))
-    #
-    #     errors = app.validate_app()
-    #     self._clean_unique_id(errors)
-    #     self.assertIn(case_tile_error, errors)
+    def test_address_popup_defined_in_case_list(self, *args):
+        case_tile_error = {
+            'type': "deprecated popup configuration",
+            'module': {'id': 0, 'name': {'en': 'first module'}},
+            'reason': 'Format "Address Popup" should be used in the Case Detail not Case List.'
+        }
+        app, module = self.create_app_with_module()
+        module.case_details.short.columns.append(DetailColumn(
+            format='address-popup',
+            field='field',
+            header={'en': 'Column'},
+            model='case',
+        ))
+
+        errors = app.validate_app()
+        self._clean_unique_id(errors)
+        self.assertIn(case_tile_error, errors)
 
     def test_address__defined_twice(self, *args):
         case_tile_error = {


### PR DESCRIPTION
## Product Description

migrate_address_popup command has been run. All apps in production conform with the validation now and it can be added in.

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-4008
Original PR: https://github.com/dimagi/commcare-hq/pull/33938

## Feature Flag

* USH: Allow use of a map in the case list in Web Apps

## Safety Assurance

### Safety story

Has been tested with previous PR locally and on staging.

### Automated test coverage

* In PR

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
