### PR TITLE
Generate user link with additional parameter

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1817,9 +1817,6 @@ def _get_raw_user_link(user, url, filter_class, additional_params=None):
     - str: A string containing an HTML anchor tag (<a>) with the constructed URL and the user's display name.
     """
     user_link_template = '<a href="{link}?{params}">{username}</a>'
-    additional_param_string = ''
-    if additional_params:
-        additional_param_string = '&' + urlencode(additional_params)
     user_link = format_html(
         user_link_template,
         link=url,

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1823,7 +1823,7 @@ def _get_raw_user_link(user, url, filter_class, additional_params=None):
     user_link = format_html(
         user_link_template,
         link=url,
-        params=urlencode(filter_class.for_user(user.user_id)) + additional_param_string,
+        params=urlencode(filter_class.for_user(user.user_id) | (additional_params or {})),
         username=user.username_in_report,
     )
     return user_link

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1819,10 +1819,7 @@ def _get_raw_user_link(user, url, filter_class, additional_params=None):
     user_link_template = '<a href="{link}?{params}">{username}</a>'
     additional_param_string = ''
     if additional_params:
-        if isinstance(additional_params, dict):
-            additional_param_string = '&' + urlencode(additional_params)
-        else:
-            raise ValueError("additional_params must be a dictionary")
+        additional_param_string = '&' + urlencode(additional_params)
     user_link = format_html(
         user_link_template,
         link=url,

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -965,10 +965,8 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
 
     def get_raw_user_link(self, user):
         from corehq.apps.reports.standard.inspect import SubmitHistory
-        sub_time_param = {
-            CompletionOrSubmissionTimeFilter.slug:
-            CompletionOrSubmissionTimeFilter.get_value(self.request, self.domain) or ''
-        }
+        value = CompletionOrSubmissionTimeFilter.get_value(self.request, self.domain)
+        sub_time_param = {CompletionOrSubmissionTimeFilter.slug: value} if value else None
         return _get_raw_user_link(user, SubmitHistory.get_url(domain=self.domain),
                                   filter_class=EMWF, additional_params=sub_time_param)
 

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -965,8 +965,12 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
 
     def get_raw_user_link(self, user):
         from corehq.apps.reports.standard.inspect import SubmitHistory
+        sub_time_param = {
+            CompletionOrSubmissionTimeFilter.slug:
+            CompletionOrSubmissionTimeFilter.get_value(self.request, self.domain) or ''
+        }
         return _get_raw_user_link(user, SubmitHistory.get_url(domain=self.domain),
-                                  filter_class=EMWF)
+                                  filter_class=EMWF, additional_params=sub_time_param)
 
     @property
     def template_context(self):
@@ -1799,16 +1803,32 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
         return rows
 
 
-def _get_raw_user_link(user, url, filter_class):
+def _get_raw_user_link(user, url, filter_class, additional_params=None):
     """
-    filter_class is expected to be either ExpandedMobileWorkerFilter or a
-    subclass of it, such as the CaseListFilter
+    Generates an HTML anchor tag (<a>) for a user link with additional query parameters.
+
+    Parameters:
+    - user (SimplifiedUserInfo object): The user for whom the link is being generated.
+    - url (str): The base URL to which filter parameters and any additional parameters will be appended.
+    - filter_class (class): A filter class expected to be either ExpandedMobileWorkerFilter or a subclass of it,
+    such as CaseListFilter.
+    - additional_params (dict, optional): An optional dictionary of additional query parameters to be appended to
+    the URL. Each key-value pair in the dictionary represents a parameter name and its value.
+
+    Returns:
+    - str: A string containing an HTML anchor tag (<a>) with the constructed URL and the user's display name.
     """
     user_link_template = '<a href="{link}?{params}">{username}</a>'
+    additional_param_string = ''
+    if additional_params:
+        if isinstance(additional_params, dict):
+            additional_param_string = '&' + urlencode(additional_params)
+        else:
+            raise ValueError("additional_params must be a dictionary")
     user_link = format_html(
         user_link_template,
         link=url,
-        params=urlencode(filter_class.for_user(user.user_id)),
+        params=urlencode(filter_class.for_user(user.user_id)) + additional_param_string,
         username=user.username_in_report,
     )
     return user_link


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
In Report > Daily Form Activity, we have following filters:
<img width="715" alt="image" src="https://github.com/dimagi/commcare-hq/assets/39149002/e3163428-8498-4104-a639-524920bcd149">

If we click on any of the results, it will navigates to Submit History of that user.
Only the user group filter and the date range filter will be saved, but not the "Filter Dates by Submission Time or Completion Time"

After the change, now the "Filter Dates by Submission Time or Completion Time" filter will be saved when user navigates to Submit History.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket:  https://dimagi.atlassian.net/browse/SAAS-15169

Modified `_get_raw_user_link` to accept an `additional_param` argument, enabling the inclusion of extra query parameters in user links. The argument is optional, so it won't affect other functions that calling `_get_raw_user_link`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Tested locally and on staging. Will also request QA.
- The change will be limited to Daily Form Activity's report's user link.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA Ticket: https://dimagi.atlassian.net/browse/QA-6063

QA should go to Daily Form Activity, try different combination of filters, and observed that:  when navigate to Submit History by clicking on the user name in the reports, all filters should be saved. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
