### PR TITLE
increase max to 1500

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -185,7 +185,7 @@ class CaseSearchQueryBuilder:
     def _get_initial_search_es(self):
         max_results = CASE_SEARCH_MAX_RESULTS
         if toggles.INCREASED_MAX_SEARCH_RESULTS.enabled(self.request_domain):
-            max_results = 1000
+            max_results = 1500
         return (CaseSearchES()
                 .domain(self.query_domains)
                 .case_type(self.case_types)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2740,7 +2740,7 @@ SUPPORT_GEO_JSON_EXPORT = StaticToggle(
 
 INCREASED_MAX_SEARCH_RESULTS = StaticToggle(
     slug='increased_max_search_results',
-    label='Support a higher number of ES results',
+    label='Increases the maximum number of Elasticsearch results from 500 to 1500',
     tag=TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
     description='Temporary increase of the max number of search results.',


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
as per conversation in ticket linked below, this increases the max number of elasticsearch to 1500 in anticipation of case generation during BHA pilot.

Jira Ticket: https://dimagi.atlassian.net/browse/USH-4244?focusedCommentId=314222

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
INCREASED_MAX_SEARCH_RESULTS
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
