### PR TITLE
Remove unnecessary location_type_object property on SQLLocation

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -1,5 +1,4 @@
 import uuid
-from collections import defaultdict
 from datetime import datetime
 from functools import partial
 
@@ -98,7 +97,12 @@ class LocationType(models.Model):
         on_delete=models.CASCADE,
     )  # levels below this location type that we start expanding from
     _expand_from_root = models.BooleanField(default=False, db_column='expand_from_root')
-    expand_to = models.ForeignKey('self', null=True, related_name='+', on_delete=models.CASCADE)  # levels above this type that are synced
+    expand_to = models.ForeignKey(
+        "self",
+        null=True,
+        related_name="+",
+        on_delete=models.CASCADE,
+    )  # levels above this type that are synced
     include_without_expanding = models.ForeignKey(
         'self',
         null=True,
@@ -523,8 +527,7 @@ class SQLLocation(AdjListModel):
     def products(self, value):
         # this will set stocks_all_products to true if the user
         # has added all products in the domain to this location
-        self.stocks_all_products = (set(value) ==
-                                    set(SQLProduct.by_domain(self.domain)))
+        self.stocks_all_products = set(value) == set(SQLProduct.by_domain(self.domain))
 
         self._products.set(value)
 
@@ -778,13 +781,13 @@ class LocationFixtureConfiguration(models.Model):
 
 def get_case_sharing_groups_for_locations(locations, for_user_id=None):
     # safety check to make sure all locations belong to same domain
-    assert len(set([l.domain for l in locations])) < 2
+    assert len({location.domain for location in locations}) <= 1
 
     for location in locations:
         if location.location_type.shares_cases:
             yield location.case_sharing_group_object(for_user_id)
 
-    location_ids = [l.pk for l in locations if l.location_type.view_descendants]
+    location_ids = [location.pk for location in locations if location.location_type.view_descendants]
     descendants = []
     if location_ids:
         where = Q(domain=locations[0].domain, parent_id__in=location_ids)

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -695,10 +695,6 @@ class SQLLocation(AdjListModel):
         return self.parent.location_id if self.parent else None
 
     @property
-    def location_type_object(self):
-        return self.location_type
-
-    @property
     def location_type_name(self):
         return self.location_type.name
 

--- a/corehq/apps/locations/templates/locations/manage/location.html
+++ b/corehq/apps/locations/templates/locations/manage/location.html
@@ -39,7 +39,7 @@
 
       <div class="btn-toolbar" style="margin-bottom: 20px;">
 
-        {% if location.get_id and location.location_type_object.can_have_children and not request.is_view_only %}
+        {% if location.get_id and location.location_type.can_have_children and not request.is_view_only %}
           <a class="btn btn-primary" href="{% url "create_location" domain %}?parent={{ location.get_id }}">
             <i class="fa fa-plus"></i> {% trans "New Child Location" %}
           </a>

--- a/corehq/apps/locations/tests/test_location_groups.py
+++ b/corehq/apps/locations/tests/test_location_groups.py
@@ -118,7 +118,7 @@ class LocationGroupTest(LocationGroupBase):
             group_obj.save()
 
     def test_get_owner_ids(self):
-        loc_type = self.loc.location_type_object
+        loc_type = self.loc.location_type
         self.assertFalse(loc_type.shares_cases)
         owner_ids = self.user.get_owner_ids()
         self.assertEqual(1, len(owner_ids))

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -745,7 +745,7 @@ class EditLocationView(BaseEditLocationView):
     @memoized
     def products_form(self):
         if (
-            self.location.location_type_object.administrative or
+            self.location.location_type.administrative or
             not toggles.PRODUCTS_PER_LOCATION.enabled(self.request.domain)
         ):
             return None

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -377,10 +377,11 @@ class LocationTypesView(BaseDomainView):
                     # to check if the name/code was swapped with another location by confirming if
                     # either name/code has changed but the current name is still present in the names/codes passed
                     if (
-                            (location_type.name != payload_loc_type_name_by_pk.get(location_type.pk) and
-                             location_type.name in names) or
-                            (location_type.code != payload_loc_type_code_by_pk.get(location_type.pk) and
-                             location_type.code in codes)
+                        location_type.name != payload_loc_type_name_by_pk.get(location_type.pk)
+                        and location_type.name in names
+                    ) or (
+                        location_type.code != payload_loc_type_code_by_pk.get(location_type.pk)
+                        and location_type.code in codes
                     ):
                         return False
             return True
@@ -745,8 +746,8 @@ class EditLocationView(BaseEditLocationView):
     @memoized
     def products_form(self):
         if (
-            self.location.location_type.administrative or
-            not toggles.PRODUCTS_PER_LOCATION.enabled(self.request.domain)
+            self.location.location_type.administrative
+            or not toggles.PRODUCTS_PER_LOCATION.enabled(self.request.domain)
         ):
             return None
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2051,7 +2051,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         user_data = self.get_user_data(self.domain)
         user_data['commcare_location_id'] = location.location_id
 
-        if not location.location_type_object.administrative:
+        if not location.location_type.administrative:
             # just need to trigger a get or create to make sure
             # this exists, otherwise things blow up
             sp = SupplyInterface(self.domain).get_or_create_by_location(location)
@@ -2219,7 +2219,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
 
         index = {}
         for location in locations:
-            if not location.location_type_object.administrative:
+            if not location.location_type.administrative:
                 sp = SupplyInterface(self.domain).get_by_location(location)
                 index.update(self.supply_point_index_mapping(sp))
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Maybe I'm wrong, but it seems unnecessary at this point to have a `location_type_object` property since the foreign key field `location_type` will return the object. First commit updates all relevant usages of `location_type_object` => `location_type`, and the second commit cleans up lint errors.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Simple refactor where no functionality is changed.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
