### PR TITLE
Remove Margins added to page with SCCS and Map after case search

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1161,10 +1161,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             }
         },
 
-        onBeforeDetach: function () {
-            CaseTileListView.__super__.onBeforeDetach.apply(this, arguments);
-            $('#content-container').removeClass('full-width');
-        },
     });
 
     const CaseTileGroupedListView = CaseTileListView.extend({


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This change keeps split screen case search a full width. Previously, searching again after already being already showing `CaseTileListView` would remove the full width.

Existing behavior shown below:

https://github.com/dimagi/commcare-hq/assets/88759246/9463ec8d-ef30-403e-8dba-859040c9fa37

New shown below:

https://github.com/dimagi/commcare-hq/assets/88759246/3c9e9635-3418-4b80-b160-1bbd1f73e62f


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-4155 
](https://dimagi.atlassian.net/browse/USH-4155?focusedCommentId=308907&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-308907)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[Split Screen Case Search](https://www.commcarehq.org/hq/flags/edit/split_screen_case_search/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested. Change does not affect data and only visual.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated tests exist

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
