### PR TITLE
Remove excess bottom padding on form title

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -8,12 +8,8 @@
   margin-bottom: 2rem;
   font-size: @form-text-size;   // Don't overshadow inputs
 
-  .page-header {
-    padding-bottom: 30px;
-
-    h1 {
-      padding-left: @form-text-indent - 8px;
-    }
+  .page-header h1 {
+    padding-left: @form-text-indent - 8px;
   }
 
   .controls {


### PR DESCRIPTION
## Product Description
Removes bottom padding from form title in web apps.

<img width="192" alt="image" src="https://github.com/dimagi/commcare-hq/assets/100609770/bdf9bab1-ebc7-4a39-b612-7a67259ff938"> => <img width="192" alt="image" src="https://github.com/dimagi/commcare-hq/assets/100609770/3a2cdfd7-faf6-4660-b4d7-f17ed6165476">

## Technical Summary
[USH-4112](https://dimagi.atlassian.net/browse/USH-4112)
"Left justify" form title as in ticket is already covered by #34133

## Safety Assurance

### Safety story
Small CSS change only.

### Automated test coverage
n/a

### QA Plan
Not planning QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4112]: https://dimagi.atlassian.net/browse/USH-4112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ