### PR TITLE
Addressed earlier dedupe test feedback

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_case_deduplication.py
+++ b/corehq/apps/data_interfaces/tests/test_case_deduplication.py
@@ -491,9 +491,7 @@ class CaseDeduplicationActionTest(TestCase):
         self.domain = 'case-dedupe-test'
         self.case_type = 'adult'
 
-        (rule, action) = self._create_rule()
-        self.rule = rule
-        self.action = action
+        (self.rule, self.action) = self._create_rule()
 
         self.action.set_properties_to_update([
             CaseDeduplicationActionDefinition.PropertyDefinition(


### PR DESCRIPTION
## Technical Summary
This just addresses earlier feedback received from [`8be0271` (#34123)](https://github.com/dimagi/commcare-hq/pull/34123/commits/8be0271223d40fdb9cb2118e9084f14f026d8f31)

## Safety Assurance

### Safety story
This only modifies one test

### Automated test coverage

Updated existing test

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
