### PR TITLE
Add support for pass_credentials_in_header to OAuth2ClientGrantManager

### DIFF
--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -183,6 +183,7 @@ class OAuth2ClientGrantManager(AuthManager):
         client_secret: str,
         token_url: str,
         refresh_url: str,
+        pass_credentials_in_header: bool,
         connection_settings: 'ConnectionSettings',
     ):
         self.base_url = base_url
@@ -190,6 +191,7 @@ class OAuth2ClientGrantManager(AuthManager):
         self.client_secret = client_secret
         self.token_url = token_url
         self.refresh_url = refresh_url
+        self.pass_credentials_in_header = pass_credentials_in_header
         self.connection_settings = connection_settings
 
     @property
@@ -206,22 +208,27 @@ class OAuth2ClientGrantManager(AuthManager):
         self.connection_settings.save()
 
     def get_session(self, domain_name: str) -> Session:
+        # Compare to OAuth2PasswordGrantManager.get_session()
+
         def set_last_token(token):
             # Used by OAuth2Session
             self.last_token = token
 
-        # This adds an extra round trip for all access tokens without refresh tokens.
-        # That is not ideal, but is the only way to ensure that we are able to guarantee
-        # the token will work without error, or refactoring the way sessions are used across
-        # all repeaters.
         if not self.last_token or self.last_token.get('refresh_token') is None:
             client = BackendApplicationClient(client_id=self.client_id)
             session = OAuth2Session(client=client)
-            self.last_token = session.fetch_token(
-                token_url=self.token_url,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-            )
+            if self.pass_credentials_in_header:
+                auth = HTTPBasicAuth(self.client_id, self.client_secret)
+                self.last_token = session.fetch_token(
+                    token_url=self.token_url,
+                    auth=auth,
+                )
+            else:
+                self.last_token = session.fetch_token(
+                    token_url=self.token_url,
+                    client_id=self.client_id,
+                    client_secret=self.client_secret,
+                )
 
         refresh_kwargs = {
             'client_id': self.client_id,

--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -234,7 +234,11 @@ class OAuth2ClientGrantManager(AuthManager):
             auto_refresh_kwargs=refresh_kwargs,
             token_updater=set_last_token
         )
-        make_session_public_only(session, domain_name, src='motech_oauth_send_attempt')
+        make_session_public_only(
+            session,
+            domain_name,
+            src='motech_oauth_send_attempt',
+        )
         return session
 
 
@@ -285,9 +289,10 @@ class OAuth2PasswordGrantManager(AuthManager):
             # Used by OAuth2Session
             self.last_token = token
 
-        # This adds an extra round trip for all access tokens without refresh tokens.
-        # That is not ideal, but is the only way to ensure that we are able to guarantee
-        # the token will work without error, or refactoring the way sessions are used across
+        # This adds an extra round trip for all access tokens without
+        # refresh tokens. That is not ideal, but is the only way to
+        # ensure that we are able to guarantee the token will work
+        # without error, or refactoring the way sessions are used across
         # all repeaters.
         if not self.last_token or self.last_token.get('refresh_token') is None:
             client = LegacyApplicationClient(client_id=self.client_id)
@@ -321,7 +326,11 @@ class OAuth2PasswordGrantManager(AuthManager):
             auto_refresh_kwargs=refresh_kwargs,
             token_updater=set_last_token
         )
-        make_session_public_only(session, domain_name, src='motech_oauth_send_attempt')
+        make_session_public_only(
+            session,
+            domain_name,
+            src='motech_oauth_send_attempt',
+        )
         return session
 
 

--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -199,6 +199,7 @@ class ConnectionSettings(models.Model):
                 client_secret=self.plaintext_client_secret,
                 token_url=self.token_url,
                 refresh_url=self.refresh_url,
+                pass_credentials_in_header=self.pass_credentials_in_header,
                 connection_settings=self,
             )
 


### PR DESCRIPTION
## Technical Summary

This change pertains to ConnectionSettings authentication. It allows OAuth2ClientGrantManager to support pass_credentials_in_header. The UI offers this option, but OAuth2ClientGrantManager ignores it. This change fixes that.

(This setting can be used by CommCare Analytics, although it is not required.)

## Feature Flag
N/A (although data forwarding is Pro Plan and higher iirc)

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Not covered by tests

### QA Plan

QA will test this as part of testing CommCare Analytics background sync.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
