### PR TITLE
Allow Copy Cases Feature to copy cases that are owned by location or group

### DIFF
--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -195,7 +195,7 @@ class CaseCopyInterface(CaseReassignmentInterface):
     @property
     def fields(self):
         return [
-            'corehq.apps.reports.filters.users.SelectMobileWorkerFilter',
+            'corehq.apps.reports.filters.case_list.CaseListFilter',
             'corehq.apps.reports.filters.select.MultiCaseTypeFilter',
             'corehq.apps.reports.standard.cases.filters.CaseSearchFilter',
             'corehq.apps.reports.standard.cases.filters.SensitiveCaseProperties',

--- a/corehq/apps/hqcase/case_helper.py
+++ b/corehq/apps/hqcase/case_helper.py
@@ -279,7 +279,7 @@ class CaseCopier:
             if orig_case.owner_id == self.to_owner:
                 errors.append(_(
                     'Original case owner {owner_id} cannot copy '
-                    'case {case_id} to themselves.'
+                    'case {case_id} to themselves'
                 ).format(
                     owner_id=orig_case.owner_id,
                     case_id=orig_case.case_id,

--- a/corehq/apps/hqcase/tests/test_case_copier.py
+++ b/corehq/apps/hqcase/tests/test_case_copier.py
@@ -34,7 +34,7 @@ class TestCaseCopier(TestCase):
             self.assertEqual(case_id_pairs, [])
             self.assertEqual(errors, [
                 'Original case owner owner_id cannot copy case '
-                f'{case.case_id} to themselves.'
+                f'{case.case_id} to themselves'
             ])
 
     def test_copy_case_to_new_owner(self):
@@ -42,7 +42,7 @@ class TestCaseCopier(TestCase):
             'family_name': 'Nature',
         }
 
-        with get_mother_case('owner_id', update=properties) as case:
+        with get_mother_case(owner_id='owner_id', update=properties) as case:
             case_copier = CaseCopier(DOMAIN, to_owner='new_owner_id')
             case_id_pairs, errors = case_copier.copy_cases([case.case_id])
 
@@ -52,14 +52,14 @@ class TestCaseCopier(TestCase):
             self.assertEqual(new_case.owner_id, 'new_owner_id')
             self.assertEqual(new_case.case_json['family_name'], 'Nature')
             self.assertEqual(new_case.opened_by, SYSTEM_USER_ID)
-            self.assertTrue(new_case.case_json[CaseCopier.COMMCARE_CASE_COPY_PROPERTY_NAME])
+            self.assertEqual(new_case.case_json[CaseCopier.COMMCARE_CASE_COPY_PROPERTY_NAME], orig_case_id)
 
     def test_copy_case_with_sensitive_properties(self):
         properties = {
             'age': '34',
         }
 
-        with get_mother_case('owner_id', update=properties) as case:
+        with get_mother_case(owner_id='owner_id', update=properties) as case:
             case_copier = CaseCopier(
                 DOMAIN,
                 to_owner='new_owner_id',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Changes the report filter from `Select Mobile Worker` to `Case Owner(s)` in Copy Cases Feature.

Before:
![image](https://github.com/dimagi/commcare-hq/assets/125016806/d9e36302-c9bc-426d-b7ea-c8750f195510)

After:
![image](https://github.com/dimagi/commcare-hq/assets/125016806/4558927a-9171-4b5a-a6e2-5f9f78c13a43)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Ticket](https://dimagi.atlassian.net/browse/SC-3153)
Only changes the filter used in report for Copy cases from `SelectMobileWorkerFilter` to `CaseListFilter`. No changes made to the logic of copying cases.

A nit improvement to the error message punctuation.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Copy Cases

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local and staging testing done.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
