### PR TITLE
Change default font size in web apps forms to 16px

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -1,10 +1,11 @@
 @form-text-indent: 20px;
+@form-text-size: 16px;
 
 .form-container {
   background-color: white;
   .box-shadow(0 0 10px 2px rgba(0,0,0,.1));
   margin-bottom: 2rem;
-  font-size: @font-size-base;   // Don't overshadow inputs
+  font-size: @form-text-size;   // Don't overshadow inputs
 
   .page-header {
     padding-bottom: 30px;
@@ -17,6 +18,10 @@
   .controls {
     padding-right: 25px;
     padding-top: 3px;
+  }
+
+  .form-control {
+    font-size: @form-text-size;
   }
 
   .form-actions {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR changes the base font size in web apps FORMS from 12px to 16px. Affects form labels and input font size.

In response to [this ticket](https://dimagi.atlassian.net/browse/USH-4054?atlOrigin=eyJpIjoiMDk3MWZhODdlMzIzNGQ4YTgyMmQ1NTQyOGZhYTY4ZDciLCJwIjoiaiJ9).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Client wants to decrease information density.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Test locally and on staging
- Can only affect CSS/font size

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
