### PR TITLE
Fix `array items[0,2] must be unique`

### DIFF
--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -42,7 +42,6 @@ services:
     command: elasticsearch --cluster.name=${ES_CLUSTER_NAME}
     environment:
       ES_CLUSTER_NAME: ES_CLUSTER_NAME
-      ES_JAVA_OPTS: "-Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
     ports:
       - "9205:9200"
 
@@ -53,7 +52,6 @@ services:
     command: elasticsearch
     environment:
       ES_CLUSTER_NAME: ${ES_CLUSTER_NAME}
-      ES_JAVA_OPTS: "-Xms750m -Xmx750m -Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
     ports:
       - "9200:9200"
 


### PR DESCRIPTION
## Technical Summary

Implements @esoergel 's fix for the `array items[0,2] must be unique` Docker error triggered by elasticsearch environment settings.

`hq-compose-services.yml` extends `hq-compose.yml`, and `hq-compose-runserver.yml` extends `hq-compose-services.yml`, so the fact that this change drops the duplicate entries downstream in `hq-compose-services.yml` means that the values that are applicable in each file remain unchanged.

## Feature Flag
N/A

## Safety Assurance

### Safety story

* Tested locally.
* Our Docker config only impacts developers.
* Removing these duplicate entries downstream means that the values in each file have not changed.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
