### PR TITLE
some additional select2 scss updates for disabled select2 state

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
@@ -78,6 +78,7 @@
 .select2-container--default .select2-selection--multiple {
   border-color: $border-color !important;
   height: 32px !important;
+  border-radius: $input-border-radius !important;
 }
 
 .select2-container--default .select2-selection--single {
@@ -155,4 +156,9 @@
     box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba(var(--#{$prefix}success-rgb), $input-btn-focus-color-opacity);
     outline: 0;
   }
+}
+
+.select2-container--default.select2-container--disabled .select2-selection--single {
+  border-color: $input-disabled-bg !important;
+  background-color: $input-disabled-bg !important;
 }

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
@@ -67,7 +67,7 @@
      .select2-search-field {
          width: 100% !important;
      }
-@@ -72,16 +64,95 @@
+@@ -72,16 +64,101 @@
      .select2-input {
          width: 100% !important;
      }
@@ -91,6 +91,7 @@
 +.select2-container--default .select2-selection--multiple {
 +  border-color: $border-color !important;
 +  height: 32px !important;
++  border-radius: $input-border-radius !important;
 +}
 +
 +.select2-container--default .select2-selection--single {
@@ -168,4 +169,9 @@
 +    box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba(var(--#{$prefix}success-rgb), $input-btn-focus-color-opacity);
 +    outline: 0;
 +  }
++}
++
++.select2-container--default.select2-container--disabled .select2-selection--single {
++  border-color: $input-disabled-bg !important;
++  background-color: $input-disabled-bg !important;
 +}


### PR DESCRIPTION
## Technical Summary
These are classes I added to the `select2` css when writing the style guide for Bootstrap 5.

## Safety Assurance

### Safety story
new scss. no public workflows affected by this.

### Automated test coverage
No

### QA Plan
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
leaving unchecked due to diffs
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
