### PR TITLE
Switch SQLUserData model to be sparsely populated

### DIFF
--- a/corehq/apps/users/management/commands/populate_sql_user_data.py
+++ b/corehq/apps/users/management/commands/populate_sql_user_data.py
@@ -1,4 +1,4 @@
-# One-off migration, November 2023
+# One-off migration, March 2024
 
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
@@ -23,5 +23,6 @@ def get_users_without_user_data():
 
 def populate_user_data(django_user):
     user = CouchUser.from_django_user(django_user, strict=True)
-    for domain in user.get_domains():
-        user.get_user_data(domain).save()
+    if user:
+        for domain in user.get_domains():
+            user.get_user_data(domain).save()

--- a/corehq/apps/users/management/commands/populate_sql_user_data.py
+++ b/corehq/apps/users/management/commands/populate_sql_user_data.py
@@ -3,7 +3,12 @@
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 
-from corehq.apps.users.models import CouchUser
+from dimagi.utils.chunked import chunked
+
+from corehq.apps.case_search.const import COMMCARE_PROJECT
+from corehq.apps.custom_data_fields.models import PROFILE_SLUG
+from corehq.apps.users.dbaccessors import get_user_docs_by_username
+from corehq.apps.users.user_data import SQLUserData
 from corehq.util.log import with_progress_bar
 from corehq.util.queries import queryset_to_iterator
 
@@ -13,16 +18,32 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         queryset = get_users_without_user_data()
-        for user in with_progress_bar(queryset_to_iterator(queryset, User), queryset.count()):
-            populate_user_data(user)
+        users = with_progress_bar(queryset_to_iterator(queryset, User), queryset.count())
+        for chunk in chunked(users, 100):
+            users_by_username = {user.username: user for user in chunk}
+            for user_doc in get_user_docs_by_username(users_by_username.keys()):
+                populate_user_data(user_doc, users_by_username[user_doc['username']])
 
 
 def get_users_without_user_data():
     return User.objects.filter(sqluserdata__isnull=True)
 
 
-def populate_user_data(django_user):
-    user = CouchUser.from_django_user(django_user, strict=True)
-    if user:
-        for domain in user.get_domains():
-            user.get_user_data(domain).save()
+def populate_user_data(user_doc, django_user):
+    if user_doc['doc_type'] == 'WebUser':
+        domains = user_doc['domains']
+    else:
+        domains = [user_doc['domain']]
+
+    for domain in domains:
+        raw_user_data = user_doc.get('user_data', {})
+        raw_user_data.pop(COMMCARE_PROJECT, None)
+        profile_id = raw_user_data.pop(PROFILE_SLUG, None)
+        if raw_user_data or profile_id:
+            SQLUserData.objects.create(
+                user_id=user_doc['_id'],
+                domain=domain,
+                data=raw_user_data,
+                django_user=django_user,
+                profile_id=profile_id,
+            )

--- a/corehq/apps/users/tests/test_user_data.py
+++ b/corehq/apps/users/tests/test_user_data.py
@@ -101,7 +101,9 @@ class TestUserData(TestCase):
         ]
         users_with_data = [self.make_commcare_user(), self.make_web_user()]
         for user in users_with_data:
-            user.get_user_data(self.domain).save()
+            ud = user.get_user_data(self.domain)
+            ud['key'] = 'dummy val so this is non-empty'
+            ud.save()
 
         users_to_migrate = get_users_without_user_data()
         self.assertItemsEqual(
@@ -131,8 +133,8 @@ class TestUserData(TestCase):
     def test_migrate_user_no_data(self):
         user = self.make_commcare_user()
         populate_user_data(user)
-        sql_data = SQLUserData.objects.get(domain=self.domain, user_id=user.user_id)
-        self.assertEqual(sql_data.data, {})
+        with self.assertRaises(SQLUserData.DoesNotExist):
+            SQLUserData.objects.get(domain=self.domain, user_id=user.user_id)
 
     def test_prime_user_data_caches(self):
         users = [
@@ -143,7 +145,9 @@ class TestUserData(TestCase):
             self.make_web_user(),
         ]
         for user in users:
-            user.get_user_data(self.domain).save()
+            ud = user.get_user_data(self.domain)
+            ud['key'] = 'dummy val so this is non-empty'
+            ud.save()
         users.append(self.make_web_user())  # add user without data
         self.assertEqual(SQLUserData.objects.count(), 5)
 

--- a/corehq/apps/users/tests/test_user_data.py
+++ b/corehq/apps/users/tests/test_user_data.py
@@ -115,7 +115,7 @@ class TestUserData(TestCase):
         user = self.make_commcare_user()
         user['user_data'] = {'favorite_color': 'purple'}
         user.save()
-        populate_user_data(user)
+        populate_user_data(CommCareUser.get_db().get(user._id), user.get_django_user())
         sql_data = SQLUserData.objects.get(domain=self.domain, user_id=user.user_id)
         self.assertEqual(sql_data.data['favorite_color'], 'purple')
 
@@ -125,14 +125,14 @@ class TestUserData(TestCase):
         user['user_data'] = {'favorite_color': 'purple'}
         user.add_domain_membership('domain2', timezone='UTC')
         user.save()
-        populate_user_data(user)
+        populate_user_data(WebUser.get_db().get(user._id), user.get_django_user())
         for domain in [self.domain, 'domain2']:
             sql_data = SQLUserData.objects.get(domain=domain, user_id=user.user_id)
             self.assertEqual(sql_data.data['favorite_color'], 'purple')
 
     def test_migrate_user_no_data(self):
         user = self.make_commcare_user()
-        populate_user_data(user)
+        populate_user_data(CommCareUser.get_db().get(user._id), user.get_django_user())
         with self.assertRaises(SQLUserData.DoesNotExist):
             SQLUserData.objects.get(domain=self.domain, user_id=user.user_id)
 

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -31,27 +31,41 @@ class UserData:
         raw_user_data = couch_user.to_json().get('user_data', {}).copy()
         raw_user_data.pop(COMMCARE_PROJECT, None)
         profile_id = raw_user_data.pop(PROFILE_SLUG, None)
-        sql_data, _ = SQLUserData.objects.get_or_create(
-            user_id=couch_user.user_id,
-            domain=domain,
-            defaults={
-                'data': raw_user_data,
-                'django_user': couch_user.get_django_user,
-                'profile_id': profile_id,
-            }
-        )
+
+        try:
+            sql_data = SQLUserData.objects.get(user_id=couch_user.user_id, domain=domain)
+        except SQLUserData.DoesNotExist:
+            if not (raw_user_data or profile_id):
+                # Don't bother saving anything to the DB
+                return cls({}, couch_user, domain)
+
+            sql_data = SQLUserData.objects.create(
+                user_id=couch_user.user_id,
+                domain=domain,
+                data=raw_user_data,
+                django_user=couch_user.get_django_user(),
+                profile_id=profile_id,
+            )
+
         return cls(sql_data.data, couch_user, domain, profile_id=sql_data.profile_id)
 
     def save(self):
-        SQLUserData.objects.update_or_create(
-            user_id=self._couch_user.user_id,
-            domain=self.domain,
-            defaults={
-                'data': self._local_to_user,
-                'django_user': self._couch_user.get_django_user,
-                'profile_id': self.profile_id,
-            },
-        )
+        try:
+            sql_data = SQLUserData.objects.get(user_id=self._couch_user.user_id, domain=self.domain)
+        except SQLUserData.DoesNotExist:
+            if self._local_to_user or self.profile_id:
+                SQLUserData.objects.create(
+                    user_id=self._couch_user.user_id,
+                    domain=self.domain,
+                    data=self._local_to_user,
+                    django_user=self._couch_user.get_django_user(),
+                    profile_id=self.profile_id,
+                )
+            # Don't save to DB if there's nothing to save
+        else:
+            sql_data.data = self._local_to_user
+            sql_data.profile_id = self.profile_id
+            sql_data.save()
 
     @property
     def _provided_by_system(self):

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -56,6 +56,7 @@ class UserData:
                         .select_for_update()
                         .get(user_id=self._couch_user.user_id, domain=self.domain))
         except SQLUserData.DoesNotExist:
+            # Only create db object if there's something to persist
             if self._local_to_user or self.profile_id:
                 SQLUserData.objects.create(
                     user_id=self._couch_user.user_id,
@@ -64,7 +65,6 @@ class UserData:
                     django_user=self._couch_user.get_django_user(),
                     profile_id=self.profile_id,
                 )
-            # Don't save to DB if there's nothing to save
         else:
             sql_data.data = self._local_to_user
             sql_data.profile_id = self.profile_id


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Tweaks the initialization and save methods of `UserData` to only create `SQLUserData` row in the DB if they will be non-empty.  This should have no user-facing impact.  Once user data _has_ been saved to the DB it won't be deleted (until the user is deleted), even if the user data is later cleared, but the `UserData` class should behave the same in either instance.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The automated tests are pretty thorough.

### Automated test coverage

All public methods are tested

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
