### PR TITLE
Add Check Before Applying KO Bindings on Bug Report

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/email-request.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/email-request.js
@@ -121,10 +121,13 @@ hqDefine('hqwebapp/js/bootstrap3/email-request', [
     };
 
     $(function () {
-        $("#modalReportIssue").koApplyBindings(new EmailRequest(
-            "modalReportIssue",
-            "hqwebapp-bugReportForm"
-        ));
+        const issueReportModal = $("#modalReportIssue");
+        if (issueReportModal.length) {
+            issueReportModal.koApplyBindings(new EmailRequest(
+                "modalReportIssue",
+                "hqwebapp-bugReportForm"
+            ));
+        }
         const featureRequestModal = $("#modalSolutionsFeatureRequest");
         if (featureRequestModal.length) {
             featureRequestModal.koApplyBindings(new EmailRequest(

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
@@ -124,10 +124,13 @@ hqDefine('hqwebapp/js/bootstrap5/email-request', [
     };
 
     $(function () {
-        $("#modalReportIssue").koApplyBindings(new EmailRequest(
-            "modalReportIssue",
-            "hqwebapp-bugReportForm"
-        ));
+        const issueReportModal = $("#modalReportIssue");
+        if (issueReportModal.length) {
+            issueReportModal.koApplyBindings(new EmailRequest(
+                "modalReportIssue",
+                "hqwebapp-bugReportForm"
+            ));
+        }
         const featureRequestModal = $("#modalSolutionsFeatureRequest");
         if (featureRequestModal.length) {
             featureRequestModal.koApplyBindings(new EmailRequest(


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR adds a conditional check to only apply KO bindings for the HQ bug report if the relevant HTML modal exists. This HTML code gets injected conditionally, and so the check is necessary to prevent a potential KO binding exception being thrown to the browser console.

For additional context on the original PR for this change, please refer to [this PR](https://github.com/dimagi/commcare-hq/pull/34026).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
