### PR TITLE
Check for and fix skipped test starts db transaction

### DIFF
--- a/corehq/apps/accounting/tests/test_autopay_with_api.py
+++ b/corehq/apps/accounting/tests/test_autopay_with_api.py
@@ -30,12 +30,12 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestBillingAutoPay, cls).setUpClass()
         # Dependabot-created PRs do not have access to secrets.
         # We skip test so the tests do not fail when dependabot creates new PR for dependency upgrades.
         # Or for developers running tests locally if they do not have stripe API key in their localsettings.
         if not settings.STRIPE_PRIVATE_KEY:
             raise SkipTest("Stripe API Key not set")
+        super(TestBillingAutoPay, cls).setUpClass()
         cls._generate_autopayable_entities()
         cls._generate_non_autopayable_entities()
         cls._generate_invoices()

--- a/corehq/tests/noseplugins/dbtransaction.py
+++ b/corehq/tests/noseplugins/dbtransaction.py
@@ -1,0 +1,39 @@
+from nose.plugins import Plugin
+
+from django.db import connection
+
+
+class DatabaseTransactionPlugin(Plugin):
+    """Verify database transaction not in progress before/after test context
+
+    A "test context" is a package, module, or test class.
+    """
+
+    name = "dbtransaction"
+    enabled = True
+
+    def options(self, parser, env):
+        """Do not call super (always enabled)"""
+
+    def startContext(self, context):
+        check_for_transaction(context)
+
+    def stopContext(self, context):
+        check_for_transaction(context)
+
+    def handleError(self, test, err):
+        if getattr(test, "error_context", None) in {"setup", "teardown"}:
+            check_for_transaction(err[1])
+
+
+def check_for_transaction(context):
+    if connection.in_atomic_block:
+        raise UnexpectedTransaction(
+            "Was an exception raised in setUpClass() after super().setUpClass() "
+            "or in tearDownClass() before super().tearDownClass()? "
+            f"Context: {context}"
+        )
+
+
+class UnexpectedTransaction(Exception):
+    pass

--- a/testsettings.py
+++ b/testsettings.py
@@ -57,6 +57,7 @@ NOSE_ARGS = [
 NOSE_PLUGINS = [
     'corehq.tests.nose.HqTestFinderPlugin',
     'corehq.tests.noseplugins.classcleanup.ClassCleanupPlugin',
+    'corehq.tests.noseplugins.dbtransaction.DatabaseTransactionPlugin',
     'corehq.tests.noseplugins.dividedwerun.DividedWeRunPlugin',
     'corehq.tests.noseplugins.djangomigrations.DjangoMigrationsPlugin',
     'corehq.tests.noseplugins.cmdline_params.CmdLineParametersPlugin',


### PR DESCRIPTION
`TestBillingAutoPay.setUpClass()` was raising `SkipTest` after opening a transaction for the class (which is done by `super().setUpClass()`), causing the transaction to remain open for subsequent tests. This eventually fails when a database operation puts the transaction in a bad state that would normally be cleaned up on transaction rollback, but in this case that was never done. Instead, the connection is closed curing savepoint rollback, which then results in `InterfaceError: connection already closed` the next time the connection is used.

## Safety Assurance

### Safety story

Affects tests only.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations