### PR TITLE
Add "SMS charges will incur" alerts to verify phone number buttons

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_deploy_modal_sms.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_deploy_modal_sms.html
@@ -23,6 +23,9 @@
                           data-bind="text: 'Update to CommCare: ' + sms_odk_url() + ' (&quot;' + short_name() + '&quot; v. ' + version() + ')'">
                 </textarea>
       </div>
+      <div class="alert alert-warning text-center">
+        <i class="fa fa-exclamation-triangle"></i> <strong>{% trans "SMS charges will incur." %}</strong>
+      </div>
       <input type="submit" class="btn btn-default" value="{% trans "Send" %}"/>
     </form>
   </div>

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -14,6 +14,7 @@ hqDefine("groups/js/group_members", [
     uiMapList
 ) {
     $(function () {
+        $('.verify-button').tooltip();
         // custom data
         var customDataEditor = uiMapList.new(initialPageData.get("group_id"), gettext("Edit Group Information"));
         customDataEditor.val(initialPageData.get("group_metadata"));

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -88,13 +88,15 @@
             </button>
             <span class="hq-help-template"
                   data-title="{% trans 'Initiate Phone Number Verification for All Mobile Workers In This Group' %}"
+                  data-html="true"
                   data-content="{% blocktrans %}
                         For all active mobile workers in this group, and for each phone number, this will
                         initiate an SMS verification workflow. If the phone number is already verified or
                         if the phone number is already in use by another contact in the system, nothing
                         will happen. If the phone number is pending verification, the verification SMS
                         will be resent.
-                        {% endblocktrans %}">
+                        {% endblocktrans %}
+                        <div class='alert alert-warning text-center'><i class='fa fa-exclamation-triangle'></i> <strong>{% trans 'SMS charges will incur.' %}</strong></div>">
                 </span>
           </form>
         {% endif %}

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -79,7 +79,11 @@
                 method="post"
                 action="{% url "bulk_sms_verification" domain group.get_id %}">
             {% csrf_token %}
-            <button id="submit-verification" type="submit" class="btn btn-default">
+            <button id="submit-verification"
+                    type="submit"
+                    data-html="true"
+                    data-title="<div class='alert alert-warning'><i class='fa fa-exclamation-triangle'></i> <strong>{% trans 'SMS charges will incur.' %}</strong></div>{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
+                    class="btn btn-default verify-button">
               <i class="fa fa-signal"></i> {% trans 'Verify Phone Numbers' %}
             </button>
             <span class="hq-help-template"

--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -30,9 +30,8 @@ hqDefine('users/js/edit_commcare_user', [
     });
 
     $('#add_phone_number').submit(function () {
-        googleAnalytics.track.event('Edit Mobile Worker', 'Update phone number', couchUserId, '', {}, function () {
-            document.getElementById('add_phone_number').submit();
-        });
+        document.getElementById('add_phone_number').submit();
+        googleAnalytics.track.event('Edit Mobile Worker', 'Update phone number', couchUserId, '', {}, function () {});
         return false;
     });
 

--- a/corehq/apps/users/templates/users/partials/basic_info_modals.html
+++ b/corehq/apps/users/templates/users/partials/basic_info_modals.html
@@ -54,6 +54,9 @@
                   The phone has not replied yet. Send again?
                 {% endblocktrans %}
               </p>
+              <div class="alert alert-warning text-center">
+                <i class="fa fa-exclamation-triangle"></i> <strong>{% trans "SMS charges will incur." %}</strong>
+              </div>
             </div>
             <div class="modal-footer">
               <a href="#" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</a>

--- a/corehq/apps/users/templates/users/partials/manage_my_numbers.html
+++ b/corehq/apps/users/templates/users/partials/manage_my_numbers.html
@@ -38,7 +38,8 @@
                       style="display: inline;">
                   {% csrf_token %}
                   <button type="submit"
-                          data-title="{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
+                          data-html="true"
+                          data-title="<div class='alert alert-warning'><i class='fa fa-exclamation-triangle'></i> <strong>{% trans 'SMS charges will incur.' %}</strong></div>{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
                           class="btn btn-primary verify-button"><i class="fa fa-signal"></i> {% trans 'Verify' %}
                   </button>
                 </form>

--- a/corehq/apps/users/templates/users/partials/manage_phone_numbers.html
+++ b/corehq/apps/users/templates/users/partials/manage_phone_numbers.html
@@ -40,7 +40,8 @@
                           style="display: inline;">
                       {% csrf_token %}
                       <button type="submit"
-                              data-title="{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
+                              data-html="true"
+                              data-title="<div class='alert alert-warning'><i class='fa fa-exclamation-triangle'></i> <strong>{% trans 'SMS charges will incur.' %}</strong></div>{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
                               class="btn btn-primary verify-button"><i class="fa fa-signal"></i> {% trans 'Verify' %}
                       </button>
                     </form>


### PR DESCRIPTION
## Product Description
This is in response to the following support feature request:
https://dimagi.atlassian.net/browse/SAAS-14815

It updates the UI in the following places to include a notification that SMS charges will incur when verifying phone numbers.

### Mobile Worker edit using info view:
![Screen Shot 2024-02-01 at 6 55 07 PM](https://github.com/dimagi/commcare-hq/assets/716573/8c7d78ee-a316-4704-8d30-d9d29a786b8f)

the pop-up when hitting re-verify button
![Screen Shot 2024-02-01 at 6 57 10 PM](https://github.com/dimagi/commcare-hq/assets/716573/97434922-f427-447b-9fe4-633a40ec77cd)

### Edit group view (when reminders are present)
![Screen Shot 2024-02-01 at 7 06 27 PM](https://github.com/dimagi/commcare-hq/assets/716573/6b3cd72f-ef76-496f-b7a2-5466593843f6)

clicking the help button next to the verify numbers button
![Screen Shot 2024-02-01 at 7 06 34 PM](https://github.com/dimagi/commcare-hq/assets/716573/f2fb76db-867f-4a9c-8494-4b50684611f4)

### App builder

after clicking "publish" on a build:
![Screen Shot 2024-02-01 at 7 09 17 PM](https://github.com/dimagi/commcare-hq/assets/716573/1976f7ab-508b-4b28-b4eb-90cf487c7aff)


## Technical Summary
In addition to the UI changes above, this also fixes a bug we ran into where using an add blocker may prevent the add phone number button from being submitted.

## Safety Assurance

### Safety story
Safe UI changes. Changes tested thoroughly locally.

### Automated test coverage
No

### QA Plan
N/A


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
