### PR TITLE
Fix invalid profile errors presented with field data errors

### DIFF
--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -143,13 +143,14 @@ class CustomDataFieldsForm(forms.Form):
 
     def clean(self):
         cleaned_data = super().clean()
-        data_fields = self.cleaned_data.get('data_fields', [])
+        data_fields = self.cleaned_data.get('data_fields')
         profiles = self.cleaned_data.get('profiles', [])
 
         errors = set()
         errors.update(self.verify_no_duplicate_profiles(profiles))
-        errors.update(self.verify_no_profiles_missing_fields(data_fields, profiles))
-        errors.update(self.verify_profiles_validate(data_fields, profiles))
+        if data_fields is not None:
+            errors.update(self.verify_no_profiles_missing_fields(data_fields, profiles))
+            errors.update(self.verify_profiles_validate(data_fields, profiles))
 
         if errors:
             separator = mark_safe('<br/>')  # nosec: no user input

--- a/corehq/apps/custom_data_fields/tests/test_edit_model.py
+++ b/corehq/apps/custom_data_fields/tests/test_edit_model.py
@@ -43,7 +43,24 @@ def fields_are_equal(left, right):
     return left.to_dict() == right.to_dict()
 
 
-class TestEditModel(TestCase):
+class FieldsViewMixin:
+
+    def create_field(self, slug='test_field', label='Test Field', is_required=False, choices=[], regex=None,
+            regex_msg=None, upstream_id=None):
+        return Field(
+            slug=slug,
+            label=label,
+            is_required=is_required,
+            choices=choices,
+            regex=regex,
+            regex_msg=regex_msg,
+            upstream_id=upstream_id,
+        )
+
+    _create_field = create_field
+
+
+class TestEditModel(FieldsViewMixin, TestCase):
     domain = 'test-domain'
 
     def test_saves_custom_fields(self):
@@ -82,18 +99,6 @@ class TestEditModel(TestCase):
         self.assertEqual(str(messages[0]),
             "Could not update 'ExistingField'. You do not have the appropriate role")
 
-    def _create_field(self, slug='test_field', label='Test Field', is_required=False, choices=[], regex=None,
-            regex_msg=None, upstream_id=None):
-        return Field(
-            slug=slug,
-            label=label,
-            is_required=is_required,
-            choices=choices,
-            regex=regex,
-            regex_msg=regex_msg,
-            upstream_id=upstream_id,
-        )
-
     def _create_initial_fields(self, fields):
         definition = CustomDataFieldsDefinition.objects.create(field_type='UserFields', domain=self.domain)
         definition.set_fields(fields)
@@ -104,7 +109,7 @@ class TestEditModel(TestCase):
         return request
 
 
-class TestValidateIncomingFields(SimpleTestCase):
+class TestValidateIncomingFields(FieldsViewMixin, SimpleTestCase):
     def test_no_conflicts_produces_no_errors(self):
         existing_fields = [self.create_field(is_required=False)]
         new_fields = [self.create_field(is_required=True)]
@@ -191,14 +196,3 @@ class TestValidateIncomingFields(SimpleTestCase):
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0], "Could not update 'two'. Synced data cannot be created this way")
 
-    def create_field(self, slug='test_field', label='Test Field', is_required=False, choices=[], regex=None,
-            regex_msg=None, upstream_id=None):
-        return Field(
-            slug=slug,
-            label=label,
-            is_required=is_required,
-            choices=choices,
-            regex=regex,
-            regex_msg=regex_msg,
-            upstream_id=upstream_id
-        )


### PR DESCRIPTION
Fixes [Incorrect validation message shown when creating user field without label](https://dimagi.atlassian.net/browse/SAAS-15131)

Introduced in https://github.com/dimagi/commcare-hq/pull/28208

The first commit is a prefactor. :fish: Review by commit.

## Safety Assurance

### Safety story

Small adjustment to user profiles validation.

### Automated test coverage

A test was written and verified to reproduce the bug before it was fixed.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations