### PR TITLE
Remove bottom margin for gr-has-no-nested-questions

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/form.less
@@ -34,6 +34,7 @@ legend {
 }
 
 .gr-has-no-nested-questions legend {
+  margin-bottom: 0px;
   > .caption {
     display: none;
   }


### PR DESCRIPTION
## Product Description
Fixes a bug introduced with a recent deploy where nested groups with no visible questions add extra vertical spacing.

Before:
![image](https://github.com/dimagi/commcare-hq/assets/100609770/9efe9938-9fb5-4c99-8a3f-326058b03df4)

After:
![image](https://github.com/dimagi/commcare-hq/assets/100609770/f5c85726-d2bb-4d6b-b09a-9dc85309a332)

## Technical Summary
[USH-4154](https://dimagi.atlassian.net/browse/USH-4154)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
The smallest CSS change to margin, very targeted.

### Automated test coverage
n/a

### QA Plan
No QA. Support/Delivery to verify on staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4154]: https://dimagi.atlassian.net/browse/USH-4154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ