### PR TITLE
Fixed many lint errors in reports

### DIFF
--- a/corehq/apps/reports/static/reports/js/aggregate_user_status.js
+++ b/corehq/apps/reports/static/reports/js/aggregate_user_status.js
@@ -1,6 +1,5 @@
-/* globals d3, nv */
 hqDefine("reports/js/aggregate_user_status", function () {
-    function aggregateTooltip(key, x, y, e, graph) {
+    function aggregateTooltip(key, x, y, e) {
         return '<p><strong>' + key + '</strong></p>' +
            '<p>' + Math.round(e.value) + '% since ' + x + '</p>';
     }

--- a/corehq/apps/reports/static/reports/js/base.js
+++ b/corehq/apps/reports/static/reports/js/base.js
@@ -2,9 +2,9 @@ hqDefine("reports/js/base", function () {
     $(function () {
         hqImport("reports/js/filters/main").init();
 
-        var initial_page_data = hqImport("hqwebapp/js/initial_page_data").get;
-        var defaultConfig = initial_page_data('default_config') || {};
-        if (initial_page_data('has_datespan')) {
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data");
+        var defaultConfig = initialPageData.get('default_config') || {};
+        if (initialPageData.get('has_datespan')) {
             defaultConfig.date_range = 'last7';
         } else {
             defaultConfig.date_range = null;
@@ -18,9 +18,9 @@ hqDefine("reports/js/base", function () {
             var reportConfigModels = hqImport("reports/js/report_config_models"),
                 reportConfigsView = reportConfigModels.reportConfigsViewModel({
                     filterForm: $("#reportFilters"),
-                    items: initial_page_data('report_configs'),
+                    items: initialPageData.get('report_configs'),
                     defaultItem: defaultConfig,
-                    saveUrl: hqImport("hqwebapp/js/initial_page_data").reverse("add_report_config"),
+                    saveUrl: initialPageData.reverse("add_report_config"),
                 });
             $savedReports.koApplyBindings(reportConfigsView);
             reportConfigsView.setConfigBeingViewed(reportConfigModels.reportConfig(defaultConfig));

--- a/corehq/apps/reports/static/reports/js/case_details.js
+++ b/corehq/apps/reports/static/reports/js/case_details.js
@@ -73,12 +73,18 @@ hqDefine("reports/js/case_details", [
         self.data_loading = ko.observable(false);
 
         self.getParameterByName = function (name, url) {
-            if (!url) url = window.location.href;
+            if (!url) {
+                url = window.location.href;
+            }
             name = name.replace(/[[\]]/g, "\\$&");
             var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
                 results = regex.exec(url);
-            if (!results) return null;
-            if (!results[2]) return '';
+            if (!results) {
+                return null;
+            }
+            if (!results[2]) {
+                return '';
+            }
             return decodeURIComponent(results[2].replace(/\+/g, " "));
         };
 
@@ -102,7 +108,7 @@ hqDefine("reports/js/case_details", [
                         container: $panel,
                     });
                 },
-                "error": function (jqXHR, textStatus, errorThrown) {
+                "error": function (jqXHR) {
                     var message;
                     if (jqXHR.status === 403) {
                         message = jqXHR.responseJSON.html;
@@ -218,8 +224,7 @@ hqDefine("reports/js/case_details", [
             var endPageNum = ((startNum - 1) * self.page_size()) + self.page_size();
             if (endPageNum > self.total_rows()) {
                 return self.total_rows();
-            }
-            else {
+            } else {
                 return endPageNum;
             }
         });

--- a/corehq/apps/reports/static/reports/js/charts/main.js
+++ b/corehq/apps/reports/static/reports/js/charts/main.js
@@ -2,13 +2,15 @@ hqDefine('reports/js/charts/main', function () {
     var init = function () {
         var pieCharts = hqImport('reports/js/charts/pie_chart');
         $('.charts-pie-chart').each(function (i, el) {
-            var $el = $(el), data = $el.data();
+            var $el = $(el),
+                data = $el.data();
             pieCharts.init(data);
         });
 
         var multibarCharts = hqImport('reports/js/charts/multibar_chart');
         $('.charts-multibar-chart').each(function (i, el) {
-            var $el = $(el), data = $el.data();
+            var $el = $(el),
+                data = $el.data();
             multibarCharts.init(data);
         });
 

--- a/corehq/apps/reports/static/reports/js/config.dataTables.bootstrap.js
+++ b/corehq/apps/reports/static/reports/js/config.dataTables.bootstrap.js
@@ -17,8 +17,8 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
         self.startAtRowNum = options.startAtRowNum || 0;
         self.showAllRowsOption = options.showAllRowsOption || false;
         self.aoColumns = options.aoColumns;
-        self.autoWidth = (options.autoWidth != undefined) ? options.autoWidth : true;
-        self.defaultSort = (options.defaultSort != undefined) ? options.defaultSort : true;
+        self.autoWidth = (options.autoWidth !== undefined) ? options.autoWidth : true;
+        self.defaultSort = (options.defaultSort !== undefined) ? options.defaultSort : true;
         self.customSort = options.customSort || null;
         self.ajaxParams = options.ajaxParams || {};
         self.ajaxSource = options.ajaxSource;
@@ -54,7 +54,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
             return function (id, row) {
                 if ($dataTableElem.find('tfoot').length === 0) {
                     var $row = $dataTableElem.find('#' + id);
-                    if ($row.length == 0) {
+                    if ($row.length === 0) {
                         $row = $('<tfoot />');
                         $dataTableElem.append($row);
                     }
@@ -121,7 +121,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                     self.fmtParams = function (defParams) {
                         var ajaxParams = $.isFunction(self.ajaxParams) ? self.ajaxParams() : self.ajaxParams;
                         for (var p in ajaxParams) {
-                            if (ajaxParams.hasOwnProperty(p)) {
+                            if (_.has(ajaxParams, p)) {
                                 var currentParam = ajaxParams[p];
                                 if (_.isObject(currentParam.value)) {
                                     for (var j = 0; j < currentParam.value.length; j++) {
@@ -138,7 +138,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                         return defParams;
                     };
                     params.fnServerData = function (sSource, aoData, fnCallback, oSettings) {
-                        var custom_callback = function (data) {
+                        var customCallback = function (data) {
                             if (data.warning) {
                                 throw new Error(data.warning);
                             }
@@ -170,7 +170,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                             "url": sSource.url,
                             "method": sSource.method,
                             "data": self.fmtParams(aoData),
-                            "success": custom_callback,
+                            "success": customCallback,
                             "error": function (jqXHR, textStatus, errorThrown) {
                                 $(".dataTables_processing").hide();
                                 if (jqXHR.status === 400) {
@@ -184,7 +184,7 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                                 }
                                 $(".dataTables_empty").show();
                                 if (self.errorCallbacks) {
-                                    for (i = 0; i < self.errorCallbacks.length; i++) {
+                                    for (var i = 0; i < self.errorCallbacks.length; i++) {
                                         self.errorCallbacks[i](jqXHR, textStatus, errorThrown);
                                     }
                                 }
@@ -205,16 +205,18 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                     }
                 };
 
-                if (self.aoColumns)
+                if (self.aoColumns) {
                     params.aoColumns = self.aoColumns;
+                }
 
                 if (self.forcePageSize) {
                     // limit the page size option to just the default size
                     params.lengthMenu = [self.defaultRows];
                 }
                 var datatable = $(this).dataTable(params);
-                if (!self.datatable)
+                if (!self.datatable) {
                     self.datatable = datatable;
+                }
 
                 if (self.fixColumns) {
                     new $.fn.dataTable.FixedColumns(datatable, {
@@ -222,12 +224,6 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                         iLeftWidth: self.fixColsWidth,
                     });
                 }
-                // only resize the window once every 5 seconds to avoid making
-                // tons of requests when the size of the window is dragged.
-                // http://manage.dimagi.com/default.asp?221237
-                var throttledResize = _.throttle(function () {
-                    datatable.fnAdjustColumnSizing();
-                }, 5000);
 
                 // This fixes a display bug in some browsers where the pagination
                 // overlaps the footer when resizing from 10 to 100 or 10 to 50 rows
@@ -272,12 +268,13 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
                     $dataTablesLength.append($selectField);
                     $selectLabel.remove();
                     $selectField.children().append(" per page");
-                    if (self.showAllRowsOption)
+                    if (self.showAllRowsOption) {
                         $selectField.append($('<option value="-1" />').text("All Rows"));
+                    }
                     $selectField.addClass('form-control');
                     $selectField.on("change", function () {
-                        var selected_value = $selectField.find('option:selected').val();
-                        googleAnalytics.track.event("Reports", "Changed number of items shown", selected_value);
+                        var selectedValue = $selectField.find('option:selected').val();
+                        googleAnalytics.track.event("Reports", "Changed number of items shown", selectedValue);
                     });
                 }
                 $(".dataTables_length select").change(function () {
@@ -302,9 +299,15 @@ hqDefine("reports/js/config.dataTables.bootstrap", [
         var y = convert(b);
 
         // sort nulls at end regardless of current sort direction
-        if (x === null && y === null) return 0;
-        if (x === null) return 1;
-        if (y === null) return -1;
+        if (x === null && y === null) {
+            return 0;
+        }
+        if (x === null) {
+            return 1;
+        }
+        if (y === null) {
+            return -1;
+        }
 
         return (asc ? 1 : -1) * ((x < y) ? -1 : ((x > y) ?  1 : 0));
     }

--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -250,7 +250,7 @@ hqDefine("reports/js/data_corrections", [
                 .filter(function (prop) { return prop.dirty(); })
                 .indexBy('name')
                 .mapObject(function (model) { return model.value(); })
-            .value();
+                .value();
             $.post({
                 url: options.saveUrl,
                 data: {

--- a/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
@@ -16,10 +16,10 @@ hqDefine("reports/js/edit_scheduled_report", [
     toggles,
     multiselectUtils
 ) {
-    var add_options_to_select = function ($select, opt_list, selected_val) {
-        for (var i = 0; i < opt_list.length; i++) {
-            var $opt = $('<option />').val(opt_list[i][0]).text(opt_list[i][1]);
-            if (opt_list[i][0] === selected_val) {
+    var addOptionsToSelect = function ($select, optList, selectedVal) {
+        for (var i = 0; i < optList.length; i++) {
+            var $opt = $('<option />').val(optList[i][0]).text(optList[i][1]);
+            if (optList[i][0] === selectedVal) {
                 $opt.prop("selected", true);
             }
             $select.append($opt);
@@ -27,25 +27,24 @@ hqDefine("reports/js/edit_scheduled_report", [
         return $select;
     };
 
-    var update_interval_aux_input = function (weekly_options, monthly_options, day_value) {
+    var updateIntervalAuxInput = function (weeklyOptions, monthlyOptions, dayValue) {
         var $interval = $interval || $('[name="interval"]');
         $('#div_id_day').remove();
         if ($interval.val() !== 'hourly' && $interval.val() !== 'daily') {
-            var opts = $interval.val() === 'weekly' ? weekly_options : monthly_options;
-            var $day_select = $('<select id="id_day" class="select form-control" name="day" />');
-            $day_select = add_options_to_select($day_select, opts, day_value);
-            var $day_control_group = $('<div id="div_id_day" class="form-group" />')
+            var opts = $interval.val() === 'weekly' ? weeklyOptions : monthlyOptions;
+            var $daySelect = $('<select id="id_day" class="select form-control" name="day" />');
+            $daySelect = addOptionsToSelect($daySelect, opts, dayValue);
+            var $dayControlGroup = $('<div id="div_id_day" class="form-group" />')
                 .append($('<label for="id_day" class="control-label col-sm-3 col-md-2 requiredField">Day<span class="asteriskField">*</span></label>'))
-                .append($('<div class="controls col-sm-9 col-md-8 col-lg-6" />').append($day_select));
-            $interval.closest('.form-group').after($day_control_group);
+                .append($('<div class="controls col-sm-9 col-md-8 col-lg-6" />').append($daySelect));
+            $interval.closest('.form-group').after($dayControlGroup);
         }
 
         $('#div_id_stop_hour').hide();
         if ($interval.val() === 'hourly') {
             $("label[for='id_hour']").text(gettext('From Time') + "*");
             $('#div_id_stop_hour').show();
-        }
-        else {
+        } else {
             $("label[for='id_hour']").text(gettext('Time') + "*");
         }
     };
@@ -60,10 +59,10 @@ hqDefine("reports/js/edit_scheduled_report", [
             $(function () {
                 _.delay(function () {
                     // Delay initialization so that widget is created by the time this code is called
-                    update_interval_aux_input(self.weekly_options, self.monthly_options, self.day_value);
+                    updateIntervalAuxInput(self.weekly_options, self.monthly_options, self.day_value);
                 });
                 $(document).on('change', '[name="interval"]', function () {
-                    update_interval_aux_input(self.weekly_options, self.monthly_options);
+                    updateIntervalAuxInput(self.weekly_options, self.monthly_options);
                 });
                 $("#id_start_date").datepicker({
                     dateFormat: "yy-mm-dd",
@@ -100,23 +99,23 @@ hqDefine("reports/js/edit_scheduled_report", [
                 return memo;
             }, {});
             var currentLanguageOptions = Object.keys(languageSet).sort();
-            var $id_language = $('#id_language');
+            var $idLanguage = $('#id_language');
 
             if (currentLanguageOptions.length === 1 && currentLanguageOptions[0] === 'en') {
-                $id_language.val('en');
+                $idLanguage.val('en');
                 $('#div_id_language').hide();
             } else {
                 // Update the options of the select2
-                var current = $id_language.val();
-                $id_language.empty();
+                var current = $idLanguage.val();
+                $idLanguage.empty();
 
                 // Populate the select2
                 _.map(currentLanguageOptions, function (l) {
-                    $id_language.append(
+                    $idLanguage.append(
                         $("<option></option>").attr("value", l).text(languagesForSelect[l][1])
                     );
                 });
-                $id_language.val(current);
+                $idLanguage.val(current);
                 $("#div_id_language").show();
             }
         } else {
@@ -137,8 +136,7 @@ hqDefine("reports/js/edit_scheduled_report", [
                 return $("<div>").text($(this).text()).get(0);
             })
         );
-    }
-    else {
+    } else {
         multiselectUtils.createFullMultiselectWidget('id_config_ids', {
             selectableHeaderTitle: gettext("Available Reports"),
             selectedHeaderTitle: gettext("Included Reports"),
@@ -147,12 +145,12 @@ hqDefine("reports/js/edit_scheduled_report", [
     }
     updateUcrElements($("#id_config_ids").val());
 
-    var scheduled_report_form_helper = new ScheduledReportFormHelper({
+    var helper = new ScheduledReportFormHelper({
         weekly_options: initialPageData.get('weekly_day_options'),
         monthly_options: initialPageData.get('monthly_day_options'),
         day_value: initialPageData.get('day_value'),
     });
-    scheduled_report_form_helper.init();
+    helper.init();
 
     $('#id-scheduledReportForm').submit(function () {
         googleAnalytics.track.event('Scheduled Reports', 'Create a scheduled report', '-', "", {}, function () {

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer.js
@@ -16,8 +16,7 @@ hqDefine("reports/js/filters/case_list_explorer", ['jquery', 'underscore', 'knoc
                     var suggestion = Object.assign({}, allSuggestions[i]);
                     if (suggestion.count === 1) {
                         filteredProperties.push(suggestion);
-                    }
-                    else if (_.findWhere(filteredProperties, {name: suggestion.name}) === undefined) {
+                    } else if (_.findWhere(filteredProperties, {name: suggestion.name}) === undefined) {
                         if (suggestion.count !== undefined) {
                             suggestion.case_type = suggestion.count + " " + gettext("case types");
                         }

--- a/corehq/apps/reports/static/reports/js/filters/main.js
+++ b/corehq/apps/reports/static/reports/js/filters/main.js
@@ -57,7 +57,8 @@ hqDefine("reports/js/filters/main", [
 
         // other Datespans *groan* TODO unify on this one
         $('.report-filter-datespan-filter').each(function (i, el) {
-            var $el = $(el), data = $el.data();
+            var $el = $(el),
+                data = $el.data();
             var $filterStart = $("#" + data.cssId + "-start");
             var $filterEnd = $("#" + data.cssId + "-end");
 
@@ -198,7 +199,8 @@ hqDefine("reports/js/filters/main", [
             });
         });
         $('.report-filter-location-async').each(function (i, el) {
-            var $el = $(el), data = $el.data();
+            var $el = $(el),
+                data = $el.data();
             var model = locationDrilldown.locationSelectViewModel({
                 "hierarchy": data.hierarchy,
                 "show_location_filter": data.makeOptional && (data.locId === 'None' || !data.locId) ? "n" : "y",
@@ -210,9 +212,14 @@ hqDefine("reports/js/filters/main", [
             model.load(data.locs, data.locId);
         });
         $('.report-filter-drilldown-options').each(function (i, el) {
-            var $el = $(el), data = $el.data();
-            if ($el.parents('.report-filter-form-drilldown').length > 0) return;
-            if (data.isEmpty) return;
+            var $el = $(el),
+                data = $el.data();
+            if ($el.parents('.report-filter-form-drilldown').length > 0) {
+                return;
+            }
+            if (data.isEmpty) {
+                return;
+            }
             var model = drilldownOptions.drilldownOptionFilterControl({
                 drilldown_map: data.drilldownMap,
                 controls: data.controls,
@@ -225,7 +232,8 @@ hqDefine("reports/js/filters/main", [
         $('.report-filter-form-drilldown').each(function (i, el) {
             // This is copied from drilldown-options above because the order matters
             // http://manage.dimagi.com/default.asp?231773
-            var $el = $(el), data = $el.data();
+            var $el = $(el),
+                data = $el.data();
             if (!data.isEmpty) {
                 var model = drilldownOptions.drilldownOptionFilterControl({
                     drilldown_map: data.drilldownMap,
@@ -253,7 +261,8 @@ hqDefine("reports/js/filters/main", [
             }
         });
         $('.report-filter-logtag').each(function (i, el) {
-            var $el = $(el), data = $el.data();
+            var $el = $(el),
+                data = $el.data();
             if (data.defaultOn) {
                 $el.attr("name", "");
                 $el.change(function () {
@@ -279,7 +288,8 @@ hqDefine("reports/js/filters/main", [
         });
 
         $('.report-filter-dynamic-choice-list').each(function (i, el) {
-            var $el = $(el), data = $el.data();
+            var $el = $(el),
+                data = $el.data();
             var initialValues = _.map(data.initialValues, function (value) {
                 return choiceListUtils.formatValueForSelect2(value);
             });

--- a/corehq/apps/reports/static/reports/js/inspect_data.js
+++ b/corehq/apps/reports/static/reports/js/inspect_data.js
@@ -16,15 +16,13 @@ hqDefine("reports/js/inspect_data", [
         return _.map($(selector).select2("data"), function (item) {
             if (item.id.startsWith(typePrefix)) {
                 return userTypes[item.id.substring(typePrefix.length)];
-            }
-            else if (item.id.startsWith(userPrefix)) {
+            } else if (item.id.startsWith(userPrefix)) {
                 if (item.is_active === undefined && dataLookup[item.id]) {
                     return item.id + (dataLookup[item.id].is_active ? " [Active]" : " [Deactivated]");
                 } else {
                     return item.id + (item.is_active ? " [Active]" : " [Deactivated]");
                 }
-            }
-            else {
+            } else {
                 return item.id;
             }
         }).join();

--- a/corehq/apps/reports/static/reports/js/maps_utils.js
+++ b/corehq/apps/reports/static/reports/js/maps_utils.js
@@ -1,4 +1,3 @@
-/* globals L */
 hqDefine("reports/js/maps_utils", function () {
     var module = {};
     module.displayDimensions = ['size', 'color', 'icon'];
@@ -47,10 +46,10 @@ hqDefine("reports/js/maps_utils", function () {
     function MetricsViewModel(control) {
         var model = this;
 
-        this.root = ko.observable();
-        this.defaultMetric = null;
+        model.root = ko.observable();
+        model.defaultMetric = null;
 
-        this.load = function (metrics) {
+        model.load = function (metrics) {
             this.root(new MetricModel({
                 title: '_root',
                 children: metrics,
@@ -64,11 +63,11 @@ hqDefine("reports/js/maps_utils", function () {
             }
         };
 
-        this.renderMetric = function (metric) {
+        model.renderMetric = function (metric) {
             control.render(metric);
         };
 
-        this.unselectAll = function () {
+        model.unselectAll = function () {
             var unselect = function (node) {
                 $.each(node.children(), function (i, e) {
                     unselect(e);
@@ -82,18 +81,18 @@ hqDefine("reports/js/maps_utils", function () {
     function MetricModel(data, parent, root) {
         var m = this;
 
-        this.metric = null;
-        this.name = ko.observable();
-        this.children = ko.observableArray();
-        this.expanded = ko.observable(false);
-        this.selected = ko.observable(false);
-        this.parent = parent;
+        m.metric = null;
+        m.name = ko.observable();
+        m.children = ko.observableArray();
+        m.expanded = ko.observable(false);
+        m.selected = ko.observable(false);
+        m.parent = parent;
 
-        this.group = ko.computed(function () {
+        m.group = ko.computed(function () {
             return this.children().length > 0;
-        }, this);
+        }, m);
 
-        this.onclick = function () {
+        m.onclick = function () {
             if (this.group()) {
                 this.toggle();
             } else {
@@ -102,11 +101,11 @@ hqDefine("reports/js/maps_utils", function () {
             }
         };
 
-        this.toggle = function () {
+        m.toggle = function () {
             this.expanded(!this.expanded());
         };
 
-        this.select = function () {
+        m.select = function () {
             root.unselectAll();
 
             var node = this;
@@ -117,7 +116,7 @@ hqDefine("reports/js/maps_utils", function () {
             }
         };
 
-        this.load = function (data) {
+        m.load = function (data) {
             this.metric = data;
             this.name(data.title);
             this.children($.map(data.children || [], function (e) {
@@ -128,7 +127,7 @@ hqDefine("reports/js/maps_utils", function () {
             }
         };
 
-        this.load(data);
+        m.load(data);
     }
 
     var LegendControl = L.Control.extend({
@@ -136,7 +135,7 @@ hqDefine("reports/js/maps_utils", function () {
             position: 'bottomright',
         },
 
-        onAdd: function (map) {
+        onAdd: function () {
             this.$div = $('#legend');
             this.div = this.$div[0];
             return this.div;
@@ -159,7 +158,7 @@ hqDefine("reports/js/maps_utils", function () {
             position: 'bottomright',
         },
 
-        onAdd: function (map) {
+        onAdd: function () {
             this.$div = $('#info');
             this.div = this.$div[0];
             return this.div;
@@ -359,8 +358,8 @@ hqDefine("reports/js/maps_utils", function () {
         zoomToAll(map);
     }
 
-    function initLayers(map, layers_spec) {
-        LAYER_FAMILIES = {
+    function initLayers(map, layersSpec) {
+        var LAYER_FAMILIES = {
             'fallback': {
                 url_template: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                 args: {
@@ -377,10 +376,10 @@ hqDefine("reports/js/maps_utils", function () {
 
         var mkLayer = function (spec) {
             if (spec.family) {
-                var family_spec = LAYER_FAMILIES[spec.family];
-                spec.url_template = family_spec.url_template;
+                var familySpec = LAYER_FAMILIES[spec.family];
+                spec.url_template = familySpec.url_template;
                 spec.args = spec.args || {};
-                $.each(family_spec.args || {}, function (k, v) {
+                $.each(familySpec.args || {}, function (k, v) {
                     spec.args[k] = v;
                 });
             }
@@ -389,7 +388,7 @@ hqDefine("reports/js/maps_utils", function () {
 
         var layers = {};
         var defaultLayer = null;
-        $.each(layers_spec, function (k, v) {
+        $.each(layersSpec, function (k, v) {
             layers[k] = mkLayer(v);
             if (v['default']) {
                 defaultLayer = k;
@@ -669,8 +668,8 @@ hqDefine("reports/js/maps_utils", function () {
         };
     }
 
-    DEFAULT_SIZE = 10;
-    DEFAULT_MIN_SIZE = 3;
+    var DEFAULT_SIZE = 10;
+    var DEFAULT_MIN_SIZE = 3;
 
     function getSize(meta, props) {
         if (meta == null) {
@@ -694,7 +693,7 @@ hqDefine("reports/js/maps_utils", function () {
         return DEFAULT_SIZE * Math.sqrt(val / baseline);
     }
 
-    DEFAULT_COLOR = 'rgba(255, 120, 0, .8)';
+    var DEFAULT_COLOR = 'rgba(255, 120, 0, .8)';
 
     function getColor(meta, props) {
         var c = (function () {
@@ -727,8 +726,6 @@ hqDefine("reports/js/maps_utils", function () {
             alpha: c.alpha(),
         };
     }
-
-    DEFAULT_ICON_URL = '/static/reports/css/leaflet/images/default_custom.png';
 
     function getIcon(meta, props) {
         //TODO support css sprites
@@ -766,18 +763,18 @@ hqDefine("reports/js/maps_utils", function () {
     // return formatted info about a row/feature, suitable for display
     // in different places (detail popup, hover infobox, table row, etc.)
     function infoContext(feature, config, mode) {
-        var prop_cols = _.keys(feature.properties);
-        var info_cols;
+        var propCols = _.keys(feature.properties);
+        var infoCols;
         if (mode == null) {
             throw "no context mode provided!";
         } else if (mode == 'detail') {
-            info_cols = config.detail_columns;
+            infoCols = config.detail_columns;
         } else if (mode == 'table') {
-            info_cols = getTableColumns(config, true);
+            infoCols = getTableColumns(config, true);
         } else {
             // 'mode' is an explicit list (subset) of columns
-            prop_cols = mode;
-            info_cols = mode;
+            propCols = mode;
+            infoCols = mode;
         }
         var formatForDisplay = function (col, datum) {
             // if display value was explicitly provided from server, use it above all else
@@ -798,7 +795,7 @@ hqDefine("reports/js/maps_utils", function () {
         var displayProperties = {};
         var rawProperties = {};
         var propTitles = {};
-        $.each(prop_cols, function (i, k) {
+        $.each(propCols, function (i, k) {
             var v = feature.properties[k];
             displayProperties[k] = formatForDisplay(k, v);
             rawProperties[k] = (v instanceof Date ? v.getTime() : v);
@@ -813,7 +810,7 @@ hqDefine("reports/js/maps_utils", function () {
             name: (config.name_column ? feature.properties[config.name_column] : null),
             info: [],
         };
-        $.each(info_cols, function (i, e) {
+        $.each(infoCols, function (i, e) {
             context.info.push({
                 slug: e, // FIXME this will cause problems if column keys have weird chars or spaces
                 label: propTitles[e],
@@ -865,9 +862,9 @@ hqDefine("reports/js/maps_utils", function () {
         if (typeof metric.color === 'object') {
             if (!metric.color.categories && !metric.color.colorstops) {
                 var stats = summarizeColumn(metric.color, data);
-                var numeric_data = (!metric.color.thresholds && !stats.nonnumeric);
-                if (numeric_data) {
-                    metric.color.colorstops = (magnitude_based_field(stats) ?
+                var numericData = (!metric.color.thresholds && !stats.nonnumeric);
+                if (numericData) {
+                    metric.color.colorstops = (magnitudeBasedField(stats) ?
                         [
                             [0, 'rgba(20, 20, 20, .8)'],
                             [stats.max || 1, DEFAULT_COLOR],
@@ -897,7 +894,7 @@ hqDefine("reports/js/maps_utils", function () {
         if (typeof metric.icon === 'object') {
             if (!metric.icon.categories) {
                 metric.icon.categories = {
-                    _other: DEFAULT_ICON_URL,
+                    _other: '/static/reports/css/leaflet/images/default_custom.png',
                 };
             }
         }
@@ -913,7 +910,7 @@ hqDefine("reports/js/maps_utils", function () {
 
         var _cols = {};
         $.each(data.features, function (i, e) {
-            $.each(e.properties, function (k, v) {
+            $.each(e.properties, function (k) {
                 if (!isIgnored(k)) {
                     _cols[k] = true;
                 }
@@ -944,7 +941,7 @@ hqDefine("reports/js/maps_utils", function () {
         };
         var stats = summarizeColumn(meta, data);
         var metric = {};
-        if (stats.nonnumeric || !magnitude_based_field(stats) || stats.nonpoint) {
+        if (stats.nonnumeric || !magnitudeBasedField(stats) || stats.nonpoint) {
             metric.color = meta;
         } else {
             metric.size = meta;
@@ -1009,7 +1006,7 @@ hqDefine("reports/js/maps_utils", function () {
             }
         });
         var uniq = [];
-        $.each(_uniq, function (k, v) {
+        $.each(_uniq, function (k) {
             uniq.push(k);
         });
         uniq.sort();
@@ -1040,12 +1037,12 @@ hqDefine("reports/js/maps_utils", function () {
 
     // based on the results of summarizeColumn, determine if this column is better
     // represented as a magnitude (0-max) or narrower range (min-max)
-    function magnitude_based_field(stats) {
+    function magnitudeBasedField(stats) {
         if (stats.min < 0 || stats.hasDates) {
             return false;
         } else if (stats.stdev != null && stats.stdev > 0) {
-            var effective_range = Math.max(stats.max, 0) - Math.min(stats.min, 0);
-            return (stats.stdev / effective_range > .1);
+            var effectiveRange = Math.max(stats.max, 0) - Math.min(stats.min, 0);
+            return (stats.stdev / effectiveRange > .1);
         } else {
             return true;
         }
@@ -1094,16 +1091,13 @@ hqDefine("reports/js/maps_utils", function () {
             });
         }
 
-        return $.map(enums, function (e, i) {
+        return $.map(enums, function (e) {
             return {
                 label: toLabel(e),
                 value: e,
             };
         });
     }
-
-    OTHER_LABEL = gettext('Other');
-    NULL_LABEL = gettext('No Data');
 
     function getEnumCaption(column, value, config, fallbacks) {
         if (isNull(value)) {
@@ -1113,8 +1107,8 @@ hqDefine("reports/js/maps_utils", function () {
 
         fallbacks = fallbacks || {};
         $.each({
-            '_other': OTHER_LABEL,
-            '_null': NULL_LABEL,
+            '_other': gettext('Other'),
+            '_null': gettext('No Data'),
         }, function (k, v) {
             fallbacks[k] = fallbacks[k] || v;
         });
@@ -1167,7 +1161,7 @@ hqDefine("reports/js/maps_utils", function () {
             $h.text(getColumnTitle(col, config));
             $e.append($h);
 
-            $div = $('<div>');
+            var $div = $('<div>');
             ({
                 size: sizeLegend,
                 color: colorLegend,
@@ -1219,10 +1213,10 @@ hqDefine("reports/js/maps_utils", function () {
         });
     }
 
-    SCALEBAR_HEIGHT = 150; //px
-    SCALEBAR_WIDTH = 20; // TODO seems like we want to tie this to em-height instead
-    TICK_SPACING = 40; //px
-    MIN_BUFFER = 15; //px
+    var SCALEBAR_HEIGHT = 150; //px
+    var SCALEBAR_WIDTH = 20; // TODO seems like we want to tie this to em-height instead
+    var TICK_SPACING = 40; //px
+    var MIN_BUFFER = 15; //px
     function colorScaleLegend($e, meta) {
         var EPOCH2000 = 946684800;
         var fromDate = function (s) {
@@ -1242,7 +1236,7 @@ hqDefine("reports/js/maps_utils", function () {
         var range = max - min;
         var step = range / (SCALEBAR_HEIGHT - 1);
 
-        var $canvas = make_canvas(SCALEBAR_WIDTH, SCALEBAR_HEIGHT);
+        var $canvas = makeConvas(SCALEBAR_WIDTH, SCALEBAR_HEIGHT);
         var ctx = $canvas[0].getContext('2d');
         for (var i = 0; i < SCALEBAR_HEIGHT; i++) {
             var k = i / (SCALEBAR_HEIGHT - 1);
@@ -1254,15 +1248,15 @@ hqDefine("reports/js/maps_utils", function () {
 
         var interval = (dateScale ? niceRoundInterval : niceRoundNumber)(step * TICK_SPACING);
         var tickvals = [];
-        for (var k = interval * Math.ceil(min / interval); k <= max; k += interval) {
+        for (var j = interval * Math.ceil(min / interval); j <= max; j += interval) {
             // TODO snap date intervals >= 1 month to start of month
-            tickvals.push(k);
+            tickvals.push(j);
         }
-        var buffer_dist = step * MIN_BUFFER;
-        if (tickvals[0] - min > buffer_dist) {
+        var bufferDist = step * MIN_BUFFER;
+        if (tickvals[0] - min > bufferDist) {
             tickvals.splice(0, 0, min);
         }
-        if (max - tickvals.slice(-1)[0] > buffer_dist) {
+        if (max - tickvals.slice(-1)[0] > bufferDist) {
             tickvals.push(max);
         }
 
@@ -1354,7 +1348,7 @@ hqDefine("reports/js/maps_utils", function () {
     function matchCategories(val, categories) {
         if (isNull(val)) {
             return categories._null;
-        } else if (categories.hasOwnProperty(val)) {
+        } else if (_.has(categories, val)) {
             return categories[val];
         } else {
             return categories._other;
@@ -1379,11 +1373,11 @@ hqDefine("reports/js/maps_utils", function () {
         });
 
         var bracket = matchThresholds(val, x);
-        var lo = (bracket == '-' ? -1 : x.indexOf(bracket));
+        var lo = (bracket === '-' ? -1 : x.indexOf(bracket));
         var hi = lo + 1;
-        if (lo == -1) {
+        if (lo === -1) {
             return y[hi];
-        } else if (hi == x.length) {
+        } else if (hi === x.length) {
             return y[lo];
         } else {
             return blendfunc(y[lo], y[hi], (val - x[lo]) / (x[hi] - x[lo]));
@@ -1419,9 +1413,9 @@ hqDefine("reports/js/maps_utils", function () {
             return $.Color(channels);
         };
 
-        lA = toLinear(a);
-        lB = toLinear(b);
-        lBlend = [];
+        var lA = toLinear(a);
+        var lB = toLinear(b);
+        var lBlend = [];
         for (var i = 0; i < 4; i++) {
             lBlend.push(blendLinear(lA[i], lB[i], k));
         }
@@ -1429,8 +1423,8 @@ hqDefine("reports/js/maps_utils", function () {
     }
 
     function niceRoundNumber(x, stops, orderOfMagnitude) {
-        var orderOfMagnitude = orderOfMagnitude || 10;
-        var stops = stops || [1, 2, 5];
+        orderOfMagnitude = orderOfMagnitude || 10;
+        stops = stops || [1, 2, 5];
         // numbers will snap to .1, .2, .5, 1, 2, 5, 10, 20, 50, 100, 200, etc.
 
         var xLog = Math.log(x) / Math.log(orderOfMagnitude);
@@ -1438,7 +1432,7 @@ hqDefine("reports/js/maps_utils", function () {
         var xNorm = Math.pow(orderOfMagnitude, xLog - exponent);
 
         var getStop = function (i) {
-            return (i == stops.length ? orderOfMagnitude * stops[0] : stops[i]);
+            return (i === stops.length ? orderOfMagnitude * stops[0] : stops[i]);
         };
         var cutoffs = $.map(stops, function (e, i) {
             var multiplier = getStop(i + 1);
@@ -1459,7 +1453,7 @@ hqDefine("reports/js/maps_utils", function () {
         var bucket = matchThresholds(xNorm, $.map(cutoffs, function (co) {
             return co.cutoff;
         }), true);
-        var multiplier = (bucket == -1 ? cutoffs.slice(-1)[0].mult / orderOfMagnitude : cutoffs[bucket].mult);
+        var multiplier = (bucket === -1 ? cutoffs.slice(-1)[0].mult / orderOfMagnitude : cutoffs[bucket].mult);
         return Math.pow(orderOfMagnitude, exponent) * multiplier;
     }
 
@@ -1537,7 +1531,7 @@ hqDefine("reports/js/maps_utils", function () {
     }
 
     // create a (hidden) canvas
-    function make_canvas(w, h) {
+    function makeConvas(w, h) {
         var $canvas = $('<canvas />');
         $canvas.attr('width', w);
         $canvas.attr('height', h);
@@ -1546,7 +1540,7 @@ hqDefine("reports/js/maps_utils", function () {
 
     // a map control map that lists the various display metrics for this report
     // and allows you to select and display them
-    MetricsControl = L.Control.extend({
+    var MetricsControl = L.Control.extend({
         options: {
             position: 'bottomleft',
         },
@@ -1638,7 +1632,7 @@ hqDefine("reports/js/maps_utils", function () {
         // Moving all the zoom controls to the bottom right for consistency.
         // Could not test this instance because of other issues.
         L.control.zoom({
-            position: 'bottomright'
+            position: 'bottomright',
         }).addTo(map);
 
         return map;

--- a/corehq/apps/reports/static/reports/js/project_health_dashboard.js
+++ b/corehq/apps/reports/static/reports/js/project_health_dashboard.js
@@ -1,4 +1,4 @@
-/* globals d3, moment, nv */
+/* globals moment */
 hqDefine("reports/js/project_health_dashboard", function () {
     // "Performing / Active User Trends" Chart
     function setupCharts(data) {
@@ -111,23 +111,23 @@ hqDefine("reports/js/project_health_dashboard", function () {
         $('a.user-popover').popover({
             "html": true,
             "content": function () {
-                var div_id =  "tmp-id-" + $.now();
-                return details_in_popup($(this).data('url'), div_id);
+                var divId =  "tmp-id-" + $.now();
+                return detailsInPopup($(this).data('url'), divId);
             },
             "sanitize": false,
         });
 
-        function details_in_popup(link, div_id) {
+        function detailsInPopup(link, divId) {
             $.ajax({
                 url: link,
                 success: function (response) {
-                    $('#' + div_id).html(response);
+                    $('#' + divId).html(response);
                 },
                 error: function () {
-                    $('#' + div_id).html(gettext("Sorry, we couldn't load that."));
+                    $('#' + divId).html(gettext("Sorry, we couldn't load that."));
                 },
             });
-            return $('<div />').attr('id', div_id).text(gettext('Loading...'))[0].outerHTML;
+            return $('<div />').attr('id', divId).text(gettext('Loading...'))[0].outerHTML;
         }
     }
 

--- a/corehq/apps/reports/static/reports/js/report_config_models.js
+++ b/corehq/apps/reports/static/reports/js/report_config_models.js
@@ -126,7 +126,7 @@ hqDefine("reports/js/report_config_models", [
             $.ajax({
                 type: "DELETE",
                 url: options.saveUrl + '/' + config._id(),
-                success: function (data) {
+                success: function () {
                     window.location.reload();
                 },
             });
@@ -145,18 +145,18 @@ hqDefine("reports/js/report_config_models", [
             self.configBeingViewed(config);
 
             var filters = config.filters;
-            update_filters = function () {
-                for (var filter_name in filters) {
-                    var val = filters[filter_name];
-                    $('[name="' + filter_name + '"]').val(val);
+            var updateFilters = function () {
+                for (var filterName in filters) {
+                    var val = filters[filterName];
+                    $('[name="' + filterName + '"]').val(val);
                 }
             };
 
             if (self.initialLoad) {
                 self.initialLoad = false;
-                update_filters();
+                updateFilters();
             } else {
-                update_filters();
+                updateFilters();
                 window.location.href = "?config_id=" + config._id();
             }
         };
@@ -174,7 +174,7 @@ hqDefine("reports/js/report_config_models", [
 
                     if (type === 'checkbox') {
                         if (el.prop('checked') === true) {
-                            if (!filters.hasOwnProperty(name)) {
+                            if (!_.has(filters, name)) {
                                 filters[name] = [];
                             }
 
@@ -256,7 +256,7 @@ hqDefine("reports/js/report_config_models", [
 
                 for (var key in configData.filters) {
                     // remove null filters
-                    if (configData.filters.hasOwnProperty(key)) {
+                    if (_.has(configData.filters, key)) {
                         if (configData.filters[key] === null) {
                             delete configData.filters[key];
                         }
@@ -272,7 +272,7 @@ hqDefine("reports/js/report_config_models", [
                         var newConfig = reportConfig(data);
                         self.addOrReplaceConfig(newConfig);
                         self.unsetConfigBeingEdited();
-                        if (newConfig.report_slug == 'configurable') {
+                        if (newConfig.report_slug === 'configurable') {
                             self.setUserConfigurableConfigBeingViewed(newConfig);
                         } else {
                             self.setConfigBeingViewed(newConfig);

--- a/corehq/apps/reports/static/reports/js/reports.async.js
+++ b/corehq/apps/reports/static/reports/js/reports.async.js
@@ -111,28 +111,28 @@ hqDefine("reports/js/reports.async", function () {
             });
         };
 
-        self.updateFilters = function (form_params) {
+        self.updateFilters = function (params) {
             self.standardReport.saveDatespanToCookie();
             self.filterRequest = $.ajax({
                 url: window.location.pathname.replace(self.standardReport.urlRoot,
-                    self.standardReport.urlRoot + 'filters/') + "?" + form_params,
+                    self.standardReport.urlRoot + 'filters/') + "?" + params,
                 dataType: 'json',
                 success: loadFilters,
             });
         };
 
         self.updateReport = function (initialLoad, params, setFilters) {
-            var process_filters = "";
+            var processFilters = "";
             if (initialLoad) {
-                process_filters = "hq_filters=true&";
+                processFilters = "hq_filters=true&";
                 if (self.standardReport.loadDatespanFromCookie()) {
-                    process_filters = process_filters +
+                    processFilters = processFilters +
                         "&startdate=" + self.standardReport.datespan.startdate +
                         "&enddate=" + self.standardReport.datespan.enddate;
                 }
             }
-            if (setFilters != undefined) {
-                process_filters = process_filters + "&filterSet=" + setFilters;
+            if (setFilters !== undefined) {
+                processFilters = processFilters + "&filterSet=" + setFilters;
             }
             if (setFilters) {
                 $(self.standardReport.exportReportButton).removeClass('hide');
@@ -142,7 +142,7 @@ hqDefine("reports/js/reports.async", function () {
 
             self.reportRequest = $.ajax({
                 url: (window.location.pathname.replace(self.standardReport.urlRoot,
-                    self.standardReport.urlRoot + 'async/')) + "?" + process_filters + "&" + params,
+                    self.standardReport.urlRoot + 'async/')) + "?" + processFilters + "&" + params,
                 dataType: 'json',
                 success: function (data) {
                     self.reportRequest = null;
@@ -195,7 +195,7 @@ hqDefine("reports/js/reports.async", function () {
                 error: function (data) {
                     var humanReadable;
                     self.reportRequest = null;
-                    if (data.status != 0) {
+                    if (data.status !== 0) {
                         // If it is a BadRequest allow for report to specify text
                         if (data.status === 400) {
                             humanReadable = data.responseText || self.humanReadableErrors[data.status];
@@ -204,13 +204,14 @@ hqDefine("reports/js/reports.async", function () {
                         }
                         self.loadingIssueModal.find('.report-error-status').html('<strong>' + data.status + '</strong> ' +
                             ((humanReadable) ? humanReadable : ""));
-                        if (self.issueAttempts > 0)
+                        if (self.issueAttempts > 0) {
                             self.loadingIssueModal.find('.btn-primary').button('fail');
+                        }
                         self.issueAttempts += 1;
                         self.loadingIssueModal.modal('show');
                     } else {
                         self.hqLoading = $(self.loaderClass);
-                        self.hqLoading.find('h4').text("Loading Stopped");
+                        self.hqLoading.find('h4').text(gettext("Loading Stopped"));
                         self.hqLoading.find('.js-loading-spinner').attr('style', 'visibility: hidden;');
                     }
                 },
@@ -230,8 +231,7 @@ hqDefine("reports/js/reports.async", function () {
             self.loadingIssueModal.find('.btn-primary').button('loading');
             if (self.isCaseListRelated(window.location.pathname)) {
                 self.getQueryId(window.location.search.substr(1), true, true, window.location.pathname);
-            }
-            else {
+            } else {
                 self.updateReport(true, window.location.search.substr(1));
             }
         });

--- a/corehq/apps/reports/static/reports/js/single_form.js
+++ b/corehq/apps/reports/static/reports/js/single_form.js
@@ -1,4 +1,3 @@
-/* globals Clipboard */
 /*
     Interactivity for a single form. Used on the list of forms in the Case History tab when viewing a case, and
     also in the single form view page that's accessible from the submit history report or the "View standalone

--- a/corehq/apps/reports/static/reports/v2/js/datagrid.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid.js
@@ -156,7 +156,9 @@ hqDefine('reports/v2/js/datagrid', [
         };
 
         self.isSortableColumn = function (columnName) {
-            if (!options.unsortableColumnNames) return true;
+            if (!options.unsortableColumnNames) {
+                return true;
+            }
             return (options.unsortableColumnNames.indexOf(columnName) === -1);
         };
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/binding_handlers.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/binding_handlers.js
@@ -20,7 +20,9 @@ hqDefine('reports/v2/js/datagrid/binding_handlers', [
 
         $select.select2(params);
 
-        if (!_.isFunction(options.getInitialValue)) return;
+        if (!_.isFunction(options.getInitialValue)) {
+            return;
+        }
 
         initialValue = options.getInitialValue();
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -42,8 +42,12 @@ hqDefine('reports/v2/js/datagrid/columns', [
         self.sort = ko.observable(data.sort);
 
         self.sortIconClass = ko.computed(function () {
-            if (self.sort() === 'asc') return 'glyphicon glyphicon-sort-by-attributes';
-            if (self.sort() === 'desc') return 'glyphicon glyphicon-sort-by-attributes-alt';
+            if (self.sort() === 'asc') {
+                return 'glyphicon glyphicon-sort-by-attributes';
+            }
+            if (self.sort() === 'desc') {
+                return 'glyphicon glyphicon-sort-by-attributes-alt';
+            }
             return 'glyphicon glyphicon-sort';
         });
 
@@ -85,7 +89,9 @@ hqDefine('reports/v2/js/datagrid/columns', [
         });
 
         self.getInitialNameValue = function () {
-            if (!data.name) return null;
+            if (!data.name) {
+                return null;
+            }
             return {
                 id: data.name,
                 text: data.name,
@@ -110,20 +116,32 @@ hqDefine('reports/v2/js/datagrid/columns', [
         self.noDeleteColumnCondition = options.noDeleteColumnCondition;
 
         self.showColumnFilters = ko.computed(function () {
-            if (!self.column()) return false;
-            if (!self.column().name()) return false;
-            if (!_.isFunction(self.hideColumnFilterCondition)) return true;
+            if (!self.column()) {
+                return false;
+            }
+            if (!self.column().name()) {
+                return false;
+            }
+            if (!_.isFunction(self.hideColumnFilterCondition)) {
+                return true;
+            }
             return !self.hideColumnFilterCondition(self.column());
         });
 
         self.showColumnFilterPlaceholder = ko.computed(function () {
-            if (!self.column()) return false;
+            if (!self.column()) {
+                return false;
+            }
             return self.column().name() === undefined || self.column().name().length === 0;
         });
 
         self.showDelete = ko.computed(function () {
-            if (!_.isFunction(self.noDeleteColumnCondition)) return true;
-            if (!self.column()) return true;
+            if (!_.isFunction(self.noDeleteColumnCondition)) {
+                return true;
+            }
+            if (!self.column()) {
+                return true;
+            }
             return !self.noDeleteColumnCondition(self.column());
         });
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
@@ -33,7 +33,9 @@ hqDefine('reports/v2/js/datagrid/data_models', [
         self.showTimeoutError = ko.observable(false);
 
         self.isDataLoading.subscribe(function (isLoading) {
-            if (!isLoading) return;
+            if (!isLoading) {
+                return;
+            }
 
             // vertically center the loading text within the table body rows,
             // and make sure the width and height of the element wrapping the
@@ -44,7 +46,9 @@ hqDefine('reports/v2/js/datagrid/data_models', [
                 position = $rows.position(),
                 marginTop = Math.max(0, $rows.height() / 2 - 50); // 50 is half the line height of the loading text
 
-            if (position.top === 0) return;
+            if (position.top === 0) {
+                return;
+            }
 
             $loading
                 .height(Math.max(100, $rows.height()))
@@ -112,7 +116,7 @@ hqDefine('reports/v2/js/datagrid/data_models', [
 
         self.sendThresholdAnalytics = setInterval(function () {
             self.thresholdTimer += self.thresholdInterval;
-            if (self.thresholds.hasOwnProperty(self.thresholdTimer)) {
+            if (_.has(self.thresholds, self.thresholdTimer)) {
                 var eventTitle = "ECD Initial Load Threshold - " + self.thresholds[self.thresholdTimer];
                 kissmetrics.track.event(eventTitle, {
                     "Domain": initialPageData.get('domain'),
@@ -129,11 +133,17 @@ hqDefine('reports/v2/js/datagrid/data_models', [
                 self.ajaxPromise.abort();
             }
 
-            if (self.isDataLoading()) return;
+            if (self.isDataLoading()) {
+                return;
+            }
 
             // wait for pagination widget to kick in
-            if (self.currentPage() === undefined) return;
-            if (self.limit() === undefined) return;
+            if (self.currentPage() === undefined) {
+                return;
+            }
+            if (self.limit() === undefined) {
+                return;
+            }
 
             self.isLoadingError(false);
             self.isDataLoading(true);


### PR DESCRIPTION
## Technical Summary
My new laptop arrived, so this is the last one of the linting PRs for now. Decided to focus on reports since that's likely the next area to get migrated to requirejs (after web apps, which is already linted pretty well).

`maps_utils.js` still has plenty of errors, since it's ~2000 lines long and 10+ years old.

## Safety Assurance

### Safety story
Linting changes only.

### Automated test coverage

no

### QA Plan
not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
