### PR TITLE
tiny whitespace fix - rebuild bootstrap diffs for two files popping up due to mis-merge

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/main.js.diff.txt
@@ -33,7 +33,7 @@
 -        $("input[type='submit']", $elem).button();
          $("input[type='text'], input[type='password'], textarea", $elem);
          $('.config', $elem).wrap('<div />').parent().addClass('container block ui-corner-all');
-
+ 
 @@ -129,7 +129,7 @@
          'use strict';
          var key;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/layouts._layouts.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/layouts._layouts.style.diff.txt
@@ -23,3 +23,4 @@
 +  border-top: 1px solid $cc-neutral-hi;
    padding-top: 8px;
    margin-top:10px;
+ 


### PR DESCRIPTION
## Technical Summary
Very simple PR updating some whitespace on two files that keep popping up when building bootstrap 5 diffs. Looking at the git history, I think a mis-merge might have happened and these files were accidentally manually edited

## Safety Assurance

### Safety story
just whitespace on some diff files

### Automated test coverage
yes

### QA Plan
No



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
