### PR TITLE
Fix infinite ping_login request of Webapps home page.

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/inactivity.js
@@ -140,12 +140,12 @@ hqDefine('hqwebapp/js/bootstrap3/inactivity', [
             var selectedAppId = '';
             try {
                 var urlParams = JSON.parse(decodeURIComponent(window.location.hash.substr(1)));
-                if(!urlParams.copyOf){
+                if (!urlParams.copyOf) {
                     // Don't show the popup when user came from versions page
                     selectedAppId = urlParams.appId;
                 }
             } catch (error) {
-                console.log(error);
+                return;
             }
             var domain = initialPageData.get('domain');
             $.ajax({

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/inactivity.js
@@ -139,7 +139,7 @@ hqDefine('hqwebapp/js/bootstrap3/inactivity', [
             log("polling HQ's ping_login to decide about showing login modal");
             var selectedAppId = '';
             try {
-                var urlParams = JSON.parse(decodeURIComponent(window.location.hash.substr(1)));
+                var urlParams = JSON.parse(decodeURIComponent(window.location.hash.substring(1)));
                 if (!urlParams.copyOf) {
                     // Don't show the popup when user came from versions page
                     selectedAppId = urlParams.appId;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/inactivity.js
@@ -139,7 +139,7 @@ hqDefine('hqwebapp/js/bootstrap5/inactivity', [
             log("polling HQ's ping_login to decide about showing login modal");
             var selectedAppId = '';
             try {
-                var urlParams = JSON.parse(decodeURIComponent(window.location.hash.substr(1)));
+                var urlParams = JSON.parse(decodeURIComponent(window.location.hash.substring(1)));
                 if (!urlParams.copyOf) {
                     // Don't show the popup when user came from versions page
                     selectedAppId = urlParams.appId;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/inactivity.js
@@ -140,12 +140,12 @@ hqDefine('hqwebapp/js/bootstrap5/inactivity', [
             var selectedAppId = '';
             try {
                 var urlParams = JSON.parse(decodeURIComponent(window.location.hash.substr(1)));
-                if(!urlParams.copyOf){
+                if (!urlParams.copyOf) {
                     // Don't show the popup when user came from versions page
                     selectedAppId = urlParams.appId;
                 }
             } catch (error) {
-                console.log(error);
+                return;
             }
             var domain = initialPageData.get('domain');
             $.ajax({


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
While looking into an issue I came across a weird scenario where on Web Apps home page was rendered unusable as there were continuous calls happening to `ping_login`. 
See the image below
<img width="1722" alt="Screenshot 2024-02-15 at 12 49 57 PM" src="https://github.com/dimagi/commcare-hq/assets/7694243/a0bd016b-b08a-45d7-8680-725a90d8be44">

On looking I found out that we were not returning in `catch` block which was then bombarding in requests with empty `selected_app_id`.

Apparently I have written this block of code couple of years back, so felt the urgency to fix it 😅 

The fix is simple that we should return from function if there is no `app_id` in the URL.

I have also removed the `console.log` for the error as it is useless and just pollutes the console and is of no real value.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
