### PR TITLE
Appearance attribute to use hint as placeholder

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -43,6 +43,7 @@ hqDefine("cloudcare/js/form_entry/const", function () {
         MEDIUM: 'medium',
         STRIPE_REPEATS: 'stripe-repeats',
         GROUP_BORDER: 'group-border',
+        HINT_AS_PLACEHOLDER: 'hint-as-placeholder',
 
         // Note it's important to differentiate these two
         NO_PENDING_ANSWER: undefined,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -19,7 +19,7 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.entryId = _.uniqueId(this.datatype);
         self.xformAction = constants.ANSWER;
         self.xformParams = function () { return {}; };
-
+        self.placeholderText = '';
         // Returns true if the rawAnswer is valid, false otherwise
         self.isValid = function (rawAnswer) {
             return self.getErrorMessage(rawAnswer) === null;
@@ -33,6 +33,10 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         self.clear = function () {
             self.answer(constants.NO_ANSWER);
         };
+        self.useHintAsPlaceHolder = ko.computed(function () {
+            return ko.utils.unwrapObservable(question.hint) && question.stylesContains(constants.HINT_AS_PLACEHOLDER);
+        });
+        self.setPlaceHolder(self.useHintAsPlaceHolder());
         self.afterRender = function () {
             // Override with any logic that comes after rendering the Entry
         };
@@ -58,6 +62,13 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         }
         this.question.error(this.getErrorMessage(newValue));
     };
+
+    Entry.prototype.setPlaceHolder = function(hasPlaceHolder) {
+        const self = this;
+        if(hasPlaceHolder) {
+            self.placeholderText = ko.utils.unwrapObservable(self.question.hint);
+        }
+    }
 
     /**
      * Serves as the base for all entries that take an array answer.
@@ -114,7 +125,6 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         Entry.call(self, question);
         self.valueUpdate = undefined;
         self.rawAnswer = ko.observable(getRawAnswer(question.answer()));
-        self.placeholderText = '';
 
         self.rawAnswer.subscribe(self.onPreProcess.bind(self));
 
@@ -434,8 +444,9 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         var self = this;
         MultiSelectEntry.call(this, question, options);
         self.templateType = 'multidropdown';
-        self.placeholderText = gettext('Please choose an item');
-
+        if (!self.placeholderText.length) {
+            self.placeholderText = gettext('Please choose an item');
+        }
         self.afterRender = function () {
             select2ify(self, {});
         };
@@ -566,8 +577,9 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         var self = this;
         EntrySingleAnswer.call(this, question, options);
         self.templateType = 'dropdown';
-        self.placeholderText = gettext('Please choose an item');
-
+        if (!self.placeholderText.length) {
+            self.placeholderText = gettext('Please choose an item');
+        }
         self.options = ko.computed(function () {
             return [{text: "", id: undefined}].concat(_.map(question.choices(), function (choice, idx) {
                 return {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -63,12 +63,12 @@ hqDefine("cloudcare/js/form_entry/entries", function () {
         this.question.error(this.getErrorMessage(newValue));
     };
 
-    Entry.prototype.setPlaceHolder = function(hasPlaceHolder) {
+    Entry.prototype.setPlaceHolder = function (hasPlaceHolder) {
         const self = this;
-        if(hasPlaceHolder) {
+        if (hasPlaceHolder) {
             self.placeholderText = ko.utils.unwrapObservable(self.question.hint);
         }
-    }
+    };
 
     /**
      * Serves as the base for all entries that take an array answer.

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -251,9 +251,13 @@ hqDefine("cloudcare/js/form_entry/spec/entries_spec", function () {
 
         it('Should return FreeTextEntry', function () {
             questionJSON.datatype = constants.STRING;
+            questionJSON.style.raw = 'hint-as-placeholder';
+            questionJSON.hint = 'this is a hint';
             var entry = formUI.Question(questionJSON).entry;
+            entry.setPlaceHolder(entry.useHintAsPlaceHolder());
             assert.isTrue(entry instanceof entries.FreeTextEntry);
             assert.equal(entry.templateType, 'text');
+            assert.equal(entry.placeholderText, 'this is a hint');
 
             entry.answer('harry');
             this.clock.tick(1000);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -90,6 +90,7 @@ hqDefine("cloudcare/js/form_entry/spec/entries_spec", function () {
                 id: 2,
             }]);
 
+            assert.equal(entry.placeholderText, 'Please choose an item')
             entry.rawAnswer(1);
             this.clock.tick(1000);
             assert.isTrue(spy.calledOnce);
@@ -98,6 +99,31 @@ hqDefine("cloudcare/js/form_entry/spec/entries_spec", function () {
             entry.rawAnswer(2);
             this.clock.tick(1000);
             assert.isTrue(spy.calledTwice);
+        });
+
+        it('Should return MultiDropdownEntry', function () {
+            var entry;
+
+            questionJSON.datatype = constants.MULTI_SELECT;
+            questionJSON.style = { raw: constants.MINIMAL};
+            questionJSON.choices = ['a', 'b'];
+            questionJSON.answer = [1, 2]; // answer is based on a 1 indexed index of the choices
+
+            entry = formUI.Question(questionJSON).entry;
+            assert.isTrue(entry instanceof entries.MultiDropdownEntry);
+            assert.equal(entry.templateType, 'multidropdown');
+            assert.equal(entry.placeholderText, 'Please choose an item')
+
+            assert.isTrue(entry instanceof entries.MultiSelectEntry);
+            assert.sameMembers(entry.answer(), [1, 2]);
+            assert.sameMembers(entry.rawAnswer(), ['a', 'b']);
+
+            entry.answer([1]);
+            entry.choices(['a', 'c']);
+            this.clock.tick(1000);
+            assert.equal(spy.calledOnce, true);
+            assert.equal(entry.rawAnswer()[0], 'a');
+            assert.equal(entry.answer()[0], 1);
         });
 
         it('Should retain Dropdown value on options change', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -90,7 +90,7 @@ hqDefine("cloudcare/js/form_entry/spec/entries_spec", function () {
                 id: 2,
             }]);
 
-            assert.equal(entry.placeholderText, 'Please choose an item')
+            assert.equal(entry.placeholderText, 'Please choose an item');
             entry.rawAnswer(1);
             this.clock.tick(1000);
             assert.isTrue(spy.calledOnce);
@@ -112,7 +112,7 @@ hqDefine("cloudcare/js/form_entry/spec/entries_spec", function () {
             entry = formUI.Question(questionJSON).entry;
             assert.isTrue(entry instanceof entries.MultiDropdownEntry);
             assert.equal(entry.templateType, 'multidropdown');
-            assert.equal(entry.placeholderText, 'Please choose an item')
+            assert.equal(entry.placeholderText, 'Please choose an item');
 
             assert.isTrue(entry instanceof entries.MultiSelectEntry);
             assert.sameMembers(entry.answer(), [1, 2]);

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -266,7 +266,10 @@
         </div>
         <!-- /ko -->
       </div>
-      <i class="hint-text" data-bind="text: ko.utils.unwrapObservable($data.hint)"></i>
+      <i class="hint-text" data-bind="
+              text: ko.utils.unwrapObservable($data.hint),
+              visible: !entry.useHintAsPlaceHolder()
+          "></i>
       <!-- ko if: required() -->
       <span class="sr-only">{% trans "A response is required for this question." %}</span>
       <!-- /ko -->
@@ -406,6 +409,7 @@
         value: $data.rawAnswer,
         valueUpdate: valueUpdate,
         attr: {
+            placeholder: placeholderText,
             maxlength: lengthLimit,
             id: entryId,
             'aria-required': $parent.required() ? 'true' : 'false',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This adds the appearance attribute `hint-as-placeholder` that will display whatever hint text is configured as placeholder text for inputs. 
<img width="1171" alt="Screenshot 2024-01-26 at 11 54 32 AM" src="https://github.com/dimagi/commcare-hq/assets/42388648/9e5e1d28-35a5-43d5-9a5d-c70eb9bf6dc1">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4107)
[Appearance Attribute docs](https://confluence.dimagi.com/display/commcarepublic/Advanced+Web+Apps+Formatting)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
tested locally and staging


### Automated test coverage
tests added [here](https://github.com/dimagi/commcare-hq/pull/34036/commits/589c1334ea78a5a73e2a6af8c8378c8ac2b6d2cc)

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
