### PR TITLE
Prevent profiles from assigning empty values to required data fields

### DIFF
--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -82,6 +82,20 @@ class CustomDataFieldsForm(forms.Form):
         return errors
 
     @classmethod
+    def verify_no_empty_profile_fields(cls, data_fields, profiles):
+        errors = set()
+
+        required_field_names = {field['slug'] for field in data_fields if field['is_required']}
+        for profile in profiles:
+            profile_fields = json.loads(profile.get('fields', '{}'))
+            for slug, value in profile_fields.items():
+                if slug in required_field_names and not value:
+                    errors.add(_("Profile '{}' does not assign a value for required field '{}'").format(
+                        profile['name'], slug
+                    ))
+        return errors
+
+    @classmethod
     def verify_profiles_validate(cls, data_fields, profiles):
         errors = set()
         fields_by_slug = {
@@ -151,6 +165,7 @@ class CustomDataFieldsForm(forms.Form):
         if data_fields is not None:
             errors.update(self.verify_no_profiles_missing_fields(data_fields, profiles))
             errors.update(self.verify_profiles_validate(data_fields, profiles))
+            errors.update(self.verify_no_empty_profile_fields(data_fields, profiles))
 
         if errors:
             separator = mark_safe('<br/>')  # nosec: no user input

--- a/corehq/apps/custom_data_fields/tests/test_edit_model.py
+++ b/corehq/apps/custom_data_fields/tests/test_edit_model.py
@@ -239,7 +239,6 @@ class TestCustomDataFieldsForm(FieldsViewMixin, SimpleTestCase):
         form = self._create_form(fields, profiles)
 
         self.assertFalse(form.is_valid())
-        print(form.errors)
 
     def _create_form(self, fields, profiles):
         fields_json = json.dumps([field.to_dict() for field in fields])

--- a/corehq/apps/custom_data_fields/tests/test_edit_model.py
+++ b/corehq/apps/custom_data_fields/tests/test_edit_model.py
@@ -216,3 +216,35 @@ class TestCustomDataModelValidation(FieldsViewMixin, SimpleTestCase):
             view.form.errors,
             {"data_fields": ["A label is required for each field."]},
         )
+
+
+class TestCustomDataFieldsForm(FieldsViewMixin, SimpleTestCase):
+    def test_valid(self):
+        fields = [self.create_field(slug='one')]
+        profiles = [CustomDataFieldsProfile(name='profile', fields={'one': 'one'})]
+        form = self._create_form(fields, profiles)
+
+        self.assertTrue(form.is_valid())
+
+    def test_can_assign_empty_profile_values_to_optional_fields(self):
+        fields = [self.create_field(slug='one', is_required=False)]
+        profiles = [CustomDataFieldsProfile(name='profile', fields={'one': ''})]
+        form = self._create_form(fields, profiles)
+
+        self.assertTrue(form.is_valid())
+
+    def test_cannot_assign_empty_profile_values_to_required_fields(self):
+        fields = [self.create_field(slug='one', is_required=True)]
+        profiles = [CustomDataFieldsProfile(name='profile', fields={'one': ''})]
+        form = self._create_form(fields, profiles)
+
+        self.assertFalse(form.is_valid())
+        print(form.errors)
+
+    def _create_form(self, fields, profiles):
+        fields_json = json.dumps([field.to_dict() for field in fields])
+        profiles_json = json.dumps([profile.to_json() for profile in profiles])
+        return CustomDataFieldsForm({
+            'data_fields': fields_json,
+            'profiles': profiles_json
+        })

--- a/corehq/apps/users/static/users/js/custom_data_fields.js
+++ b/corehq/apps/users/static/users/js/custom_data_fields.js
@@ -65,7 +65,7 @@ hqDefine("users/js/custom_data_fields", [
             }
             _.each(self.slugs, function (slug) {
                 var field = self[slug];
-                if (fields[slug]) {
+                if (Object.prototype.hasOwnProperty.call(fields, slug)) {
                     if (!field.disable()) {
                         field.previousValue(field.value());
                     }


### PR DESCRIPTION
## Product Description
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15091.

Users will now be unable to specify blank values for required fields on user profiles.  Users can still specify blank values for optional fields. Additionally, _all_ fields populated from a profile will now be disabled.

It should be noted that any existing profiles in this state will display validation errors just upon navigating to their edit page.

<img width="1189" alt="Screenshot 2024-02-01 at 3 13 54 PM" src="https://github.com/dimagi/commcare-hq/assets/970609/49ebf78c-44d9-4c37-9e8e-1a8bb99570d4">

<img width="1176" alt="Screenshot 2024-02-01 at 3 14 26 PM" src="https://github.com/dimagi/commcare-hq/assets/970609/22a655e0-dc45-4780-a694-811bd06b351b">

<img width="782" alt="Screenshot 2024-02-01 at 3 17 15 PM" src="https://github.com/dimagi/commcare-hq/assets/970609/bc186dc2-ed8d-4ddc-9d7c-bdbe98e6f1a4">

## Technical Summary
There was a bug where we allowed users to create profiles that attempted to specify required fields, but to leave them unassigned. Because these empty values were not disabled when using the profile, it led to confusing situations where it appeared that the user should overwrite those empty values -- and then those overwritten values were not being respected.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Performed local testing to verify that the user cannot assign empty values to new profiles, and that existing ones display the error message. Also verified that the user screen now disables optional fields with blank values that are populated through profiles.

We are slightly concerned that users will be unable to make any changes to the custom user fields until these invalid profiles are resolved. We don't think there are users out there that have enough of these kind of profiles to pose a significant burden, but if so, this PR is easily rolled back.

### Automated test coverage
Created the `TestCustomDataFieldsForm` suite to verify the form validation.

### QA Plan
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
