### PR TITLE
Use natural keys for foreign key relationships during serialization/deserialization

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -234,14 +234,14 @@ class SqlDataDumper(DataDumper):
         the following reasons:
 
         use_natural_primary_keys is necessary for sharded models to ensure the primary key, which will not be
-        unique across shards, is not used.
+        unique across shards, is not used. This can be thought of as "use natural primary keys when defined".
 
-        use_natural_foreign_keys is necessary for fk relationships where the primary key is used. For instance,
-        SQLUserData foreign keys to auth.User, relying on the auth.User primary key. However auth.User has a
-        natural_key method defined, so it's primary key will not be included due to use_natural_primary_keys
-        being set to True. To resolve, we can use_natural_foreign_keys for any object that has get_by_natural_key
-        defined, which auth.User does. This enables identifying the correct auth.User when loading serialized
-        SQLUserData back into a database.
+        use_natural_foreign_keys is necessary for foreign keys that reference primary keys on models that have a
+        natural_key method defined. This can be thought of as "use natural foreign keys when defined". For example,
+        SQLUserData has a foreign key to User based on the primary key. However a natural_key method is defined on
+        the User model, so its primary key will not be serialized when use_natural_primary_keys=True. To resolve,
+        we set use_natural_foreign_keys=True which will result in natural keys being serialized as part of the
+        foreign key field when referencing a model with natural_key defined.
         """
         stats = Counter()
         objects = get_objects_to_dump(

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -229,6 +229,20 @@ class SqlDataDumper(DataDumper):
     slug = 'sql'
 
     def dump(self, output_stream):
+        """
+        When serializing data using JsonLinesSerializer().serialize(...), the additional parameters are set for
+        the following reasons:
+
+        use_natural_primary_keys is necessary for sharded models to ensure the primary key, which will not be
+        unique across shards, is not used.
+
+        use_natural_foreign_keys is necessary for fk relationships where the primary key is used. For instance,
+        SQLUserData foreign keys to auth.User, relying on the auth.User primary key. However auth.User has a
+        natural_key method defined, so it's primary key will not be included due to use_natural_primary_keys
+        being set to True. To resolve, we can use_natural_foreign_keys for any object that has get_by_natural_key
+        defined, which auth.User does. This enables identifying the correct auth.User when loading serialized
+        SQLUserData back into a database.
+        """
         stats = Counter()
         objects = get_objects_to_dump(
             self.domain,
@@ -237,9 +251,10 @@ class SqlDataDumper(DataDumper):
             stats_counter=stats,
             stdout=self.stdout,
         )
+
         JsonLinesSerializer().serialize(
             objects,
-            use_natural_foreign_keys=False,
+            use_natural_foreign_keys=True,
             use_natural_primary_keys=True,
             stream=output_stream
         )

--- a/corehq/apps/dump_reload/tests/test_serialization.py
+++ b/corehq/apps/dump_reload/tests/test_serialization.py
@@ -3,19 +3,22 @@ from django.test import SimpleTestCase
 
 
 class TestJSONFieldSerialization(SimpleTestCase):
-    """See https://github.com/bradjasper/django-jsonfield/pull/173"""
+    """
+    See https://github.com/bradjasper/django-jsonfield/pull/173
+    We just need to test that a model that uses jsonfield.JSONField is serialized correctly
+    """
 
     def test(self):
         serialized_model_with_primary_key = {
-            'model': 'form_processor.XFormInstance', 'pk': 1, 'fields': {'auth_context': '{}'}
+            'model': 'accounting.BillingContactInfo', 'pk': 1, 'fields': {'email_list': '{}'}
         }
         serialized_model_with_natural_key = {
-            'model': 'form_processor.XFormInstance', 'fields': {'auth_context': '{}'}
+            'model': 'accounting.BillingContactInfo', 'fields': {'email_list': '{}'}
         }
 
         def _test_json_field_after_serialization(serialized):
             for obj in Deserializer([serialized]):
-                self.assertIsInstance(obj.object.auth_context, dict)
+                self.assertIsInstance(obj.object.email_list, dict)
 
         _test_json_field_after_serialization(serialized_model_with_primary_key)
         _test_json_field_after_serialization(serialized_model_with_natural_key)

--- a/corehq/apps/dump_reload/tests/test_serialization.py
+++ b/corehq/apps/dump_reload/tests/test_serialization.py
@@ -2,10 +2,13 @@ import json
 from io import StringIO
 from unittest.mock import patch
 
+from django.contrib.auth.models import User
 from django.core.serializers.python import Deserializer
 from django.test import SimpleTestCase
 
 from corehq.apps.dump_reload.sql.dump import SqlDataDumper
+from corehq.apps.users.models import SQLUserData
+from corehq.apps.users.models_role import Permission, RolePermission, UserRole
 from corehq.form_processor.models.cases import CaseTransaction, CommCareCase
 from corehq.form_processor.models.forms import XFormInstance, XFormOperation
 
@@ -42,10 +45,7 @@ class TestForeignKeyFieldSerialization(SimpleTestCase):
     a model that foreign keys to cases or forms in SqlDataLoader.
     """
 
-    def test_serialized_foreign_key_field_referencing_User_returns_an_iterable(self):
-        from django.contrib.auth.models import User
-
-        from corehq.apps.users.models import SQLUserData
+    def test_natural_foreign_key_returns_iterable_when_serialized(self):
         user = User(username='testuser')
         user_data = SQLUserData(django_user=user, data={'test': 1})
 
@@ -57,7 +57,22 @@ class TestForeignKeyFieldSerialization(SimpleTestCase):
         fk_field = deserialized_model['fields']['django_user']
         self.assertEqual(fk_field, ['testuser'])
 
-    def test_serialized_foreign_key_field_referencing_CommCareCase_returns_a_str(self):
+    def test_foreign_key_on_model_without_natural_key_returns_primary_key_when_serialized(self):
+        role = UserRole(pk=10, domain='test', name='test-role')
+        permission = Permission(pk=500, value='test')
+        role_permission = RolePermission(role=role, permission_fk=permission)
+
+        output_stream = StringIO()
+        with patch('corehq.apps.dump_reload.sql.dump.get_objects_to_dump', return_value=[role_permission]):
+            SqlDataDumper('test', [], []).dump(output_stream)
+
+        deserialized_model = json.loads(output_stream.getvalue())
+        role_field = deserialized_model['fields']['role']
+        self.assertEqual(role_field, 10)
+        permission_field = deserialized_model['fields']['permission_fk']
+        self.assertEqual(permission_field, 500)
+
+    def test_natural_foreign_key_for_CommCareCase_returns_str_when_serialized(self):
         cc_case = CommCareCase(domain='test', case_id='abc123')
         transaction = CaseTransaction(case=cc_case)
 
@@ -69,7 +84,7 @@ class TestForeignKeyFieldSerialization(SimpleTestCase):
         fk_field = deserialized_model['fields']['case']
         self.assertEqual(fk_field, 'abc123')
 
-    def test_serialized_foreign_key_field_referencing_XFormInstance_returns_a_str(self):
+    def test_natural_foreign_key_for_XFormInstance_returns_str_when_serialized(self):
         xform = XFormInstance(domain='test', form_id='abc123')
         operation = XFormOperation(form=xform)
 

--- a/corehq/apps/dump_reload/tests/test_serialization.py
+++ b/corehq/apps/dump_reload/tests/test_serialization.py
@@ -1,5 +1,13 @@
+import json
+from io import StringIO
+from unittest.mock import patch
+
 from django.core.serializers.python import Deserializer
 from django.test import SimpleTestCase
+
+from corehq.apps.dump_reload.sql.dump import SqlDataDumper
+from corehq.form_processor.models.cases import CaseTransaction, CommCareCase
+from corehq.form_processor.models.forms import XFormInstance, XFormOperation
 
 
 class TestJSONFieldSerialization(SimpleTestCase):
@@ -22,3 +30,53 @@ class TestJSONFieldSerialization(SimpleTestCase):
 
         _test_json_field_after_serialization(serialized_model_with_primary_key)
         _test_json_field_after_serialization(serialized_model_with_natural_key)
+
+
+class TestForeignKeyFieldSerialization(SimpleTestCase):
+    """
+    We use natural foreign keys when dumping SQL data, but CommCareCase and XFormInstance have natural_key methods
+    that intentionally return a string for the case_id or form_id, rather than a tuple as Django recommends for
+    all natural_key methods. We made this decision to optimize loading deserialized data back into a database. If
+    the natural_key method returns a tuple, it will use the get_by_natural_key method on the foreign key model's
+    default object manager to fetch the foreign keyed object, resulting in a database lookup everytime we write
+    a model that foreign keys to cases or forms in SqlDataLoader.
+    """
+
+    def test_serialized_foreign_key_field_referencing_User_returns_an_iterable(self):
+        from django.contrib.auth.models import User
+
+        from corehq.apps.users.models import SQLUserData
+        user = User(username='testuser')
+        user_data = SQLUserData(django_user=user, data={'test': 1})
+
+        output_stream = StringIO()
+        with patch('corehq.apps.dump_reload.sql.dump.get_objects_to_dump', return_value=[user_data]):
+            SqlDataDumper('test', [], []).dump(output_stream)
+
+        deserialized_model = json.loads(output_stream.getvalue())
+        fk_field = deserialized_model['fields']['django_user']
+        self.assertEqual(fk_field, ['testuser'])
+
+    def test_serialized_foreign_key_field_referencing_CommCareCase_returns_a_str(self):
+        cc_case = CommCareCase(domain='test', case_id='abc123')
+        transaction = CaseTransaction(case=cc_case)
+
+        output_stream = StringIO()
+        with patch('corehq.apps.dump_reload.sql.dump.get_objects_to_dump', return_value=[transaction]):
+            SqlDataDumper('test', [], []).dump(output_stream)
+
+        deserialized_model = json.loads(output_stream.getvalue())
+        fk_field = deserialized_model['fields']['case']
+        self.assertEqual(fk_field, 'abc123')
+
+    def test_serialized_foreign_key_field_referencing_XFormInstance_returns_a_str(self):
+        xform = XFormInstance(domain='test', form_id='abc123')
+        operation = XFormOperation(form=xform)
+
+        output_stream = StringIO()
+        with patch('corehq.apps.dump_reload.sql.dump.get_objects_to_dump', return_value=[operation]):
+            SqlDataDumper('test', [], []).dump(output_stream)
+
+        deserialized_model = json.loads(output_stream.getvalue())
+        fk_field = deserialized_model['fields']['form']
+        self.assertEqual(fk_field, 'abc123')

--- a/corehq/apps/dump_reload/tests/test_sql_data_loader.py
+++ b/corehq/apps/dump_reload/tests/test_sql_data_loader.py
@@ -1,0 +1,55 @@
+import json
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from corehq.apps.dump_reload.sql.load import SqlDataLoader
+from corehq.apps.users.models import SQLUserData
+from corehq.form_processor.models.cases import CaseTransaction
+from corehq.form_processor.tests.utils import create_case
+
+
+class TestSqlDataLoader(TestCase):
+
+    def test_loading_foreign_keys_using_iterable_natural_key(self):
+        user = User.objects.create(username='testuser')
+        model = {
+            "model": "users.sqluserdata",
+            "fields": {
+                "domain": "test",
+                "user_id": "testuser",
+                "django_user": ["testuser"],
+                "modified_on": "2024-01-01T12:00:00.000000Z",
+                "profile": None,
+                "data": {"test": "1"},
+            },
+        }
+        serialized_model = json.dumps(model)
+
+        SqlDataLoader().load_objects([serialized_model])
+
+        user_data = SQLUserData.objects.get(django_user=user)
+        self.assertEqual(user_data.django_user.pk, user.pk)
+
+    def test_loading_foreign_keys_using_non_iterable_natural_key(self):
+        # create_case will create a CaseTransaction too so test verifies the serialized one is saved properly
+        cc_case = create_case('test', case_id='abc123', save=True)
+        model = {
+            "model": "form_processor.casetransaction",
+            "fields": {
+                "case": "abc123",
+                "form_id": "fk-test",
+                "sync_log_id": None,
+                "server_date": "2024-01-01T12:00:00.000000Z",
+                "_client_date": None,
+                "type": 1,
+                "revoked": False,
+                "details": {},
+            },
+        }
+        serialized_model = json.dumps(model)
+
+        SqlDataLoader().load_objects([serialized_model])
+
+        transaction = CaseTransaction.objects.partitioned_query('abc123').get(case=cc_case, form_id='fk-test')
+        self.assertEqual(transaction.case_id, 'abc123')

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -360,6 +360,26 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
 
         self._dump_and_load(expected_object_counts)
 
+    def test_sqluserdata(self):
+        from corehq.apps.users.models import SQLUserData, WebUser
+        from django.contrib.auth.models import User
+
+        expected_object_counts = Counter({User: 1, SQLUserData: 1})
+
+        web_user = WebUser.create(
+            domain=self.domain_name,
+            username='webuser_t1',
+            password='secret',
+            created_by=None,
+            created_via=None,
+            email='webuser@example.com',
+        )
+        self.addCleanup(web_user.delete, self.domain_name, deleted_by=None)
+        user = web_user.get_django_user()
+        SQLUserData.objects.create(domain=self.domain_name, data={'test': 1}, django_user=user)
+
+        self._dump_and_load(expected_object_counts)
+
     def test_dump_roles(self):
         from corehq.apps.users.models import UserRole, HqPermissions, RoleAssignableBy, RolePermission
 

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -343,10 +343,10 @@ class CommCareCase(PartitionedModel, models.Model, RedisLockableMixIn,
 
     def natural_key(self):
         """
-        Django recommends always returning a tuple in natural_key methods:
+        Django requires returning a tuple in natural_key methods:
         https://docs.djangoproject.com/en/3.2/topics/serialization/#serialization-of-natural-keys
         We intentionally do not follow this to optimize corehq.apps.dump_reload.sql.load.SqlDataLoader when other
-        models foreign key to CommCareCase or XFormInstance. This means our loader code is subject to break in
+        models reference CommCareCase or XFormInstance via a foreign key. This means our loader code may break in
         future Django upgrades.
         """
         # necessary for dumping models from a sharded DB so that we exclude the

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -542,10 +542,10 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
 
     def natural_key(self):
         """
-        Django recommends always returning a tuple in natural_key methods:
+        Django requires returning a tuple in natural_key methods:
         https://docs.djangoproject.com/en/3.2/topics/serialization/#serialization-of-natural-keys
         We intentionally do not follow this to optimize corehq.apps.dump_reload.sql.load.SqlDataLoader when other
-        models foreign key to CommCareCase or XFormInstance. This means our loader code is subject to break in
+        models reference CommCareCase or XFormInstance via a foreign key. This means our loader code may break in
         future Django upgrades.
         """
         # necessary for dumping models from a sharded DB so that we exclude the

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -52,6 +52,9 @@ ARCHIVE_FORM = "archive_form"
 
 class XFormInstanceManager(RequireDBManager):
 
+    def get_by_natural_key(self, form_id):
+        return self.partitioned_query(form_id).get(form_id=form_id)
+
     def get_form(self, form_id, domain=None):
         """Get form in domain
 
@@ -432,6 +435,9 @@ class XFormInstanceManager(RequireDBManager):
 
 class XFormOperationManager(RequireDBManager):
 
+    def get_by_natural_key(self, form_id, user_id, date):
+        return self.partitioned_query(form_id).get(form_id=form_id, user_id=user_id, date=date)
+
     def get_form_operations(self, form_id):
         return list(self.partitioned_query(form_id).filter(form_id=form_id).order_by('date'))
 
@@ -540,7 +546,7 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
     def natural_key(self):
         # necessary for dumping models from a sharded DB so that we exclude the
         # SQL 'id' field which won't be unique across all the DB's
-        return self.form_id
+        return (self.form_id,)
 
     @classmethod
     def get_obj_id(cls, obj):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -52,9 +52,6 @@ ARCHIVE_FORM = "archive_form"
 
 class XFormInstanceManager(RequireDBManager):
 
-    def get_by_natural_key(self, form_id):
-        return self.partitioned_query(form_id).get(form_id=form_id)
-
     def get_form(self, form_id, domain=None):
         """Get form in domain
 
@@ -544,9 +541,16 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
         return XFormOperation.objects.get_form_operations(self.__original_form_id)
 
     def natural_key(self):
+        """
+        Django recommends always returning a tuple in natural_key methods:
+        https://docs.djangoproject.com/en/3.2/topics/serialization/#serialization-of-natural-keys
+        We intentionally do not follow this to optimize corehq.apps.dump_reload.sql.load.SqlDataLoader when other
+        models foreign key to CommCareCase or XFormInstance. This means our loader code is subject to break in
+        future Django upgrades.
+        """
         # necessary for dumping models from a sharded DB so that we exclude the
         # SQL 'id' field which won't be unique across all the DB's
-        return (self.form_id,)
+        return self.form_id
 
     @classmethod
     def get_obj_id(cls, obj):

--- a/corehq/form_processor/models/ledgers.py
+++ b/corehq/form_processor/models/ledgers.py
@@ -4,11 +4,17 @@ from django.db import models
 
 from memoized import memoized
 
-from corehq.sql_db.models import PartitionedModel
+from corehq.sql_db.models import PartitionedModel, RequireDBManager
 from corehq.util.models import TruncatingCharField
 
 from ..track_related import TrackRelatedChanges
 from .mixin import SaveStateMixin
+
+
+class LedgerValueManager(RequireDBManager):
+
+    def get_by_natural_key(self, case_id, section_id, entry_id):
+        return self.partitioned_query(case_id).get(case_id=case_id, section_id=section_id, entry_id=entry_id)
 
 
 class LedgerValue(PartitionedModel, SaveStateMixin, models.Model, TrackRelatedChanges):
@@ -16,6 +22,7 @@ class LedgerValue(PartitionedModel, SaveStateMixin, models.Model, TrackRelatedCh
     Represents the current state of a ledger.
     """
     partition_attr = 'case_id'
+    objects = LedgerValueManager()
 
     domain = models.CharField(max_length=255, null=False, default=None)
     case = models.ForeignKey(
@@ -99,8 +106,17 @@ class LedgerValue(PartitionedModel, SaveStateMixin, models.Model, TrackRelatedCh
         unique_together = ("case", "section_id", "entry_id")
 
 
+class LedgerTransactionManager(RequireDBManager):
+
+    def get_by_natural_key(self, case_id, form_id, section_id, entry_id):
+        return self.partitioned_query(case_id).get(
+            case_id=case_id, form_id=form_id, section_id=section_id, entry_id=entry_id
+        )
+
+
 class LedgerTransaction(PartitionedModel, SaveStateMixin, models.Model):
     partition_attr = 'case_id'
+    objects = LedgerTransactionManager()
 
     TYPE_BALANCE = 1
     TYPE_TRANSFER = 2


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I added what is hopefully a thorough description of this change in the comment for the dump method, but I'll rephrase that here and provide some additional proof for why this is necessary.

When loading domain data into a fresh environment from a file generated by the existing `dump_domain_data` command, we hit a ForeignKey violation when loading SQLUserData, which foreign keys to the Django auth.User object via the primary key.

The problem is that when we serialize our dumped data, we set `use_natural_primary_keys=True` to use natural keys for our sharded objects (the only place we defined `natural_key` methods in our code). However the auth.User defines a `natural_key` method, which ensures that the primary key is not included when serializing this object (docs [here](https://docs.djangoproject.com/en/3.2/topics/serialization/#natural-keys)). Since SQLUserData foreign keys to this object, and we have `use_natural_foreign_keys=False` in our serializer, the foreign key relationship is serialized using the auth.User's primary key, instead of its natural key.

Setting `use_natural_foreign_keys=True` ensures that the serialized SQLUserData will reference auth.User's natural key. Also have glossed over it, but auth.User also defines a `get_by_natural_key` method which is used when deserializing data, enabling SQLUserData to foreign key to the correct object at that point.

Here's an example of what a serialized SQLUserData object looks like before and after this change, looking most closely at the value for the "django_user" field:

Before
```
{"model": "users.sqluserdata", "pk": 1, "fields": {"domain": "gherceg", "user_id": "32ea2287870244ca8c448b1664be4f41", "django_user": 2, "modified_on": "2023-12-12T03:09:48.924945Z", "profile": null, "data": {}}}
```
After
```
{"model": "users.sqluserdata", "pk": 1, "fields": {"domain": "gherceg", "user_id": "32ea2287870244ca8c448b1664be4f41", "django_user": ["gherceg+admin@dimagi.com"], "modified_on": "2023-12-12T03:09:48.924945Z", "profile": null, "data": {}}}
```

The reason this came up recently is because SQLUserData is the first object we include in dumped data that foreign keys to auth.User. All other objects that foreign key to auth.User are excluded from the dump.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This code is run manually by developers and does not have any direct user facing impact. 

I confirmed the following:
- this does not impact the output of sharded objects that foreign key using form and case ids, since those foreign keys do not rely on the default model's primary key.
- verified that `natural_key` is only used on sharded objects in our code
- verified that `get_by_natural_key` is not used anywhere in our codej

The worst case is that this change corrupts the load_domain_data command, which is already broken because of this issue so 🤷🏻.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
This area doesn't have the greatest test coverage. It is a bit tricky to ensure that _all_ models are dumped and loaded properly, but I intend to spend time improving the test suite here. When debugging this specific issue, I used some simple unit tests, but those didn't feel worth committing as they really just verify django serialization behavior as it is documented.
 
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
