### PR TITLE
Remove django-logentry-admin dependency

### DIFF
--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -30,7 +30,6 @@ WHITELIST = [
         "two_factor",
     ]) + ")' defines default_app_config"), RemovedInDjango41Warning),
     ("django_celery_results", "ugettext_lazy() is deprecated"),
-    ("logentry_admin.admin", "ugettext_lazy() is deprecated"),
     ("nose.importer", "the imp module is deprecated"),
     ("nose.util", "inspect.getargspec() is deprecated"),
     ("pkg_resources", "pkg_resources.declare_namespace"),

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -26,7 +26,6 @@ crispy-bootstrap3to5 @ git+https://github.com/dimagi/crispy-bootstrap3to5.git@77
 django-cte
 django-field-audit
 django-formtools
-django-logentry-admin
 django-oauth-toolkit
 django-otp
 django-phonenumber-field

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -145,7 +145,6 @@ django==3.2.24
     #   django-crispy-forms
     #   django-extensions
     #   django-formtools
-    #   django-logentry-admin
     #   django-oauth-toolkit
     #   django-otp
     #   django-phonenumber-field
@@ -190,8 +189,6 @@ django-formtools==2.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-logentry-admin==1.0.6
-    # via -r base-requirements.in
 django-nose @ https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/releases/django_nose-1.4.6.1-py2.py3-none-any.whl
     # via -r test-requirements.in
 django-oauth-toolkit==2.3.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -125,7 +125,6 @@ django==3.2.24
     #   django-crispy-forms
     #   django-extensions
     #   django-formtools
-    #   django-logentry-admin
     #   django-oauth-toolkit
     #   django-otp
     #   django-phonenumber-field
@@ -168,8 +167,6 @@ django-formtools==2.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-logentry-admin==1.0.6
-    # via -r base-requirements.in
 django-oauth-toolkit==2.3.0
     # via -r base-requirements.in
 django-otp==1.1.3

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -129,7 +129,6 @@ django==3.2.24
     #   django-bulk-update
     #   django-crispy-forms
     #   django-formtools
-    #   django-logentry-admin
     #   django-oauth-toolkit
     #   django-otp
     #   django-phonenumber-field
@@ -169,8 +168,6 @@ django-formtools==2.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-logentry-admin==1.0.6
-    # via -r base-requirements.in
 django-oauth-toolkit==2.3.0
     # via -r base-requirements.in
 django-otp==1.1.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -121,7 +121,6 @@ django==3.2.24
     #   django-bulk-update
     #   django-crispy-forms
     #   django-formtools
-    #   django-logentry-admin
     #   django-oauth-toolkit
     #   django-otp
     #   django-phonenumber-field
@@ -161,8 +160,6 @@ django-formtools==2.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-logentry-admin==1.0.6
-    # via -r base-requirements.in
 django-oauth-toolkit==2.3.0
     # via -r base-requirements.in
 django-otp==1.1.3

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -128,7 +128,6 @@ django==3.2.24
     #   django-bulk-update
     #   django-crispy-forms
     #   django-formtools
-    #   django-logentry-admin
     #   django-oauth-toolkit
     #   django-otp
     #   django-phonenumber-field
@@ -168,8 +167,6 @@ django-formtools==2.3
     # via
     #   -r base-requirements.in
     #   django-two-factor-auth
-django-logentry-admin==1.0.6
-    # via -r base-requirements.in
 django-nose @ https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/releases/django_nose-1.4.6.1-py2.py3-none-any.whl
     # via -r test-requirements.in
 django-oauth-toolkit==2.3.0

--- a/settings.py
+++ b/settings.py
@@ -234,7 +234,6 @@ DEFAULT_APPS = (
     'ws4redis',
     'statici18n',
     'django_user_agents',
-    'logentry_admin',
     'oauth2_provider',
 )
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15366

It appears that this package is no longer maintained and is not compatible with Django 4.2 at the moment. I've looked into this and don't think we actually need this dependency as the UserHistory model is our adaptation of the LogEntry model built-in to Django.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. Internal facing only.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
