### PR TITLE
 End-of-form navigation manual linking advanced mode

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -201,7 +201,7 @@ hqDefine('app_manager/js/forms/form_workflow', function () {
                 gettext("Set datums required to navigate to the selected form or menu"),
                 {key: gettext("Datum ID"), value: gettext("XPath Expression")}  // placeholders
             );
-            let datumsDict = {};
+            const datumsDict = {};
             _.each(datums, function (datum) {
                 datumsDict[datum.name] = datum.xpath;
             });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -1,5 +1,6 @@
 hqDefine('app_manager/js/forms/form_workflow', function () {
     'use strict';
+    const uiElementKeyValueList = hqImport("hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list");
 
     var FormWorkflow = function (options) {
         var self = this;
@@ -143,6 +144,7 @@ hqDefine('app_manager/js/forms/form_workflow', function () {
         self.formId = ko.observable(formId);
         self.autoLink = ko.observable();
         self.allowManualLinking = ko.observable();
+        self.advancedMode = hqImport("hqwebapp/js/toggles").toggleEnabled('FORM_LINK_ADVANCED_MODE');
         self.forms = workflow.forms || [];
         self.datums = ko.observableArray();
         self.manualDatums = ko.observable(false);
@@ -191,6 +193,26 @@ hqDefine('app_manager/js/forms/form_workflow', function () {
         self.showLinkDatums = ko.computed(function () {
             return (!self.autoLink() || self.manualDatums());
         });
+
+        if (self.advancedMode) {
+            self.advancedModeDatumsElement = uiElementKeyValueList.new(
+                String(Math.random()).slice(2),  // random id
+                gettext("Manual Linking Datums"),
+                gettext("Set datums required to navigate to the selected form or menu"),
+                {key: gettext("Datum ID"), value: gettext("XPath Expression")}  // placeholders
+            );
+            let datumsDict = {};
+            _.each(datums, function (datum) {
+                datumsDict[datum.name] = datum.xpath;
+            });
+            self.advancedModeDatumsElement.val(datumsDict);
+            self.advancedModeDatumsElement.on("change", function () {
+                self.serializedDatums(JSON.stringify(_.map(this.val(), function (xpath, name) {
+                    return {name: name, xpath: xpath};
+                })));
+                workflow.$changeEl.trigger('change'); // Manually trigger change so Save button activates
+            });
+        }
 
         self.formId.subscribe(function (form_id) {
             let form = self.get_form_by_id(form_id);

--- a/corehq/apps/app_manager/static/app_manager/spec/form_workflow_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_workflow_spec.js
@@ -3,6 +3,11 @@ describe('Form Workflow', function () {
     var FormWorkflow = hqImport('app_manager/js/forms/form_workflow').FormWorkflow;
 
     describe('#workflowOptions', function () {
+        const Toggles = hqImport('hqwebapp/js/toggles'),
+            sandbox = sinon.sandbox.create();
+
+        sandbox.stub(Toggles, 'toggleEnabled').withArgs('FORM_LINK_ADVANCED_MODE').returns(true);
+
         beforeEach(function () {
             var labels = {},
                 options = {};

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -405,7 +405,7 @@ class EndOfFormNavigationWorkflow(object):
                 if child not in frame_children:
                     frame_children.append(child)
         else:
-            module_command = id_strings.menu_id(module)
+            module_command = id_strings.menu_id(module, WorkflowHelper._get_id_suffix(module))
             if module_command != id_strings.ROOT:
                 frame_children.append(CommandId(module_command))
 

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -272,16 +272,14 @@ def _get_datums_matched_to_manual_values(target_frame_elements, manual_values, f
     """
     manual_values_by_name = {datum.name: datum.xpath for datum in manual_values}
     for child in target_frame_elements:
-        if not isinstance(child, WorkflowSessionMeta) or not child.requires_selection:
+        if child.id in manual_values_by_name:
+            yield StackDatum(id=child.id, value=manual_values_by_name.get(child.id))
+        elif not isinstance(child, WorkflowSessionMeta) or not child.requires_selection:
             yield child
         else:
-            manual_value = manual_values_by_name.get(child.id)
-            if manual_value:
-                yield StackDatum(id=child.id, value=manual_value)
-            else:
-                raise SuiteValidationError("Unable to link form '{}', missing variable '{}'".format(
-                    form.default_name(), child.id
-                ))
+            raise SuiteValidationError("Unable to link form '{}', missing variable '{}'".format(
+                form.default_name(), child.id
+            ))
 
 
 def _get_datums_matched_to_source(target_frame_elements, source_datums):

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -101,42 +101,44 @@
               {% trans "Disable manual linking" %}
             </span>
           </div>
-          <div class="help-block" data-bind="visible: formLink.showLinkDatums()">
-            <button class="btn btn-default btn-xs" data-bind="click: formLink.fetchDatums">
-              <!-- ko if: formLink.datumsFetched() -->
+          <div>  {# manual linking #}
+            <div class="help-block" data-bind="visible: formLink.showLinkDatums()">
+              <button class="btn btn-default btn-xs" data-bind="click: formLink.fetchDatums">
+                <!-- ko if: formLink.datumsFetched() -->
                 {% trans "Refresh" %}
-              <!-- /ko -->
-              <!-- ko if: !formLink.datumsFetched() -->
+                <!-- /ko -->
+                <!-- ko if: !formLink.datumsFetched() -->
                 {% trans "Continue" %}
-              <!-- /ko -->
-            </button>
-          </div>
-          <div class="help-block" data-bind="visible: formLink.datumsFetched() && formLink.datums().length === 0 && !formLink.autoLink()">
-            {% trans "No additional linking required." %}
-          </div>
-          <div class="text-danger" data-bind="visible: formLink.datumsError()">
-            {% trans "Error fetching link data." %}
-          </div>
-        </div>
-      </div>
-      <div data-bind="foreach: formLink.datums, visible: formLink.datumsFetched() && formLink.datums().length">
-        <div class="form-group">
-          <div class="panel panel-appmanager">
-            <div class="panel-heading">
-              <h4 class="panel-title panel-title-nolink">
-                <span data-bind="text: name"></span>
-                <span class="label label-primary" data-bind="text: caseType"></span>
-              </h4>
+                <!-- /ko -->
+              </button>
             </div>
-            <div class="panel-body">
-              <div class="controls">
-                <textarea name="_xpath"
-                          placeholder="XPath Expression"
-                          rows="1"
-                          data-bind="text: xpath, value: xpath"
-                          class="form-control vertical-resize"
-                          spellcheck="false">
-                </textarea>
+            <div class="help-block" data-bind="visible: formLink.datumsFetched() && formLink.datums().length === 0 && !formLink.autoLink()">
+              {% trans "No additional linking required." %}
+            </div>
+            <div class="text-danger" data-bind="visible: formLink.datumsError()">
+              {% trans "Error fetching link data." %}
+            </div>
+            <div data-bind="foreach: formLink.datums, visible: formLink.datumsFetched() && formLink.datums().length">
+              <div class="form-group">
+                <div class="panel panel-appmanager">
+                  <div class="panel-heading">
+                    <h4 class="panel-title panel-title-nolink">
+                      <span data-bind="text: name"></span>
+                      <span class="label label-primary" data-bind="text: caseType"></span>
+                    </h4>
+                  </div>
+                  <div class="panel-body">
+                    <div class="controls">
+                      <textarea name="_xpath"
+                        placeholder="XPath Expression"
+                        rows="1"
+                        data-bind="text: xpath, value: xpath"
+                        class="form-control vertical-resize"
+                        spellcheck="false">
+                      </textarea>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -101,7 +101,7 @@
               {% trans "Disable manual linking" %}
             </span>
           </div>
-          <div>  {# manual linking #}
+          <!-- ko ifnot: formLink.advancedMode -->
             <div class="help-block" data-bind="visible: formLink.showLinkDatums()">
               <button class="btn btn-default btn-xs" data-bind="click: formLink.fetchDatums">
                 <!-- ko if: formLink.datumsFetched() -->
@@ -141,7 +141,10 @@
                 </div>
               </div>
             </div>
-          </div>
+          <!-- /ko -->
+          <!-- ko if: formLink.advancedMode && formLink.showLinkDatums() -->
+            <div data-bind="jqueryElement: formLink.advancedModeDatumsElement.ui"></div>
+          <!-- /ko -->
         </div>
       </div>
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/spec/mocha.html
+++ b/corehq/apps/app_manager/templates/app_manager/spec/mocha.html
@@ -2,6 +2,8 @@
 {% load hq_shared_tags %}
 
 {% block dependencies %}
+  <script src="{% static 'hqwebapp/js/bootstrap3/main.js' %}"></script>
+  <script src="{% static 'hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list.js' %}"></script>
   <script src="{% static 'app_manager/js/forms/form_workflow.js' %}"></script>
   <script src="{% static 'app_manager/js/download_async_modal.js' %}"></script>
   <script src="{% static 'app_manager/js/releases/releases.js' %}"></script>

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module.xml
@@ -245,7 +245,7 @@
     <stack>
       <create>
         <command value="'m6'"/>
-        <command value="'m7'"/>
+        <command value="'m7.m6'"/>
       </create>
     </stack>
   </entry>

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -102,7 +102,8 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
             FormLink(xpath='true()', form_id=m1f0.unique_id, form_module_id=m1.unique_id)
         ]
 
-        self.assertXmlPartialEqual(self.get_xml('form_link_create_update_case'), factory.app.create_suite(), "./entry[1]")
+        self.assertXmlPartialEqual(self.get_xml('form_link_create_update_case'),
+                                   factory.app.create_suite(), "./entry[1]")
 
     def test_with_case_management_multiple_links(self, *args):
         factory = AppFactory(build_version='2.9.0')
@@ -285,7 +286,8 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         m1f0.form_links = [
             FormLink(xpath="true()", form_id=m2f0.unique_id, form_module_id=m2.unique_id, datums=[
                 FormDatum(name='case_id', xpath="instance('commcaresession')/session/data/case_id"),
-                FormDatum(name='case_id_load_visit_0', xpath="instance('commcaresession')/session/data/case_id_new_visit_0"),
+                FormDatum(name='case_id_load_visit_0',
+                          xpath="instance('commcaresession')/session/data/case_id_new_visit_0"),
             ]),
         ]
 
@@ -346,8 +348,10 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         # so items put into the session in one step aren't available later steps
         #
         #    <datum id="case_id_A" value="instance('commcaresession')/session/data/case_id_new_A"/>
-        # -  <datum id="case_id_B" value="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_A]/index/host"/>
-        # +  <datum id="case_id_B" value="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_new_A]/index/host"/>
+        # -  <datum id="case_id_B" value="instance('casedb')/casedb/case[
+        #       @case_id=instance('commcaresession')/session/data/case_id_A]/index/host"/>
+        # +  <datum id="case_id_B" value="instance('casedb')/casedb/case[
+        #       @case_id=instance('commcaresession')/session/data/case_id_new_A]/index/host"/>
         #
         # in the above example ``case_id_A`` is being added to the session and then
         # later referenced. However since the session doesn't get updated
@@ -373,7 +377,8 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         m1f0.post_form_workflow = WORKFLOW_FORM
         m1f0.form_links = [
             FormLink(xpath="true()", form_id=m2f0.unique_id, form_module_id=m2.unique_id, datums=[
-                FormDatum(name='case_id_load_episode_0', xpath="instance('commcaresession')/session/data/case_id_new_episode_0")
+                FormDatum(name='case_id_load_episode_0',
+                          xpath="instance('commcaresession')/session/data/case_id_new_episode_0")
             ]),
         ]
 
@@ -444,7 +449,7 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
         factory.form_requires_case(m0f0)
         m0f0.post_form_workflow = WORKFLOW_MODULE
 
-        m1 = factory.new_shadow_module('shadow_module', m0, with_form=False)
+        factory.new_shadow_module('shadow_module', m0, with_form=False)
 
         expected = """
         <partial>
@@ -475,7 +480,8 @@ class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
             FormLink(xpath="true()", form_id=m1f0.unique_id, form_module_id=m1.unique_id),
         ]
 
-        self.assertXmlPartialEqual(self.get_xml('form_link_child_modules'), factory.app.create_suite(), "./entry[3]")
+        self.assertXmlPartialEqual(self.get_xml('form_link_child_modules'),
+                                   factory.app.create_suite(), "./entry[3]")
 
     def test_form_links_submodule(self, *args):
         # Test that when linking between two forms in a submodule we match up the
@@ -738,8 +744,8 @@ class TestReplaceSessionRefs(SimpleTestCase):
             CommandId('m0'),
             StackDatum(id='a', value=session_var('new_a')),
             StackDatum(id='b', value=session_var('new_b')),
-            StackDatum(id='c', value="instance('casedb')/case/[@case_id = {a}]/index/parent".format(a=session_var('a'))),
-            StackDatum(id='d', value="if({c}, {c}, {a}]".format(a=session_var('a'), c=session_var('c')))
+            StackDatum(id='c', value=f"instance('casedb')/case/[@case_id = {session_var('a')}]/index/parent"),
+            StackDatum(id='d', value=f"if({session_var('c')}, {session_var('c')}, {session_var('a')}]"),
         ]
 
         clean = _replace_session_references_in_stack(children)

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -21,10 +21,10 @@ from django.views.decorators.http import require_GET
 
 from diff_match_patch import diff_match_patch
 from lxml import etree
+from no_exceptions.exceptions import Http400
 from text_unidecode import unidecode
 
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
-from corehq.apps.hqwebapp.decorators import waf_allow
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import json_response
 
@@ -38,11 +38,11 @@ from corehq.apps.app_manager.const import (
     USERCASE_PREFIX,
     USERCASE_TYPE,
     WORKFLOW_DEFAULT,
-    WORKFLOW_ROOT,
-    WORKFLOW_PARENT_MODULE,
-    WORKFLOW_MODULE,
-    WORKFLOW_PREVIOUS,
     WORKFLOW_FORM,
+    WORKFLOW_MODULE,
+    WORKFLOW_PARENT_MODULE,
+    WORKFLOW_PREVIOUS,
+    WORKFLOW_ROOT,
 )
 from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain
 from corehq.apps.app_manager.decorators import (
@@ -53,8 +53,8 @@ from corehq.apps.app_manager.decorators import (
 from corehq.apps.app_manager.exceptions import (
     AppMisconfigurationError,
     FormNotFoundException,
-    XFormValidationFailed,
     ModuleNotFoundException,
+    XFormValidationFailed,
 )
 from corehq.apps.app_manager.helpers.validators import load_case_reserved_words
 from corehq.apps.app_manager.models import (
@@ -86,9 +86,9 @@ from corehq.apps.app_manager.util import (
     advanced_actions_use_usercase,
     enable_usercase,
     is_usercase_in_use,
-    save_xform,
     module_loads_registry_case,
     module_uses_inline_search,
+    save_xform,
 )
 from corehq.apps.app_manager.views.media_utils import handle_media_edits
 from corehq.apps.app_manager.views.notifications import notify_form_changed
@@ -101,8 +101,8 @@ from corehq.apps.app_manager.views.utils import (
     form_has_submissions,
     get_langs,
     handle_custom_icon_edits,
-    validate_custom_assertions,
     set_session_endpoint,
+    validate_custom_assertions,
 )
 from corehq.apps.app_manager.xform import (
     CaseError,
@@ -119,11 +119,11 @@ from corehq.apps.domain.decorators import (
     login_or_digest,
     track_domain_request,
 )
+from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.programs.models import Program
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
 from corehq.util.view_utils import set_file_download
-from no_exceptions.exceptions import Http400
 
 
 @no_conflict_require_POST

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -742,6 +742,18 @@ SHOW_PERSIST_CASE_CONTEXT_SETTING = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+FORM_LINK_ADVANCED_MODE = StaticToggle(
+    'form_link_advanced_mode',
+    'USH: Form linking advanced mode',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+    description=(
+        "Switches manual datum configuration for form linking to a UI where app "
+        "builders must specify the datum IDs to provide. Allows for linking to "
+        "more targets, but is way harder to use."
+    ),
+)
+
 CASE_LIST_LOOKUP = StaticToggle(
     'case_list_lookup',
     'Allow external android callouts to search the case list',


### PR DESCRIPTION
## Product Description
Adds an "advanced mode" feature flag for end of form navigation manual linking.

Without the feature flag:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/23c08a0c-8a13-4c74-af81-35bdb9a2d513)

With the feature flag:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/d03e8453-3d4f-4bdc-9351-4a10d53e9d45)


## Technical Summary
https://dimagi-dev.atlassian.net/browse/USH-3966

Note: This reorganizes https://github.com/dimagi/commcare-hq/pull/33950, which got pretty messy.  It also removes the changes to `get_form_datums`, which ended up not being useful.  Commits should be much easier to review now.


EoF navigation involves populating the stack to navigate through the app to the desired target.  Some forms and modules expect certain variables (like case IDs) to be available in the session.  Automatic linking attempts to align existing session variables with those needed to navigate to the target.  Where that isn't possible, the app builder must provide an xpath expression for each of these datum IDs.  This manual linking is also sometimes used when automatic linking doesn't do what's desired.

However, we can't always reliably get the set of datum IDs needed to get to a target without going through the full build process, especially when child and shadow modules are involved, as the datum IDs are modified at various stages in the build process.

This PR introduces an "advanced mode" feature flag for manual linking that essentially gives up trying to predict the IDs needed, and requires the user to specify all sets of IDs and xpath expressions needed to navigate to the endpoint.  This will likely be a pain to use, though build validation should catch errors here.

Depending on how this is used, we may consider an extension of this work where advanced mode is used only on a case-by-case basis, so app builders could decide whether to enable it per module, and otherwise use the existing manual linking UI (we'd need to ensure switching between the two doesn't break anything).

In testing this workflow out, we ran into a couple suite generation bugs which I've also addressed here in the last couple commits.

## Feature Flag
This adds a new feature flag: 
FORM_LINK_ADVANCED_MODE - USH: Form linking advanced mode

## Safety Assurance

### Safety story
Testing on staging.  The UI itself is pretty small, it uses an existing widget for specifying key/value pairs.  Everything should be sufficiently hidden behind the feature flag that I'm not too concerned about affecting projects that don't enable the FF.

### Automated test coverage

none

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
none


### Rollback instructions
 
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
