### PR TITLE
Only Show Feature Request on Dimagi Environment

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/global_navigation_bar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/global_navigation_bar.html
@@ -129,7 +129,7 @@
                     </a>
                 </li>
             {% endif %}
-            {% if request.couch_user and request.couch_user.is_dimagi %}
+            {% if request.couch_user and request.couch_user.is_dimagi and is_dimagi_environment %}
                 <li>
                     <a href="#modalSolutionsFeatureRequest" data-toggle="modal" class="track-usage-link"
                     data-category="Nav Bar" data-action="Question Mark" data-label="Solutions Feature Request">

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/global_navigation_bar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/global_navigation_bar.html
@@ -158,7 +158,7 @@
               </a>
             </li>
           {% endif %}
-          {% if request.couch_user and request.couch_user.is_dimagi %}
+          {% if request.couch_user and request.couch_user.is_dimagi and is_dimagi_environment %}
                 <li>
                     <a href="#modalSolutionsFeatureRequest"
                        data-bs-toggle="modal"

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/global_navigation_bar.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/global_navigation_bar.html.diff.txt
@@ -255,7 +255,7 @@
 +              </a>
 +            </li>
 +          {% endif %}
-+          {% if request.couch_user and request.couch_user.is_dimagi %}
++          {% if request.couch_user and request.couch_user.is_dimagi and is_dimagi_environment %}
                  <li>
 -                    <a href="{% trans 'https://wiki.commcarehq.org/display/commcarepublic/Home' %}" class="track-usage-link" target="_blank"
 -                       data-category="Nav Bar" data-action="Question Mark" data-label="Visit the Help Site">
@@ -285,7 +285,7 @@
 -                    </a>
 -                </li>
 -            {% endif %}
--            {% if request.couch_user and request.couch_user.is_dimagi %}
+-            {% if request.couch_user and request.couch_user.is_dimagi and is_dimagi_environment %}
 -                <li>
 -                    <a href="#modalSolutionsFeatureRequest" data-toggle="modal" class="track-usage-link"
 -                    data-category="Nav Bar" data-action="Question Mark" data-label="Solutions Feature Request">

--- a/corehq/apps/hqwebapp/tests/test_views.py
+++ b/corehq/apps/hqwebapp/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
@@ -279,24 +281,25 @@ class TestSolutionsFeatureRequestView(TestCase):
             'sentry_event_id': '',
         }
 
-    def _post_request(self, payload):
-        return self.client.post(
-            self.url,
-            payload,
-            HTTP_USER_AGENT='firefox'
-        )
+    def _post_request(self, payload, is_dimagi_env):
+        with patch('corehq.apps.hqwebapp.views.settings.IS_DIMAGI_ENVIRONMENT', is_dimagi_env):
+            return self.client.post(
+                self.url,
+                payload,
+                HTTP_USER_AGENT='firefox'
+            )
 
     def test_non_staff_email_submission(self):
         self.client.login(username=self.web_user.username, password='123')
         payload = self._default_payload(self.web_user.username)
-        response = self._post_request(payload)
+        response = self._post_request(payload, True)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(len(mail.outbox), 0)
 
     def test_email_submission(self):
         self.client.login(username=self.staff_web_user.username, password='123')
         payload = self._default_payload(self.staff_web_user.username)
-        response = self._post_request(payload)
+        response = self._post_request(payload, True)
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(len(mail.outbox), 1)

--- a/corehq/apps/hqwebapp/tests/test_views.py
+++ b/corehq/apps/hqwebapp/tests/test_views.py
@@ -296,6 +296,13 @@ class TestSolutionsFeatureRequestView(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_non_dimagi_env_submission(self):
+        self.client.login(username=self.web_user.username, password='123')
+        payload = self._default_payload(self.staff_web_user.username)
+        response = self._post_request(payload, False)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(len(mail.outbox), 0)
+
     def test_email_submission(self):
         self.client.login(username=self.staff_web_user.username, password='123')
         payload = self._default_payload(self.staff_web_user.username)

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -228,16 +228,16 @@ def _get_cc_name(request, var):
 def mobile_experience(request):
     show_mobile_ux_warning = False
     mobile_ux_cookie_name = ''
-    if (hasattr(request, 'couch_user') and
-            hasattr(request, 'user_agent') and
-            settings.SERVER_ENVIRONMENT in ['production', 'staging', settings.LOCAL_SERVER_ENVIRONMENT]):
+    if (hasattr(request, 'couch_user')
+            and hasattr(request, 'user_agent')
+            and settings.SERVER_ENVIRONMENT in ['production', 'staging', settings.LOCAL_SERVER_ENVIRONMENT]):
         mobile_ux_cookie_name = '{}-has-seen-mobile-ux-warning'.format(request.couch_user.get_id)
         show_mobile_ux_warning = (
-            not request.COOKIES.get(mobile_ux_cookie_name) and
-            request.user_agent.is_mobile and
-            request.user.is_authenticated and
-            request.user.is_active and
-            not mobile_experience_hidden_by_toggle(request)
+            not request.COOKIES.get(mobile_ux_cookie_name)
+            and request.user_agent.is_mobile
+            and request.user.is_authenticated
+            and request.user.is_active
+            and not mobile_experience_hidden_by_toggle(request)
         )
     return {
         'show_mobile_ux_warning': show_mobile_ux_warning,

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -176,6 +176,7 @@ def enterprise_mode(request):
     return {
         'enterprise_mode': settings.ENTERPRISE_MODE,
         'is_saas_environment': settings.IS_SAAS_ENVIRONMENT,
+        'is_dimagi_environment': settings.IS_DIMAGI_ENVIRONMENT,
     }
 
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3409).

This PR adds an additional safety check to only show the feature request dropdown option if the flag `IS_DIMAGI_ENVIRONMENT` is set to true.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Change affects feature which is only available to staff members.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
A unit test has been added to ensure view only sends email if on a Dimagi environment.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
