### PR TITLE
Render report delete button for user 

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -312,6 +312,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
                     'is_static': self.is_static,
                     'error_message': error_message,
                     'details': details,
+                    'allow_delete': can_delete_report(request, self.spec),
                 }
                 context.update(self.main_context)
                 return self.render_to_response(context)

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -307,12 +307,18 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
                     )
                     details = str(e)
                 self.template_name = 'userreports/report_error.html'
+                allow_delete = (
+                    self.report_config_id
+                    and not self.is_static
+                    and can_delete_report(request, self.spec)
+                )
+
                 context = {
                     'report_id': self.report_config_id,
                     'is_static': self.is_static,
                     'error_message': error_message,
                     'details': details,
-                    'allow_delete': can_delete_report(request, self.spec),
+                    'allow_delete': allow_delete,
                 }
                 context.update(self.main_context)
                 return self.render_to_response(context)


### PR DESCRIPTION
## Product Description
When a report is rendered and something goes wrong (e.g. the underlying data source has been removed), accessing that report will render an error (as seen below). The error message instructs the user that the report can be removed by clicking a button, but the button does not render, hence removing such report requires developer intervention.

This PR pushes out a simple change to render the button.

Before:
![image](https://github.com/dimagi/commcare-hq/assets/44245062/b00488a6-d10d-4232-9280-af087de76a12)


After:
![image](https://github.com/dimagi/commcare-hq/assets/44245062/ba934c94-3cd6-47c1-9d24-ad44c6529f70)


## Technical Summary
The template rendering the report error already has the button input to remove the report, but only renders the button when a flag, `allow_delete`, is specified. This PR simply adds this flag based on whether the user has permissions to edit configurable reports.

## Feature Flag
`USER_CONFIGURABLE_REPORTS`

## Safety Assurance

### Safety story
Tested locally:
- With user having UCR edit permission
- With user not having UCR edit permission

### Automated test coverage

### QA Plan
No QA planned

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
