### PR TITLE
Expire cache on deletion of case properties on Data Dictionary

### DIFF
--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -543,3 +543,10 @@ def _get_usercase_default_properties(domain):
 
     fields_def = CustomDataFieldsDefinition.get_or_create(domain, CUSTOM_USER_DATA_FIELD_TYPE)
     return [f.slug for f in fields_def.get_fields()]
+
+
+def expire_case_properties_caches(domain):
+    all_case_properties_by_domain.clear(domain, True, True)
+    all_case_properties_by_domain.clear(domain, True, False)
+    all_case_properties_by_domain.clear(domain, False, True)
+    all_case_properties_by_domain.clear(domain, False, False)

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -546,7 +546,12 @@ def _get_usercase_default_properties(domain):
 
 
 def expire_case_properties_caches(domain):
-    all_case_properties_by_domain.clear(domain, True, True)
-    all_case_properties_by_domain.clear(domain, True, False)
-    all_case_properties_by_domain.clear(domain, False, True)
-    all_case_properties_by_domain.clear(domain, False, False)
+    # expire all possible combinations of arguments
+    all_case_properties_by_domain.clear(domain=domain,
+                                        include_parent_properties=True, exclude_deprecated_properties=True)
+    all_case_properties_by_domain.clear(domain=domain,
+                                        include_parent_properties=True, exclude_deprecated_properties=False)
+    all_case_properties_by_domain.clear(domain=domain,
+                                        include_parent_properties=False, exclude_deprecated_properties=True)
+    all_case_properties_by_domain.clear(domain=domain,
+                                        include_parent_properties=False, exclude_deprecated_properties=False)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -65,7 +65,7 @@ from corehq.apps.app_manager import (
     remote_app,
 )
 from corehq.apps.app_manager.app_schemas.case_properties import (
-    all_case_properties_by_domain,
+    expire_case_properties_caches,
     get_all_case_properties,
     get_usercase_properties,
 )
@@ -4537,10 +4537,7 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
             # expire cache unless new application
             self.global_app_config.clear_version_caches()
         get_all_case_properties.clear(self)
-        all_case_properties_by_domain.clear(self.domain, True, True)
-        all_case_properties_by_domain.clear(self.domain, True, False)
-        all_case_properties_by_domain.clear(self.domain, False, True)
-        all_case_properties_by_domain.clear(self.domain, False, False)
+        expire_case_properties_caches(self.domain)
         get_usercase_properties.clear(self)
         get_app_languages.clear(self.domain)
         get_apps_in_domain.clear(self.domain, True)

--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -6,6 +6,9 @@ from django.utils.translation import gettext as _, gettext_lazy
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.parsing import ISO_DATE_FORMAT
 
+from corehq import privileges
+from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.app_manager.app_schemas.case_properties import expire_case_properties_caches
 from corehq.apps.case_importer import exceptions
 
 
@@ -147,6 +150,8 @@ class CaseProperty(models.Model):
         )
         get_data_dict_props_by_case_type.clear(domain)
         get_gps_properties.clear(domain, case_type)
+        if domain_has_privilege(domain, privileges.DATA_DICTIONARY):
+            expire_case_properties_caches(domain)
 
     def save(self, *args, **kwargs):
         self.clear_caches(self.case_type.domain, self.case_type.name)

--- a/corehq/apps/export/tests/test_add_inferred_export_properties.py
+++ b/corehq/apps/export/tests/test_add_inferred_export_properties.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from django.core.cache import caches, DEFAULT_CACHE_ALIAS
 from django.test import TestCase
 
@@ -36,7 +37,8 @@ class InferredSchemaSignalTest(TestCase):
         dd_props = {c.name for c in sql_props}
         self.assertEqual(dd_props, props)
 
-    def test_add_inferred_export_properties(self):
+    @patch('corehq.apps.data_dictionary.models.domain_has_privilege', return_value=True)
+    def test_add_inferred_export_properties(self, mock_domain_has_privilege):
         props = set(['one', 'two'])
         self._add_props(props)
         schema = get_case_inferred_schema(self.domain, self.case_type)
@@ -44,7 +46,8 @@ class InferredSchemaSignalTest(TestCase):
         self.assertEqual(set([item.path[0].name for item in group_schema.items]), props)
         self._check_sql_props(props)
 
-    def test_add_inferred_export_properties_saved_schema(self):
+    @patch('corehq.apps.data_dictionary.models.domain_has_privilege', return_value=True)
+    def test_add_inferred_export_properties_saved_schema(self, mock_domain_has_privilege):
         props = set(['one', 'two'])
         props_two = set(['one', 'three'])
         combined_props = props | props_two
@@ -62,7 +65,8 @@ class InferredSchemaSignalTest(TestCase):
         )
         self._check_sql_props(combined_props)
 
-    def test_add_inferred_export_properties_system(self):
+    @patch('corehq.apps.data_dictionary.models.domain_has_privilege', return_value=True)
+    def test_add_inferred_export_properties_system(self, mock_domain_has_privilege):
         """
         Ensures that when we add a system property, it uses the system's item type
         """
@@ -74,7 +78,8 @@ class InferredSchemaSignalTest(TestCase):
         self.assertEqual(group_schema.items[0].__class__, ExportItem)
         self._check_sql_props(props)
 
-    def test_add_inferred_export_properties_system_with_transform(self):
+    @patch('corehq.apps.data_dictionary.models.domain_has_privilege', return_value=True)
+    def test_add_inferred_export_properties_system_with_transform(self, mock_domain_has_privilege):
         """
         Ensures that when we add a system property with redundant paths, it uses the item's transform
         """
@@ -84,7 +89,8 @@ class InferredSchemaSignalTest(TestCase):
         group_schema = schema.group_schemas[0]
         self.assertEqual(len(group_schema.items), 1)
 
-    def test_cache_add_inferred_export_properties(self):
+    @patch('corehq.apps.data_dictionary.models.domain_has_privilege', return_value=True)
+    def test_cache_add_inferred_export_properties(self, mock_domain_has_privilege):
         props = set(['one', 'two'])
         self._add_props(props)
         self._add_props(props, 0)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
For projects that are on advance plan or higher, When a user adds, updates or deletes a case property on Data dictionary, show them updated case properties on CLE.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3336

CLE has a list of column options which it populates by using the case properties for the project fetched by [all_case_properties_by_domain](https://github.com/dimagi/commcare-hq/blob/2408dd86005d11f70ecd795c7fdbc61255a74c23/corehq/apps/app_manager/app_schemas/case_properties.py#L512) which is cached for 5 minutes.
The change here expires that cache when case property is saved or deleted. The same expiration is done for Application changes, so extracted that as a function and called that.
A more ideal change would be to expire cache only for the case type of the case property but the way caching is set that isn't feasible.
Though since CLE only fetches case properties from Data Dictionary for projects that have the privilege for DD, the expiration was done only for such projects which are `Advanced Plan and higher` plans. So, the impact of the cache expiry would be low.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`DATA_DICTIONARY`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
No functional change. Tested locally that CLE UI continues to work well.
The only concern was that expiring cache more frequently should not result in any performance issues on production which should not happen considering its only for advance plan and higher and additionally the updates to DD are rare.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-6148

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
