### PR TITLE
Run migrate_to_conditional_case_update on snapshot domains

### DIFF
--- a/corehq/apps/app_manager/management/commands/migrate_to_conditional_case_update.py
+++ b/corehq/apps/app_manager/management/commands/migrate_to_conditional_case_update.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+import traceback
+import random
+from corehq.apps.app_manager.dbaccessors import wrap_app
+from corehq.apps.app_manager.management.commands.helpers import AppMigrationCommandBase, get_deleted_app_ids
+from corehq.apps.domain.models import Domain
+
+
+def get_new_case_update_json(name_path):
+    return {
+        'question_path': name_path,
+        'update_mode': 'always'
+    }
+
+
+class Command(AppMigrationCommandBase):
+    help = """
+    One-time migration to transition form action models to use ConditionalCaseUpdate as part of the new
+    "save only if edited" feature: https://github.com/dimagi/commcare-hq/pull/30910.
+    """
+
+    include_linked_apps = True
+    include_builds = True
+    chunk_size = 5
+    DOMAIN_LIST_FILENAME = "migrate_to_cond_case_update_cmd_domain_list.txt"
+    DOMAIN_PROGRESS_NUMBER_FILENAME = "migrate_to_cond_case_update_cmd_domain_progress.txt"
+    APP_WRAPPING_ERRORS_LOG = "migrate_to_cond_case_update_wrapping_errors.txt"
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+
+        # Used for a dry run on 1000 domains to get a taste of how long a full migration would take.
+        parser.add_argument(
+            '--num-domains-test',
+            action='store',
+            default=None,
+            help='''For a dry run, use this argument to test on X number of domains. Dry run flag must be
+                    included and domain flag cannot be included.''',
+        )
+        parser.add_argument(
+            '--deleted-apps-only',
+            action='store_true',
+            default=False,
+            help='''Only include deleted apps in the migration.''',
+        )
+
+    def _has_been_migrated(self, app_doc):
+        for module in app_doc['modules']:
+            for form in module['forms']:
+                if module['module_type'] == "basic":
+                    actions = form.get('actions', '')
+                    if actions:
+                        open_case_action = actions.get('open_case', '')
+                        if open_case_action:
+                            if (open_case_action.get('name_update', '')
+                            and not open_case_action.get('name_path', '')):
+                                return True
+                            if open_case_action.get('name_path', ''):
+                                return False
+                elif module['module_type'] == "advanced":
+                    for form in module['forms']:
+                        if form['form_type'] == 'advanced_form':
+                            actions = form.get('actions', '')
+                            if actions:
+                                open_case_action = actions.get('open_cases', '')[0] \
+                                    if actions.get('open_cases', '') else None
+                                if open_case_action:
+                                    if (open_case_action.get('name_update', '')
+                                    and not open_case_action.get('name_path', '')):
+                                        return True
+                                    if open_case_action.get('name_path', ''):
+                                        return False
+        # Catch-all; if it's all surveys or something else strange, migrate it by default
+        return False
+
+    def migrate_app(self, app_doc):
+        if self._has_been_migrated(app_doc):
+            return None
+        else:
+            try:
+                wrapped_app = wrap_app(app_doc)
+                return wrapped_app
+            except Exception as e:
+                print(e)
+                self.log_error(app_doc)
+                return None
+
+    @property
+    def num_domains_test(self):
+        return self.options.get('num_domains_test', None)
+
+    def get_domains(self):
+        if self.is_dry_run and self.num_domains_test:
+            all_domain_names = Domain.get_all_names()
+            random.shuffle(all_domain_names)
+            return all_domain_names[:int(self.num_domains_test)]
+        else:
+            return Domain.get_all_names()
+
+    def log_error(self, app_doc):
+        with open(self.APP_WRAPPING_ERRORS_LOG, 'a') as f:
+            error_string = (f"{datetime.now()}\nOn domain: {app_doc['domain']}, "
+                            f"App ID: {app_doc['_id']}\n{traceback.format_exc().strip()}\n")
+            f.write(error_string)
+
+    def get_app_ids(self, domain=None):
+        if self.options.get('deleted_apps_only', None):
+            if not domain:
+                raise Exception("Getting deleted app IDs requires a domain.")
+            return get_deleted_app_ids(domain)
+        else:
+            return super().get_app_ids(domain)

--- a/corehq/apps/app_manager/management/commands/migrate_to_conditional_case_update.py
+++ b/corehq/apps/app_manager/management/commands/migrate_to_conditional_case_update.py
@@ -90,12 +90,19 @@ class Command(AppMigrationCommandBase):
         return self.options.get('num_domains_test', None)
 
     def get_domains(self):
+        domain_objs = Domain.view(
+            "domain/snapshots",
+            startkey=[],
+            endkey=[{}],
+            include_docs=True,
+            reduce=False,
+        )
+
+        all_domain_names = [d.name for d in domain_objs]
         if self.is_dry_run and self.num_domains_test:
-            all_domain_names = Domain.get_all_names()
             random.shuffle(all_domain_names)
-            return all_domain_names[:int(self.num_domains_test)]
-        else:
-            return Domain.get_all_names()
+            all_domain_names = all_domain_names[:int(self.num_domains_test)]
+        return all_domain_names
 
     def log_error(self, app_doc):
         with open(self.APP_WRAPPING_ERRORS_LOG, 'a') as f:

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -745,3 +745,23 @@ def extract_instance_id_from_nodeset_ref(nodeset):
     if nodeset:
         matches = re.findall(r"instance\('(.*?)'\)", nodeset)
         return matches[0] if matches else None
+
+
+def wrap_transition_from_old_update_case_action(properties_dict):
+    """
+    This function assists wrap functions for changes to the FormActions and AdvancedFormActions models.
+    A modification of UpdateCaseAction to use a ConditionalCaseUpdate instead of a simple question path
+    was part of these changes. It also used as part of a follow-up migration.
+    """
+    if(properties_dict):
+        first_prop_value = list(properties_dict.values())[0]
+        # If the dict just holds question paths (strings) as values we want to translate the old
+        # type of UpdateCaseAction model to the new.
+        if isinstance(first_prop_value, str):
+            new_dict_values = {}
+            for case_property, question_path in properties_dict.items():
+                new_dict_values[case_property] = {
+                    'question_path': question_path
+                }
+            return new_dict_values
+    return properties_dict

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -310,9 +310,9 @@ def languages_mapping():
     if not mapping:
         with open('submodules/langcodes/langs.json', encoding='utf-8') as langs_file:
             lang_data = json.load(langs_file)
-            mapping = dict([(l["two"], l["names"]) for l in lang_data])
+            mapping = dict([(lang["two"], lang["names"]) for lang in lang_data])
         mapping["default"] = ["Default Language"]
-        cache.set('__languages_mapping', mapping, 12*60*60)
+        cache.set('__languages_mapping', mapping, 12 * 60 * 60)
     return mapping
 
 
@@ -358,8 +358,9 @@ def get_commcare_builds(request_user):
 
 
 def actions_use_usercase(actions):
-    return (('usercase_update' in actions and actions['usercase_update'].update) or
-            ('usercase_preload' in actions and actions['usercase_preload'].preload))
+    return ("usercase_update" in actions and actions["usercase_update"].update) or (
+        "usercase_preload" in actions and actions["usercase_preload"].preload
+    )
 
 
 def advanced_actions_use_usercase(actions):
@@ -407,10 +408,9 @@ def module_offers_search(module):
     from corehq.apps.app_manager.models import AdvancedModule, Module, ShadowModule
 
     return (
-        isinstance(module, (Module, AdvancedModule, ShadowModule)) and
-        module.search_config
-        and (module.search_config.properties
-        or module.search_config.default_properties)
+        isinstance(module, (Module, AdvancedModule, ShadowModule))
+        and module.search_config
+        and (module.search_config.properties or module.search_config.default_properties)
     )
 
 
@@ -589,7 +589,9 @@ def get_sort_and_sort_only_columns(detail_columns, sort_elements):
             except IndexError:
                 raise AppManagerException(f"Sort column references an unknown column at index: {column_index}")
             if not column.useXpathExpression:
-                raise AppManagerException(f"Calculation sort column references an incorrect column: {column.field}")
+                raise AppManagerException(
+                    f"Calculation sort column references an incorrect column: {column.field}"
+                )
             sort_columns[column.field] = (element, element_order)
 
     sort_only_elements = [
@@ -753,7 +755,7 @@ def wrap_transition_from_old_update_case_action(properties_dict):
     A modification of UpdateCaseAction to use a ConditionalCaseUpdate instead of a simple question path
     was part of these changes. It also used as part of a follow-up migration.
     """
-    if(properties_dict):
+    if properties_dict:
         first_prop_value = list(properties_dict.values())[0]
         # If the dict just holds question paths (strings) as values we want to translate the old
         # type of UpdateCaseAction model to the new.


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-14775

@millerdev and I paired on this bug, which is essentially that a 500 error is returned when viewing an app in a snapshot domain. After digging into this (see [this comment](https://dimagi.atlassian.net/browse/SAAS-14775?focusedCommentId=308663) for more details), we discovered that the cause was that apps that were part of snapshot domains were not included in a migration that was run to update the schema of the UpdateCaseAction form action.

This PR reverts two commits which removed code that is now necessary to "complete" this migration. The first is the management command `migrate_to_conditional_case_update`, and the other is reverting the commit that removed the wrap methods for FormAction subclasses that is necessary to properly wrap the application in the updated format.

There is no intention to merge this PR, but rather to create a private release on each SaaS environment, and ensure that snapshot domains are migrated.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The impacted snapshot domain apps have raised a 500 when attempting to access them for almost a year now, so we can only go up from here 😄
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Nope

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
