### PR TITLE
Remove apps_update_calculated_properties periodic task

### DIFF
--- a/corehq/apps/es/mappings/app_mapping.py
+++ b/corehq/apps/es/mappings/app_mapping.py
@@ -103,9 +103,6 @@ APP_MAPPING = {
         "copy_of": {
             "type": "keyword"
         },
-        "cp_is_active": {
-            "type": "boolean"
-        },
         "created_from_template": {
             "type": "keyword"
         },

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -8,7 +8,6 @@ from celery.utils.log import get_task_logger
 from text_unidecode import unidecode
 
 from casexml.apps.case.xform import extract_case_blocks
-from couchforms.analytics import app_has_been_submitted_to_in_last_30_days
 from dimagi.utils.chunked import chunked
 from dimagi.utils.logging import notify_exception
 from soil import DownloadBase
@@ -17,8 +16,7 @@ from soil.util import expose_blob_download
 from corehq.apps.celery import periodic_task, task
 from corehq.apps.domain.calculations import all_domain_stats, calced_props
 from corehq.apps.domain.models import Domain
-from corehq.apps.es import AppES, DomainES, FormES, filters
-from corehq.apps.es.apps import app_adapter
+from corehq.apps.es import DomainES, FormES, filters
 from corehq.apps.es.domains import domain_adapter
 from corehq.apps.export.const import MAX_MULTIMEDIA_EXPORT_SIZE
 from corehq.apps.reports.models import QueryStringHash
@@ -144,20 +142,6 @@ def get_domains_to_update_es_filter():
             filters.term('name', domains_submitted_today)
         )
     )
-
-
-def is_app_active(app_id, domain):
-    return app_has_been_submitted_to_in_last_30_days(domain, app_id)
-
-
-@periodic_task(run_every=crontab(hour="2", minute="0", day_of_week="*"), queue='background_queue')
-def apps_update_calculated_properties():
-    query = AppES().is_build(False).values_list('_id', 'domain', scroll=True)
-    for doc_id, domain in query:
-        doc = {
-            "cp_is_active": is_app_active(doc_id, domain),
-        }
-        app_adapter.update(doc_id, doc)
 
 
 @task(serializer='pickle', ignore_result=True)

--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -50,18 +50,6 @@ def get_last_form_submission_received(domain):
     return iso_string_to_datetime(result[0]['received_on'])
 
 
-def app_has_been_submitted_to_in_last_30_days(domain, app_id):
-    now = datetime.datetime.utcnow()
-    _30_days = datetime.timedelta(days=30)
-
-    result = _received_on_query(domain, desc=True).app(app_id)[0]
-
-    if not result:
-        return False
-
-    return iso_string_to_datetime(result[0]['received_on']) > (now - _30_days)
-
-
 @quickcache(['domain'], memoize_timeout=0, timeout=12 * 3600)
 def get_all_xmlns_app_id_pairs_submitted_to_in_domain(domain):
     """This is used to get (XMLNS, app_id) from submitted forms. The results

--- a/corehq/ex-submodules/couchforms/tests/test_analytics.py
+++ b/corehq/ex-submodules/couchforms/tests/test_analytics.py
@@ -4,7 +4,6 @@ import uuid
 from django.test import TestCase
 
 from couchforms.analytics import (
-    app_has_been_submitted_to_in_last_30_days,
     domain_has_submission_in_last_30_days,
     get_all_xmlns_app_id_pairs_submitted_to_in_domain,
     get_exports_by_form,
@@ -174,11 +173,6 @@ class CouchformsESAnalyticsTest(TestCase):
     def test_get_last_form_submission_received(self):
         self.assertEqual(
             get_last_form_submission_received(self.domain), self.now)
-
-    def test_app_has_been_submitted_to_in_last_30_days(self):
-        self.assertEqual(
-            app_has_been_submitted_to_in_last_30_days(self.domain, self.app_id),
-            True)
 
     def test_get_all_xmlns_app_id_pairs_submitted_to_in_domain(self):
         self.assertEqual(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15317

To my knowledge, this calculated property on applications is no longer used. I've posted in slack about removing this and am waiting to see if anyone speaks up, otherwise I think this is safe. (See comment [below](https://github.com/dimagi/commcare-hq/pull/34192#issuecomment-2051661399))

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
