### PR TITLE
Remove get_by_natural_key methods

### DIFF
--- a/corehq/apps/dump_reload/tests/test_sql_data_loader.py
+++ b/corehq/apps/dump_reload/tests/test_sql_data_loader.py
@@ -7,7 +7,9 @@ from corehq.apps.dump_reload.sql.load import SqlDataLoader
 from corehq.apps.users.models import SQLUserData
 from corehq.apps.users.models_role import Permission, RolePermission, UserRole
 from corehq.form_processor.models.cases import CaseTransaction
-from corehq.form_processor.tests.utils import create_case
+from corehq.form_processor.models.forms import XFormOperation
+from corehq.form_processor.models.ledgers import LedgerTransaction
+from corehq.form_processor.tests.utils import create_case, create_form_for_test
 
 
 class TestSqlDataLoader(TestCase):
@@ -69,3 +71,90 @@ class TestSqlDataLoader(TestCase):
 
         role_permission = RolePermission.objects.get(role=role, permission_fk=permission)
         self.assertEqual(role_permission.pk, 1)
+
+
+class TestLoadingNonUniqueNaturalKeys(TestCase):
+    """
+    The models tested below have ``natural_key`` methods that do not guarantee a unique value. This means we need
+    to avoid using ``get_by_natural_key`` on these models because if implemented, Django's deserializer will try
+    to save an object using an existing primary key/inserted object.
+    """
+
+    def test_loading_conflicting_case_transactions(self):
+        cc_case = create_case("test", case_id="abc123", save=True)
+        serialized_models = []
+        for _ in range(2):
+            model = {
+                "model": "form_processor.casetransaction",
+                "fields": {
+                    "case": cc_case.case_id,
+                    "form_id": None,
+                    "type": 16,
+                    "server_date": "2019-11-07T09:10:12.318008Z",
+                }
+            }
+            serialized_models.append(json.dumps(model))
+
+        SqlDataLoader().load_objects(serialized_models)
+
+        self.assertEqual(
+            CaseTransaction.objects.partitioned_query(cc_case.case_id)
+            .filter(case=cc_case.case_id, form_id=None, type=16).count(),
+            2,
+        )
+
+    def test_loading_conflicting_xform_operations(self):
+        xform = create_form_for_test("test", form_id="abc123", save=True)
+        serialized_models = []
+        for _ in range(2):
+            model = {
+                "model": "form_processor.xformoperationsql",
+                "fields": {
+                    "form": xform.form_id,
+                    "user_id": 'conflicting-user-id',
+                    "date": "2019-11-07T09:10:12.318008Z",
+                    "operation": "test",
+                }
+            }
+            serialized_models.append(json.dumps(model))
+
+        SqlDataLoader().load_objects(serialized_models)
+
+        self.assertEqual(
+            XFormOperation.objects.partitioned_query(xform.form_id)
+            .filter(form=xform.form_id, user_id="conflicting-user-id").count(),
+            2,
+        )
+
+    def test_loading_conflicting_ledger_transaction(self):
+        cc_case = create_case("test", case_id="abc123", save=True)
+        xform = create_form_for_test("test", form_id="abc123", save=True)
+        serialized_models = []
+        for _ in range(2):
+            model = {
+                "model": "form_processor.ledgertransaction",
+                "fields": {
+                    "case": cc_case.case_id,
+                    "form_id": xform.form_id,
+                    "section_id": "conflicting-section-id",
+                    "entry_id": "conflicting-entry-id",
+                    "server_date": "2019-11-07T09:10:12.318008Z",
+                    "report_date": "2019-11-07T09:10:12.318008Z",
+                    "type": 1,
+                }
+            }
+            serialized_models.append(json.dumps(model))
+
+        SqlDataLoader().load_objects(serialized_models)
+
+        self.assertEqual(
+            LedgerTransaction.objects.partitioned_query(cc_case.case_id)
+            .filter(
+                case=cc_case.case_id,
+                form_id=xform.form_id,
+                section_id="conflicting-section-id",
+                entry_id="conflicting-entry-id",
+            )
+            .count(),
+            2,
+        )

--- a/corehq/apps/dump_reload/tests/test_sql_data_loader.py
+++ b/corehq/apps/dump_reload/tests/test_sql_data_loader.py
@@ -80,81 +80,78 @@ class TestLoadingNonUniqueNaturalKeys(TestCase):
     to save an object using an existing primary key/inserted object.
     """
 
-    def test_loading_conflicting_case_transactions(self):
+    def test_loading_conflicting_case_transactions_saves_distinct_objects_to_db(self):
         cc_case = create_case("test", case_id="abc123", save=True)
-        serialized_models = []
-        for _ in range(2):
-            model = {
-                "model": "form_processor.casetransaction",
-                "fields": {
-                    "case": cc_case.case_id,
-                    "form_id": None,
-                    "type": 16,
-                    "server_date": "2019-11-07T09:10:12.318008Z",
-                }
+        model = {
+            "model": "form_processor.casetransaction",
+            "fields": {
+                "case": cc_case.case_id,
+                "form_id": None,
+                "type": 16,
+                "server_date": "2019-11-07T09:10:12.318008Z",
             }
-            serialized_models.append(json.dumps(model))
+        }
+        serialized_models = [json.dumps(model) for _ in range(2)]
 
         SqlDataLoader().load_objects(serialized_models)
 
         self.assertEqual(
-            CaseTransaction.objects.partitioned_query(cc_case.case_id)
-            .filter(case=cc_case.case_id, form_id=None, type=16).count(),
+            CaseTransaction.objects.partitioned_query(cc_case.case_id).filter(
+                case=cc_case.case_id,
+                form_id=None,
+                type=16
+            ).count(),
             2,
         )
 
-    def test_loading_conflicting_xform_operations(self):
+    def test_loading_conflicting_xform_operations_saves_distinct_objects_to_db(self):
         xform = create_form_for_test("test", form_id="abc123", save=True)
-        serialized_models = []
-        for _ in range(2):
-            model = {
-                "model": "form_processor.xformoperationsql",
-                "fields": {
-                    "form": xform.form_id,
-                    "user_id": 'conflicting-user-id',
-                    "date": "2019-11-07T09:10:12.318008Z",
-                    "operation": "test",
-                }
+        model = {
+            "model": "form_processor.xformoperationsql",
+            "fields": {
+                "form": xform.form_id,
+                "user_id": 'conflicting-user-id',
+                "date": "2019-11-07T09:10:12.318008Z",
+                "operation": "test",
             }
-            serialized_models.append(json.dumps(model))
+        }
+        serialized_models = [json.dumps(model) for _ in range(2)]
 
         SqlDataLoader().load_objects(serialized_models)
 
         self.assertEqual(
-            XFormOperation.objects.partitioned_query(xform.form_id)
-            .filter(form=xform.form_id, user_id="conflicting-user-id").count(),
+            XFormOperation.objects.partitioned_query(xform.form_id).filter(
+                form=xform.form_id,
+                user_id="conflicting-user-id"
+            ).count(),
             2,
         )
 
-    def test_loading_conflicting_ledger_transaction(self):
+    def test_loading_conflicting_ledger_transactions_saves_distinct_objects_to_db(self):
         cc_case = create_case("test", case_id="abc123", save=True)
         xform = create_form_for_test("test", form_id="abc123", save=True)
-        serialized_models = []
-        for _ in range(2):
-            model = {
-                "model": "form_processor.ledgertransaction",
-                "fields": {
-                    "case": cc_case.case_id,
-                    "form_id": xform.form_id,
-                    "section_id": "conflicting-section-id",
-                    "entry_id": "conflicting-entry-id",
-                    "server_date": "2019-11-07T09:10:12.318008Z",
-                    "report_date": "2019-11-07T09:10:12.318008Z",
-                    "type": 1,
-                }
+        model = {
+            "model": "form_processor.ledgertransaction",
+            "fields": {
+                "case": cc_case.case_id,
+                "form_id": xform.form_id,
+                "section_id": "conflicting-section-id",
+                "entry_id": "conflicting-entry-id",
+                "server_date": "2019-11-07T09:10:12.318008Z",
+                "report_date": "2019-11-07T09:10:12.318008Z",
+                "type": 1,
             }
-            serialized_models.append(json.dumps(model))
+        }
+        serialized_models = [json.dumps(model) for _ in range(2)]
 
         SqlDataLoader().load_objects(serialized_models)
 
         self.assertEqual(
-            LedgerTransaction.objects.partitioned_query(cc_case.case_id)
-            .filter(
+            LedgerTransaction.objects.partitioned_query(cc_case.case_id).filter(
                 case=cc_case.case_id,
                 form_id=xform.form_id,
                 section_id="conflicting-section-id",
-                entry_id="conflicting-entry-id",
-            )
-            .count(),
+                entry_id="conflicting-entry-id"
+            ).count(),
             2,
         )

--- a/corehq/blobs/models.py
+++ b/corehq/blobs/models.py
@@ -13,7 +13,7 @@ from django.db.models import (
 )
 from memoized import memoized
 
-from corehq.sql_db.models import PartitionedModel, RequireDBManager
+from corehq.sql_db.models import PartitionedModel
 from corehq.util.models import NullJsonField
 
 from .util import get_content_md5
@@ -23,17 +23,10 @@ def uuid4_hex():
     return uuid4().hex
 
 
-class BlobMetaManager(RequireDBManager):
-
-    def get_by_natural_key(self, parent_id, key):
-        return self.partitioned_query(parent_id).get(key=key)
-
-
 class BlobMeta(PartitionedModel, Model):
     """Metadata about an object stored in the blob db"""
 
     partition_attr = "parent_id"
-    objects = BlobMetaManager()
 
     domain = CharField(max_length=255)
     parent_id = CharField(

--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -843,9 +843,6 @@ def get_index_map(indices):
 
 class CaseAttachmentManager(RequireDBManager):
 
-    def get_by_natural_key(self, case_id, attachment_id):
-        return self.partitioned_query(case_id).get(attachment_id=attachment_id)
-
     def get_attachments(self, case_id):
         return list(self.partitioned_query(case_id).filter(case_id=case_id))
 
@@ -975,9 +972,6 @@ class CaseAttachment(PartitionedModel, models.Model, SaveStateMixin, IsImageMixi
 
 
 class CommCareCaseIndexManager(RequireDBManager):
-
-    def get_by_natural_key(self, domain, case_id, identifier):
-        return self.partitioned_query(case_id).get(domain=domain, case_id=case_id, identifier=identifier)
 
     def get_indices(self, domain, case_id):
         query = self.partitioned_query(case_id)
@@ -1117,7 +1111,7 @@ class CommCareCaseIndex(PartitionedModel, models.Model, SaveStateMixin):
     def natural_key(self):
         # necessary for dumping models from a sharded DB so that we exclude the
         # SQL 'id' field which won't be unique across all the DB's
-        return self.domain, self.case, self.identifier
+        return self.domain, self.case_id, self.identifier
 
     @property
     def is_deleted(self):
@@ -1188,9 +1182,6 @@ class CommCareCaseIndex(PartitionedModel, models.Model, SaveStateMixin):
 
 
 class CaseTransactionManager(RequireDBManager):
-
-    def get_by_natural_key(self, case_id, form_id, transaction_type):
-        return self.partitioned_query(case_id).get(case_id=case_id, form_id=form_id, type=transaction_type)
 
     def get_transactions(self, case_id):
         return list(
@@ -1323,7 +1314,7 @@ class CaseTransaction(PartitionedModel, SaveStateMixin, models.Model):
     def natural_key(self):
         # necessary for dumping models from a sharded DB so that we exclude the
         # SQL 'id' field which won't be unique across all the DB's
-        return self.case, self.form_id, self.type
+        return self.case_id, self.form_id, self.type
 
     @staticmethod
     def _should_process(transaction_type):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -432,9 +432,6 @@ class XFormInstanceManager(RequireDBManager):
 
 class XFormOperationManager(RequireDBManager):
 
-    def get_by_natural_key(self, form_id, user_id, date):
-        return self.partitioned_query(form_id).get(form_id=form_id, user_id=user_id, date=date)
-
     def get_form_operations(self, form_id):
         return list(self.partitioned_query(form_id).filter(form_id=form_id).order_by('date'))
 
@@ -790,7 +787,7 @@ class XFormOperation(PartitionedModel, SaveStateMixin, models.Model):
     def natural_key(self):
         # necessary for dumping models from a sharded DB so that we exclude the
         # SQL 'id' field which won't be unique across all the DB's
-        return self.form, self.user_id, self.date
+        return self.form_id, self.user_id, self.date
 
     @property
     def user(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup to https://github.com/dimagi/commcare-hq/pull/33999

> The worst case is that this change corrupts the load_domain_data command, which is already broken because of this issue

^ This is exactly what happened. In summary, not all of our natural keys are actually unique.

One example is CaseTransaction which has a natural_key consisting of `case_id`, `form_id`, and `type`. `form_id` is nullable, which means a CaseTransaction inserted with a null `form_id` will not trigger the unique constraint on `case_id`, `form_id`, and `type`. So we end up with CaseTransaction objects that could have the same `case_id` and `type`, and a null `form_id`. The Django deserializer will then try to assign a primary key to this object when initializing it from json, and use `get_by_natural_key` if defined to fetch an existing object that matches the natural key fields. Our code for loading SQL objects saves objects with `force_insert=True`, which means a DuplicateKey error is raised because we try to create an object with a primary key that is already in use.

We already have a unique way of using natural keys (see the previously linked PR), so rather than try to make our natural keys unique for all models, it seems easier to revert the addition of `get_by_natural_key` as it was not necessary. I added it simply to conform to Django expectations, but am glad there is now a good reason for not defining those methods. Additionally, I've added automated tests that will fail if `get_by_natural_key` is added to these problematic models in the future, assuming nothing else is changed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I added tests to ensure there isn't a regression here.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
