### PR TITLE
Tests for "Registration from Case List"  suite

### DIFF
--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite.xml
@@ -42,6 +42,18 @@
         </text>
       </template>
     </field>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_short.case_dob_2.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="dob"/>
+        </text>
+      </template>
+    </field>
     <action>
       <display>
         <text>

--- a/corehq/apps/app_manager/tests/test_case_list_form.py
+++ b/corehq/apps/app_manager/tests/test_case_list_form.py
@@ -36,6 +36,7 @@ class CaseListFormSuiteTests(SimpleTestCase, TestXmlMixin):
         factory = self._prep_case_list_form_app()
         app = factory.app
         case_module = app.get_module(0)
+        AppFactory.add_module_case_detail_column(case_module, 'short', 'dob', 'birthday')
         case_module.case_list_form.set_icon('en', 'jr://file/commcare/image/new_case.png')
         case_module.case_list_form.set_audio('en', 'jr://file/commcare/audio/new_case.mp3')
         self.assertXmlEqual(self.get_xml('case-list-form-suite'), app.create_suite())

--- a/corehq/apps/app_manager/tests/test_suite_case_tiles.py
+++ b/corehq/apps/app_manager/tests/test_suite_case_tiles.py
@@ -629,6 +629,7 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
             suite,
             "detail[@id='m0_case_short']/action[1]",
         )
+        self.assertXmlDoesNotHaveXpath(suite, "detail[@id='m0_case_short']/action[2]")
 
     def test_case_tile_without_register_from_case_list_because_of_person_simple(self, *args):
         factory = AppFactory()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
no user facing changes 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR adds tests that would have caught two separate bugs. Both bugs are related to additional <action> elements being added to the suite element when:
1. "Registration from Case List" is configured with case display properties
2. "Registration from Case List" is used with case tiles

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Tests [Case Tile](https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146602199/Allow+Configuration+of+Case+List+Tiles#AllowConfigurationofCaseListTiles-ImplementationExample(WebApps)) and ["Registration from Case List" ](https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955310/Minimize+Duplicates+Method+1+Registration+From+the+Case+List)
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
only tests
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
