### PR TITLE
Create a `match-none` case search query function

### DIFF
--- a/corehq/apps/case_search/tests/test_case_search_filters.py
+++ b/corehq/apps/case_search/tests/test_case_search_filters.py
@@ -221,3 +221,22 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             None,
             ['c1', 'c2', 'c3']
         )
+
+    def test_match_none(self):
+        self._create_case_search_config()
+        cases = [
+            {'_id': 'c1', 'case_type': 'song', 'description': 'New York'},
+            {'_id': 'c2', 'case_type': 'song', 'description': 'Manchester'},
+            {'_id': 'c3', 'case_type': 'song', 'description': 'Manchester Boston'},
+        ]
+        self._assert_query_runs_correctly(
+            self.domain,
+            cases,
+            get_case_search_query(
+                self.domain,
+                ['song'],
+                {'_xpath_query': "match-none()"},
+            ),
+            None,
+            []
+        )

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -746,6 +746,14 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
+    def test_match_none(self):
+        parsed = parse_xpath("match-none()")
+        expected_filter = {
+            "match_none": {}
+        }
+        built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
 
 @es_test(requires=[case_search_adapter], setup_class=True)
 class TestFilterDslLookups(ElasticTestMixin, TestCase):

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -229,7 +229,6 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, query, is_raw_query=True)
 
-
     @freeze_time('2021-08-02')
     def test_date_comparison__today(self):
         parsed = parse_xpath("dob >= today()")
@@ -880,7 +879,8 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         }
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
-        self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
+        self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(
+            built_filter).values_list('_id', flat=True))
 
     def test_nested_parent_lookups(self):
         parsed = parse_xpath("father/mother/house = 'Tyrell'")
@@ -917,7 +917,8 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         }
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
-        self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(built_filter).values_list('_id', flat=True))
+        self.assertEqual([self.child_case1_id, self.child_case2_id], CaseSearchES().filter(
+            built_filter).values_list('_id', flat=True))
 
     def test_subcase_exists(self):
         parsed = parse_xpath("subcase-exists('father', name='Margaery')")

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -6,7 +6,8 @@ from .query_functions import (
     within_distance,
     phonetic_match,
     starts_with,
-    match_all
+    match_all,
+    match_none
 )
 from .subcase_functions import subcase
 from .ancestor_functions import ancestor_exists
@@ -33,5 +34,6 @@ XPATH_QUERY_FUNCTIONS = {
     'phonetic-match': phonetic_match,
     'starts-with': starts_with,
     'ancestor-exists': ancestor_exists,
-    'match-all': match_all
+    'match-all': match_all,
+    'match-none': match_none,
 }

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -114,3 +114,12 @@ def match_all(node, context):
             serialize(node)
         )
     return filters.match_all()
+
+
+def match_none(node, context):
+    if len(node.args):
+        raise XPathFunctionException(
+            _("'match-none()' does not take any arguments"),
+            serialize(node)
+        )
+    return filters.match_none()

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -22,6 +22,10 @@ def match_all():
     return {"match_all": {}}
 
 
+def match_none():
+    return {"match_none": {}}
+
+
 def prefix(field, value):
     return {"prefix": {field: value}}
 


### PR DESCRIPTION
Separating this out from https://github.com/dimagi/commcare-hq/pull/33991 which included the now-defunct OR function.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Jira: [USH-4134](https://dimagi-dev.atlassian.net/browse/USH-4134?atlOrigin=eyJpIjoiMjgwYzY3M2RlZWNlNGE1ODk5YzUwZTFkYTRmYWNiZjEiLCJwIjoiaiJ9)
Sequel to https://github.com/dimagi/commcare-hq/pull/33977

Adds a `match-none` function in case search to intentionally return no results.

In the CLE, this query:

![image](https://github.com/dimagi/commcare-hq/assets/6729291/cdea7559-dd7b-4610-a203-440ecd31821d)

Returns no results:

![image](https://github.com/dimagi/commcare-hq/assets/6729291/31175955-2461-4570-a4e2-91e7c3a21095)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Purely opt-in, will not affect projects that don't use the function
- Tested thoroughly on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Tests added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

https://dimagi-dev.atlassian.net/browse/QA-6034

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change

Giving this the "invisible" label since the functions are purely opt-in.


[USH-4134]: https://dimagi-dev.atlassian.net/browse/USH-4134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ