### PR TITLE
Add Check Before Applying KO Bindings

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/email-request.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/email-request.js
@@ -125,9 +125,12 @@ hqDefine('hqwebapp/js/bootstrap3/email-request', [
             "modalReportIssue",
             "hqwebapp-bugReportForm"
         ));
-        $("#modalSolutionsFeatureRequest").koApplyBindings(new EmailRequest(
-            "modalSolutionsFeatureRequest",
-            "hqwebapp-requestReportForm"
-        ));
+        const featureRequestModal = $("#modalSolutionsFeatureRequest");
+        if (featureRequestModal.length) {
+            featureRequestModal.koApplyBindings(new EmailRequest(
+                "modalSolutionsFeatureRequest",
+                "hqwebapp-requestReportForm"
+            ));
+        }
     });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
@@ -128,9 +128,12 @@ hqDefine('hqwebapp/js/bootstrap5/email-request', [
             "modalReportIssue",
             "hqwebapp-bugReportForm"
         ));
-        $("#modalSolutionsFeatureRequest").koApplyBindings(new EmailRequest(
-            "modalSolutionsFeatureRequest",
-            "hqwebapp-requestReportForm"
-        ));
+        const featureRequestModal = $("#modalSolutionsFeatureRequest");
+        if (featureRequestModal.length) {
+            featureRequestModal.koApplyBindings(new EmailRequest(
+                "modalSolutionsFeatureRequest",
+                "hqwebapp-requestReportForm"
+            ));
+        }
     });
 });


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR fixes a bug that was introduced in [this PR](https://github.com/dimagi/commcare-hq/pull/34026).

The bug caused non-Dimagi users to have a JS error get thrown in their consoles. This is because KO bindings were being applied to the solutions feature request modal, which doesn't exist for non-Dimagi users.

![Screenshot 2024-02-15 at 12 33 35 PM](https://github.com/dimagi/commcare-hq/assets/122617251/ac681c59-728c-412d-b47a-1e1bd7532491)

This PR adds in a conditional check to only apply KO bindings if a valid JQuery element is returned.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Fix resolves original issue

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests exist for solutions feature request view.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
