### PR TITLE
update datatables library support (css and js) for bootstrap 5 pages

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -106,13 +106,26 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_datatables and not use_bootstrap5 %}
-      {% compress css %}
-        <link type="text/css"
-              rel="stylesheet"
-              media="all"
-              href="{% static 'datatables-bootstrap3/BS3/assets/css/datatables.css' %}" />
-      {% endcompress %}
+    {% if request.use_datatables %}
+      {% if use_bootstrap5 %}
+        {% compress css %}
+          <link type="text/css"
+                rel="stylesheet"
+                media="all"
+                href="{% static 'datatables.net-bs5/css/dataTables.bootstrap5.min.css' %}" />
+          <link type="text/css"
+                rel="stylesheet"
+                media="all"
+                href="{% static 'datatables.net-fixedcolumns-bs5/css/fixedColumns.bootstrap5.min.css' %}" />
+        {% endcompress %}
+      {% else %}
+        {% compress css %}
+          <link type="text/css"
+                rel="stylesheet"
+                media="all"
+                href="{% static 'datatables-bootstrap3/BS3/assets/css/datatables.css' %}" />
+        {% endcompress %}
+      {% endif %}
     {% endif %}
 
     {% if request.use_multiselect %}
@@ -363,12 +376,21 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_datatables and not requirejs_main and not use_bootstrap5 %}
-      {% compress js %}
-        <script src="{% static 'datatables.net/js/jquery.dataTables.min.js' %}"></script>
-        <script src="{% static 'datatables-fixedcolumns/js/dataTables.fixedColumns.js' %}"></script>
-        <script src="{% static 'datatables-bootstrap3/BS3/assets/js/datatables.js' %}"></script>
-      {% endcompress %}
+    {% if request.use_datatables and not requirejs_main %}
+      {% if use_bootstrap5 %}
+        {% compress js %}
+          <script src="{% static 'datatables.net/js/jquery.dataTables.min.js' %}"></script>
+          <script src="{% static 'datatables.net-bs5/js/dataTables.bootstrap5.min.js' %}"></script>
+          <script src="{% static 'datatables.net-fixedcolumns/js/dataTables.fixedColumns.min.js' %}"></script>
+          <script src="{% static 'datatables.net-fixedcolumns-bs5/js/fixedColumns.bootstrap5.min.js' %}"></script>
+        {% endcompress %}
+      {% else %}
+        {% compress js %}
+          <script src="{% static 'datatables.net/js/jquery.dataTables.min.js' %}"></script>
+          <script src="{% static 'datatables-fixedcolumns/js/dataTables.fixedColumns.js' %}"></script>
+          <script src="{% static 'datatables-bootstrap3/BS3/assets/js/datatables.js' %}"></script>
+        {% endcompress %}
+      {% endif %}
     {% endif %}
 
     {% if request.use_typeahead and not requirejs_main and not use_bootstrap5 %}


### PR DESCRIPTION
## Technical Summary
This makes sure we include updated css and javascript for datatables (and related extensions) in bootstrap 5 pages using the `@use_datatables` decorator.

## Safety Assurance

### Safety story
Safe change that only applies to bootstrap 5 pages using the `@use_datatables` decorator, of which there are non in production just yet.

### Automated test coverage
No

### QA Plan
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
