### PR TITLE
Remove progres bar while processing file validation request

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -803,6 +803,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             var self = this;
             var promise = $.Deferred();
             self.updateModelsForValidation = promise;
+            sessionStorage.validationInProgress = true;
 
             var urlObject = formplayerUtils.currentUrlToObject();
             urlObject.setQueryData({
@@ -835,7 +836,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 promise.resolve(response);
 
             });
-
+            sessionStorage.validationInProgress = false;
             return promise;
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -314,6 +314,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             this.sessionId = null;
             sessionStorage.removeItem('submitPerformed');
             sessionStorage.removeItem('geocoderValues');
+            sessionStorage.removeItem('validationInProgress');
         };
 
         this.onSubmit = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -129,7 +129,7 @@ hqDefine('cloudcare/js/utils', [
     };
 
     var formplayerLoading = function () {
-        var validationInProgress= sessionStorage.validationInProgress === undefined ?
+        var validationInProgress = sessionStorage.validationInProgress === undefined ?
             undefined : JSON.parse(sessionStorage.validationInProgress);
         if (!validationInProgress) {
             showLoading();

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -135,9 +135,7 @@ hqDefine('cloudcare/js/utils', [
     };
 
     var formplayerLoadingComplete = function (isError, message) {
-        if (!sessionStorage.validationInProgress) {
-            hideLoading();
-        }
+        hideLoading();
         if (isError) {
             showError(message || gettext('Error saving!'), $('#cloudcare-notifications'));
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -129,7 +129,9 @@ hqDefine('cloudcare/js/utils', [
     };
 
     var formplayerLoading = function () {
-        if (!(JSON.parse(sessionStorage.validationInProgress))) {
+        var validationInProgress= sessionStorage.validationInProgress === undefined ?
+            undefined : JSON.parse(sessionStorage.validationInProgress);
+        if (!validationInProgress) {
             showLoading();
         }
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -129,7 +129,7 @@ hqDefine('cloudcare/js/utils', [
     };
 
     var formplayerLoading = function () {
-        if (!sessionStorage.validationInProgress) {
+        if (!(JSON.parse(sessionStorage.validationInProgress))) {
             showLoading();
         }
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -129,11 +129,15 @@ hqDefine('cloudcare/js/utils', [
     };
 
     var formplayerLoading = function () {
-        showLoading();
+        if (!sessionStorage.validationInProgress) {
+            showLoading();
+        }
     };
 
     var formplayerLoadingComplete = function (isError, message) {
-        hideLoading();
+        if (!sessionStorage.validationInProgress) {
+            hideLoading();
+        }
         if (isError) {
             showError(message || gettext('Error saving!'), $('#cloudcare-notifications'));
         }


### PR DESCRIPTION
[USH-4044](https://dimagi.atlassian.net/browse/USH-4044)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This removes the progress bar during the validation request because the end-users found it confusing whether the search was being performed or just validated

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I looked into other methods to make this look different, rather than removing based on ticket comments and because we use `NProgress` it would be a much higher LOE to change and I reached out to delivery and they were happy with this solution

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case Search

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
There is no change other than appearance to the request

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4044]: https://dimagi.atlassian.net/browse/USH-4044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ