### PR TITLE
Feature flag to increase case search results limit

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -39,6 +39,7 @@ from corehq.apps.registry.exceptions import (
     RegistryNotFound,
 )
 from corehq.apps.registry.helper import DataRegistryHelper
+from corehq.toggles import USH_CASE_SEARCH_LIMIT_INCREASE
 
 
 def get_case_search_results_from_request(domain, app_id, couch_user, request_dict):
@@ -182,11 +183,13 @@ class CaseSearchQueryBuilder:
         return search_es
 
     def _get_initial_search_es(self):
+        size = (1500 if USH_CASE_SEARCH_LIMIT_INCREASE.enabled(self.request_domain)
+                else CASE_SEARCH_MAX_RESULTS)
         return (CaseSearchES()
                 .domain(self.query_domains)
                 .case_type(self.case_types)
                 .is_closed(False)
-                .size(CASE_SEARCH_MAX_RESULTS))
+                .size(size))
 
     def _apply_sort(self, search_es, commcare_sort=None):
         if commcare_sort:

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1008,6 +1008,14 @@ USH_CASE_CLAIM_UPDATES = StaticToggle(
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
 )
 
+USH_CASE_SEARCH_LIMIT_INCREASE = StaticToggle(
+    'ush_case_search_limit_increase',
+    "USH: Temporarily increase the CASE_SEARCH_MAX_RESULTS limit",
+    TAG_INTERNAL,
+    description="Please do not enable this for your project",
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
     "geocoder_my_location_button",
     "USH: Add button to geocoder to populate search with the user's current location",


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
https://dimagi.atlassian.net/browse/USH-4244

Jonathan wrote:
> I dug through the related PR histories and I didn't find any documented reasoning but it has been increased from [10](https://github.com/dimagi/commcare-hq/commit/158a3cd67110eeeb02eafe5f3674735c132c21ae) -> [100](https://github.com/dimagi/commcare-hq/pull/15931) -> [500](https://github.com/dimagi/commcare-hq/pull/28883)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
