### PR TITLE
Remove Old Geospatial TODO

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -335,8 +335,6 @@ hqDefine("geospatial/js/geospatial_map", [
                 url: initialPageData.reverse('get_users_with_gps'),
                 success: function (data) {
                     self.hasFiltersChanged(false);
-
-                    // TODO: There is a lot of indexing happening here. This should be replaced with a mapping to make reading it more explicit
                     const userData = _.object(_.map(data.user_data, function (userData) {
                         const gpsData = (userData.gps_point) ? userData.gps_point.split(' ') : [];
                         const lat = parseFloat(gpsData[0]);


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
As per the discussion from [this comment thread](https://github.com/dimagi/commcare-hq/pull/33965#discussion_r1457803263), a TODO comment which is no longer relevant has been removed from the Geospatial code.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Only a code comment removed.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
