### PR TITLE
Update check to allow link clicks in case list rows/tiles

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -363,7 +363,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             if (!(
                 e.target.classList.contains('module-case-list-column-checkbox') ||  // multiselect checkbox
                 e.target.classList.contains("select-row-checkbox") ||               // multiselect select all
-                $(e.target).is('a') ||                                              // actual link, as in markdown
+                $(e.target).parent().is('a') ||                                     // actual link, as in markdown
                 e.target.classList.contains('show-more') ||
                 $(e.target).parent().hasClass('show-more')
             )) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -363,7 +363,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             if (!(
                 e.target.classList.contains('module-case-list-column-checkbox') ||  // multiselect checkbox
                 e.target.classList.contains("select-row-checkbox") ||               // multiselect select all
-                $(e.target).parent().is('a') ||                                     // actual link, as in markdown
+                $(e.target).closest('a').length ||                                  // actual link, as in markdown
                 e.target.classList.contains('show-more') ||
                 $(e.target).parent().hasClass('show-more')
             )) {


### PR DESCRIPTION
## Product Description
Bugfix; allows case tile/list clicks on links to go through as expected.

## Technical Summary
[USH-4138](https://dimagi-dev.atlassian.net/browse/USH-4138)
#33887 modified markdown processing of links to generate a `<u>` inside the `<a>`, effectively changing the target of a click on that link to the `<u>`. This modifies the conditional check in the case list row/tile click action to look for a direct ancestor element that is an `<a>`.

```html
<a href="#"> <!-- ancestor -->
  <u> <!-- target -->
    Link text
  </u>
</a>
```


## Safety Assurance

### Safety story
Tested locally in case tiles and case list. Very small change to case list row/tile click logic.

### QA Plan
n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4138]: https://dimagi-dev.atlassian.net/browse/USH-4138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ