### PR TITLE
Ensure BlobMeta objects for multimedia are included in domain dump

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -6,15 +6,14 @@ from django.core import serializers
 from django.db import router
 
 from corehq.apps.dump_reload.exceptions import DomainDumpError
-
 from corehq.apps.dump_reload.interface import DataDumper
 from corehq.apps.dump_reload.sql.filters import (
     FilteredModelIteratorBuilder,
     ManyFilters,
     MultimediaBlobMetaFilter,
     SimpleFilter,
-    UniqueFilteredModelIteratorBuilder,
     UnfilteredModelIteratorBuilder,
+    UniqueFilteredModelIteratorBuilder,
     UserIDFilter,
     UsernameFilter,
 )
@@ -368,6 +367,7 @@ def get_apps_and_models(app_or_model_label):
             except LookupError:
                 from corehq.util.couch import get_document_class_by_doc_type
                 from corehq.util.exceptions import DocumentClassNotFound
+
                 # ignore this if it's a couch doc type
                 try:
                     get_document_class_by_doc_type(label)

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -10,6 +10,7 @@ from corehq.apps.dump_reload.interface import DataDumper
 from corehq.apps.dump_reload.sql.filters import (
     FilteredModelIteratorBuilder,
     ManyFilters,
+    MultimediaBlobMetaFilter,
     SimpleFilter,
     UniqueFilteredModelIteratorBuilder,
     UnfilteredModelIteratorBuilder,
@@ -25,6 +26,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('locations.LocationType', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('locations.SQLLocation', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('blobs.BlobMeta', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('blobs.BlobMeta', MultimediaBlobMetaFilter()),
 
     FilteredModelIteratorBuilder('form_processor.XFormInstance', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.XFormOperation', SimpleFilter('form__domain')),

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -6,6 +6,7 @@ from django.core import serializers
 from django.db import router
 
 from corehq.apps.dump_reload.exceptions import DomainDumpError
+
 from corehq.apps.dump_reload.interface import DataDumper
 from corehq.apps.dump_reload.sql.filters import (
     FilteredModelIteratorBuilder,

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -11,7 +11,7 @@ from corehq.util.queries import queryset_to_iterator
 
 class DomainFilter(metaclass=ABCMeta):
     @abstractmethod
-    def get_filters(self, domain_name):
+    def get_filters(self, domain_name, db_alias=None):
         """Return a list of filters. Each filter will be applied to a queryset independently
         of the others."""
         raise NotImplementedError()
@@ -24,7 +24,7 @@ class SimpleFilter(DomainFilter):
     def __init__(self, filter_kwarg):
         self.filter_kwarg = filter_kwarg
 
-    def get_filters(self, domain_name):
+    def get_filters(self, domain_name, db_alias=None):
         return [Q(**{self.filter_kwarg: domain_name})]
 
 
@@ -36,7 +36,7 @@ class ManyFilters(DomainFilter):
         assert filter_kwargs, 'Please set one of more filter_kwargs'
         self.filter_kwargs = filter_kwargs
 
-    def get_filters(self, domain_name):
+    def get_filters(self, domain_name, db_alias=None):
         filter_ = Q(**{self.filter_kwargs[0]: domain_name})
         for filter_kwarg in self.filter_kwargs[1:]:
             filter_ &= Q(**{filter_kwarg: domain_name})
@@ -50,7 +50,7 @@ class UsernameFilter(DomainFilter):
     def count(self, domain_name):
         return len(self.usernames) if self.usernames is not None else None
 
-    def get_filters(self, domain_name):
+    def get_filters(self, domain_name, db_alias=None):
         """
         :return: A generator of filters each filtering for at most 500 users.
         """
@@ -75,11 +75,11 @@ class IDFilter(DomainFilter):
     def count(self, domain_name):
         return len(self.get_ids(domain_name))
 
-    def get_ids(self, domain_name):
+    def get_ids(self, domain_name, db_alias=None):
         return self.ids
 
-    def get_filters(self, domain_name):
-        for chunk in chunked(self.get_ids(domain_name), self.chunksize):
+    def get_filters(self, domain_name, db_alias=None):
+        for chunk in chunked(self.get_ids(domain_name, db_alias=db_alias), self.chunksize):
             query_kwarg = '{}__in'.format(self.field)
             yield Q(**{query_kwarg: chunk})
 
@@ -89,7 +89,7 @@ class UserIDFilter(IDFilter):
         super().__init__(user_id_field, None)
         self.include_web_users = include_web_users
 
-    def get_ids(self, domain_name):
+    def get_ids(self, domain_name, db_alias=None):
         from corehq.apps.users.dbaccessors import get_all_user_ids_by_domain
         return get_all_user_ids_by_domain(domain_name, include_web_users=self.include_web_users)
 
@@ -103,7 +103,7 @@ class MultimediaBlobMetaFilter(IDFilter):
         # 'id' is used in query (e.g., ...filter(id__in=blobmeta_ids))
         super().__init__('id', None)
 
-    def get_ids(self, domain_name):
+    def get_ids(self, domain_name, db_alias=None):
         multimedia_provider = DOC_PROVIDERS_BY_DOC_TYPE['CommCareMultimedia']
         for doc_class, doc_ids in multimedia_provider.get_doc_ids(domain_name):
             couch_db = doc_class.get_db()
@@ -158,7 +158,7 @@ class FilteredModelIteratorBuilder(UnfilteredModelIteratorBuilder):
 
     def querysets(self):
         queryset = self._base_queryset()
-        filters = self.filter.get_filters(self.domain)
+        filters = self.filter.get_filters(self.domain, db_alias=self.db_alias)
         for filter_ in filters:
             yield queryset.filter(filter_)
 

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from corehq.apps.dump_reload.sql.filters import MultimediaBlobMetaFilter
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.blobs.models import BlobMeta
+from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 
 
 class TestMultimediaBlobMetaFilter(TestCase):
@@ -16,7 +17,7 @@ class TestMultimediaBlobMetaFilter(TestCase):
         )
 
         filter = MultimediaBlobMetaFilter()
-        actual_ids = list(filter.get_ids(self.domain))
+        actual_ids = list(filter.get_ids(self.domain, db_alias=self.db_alias))
 
         self.assertEqual(actual_ids, expected_ids)
 
@@ -24,9 +25,9 @@ class TestMultimediaBlobMetaFilter(TestCase):
         self.create_multimedia(b'content', 'different-domain')
 
         filter = MultimediaBlobMetaFilter()
-        blobmeta_ids = list(filter.get_ids(self.domain))
+        actual_ids = list(filter.get_ids(self.domain, db_alias=self.db_alias))
 
-        self.assertEqual(blobmeta_ids, [])
+        self.assertEqual(actual_ids, [])
 
     def test_returns_multiple_blobmeta_ids_if_multiple_attached_to_domain(self):
         multimedia = self.create_multimedia(b'content', domain=self.domain)
@@ -39,7 +40,7 @@ class TestMultimediaBlobMetaFilter(TestCase):
         )
 
         filter = MultimediaBlobMetaFilter()
-        actual_ids = list(filter.get_ids(self.domain))
+        actual_ids = list(filter.get_ids(self.domain, db_alias=self.db_alias))
 
         self.assertEqual(len(actual_ids), 2)
         self.assertEqual(actual_ids, expected_ids)
@@ -58,3 +59,4 @@ class TestMultimediaBlobMetaFilter(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.domain = 'test-multimedia'
+        cls.db_alias = get_db_aliases_for_partitioned_query()[0]

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -1,0 +1,60 @@
+from django.test import TestCase
+
+from corehq.apps.dump_reload.sql.filters import MultimediaBlobMetaFilter
+from corehq.apps.hqmedia.models import CommCareMultimedia
+from corehq.blobs.models import BlobMeta
+
+
+class TestMultimediaBlobMetaFilter(TestCase):
+
+    def test_returns_blobmeta_ids_for_multimedia_attached_to_domain(self):
+        multimedia = self.create_multimedia(b'content', domain=self.domain)
+        expected_ids = list(
+            BlobMeta.objects.partitioned_query(multimedia._id)
+            .filter(parent_id=multimedia._id)
+            .values_list("id", flat=True)
+        )
+
+        filter = MultimediaBlobMetaFilter()
+        actual_ids = list(filter.get_ids(self.domain))
+
+        self.assertEqual(actual_ids, expected_ids)
+
+    def test_does_not_return_blobmeta_ids_for_multimedia_outside_of_domain(self):
+        self.create_multimedia(b'content', 'different-domain')
+
+        filter = MultimediaBlobMetaFilter()
+        blobmeta_ids = list(filter.get_ids(self.domain))
+
+        self.assertEqual(blobmeta_ids, [])
+
+    def test_returns_multiple_blobmeta_ids_if_multiple_attached_to_domain(self):
+        multimedia = self.create_multimedia(b'content', domain=self.domain)
+        multimedia.attach_data(b'more-content', attachment_id='abc123')
+        multimedia.save()  # already set to be cleaned up
+        expected_ids = list(
+            BlobMeta.objects.partitioned_query(multimedia._id)
+            .filter(parent_id=multimedia._id)
+            .values_list("id", flat=True)
+        )
+
+        filter = MultimediaBlobMetaFilter()
+        actual_ids = list(filter.get_ids(self.domain))
+
+        self.assertEqual(len(actual_ids), 2)
+        self.assertEqual(actual_ids, expected_ids)
+
+    def create_multimedia(self, content, domain=None):
+        multimedia = CommCareMultimedia.get_by_data(content)
+        # this will create a BlobMeta object
+        multimedia.attach_data(content)
+        if domain:
+            multimedia.add_domain(domain)
+        multimedia.save()
+        self.addCleanup(multimedia.delete)
+        return multimedia
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-multimedia'

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from corehq.apps.dump_reload.sql.filters import MultimediaBlobMetaFilter
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.blobs.models import BlobMeta
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 
 
@@ -58,5 +59,7 @@ class TestMultimediaBlobMetaFilter(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.db = TemporaryFilesystemBlobDB()
+        cls.addClassCleanup(cls.db.close)
         cls.domain = 'test-multimedia'
         cls.db_alias = get_db_aliases_for_partitioned_query()[0]


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15310

Currently the only BlobMeta objects that are dumped for a domain are those that have the `domain` attribute set to the current domain being dumped. This presents an issue for multimedia objects because we can share multimedia across multiple domains. In this case, the `domain` attribute is set to "<shared>" and therefore not included in the `SimpleFilter('domain')` filter used to export BlobMeta objects currently.

The logic needed here can be seen in `run_blob_export`, specifically the [ExportMultimedia](https://github.com/dimagi/commcare-hq/blob/223d9900cc7ae62126b24854aaf02825e3e678c1/corehq/blobs/export.py#L93-L110) exporter. Similar to how we have two different exporters defined for `run_blob_export` (ExportByDomain and ExportMultimedia), we need two different ways of collecting BlobMeta objects to dump to the SQL file as well.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The blast radius is low as this code is only run manually. I was successfully able to still run this command locally, and plan to verify that this exports the exact objects I expect it to with domains I'm currently in the process of helping migrate.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
