### PR TITLE
actually paginate the ucr expressions page

### DIFF
--- a/corehq/apps/userreports/tests/test_views.py
+++ b/corehq/apps/userreports/tests/test_views.py
@@ -1,6 +1,9 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase, RequestFactory
 from django.utils.safestring import SafeString
 
+from corehq.apps.userreports.models import UCRExpression
+from corehq.apps.userreports.views import UCRExpressionListView
+from corehq.apps.userreports.const import UCR_NAMED_EXPRESSION
 from ..views import NamedExpressionHighlighter
 
 
@@ -15,3 +18,46 @@ class NamedExpressionHighlighterTests(SimpleTestCase):
     def test_result_is_html_safe(self):
         highlighted = NamedExpressionHighlighter.highlight_links('NamedFilter:abc')
         self.assertIsInstance(highlighted, SafeString)
+
+
+class UCRExpressionListViewTests(TestCase):
+    def test_paginated_list_limits_results(self):
+        expressions = [self._create_expression(i) for i in range(3)]
+        UCRExpression.objects.bulk_create(expressions)
+        view = self._create_view(page=1, limit=2)
+
+        names = {expression['itemData']['name'] for expression in view.paginated_list}
+        self.assertSetEqual(names, {'expression0', 'expression1'})
+
+    def test_paginated_list_respects_page(self):
+        expressions = [self._create_expression(i) for i in range(3)]
+        UCRExpression.objects.bulk_create(expressions)
+        view = self._create_view(page=2, limit=2)
+
+        names = {expression['itemData']['name'] for expression in view.paginated_list}
+        self.assertSetEqual(names, {'expression2'})
+
+    def test_default_limit(self):
+        expressions = [self._create_expression(i) for i in range(12)]
+        UCRExpression.objects.bulk_create(expressions)
+        view = self._create_view(page=1)
+
+        self.assertEqual(len(list(view.paginated_list)), 10)
+
+    @staticmethod
+    def _create_expression(index):
+        return UCRExpression(
+            name=f'expression{index}',
+            domain='test-domain',
+            expression_type=UCR_NAMED_EXPRESSION
+        )
+
+    @staticmethod
+    def _create_view(page=1, limit=None):
+        view = UCRExpressionListView()
+        view.args = ['test-domain']
+        kwargs = {'page': page}
+        if limit:
+            kwargs['limit'] = limit
+        view.request = RequestFactory().get('/', kwargs)
+        return view

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1736,7 +1736,7 @@ class UCRExpressionListView(BaseProjectDataView, CRUDPaginatedViewMixin):
 
     @property
     def paginated_list(self):
-        for expression in self.base_query.all():
+        for expression in self.base_query[self.skip:self.skip + self.limit]:
             yield {
                 "itemData": self._item_data(expression),
                 "template": "base-ucr-statement-template",


### PR DESCRIPTION
## Technical Summary
This fixes the bug in https://dimagi.atlassian.net/browse/SAAS-14691 where the UCR expressions page was not properly paginating

## Safety Assurance

### Safety story
very small safe change, tested locally

### Automated test coverage
yes! @mjriley has added tests —teamwork!

### QA Plan
No, tested locally

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
