### PR TITLE
Add Mapbox Streets Layers

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -225,7 +225,7 @@ hqDefine("geospatial/js/geospatial_map", [
     };
 
     function initMap() {
-        mapModel = new models.Map();
+        mapModel = new models.Map(false, true);
         mapModel.initMap(MAP_CONTAINER_ID);
 
         let selectedCases = ko.computed(function () {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -132,7 +132,55 @@ hqDefine('geospatial/js/models', [
             if (self.usesClusters) {
                 createClusterLayers();
             }
+
+            loadMapBoxStreetsLayers();
         };
+
+        function loadMapBoxStreetsLayers() {
+            self.mapInstance.on('load', () => {
+                self.mapInstance.addSource('mapbox-streets', {
+                    type: 'vector',
+                    url: 'mapbox://mapbox.mapbox-streets-v8',
+                });
+
+                self.mapInstance.addLayer({
+                    id: 'landuse_overlay',
+                    source: 'mapbox-streets',
+                    'source-layer': 'landuse_overlay',
+                    type: 'line',
+                    paint: {
+                        'line-color': '#800080', // purple
+                    },
+                    layout: {
+                        'visibility': 'none',
+                    },
+                });
+                self.mapInstance.addLayer({
+                    id: 'road',
+                    source: 'mapbox-streets',
+                    'source-layer': 'road',
+                    type: 'line',
+                    paint: {
+                        'line-color': '#000000', // black
+                    },
+                    'layout': {
+                        'visibility': 'none',
+                    },
+                });
+                self.mapInstance.addLayer({
+                    id: 'admin',
+                    source: 'mapbox-streets',
+                    'source-layer': 'admin',
+                    type: 'line',
+                    paint: {
+                        'line-color': '#800080', // purple
+                    },
+                    'layout': {
+                        'visibility': 'none',
+                    },
+                });
+            });
+        }
 
         function createClusterLayers() {
             // const mapInstance = self.mapInstance;

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -219,6 +219,7 @@ hqDefine('geospatial/js/models', [
 
                     menuElement.appendChild(link);
                 }
+                menuElement.classList.remove('hidden');
             });
         }
 

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -220,7 +220,6 @@ hqDefine('geospatial/js/models', [
         }
 
         function createClusterLayers() {
-            // const mapInstance = self.mapInstance;
             self.mapInstance.on('load', () => {
                 self.mapInstance.addSource('caseWithGPS', {
                     type: 'geojson',

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -134,6 +134,7 @@ hqDefine('geospatial/js/models', [
             }
 
             loadMapBoxStreetsLayers();
+            addLayersToPanel();
         };
 
         function loadMapBoxStreetsLayers() {
@@ -179,6 +180,42 @@ hqDefine('geospatial/js/models', [
                         'visibility': 'none',
                     },
                 });
+            });
+        }
+
+        function addLayersToPanel() {
+            self.mapInstance.on('idle', () => {
+                const toggleableLayerIds = ['landuse_overlay', 'admin', 'road'];
+                const menuElement = document.getElementById('layer-toggle-menu');
+                for (const layerId of toggleableLayerIds) {
+                    // Skip if layer doesn't exist or button is already present
+                    if (!self.mapInstance.getLayer(layerId) || document.getElementById(layerId)) {
+                        continue;
+                    }
+
+                    const link = document.createElement('a');
+                    link.id = layerId;
+                    link.role = 'button';
+                    link.href = '#';
+                    link.textContent = layerId;
+                    link.className = 'btn btn-secondary';
+                    link.onclick = function (e) {
+                        const clickedLayer = this.textContent;
+                        e.preventDefault();
+                        e.stopPropagation();
+
+                        const visibility = self.mapInstance.getLayoutProperty(clickedLayer, 'visibility');
+                        if (visibility === 'visible') {
+                            self.mapInstance.setLayoutProperty(clickedLayer, 'visibility', 'none');
+                            this.classList.remove('active');
+                        } else {
+                            this.classList.add('active');
+                            self.mapInstance.setLayoutProperty(clickedLayer, 'visibility', 'visible');
+                        }
+                    };
+
+                    menuElement.appendChild(link);
+                }
             });
         }
 

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -91,10 +91,11 @@ hqDefine('geospatial/js/models', [
         };
     };
 
-    var Map = function (usesClusters) {
+    var Map = function (usesClusters, usesStreetsLayers) {
         var self = this;
 
         self.usesClusters = usesClusters;
+        self.usesStreetsLayers = usesStreetsLayers;
 
         self.mapInstance;
         self.drawControls;
@@ -133,8 +134,10 @@ hqDefine('geospatial/js/models', [
                 createClusterLayers();
             }
 
-            loadMapBoxStreetsLayers();
-            addLayersToPanel();
+            if (self.usesStreetsLayers) {
+                loadMapBoxStreetsLayers();
+                addLayersToPanel();
+            }
         };
 
         function loadMapBoxStreetsLayers() {

--- a/corehq/apps/geospatial/templates/base_template.html
+++ b/corehq/apps/geospatial/templates/base_template.html
@@ -14,6 +14,19 @@
  {{ block.super }}
  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.css">
  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.0/mapbox-gl-draw.css" type="text/css">
+ <style>
+    #layer-toggle-menu {
+      background: #fff;
+      position: absolute;
+      z-index: 1;
+      top: 10px;
+      left: 10px;
+      max-height: 150px;
+      border: 1px solid rgba(0, 0, 0, 0.4);
+      overflow-y: auto;
+    }
+  </style>
+
  {% endblock %}
 
 

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -107,7 +107,7 @@
     {% endblocktrans %}
 </div>
 <div id="geospatial-map" style="height: 500px">
-    <div id="layer-toggle-menu" class="btn-group-vertical">
+    <div id="layer-toggle-menu" class="btn-group-vertical hidden">
         <h4 class="text-center">
             {% trans 'Layers' %}
         </h4>

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -106,7 +106,13 @@
         Previous disbursement was cleared.
     {% endblocktrans %}
 </div>
-<div id="geospatial-map" style="height: 500px"></div>
+<div id="geospatial-map" style="height: 500px">
+    <div id="layer-toggle-menu" class="btn-group-vertical">
+        <h4 class="text-center">
+            {% trans 'Layers' %}
+        </h4>
+    </div>
+</div>
 
 <!-- For Pagination -->
 <div class="panel-body-datatable">


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A layer toggle menu is added to the "Case Management" map:
![toggle-layers-menu](https://github.com/dimagi/commcare-hq/assets/122617251/8cd80d3b-2867-40a2-8b0d-4e907a4439f7)


When a layer is active, it will show an active dark blue color on the layer toggle menu. By default all layers will be off when the page is loaded.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3304).

This PR implements the following Mapbox Streets V8 layers to the "Case Management" page map:
- landuse_overlay
- admin
- road

For more information regarding Mapbox Streets layers, please refer to [this](https://docs.mapbox.com/data/tilesets/reference/mapbox-streets-v8/#layer-reference) documentation.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Small front-end only change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests exist.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
