### PR TITLE
Updates message to user when limiting active alerts

### DIFF
--- a/corehq/apps/domain/tests/test_views.py
+++ b/corehq/apps/domain/tests/test_views.py
@@ -334,7 +334,7 @@ class TestUpdateDomainAlertStatusView(TestBaseDomainAlertView):
         )
 
         messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(messages[0].message, 'Alert not updated. Only 3 active alerts allowed.')
+        self.assertEqual(messages[0].message, 'Alert not activated. Only 3 active alerts allowed.')
 
 
 class TestDeleteDomainAlertView(TestBaseDomainAlertView):

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -731,7 +731,7 @@ def _apply_update(request, alert):
     command = request.POST.get('command')
     if command == "activate":
         if Alert.objects.filter(created_by_domain=request.domain, active=True).count() >= MAX_ACTIVE_ALERTS:
-            messages.error(request, _("Alert not updated. Only 3 active alerts allowed."))
+            messages.error(request, _("Alert not activated. Only 3 active alerts allowed."))
             return
 
     if command in ['activate', 'deactivate']:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Minor message change from "Alert not updated. Only 3 active alerts allowed." to "Alert not activated. Only 3 active alerts allowed." when rejecting request to activate an alert in case 3 alerts are already active.

![Screenshot from 2024-01-25 03-02-16](https://github.com/dimagi/commcare-hq/assets/3864163/7ec1fe54-7412-4c8e-8197-58a50186862f)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/SC-3324

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`CUSTOM_DOMAIN_BANNER_ALERTS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
`corehq.apps.domain.tests.test_views.TestUpdateDomainAlertStatusView.test_limiting_active_alerts`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
