### PR TITLE
SSCS: Disabe submit button until changes are made to fields

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -610,7 +610,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
 
         onRender() {
             var submitButton = this.ui.submitButton;
-            if (this.sidebarEnabled) {
+            if (this.options.sidebarEnabled) {
                 if (sessionStorage.submitDisabled === false || sessionStorage.submitDisabled === "false") {
                     submitButton.prop('disabled', false);
                 } else {
@@ -766,7 +766,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         },
 
         updateSubmitButtonDisabled: function (disabled) {
-            if (this.sidebarEnabled) {
+            if (this.options.sidebarEnabled) {
                 sessionStorage.submitDisabled = disabled;
                 this.render();
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -588,6 +588,9 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 (toggles.toggleEnabled('DYNAMICALLY_UPDATE_SEARCH_RESULTS') && this.options.sidebarEnabled);
             this.searchOnClear = (options.searchOnClear && !this.smallScreenEnabled);
 
+            sessionStorage.submitDisabled = sessionStorage.submitDisabled === undefined ?
+                true : sessionStorage.submitDisabled;
+
             if (Object.keys(options.groupHeaders).length > 0) {
                 const groupedCollection = groupDisplays(options.collection, options.groupHeaders);
                 this.collection = new Collection(groupedCollection);
@@ -603,6 +606,17 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                 sidebarEnabled: this.options.sidebarEnabled,
                 grouped: Boolean(this.collection.find(c => c.has("groupKey"))),
             };
+        },
+
+        onRender() {
+            var submitButton = this.ui.submitButton;
+            if (this.sidebarEnabled) {
+                if (sessionStorage.submitDisabled === false || sessionStorage.submitDisabled === "false") {
+                    submitButton.prop('disabled', false);
+                } else {
+                    submitButton.prop('disabled', true);
+                }
+            }
         },
 
         ui: {
@@ -697,6 +711,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
                     }
                 }
             });
+            self.updateSubmitButtonDisabled(false);
             if (self.dynamicSearchEnabled && useDynamicSearch) {
                 self.updateSearchResults();
             }
@@ -711,12 +726,14 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             if (self.dynamicSearchEnabled || this.searchOnClear) {
                 self.updateSearchResults();
             }
+            self.updateSubmitButtonDisabled(false);
         },
 
         submitAction: function (e) {
             var self = this;
             e.preventDefault();
             self.performSubmit();
+            self.updateSubmitButtonDisabled(true);
         },
 
         performSubmit: function (initiatedBy) {
@@ -745,6 +762,13 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
             });
             if (invalidRequiredFields.length === 0) {
                 self.performSubmit(formplayerConstants.queryInitiatedBy.DYNAMIC_SEARCH);
+            }
+        },
+
+        updateSubmitButtonDisabled: function (disabled) {
+            if (this.sidebarEnabled) {
+                sessionStorage.submitDisabled = disabled;
+                this.render();
             }
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -611,10 +611,10 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", function () {
         onRender() {
             var submitButton = this.ui.submitButton;
             if (this.options.sidebarEnabled) {
-                if (sessionStorage.submitDisabled === false || sessionStorage.submitDisabled === "false") {
-                    submitButton.prop('disabled', false);
-                } else {
+                if (JSON.parse(sessionStorage.submitDisabled)) {
                     submitButton.prop('disabled', true);
+                } else {
+                    submitButton.prop('disabled', false);
                 }
             }
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -329,6 +329,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
             sessionStorage.removeItem('submitPerformed');
             sessionStorage.removeItem('geocoderValues');
             sessionStorage.removeItem('validationInProgress');
+            sessionStorage.removeItem('submitDisabled');
         };
 
         this.onSubmit = function () {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
[USH-3989](https://dimagi-dev.atlassian.net/browse/USH-3989)
Disables search button until search results are modified (including cleared) after each search.

Gif coming soon

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The last PR worked with the listener, but in the PR instead I check if `sessionStorage.submitDisabled` is a string to get rid of the need of the listener

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
SSCS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such a
In particular consider how existing data may be impacted by this change.
-->
Followup to [34008](https://github.com/dimagi/commcare-hq/pull/34008)
In addition to the last safety story, I will do testing on the BHA cloned app on staging. I also removed the refactoring of the variable that was the source of the last issue and will save that refactor for a separate PR with separate testing. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None for now

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-3989]: https://dimagi-dev.atlassian.net/browse/USH-3989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ