### PR TITLE
Fix issue with trying to hash empty arguments

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1416,9 +1416,9 @@ def hash_arguments(*args):
     writer = csv.writer(
         updater,
         delimiter='\t',
-        quotechar=None,
+        quotechar='"',
         escapechar='|',
-        quoting=csv.QUOTE_NONE,
+        quoting=csv.QUOTE_MINIMAL,
     )
 
     writer.writerow(args)

--- a/corehq/apps/data_interfaces/tests/test_models.py
+++ b/corehq/apps/data_interfaces/tests/test_models.py
@@ -515,6 +515,15 @@ class HashArguments_Tests(SimpleTestCase):
         result2 = hash_arguments('1\t2')
         self.assertNotEqual(result1, result2)
 
+    def test_handles_empty_arguments(self):
+        result = hash_arguments('')
+        self.assertTrue(type(result), str)
+
+    def test_empty_arguments_match(self):
+        result1 = hash_arguments('')
+        result2 = hash_arguments('')
+        self.assertEqual(result1, result2)
+
 
 def create_dict_mock(class_, data):
     '''Create an empty object of the given class whose `to_dict` method returns the specified data'''


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
The dedupe backfill migration is currently blocking on production due to some arguments having an empty value. Apparently that was not supported with our current code

## Safety Assurance

### Safety story
Inspected what the quoted results look like in a console and created new test to verify that empty values were handled

### Automated test coverage

Two new tests

### QA Plan

N/A

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
