### PR TITLE
Clear Cache in Data Dictionary

### DIFF
--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -34,10 +34,18 @@ class CaseType(models.Model):
                 case_type_obj = CaseType.objects.create(domain=domain, name=case_type)
             return case_type_obj
 
-    def save(self, *args, **kwargs):
+    @classmethod
+    def clear_cache(cls, domain):
         from .util import get_data_dict_case_types
-        get_data_dict_case_types.clear(self.domain)
+        get_data_dict_case_types.clear(domain)
+
+    def save(self, *args, **kwargs):
+        self.clear_cache(self.domain)
         return super(CaseType, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        self.clear_cache(self.domain)
+        return super(CaseType, self).delete(*args, **kwargs)
 
 
 class CasePropertyGroup(models.Model):
@@ -143,6 +151,10 @@ class CaseProperty(models.Model):
     def save(self, *args, **kwargs):
         self.clear_caches(self.case_type.domain, self.case_type.name)
         return super(CaseProperty, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        self.clear_caches(self.case_type.domain, self.case_type.name)
+        return super(CaseProperty, self).delete(*args, **kwargs)
 
     def check_validity(self, value):
         if value and self.data_type == 'date':

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -382,7 +382,7 @@ def is_case_type_or_prop_name_valid(case_prop_name):
     return match_obj is not None
 
 
-@quickcache(vary_on=['domain'], timeout=60 * 60)
+@quickcache(vary_on=['domain'], timeout=60 * 10)
 def get_used_props_by_case_type(domain):
     agg = TermsAggregation('case_types', 'type.exact').aggregation(
         NestedAggregation('case_props', CASE_PROPERTIES_PATH).aggregation(


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3331).

This PR reduces the cache time for `get_used_props_by_case_type()` to ten minutes. When data is added to a domain (e.g. form submissions or case imports) a case property will be incorrectly marked as safe to delete until the cache for the util function is cleared. Decreasing the cache time will help to reduce the lag between when data is added to a domain and when a case type/prop is correctly flagged as unsafe to delete.

Additionally, this PR also clears the cache for `get_data_dict_case_types()` on case type/prop save or delete. There are various places on HQ, such as the case type filter in reports, that showed a case type even after it has been deleted. This is because the results were being cached. Clearing the cache on case type/prop save or delete helps to ensure that these deleted items are not shown around HQ.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Only afffects caching

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
