### PR TITLE
Add zandre-eng to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 /corehq/apps/callcenter/ @snopoke
 /corehq/apps/change_feed/ @dannyroberts
 /corehq/apps/commtrack/ @esoergel
-/corehq/apps/data_dictionary/ @esoergel @orangejenny
+/corehq/apps/data_dictionary/ @esoergel @orangejenny @zandre-eng
 /corehq/apps/domain/decorators.py @esoergel
 /corehq/apps/domain/auth.py @esoergel
 /corehq/apps/es/ @esoergel @amitphulera


### PR DESCRIPTION
## Technical Summary

Adding @zandre-eng to CODEOWNERS for the Data Dictionary

## Feature Flag
N/A

## Safety Assurance

### Safety story
N/A

### Automated test coverage
N/A

### QA Plan
N/A


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
