### PR TITLE
Do not store config_id and table_id on class instance

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -985,29 +985,27 @@ class DomainUsernames(Resource):
 
 
 class BaseODataResource(HqBaseResource, DomainSpecificResourceMixin):
-    config_id = None
-    table_id = None
 
     def dispatch(self, request_type, request, **kwargs):
         if not domain_has_privilege(request.domain, privileges.ODATA_FEED):
             raise ImmediateHttpResponse(
                 response=HttpResponseNotFound('Feature flag not enabled.')
             )
-        self.config_id = kwargs['config_id']
-        self.table_id = int(kwargs.get('table_id', 0))
         with TimingContext() as timer:
             response = super(BaseODataResource, self).dispatch(
                 request_type, request, **kwargs
             )
-        record_feed_access_in_datadog(request, self.config_id, timer.duration, response)
+        record_feed_access_in_datadog(request, kwargs['config_id'], timer.duration, response)
         return response
 
     def create_response(self, request, data, response_class=HttpResponse,
                         **response_kwargs):
         data['domain'] = request.domain
-        data['config_id'] = self.config_id
         data['api_path'] = request.path
-        data['table_id'] = self.table_id
+        # Avoids storing these properties on the class instance which protects against the possibility of
+        # concurrent requests making conflicting updates to properties
+        data['config_id'] = request.resolver_match.kwargs['config_id']
+        data['table_id'] = int(request.resolver_match.kwargs.get('table_id', 0))
         response = super(BaseODataResource, self).create_response(
             request, data, response_class, **response_kwargs)
         return add_odata_headers(response)
@@ -1027,7 +1025,7 @@ class BaseODataResource(HqBaseResource, DomainSpecificResourceMixin):
 class ODataCaseResource(BaseODataResource):
 
     def obj_get_list(self, bundle, domain, **kwargs):
-        config = get_document_or_404(CaseExportInstance, domain, self.config_id)
+        config = get_document_or_404(CaseExportInstance, domain, kwargs['config_id'])
         if raise_odata_permissions_issues(bundle.request.couch_user, domain, config):
             raise ImmediateHttpResponse(
                 HttpForbidden(gettext_noop(
@@ -1068,7 +1066,7 @@ class ODataCaseResource(BaseODataResource):
 class ODataFormResource(BaseODataResource):
 
     def obj_get_list(self, bundle, domain, **kwargs):
-        config = get_document_or_404(FormExportInstance, domain, self.config_id)
+        config = get_document_or_404(FormExportInstance, domain, kwargs['config_id'])
         if raise_odata_permissions_issues(bundle.request.couch_user, domain, config):
             raise ImmediateHttpResponse(
                 HttpForbidden(gettext_noop(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi.atlassian.net/browse/SAAS-15308

See the ticket for more details, but basically, Tastypie Resource objects are created when the django process first starts up ([here](https://github.com/dimagi/commcare-hq/blob/878b3c6dfd7600829510b20f952bf22d3593fa79/corehq/apps/api/urls.py#L98-L103)) and are shared across all requests for the lifetime of the gunicorn worker. Given the worker can process requests concurrently, we need to avoid storing data at the class instance level since it could be updated/referenced by other concurrent requests. In this case, we can get all of the information we need from the existing arguments passed into the various resource methods.

I confirmed this will work locally as both the config_id and table_id (when specified) are stored on the ResolverMatch object.
![Screenshot from 2024-02-13 14-36-53](https://github.com/dimagi/commcare-hq/assets/15785053/818c4e45-d3f7-4e92-8cfb-46f680027310)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested this locally.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There are existing automated tests (`corehq.apps.api.odata.tests.test_feed`) to ensure these resources still behave as expected.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
