### PR TITLE
Remove unnecessary group headers in Web Apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -595,10 +595,12 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         let oneQuestionPerScreen = parentForm.displayOptions.oneQuestionPerScreen !== undefined && parentForm.displayOptions.oneQuestionPerScreen();
 
         // Header and captions
-        self.needsHeader = oneQuestionPerScreen || self.isRepetition || ko.utils.unwrapObservable(self.caption) || ko.utils.unwrapObservable(self.caption_markdown);
-        if (self.needsHeader && !oneQuestionPerScreen && self.isRepetition) {
-            self.caption(null);
-            self.hideCaption = true;
+        self.showHeader = oneQuestionPerScreen || self.isRepetition || ko.utils.unwrapObservable(self.caption) || ko.utils.unwrapObservable(self.caption_markdown);
+        if (self.showHeader) {
+            if (!oneQuestionPerScreen && self.isRepetition) {
+                self.caption(null);
+                self.hideCaption = true;
+            }
         }
 
         if (_.has(json, 'domain_meta') && _.has(json, 'style')) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -594,10 +594,13 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         let parentForm = getParentForm(self);
         let oneQuestionPerScreen = parentForm.displayOptions.oneQuestionPerScreen !== undefined && parentForm.displayOptions.oneQuestionPerScreen();
 
-        if (!oneQuestionPerScreen && self.isRepetition) {
+        // Header and captions
+        self.needsHeader = oneQuestionPerScreen || self.isRepetition || self.caption() || ko.utils.unwrapObservable(self.caption_markdown);
+        if (self.needsHeader && !oneQuestionPerScreen && self.isRepetition) {
             self.caption(null);
             self.hideCaption = true;
         }
+
         if (_.has(json, 'domain_meta') && _.has(json, 'style')) {
             self.domain_meta = parseMeta(json.datatype, json.style);
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -595,7 +595,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
         let oneQuestionPerScreen = parentForm.displayOptions.oneQuestionPerScreen !== undefined && parentForm.displayOptions.oneQuestionPerScreen();
 
         // Header and captions
-        self.needsHeader = oneQuestionPerScreen || self.isRepetition || self.caption() || ko.utils.unwrapObservable(self.caption_markdown);
+        self.needsHeader = oneQuestionPerScreen || self.isRepetition || ko.utils.unwrapObservable(self.caption) || ko.utils.unwrapObservable(self.caption_markdown);
         if (self.needsHeader && !oneQuestionPerScreen && self.isRepetition) {
             self.caption(null);
             self.hideCaption = true;

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -31,7 +31,7 @@
               },
         click: toggleChildren,
         event: {keypress: keyPressAction},
-        style: {'display': needsHeader ? 'block': 'none',
+        style: {'display': showHeader ? 'block': 'none',
                 'background-color': headerBackgroundColor(),
                 'color': headerBackgroundColor() ? 'white' : ''
         }">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -31,8 +31,9 @@
               },
         click: toggleChildren,
         event: {keypress: keyPressAction},
-        style: {'background-color': headerBackgroundColor(),
-                'color': headerBackgroundColor() ? 'white' : '',
+        style: {'display': needsHeader ? 'block': 'none',
+                'background-color': headerBackgroundColor(),
+                'color': headerBackgroundColor() ? 'white' : ''
         }">
       <div data-bind="ifnot: collapsible">
         <legend>

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -246,12 +246,13 @@
 }
 
 .question-tile-row:has(div.q) {
-  margin-bottom: 15px;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
 .question-tile-row {
   display: flex;
-  align-items: top;
+  align-items: start;
   margin-left: 10px;
   margin-right: 10px;
   * .form-group, * p, * .control-label {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This addresses the padding issue described in the latest comments on [this support ticket](https://dimagi.atlassian.net/browse/SUPPORT-18466).

This PR turns this uneven padding:

![Screenshot 2024-02-01 at 11 00 44 AM](https://github.com/dimagi/commcare-hq/assets/6729291/c5c316c5-d7a0-4d49-b36c-cfa651a35e2b)

Into this:

![Screenshot 2024-02-01 at 11 00 07 AM](https://github.com/dimagi/commcare-hq/assets/6729291/be95509b-0c30-4fa6-bb79-84fd7322e685)

A subtle but noticeable difference. But this PR also addresses the underlying issue.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Small UI change that required a surprising amount of tweaking.

We add a 15px margin to the bottom of question rows to account for the padding of the heading that's added to the top. Instead, we shouldn't have a header at all to a `Group` if there's no content in it, and the padding should be even on top and bottom.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Looks good locally with and without the header
- Tested as regular repeat group with the X button, regular question tile
- Only affects specific form elements

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Think I'm going to request a quick QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
