### PR TITLE
Return boolean value for app_has_been_submitted_to_in_last_30_days

### DIFF
--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -57,7 +57,7 @@ def app_has_been_submitted_to_in_last_30_days(domain, app_id):
     result = _received_on_query(domain, desc=True).app(app_id)[0]
 
     if not result:
-        return
+        return False
 
     return iso_string_to_datetime(result[0]['received_on']) > (now - _30_days)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15317

This led to [this issue](https://dimagi.sentry.io/issues/4978868442/?project=136860), which is basically that we were trying to save None to cp_is_active on an app doc, which is a boolean field according to the ES mapping. If the results variable is empty, we should return False, not None. This method is only used in `app_is_active` and that method is only used to calculate this property, so this is safe.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
