### PR TITLE
Case Tile bug Repeated Elements within Suite Detai

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -13,10 +13,6 @@ from corehq.apps.app_manager.exceptions import SuiteError
 from corehq.apps.app_manager.suite_xml.xml_models import (
     Detail, XPathVariable, TileGroup, Style, EndpointAction
 )
-from corehq.apps.app_manager.util import (
-    module_offers_search,
-    module_uses_inline_search,
-)
 
 TILE_DIR = Path(__file__).parent.parent / "case_tile_templates"
 
@@ -134,14 +130,6 @@ class CaseTileHelper(object):
 
         # Add case search action if needed
         if self.detail_type.endswith('short'):
-            if module_offers_search(self.module) and not module_uses_inline_search(self.module):
-                if (case_search_action := DetailContributor.get_case_search_action(
-                    self.module,
-                    self.build_profile_id,
-                    self.detail_id
-                )) is not None:
-                    detail.actions.append(case_search_action)
-
             #  Excludes legacy tile template to preserve behavior of existing apps using this template.
             if self.detail.case_tile_template not in [CaseTileTemplates.PERSON_SIMPLE.value, CUSTOM]:
                 self._populate_sort_elements_in_detail(detail)

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -134,10 +134,6 @@ class CaseTileHelper(object):
             if self.detail.case_tile_template not in [CaseTileTemplates.PERSON_SIMPLE.value, CUSTOM]:
                 self._populate_sort_elements_in_detail(detail)
 
-            DetailContributor.add_no_items_text_to_detail(detail, self.app, self.detail_type, self.module)
-
-            DetailContributor.add_select_text_to_detail(detail, self.app, self.detail_type, self.module)
-
             if self.module.has_grouped_tiles():
                 detail.tile_group = TileGroup(
                     function=f"string(./index/{self.detail.case_tile_group.index_identifier})",

--- a/corehq/apps/app_manager/suite_xml/features/case_tiles.py
+++ b/corehq/apps/app_manager/suite_xml/features/case_tiles.py
@@ -128,7 +128,6 @@ class CaseTileHelper(object):
             DetailContributor.add_register_action(
                 self.app, self.module, detail.actions, self.build_profile_id, self.entries_helper)
 
-        # Add case search action if needed
         if self.detail_type.endswith('short'):
             #  Excludes legacy tile template to preserve behavior of existing apps using this template.
             if self.detail.case_tile_template not in [CaseTileTemplates.PERSON_SIMPLE.value, CUSTOM]:

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -204,8 +204,6 @@ class DetailContributor(SectionContributor):
             if detail.lookup_enabled and detail.lookup_action:
                 d.lookup = self._get_lookup_element(detail, module)
 
-            self.add_no_items_text_to_detail(d, self.app, detail_type, module)
-
             # Add variables
             variables = list(
                 schedule_detail_variables(module, detail, detail_column_infos)
@@ -256,6 +254,7 @@ class DetailContributor(SectionContributor):
                         d.actions.append(case_search_action)
             # Add select text
             self.add_select_text_to_detail(d, self.app, detail_type, module)
+            self.add_no_items_text_to_detail(d, self.app, detail_type, module)
 
             try:
                 if not self.app.enable_multi_sort:

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -217,12 +217,11 @@ class DetailContributor(SectionContributor):
 
             # Add fields
             if detail.case_tile_template:
-                detail_id = id_strings.detail(module, detail_type)
                 helper = CaseTileHelper(
                     self.app,
                     module,
                     detail,
-                    detail_id,
+                    id,
                     detail_type,
                     self.build_profile_id,
                     detail_column_infos,

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -239,12 +239,14 @@ class DetailContributor(SectionContributor):
                     for field in fields:
                         d.fields.append(field)
 
+                    # Add actions
+                    if detail_type.endswith('short') and not module.put_in_root:
+                        if module.case_list_form.form_id:
+                            DetailContributor.add_register_action(
+                                self.app, module, d.actions, self.build_profile_id, self.entries_helper)
+
             # Add actions
             if detail_type.endswith('short') and not module.put_in_root:
-                if module.case_list_form.form_id:
-                    DetailContributor.add_register_action(
-                        self.app, module, d.actions, self.build_profile_id, self.entries_helper)
-
                 if module_offers_search(module) and not module_uses_inline_search(module):
                     if (case_search_action := DetailContributor.get_case_search_action(
                         module,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Currently, when both ["Registration from Case List" ](https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955310/Minimize+Duplicates+Method+1+Registration+From+the+Case+List) and case tile is configured, the same action element is added twice to the same detail element in the suite.

<img src="https://github.com/dimagi/commcare-hq/assets/88759246/87cfc51c-49c4-4ae2-aa79-f706b40cc65e" width="300" height="300">

<img src="https://github.com/dimagi/commcare-hq/assets/88759246/09543833-9317-499d-89a7-a84fea23e3ee" width="200" height="50">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-4193](https://dimagi.atlassian.net/browse/USH-4193?focusedCommentId=310538&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-310538)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[Case Tile](https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146602199/Allow+Configuration+of+Case+List+Tiles#AllowConfigurationofCaseListTiles-ImplementationExample(WebApps))

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested. blast radius of change is limited to case tiles.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests exist that checks [case tile adds the required suite element](https://github.com/dimagi/commcare-hq/blob/9c19edaa1eb6019ef80c2356a6a9b29a543bb137/corehq/apps/app_manager/tests/test_suite_case_tiles.py)s

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Apps will require rebuild to revert changes since this PR changes suite generation.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4193]: https://dimagi.atlassian.net/browse/USH-4193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ