### PR TITLE
Filter by App on User Aggregation Status Report

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -792,9 +792,8 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
 
         aggregations = query.aggregations
         if self.selected_app_id:
-            (last_submission_buckets, last_sync_buckets) = [
-                agg.filtered_agg.date_histogram.normalized_buckets for agg in aggregations
-            ]
+            last_submission_buckets = aggregations[0].filtered_agg.date_histogram.normalized_buckets
+            last_sync_buckets = aggregations[1].filtered_agg.date_histogram.normalized_buckets
         else:
             last_submission_buckets = aggregations[0].normalized_buckets
             last_sync_buckets = aggregations[1].normalized_buckets

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -216,8 +216,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
     def user_query(self, pagination=True):
         mobile_user_and_group_slugs = set(
             # Cater for old ReportConfigs
-            self.request.GET.getlist('location_restricted_mobile_worker') +
-            self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)
+            self.request.GET.getlist('location_restricted_mobile_worker')
+            + self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)
         )
         user_query = ExpandedMobileWorkerFilter.user_es_query(
             self.domain,
@@ -438,8 +438,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
     def get_user_ids(self):
         mobile_user_and_group_slugs = set(
             # Cater for old ReportConfigs
-            self.request.GET.getlist('location_restricted_mobile_worker') +
-            self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)
+            self.request.GET.getlist('location_restricted_mobile_worker')
+            + self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)
         )
         user_ids = ExpandedMobileWorkerFilter.user_es_query(
             self.domain,
@@ -713,7 +713,6 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
             def get_buckets(self):
                 return self.bucket_series.get_summary_data()
 
-
         class BucketSeries(namedtuple('Bucket', 'data_series total_series total user_count')):
             @property
             @memoized
@@ -809,8 +808,6 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
                 }
             )
             return BucketSeries(daily_series, running_total_series, total, user_count)
-
-
 
         submission_series = SeriesData(
             id='submission',

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -811,6 +811,7 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
 
         aggregations = query.aggregations
         if self.selected_app_id:
+            # Nested aggregation names used here are defined in _get_histogram_aggregation_for_app()
             last_submission_buckets = (aggregations[0]
                                        .filtered_last_submissions
                                        .last_submissions_date_histogram

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -655,6 +655,7 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
 
     fields = [
         'corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',
+        'corehq.apps.reports.filters.select.SelectApplicationFilter',
     ]
     exportable = False
     emailable = False

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -673,16 +673,16 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
     def selected_app_id(self):
         return self.request_params.get(SelectApplicationFilter.slug, None)
 
-    def _get_histogram_aggregation_for_app(self, field_name):
-        nested_field_name = f'reporting_metadata.{field_name}'
-        nested_agg = NestedAggregation(f'nested_{field_name}', nested_field_name)
+    def _get_histogram_aggregation_for_app(self, nested_field_name, date_field_name):
+        nested_field_path = f'reporting_metadata.{nested_field_name}'
+        nested_agg = NestedAggregation(f'nested_{nested_field_name}', nested_field_path)
         filter_agg = FilterAggregation(
-            f'filtered_{field_name}',
-            filters.term(f'{nested_field_name}.app_id', self.selected_app_id)
+            f'filtered_{nested_field_name}',
+            filters.term(f'{nested_field_path}.app_id', self.selected_app_id)
         )
         histogram_agg = DateHistogram(
-            f'{field_name}_date_histogram',
-            f'{nested_field_name}.submission_date',
+            f'{nested_field_name}_date_histogram',
+            f'{nested_field_path}.{date_field_name}',
             DateHistogram.Interval.DAY
         )
 
@@ -701,8 +701,8 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
         )
 
         if self.selected_app_id:
-            last_submission_agg = self._get_histogram_aggregation_for_app('last_submissions')
-            last_sync_agg = self._get_histogram_aggregation_for_app('last_syncs')
+            last_submission_agg = self._get_histogram_aggregation_for_app('last_submissions', 'submission_date')
+            last_sync_agg = self._get_histogram_aggregation_for_app('last_syncs', 'sync_date')
         else:
             last_submission_agg = DateHistogram(
                 'last_submission',

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -815,15 +815,9 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
 
         aggregations = query.aggregations
         if self.selected_app_id:
-            # Nested aggregation names used here are defined in _get_histogram_aggregation_for_app()
-            last_submission_buckets = (aggregations[0]
-                                       .filtered_last_submissions
-                                       .last_submissions_date_histogram
-                                       .normalized_buckets)
-            last_sync_buckets = (aggregations[1]
-                                 .filtered_last_syncs
-                                 .last_syncs_date_histogram
-                                 .normalized_buckets)
+            (last_submission_buckets, last_sync_buckets) = [
+                agg.filtered_agg.date_histogram.normalized_buckets for agg in aggregations
+            ]
         else:
             last_submission_buckets = aggregations[0].normalized_buckets
             last_sync_buckets = aggregations[1].normalized_buckets

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -673,7 +673,7 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
     def selected_app_id(self):
         return self.request_params.get(SelectApplicationFilter.slug, None)
 
-    def _get_histogram_aggregation_for_app(self, nested_field_name, date_field_name):
+    def _get_histogram_aggregation_for_app(self, field_name, date_field_name):
         """
         The histogram aggregation is put inside a nested and filter aggregation to only query
         the nested documents that match the selected app ID.
@@ -703,15 +703,15 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
             }
         }
         """
-        nested_field_path = f'reporting_metadata.{nested_field_name}'
-        nested_agg = NestedAggregation(f'nested_{nested_field_name}', nested_field_path)
+        field_path = f'reporting_metadata.{field_name}'
+        nested_agg = NestedAggregation(f'nested_{field_name}', field_path)
         filter_agg = FilterAggregation(
-            f'filtered_{nested_field_name}',
-            filters.term(f'{nested_field_path}.app_id', self.selected_app_id)
+            f'filtered_{field_name}',
+            filters.term(f'{field_path}.app_id', self.selected_app_id)
         )
         histogram_agg = DateHistogram(
-            f'{nested_field_name}_date_histogram',
-            f'{nested_field_path}.{date_field_name}',
+            f'{field_name}_date_histogram',
+            f'{field_path}.{date_field_name}',
             DateHistogram.Interval.DAY
         )
 

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -781,8 +781,18 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
         query = self.user_query().run()
 
         aggregations = query.aggregations
-        last_submission_buckets = aggregations[0].normalized_buckets
-        last_sync_buckets = aggregations[1].normalized_buckets
+        if self.selected_app_id:
+            last_submission_buckets = (aggregations[0]
+                                       .filtered_last_submissions
+                                       .last_submissions_date_histogram
+                                       .normalized_buckets)
+            last_sync_buckets = (aggregations[1]
+                                 .filtered_last_syncs
+                                 .last_syncs_date_histogram
+                                 .normalized_buckets)
+        else:
+            last_submission_buckets = aggregations[0].normalized_buckets
+            last_sync_buckets = aggregations[1].normalized_buckets
         total_users = query.total
 
         def _buckets_to_series(buckets, user_count):

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -549,30 +549,7 @@ def _get_histogram_aggregation_for_app(field_name, date_field_name, app_id):
     The histogram aggregation is put inside a nested and filter aggregation to only query
     the nested documents that match the selected app ID.
 
-    This function will return a nested aggregation that looks like the following:
-    "aggs": {
-        {field_name}: {
-            "nested": {
-                "path": "reporting_metadata.{field_name}"
-            }
-        },
-        "aggs": {
-            "filtered_agg": {
-                "filter": {
-                    "term": {
-                        "reporting_metadata.{field_name}.app_id": self.selected_app_id
-                    }
-                }
-                "aggs": {
-                    "date_histogram": {
-                        "date_histogram": {
-                            ...
-                        }
-                    }
-                }
-            }
-        }
-    }
+    Refer to `TestGetHistogramAggregationForApp` to see the final output.
     """
     field_path = f'reporting_metadata.{field_name}'
     nested_agg = NestedAggregation(field_name, field_path)

--- a/corehq/apps/reports/tests/standard/test_deployments.py
+++ b/corehq/apps/reports/tests/standard/test_deployments.py
@@ -1,0 +1,34 @@
+from django.test import SimpleTestCase
+from corehq.apps.reports.standard.deployments import _get_histogram_aggregation_for_app
+
+
+class TestGetHistogramAggregationForApp(SimpleTestCase):
+
+    def test_get_histogram_aggregation_for_app(self):
+        expected_output = {
+            "nested": {
+                "path": "reporting_metadata.test_field"
+            },
+            "aggs": {
+                "filtered_agg": {
+                    "filter": {
+                        "term": {
+                            "reporting_metadata.test_field.app_id": "123"
+                        }
+                    },
+                    "aggs": {
+                        "date_histogram": {
+                            "date_histogram": {
+                                "field": "reporting_metadata.test_field.test_date",
+                                "interval": "day",
+                                "format": "yyyy-MM-dd",
+                                "min_doc_count": 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        aggs = _get_histogram_aggregation_for_app('test_field', 'test_date', '123')
+        self.assertEqual(expected_output, aggs.assemble())


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A new "Application" filter has been added to the User Aggregation Status report:
![Screenshot from 2024-02-26 12-30-09](https://github.com/dimagi/commcare-hq/assets/122617251/b9e3b5ae-3f75-4f5b-b274-6c696bfc38ab)

When no application filter is selected the report will show aggregation statistics for all applications (current behaviour).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3412).

Currently the report simply looks at the last submission and sync dates for users when aggregating the statistics. This does not work when filtering by application however, as this data sits inside a nested ES field that contains the submission and sync dates for each application the mobile worker has used. As such, nested filtering and aggregation has been implemented to correctly retrieve the submission/sync date according to the filtered app ID. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- QA done

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
A unit test is added to ensure that the `test_get_histogram_aggregation_for_app()` function returns the expected ES aggregates.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA completed. Ticket is available [here](https://dimagi.atlassian.net/browse/QA-6155).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
