### PR TITLE
Update bootstrap 5 version of hqwebapp/js/widgets to use Tempus Dominus for date picker widget

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
@@ -4,7 +4,7 @@ hqDefine("hqwebapp/js/bootstrap5/widgets",[
     '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
     'hqwebapp/js/initial_page_data',
     'select2/dist/js/select2.full.min',
-    'jquery-ui/ui/widgets/datepicker',
+    'datepicker',  // jquery plugin for tempusDominus
 ], function ($, _, MapboxGeocoder, initialPageData) {
     var init = function () {
         var MAPBOX_ACCESS_TOKEN = initialPageData.get(
@@ -107,7 +107,18 @@ hqDefine("hqwebapp/js/bootstrap5/widgets",[
             }
         });
 
-        $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
+        // datepicker / tempus dominus
+        $('.date-picker').tempusDominus({
+            display: {
+                theme: 'light',
+                components: {
+                    clock: false,
+                },
+            },
+            localization: {
+                format: 'yyyy-MM-dd',
+            },
+        });
     };
 
     var parseEmails = function (input) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
@@ -4,7 +4,7 @@ hqDefine("hqwebapp/js/bootstrap5/widgets",[
     '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
     'hqwebapp/js/initial_page_data',
     'select2/dist/js/select2.full.min',
-    'datepicker',  // jquery plugin for tempusDominus
+    'datetimepicker',  // jquery plugin for tempusDominus
 ], function ($, _, MapboxGeocoder, initialPageData) {
     var init = function () {
         var MAPBOX_ACCESS_TOKEN = initialPageData.get(

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
@@ -1,126 +1,125 @@
 hqDefine("hqwebapp/js/bootstrap5/widgets",[
-        'jquery',
-        'underscore',
-        '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
-        'hqwebapp/js/initial_page_data',
-        'select2/dist/js/select2.full.min',
-        'jquery-ui/ui/widgets/datepicker',
-    ], function ($, _, MapboxGeocoder, initialPageData) {
-        var init = function () {
-            var MAPBOX_ACCESS_TOKEN = initialPageData.get(
-                "mapbox_access_token"
-            );
-            // .hqwebapp-select2 is a basic select2-based dropdown or multiselect
-            _.each($(".hqwebapp-select2"), function (element) {
-                $(element).select2({
-                    width: '100%',
-                });
-                if (window.USE_BOOTSTRAP5 && $(element).hasClass('is-invalid')) {
-                    $(element).data('select2').$container.addClass('is-invalid');
-                }
-                if (window.USE_BOOTSTRAP5 && $(element).hasClass('is-valid')) {
-                    $(element).data('select2').$container.addClass('is-valid');
-                }
+    'jquery',
+    'underscore',
+    '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
+    'hqwebapp/js/initial_page_data',
+    'select2/dist/js/select2.full.min',
+    'jquery-ui/ui/widgets/datepicker',
+], function ($, _, MapboxGeocoder, initialPageData) {
+    var init = function () {
+        var MAPBOX_ACCESS_TOKEN = initialPageData.get(
+            "mapbox_access_token"
+        );
+        // .hqwebapp-select2 is a basic select2-based dropdown or multiselect
+        _.each($(".hqwebapp-select2"), function (element) {
+            $(element).select2({
+                width: '100%',
             });
-
-            // .hqwebapp-autocomplete also allows for free text entry
-            _.each($(".hqwebapp-autocomplete"), function (input) {
-                var $input = $(input);
-                $input.select2({
-                    multiple: true,
-                    tags: true,
-                    width: '100%',
-                });
-            });
-
-            _.each($(".hqwebapp-autocomplete-email"), function (input) {
-                var $input = $(input);
-                $input.select2({
-                    multiple: true,
-                    placeholder: ' ',
-                    tags: true,
-                    tokenSeparators: [','],
-                    width: '100%',
-                    createTag: function (params) {
-                        // Support pasting in comma-separated values
-                        var terms = parseEmails(params.term);
-                        if (terms.length === 1) {
-                            return {
-                                id: terms[0],
-                                text: terms[0],
-                            };
-                        }
-                        $input.select2('close');
-                        var values = $input.val() || [];
-                        if (!_.isArray(values)) {
-                            values = [values];
-                        }
-                        _.each(terms, function (term) {
-                            if (!_.contains(values, term)) {
-                                $input.append(new Option(term, term));
-                                values.push(term);
-                            }
-                        });
-                        $input.val(values).trigger("change");
-
-                        return null;
-                    },
-                });
-            });
-
-            _.each($(".geocoder-proximity"), function (input) {
-                var $input = $(input).find('input');
-
-                function getGeocoderItem(item) {
-                    var inputEl = $input;
-                    var geoObj = {};
-                    geoObj.place_name = item.place_name;
-                    geoObj.coordinates = {
-                        longitude: item.geometry.coordinates[0],
-                        latitude: item.geometry.coordinates[1],
-                    };
-                    geoObj.bbox = item.bbox;
-                    inputEl.attr("value", JSON.stringify(geoObj));
-                    return item.place_name;
-                }
-
-                function getGeocoderValue() {
-                    var geocoderValue = $input.val();
-                    if (geocoderValue) {
-                        geocoderValue = JSON.parse(geocoderValue);
-                        return geocoderValue.place_name;
-                    }
-                    return null;
-                }
-
-                var geocoder = new MapboxGeocoder({
-                    accessToken: MAPBOX_ACCESS_TOKEN,
-                    types:
-                        "country,region,place,postcode,locality,neighborhood",
-                    getItemValue: getGeocoderItem,
-                });
-
-                geocoder.addTo(".geocoder-proximity");
-                var geocoderValue = getGeocoderValue();
-                if (geocoderValue) {
-                    geocoder.setInput(getGeocoderValue());
-                }
-            });
-
-            $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
-        };
-
-        var parseEmails = function (input) {
-            return $.trim(input).split(/[, ]\s*/);
-        };
-
-        $(function () {
-            init();
+            if (window.USE_BOOTSTRAP5 && $(element).hasClass('is-invalid')) {
+                $(element).data('select2').$container.addClass('is-invalid');
+            }
+            if (window.USE_BOOTSTRAP5 && $(element).hasClass('is-valid')) {
+                $(element).data('select2').$container.addClass('is-valid');
+            }
         });
 
-        return {
-            init: init,
-            parseEmails: parseEmails, // export for testing
-        };
-    }
-);
+        // .hqwebapp-autocomplete also allows for free text entry
+        _.each($(".hqwebapp-autocomplete"), function (input) {
+            var $input = $(input);
+            $input.select2({
+                multiple: true,
+                tags: true,
+                width: '100%',
+            });
+        });
+
+        _.each($(".hqwebapp-autocomplete-email"), function (input) {
+            var $input = $(input);
+            $input.select2({
+                multiple: true,
+                placeholder: ' ',
+                tags: true,
+                tokenSeparators: [','],
+                width: '100%',
+                createTag: function (params) {
+                    // Support pasting in comma-separated values
+                    var terms = parseEmails(params.term);
+                    if (terms.length === 1) {
+                        return {
+                            id: terms[0],
+                            text: terms[0],
+                        };
+                    }
+                    $input.select2('close');
+                    var values = $input.val() || [];
+                    if (!_.isArray(values)) {
+                        values = [values];
+                    }
+                    _.each(terms, function (term) {
+                        if (!_.contains(values, term)) {
+                            $input.append(new Option(term, term));
+                            values.push(term);
+                        }
+                    });
+                    $input.val(values).trigger("change");
+
+                    return null;
+                },
+            });
+        });
+
+        _.each($(".geocoder-proximity"), function (input) {
+            var $input = $(input).find('input');
+
+            function getGeocoderItem(item) {
+                var inputEl = $input;
+                var geoObj = {};
+                geoObj.place_name = item.place_name;
+                geoObj.coordinates = {
+                    longitude: item.geometry.coordinates[0],
+                    latitude: item.geometry.coordinates[1],
+                };
+                geoObj.bbox = item.bbox;
+                inputEl.attr("value", JSON.stringify(geoObj));
+                return item.place_name;
+            }
+
+            function getGeocoderValue() {
+                var geocoderValue = $input.val();
+                if (geocoderValue) {
+                    geocoderValue = JSON.parse(geocoderValue);
+                    return geocoderValue.place_name;
+                }
+                return null;
+            }
+
+            var geocoder = new MapboxGeocoder({
+                accessToken: MAPBOX_ACCESS_TOKEN,
+                types:
+                    "country,region,place,postcode,locality,neighborhood",
+                getItemValue: getGeocoderItem,
+            });
+
+            geocoder.addTo(".geocoder-proximity");
+            var geocoderValue = getGeocoderValue();
+            if (geocoderValue) {
+                geocoder.setInput(getGeocoderValue());
+            }
+        });
+
+        $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
+    };
+
+    var parseEmails = function (input) {
+        return $.trim(input).split(/[, ]\s*/);
+    };
+
+    $(function () {
+        init();
+    });
+
+    return {
+        init: init,
+        parseEmails: parseEmails, // export for testing
+    };
+});

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/widgets.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/widgets.js.diff.txt
@@ -1,251 +1,35 @@
 --- 
 +++ 
-@@ -1,125 +1,126 @@
+@@ -1,10 +1,10 @@
 -hqDefine("hqwebapp/js/bootstrap3/widgets",[
--    'jquery',
--    'underscore',
--    '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
--    'hqwebapp/js/initial_page_data',
--    'select2/dist/js/select2.full.min',
--    'jquery-ui/ui/widgets/datepicker',
--], function ($, _, MapboxGeocoder, initialPageData) {
--    var init = function () {
--        var MAPBOX_ACCESS_TOKEN = initialPageData.get(
--            "mapbox_access_token"
--        );
--        // .hqwebapp-select2 is a basic select2-based dropdown or multiselect
--        _.each($(".hqwebapp-select2"), function (element) {
--            $(element).select2({
--                width: '100%',
 +hqDefine("hqwebapp/js/bootstrap5/widgets",[
-+        'jquery',
-+        'underscore',
-+        '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
-+        'hqwebapp/js/initial_page_data',
-+        'select2/dist/js/select2.full.min',
-+        'jquery-ui/ui/widgets/datepicker',
-+    ], function ($, _, MapboxGeocoder, initialPageData) {
-+        var init = function () {
-+            var MAPBOX_ACCESS_TOKEN = initialPageData.get(
-+                "mapbox_access_token"
-+            );
-+            // .hqwebapp-select2 is a basic select2-based dropdown or multiselect
-+            _.each($(".hqwebapp-select2"), function (element) {
-+                $(element).select2({
-+                    width: '100%',
-+                });
-+                if (window.USE_BOOTSTRAP5 && $(element).hasClass('is-invalid')) {
-+                    $(element).data('select2').$container.addClass('is-invalid');
-+                }
-+                if (window.USE_BOOTSTRAP5 && $(element).hasClass('is-valid')) {
-+                    $(element).data('select2').$container.addClass('is-valid');
-+                }
-             });
--            if (window.USE_BOOTSTRAP5 && $(element).hasClass('is-invalid')) {
--                $(element).data('select2').$container.addClass('is-invalid');
--            }
--            if (window.USE_BOOTSTRAP5 && $(element).hasClass('is-valid')) {
--                $(element).data('select2').$container.addClass('is-valid');
--            }
-+
-+            // .hqwebapp-autocomplete also allows for free text entry
-+            _.each($(".hqwebapp-autocomplete"), function (input) {
-+                var $input = $(input);
-+                $input.select2({
-+                    multiple: true,
-+                    tags: true,
-+                    width: '100%',
-+                });
-+            });
-+
-+            _.each($(".hqwebapp-autocomplete-email"), function (input) {
-+                var $input = $(input);
-+                $input.select2({
-+                    multiple: true,
-+                    placeholder: ' ',
-+                    tags: true,
-+                    tokenSeparators: [','],
-+                    width: '100%',
-+                    createTag: function (params) {
-+                        // Support pasting in comma-separated values
-+                        var terms = parseEmails(params.term);
-+                        if (terms.length === 1) {
-+                            return {
-+                                id: terms[0],
-+                                text: terms[0],
-+                            };
-+                        }
-+                        $input.select2('close');
-+                        var values = $input.val() || [];
-+                        if (!_.isArray(values)) {
-+                            values = [values];
-+                        }
-+                        _.each(terms, function (term) {
-+                            if (!_.contains(values, term)) {
-+                                $input.append(new Option(term, term));
-+                                values.push(term);
-+                            }
-+                        });
-+                        $input.val(values).trigger("change");
-+
-+                        return null;
-+                    },
-+                });
-+            });
-+
-+            _.each($(".geocoder-proximity"), function (input) {
-+                var $input = $(input).find('input');
-+
-+                function getGeocoderItem(item) {
-+                    var inputEl = $input;
-+                    var geoObj = {};
-+                    geoObj.place_name = item.place_name;
-+                    geoObj.coordinates = {
-+                        longitude: item.geometry.coordinates[0],
-+                        latitude: item.geometry.coordinates[1],
-+                    };
-+                    geoObj.bbox = item.bbox;
-+                    inputEl.attr("value", JSON.stringify(geoObj));
-+                    return item.place_name;
-+                }
-+
-+                function getGeocoderValue() {
-+                    var geocoderValue = $input.val();
-+                    if (geocoderValue) {
-+                        geocoderValue = JSON.parse(geocoderValue);
-+                        return geocoderValue.place_name;
-+                    }
-+                    return null;
-+                }
-+
-+                var geocoder = new MapboxGeocoder({
-+                    accessToken: MAPBOX_ACCESS_TOKEN,
-+                    types:
-+                        "country,region,place,postcode,locality,neighborhood",
-+                    getItemValue: getGeocoderItem,
-+                });
-+
-+                geocoder.addTo(".geocoder-proximity");
-+                var geocoderValue = getGeocoderValue();
-+                if (geocoderValue) {
-+                    geocoder.setInput(getGeocoderValue());
-+                }
-+            });
-+
-+            $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
-+        };
-+
-+        var parseEmails = function (input) {
-+            return $.trim(input).split(/[, ]\s*/);
-+        };
-+
-+        $(function () {
-+            init();
+     'jquery',
+     'underscore',
+     '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
+     'hqwebapp/js/initial_page_data',
+     'select2/dist/js/select2.full.min',
+-    'jquery-ui/ui/widgets/datepicker',
++    'datetimepicker',  // jquery plugin for tempusDominus
+ ], function ($, _, MapboxGeocoder, initialPageData) {
+     var init = function () {
+         var MAPBOX_ACCESS_TOKEN = initialPageData.get(
+@@ -107,7 +107,18 @@
+             }
          });
  
--        // .hqwebapp-autocomplete also allows for free text entry
--        _.each($(".hqwebapp-autocomplete"), function (input) {
--            var $input = $(input);
--            $input.select2({
--                multiple: true,
--                tags: true,
--                width: '100%',
--            });
--        });
--
--        _.each($(".hqwebapp-autocomplete-email"), function (input) {
--            var $input = $(input);
--            $input.select2({
--                multiple: true,
--                placeholder: ' ',
--                tags: true,
--                tokenSeparators: [','],
--                width: '100%',
--                createTag: function (params) {
--                    // Support pasting in comma-separated values
--                    var terms = parseEmails(params.term);
--                    if (terms.length === 1) {
--                        return {
--                            id: terms[0],
--                            text: terms[0],
--                        };
--                    }
--                    $input.select2('close');
--                    var values = $input.val() || [];
--                    if (!_.isArray(values)) {
--                        values = [values];
--                    }
--                    _.each(terms, function (term) {
--                        if (!_.contains(values, term)) {
--                            $input.append(new Option(term, term));
--                            values.push(term);
--                        }
--                    });
--                    $input.val(values).trigger("change");
--
--                    return null;
--                },
--            });
--        });
--
--        _.each($(".geocoder-proximity"), function (input) {
--            var $input = $(input).find('input');
--
--            function getGeocoderItem(item) {
--                var inputEl = $input;
--                var geoObj = {};
--                geoObj.place_name = item.place_name;
--                geoObj.coordinates = {
--                    longitude: item.geometry.coordinates[0],
--                    latitude: item.geometry.coordinates[1],
--                };
--                geoObj.bbox = item.bbox;
--                inputEl.attr("value", JSON.stringify(geoObj));
--                return item.place_name;
--            }
--
--            function getGeocoderValue() {
--                var geocoderValue = $input.val();
--                if (geocoderValue) {
--                    geocoderValue = JSON.parse(geocoderValue);
--                    return geocoderValue.place_name;
--                }
--                return null;
--            }
--
--            var geocoder = new MapboxGeocoder({
--                accessToken: MAPBOX_ACCESS_TOKEN,
--                types:
--                    "country,region,place,postcode,locality,neighborhood",
--                getItemValue: getGeocoderItem,
--            });
--
--            geocoder.addTo(".geocoder-proximity");
--            var geocoderValue = getGeocoderValue();
--            if (geocoderValue) {
--                geocoder.setInput(getGeocoderValue());
--            }
--        });
--
 -        $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
--    };
--
--    var parseEmails = function (input) {
--        return $.trim(input).split(/[, ]\s*/);
--    };
--
--    $(function () {
--        init();
--    });
--
--    return {
--        init: init,
--        parseEmails: parseEmails, // export for testing
--    };
--});
-+        return {
-+            init: init,
-+            parseEmails: parseEmails, // export for testing
-+        };
-+    }
-+);
++        // datepicker / tempus dominus
++        $('.date-picker').tempusDominus({
++            display: {
++                theme: 'light',
++                components: {
++                    clock: false,
++                },
++            },
++            localization: {
++                format: 'yyyy-MM-dd',
++            },
++        });
+     };
+ 
+     var parseEmails = function (input) {


### PR DESCRIPTION
## Technical Summary
This updates the default date-picker widget to use Tempus Dominus instead of jQuery UI in the Bootstrap 5 version of `hqwebapp/js/widgets`. This also includes a rename update related to [this pr](https://github.com/dimagi/commcare-hq/pull/34009) and is to be merged alongside that PR.

## Safety Assurance

### Safety story
Only affects a very small set of bootstrap 5 pages. Tested on staging.

### Automated test coverage
Yes, diffs are covered.

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

unchecked due to bootstrap 5 diff complications
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
