### PR TITLE
display error to user if form can't be found and user tries to edit UCR

### DIFF
--- a/corehq/apps/userreports/const.py
+++ b/corehq/apps/userreports/const.py
@@ -18,7 +18,7 @@ DATA_SOURCE_NOT_FOUND_ERROR_MESSAGE = _(
 )
 FORM_NOT_FOUND_ERROR_MESSAGE = _(
     'Sorry! There was a problem trying to edit your report. '
-    'This likely occurred because form associated with this report was deleted from the application. '
+    'This likely occurred because the form associated with this report was deleted from the application. '
     'You can go back and view historical data submitted. However, you may not edit this report again. '
     'You also have the option of deleting this report by clicking the delete button below.'
 )

--- a/corehq/apps/userreports/const.py
+++ b/corehq/apps/userreports/const.py
@@ -16,6 +16,12 @@ DATA_SOURCE_NOT_FOUND_ERROR_MESSAGE = _(
     'In order to view this data using the Report Builder you will have to delete this report '
     'and then build it again. Click below to delete it.'
 )
+FORM_NOT_FOUND_ERROR_MESSAGE = _(
+    'Sorry! There was a problem trying to edit your report. '
+    'This likely occurred because form associated with this report was deleted from the application. '
+    'You can go back and view historical data submitted. However, you may not edit this report again. '
+    'You also have the option of deleting this report by clicking the delete button below.'
+)
 DATA_SOURCE_MISSING_APP_ERROR_MESSAGE = _(
     "Report builder data source doesn't reference an application. "
     "It is likely this report has been customized and it is no longer editable. "

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -31,7 +31,6 @@ from couchexport.files import Temp
 from couchexport.models import Format
 from couchexport.shortcuts import export_response
 
-from corehq.apps.app_manager.exceptions import FormNotFoundException
 from dimagi.utils.couch.undo import (
     get_deleted_doc_type,
     is_deleted,
@@ -52,6 +51,7 @@ from corehq.apps.analytics.tasks import (
     update_hubspot_properties,
 )
 from corehq.apps.api.decorators import api_throttle
+from corehq.apps.app_manager.exceptions import FormNotFoundException
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.util import purge_report_from_mobile_ucr
 from corehq.apps.change_feed.data_sources import (

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -30,6 +30,8 @@ from couchexport.export import export_from_tables
 from couchexport.files import Temp
 from couchexport.models import Format
 from couchexport.shortcuts import export_response
+
+from corehq.apps.app_manager.exceptions import FormNotFoundException
 from dimagi.utils.couch.undo import (
     get_deleted_doc_type,
     is_deleted,
@@ -91,6 +93,7 @@ from corehq.apps.userreports.app_manager.helpers import (
 from corehq.apps.userreports.const import (
     DATA_SOURCE_MISSING_APP_ERROR_MESSAGE,
     DATA_SOURCE_NOT_FOUND_ERROR_MESSAGE,
+    FORM_NOT_FOUND_ERROR_MESSAGE,
     NAMED_EXPRESSION_PREFIX,
     NAMED_FILTER_PREFIX,
     REPORT_BUILDER_EVENTS_KEY,
@@ -559,11 +562,19 @@ class ConfigureReport(ReportBuilderView):
             )
         except ResourceNotFound:
             return self.render_error_response(DATA_SOURCE_NOT_FOUND_ERROR_MESSAGE)
+        except FormNotFoundException:
+            return self.render_error_response(
+                FORM_NOT_FOUND_ERROR_MESSAGE,
+                allow_delete=True,
+                # when this error is thrown, the report_id in the template context is still not set
+                # this ensures the correct id is set so that the delete action is functional
+                report_id=self.existing_report.get_id
+            )
 
         self._populate_data_source_properties_from_interface(data_source_interface)
         return super(ConfigureReport, self).dispatch(request, *args, **kwargs)
 
-    def render_error_response(self, message, allow_delete=None):
+    def render_error_response(self, message, allow_delete=None, report_id=None):
         if self.existing_report:
             context = {
                 'allow_delete': self.existing_report.get_id and not self.existing_report.is_static
@@ -574,6 +585,8 @@ class ConfigureReport(ReportBuilderView):
             context['allow_delete'] = allow_delete
         context['error_message'] = message
         context.update(self.main_context)
+        if report_id:
+            context['report_id'] = report_id
         return render(self.request, 'userreports/report_error.html', context)
 
     @property


### PR DESCRIPTION
## Technical Summary
Currently a user can trigger a 500 if the form referenced by a UCR is deleted from the application. See this bug: https://dimagi.atlassian.net/browse/SAAS-15048

This change displays a more friendly error message to the user and allows the user to delete that report.
![Screen Shot 2024-01-31 at 5 21 48 PM](https://github.com/dimagi/commcare-hq/assets/716573/7946276a-eb12-4d4f-b570-c152f79ed990)


## Safety Assurance

### Safety story
very small change tested thoroughly locally

### Automated test coverage
No

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
