### PR TITLE
Do not diff failure_reason if record succeeded

### DIFF
--- a/corehq/motech/repeaters/management/commands/populate_repeatrecords.py
+++ b/corehq/motech/repeaters/management/commands/populate_repeatrecords.py
@@ -70,7 +70,7 @@ class Command(PopulateSQLCommand):
                 couch["next_check"],
                 json_format_datetime(sql.next_check) if sql.next_check else sql.next_check,
             ))
-        if couch.get("failure_reason"):
+        if couch.get("failure_reason") and not couch.get("succeeded"):
             diffs.append(cls.diff_value(
                 "failure_reason",
                 couch["failure_reason"],


### PR DESCRIPTION
Tiny change for Repeat Records Couch to SQL migration.

## Safety Assurance

### Safety story

Affects a management command only.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations