### PR TITLE
Bootstrap 5 updates to sidebar nav SCSS and text

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_nav.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_nav.scss
@@ -22,8 +22,11 @@
       background-color: #dbdbdb;
     }
   }
-  &.nav li.active {
-    > a, > a:link, > a:visited, > a:hover {
+  &.nav li {
+    > a.active,
+    > a.active:link,
+    > a.active:visited,
+    > a.active:hover {
       background-color: $brand-primary;
       color: #ffffff;
     }

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/navigation_left_sidebar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/navigation_left_sidebar.html
@@ -25,7 +25,11 @@
           </a>
           {% if nav.subpage and nav.subpage.title %}
             <ul class="nav">
-              <li class="nav-item"><a href="#" class="nav-link active">{{ nav.subpage.title }}</a></li>
+              <li class="nav-item">
+                <a href="#" class="nav-link active" aria-current="page">
+                  {{ nav.subpage.title }}
+                </a>
+              </li>
             </ul>
           {% endif %}
         </li>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/navigation_left_sidebar.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/navigation_left_sidebar.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,27 +1,31 @@
+@@ -1,27 +1,35 @@
  <nav>
    {% for section_title, navs in sections %}
      <h2 class="text-hq-nav-header">{{ section_title }}</h2>
@@ -41,7 +41,11 @@
            {% if nav.subpage and nav.subpage.title %}
              <ul class="nav">
 -              <li class="active"><a href="#">{{ nav.subpage.title }}</a></li>
-+              <li class="nav-item"><a href="#" class="nav-link active">{{ nav.subpage.title }}</a></li>
++              <li class="nav-item">
++                <a href="#" class="nav-link active" aria-current="page">
++                  {{ nav.subpage.title }}
++                </a>
++              </li>
              </ul>
            {% endif %}
          </li>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/navs._nav.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/navs._nav.style.diff.txt
@@ -9,7 +9,7 @@
    padding: 0;
    padding-bottom: 20px;
  }
-@@ -16,7 +16,7 @@
+@@ -16,15 +16,18 @@
    &.nav > li {
      a {
        padding: 3px 20px;
@@ -18,16 +18,21 @@
      }
      > a:hover {
        background-color: #dbdbdb;
-@@ -24,7 +24,7 @@
+     }
    }
-   &.nav li.active {
-     > a, > a:link, > a:visited, > a:hover {
+-  &.nav li.active {
+-    > a, > a:link, > a:visited, > a:hover {
 -      background-color: @brand-primary;
++  &.nav li {
++    > a.active,
++    > a.active:link,
++    > a.active:visited,
++    > a.active:hover {
 +      background-color: $brand-primary;
        color: #ffffff;
      }
    }
-@@ -36,7 +36,7 @@
+@@ -36,7 +39,7 @@
      margin: 8px 10px;
      overflow: hidden;
      background-color: white;
@@ -36,7 +41,7 @@
    }
    .nav-input {
      padding: 3px 20px;
-@@ -54,6 +54,7 @@
+@@ -54,6 +57,7 @@
  .nav-main-icon {
    font-size: 1.7em;
    line-height: 0.7em;
@@ -44,7 +49,7 @@
  }
  
  .text-hq-nav-header {
-@@ -68,7 +69,7 @@
+@@ -68,7 +72,7 @@
  }
  
  .nav > li > a {


### PR DESCRIPTION
## Technical Summary
when creating the styleguide, I realized the current page on the sidebar navigation was not being highlighted in boostrap 5 stylesheets. This fixes the problem.

## Safety Assurance

### Safety story
safe change. does not affect current user workflows

### Automated test coverage
yes. diffs

### QA Plan
no

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
unchecked due to diff conflicts
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
