### PR TITLE
bug: additional spacing should be applied only to persistent case tiles

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -289,7 +289,7 @@
   background-color: transparent;
   color: #685c53;
   justify-items: left;
-  padding: 10px 20px 0 20px;
+  padding: <%= model.prefix === "persistent" ? "20px 20px 10px 20px" : "10px 20px 0 20px" %>;
   }
 </script>
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Padding to case tile added by https://github.com/dimagi/commcare-hq/pull/34065 was supposed to apply to only "persistent Case Tile". This change reverts the padding for non-persistent case tiles.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
see https://github.com/dimagi/commcare-hq/pull/34065

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
see https://github.com/dimagi/commcare-hq/pull/34065

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test exists


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
