### PR TITLE
Fix runserver command documentation

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -809,7 +809,7 @@ LOCAL_APPS += ('django_extensions',)
 **IMPORTANT:** When running HQ, be sure to use `runserver_plus`
 
 ```sh
-./manage.py runserver_plus localhost:8000
+./manage.py runserver_plus localhost:8000 --keep-meta-shutdown
 ```
 
 Then you need to have Formplayer running.


### PR DESCRIPTION
Without this option, the latest version of werkzeug fail:

```
  File "/home/jeremi/.pyenv/versions/hq/lib/python3.9/site-packages/django_extensions/management/commands/runserver_plus.py", line 322, in make_environ
    del environ['werkzeug.server.shutdown']
KeyError: 'werkzeug.server.shutdown'
```