### PR TITLE
Pass closed cases to the dedupe action

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -334,7 +334,14 @@ class AutomaticUpdateRule(models.Model):
             return self.run_actions_when_case_does_not_match(case)
 
     def criteria_match(self, case, now):
-        if case.is_deleted or case.closed:
+        if case.is_deleted:
+            return False
+
+        # bit of a hack due to the architecture constraints.
+        # Dedupe needs to be able to consider closed cases,
+        # both for rules that process closed cases, and to be able to identify
+        # when an open case becomes closed
+        if case.closed and self.workflow != self.WORKFLOW_DEDUPLICATE:
             return False
 
         if case.type != self.case_type:

--- a/corehq/apps/data_interfaces/tests/test_case_deduplication.py
+++ b/corehq/apps/data_interfaces/tests/test_case_deduplication.py
@@ -790,7 +790,7 @@ class CaseDeduplicationActionTest(TestCase):
         CaseDuplicateNew.objects.bulk_create(duplicate_entries)
         closed_case = self._create_case(case_id=duplicates[0].case_id, closed=True, save=False)
 
-        self.rule.run_actions_when_case_matches(closed_case)
+        self.rule.run_rule(closed_case, datetime.now())
 
         self.assertEqual(CaseDuplicateNew.objects.filter(case_id__in=duplicate_case_ids).count(), 0)
 
@@ -806,7 +806,7 @@ class CaseDeduplicationActionTest(TestCase):
         rule, action = self._create_rule(include_closed=True)
         closed_case = self._create_case(case_id=duplicates[0].case_id, closed=True, save=False)
 
-        rule.run_actions_when_case_matches(closed_case)
+        rule.run_rule(closed_case, datetime.now())
 
         self.assertEqual(CaseDuplicateNew.objects.filter(action=action, case_id__in=duplicate_case_ids).count(), 2)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
In trying to support removing closed cases from rules that did not look at closed cases, I missed that the AutomaticUpdateRule hierarchy explicitly does not process closed cases, regardless of how the DedupeAction is configured. The reason this vaguely worked in the past was that open duplicates would always populate all other duplicates. So, provided that an open case was detected as a duplicate, it would then scan elasticsearch for all cases that followed the rule, and it would respect the closed case setting there. However, if all duplicates were closed, none of those would get processed, and so none of those duplicates would get listed, even if the rule was configured to show closed cases.

## Safety Assurance

### Safety story
I've locally tested this with rules configured both to support closed and cases and those that don't. I've verified that initial population as well as changing the closed status has the expected results. However, undo-ing the close or archiving the close action still does not get detected. We view this workflow as much more common, and so want to push out this fix and believe that undo fix can come later.

### Automated test coverage

The two tests that should have covered this have been updated to use `rule.run_rule` rather than `rule.run_actions_when_case_matches`, which was the issue here (`run_actions_when_case_matches` was never being called)

### QA Plan
N/A

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
