### PR TITLE
Add @use_datetimepicker decorator to use Tempus Dominus on Bootstrap 5 pages

### DIFF
--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -236,6 +236,28 @@ def use_bootstrap5(view_func):
     return _inner
 
 
+def use_datetimepicker(view_func):
+    """Use this decorator on the dispatch method of a TemplateView subclass
+    to include CSS for Tempus Dominus (Date and/or Time picking widget).
+    NOTE: Only available for Bootstrap 5 pages!
+
+    Example:
+        @use_datetimepicker
+        def dispatch(self, request, *args, **kwargs):
+            return super().dispatch(request, *args, **kwargs)
+
+    Or alternatively:
+        @method_decorator(use_datetimepicker, name='dispatch')
+        class MyViewClass(MyViewSubclass):
+            ...
+    """
+    @wraps(view_func)
+    def _inner(request, *args, **kwargs):
+        request.use_datetimepicker = True
+        return view_func(request, *args, **kwargs)
+    return _inner
+
+
 def waf_allow(kind, hard_code_pattern=None):
     """
     Using this decorator simply registers a function for later use

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/requirejs_config.js
@@ -9,7 +9,7 @@ requirejs.config({
         "datatables.bootstrap": "datatables.net-bs5/js/dataTables.bootstrap5.min",
         "datatables.fixedColumns": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
         "datatables.fixedColumns.bootstrap": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
-        "datepicker": "@eonasdan/tempus-dominus/dist/js/jQuery-provider.min",  // import this if you need jquery plugin of tempus-dominus
+        "datetimepicker": "@eonasdan/tempus-dominus/dist/js/jQuery-provider.min",  // import this if you need jquery plugin of tempus-dominus
         "es6": "requirejs-babel7/es6",
         "jquery": "jquery/dist/jquery.min",
         "knockout": "knockout/build/output/knockout-latest.debug",
@@ -25,7 +25,7 @@ requirejs.config({
         "ace-builds/src-min-noconflict/ace": { exports: "ace" },
         "datatables.bootstrap": { deps: ['datatables'] },
         "datatables.fixedColumns.bootstrap": { deps: ['datatables.fixedColumns'] },
-        "datepicker": {
+        "datetimepicker": {
             deps: ['popper', 'tempus-dominus'],
         },
         "d3/d3.min": {

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -128,6 +128,15 @@
       {% endif %}
     {% endif %}
 
+    {% if request.use_datetimepicker and use_bootstrap5 %}
+      {% compress css %}
+        <link type="text/css"
+              rel="stylesheet"
+              media="screen"
+              href="{% static "@eonasdan/tempus-dominus/dist/css/tempus-dominus.min.css" %}" />
+      {% endcompress %}
+    {% endif %}
+
     {% if request.use_multiselect %}
       {% compress css %}
         <link type="text/css"
@@ -397,6 +406,14 @@
       {% compress js %}
         <script src="{% static 'bootstrap3-typeahead/bootstrap3-typeahead.min.js' %}"></script>
         <script src="{% static 'hqwebapp/js/bootstrap-multi-typeahead.js' %}"></script>
+      {% endcompress %}
+    {% endif %}
+
+    {% if request.use_datetimepicker and not requirejs_main and use_bootstrap5 %}
+      {% compress js %}
+        <script src="{% static '@popperjs/core/dist/umd/popper.min.js' %}"></script>
+        <script src="{% static '@eonasdan/tempus-dominus/dist/js/tempus-dominus.min.js' %}"></script>
+        <script src="{% static '@eonasdan/tempus-dominus/dist/js/jQuery-provider.min.js' %}"></script>
       {% endcompress %}
     {% endif %}
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/requirejs_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/requirejs_config.js.diff.txt
@@ -14,7 +14,7 @@
 +        "datatables.bootstrap": "datatables.net-bs5/js/dataTables.bootstrap5.min",
 +        "datatables.fixedColumns": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
 +        "datatables.fixedColumns.bootstrap": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
-+        "datepicker": "@eonasdan/tempus-dominus/dist/js/jQuery-provider.min",  // import this if you need jquery plugin of tempus-dominus
++        "datetimepicker": "@eonasdan/tempus-dominus/dist/js/jQuery-provider.min",  // import this if you need jquery plugin of tempus-dominus
 +        "es6": "requirejs-babel7/es6",
          "jquery": "jquery/dist/jquery.min",
          "knockout": "knockout/build/output/knockout-latest.debug",
@@ -31,7 +31,7 @@
 -        "bootstrap": { deps: ['jquery'] },
          "datatables.bootstrap": { deps: ['datatables'] },
 +        "datatables.fixedColumns.bootstrap": { deps: ['datatables.fixedColumns'] },
-+        "datepicker": {
++        "datetimepicker": {
 +            deps: ['popper', 'tempus-dominus'],
 +        },
          "d3/d3.min": {


### PR DESCRIPTION
## Technical Summary
This adds the `@use_datetimepicker` decorator and corresponding javascript and CSS includes so that bootstrap 5 pages can easily use Tempus Dominus. This also renames `datepicker` to `datetimepicker` in the Bootstrap 5 version of `requirejs_config` so that there is standardization on names.


## Safety Assurance

### Safety story
Safe change, only affects bootstrap 5 pages....of which there are few right now

### Automated test coverage
diffs are covered

### QA Plan
No


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
unchecked due to complexity around bootstrap 5 diffs
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
