### PR TITLE
Prevent adblock from interfering with updating a user

### DIFF
--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -165,9 +165,8 @@ hqDefine('users/js/edit_commcare_user', [
 
     // Analytics
     $("button:submit", $userInformationForm).on("click", function () {
-        googleAnalytics.track.event("Edit Mobile Worker", "Updated user info", couchUserId, "", {}, function () {
-            $userInformationForm.submit();
-        });
+        $userInformationForm.submit();
+        googleAnalytics.track.event("Edit Mobile Worker", "Updated user info", couchUserId, "", {});
         return false;
     });
 });


### PR DESCRIPTION
## Technical Summary
Addresses the issue mentioned in https://dimagi.atlassian.net/browse/SAAS-14976. This was caused by an interaction with adblock, where the critical call, to submit the form, was gated behind the analytics call succeeding. When adblock prevented the call from succeeding, the form was never submitted, and no error was raised to the user

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Verified this behavior and the fix locally.

### Automated test coverage

No tests added

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
