### PR TITLE
Design improvement to custom banners

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/manage_alerts.html
+++ b/corehq/apps/domain/templates/domain/admin/manage_alerts.html
@@ -38,7 +38,7 @@
               {% trans "Added By" %}
             </th>
             <th>
-              {% trans "Activate or De-activate" %}
+              {% trans "Status" %}
             </th>
             <th>
               {% trans "Actions" %}

--- a/corehq/apps/domain/templates/domain/admin/manage_alerts.html
+++ b/corehq/apps/domain/templates/domain/admin/manage_alerts.html
@@ -80,6 +80,7 @@
             </td>
             <td>
               <a class="btn btn-default" data-bind="attr: {href: editUrl}" style="float: left; margin-right: 5px;">
+                <i class="fa fa-edit"></i>
                 {% trans "Edit" %}
               </a>
               <form action="{% url 'delete_domain_alert' domain %}" method="post" style="float: left">
@@ -89,6 +90,7 @@
                        data-bind="value: id">
                 <button type="submit"
                       class="btn btn-danger">
+                  <i class="fa fa-trash"></i>
                   {% trans "Delete" %}
                 </button>
               </form>

--- a/corehq/apps/domain/templates/domain/admin/manage_alerts.html
+++ b/corehq/apps/domain/templates/domain/admin/manage_alerts.html
@@ -38,9 +38,6 @@
               {% trans "Added By" %}
             </th>
             <th>
-              {% trans "Status" %}
-            </th>
-            <th>
               {% trans "Actions" %}
             </th>
           </tr>
@@ -57,7 +54,7 @@
             <td data-bind="text: created_by_user">
             </td>
             <td>
-              <form action="{% url 'update_domain_alert_status' domain %}" method="post">
+              <form action="{% url 'update_domain_alert_status' domain %}" method="post" style="float: left; margin-right: 5px;">
                 {% csrf_token %}
                 <input name="alert_id"
                        type="hidden"
@@ -77,8 +74,6 @@
                   {% trans "De-activate Alert" %}
                 </button>
               </form>
-            </td>
-            <td>
               <a class="btn btn-default" data-bind="attr: {href: editUrl}" style="float: left; margin-right: 5px;">
                 <i class="fa fa-edit"></i>
                 {% trans "Edit" %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Minor improvement to design of Custom domain alerts page.
1. Club all buttons under "Actions"
2. Add icons to buttons for edit and delete

Before
![Screenshot from 2024-02-18 01-01-38](https://github.com/dimagi/commcare-hq/assets/3864163/396415de-40bb-4973-90cd-9a6f035a8f3c)

After
![Screenshot from 2024-02-19 12-24-41](https://github.com/dimagi/commcare-hq/assets/3864163/9c633a2a-2dd7-4c99-898d-0a13caeaa35a)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3395

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
