### PR TITLE
Clear Cache on Successful Import

### DIFF
--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -29,6 +29,7 @@ from corehq.apps.data_dictionary.util import (
     save_case_property_group,
     delete_case_property,
     get_used_props_by_case_type,
+    get_data_dict_props_by_case_type,
 )
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.hqwebapp.decorators import use_jquery_ui
@@ -488,6 +489,7 @@ class UploadDataDictionaryView(BaseProjectDataView):
                 "<ul>{}</ul>".format("".join([f"<li>{e}</li>" for e in errors]))
             ), extra_tags="html")
         else:
+            get_data_dict_props_by_case_type.clear(self.domain)
             messages.success(request, _('Data dictionary import complete'))
             if warnings:
                 messages.warning(request, _("Warnings in upload: {}").format(


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3490).

Upon successful import of an Excel file in the Data Dictionary, the cache for `get_data_dict_props_by_case_type()` will be cleared. New case properties might have been added to the DD, and so we should ensure that there does not exist actual case data linked to these properties which would mark them as unsafe for deletion.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

This change is only relevant for domains on the Advanced Plan and higher, since this PR only touches code from the Data Dictionary feature.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
