### PR TITLE
small icon fixes (fontawesome)

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -759,7 +759,7 @@ class ProjectDataTab(UITab):
                         'url': reverse(CaseExportListView.urlname,
                                        args=(self.domain,)),
                         'show_in_dropdown': True,
-                        'icon': 'icon icon-share fa fa-share-form-square',
+                        'icon': 'icon icon-share fa-solid fa-share-square',
                         'subpages': [_f for _f in [
                             {
                                 'title': _(CreateNewCustomCaseExportView.page_title),


### PR DESCRIPTION
## Technical Summary
It looks like the [documented way](https://fontawesome.com/icons/share-from-square?f=classic&s=solid) of displaying the "share from square" icon isn't working. `fa-solid fa-share-square` appears to be the fix. even `fa-solid fa-share-from-square` doesn't work. 

## Safety Assurance

### Safety story
Makes the icon show up when it isn't right now. not disruptive to the user, just looks bad.

### Automated test coverage
No

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
