### PR TITLE
Check for multi-select indicator id instead of recreating it

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1543,10 +1543,9 @@ class ConfigureNewReportBase(forms.Form):
         :param column_field: The "field" property of a report column
         :return: a data source indicator id
         """
-        indicator_id = "_".join(column_field.split("_")[:-1])
         for indicator in indicators:
-            if indicator['column_id'] == indicator_id and indicator['type'] == 'choice_list':
-                return indicator_id
+            if column_field.startswith(indicator['column_id']) and indicator['type'] == 'choice_list':
+                return indicator['column_id']
         return None
 
     @property


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Previously, if a multi-select question (checkbox type) had a choice value (it's id, not display value) longer than one word (ex. choice_1), the report builder config would think it was a question by itself and show error messages about how that question no longer exists. This fixes that so that it only shows the main checkbox question. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Bug Ticket](https://dimagi.atlassian.net/browse/SAAS-15132)

For a given checkbox question type, you have a `column_id` that looks something like `data_<question_id of checkbox>_<random 8 char string>` and each choice under that checkbox question are assigned a `field` value that looks like `data_<question_id of checkbox>_<random 8 char string>_<choice_id>`. Previously, to determine whether a choice belonged to a specific checkbox question, it would remove the last bit of the choice's field value and check if it matched an existing column_id. If however the choice_id was something longer than one word, commonly something like `choice_1`, it wouldn't match anything since it would be looking for something like `data_<question_id of checkbox>_<random 8 char string>_choice` which isn't a valid column_id. All this changes is to take advantage of the way these ids are formatted and looks for the whole column_id string in the field value, since the choice_id could be any amount of words separated by an underscore.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

n/a

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally. This should be pretty safe since its limited only to multi-select questions.

This also doesn't change any data, only how it shows it in the report builder configuration page.


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
