### PR TITLE
Restore SMS SSL verification

### DIFF
--- a/corehq/messaging/smsbackends/http/models.py
+++ b/corehq/messaging/smsbackends/http/models.py
@@ -1,4 +1,3 @@
-import ssl
 import sys
 
 from django.conf import settings
@@ -54,6 +53,10 @@ class SQLHttpBackend(SQLSMSBackend):
     def url(self):
         return self.config.url
 
+    @property
+    def extra_urlopen_kwargs(self):
+        return {}
+
     def send(self, msg, *args, **kwargs):
         config = self.config
         if config.additional_params:
@@ -74,19 +77,18 @@ class SQLHttpBackend(SQLSMSBackend):
 
         url_params = urlencode(params)
         try:
-            unverified = ssl._create_unverified_context()
             if config.method == "GET":
                 urlopen(
                     "%s?%s" % (config.url, url_params),
-                    context=unverified,
                     timeout=settings.SMS_GATEWAY_TIMEOUT,
+                    **self.extra_urlopen_kwargs,
                 ).read()
             else:
                 urlopen(
                     config.url,
                     url_params,
-                    context=unverified,
                     timeout=settings.SMS_GATEWAY_TIMEOUT,
+                    **self.extra_urlopen_kwargs,
                 ).read()
         except Exception as e:
             msg = "Error sending message from backend: '{}'\n\n{}".format(self.pk, str(e))

--- a/corehq/messaging/smsbackends/http/models.py
+++ b/corehq/messaging/smsbackends/http/models.py
@@ -4,8 +4,8 @@ import sys
 from django.conf import settings
 
 import six
-from six.moves.urllib.parse import urlencode
-from six.moves.urllib.request import urlopen
+from urllib.parse import urlencode
+from urllib.request import urlopen
 
 from corehq.apps.sms.mixin import BackendProcessingException
 from corehq.apps.sms.models import SQLSMSBackend

--- a/corehq/messaging/smsbackends/http/tests/test_models.py
+++ b/corehq/messaging/smsbackends/http/tests/test_models.py
@@ -9,6 +9,8 @@ from .. import models
 
 
 class TestHttpBackend(SimpleTestCase):
+    backend_model = SQLHttpBackend
+
     @patch.object(models, 'urlopen')
     def test_sends_without_error(self, mock_urlopen):
         message = self._create_message(phone_number='1234567890', text='Hello World')
@@ -16,7 +18,7 @@ class TestHttpBackend(SimpleTestCase):
 
         backend.send(message)
         mock_urlopen.assert_called_with('http://www.dimagi.com?message=Hello+World&number=1234567890',
-            context=ANY, timeout=ANY)
+            timeout=ANY)
 
     @hostname_resolving_to_ips('malicious.address', ['127.0.0.1'])
     @patch.object(SMS, 'save')  # mocked to avoid the database
@@ -29,7 +31,7 @@ class TestHttpBackend(SimpleTestCase):
 
     def _create_backend(self, url='http://www.dimagi.com',
             message_param='message', number_param='number', method='GET'):
-        return SQLHttpBackend(extra_fields={
+        return self.backend_model(extra_fields={
             'url': url,
             'message_param': message_param,
             'number_param': number_param,

--- a/corehq/messaging/smsbackends/sislog/models.py
+++ b/corehq/messaging/smsbackends/sislog/models.py
@@ -1,3 +1,4 @@
+import ssl
 from corehq.messaging.smsbackends.http.models import SQLHttpBackend
 
 
@@ -18,3 +19,7 @@ class SQLSislogBackend(SQLHttpBackend):
     @staticmethod
     def _encode_http_message(text):
         return text.encode("utf-8")
+
+    @property
+    def extra_urlopen_kwargs(self):
+        return {'context': ssl._create_unverified_context()}

--- a/corehq/messaging/smsbackends/sislog/tests/test_backend.py
+++ b/corehq/messaging/smsbackends/sislog/tests/test_backend.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch, ANY
+
+from ..models import SQLSislogBackend
+from ...http import models as http_models
+from ...http.tests.test_models import TestHttpBackend
+
+
+class TestSQLSislogBackend(TestHttpBackend):
+    backend_model = SQLSislogBackend
+
+    @patch.object(http_models, 'urlopen')
+    def test_sends_without_error(self, mock_urlopen):
+        message = self._create_message(phone_number='1234567890', text='Hello World')
+        backend = self._create_backend(url='http://www.dimagi.com')
+
+        backend.send(message)
+        mock_urlopen.assert_called_with(
+            'http://www.dimagi.com?message=Hello+World&number=1234567890',
+            context=ANY,
+            timeout=ANY,
+        )


### PR DESCRIPTION
Previously SSL verification was intended to be disabled for one particular backend (Sislog), but the implementation inadvertently disabled verification on all backends that subclass SQLHttpBackend. This PR fixes the implementation so it only applies to Sislog.

https://dimagi.atlassian.net/browse/SAAS-14728

## Safety Assurance

### Safety story

Tiny change to limit the scope of custom SSL context.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations