### PR TITLE
Navigate to Dedupe Rule List from Reports

### DIFF
--- a/corehq/apps/reports/standard/cases/duplicate_cases.py
+++ b/corehq/apps/reports/standard/cases/duplicate_cases.py
@@ -33,8 +33,8 @@ class DuplicateCasesExplorer(CaseListExplorer):
             from corehq.apps.data_interfaces.views import DeduplicationRuleListView
             message = format_html(
                 gettext(
-                    'Please select a duplicate case rule to filter by above. Rules can be created '
-                    ' <a href={} target="_blank">here</a>'
+                    'Please select a duplicate case rule to filter by above. If one does not exist, you may '
+                    ' <a href={} target="_blank">create a new rule</a>'
                 ),
                 reverse(DeduplicationRuleListView.urlname, args=[self.domain])
             )

--- a/corehq/apps/reports/standard/cases/duplicate_cases.py
+++ b/corehq/apps/reports/standard/cases/duplicate_cases.py
@@ -1,4 +1,8 @@
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext
+from django.utils.html import format_html
+from django.urls import reverse
+
 from corehq.apps.reports.exceptions import BadRequestError
 from corehq.apps.reports.standard.cases.case_list_explorer import (
     CaseListExplorer,
@@ -26,7 +30,16 @@ class DuplicateCasesExplorer(CaseListExplorer):
     def _get_case_ids(self):
         case_rule_id = DuplicateCaseRuleFilter.get_value(self.request, self.domain)
         if not case_rule_id:
-            raise BadRequestError(_("Please select a duplicate case rule to filter by above."))
+            from corehq.apps.data_interfaces.views import DeduplicationRuleListView
+            message = format_html(
+                gettext(
+                    'Please select a duplicate case rule to filter by above. Rules can be created '
+                    ' <a href={} target="_blank">here</a>'
+                ),
+                reverse(DeduplicationRuleListView.urlname, args=[self.domain])
+            )
+
+            raise BadRequestError(message)
         return CaseDuplicateNew.get_case_ids(case_rule_id)
 
     def _build_query(self, sort=True):

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -2,6 +2,8 @@ import json
 from collections import Counter
 
 from django.utils.safestring import mark_safe
+from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy, gettext
 from django.utils.functional import lazy
 
@@ -51,10 +53,23 @@ class CaseSearchFilter(BaseSimpleFilter):
 class DuplicateCaseRuleFilter(BaseSingleOptionFilter):
     slug = 'duplicate_case_rule'
     label = gettext_lazy("Duplicate Case Rule")
-    help_text = gettext_lazy(
-        """Show cases that are determined to be duplicates based on this rule.
-        You can further filter them with a targeted search below."""
-    )
+
+    @property
+    def help_text(self):
+        from corehq.apps.data_interfaces.views import DeduplicationRuleListView
+
+        description = gettext(
+            "Show cases that are determined to be duplicates based on this rule. "
+            "You can further filter them with a targeted search below."
+        )
+
+        link = format_html(
+            '<a href="{}" target="_blank">{}</a>',
+            reverse(DeduplicationRuleListView.urlname, args=[self.domain]),
+            gettext('View Rules')
+        )
+
+        return format_html('{} {}', description, link)
 
     @property
     def options(self):


### PR DESCRIPTION
## Product Description
We saw some errors with users performing faulty searches for duplicates when no rules were configured, so the hope is adding in navigation prompts makes this process more intuitive.

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15350

## Safety Assurance

### Safety story
No logic changes. This is limited to displayed links. Verified the changes locally.

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
