### PR TITLE
Add a second save buttom at the bottom of feature flag toggle page

### DIFF
--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -69,15 +69,15 @@ hqDefine('toggle_ui/js/edit-flag', [
             self.saveButtonBottom.fire('change');
         };
 
-        self.createSaveButton = function() {
-            return hqMain.initSaveButton ({
+        self.createSaveButton = function () {
+            return hqMain.initSaveButton({
                 unsavedMessage: "You have unsaved changes",
                 save: function () {
                     var items = _.map(_.filter(self.items(), function (item) {
                         return item.value();
                     }), function (item) {
-                        var ns_raw = item.namespace().replace(new RegExp(PAD_CHAR, 'g'), ''),
-                            namespace = ns_raw === 'user' ? null : ns_raw,
+                        var nsRaw = item.namespace().replace(new RegExp(PAD_CHAR, 'g'), ''),
+                            namespace = nsRaw === 'user' ? null : nsRaw,
                             value = namespace === null ? item.value() : namespace + ':' + item.value();
                         return value;
                     });
@@ -92,13 +92,13 @@ hqDefine('toggle_ui/js/edit-flag', [
                         success: function (data) {
                             self.init_items(data);
                             self.saveButtonBottom.ajax({
-                                success: function () {}
+                                success: function () {},
                             });
                         },
                     });
 
                 },
-            })
+            });
         };
 
         self.saveButtonTop = self.createSaveButton();

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -65,34 +65,44 @@ hqDefine('toggle_ui/js/edit-flag', [
         };
 
         self.change = function () {
-            self.saveButton.fire('change');
+            self.saveButtonTop.fire('change');
+            self.saveButtonBottom.fire('change');
         };
 
-        self.saveButton = hqMain.initSaveButton({
-            unsavedMessage: "You have unsaved changes",
-            save: function () {
-                var items = _.map(_.filter(self.items(), function (item) {
-                    return item.value();
-                }), function (item) {
-                    var ns_raw = item.namespace().replace(new RegExp(PAD_CHAR, 'g'), ''),
-                        namespace = ns_raw === 'user' ? null : ns_raw,
-                        value = namespace === null ? item.value() : namespace + ':' + item.value();
-                    return value;
-                });
-                self.saveButton.ajax({
-                    type: 'post',
-                    url: initialPageData.reverse('edit_toggle') + location.search,
-                    data: {
-                        item_list: JSON.stringify(items),
-                        randomness: self.randomness(),
-                    },
-                    dataType: 'json',
-                    success: function (data) {
-                        self.init_items(data);
-                    },
-                });
-            },
-        });
+        self.createSaveButton = function() {
+            return hqMain.initSaveButton ({
+                unsavedMessage: "You have unsaved changes",
+                save: function () {
+                    var items = _.map(_.filter(self.items(), function (item) {
+                        return item.value();
+                    }), function (item) {
+                        var ns_raw = item.namespace().replace(new RegExp(PAD_CHAR, 'g'), ''),
+                            namespace = ns_raw === 'user' ? null : ns_raw,
+                            value = namespace === null ? item.value() : namespace + ':' + item.value();
+                        return value;
+                    });
+                    self.saveButtonTop.ajax({
+                        type: 'post',
+                        url: initialPageData.reverse('edit_toggle') + location.search,
+                        data: {
+                            item_list: JSON.stringify(items),
+                            randomness: self.randomness(),
+                        },
+                        dataType: 'json',
+                        success: function (data) {
+                            self.init_items(data);
+                            self.saveButtonBottom.ajax({
+                                success: function () {}
+                            });
+                        },
+                    });
+
+                },
+            })
+        };
+
+        self.saveButtonTop = self.createSaveButton();
+        self.saveButtonBottom = self.createSaveButton();
 
         var projectInfoUrl = '<a href="' + initialPageData.reverse('domain_internal_settings') + '">domain</a>';
         self.getNamespaceHtml = function (namespace, value) {

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -153,7 +153,7 @@
 
       <hr/>
       <div id="toggle_editing_ko">
-        <div data-bind="saveButton: saveButton"></div>
+        <div data-bind="saveButton: saveButtonTop"></div>
         {% if is_random_editable %}
           <div class="input-group">
             <label for="randomness-edit">Randomness Level: </label>
@@ -200,6 +200,7 @@
             </button>
           {% endfor %}
         {% endif %}
+        <div data-bind="saveButton: saveButtonBottom"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This is for internal use. Adds a second save button to the bottom of the feature flag toggle page, useful for when a feature flag has a long list of domains. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/SAAS-15224)

It will now instantiate two different buttons (`hqMain.initSaveButton`) to retain button updates. Unfortunately I couldn't figure out a clean way to have them both work in sync so the buttons will update sequentially by nesting the ajax call - the first one forwards the domain list to update the toggle and resets the button, the second call is intentionally blank to only trigger the [button updates](https://github.com/dimagi/commcare-hq/blob/8b5b05bbae3ccead34bfa6bc9da3981d57b39f55/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js#L199). I lag isn't great but I figured since this is only for internal use and in the interest of time I'll leave it here. 

I might be misunderstanding how the button reset works with ajax so please let me know if this is an unreliable way to reset the button! 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

All of them technically. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally. Still not 100% sure about the empty ajax to trigger the button reset but it's not responsible for saving data, just updating the UI and its not public facing so I feel this is still pretty safe overall. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
