### PR TITLE
Delete in Data Dictionary UI Improvements

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -212,6 +212,7 @@
           {% endif %}
           {% if not request.is_view_only %}
             <div class="row-item-small"></div>
+            <div class="row-item-small"></div>
           {% endif %}
           </div>
           <div data-bind="sortable: { data: caseGroupList, connectClass: 'groups', options: { handle: 'i.sortable-handle' } }">
@@ -264,6 +265,7 @@
               <button title="{% trans_html_attr 'Restore Group' %}" data-bind="click: restoreGroup" class="fa fa-undo"></button>
               <!-- /ko -->
             </div>
+            <div class="row-item-small"></div>
             {% endif %}
           </div>
           <div data-bind="sortable: { data: properties, connectClass: 'properties', options: { handle: 'i.sortable-handle' } }, visible: expanded() && (!deprecated || $root.showAll())">
@@ -343,6 +345,8 @@
                   <i class="fa fa-trash"></i>
                   {% trans 'Delete' %}
                 </button>
+              </div>
+              <div class="row-item-small m-auto">
                 <!-- ko if: !deprecated() -->
                 <button title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="btn btn-default">
                   <i class="fa fa-archive"></i>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -337,17 +337,23 @@
             {% endif %}
             {% if not request.is_view_only %}
               <div class="row-item-small m-auto">
-                  <button title="{% trans_html_attr 'Delete Property' %}"
-                          data-bind="click: confirmDeleteProperty, visible: isSafeToDelete"
-                          class="btn btn-danger">
-                    <i class="fa fa-trash"></i>
-                    {% trans 'Delete' %}
-                  </button>
+                <button title="{% trans_html_attr 'Delete Property' %}"
+                        data-bind="click: confirmDeleteProperty, visible: isSafeToDelete"
+                        class="btn btn-danger">
+                  <i class="fa fa-trash"></i>
+                  {% trans 'Delete' %}
+                </button>
                 <!-- ko if: !deprecated() -->
-                <button title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="fa fa-archive"></button>
+                <button title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="btn btn-default">
+                  <i class="fa fa-archive"></i>
+                  {% trans 'Deprecate' %}
+                </button>
                 <!-- /ko -->
                 <!-- ko if: deprecated() -->
-                <button title="{% trans_html_attr 'Restore Property' %}" data-bind="click: restoreProperty" class="fa fa-undo"></button>
+                <button title="{% trans_html_attr 'Restore Property' %}" data-bind="click: restoreProperty" class="btn btn-default">
+                  <i class="fa fa-undo"></i>
+                  {% trans 'Restore' %}
+                </button>
                 <!-- /ko -->
               </div>
             {% endif %}

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
@@ -118,7 +118,8 @@
                 </p>
                 <p>
                     {% blocktrans %}
-                        Would you like to proceed with deleting this case property?
+                        Would you like to mark this case property as deleted? Once confirmed the case
+                        property will be deleted upon clicking the "Save" button.
                     {% endblocktrans %}
                 </p>
             </div>
@@ -128,7 +129,7 @@
                 </button>
                 <button id="delete-case-prop-btn" type="button" class="btn btn-danger">
                     <i class="fa fa-trash"></i>
-                    {% trans 'Delete' %}
+                    {% trans 'Confirm' %}
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

The deprecate and restore icons for the DD have been switched out to buttons to be more in line with the rest of the UI:
**old:**
![Screenshot from 2024-02-29 11-39-35](https://github.com/dimagi/commcare-hq/assets/122617251/d51022a8-0289-4b67-98e9-36acabe217c1)

**new:**
![Screenshot from 2024-02-29 11-39-47](https://github.com/dimagi/commcare-hq/assets/122617251/b59e8e21-f9b3-451e-ba70-ebed0a7ed78d)

The confirmation modal for deleting a case property has also been slightly changed. The change was to make it more obvious that a case property is only being marked for deletion and is not immediately getting deleted upon clicking confirm:
**old:**
![Screenshot from 2024-02-29 11-40-05](https://github.com/dimagi/commcare-hq/assets/122617251/ee9d1bf3-58fc-4a89-afa5-4adbd0c5e9e5)

**new:**
![Screenshot from 2024-02-29 11-39-59](https://github.com/dimagi/commcare-hq/assets/122617251/472ad3cc-fb4c-415d-9f52-fafd34eefdb2)

Relevant documentation screenshots will be upated on Confluence to match new UI changes.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3406).

This PR makes a few minor UI adjustments to the delete feature in the Data Dictionary.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Small UI changes

This change only affects domains that have access to the Data Dictionary (Advanced Plan and higher).

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
