### PR TITLE
Web apps tests: make toggle dependencies explicit

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -23,6 +23,10 @@ hqDefine("cloudcare/js/form_entry/spec/entries_spec", function () {
             );
         });
 
+        after(function () {
+            hqImport("hqwebapp/js/initial_page_data").unregister("toggles_dict");
+        });
+
         beforeEach(function () {
             window.MAPBOX_ACCESS_TOKEN = 'xxx';
             questionJSON = {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
@@ -13,6 +13,20 @@ hqDefine("cloudcare/js/form_entry/spec/form_ui_spec", function () {
             repeatJSON,
             repeatNestJSON;
 
+        before(function () {
+            hqImport("hqwebapp/js/initial_page_data").register(
+                "toggles_dict",
+                {
+                    WEB_APPS_UPLOAD_QUESTIONS: true,
+                    WEB_APPS_ANCHORED_SUBMIT: false,
+                }
+            );
+        });
+
+        after(function () {
+            hqImport("hqwebapp/js/initial_page_data").unregister("toggles_dict");
+        });
+
         beforeEach(function () {
             questionJSON = fixtures.selectJSON();
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/integration_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/integration_spec.js
@@ -7,6 +7,14 @@ hqDefine("cloudcare/js/form_entry/spec/integration_spec", function () {
             questionJSONMulti,
             questionJSONString;
 
+        before(function () {
+            hqImport("hqwebapp/js/initial_page_data").register("toggles_dict", { WEB_APPS_ANCHORED_SUBMIT: false });
+        });
+
+        after(function () {
+            hqImport("hqwebapp/js/initial_page_data").unregister("toggles_dict");
+        });
+
         beforeEach(function () {
             questionJSONMulti = {
                 "caption_audio": null,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
@@ -31,6 +31,7 @@ hqDefine("cloudcare/js/form_entry/spec/utils_spec", function () {
              *         groupInRepeat
              *             textInRepeat
              */
+            hqImport("hqwebapp/js/initial_page_data").register("toggles_dict", { WEB_APPS_ANCHORED_SUBMIT: false });
             var text = fixtures.textJSON({ix: "0"}),
                 textInGroup = fixtures.textJSON({ix: "1,0"}),
                 group = fixtures.groupJSON({ix: "1", children: [textInGroup]}),
@@ -52,6 +53,8 @@ hqDefine("cloudcare/js/form_entry/spec/utils_spec", function () {
 
             assert.equal(utils.getBroadcastContainer(text), form);
             assert.equal(utils.getBroadcastContainer(textInRepeat), groupInRepeat);
+
+            hqImport("hqwebapp/js/initial_page_data").unregister("toggles_dict");
         });
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/web_form_session_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/web_form_session_spec.js
@@ -5,6 +5,14 @@ hqDefine("cloudcare/js/form_entry/spec/web_form_session_spec", function () {
         var constants = hqImport("cloudcare/js/form_entry/const"),
             formUI = hqImport("cloudcare/js/form_entry/form_ui");
 
+        before(function () {
+            hqImport("hqwebapp/js/initial_page_data").register("toggles_dict", { WEB_APPS_ANCHORED_SUBMIT: false });
+        });
+
+        after(function () {
+            hqImport("hqwebapp/js/initial_page_data").unregister("toggles_dict");
+        });
+
         describe('TaskQueue', function () {
             var callCount,
                 flag,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_spec.js
@@ -17,6 +17,10 @@ hqDefine("cloudcare/js/formplayer/spec/menu_list_spec", function () {
             sinon.stub(Utils, 'getCurrentQueryInputs').callsFake(function () { return {}; });
         });
 
+        after(function () {
+            hqImport("hqwebapp/js/initial_page_data").unregister("toggles_dict");
+        });
+
         describe('#getMenuView', function () {
             let FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),
                 server,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/query_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/query_spec.js
@@ -11,6 +11,8 @@ hqDefine("cloudcare/js/formplayer/spec/query_spec", function () {
                 const QueryListView = hqImport("cloudcare/js/formplayer/menus/views/query");
                 const Utils = hqImport("cloudcare/js/formplayer/utils/utils");
 
+                hqImport("hqwebapp/js/initial_page_data").register("toggles_dict", { DYNAMICALLY_UPDATE_SEARCH_RESULTS: false });
+
                 const QueryViewModel = Backbone.Model.extend();
                 const QueryViewCollection = Backbone.Collection.extend();
                 const keyModel = new QueryViewModel({
@@ -32,6 +34,10 @@ hqDefine("cloudcare/js/formplayer/spec/query_spec", function () {
 
                 const childViewConstructor = keyQueryListView.childView(new Backbone.Model({}));
                 keyQueryView = new childViewConstructor({ parentView: keyQueryListView, model: keyModel});
+            });
+
+            after(function () {
+                hqImport("hqwebapp/js/initial_page_data").unregister("toggles_dict");
             });
 
             it('should create dictionary with either keys', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/utils_spec.js
@@ -37,6 +37,17 @@ hqDefine("cloudcare/js/formplayer/spec/utils_spec", function () {
         describe('CloudcareUrl', function () {
             let stubs = {};
 
+            before(function () {
+                hqImport("hqwebapp/js/initial_page_data").register("toggles_dict", {
+                    SPLIT_SCREEN_CASE_SEARCH: false,
+                    DYNAMICALLY_UPDATE_SEARCH_RESULTS: false,
+                });
+            });
+
+            after(function () {
+                hqImport("hqwebapp/js/initial_page_data").unregister("toggles_dict");
+            });
+
             beforeEach(function () {
                 let currentUrl = new Utils.CloudcareUrl({appId: 'abc123'});
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -55,6 +55,17 @@ hqDefine('hqwebapp/js/initial_page_data', ['jquery', 'underscore'], function ($,
         _initData[name] = value;
     };
 
+    /*
+     * Remove item from initial page data.
+     * Useful for mocha test cleanup.
+     */
+    var unregister = function (name) {
+        if (_initData[name] === undefined) {
+            throw new Error("Could not unregister initial page data: " + name);
+        }
+        delete _initData[name];
+    };
+
     // http://stackoverflow.com/a/21903119/240553
     var getUrlParameter = function (param) {
         return getUrlParameterFromString(param, window.location.search);
@@ -116,6 +127,7 @@ hqDefine('hqwebapp/js/initial_page_data', ['jquery', 'underscore'], function ($,
         gather: gather,
         get: get,
         register: register,
+        unregister: unregister,
         getUrlParameter: getUrlParameter,
         getUrlParameterFromString: getUrlParameterFromString,
         registerUrl: registerUrl,


### PR DESCRIPTION
## Technical Summary
Registering initial page data in a js test makes that data available to all subsequent tests, since all test files in a given mocha template share the same DOM. This has led to implicit dependencies where one test uses a feature flag that was set in a test in a previously-loaded file.

Implicit dependencies are, generally, bad. These ones are breaking tests in the web apps RequireJS proof of concept, where module load order has changed.

This PR adds the ability to unregister initial page data and employs it in cloudcare js tests so that each test cleans up any feature flags that it set.

There are other uses of `initialPageData.register` in js tests. I'm calling these out of scope because they aren't currently causing problems.

## Safety Assurance

### Safety story
it is tests

### Automated test coverage

it is tests

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
