### PR TITLE
[bug fix] missing $().datepicker() error messages when not needed on page

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/widgets.js
@@ -107,7 +107,9 @@ hqDefine("hqwebapp/js/bootstrap3/widgets",[
             }
         });
 
-        $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
+        _.each($(".date-picker"), function (input) {
+            $(input).datepicker({ dateFormat: "yy-mm-dd" });
+        });
     };
 
     var parseEmails = function (input) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
@@ -107,17 +107,19 @@ hqDefine("hqwebapp/js/bootstrap5/widgets",[
             }
         });
 
-        // datepicker / tempus dominus
-        $('.date-picker').tempusDominus({
-            display: {
-                theme: 'light',
-                components: {
-                    clock: false,
+        _.each($(".date-picker"), function (input) {
+            // datepicker / tempus dominus
+            $(input).tempusDominus({
+                display: {
+                    theme: 'light',
+                    components: {
+                        clock: false,
+                    },
                 },
-            },
-            localization: {
-                format: 'yyyy-MM-dd',
-            },
+                localization: {
+                    format: 'yyyy-MM-dd',
+                },
+            });
         });
     };
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/widgets.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/widgets.js.diff.txt
@@ -13,23 +13,23 @@
  ], function ($, _, MapboxGeocoder, initialPageData) {
      var init = function () {
          var MAPBOX_ACCESS_TOKEN = initialPageData.get(
-@@ -107,7 +107,18 @@
-             }
+@@ -108,7 +108,18 @@
          });
  
--        $('.date-picker').datepicker({ dateFormat: "yy-mm-dd" });
-+        // datepicker / tempus dominus
-+        $('.date-picker').tempusDominus({
-+            display: {
-+                theme: 'light',
-+                components: {
-+                    clock: false,
+         _.each($(".date-picker"), function (input) {
+-            $(input).datepicker({ dateFormat: "yy-mm-dd" });
++            // datepicker / tempus dominus
++            $(input).tempusDominus({
++                display: {
++                    theme: 'light',
++                    components: {
++                        clock: false,
++                    },
 +                },
-+            },
-+            localization: {
-+                format: 'yyyy-MM-dd',
-+            },
-+        });
++                localization: {
++                    format: 'yyyy-MM-dd',
++                },
++            });
+         });
      };
  
-     var parseEmails = function (input) {


### PR DESCRIPTION
## Technical Summary
This ensures that we don't hard fail on calling jquery plugs that aren't actually needed on a page. 

In this case, the original code for instantiating default date-picker widgets for all inputs with the `date-picker` class would always require jquery ui to be present on the page, even if there were no inputs with the `date-picker` class. This manifests as javascript error noise as reported here: https://dimagi.atlassian.net/browse/SAAS-14689

On a `requirejs` page, this doesn't manifest as a problem due to [this line](https://github.com/dimagi/commcare-hq/blob/982c4ce0878f04f88955501262d1635c9dcb8582/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/widgets.js#L7) ensuring the plugin is actually imported. However, on non-`requirejs` pages like app builder, including `hqwebapp/js/widgets` always produces the noisy error. It's noisy because there are no inputs in app manager requiring the `date-picker`widget.

By wrapping this call in a jQuery `each`, we ensure that the plugin is only initialized when it is actually needed, removing the need to unnecessarily include jquery ui on a page that really doesn't need it (like app manager).

I've also done the same for `date-picker` using Tempus Dominus in the bootstrap 5 version of `hqwebapp/js/widgets`

## Safety Assurance

### Safety story
Simple change. tested on pages needing the widget and pages that don't need it. also mimics the structure of other widgets requiring a jquery plugin

### Automated test coverage
diffs covered

### QA Plan
no

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
