### PR TITLE
Make ElasticProcessor inserts and updates synchronous

### DIFF
--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -107,6 +107,7 @@ class ElasticProcessor(PillowProcessor):
                 adapter=self.adapter,
                 name='ElasticProcessor',
                 data=doc,
+                refresh=True,
             )
 
     def _delete_doc_if_exists(self, doc_id):
@@ -183,7 +184,7 @@ class BulkElasticProcessor(ElasticProcessor, BulkPillowProcessor):
 
 
 def send_to_elasticsearch(adapter, doc_id, name,
-                        data=None, delete=False, es_merge_update=False):
+                        data=None, delete=False, es_merge_update=False, refresh=False):
     """
     More fault tolerant es.put method
     kwargs:
@@ -204,10 +205,10 @@ def send_to_elasticsearch(adapter, doc_id, name,
                     # The `retry_on_conflict` param is only valid on `update`
                     # requests. ES <5.x was lenient of its presence on `index`
                     # requests, ES >=5.x is not.
-                    adapter.update(doc_id, fields=data, retry_on_conflict=2)
+                    adapter.update(doc_id, fields=data, retry_on_conflict=2, refresh=refresh)
                 else:
                     # use the same index API to create or update doc
-                    adapter.index(data)
+                    adapter.index(data, refresh=refresh)
             break
         except ConnectionError:
             current_tries += 1


### PR DESCRIPTION
## Technical Summary
In updating the deduplication processor, I was working under the assumption that the `case_to_es_processor` in `case-pillow` was processing its updates synchronously. The deduplication processor was specifically inserted after this processing, in the belief that new cases would be processed by `case_to_es_processor`, which would then make the ES results reliable for the deduplication processor. 

However, it appears that is not what happens -- instead, these updates appear to be asynchronous, and so, when new cases appear in the dedupe processor, they are reliably not yet present in elasticsearch. I'd like to make this process synchronous, however I'm very concerned about the performance effects this could have on our system. Looking to hear thoughts on whether this is a good idea or not.

## Safety Assurance

### Safety story
I'm opening this as a draft PR, as I'm not sure this change is safe. My concern is entirely around performance.

### Automated test coverage
None

### QA Plan

I'd like to run this through QA if we sign off on the approach

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
