### PR TITLE
[USH-4025] Add waf_allow to EditBasicProjectInfoView

### DIFF
--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -137,7 +137,7 @@ urlpatterns = [
 domain_settings = [
     url(r'^$', DefaultProjectSettingsView.as_view(), name=DefaultProjectSettingsView.urlname),
     url(r'^my_settings/$', EditMyProjectSettingsView.as_view(), name=EditMyProjectSettingsView.urlname),
-    url(r'^basic/$', 
+    url(r'^basic/$',
         waf_allow('XSS_BODY')(EditBasicProjectInfoView.as_view()), name=EditBasicProjectInfoView.urlname),
     url(r'^call_center_owner_options/', CallCenterOwnerOptionsView.as_view(),
         name=CallCenterOwnerOptionsView.url_name),

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -137,7 +137,8 @@ urlpatterns = [
 domain_settings = [
     url(r'^$', DefaultProjectSettingsView.as_view(), name=DefaultProjectSettingsView.urlname),
     url(r'^my_settings/$', EditMyProjectSettingsView.as_view(), name=EditMyProjectSettingsView.urlname),
-    url(r'^basic/$', waf_allow('XSS_BODY')(EditBasicProjectInfoView.as_view()), name=EditBasicProjectInfoView.urlname),
+    url(r'^basic/$', 
+        waf_allow('XSS_BODY')(EditBasicProjectInfoView.as_view()), name=EditBasicProjectInfoView.urlname),
     url(r'^call_center_owner_options/', CallCenterOwnerOptionsView.as_view(),
         name=CallCenterOwnerOptionsView.url_name),
     url(r'^privacy/$', EditPrivacySecurityView.as_view(), name=EditPrivacySecurityView.urlname),

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -76,6 +76,7 @@ from corehq.apps.domain.views.settings import (
     RecoveryMeasuresHistory,
 )
 from corehq.apps.domain.views.sms import SMSRatesView
+from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.integration.urls import settings_patterns as integration_settings
 from corehq.apps.linked_domain.views import DomainLinkView
 from corehq.apps.reports.dispatcher import DomainReportDispatcher
@@ -136,7 +137,7 @@ urlpatterns = [
 domain_settings = [
     url(r'^$', DefaultProjectSettingsView.as_view(), name=DefaultProjectSettingsView.urlname),
     url(r'^my_settings/$', EditMyProjectSettingsView.as_view(), name=EditMyProjectSettingsView.urlname),
-    url(r'^basic/$', EditBasicProjectInfoView.as_view(), name=EditBasicProjectInfoView.urlname),
+    url(r'^basic/$', waf_allow('XSS_BODY')(EditBasicProjectInfoView.as_view()), name=EditBasicProjectInfoView.urlname),
     url(r'^call_center_owner_options/', CallCenterOwnerOptionsView.as_view(),
         name=CallCenterOwnerOptionsView.url_name),
     url(r'^privacy/$', EditPrivacySecurityView.as_view(), name=EditPrivacySecurityView.urlname),


### PR DESCRIPTION
## Product Description
Currently some of the image upload in project settings result in 403 forbidden due to metadata attached to it. Adding a WAF rule to allow such requests.

## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-4025

From WAF logs in Athena, getting `XBODY_XSS` blocking - `[{conditiontype=XSS, location=BODY, matcheddata=[<?, ]}]`

## Feature Flag
NA

## Safety Assurance

### Safety story
https://confluence.dimagi.com/pages/viewpage.action?spaceKey=saas&title=How+traffic+gets+to+our+system%3A+Global+Accelerator%2C+ALB%2C+and+WAF

To be tested on staging

### Automated test coverage
NA

### QA Plan
NA


### Migrations
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
