### PR TITLE
Refresh results on form submission: followup

### DIFF
--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -497,7 +497,7 @@ class SubmissionPost(object):
             for case_model in case_models
         ]
         try:
-            _, errors = case_search_adapter.bulk(actions, raise_errors=False)
+            _, errors = case_search_adapter.bulk(actions, raise_errors=False, refresh=True)
         except Exception as e:
             errors = [str(e)]
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Ticket here: [USH-3665](https://dimagi.atlassian.net/browse/USH-3665)
This fix was suggested by Jenny as a followup to the issue for one specific workflow (‘Skip to Default Case Search Results’ and after a form submission with EOF)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
ES docs  of refresh param [here](https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.bulk)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Case Claim

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
My understanding is that it would refresh more than needed, but not other logic changes

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3665]: https://dimagi.atlassian.net/browse/USH-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ