### PR TITLE
Excludes copied cases from the dedeuplication report

### DIFF
--- a/corehq/apps/data_interfaces/deduplication.py
+++ b/corehq/apps/data_interfaces/deduplication.py
@@ -6,8 +6,8 @@ from corehq.apps.case_search.const import SPECIAL_CASE_PROPERTIES_MAP
 from corehq.apps.data_interfaces.utils import iter_cases_and_run_rules
 from corehq.apps.es import queries
 from corehq.apps.es.case_search import CaseSearchES, case_property_missing
-from corehq.messaging.util import MessagingRuleProgressHelper
 from corehq.apps.locations.dbaccessors import user_ids_at_locations
+from corehq.messaging.util import MessagingRuleProgressHelper
 
 DUPLICATE_LIMIT = 1000
 DEDUPE_XMLNS = 'http://commcarehq.org/hq_case_deduplication_rule'
@@ -16,8 +16,8 @@ DEDUPE_XMLNS = 'http://commcarehq.org/hq_case_deduplication_rule'
 def _get_es_filtered_case_query(domain, case, case_filter_criteria=None):
     # Import here to avoid circular import error
     from corehq.apps.data_interfaces.models import (
+        LocationFilterDefinition,
         MatchPropertyDefinition,
-        LocationFilterDefinition
     )
 
     if case_filter_criteria is None:

--- a/corehq/apps/data_interfaces/deduplication.py
+++ b/corehq/apps/data_interfaces/deduplication.py
@@ -67,7 +67,8 @@ def find_duplicate_case_ids(
     case_properties,
     include_closed=False,
     match_type="ALL",
-    case_filter_criteria=None
+    case_filter_criteria=None,
+    exclude_copied_cases=True,
 ):
     if case_filter_criteria is None:
         case_filter_criteria = []
@@ -76,6 +77,10 @@ def find_duplicate_case_ids(
 
     if not include_closed:
         es = es.is_closed(False)
+
+    if exclude_copied_cases:
+        from corehq.apps.hqcase.case_helper import CaseCopier
+        es = es.case_property_missing(CaseCopier.COMMCARE_CASE_COPY_PROPERTY_NAME)
 
     clause = queries.MUST if match_type == "ALL" else queries.SHOULD
     _case_json = None

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -23,6 +23,7 @@ from jsonobject.properties import (
 from memoized import memoized
 
 from casexml.apps.case.xform import get_case_updates
+from corehq.apps.hqcase.case_helper import CaseCopier
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from dimagi.utils.chunked import chunked
 from dimagi.utils.couch import CriticalSection
@@ -1115,6 +1116,9 @@ class CaseDeduplicationActionDefinition(BaseUpdateCaseDefinition):
         return all_match or any_match
 
     def when_case_matches(self, case, rule):
+        if CaseCopier.COMMCARE_CASE_COPY_PROPERTY_NAME in case.case_json:
+            return CaseRuleActionResult()
+
         domain = case.domain
         new_duplicate_case_ids = set(find_duplicate_case_ids(
             domain,

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -23,7 +23,6 @@ from jsonobject.properties import (
 from memoized import memoized
 
 from casexml.apps.case.xform import get_case_updates
-from corehq.apps.hqcase.case_helper import CaseCopier
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from dimagi.utils.chunked import chunked
 from dimagi.utils.couch import CriticalSection
@@ -40,7 +39,7 @@ from corehq.apps.data_interfaces.deduplication import (
     reset_deduplicate_rule,
 )
 from corehq.apps.data_interfaces.utils import property_references_parent
-from corehq.apps.hqcase.utils import bulk_update_cases, update_case, AUTO_UPDATE_XMLNS
+from corehq.apps.hqcase.utils import bulk_update_cases, update_case, AUTO_UPDATE_XMLNS, is_copied_case
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.apps.users.cases import get_wrapped_owner
 from corehq.form_processor.models import DEFAULT_PARENT_IDENTIFIER
@@ -1116,7 +1115,7 @@ class CaseDeduplicationActionDefinition(BaseUpdateCaseDefinition):
         return all_match or any_match
 
     def when_case_matches(self, case, rule):
-        if CaseCopier.COMMCARE_CASE_COPY_PROPERTY_NAME in case.case_json:
+        if is_copied_case(case):
             return CaseRuleActionResult()
 
         domain = case.domain

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -300,3 +300,9 @@ def get_deidentified_data(case, censor_data):
                 attrs[attr_or_prop] = censored_value
 
     return attrs, props
+
+
+def is_copied_case(case):
+    """Returns True if the case was created by copying an existing case using the 'COPY_CASES' feature"""
+    from corehq.apps.hqcase.case_helper import CaseCopier
+    return CaseCopier.COMMCARE_CASE_COPY_PROPERTY_NAME in case.case_json


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The results obtained from deduplication report will no longer contain the cases that were copied using the Copy Cases Feature.

**Before**: 
![image](https://github.com/dimagi/commcare-hq/assets/125016806/2c560af5-8749-4c7f-8671-d02b6f5aba82)

**After the fix**:
![image](https://github.com/dimagi/commcare-hq/assets/125016806/8d5359ad-41bc-49c5-b250-f5f2d63dbe34)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3152

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CASE_DEDUPE
COPY_CASES

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The change is limited to reports using the said feature flags . Testing done on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test cases were added/updated.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-6073

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
