### PR TITLE
Upgrade pytz to 2024.1

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -88,6 +88,7 @@ python-dateutil
 python-imap
 pyphonetics
 python-magic
+pytz
 pyjwt
 PyYAML
 hl7apy

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -577,8 +577,9 @@ python-termstyle==0.1.10
     # via sniffer
 python3-saml==1.12.0
     # via -r sso-requirements.in
-pytz==2022.1
+pytz==2024.1
     # via
+    #   -r base-requirements.in
     #   babel
     #   celery
     #   django

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -474,8 +474,9 @@ python-magic==0.4.27
     # via -r base-requirements.in
 python-mimeparse==1.6.0
     # via django-tastypie
-pytz==2022.1
+pytz==2024.1
     # via
+    #   -r base-requirements.in
     #   babel
     #   celery
     #   django

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -492,8 +492,9 @@ python-mimeparse==1.6.0
     # via django-tastypie
 python3-saml==1.12.0
     # via -r sso-requirements.in
-pytz==2022.1
+pytz==2024.1
     # via
+    #   -r base-requirements.in
     #   celery
     #   django
     #   djangorestframework

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -447,8 +447,9 @@ python-mimeparse==1.6.0
     # via django-tastypie
 python3-saml==1.12.0
     # via -r sso-requirements.in
-pytz==2022.1
+pytz==2024.1
     # via
+    #   -r base-requirements.in
     #   celery
     #   django
     #   djangorestframework

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -482,8 +482,9 @@ python-mimeparse==1.6.0
     # via django-tastypie
 python3-saml==1.12.0
     # via -r sso-requirements.in
-pytz==2022.1
+pytz==2024.1
     # via
+    #   -r base-requirements.in
     #   celery
     #   django
     #   djangorestframework


### PR DESCRIPTION
Multimajor upgrade. Reviewed issues on github, saw nothing alarming.

A note from the [README](https://github.com/stub42/pytz/blob/master/src/README.rst):

> This project is in maintenance mode. Projects using Python 3.9 or later are best served by using the timezone functionaly now included in core Python and packages that work with it such as [tzdata](https://pypi.org/project/tzdata/).

Should we start to think about migrating to the built in `timezone`? Most assuredly all new code should use `timezone`.

## Safety Assurance

### Safety story

pytz is a very stable dependency with wide usage.

### Automated test coverage

Not directly that I know of, although many tests probably exercise the various ways it is used.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations