### PR TITLE
Skip duplicate processing for CommTrack cases

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_case_deduplication.py
+++ b/corehq/apps/data_interfaces/tests/test_case_deduplication.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from itertools import chain
 from unittest.mock import patch
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from freezegun import freeze_time
 
 from faker import Faker
@@ -10,8 +10,6 @@ from faker import Faker
 from casexml.apps.case.mock import CaseFactory
 from corehq.form_processor.tests.utils import create_case
 
-from corehq.apps.change_feed import topics
-from corehq.apps.change_feed.topics import get_topic_offset
 from corehq.apps.data_interfaces.deduplication import (
     _get_es_filtered_case_query,
     backfill_deduplicate_rule,
@@ -36,9 +34,7 @@ from corehq.apps.hqcase.case_helper import CaseCopier
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.tasks import tag_cases_as_deleted_and_remove_indices
 from corehq.form_processor.models import CommCareCase
-from corehq.pillows.case import get_case_pillow
 from corehq.util.test_utils import flag_enabled, set_parent_case
-from corehq.apps.hqcase.utils import resave_case
 
 
 @es_test(requires=[case_search_adapter])
@@ -849,134 +845,6 @@ class CaseDeduplicationActionTest(TestCase):
 
         updated_parent_case = CommCareCase.objects.get_case(parent.case_id, self.domain)
         self.assertEqual(updated_parent_case.get_case_property('name'), new_parent_case_property_value)
-
-
-@override_settings(RUN_UNKNOWN_USER_PILLOW=False)
-@override_settings(RUN_FORM_META_PILLOW=False)
-@flag_enabled('CASE_DEDUPE_UPDATES')
-class DeduplicationPillowTest(TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        cls.domain = 'naboo'
-        cls.case_type = 'people'
-        cls.factory = CaseFactory(cls.domain)
-        cls.pillow = get_case_pillow(skip_ucr=True)
-
-    def setUp(self):
-        self.kafka_offset = get_topic_offset(topics.CASE_SQL)
-
-        find_duplicates_patcher = patch('corehq.apps.data_interfaces.models._find_duplicate_case_ids')
-        self.find_duplicates_mock = find_duplicates_patcher.start()
-        self.addCleanup(find_duplicates_patcher.stop)
-
-        case_exists_patcher = patch('corehq.apps.data_interfaces.models._case_exists_in_es')
-        self.case_exists_mock = case_exists_patcher.start()
-        self.case_exists_mock.return_value = True
-        self.addCleanup(case_exists_patcher.stop)
-
-    def test_pillow_processes_changes(self):
-        rule = self._create_rule('test', ["age"])
-        self._configure_properties_to_update(rule, {"name": "Herman Miller", "age": "5"})
-
-        case1 = self.factory.create_case(case_type=self.case_type, update={"age": 2})
-        case2 = self.factory.create_case(case_type=self.case_type, update={"age": 2})
-
-        self.find_duplicates_mock.return_value = [case1.case_id, case2.case_id]
-
-        new_kafka_sec = get_topic_offset(topics.CASE_SQL)
-        self.pillow.process_changes(since=self.kafka_offset, forever=False)
-
-        self.assertEqual(CaseDuplicateNew.objects.count(), 2)
-        self.assertEqual(CommCareCase.objects.get_case(case1.case_id, self.domain).get_case_property('age'), '5')
-        self.assertEqual(CommCareCase.objects.get_case(case1.case_id, self.domain).name, 'Herman Miller')
-
-        self.pillow.process_changes(since=new_kafka_sec, forever=False)
-
-    def test_pillow_ignores_deduplication_changes(self):
-        rule = self._create_rule('test', ["age"])
-        self._configure_properties_to_update(rule, {"name": "Herman Miller", "age": "5"})
-
-        case = self.factory.create_case(case_type=self.case_type, update={"age": 2})
-        self.find_duplicates_mock.return_value = [case.case_id, 'test_id']
-
-        new_kafka_sec = get_topic_offset(topics.CASE_SQL)
-        self.pillow.process_changes(since=self.kafka_offset, forever=False)
-
-        with patch('corehq.apps.data_interfaces.pillow.run_rules_for_case') as p:
-            self.pillow.process_changes(since=new_kafka_sec, forever=False)
-            p.assert_not_called()
-
-    def test_pillow_processes_normalized_system_properties(self):
-        rule = self._create_rule('system_prop_test', ['name'])
-        action = CaseDeduplicationActionDefinition.from_rule(rule)
-
-        case = self.factory.create_case(case_name="foo", case_type=self.case_type)
-
-        self.find_duplicates_mock.return_value = [case.case_id, 'duplicate_case_id']
-
-        self.pillow.process_changes(since=self.kafka_offset, forever=False)
-
-        hash = CaseDuplicateNew.case_and_action_to_hash(case, action)
-        results = CaseDuplicateNew.objects.filter(
-            action=action, hash=hash).values_list('case_id', flat=True)
-
-        self.assertSetEqual(set(results), {case.case_id, 'duplicate_case_id'})
-
-    def test_pillow_processes_resaves(self):
-        rule = self._create_rule('test', ['age'])
-        action = CaseDeduplicationActionDefinition.from_rule(rule)
-
-        case = self.factory.create_case(case_type=self.case_type, update={"age": 2})
-        new_kafka_sec = get_topic_offset(topics.CASE_SQL)
-        resave_case(self.domain, case, send_post_save_signal=False)
-
-        self.find_duplicates_mock.return_value = [case.case_id, 'duplicate_case_id']
-
-        self.pillow.process_changes(since=new_kafka_sec, forever=False)
-
-        hash = CaseDuplicateNew.case_and_action_to_hash(case, action)
-        results = CaseDuplicateNew.objects.filter(
-            action=action, hash=hash).values_list('case_id', flat=True)
-
-        self.assertSetEqual(set(results), {case.case_id, 'duplicate_case_id'})
-
-    def _create_rule(self, name='test', match_on=None):
-        rule = AutomaticUpdateRule.objects.create(
-            domain=self.domain,
-            name=name,
-            case_type=self.case_type,
-            active=True,
-            deleted=False,
-            filter_on_server_modified=False,
-            server_modified_boundary=None,
-            workflow=AutomaticUpdateRule.WORKFLOW_DEDUPLICATE
-        )
-
-        match_on = match_on or []
-
-        rule.add_action(
-            CaseDeduplicationActionDefinition,
-            match_type=CaseDeduplicationMatchTypeChoices.ALL,
-            case_properties=match_on
-        )
-
-        AutomaticUpdateRule.clear_caches(self.domain, AutomaticUpdateRule.WORKFLOW_DEDUPLICATE)
-
-        return rule
-
-    def _configure_properties_to_update(self, rule, prop_map):
-        action = rule.memoized_actions[0].definition
-        action.set_properties_to_update([
-            CaseDeduplicationActionDefinition.PropertyDefinition(
-                name=name,
-                value=value,
-                value_type=CaseDeduplicationActionDefinition.VALUE_TYPE_EXACT,
-            ) for (name, value) in prop_map.items()
-        ])
-        action.save()
 
 
 @flag_enabled('CASE_DEDUPE_UPDATES')

--- a/corehq/apps/data_interfaces/tests/test_pillow.py
+++ b/corehq/apps/data_interfaces/tests/test_pillow.py
@@ -43,11 +43,11 @@ class DeduplicationPillowTest(TestCase):
         self.addCleanup(case_exists_patcher.stop)
 
     def test_pillow_processes_changes(self):
-        rule = self._create_rule('test', ["age"])
-        self._configure_properties_to_update(rule, {"name": "Herman Miller", "age": "5"})
+        rule = self._create_rule('test', ['age'])
+        self._configure_properties_to_update(rule, {'name': 'Herman Miller', 'age': '5'})
 
-        case1 = self.factory.create_case(case_type=self.case_type, update={"age": 2})
-        case2 = self.factory.create_case(case_type=self.case_type, update={"age": 2})
+        case1 = self.factory.create_case(case_type=self.case_type, update={'age': 2})
+        case2 = self.factory.create_case(case_type=self.case_type, update={'age': 2})
 
         self.find_duplicates_mock.return_value = [case1.case_id, case2.case_id]
 
@@ -61,10 +61,10 @@ class DeduplicationPillowTest(TestCase):
         self.pillow.process_changes(since=new_kafka_sec, forever=False)
 
     def test_pillow_ignores_deduplication_changes(self):
-        rule = self._create_rule('test', ["age"])
-        self._configure_properties_to_update(rule, {"name": "Herman Miller", "age": "5"})
+        rule = self._create_rule('test', ['age'])
+        self._configure_properties_to_update(rule, {'name': 'Herman Miller', 'age': '5'})
 
-        case = self.factory.create_case(case_type=self.case_type, update={"age": 2})
+        case = self.factory.create_case(case_type=self.case_type, update={'age': 2})
         self.find_duplicates_mock.return_value = [case.case_id, 'test_id']
 
         new_kafka_sec = get_topic_offset(topics.CASE_SQL)
@@ -94,7 +94,7 @@ class DeduplicationPillowTest(TestCase):
         rule = self._create_rule('test', ['age'])
         action = CaseDeduplicationActionDefinition.from_rule(rule)
 
-        case = self.factory.create_case(case_type=self.case_type, update={"age": 2})
+        case = self.factory.create_case(case_type=self.case_type, update={'age': 2})
         new_kafka_sec = get_topic_offset(topics.CASE_SQL)
         resave_case(self.domain, case, send_post_save_signal=False)
 

--- a/corehq/apps/data_interfaces/tests/test_pillow.py
+++ b/corehq/apps/data_interfaces/tests/test_pillow.py
@@ -1,0 +1,144 @@
+from django.test import TestCase, override_settings
+from unittest.mock import patch
+from corehq.util.test_utils import flag_enabled
+from casexml.apps.case.mock import CaseFactory
+from corehq.pillows.case import get_case_pillow
+from corehq.apps.change_feed import topics
+from corehq.apps.change_feed.topics import get_topic_offset
+
+from corehq.apps.data_interfaces.models import (
+    AutomaticUpdateRule,
+    CaseDuplicateNew,
+    CaseDeduplicationMatchTypeChoices,
+    CaseDeduplicationActionDefinition
+)
+from corehq.form_processor.models import CommCareCase
+from corehq.apps.hqcase.utils import resave_case
+
+
+@override_settings(RUN_UNKNOWN_USER_PILLOW=False)
+@override_settings(RUN_FORM_META_PILLOW=False)
+@flag_enabled('CASE_DEDUPE_UPDATES')
+class DeduplicationPillowTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.domain = 'naboo'
+        cls.case_type = 'people'
+        cls.factory = CaseFactory(cls.domain)
+        cls.pillow = get_case_pillow(skip_ucr=True)
+
+    def setUp(self):
+        self.kafka_offset = get_topic_offset(topics.CASE_SQL)
+
+        find_duplicates_patcher = patch('corehq.apps.data_interfaces.models._find_duplicate_case_ids')
+        self.find_duplicates_mock = find_duplicates_patcher.start()
+        self.addCleanup(find_duplicates_patcher.stop)
+
+        case_exists_patcher = patch('corehq.apps.data_interfaces.models._case_exists_in_es')
+        self.case_exists_mock = case_exists_patcher.start()
+        self.case_exists_mock.return_value = True
+        self.addCleanup(case_exists_patcher.stop)
+
+    def test_pillow_processes_changes(self):
+        rule = self._create_rule('test', ["age"])
+        self._configure_properties_to_update(rule, {"name": "Herman Miller", "age": "5"})
+
+        case1 = self.factory.create_case(case_type=self.case_type, update={"age": 2})
+        case2 = self.factory.create_case(case_type=self.case_type, update={"age": 2})
+
+        self.find_duplicates_mock.return_value = [case1.case_id, case2.case_id]
+
+        new_kafka_sec = get_topic_offset(topics.CASE_SQL)
+        self.pillow.process_changes(since=self.kafka_offset, forever=False)
+
+        self.assertEqual(CaseDuplicateNew.objects.count(), 2)
+        self.assertEqual(CommCareCase.objects.get_case(case1.case_id, self.domain).get_case_property('age'), '5')
+        self.assertEqual(CommCareCase.objects.get_case(case1.case_id, self.domain).name, 'Herman Miller')
+
+        self.pillow.process_changes(since=new_kafka_sec, forever=False)
+
+    def test_pillow_ignores_deduplication_changes(self):
+        rule = self._create_rule('test', ["age"])
+        self._configure_properties_to_update(rule, {"name": "Herman Miller", "age": "5"})
+
+        case = self.factory.create_case(case_type=self.case_type, update={"age": 2})
+        self.find_duplicates_mock.return_value = [case.case_id, 'test_id']
+
+        new_kafka_sec = get_topic_offset(topics.CASE_SQL)
+        self.pillow.process_changes(since=self.kafka_offset, forever=False)
+
+        with patch('corehq.apps.data_interfaces.pillow.run_rules_for_case') as p:
+            self.pillow.process_changes(since=new_kafka_sec, forever=False)
+            p.assert_not_called()
+
+    def test_pillow_processes_normalized_system_properties(self):
+        rule = self._create_rule('system_prop_test', ['name'])
+        action = CaseDeduplicationActionDefinition.from_rule(rule)
+
+        case = self.factory.create_case(case_name="foo", case_type=self.case_type)
+
+        self.find_duplicates_mock.return_value = [case.case_id, 'duplicate_case_id']
+
+        self.pillow.process_changes(since=self.kafka_offset, forever=False)
+
+        hash = CaseDuplicateNew.case_and_action_to_hash(case, action)
+        results = CaseDuplicateNew.objects.filter(
+            action=action, hash=hash).values_list('case_id', flat=True)
+
+        self.assertSetEqual(set(results), {case.case_id, 'duplicate_case_id'})
+
+    def test_pillow_processes_resaves(self):
+        rule = self._create_rule('test', ['age'])
+        action = CaseDeduplicationActionDefinition.from_rule(rule)
+
+        case = self.factory.create_case(case_type=self.case_type, update={"age": 2})
+        new_kafka_sec = get_topic_offset(topics.CASE_SQL)
+        resave_case(self.domain, case, send_post_save_signal=False)
+
+        self.find_duplicates_mock.return_value = [case.case_id, 'duplicate_case_id']
+
+        self.pillow.process_changes(since=new_kafka_sec, forever=False)
+
+        hash = CaseDuplicateNew.case_and_action_to_hash(case, action)
+        results = CaseDuplicateNew.objects.filter(
+            action=action, hash=hash).values_list('case_id', flat=True)
+
+        self.assertSetEqual(set(results), {case.case_id, 'duplicate_case_id'})
+
+    def _create_rule(self, name='test', match_on=None):
+        rule = AutomaticUpdateRule.objects.create(
+            domain=self.domain,
+            name=name,
+            case_type=self.case_type,
+            active=True,
+            deleted=False,
+            filter_on_server_modified=False,
+            server_modified_boundary=None,
+            workflow=AutomaticUpdateRule.WORKFLOW_DEDUPLICATE
+        )
+
+        match_on = match_on or []
+
+        rule.add_action(
+            CaseDeduplicationActionDefinition,
+            match_type=CaseDeduplicationMatchTypeChoices.ALL,
+            case_properties=match_on
+        )
+
+        AutomaticUpdateRule.clear_caches(self.domain, AutomaticUpdateRule.WORKFLOW_DEDUPLICATE)
+
+        return rule
+
+    def _configure_properties_to_update(self, rule, prop_map):
+        action = rule.memoized_actions[0].definition
+        action.set_properties_to_update([
+            CaseDeduplicationActionDefinition.PropertyDefinition(
+                name=name,
+                value=value,
+                value_type=CaseDeduplicationActionDefinition.VALUE_TYPE_EXACT,
+            ) for (name, value) in prop_map.items()
+        ])
+        action.save()


### PR DESCRIPTION
## Technical Summary
Associated Ticket: https://dimagi.atlassian.net/browse/SAAS-15338.

We've been receiving error reports for CommTrack cases, as the [soft assert](https://github.com/dimagi/commcare-hq/blob/dd05b2d6ca56626a82d6f87300012659d0087bad/corehq/apps/data_interfaces/pillow.py#L87-L101) for a missing associated form is failing. Digging deeper, it seems appropriate that the duplication processor should only handle user submitted cases, so this is a first step in that direction while fixing the CommTrack errors.

Probably best to review commit-by-commit, as the first commit is just moving test code out to its own file.

## Safety Assurance

### Safety story
This should only impact processing CommTrack types, which are currently raising asserts anyhow. At worst, if this didn't work, the same asserts would still be raised.

### Automated test coverage

A new test is included to ensure that CommTrack cases are skipped

### QA Plan

No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
