### PR TITLE
Add some extra margin to the module-column-name to force wrapping of the text

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/module.less
@@ -15,6 +15,10 @@
   }
 }
 
+.module-column-name {
+  margin: 0 10px 0 10px;
+}
+
 .badge-container {
   position: relative;
   > .badge {


### PR DESCRIPTION
## Product Description

There was very little margin around the text on the menu selection screen causing it to get very close to the edge before wrapping. This just adds a little margin to make it break lines faster.

<img width="1292" alt="image" src="https://github.com/dimagi/commcare-hq/assets/1946138/e162f7a7-cd1e-460a-950f-d84884f3c885">


## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-4127

## Feature Flag

None

## Safety Assurance

### Safety story

Manually tested locally and on staging with the original app.

### Automated test coverage

No, just UI fiddling 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
