### PR TITLE
Default undefined user data that corresponds to defined schema to the blank string

### DIFF
--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -100,7 +100,7 @@ class TestCommCareUserResource(APIResourceTest):
             'last_name': '',
             'phone_numbers': [],
             'resource_uri': '/a/qwerty/api/v0.5/user/{}/'.format(backend_id),
-            'user_data': {'commcare_project': 'qwerty', PROFILE_SLUG: ''},
+            'user_data': {'commcare_project': 'qwerty', PROFILE_SLUG: '', 'imaginary': ''},
             'username': 'fake_user'
         })
 
@@ -126,7 +126,7 @@ class TestCommCareUserResource(APIResourceTest):
             'last_name': '',
             'phone_numbers': [],
             'resource_uri': '/a/qwerty/api/v0.5/user/{}/'.format(backend_id),
-            'user_data': {'commcare_project': 'qwerty', PROFILE_SLUG: ''},
+            'user_data': {'commcare_project': 'qwerty', PROFILE_SLUG: '', 'imaginary': ''},
             'username': 'fake_user',
         })
 

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -111,7 +111,8 @@ class TestUserDataMixin:
             self.upload_record.pk,
             is_web_upload
         )
-        self.assert_user_data_equals({'commcare_project': 'mydomain', 'key': 'F#', 'commcare_profile': ''})
+        self.assert_user_data_equals({
+            'commcare_project': 'mydomain', 'key': 'F#', 'commcare_profile': '', 'mode': ''})
 
         # Update user_data
         import_users_and_groups(
@@ -122,7 +123,8 @@ class TestUserDataMixin:
             self.upload_record.pk,
             is_web_upload
         )
-        self.assert_user_data_equals({'commcare_project': 'mydomain', 'key': 'Bb', 'commcare_profile': ''})
+        self.assert_user_data_equals({
+            'commcare_project': 'mydomain', 'key': 'Bb', 'commcare_profile': '', 'mode': ''})
 
         # set user data to blank
         import_users_and_groups(
@@ -133,7 +135,8 @@ class TestUserDataMixin:
             self.upload_record.pk,
             is_web_upload
         )
-        self.assert_user_data_equals({'commcare_project': 'mydomain', 'key': '', 'commcare_profile': ''})
+        self.assert_user_data_equals({
+            'commcare_project': 'mydomain', 'key': '', 'commcare_profile': '', 'mode': ''})
 
         # Allow falsy but non-blank values
         import_users_and_groups(
@@ -144,7 +147,8 @@ class TestUserDataMixin:
             self.upload_record.pk,
             is_web_upload
         )
-        self.assert_user_data_equals({'commcare_project': 'mydomain', 'key': 0, 'commcare_profile': ''})
+        self.assert_user_data_equals({
+            'commcare_project': 'mydomain', 'key': 0, 'commcare_profile': '', 'mode': ''})
 
     def _test_user_data_profile(self, is_web_upload=False):
         import_users_and_groups(
@@ -162,9 +166,12 @@ class TestUserDataMixin:
             'mode': 'minor',
             PROFILE_SLUG: self.profile.id,
         })
-        user_history = UserHistory.objects.get(user_id=self.user.get_id, changed_by=self.uploading_user.get_id,
-                                               # web users are setup first and then updated
-                                               action=UserModelAction.UPDATE.value if is_web_upload else UserModelAction.CREATE.value)
+        user_history = UserHistory.objects.get(
+            user_id=self.user.get_id,
+            changed_by=self.uploading_user.get_id,
+            # web users are setup first and then updated
+            action=UserModelAction.UPDATE.value if is_web_upload else UserModelAction.CREATE.value
+        )
         change_messages = UserChangeMessage.profile_info(self.profile.id, self.profile.name)
         self.assertDictEqual(user_history.change_messages['profile'], change_messages['profile'])
 
@@ -180,6 +187,7 @@ class TestUserDataMixin:
         self.assert_user_data_equals({
             'commcare_project': 'mydomain',
             'mode': 'minor',
+            'key': '',
             PROFILE_SLUG: self.profile.id,
         })
         # Profile fields shouldn't actually be added to user_data
@@ -197,6 +205,7 @@ class TestUserDataMixin:
         self.assert_user_data_equals({
             'commcare_project': 'mydomain',
             'mode': 'minor',
+            'key': '',
             PROFILE_SLUG: self.profile.id,
         })
 
@@ -215,6 +224,7 @@ class TestUserDataMixin:
         )
         self.assert_user_data_equals({
             'commcare_project': 'mydomain',
+            'key': '',
             'mode': 'minor',
             PROFILE_SLUG: self.profile.id,
         })
@@ -264,6 +274,7 @@ class TestUserDataMixin:
         )
         self.assert_user_data_equals({
             'commcare_project': 'mydomain',
+            'key': '',
             'mode': 'minor',
             PROFILE_SLUG: self.profile.id,
         })
@@ -289,7 +300,13 @@ class TestUserDataMixin:
             self.upload_record.pk,
             is_web_upload
         )
-        self.assert_user_data_equals({'commcare_project': 'mydomain', 'tempo': 'presto', 'commcare_profile': ''})
+        self.assert_user_data_equals({
+            'commcare_project': 'mydomain',
+            'key': '',
+            'mode': '',
+            'tempo': 'presto',
+            'commcare_profile': ''
+        })
 
         # Update data
         import_users_and_groups(
@@ -300,7 +317,13 @@ class TestUserDataMixin:
             self.upload_record.pk,
             is_web_upload
         )
-        self.assert_user_data_equals({'commcare_project': 'mydomain', 'tempo': 'andante', 'commcare_profile': ''})
+        self.assert_user_data_equals({
+            'commcare_project': 'mydomain',
+            'key': '',
+            'mode': '',
+            'tempo': 'andante',
+            'commcare_profile': ''
+        })
 
     @patch('corehq.apps.user_importer.importer.domain_has_privilege', lambda x, y: True)
     def _test_user_data_ignore_system_fields(self, is_web_upload=False):
@@ -317,6 +340,7 @@ class TestUserDataMixin:
             'commcare_project': 'mydomain',
             'commcare_profile': '',
             'key': 'F#',
+            'mode': '',
         }
         if not is_web_upload:
             data.update({
@@ -924,7 +948,7 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin, TestUserDataMi
         self.assertTrue(self.user.is_active)
 
     def test_password_is_not_string(self):
-        rows = import_users_and_groups(
+        import_users_and_groups(
             self.domain.name,
             [self._get_spec(password=123)],
             [],

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -43,7 +43,7 @@ from corehq.apps.users.models import (
     WebUser,
 )
 from corehq.apps.users.models_role import UserRole
-from corehq.apps.users.tests.util import patch_user_data_db_layer
+from corehq.apps.users.tests.util import patch_user_data_db_layer, patch_user_data_schema
 from corehq.apps.users.util import normalize_username
 from corehq.util.es.testing import sync_users_to_es
 from corehq.util.test_utils import flag_disabled, flag_enabled
@@ -263,6 +263,7 @@ class UserChoiceProviderTest(SimpleTestCase, ChoiceProviderTestMixin):
     domain = 'user-choice-provider'
 
     @classmethod
+    @patch_user_data_schema
     @patch_user_data_db_layer
     def make_mobile_worker(cls, username, domain=None):
         domain = domain or cls.domain

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1105,7 +1105,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         self.last_name = ' '.join(data)
 
     def get_user_data(self, domain):
-        # To do this in bulk, try bulk_populate_user_data
+        # To do this in bulk, try UserData's prime_user_data_caches
         from .user_data import UserData
         if domain not in self._user_data_accessors:
             self._user_data_accessors[domain] = UserData.lazy_init(self, domain)

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -9,7 +9,7 @@ from corehq.apps.es.client import manager
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.es.users import user_adapter
 from corehq.apps.reports.analytics.esaccessors import get_user_stubs
-from corehq.apps.users.tests.util import patch_user_data_db_layer
+from corehq.apps.users.tests.util import patch_user_data_db_layer, patch_user_data_schema
 from corehq.util.es.testing import sync_users_to_es
 from corehq.util.test_utils import mock_out_couch
 
@@ -58,6 +58,7 @@ class TestUserSignals(SimpleTestCase):
 
 
 @mock_out_couch()
+@patch_user_data_schema
 @patch_user_data_db_layer
 @patch('corehq.apps.users.models.CouchUser.sync_to_django_user', new=MagicMock)
 @patch('corehq.apps.analytics.signals.update_hubspot_properties')

--- a/corehq/apps/users/tests/test_user_data.py
+++ b/corehq/apps/users/tests/test_user_data.py
@@ -178,7 +178,7 @@ class TestUserDataModel(SimpleTestCase):
 
     def setUp(self):
         self.user_fields = []
-        field_patcher = patch('corehq.apps.users.user_data.UserData._get_schema_fields')
+        field_patcher = patch('corehq.apps.users.user_data.UserData._schema_fields')
         mocked_schema_fields = field_patcher.start()
         mocked_schema_fields.side_effect = lambda: self.user_fields
 

--- a/corehq/apps/users/tests/test_user_data.py
+++ b/corehq/apps/users/tests/test_user_data.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 from django.test import SimpleTestCase, TestCase
 
@@ -178,7 +178,7 @@ class TestUserDataModel(SimpleTestCase):
 
     def setUp(self):
         self.user_fields = []
-        field_patcher = patch('corehq.apps.users.user_data.UserData._schema_fields')
+        field_patcher = patch('corehq.apps.users.user_data.UserData._schema_fields', new_callable=PropertyMock)
         mocked_schema_fields = field_patcher.start()
         mocked_schema_fields.side_effect = lambda: self.user_fields
 

--- a/corehq/apps/users/tests/util.py
+++ b/corehq/apps/users/tests/util.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.users.user_data import UserData
@@ -22,3 +22,6 @@ def create_usercase(user):
 
 patch_user_data_db_layer = patch('corehq.apps.users.user_data.UserData.lazy_init',
                                  new=lambda u, d: UserData({}, None, d))
+
+patch_user_data_schema = patch('corehq.apps.users.user_data.UserData._schema_defaults',
+                               new=PropertyMock(return_value={}))

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -260,7 +260,7 @@ def prime_user_data_caches(users, domain):
             user._user_data_accessors[domain] = user_data
 
             # prime the user schema data to avoid individual database calls
-            user._schema_fields = schema_fields
+            user_data._schema_fields = schema_fields
             if user_data.profile_id and user_data.profile_id in profiles_by_id:
                 user_data.profile = profiles_by_id[user_data.profile_id]
 

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -225,8 +225,13 @@ def get_all_profiles_by_id(domain):
 def get_user_schema_fields(domain):
     from corehq.apps.users.views.mobile.custom_data_fields import CUSTOM_USER_DATA_FIELD_TYPE
 
-    definition = CustomDataFieldsDefinition.objects.get(domain=domain, field_type=CUSTOM_USER_DATA_FIELD_TYPE)
-    return definition.get_fields()
+    try:
+        definition = CustomDataFieldsDefinition.objects.get(domain=domain, field_type=CUSTOM_USER_DATA_FIELD_TYPE)
+    except CustomDataFieldsDefinition.DoesNotExist:
+        fields = []
+    else:
+        fields = definition.get_fields()
+    return fields
 
 
 def prime_user_data_caches(users, domain):

--- a/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
+++ b/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
@@ -16,7 +16,7 @@ from corehq.apps.hqcase.management.commands.ptop_reindexer_v2 import (
     reindex_and_clean,
 )
 from corehq.apps.users.models import CommCareUser
-from corehq.apps.users.tests.util import patch_user_data_db_layer
+from corehq.apps.users.tests.util import patch_user_data_db_layer, patch_user_data_schema
 from corehq.pillows.groups_to_user import (
     get_group_pillow,
     remove_group_from_users,
@@ -134,7 +134,7 @@ def _create_es_user(user_id, domain):
         last_name='Casual',
         is_active=True,
     )
-    with patch_user_data_db_layer:
+    with (patch_user_data_schema, patch_user_data_db_layer):
         user_adapter.index(user, refresh=True)
     return user
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15153

User had an application configured to reference a field that was defined in the domain's Custom User Data (as required), but wasn't present on many users. When those users would attempt to access the application, rather than coalesce into the alternative value, the application would throw an exception because it was accessing a null value. As our applications don't distinguish between the null/blank string and because we don't provide any indicator for a user to know that there's a difference, we're changing it so that these properties will instead get auto-filled to the blank string, and thus not call a null reference error in the future.

## Safety Assurance

### Safety story
Locally verified, but did not perform any testing against the modifications to the bulk operations.

### Automated test coverage

Added a few new tests

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
