### PR TITLE
Automatically include case_id in form export

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -394,7 +394,7 @@ class ExportColumn(DocumentSchema):
         column.selected = (
             auto_select
             and not column._is_deleted(app_ids_and_versions)
-            and not is_case_update
+            and (not is_case_update or is_case_id)
             and not is_label_question
             and (is_main_table or is_bulk_export)
             and not is_deprecated


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
In Data > Export Form Data, click on "Add Export", then in the drilldown modal, select "Case List" for Menu, click on "Add Export"
Then in the Export Settings, we can see the checkbox for `case_id` is already checked
<img width="805" alt="image" src="https://github.com/dimagi/commcare-hq/assets/39149002/707926a9-abab-4855-a4c1-a10b52b6b632">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-14868

If the column is case id, then when we determine if we should pre-check the column in `column.selected`, we will return True.


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The change only relates to whether a column is auto checked. So it should be safe.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

QA Ticket: https://dimagi.atlassian.net/browse/QA-6093

QA should validate that `case_id` will be auto checked in form export for Case List. (Surveys won't have `case_id`)
Also make sure the form export still function well.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
