### PR TITLE
Fix handling of deleted and restored duplicate cases

### DIFF
--- a/corehq/apps/data_interfaces/pillow.py
+++ b/corehq/apps/data_interfaces/pillow.py
@@ -63,13 +63,13 @@ class CaseDeduplicationProcessor(PillowProcessor):
         domain = change.metadata.domain
         associated_form_id = change.metadata.associated_document_id
 
-        if not associated_form_id:
-            return []
-
         # TODO: feels like there should be some enforced order for running through rules?
         rules = self._get_rules(domain)
 
-        if associated_form_id == UPDATE_REASON_RESAVE:
+        if not associated_form_id or associated_form_id == UPDATE_REASON_RESAVE:
+            # no associated form occurs whenever a form is rebuilt. Forms can be rebuilt
+            # when a deletion is being undone or a form is being restored. In either case,
+            # all rules may be interested in these changes
             applicable_rules = rules
         else:
             associated_form = self._get_associated_form(change)

--- a/corehq/apps/data_interfaces/tests/test_case_deduplication.py
+++ b/corehq/apps/data_interfaces/tests/test_case_deduplication.py
@@ -623,7 +623,7 @@ class CaseDeduplicationActionTest(TestCase):
         self.assertGreater(len(resulting_case_ids), 1)
 
     @patch("corehq.apps.data_interfaces.models._find_duplicate_case_ids")
-    @patch("corehq.apps.data_interfaces.models.case_matching_rule_exists_in_es")
+    @patch("corehq.apps.data_interfaces.models.case_matching_rule_criteria_exists_in_es")
     def test_ignores_recent_submissions_not_in_elasticsearch(self, mock_case_exists, find_duplicates_mock):
         # create existing duplicates
         existing_duplicates, _ = self._create_cases(num_cases=2)
@@ -632,7 +632,7 @@ class CaseDeduplicationActionTest(TestCase):
         # create a new case that will qualify as a duplicate, but has been submitted recently
         current_time = datetime(year=2024, month=2, day=5, hour=10)
         new_case = self._create_case()
-        new_case.modified_on = current_time - timedelta(hours=1)
+        new_case.server_modified_on = current_time - timedelta(hours=1)
         mock_case_exists.return_value = False
 
         with freeze_time(current_time):
@@ -641,11 +641,11 @@ class CaseDeduplicationActionTest(TestCase):
         created_duplicates = CaseDuplicateNew.objects.filter(case_id=new_case.case_id)
         self.assertEqual(created_duplicates.count(), 0)
 
-    @patch("corehq.apps.data_interfaces.models.case_matching_rule_exists_in_es")
+    @patch("corehq.apps.data_interfaces.models.case_matching_rule_criteria_exists_in_es")
     def test_raises_error_when_case_not_in_elasticsearch(self, mock_case_exists):
         current_time = datetime(year=2024, month=2, day=5, hour=10)
         case = self._create_case()
-        case.modified_on = current_time - timedelta(hours=1, seconds=1)
+        case.server_modified_on = current_time - timedelta(hours=1, seconds=1)
         mock_case_exists.return_value = False
 
         with self.assertRaisesRegex(

--- a/corehq/apps/data_interfaces/tests/test_pillow.py
+++ b/corehq/apps/data_interfaces/tests/test_pillow.py
@@ -124,6 +124,10 @@ class DeduplicationPillowTest(TestCase):
         mock_run_rules.assert_not_called()
 
     def test_pillow_processes_restored_forms(self):
+        # This test was created to ensure that 'Undo-ing' a delete, or archiving a deletion request,
+        # was not causing the correct deduplication logic to occur.
+        # Because, from the code's perspective, these situations both just appear
+        # as a case published without an associated form, that is what is being tested here
         rule = self._create_rule('test', ['name'])
         action = CaseDeduplicationActionDefinition.from_rule(rule)
         case1 = create_case(domain=self.domain, name='test', case_type=self.case_type, save=True)

--- a/corehq/apps/data_interfaces/tests/test_pillow.py
+++ b/corehq/apps/data_interfaces/tests/test_pillow.py
@@ -16,6 +16,9 @@ from corehq.form_processor.models import CommCareCase
 from corehq.apps.hqcase.utils import resave_case
 from corehq.apps.commtrack.const import USER_LOCATION_OWNER_MAP_TYPE
 
+from corehq.form_processor.tests.utils import create_case
+from corehq.form_processor.change_publishers import publish_case_saved
+
 
 @override_settings(RUN_UNKNOWN_USER_PILLOW=False)
 @override_settings(RUN_FORM_META_PILLOW=False)
@@ -119,6 +122,21 @@ class DeduplicationPillowTest(TestCase):
         self.pillow.process_changes(since=self.kafka_offset, forever=False)
 
         mock_run_rules.assert_not_called()
+
+    def test_pillow_processes_restored_forms(self):
+        rule = self._create_rule('test', ['name'])
+        action = CaseDeduplicationActionDefinition.from_rule(rule)
+        case1 = create_case(domain=self.domain, name='test', case_type=self.case_type, save=True)
+        case2 = create_case(domain=self.domain, name='test', case_type=self.case_type, save=True)
+        publish_case_saved(case1)
+
+        self.find_duplicates_mock.return_value = [case1.case_id, case2.case_id]
+
+        self.pillow.process_changes(since=self.kafka_offset, forever=False)
+
+        hash = CaseDuplicateNew.case_and_action_to_hash(case1, action)
+        resulting_ids = CaseDuplicateNew.objects.filter(action=action, hash=hash).values_list('case_id', flat=True)
+        self.assertIn(case1.case_id, resulting_ids)
 
     def _create_rule(self, name='test', match_on=None):
         rule = AutomaticUpdateRule.objects.create(


### PR DESCRIPTION
## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15340.
As mentioned, after a case was closed, hitting 'Undo' or archiving the deletion form was not causing the duplicate to re-appear in the duplicate case list. However, the issue was deeper than this. First, all re-processed cases would also not be processed. Second, even after restoring their processing, these cases were often not processing correctly. Closing and reprocessing forms doesn't update the `modified_on` timestamp, so reprocessing an older cases that wasn't found in elasticsearch would throw an exception, rather than silently ignore it.  And finally, we were performing an initial check that discarded all closed cases, despite needing to include cases to determine if the closing was an actionable change.

## Safety Assurance

### Safety story
Verified locally that closing and re-opening older cases works as expected. Processing cases with no associated form ids increases the number of cases we process, but I see little way around this, as both undoing a close and archiving a closed form trigger resaving the case, and it does not seem practical to add associated form ids to that action. The real point of filtering out some cases was to avoid processing updates that resulted from the dedupe process (i.e. an infinite loop), and those cases will all have forms attached.

### Automated test coverage

Added a test to ensure that the pillow processes changes without an associated form. Also updated existing tests to account for the error with ignoring closed cases.

### QA Plan

No QA -- will verify correct functionality on staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
