### PR TITLE
Fix Delete Case Type/Prop Errors for Data Dictionary

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -220,6 +220,10 @@ hqDefine("data_dictionary/js/data_dictionary", [
                     }
 
                     _.each(group.properties(), function (element, index) {
+                        if (element.deleted && !element.id) {
+                            return;
+                        }
+
                         const allowedValues = element.allowedValues.val();
                         let pureAllowedValues = {};
                         for (const key in allowedValues) {

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -171,10 +171,6 @@ hqDefine("data_dictionary/js/data_dictionary", [
         });
 
         self.confirmDeleteProperty = function () {
-            if (!self.id) {
-                self.deleted(true);
-                return;
-            }
             const $modal = $("#delete-case-prop-modal").modal('show');
             $("#delete-case-prop-btn").off("click").on("click", () => {
                 self.deleted(true);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -171,6 +171,10 @@ hqDefine("data_dictionary/js/data_dictionary", [
         });
 
         self.confirmDeleteProperty = function () {
+            if (!self.id) {
+                self.deleted(true);
+                return;
+            }
             const $modal = $("#delete-case-prop-modal").modal('show');
             $("#delete-case-prop-btn").off("click").on("click", () => {
                 self.deleted(true);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -49,7 +49,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
                     var propObj = propertyListItem(prop.name, prop.label, false, group.name, self.name, prop.data_type,
                         prop.description, prop.allowed_values, prop.fhir_resource_prop_path, prop.deprecated,
-                        prop.removeFHIRResourcePropertyPath, isGeoCaseProp, prop.is_safe_to_delete);
+                        prop.removeFHIRResourcePropertyPath, isGeoCaseProp, prop.is_safe_to_delete, prop.id);
                     propObj.description.subscribe(changeSaveButton);
                     propObj.label.subscribe(changeSaveButton);
                     propObj.fhirResourcePropPath.subscribe(changeSaveButton);
@@ -95,8 +95,9 @@ hqDefine("data_dictionary/js/data_dictionary", [
     };
 
     var propertyListItem = function (name, label, isGroup, groupName, caseType, dataType, description, allowedValues,
-        fhirResourcePropPath, deprecated, removeFHIRResourcePropertyPath, isGeoCaseProp, isSafeToDelete) {
+        fhirResourcePropPath, deprecated, removeFHIRResourcePropertyPath, isGeoCaseProp, isSafeToDelete, id) {
         var self = {};
+        self.id = id;
         self.name = name;
         self.label = ko.observable(label);
         self.expanded = ko.observable(true);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -23,7 +23,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
     DOMPurify,
     toggles
 ) {
-    var caseType = function (name, fhirResourceType, deprecated, moduleCount, geoCaseProp, containsCaseData) {
+    var caseType = function (name, fhirResourceType, deprecated, moduleCount, geoCaseProp, isSafeToDelete) {
         var self = {};
         self.name = name || gettext("No Name");
         self.deprecated = deprecated;
@@ -32,7 +32,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.fhirResourceType = ko.observable(fhirResourceType);
         self.groups = ko.observableArray();
         self.geoCaseProp = geoCaseProp;
-        self.canDelete = !containsCaseData;
+        self.canDelete = isSafeToDelete;
 
         self.init = function (groupData, changeSaveButton) {
             for (let group of groupData) {
@@ -43,13 +43,13 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
                 for (let prop of group.properties) {
                     const isGeoCaseProp = (self.geoCaseProp === prop.name && prop.data_type === 'gps');
-                    if (prop.contains_case_data) {
+                    if (!prop.is_safe_to_delete) {
                         self.canDelete = false;
                     }
 
                     var propObj = propertyListItem(prop.name, prop.label, false, group.name, self.name, prop.data_type,
                         prop.description, prop.allowed_values, prop.fhir_resource_prop_path, prop.deprecated,
-                        prop.removeFHIRResourcePropertyPath, isGeoCaseProp, prop.contains_case_data);
+                        prop.removeFHIRResourcePropertyPath, isGeoCaseProp, prop.is_safe_to_delete);
                     propObj.description.subscribe(changeSaveButton);
                     propObj.label.subscribe(changeSaveButton);
                     propObj.fhirResourcePropPath.subscribe(changeSaveButton);
@@ -95,7 +95,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
     };
 
     var propertyListItem = function (name, label, isGroup, groupName, caseType, dataType, description, allowedValues,
-        fhirResourcePropPath, deprecated, removeFHIRResourcePropertyPath, isGeoCaseProp, containsCaseData) {
+        fhirResourcePropPath, deprecated, removeFHIRResourcePropertyPath, isGeoCaseProp, isSafeToDelete) {
         var self = {};
         self.name = name;
         self.label = ko.observable(label);
@@ -109,7 +109,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.originalResourcePropPath = fhirResourcePropPath;
         self.deprecated = ko.observable(deprecated || false);
         self.isGeoCaseProp = ko.observable(isGeoCaseProp);
-        self.containsCaseData = ko.observable(containsCaseData);
+        self.isSafeToDelete = ko.observable(isSafeToDelete);
         self.deleted = ko.observable(false);
         self.removeFHIRResourcePropertyPath = ko.observable(removeFHIRResourcePropertyPath || false);
         let subTitle;
@@ -275,7 +275,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                             caseTypeData.is_deprecated,
                             caseTypeData.module_count,
                             data.geo_case_property,
-                            caseTypeData.contains_case_data
+                            caseTypeData.is_safe_to_delete
                         );
                         caseTypeObj.init(caseTypeData.groups, changeSaveButton);
                         self.caseTypes.push(caseTypeObj);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -43,7 +43,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
                 for (let prop of group.properties) {
                     const isGeoCaseProp = (self.geoCaseProp === prop.name && prop.data_type === 'gps');
-                    if (!prop.is_safe_to_delete) {
+                    if (self.canDelete && !prop.is_safe_to_delete) {
                         self.canDelete = false;
                     }
 

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -338,7 +338,7 @@
             {% if not request.is_view_only %}
               <div class="row-item-small">
                 <button title="{% trans_html_attr 'Delete Property' %}"
-                        data-bind="click: confirmDeleteProperty, visible: isSafeToDelete && !isGeoCaseProp()"
+                        data-bind="click: confirmDeleteProperty, visible: isSafeToDelete"
                         class="fa fa-trash"></button>
               </div>
               <div class="row-item-small">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -338,7 +338,7 @@
             {% if not request.is_view_only %}
               <div class="row-item-small">
                 <button title="{% trans_html_attr 'Delete Property' %}"
-                        data-bind="click: confirmDeleteProperty, hidden: containsCaseData() || isGeoCaseProp()"
+                        data-bind="click: confirmDeleteProperty, visible: isSafeToDelete && !isGeoCaseProp()"
                         class="fa fa-trash"></button>
               </div>
               <div class="row-item-small">

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -381,6 +381,7 @@ class DataDictionaryJsonTest(TestCase):
                             "deprecated": False,
                             "properties": [
                                 {
+                                    "id": self.case_prop_obj.id,
                                     "description": "",
                                     "label": "",
                                     "fhir_resource_prop_path": None,

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -372,7 +372,7 @@ class DataDictionaryJsonTest(TestCase):
                 {
                     "name": "caseType",
                     "fhir_resource_type": None,
-                    "contains_case_data": False,
+                    "is_safe_to_delete": True,
                     "groups": [
                         {
                             "id": self.case_prop_group.id,
@@ -386,7 +386,7 @@ class DataDictionaryJsonTest(TestCase):
                                     "fhir_resource_prop_path": None,
                                     "name": "property",
                                     "deprecated": False,
-                                    "contains_case_data": False,
+                                    "is_safe_to_delete": True,
                                     "allowed_values": {},
                                     "data_type": "number",
                                 },
@@ -406,7 +406,7 @@ class DataDictionaryJsonTest(TestCase):
                 {
                     "name": "depCaseType",
                     "fhir_resource_type": None,
-                    "contains_case_data": False,
+                    "is_safe_to_delete": True,
                     "groups": [
                         {
                             "name": '',

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -87,7 +87,7 @@ def data_dictionary_json(request, domain, case_type_name=None):
             "is_deprecated": case_type.is_deprecated,
             "module_count": module_count,
             "properties": [],
-            "contains_case_data": len(used_props) > 0,
+            "is_safe_to_delete": len(used_props) == 0,
         }
         grouped_properties = {
             group: [
@@ -99,7 +99,7 @@ def data_dictionary_json(request, domain, case_type_name=None):
                     ),
                     'name': prop.name,
                     'deprecated': prop.deprecated,
-                    'contains_case_data': prop.name in used_props,
+                    'is_safe_to_delete': prop.name not in used_props,
                 }
                 | (
                     {

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -93,6 +93,7 @@ def data_dictionary_json(request, domain, case_type_name=None):
         grouped_properties = {
             group: [
                 {
+                    'id': prop.id,
                     'description': prop.description,
                     'label': prop.label,
                     'fhir_resource_prop_path': fhir_resource_prop_by_case_prop.get(

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -88,7 +88,7 @@ def data_dictionary_json(request, domain, case_type_name=None):
             "is_deprecated": case_type.is_deprecated,
             "module_count": module_count,
             "properties": [],
-            "is_safe_to_delete": len(used_props) == 0,
+            "is_safe_to_delete": bool(used_props),
         }
         grouped_properties = {
             group: [

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -77,6 +77,7 @@ def data_dictionary_json(request, domain, case_type_name=None):
     case_type_app_module_count = get_case_type_app_module_count(domain)
     data_validation_enabled = toggles.CASE_IMPORT_DATA_DICTIONARY_VALIDATION.enabled(domain)
     used_props_by_case_type = get_used_props_by_case_type(domain)
+    geo_case_prop = get_geo_case_property(domain)
     for case_type in queryset:
         module_count = case_type_app_module_count.get(case_type.name, 0)
         used_props = used_props_by_case_type[case_type.name] if case_type.name in used_props_by_case_type else []
@@ -99,7 +100,7 @@ def data_dictionary_json(request, domain, case_type_name=None):
                     ),
                     'name': prop.name,
                     'deprecated': prop.deprecated,
-                    'is_safe_to_delete': prop.name not in used_props,
+                    'is_safe_to_delete': prop.name not in used_props and prop.name != geo_case_prop,
                 }
                 | (
                     {
@@ -135,7 +136,7 @@ def data_dictionary_json(request, domain, case_type_name=None):
         props.append(p)
     return JsonResponse({
         'case_types': props,
-        'geo_case_property': get_geo_case_property(domain),
+        'geo_case_property': geo_case_prop,
     })
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When a new case property is created and, before clicking "Save", a user can now click on the delete icon to remove the case property and have it not be persisted in the back-end.

Additionally, users are now no longer able to delete a case type if it contains a case property being used as the gelocation case property by the geospatial feature.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to tickets:
- [Prevent case type delete if has geolocation case property](https://dimagi.atlassian.net/browse/SC-3333)
- [Fix error when creating and deleting case property](https://dimagi.atlassian.net/browse/SC-3335)

This PR addresses two bugs related to the feature for deleting case types/props in the Data Dictionary. These fixes will be merged into the feature branch which, in turn, will get merged to master.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Automated tests exist

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated test exists for back-end view to fetch DD case types and properties.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

This PR will be merged into the `ze/delete-in-dd` branch, so that PR should be reverted.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
