### PR TITLE
`mark_safe` in Django>=4.1 supports lazy strings

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -29,7 +29,7 @@ from django.forms.widgets import Select
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.encoding import force_bytes, smart_str
-from django.utils.functional import cached_property, lazy
+from django.utils.functional import cached_property
 from django.utils.http import urlsafe_base64_encode
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
@@ -115,6 +115,7 @@ from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.crispy import DatetimeLocalWidget, HQFormHelper
 from corehq.apps.hqwebapp.fields import MultiCharField
 from corehq.apps.hqwebapp.tasks import send_html_email_async
+from corehq.apps.hqwebapp.utils.translation import mark_safe_lazy
 from corehq.apps.hqwebapp.widgets import (
     BootstrapCheckboxInput,
     GeoCoderInput,
@@ -132,8 +133,6 @@ from corehq.toggles import (
 )
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
-
-mark_safe_lazy = lazy(mark_safe, str)  # TODO: Use library method
 
 
 # used to resize uploaded custom logos, aspect ratio is preserved

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -7,9 +7,7 @@ from django.http import Http404
 from django.template.defaultfilters import filesizeformat
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
 from django.utils.html import format_html
-from django.utils.functional import lazy
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
 from django.views.decorators.csrf import csrf_exempt
@@ -69,6 +67,7 @@ from corehq.apps.export.views.utils import (
     ExportsPermissionsManager,
     user_can_view_deid_exports,
 )
+from corehq.apps.hqwebapp.utils.translation import mark_safe_lazy
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import (
     location_restricted_response,
@@ -86,9 +85,6 @@ from corehq.privileges import DAILY_SAVED_EXPORT, EXPORT_OWNERSHIP, EXCEL_DASHBO
 from corehq.util.download import get_download_response
 from corehq.util.view_utils import absolute_reverse
 from corehq.apps.data_dictionary.util import is_case_type_deprecated
-
-
-mark_safe_lazy = lazy(mark_safe, str)  # TODO: replace with library function
 
 
 class ExportListHelper(object):

--- a/corehq/apps/hqwebapp/utils/translation.py
+++ b/corehq/apps/hqwebapp/utils/translation.py
@@ -2,5 +2,8 @@ from django.utils.functional import lazy
 from django.utils.safestring import mark_safe
 from django.utils.html import format_html
 
+
+# Bandit does not catch any references to mark_safe using this,
+# so please use it with caution, and only on segments that do not contain user input
 mark_safe_lazy = lazy(mark_safe, str)
 format_html_lazy = lazy(format_html, str)

--- a/corehq/apps/hqwebapp/utils/translation.py
+++ b/corehq/apps/hqwebapp/utils/translation.py
@@ -1,9 +1,21 @@
+from django import VERSION as django_version
 from django.utils.functional import lazy
 from django.utils.safestring import mark_safe
 from django.utils.html import format_html
 
 
-# Bandit does not catch any references to mark_safe using this,
-# so please use it with caution, and only on segments that do not contain user input
-mark_safe_lazy = lazy(mark_safe, str)
 format_html_lazy = lazy(format_html, str)
+
+
+def mark_safe_lazy(s):
+    """
+    mark_safe in Django>=4.1 supports lazy strings
+    TODO: Replace with call to django.utils.safestring.mark_safe directly once on Django 4.2 LTS
+    """
+    if django_version[:2] >= (4, 1):
+        return mark_safe(s)
+    else:
+        # Bandit does not catch any references to mark_safe using this,
+        # so please use it with caution, and only on segments that do not contain user input
+        mark_safe_lazy = lazy(mark_safe, str)
+        return mark_safe_lazy(s)

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -6,7 +6,6 @@ from django.contrib.auth.models import User
 from django.core.validators import validate_email
 # https://docs.djangoproject.com/en/dev/topics/i18n/translation/#other-uses-of-lazy-in-delayed-translations
 from django.template.loader import render_to_string
-from django.utils.functional import lazy
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
@@ -20,15 +19,12 @@ from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.domain.forms import NoAutocompleteMixin, clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp import crispy as hqcrispy
+from corehq.apps.hqwebapp.utils.translation import mark_safe_lazy
 from corehq.apps.locations.forms import LocationSelectWidget
 from corehq.apps.programs.models import Program
 from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter as EMWF
 from corehq.apps.users.forms import RoleForm
 from corehq.apps.users.models import CouchUser
-
-# Bandit does not catch any references to mark_safe using this,
-# so please use it with caution, and only on segments that do not contain user input
-mark_safe_lazy = lazy(mark_safe, str)
 
 
 class RegisterWebUserForm(forms.Form):

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -1,5 +1,3 @@
-from django.utils.functional import lazy
-from django.utils.safestring import mark_safe
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
@@ -13,6 +11,7 @@ from couchforms.analytics import (
 )
 
 from corehq.apps.app_manager.models import Application
+from corehq.apps.hqwebapp.utils.translation import mark_safe_lazy
 from corehq.apps.reports.analytics.couchaccessors import (
     get_all_form_definitions_grouped_by_app_and_xmlns,
     get_all_form_details,
@@ -39,9 +38,6 @@ PARAM_SLUG_XMLNS = 'xmlns'
 
 PARAM_VALUE_STATUS_ACTIVE = 'active'
 PARAM_VALUE_STATUS_DELETED = 'deleted'
-
-# TODO: Replace with library method
-mark_safe_lazy = lazy(mark_safe, str)
 
 
 class FormsByApplicationFilterParams(object):

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -10,7 +10,7 @@ from couchforms.analytics import (
 )
 
 from corehq.apps.app_manager.models import Application
-from corehq.apps.hqwebapp.utils.translation import format_html_lazy
+from corehq.apps.hqwebapp.utils.translation import format_html_lazy, mark_safe_lazy
 from corehq.apps.reports.analytics.couchaccessors import (
     get_all_form_definitions_grouped_by_app_and_xmlns,
     get_all_form_details,
@@ -617,12 +617,12 @@ class CompletionOrSubmissionTimeFilter(BaseSingleOptionFilter):
     default_text = gettext_lazy("Completion Time")
 
     def _generate_help_message():
-        completion_help = gettext_lazy(  # nosec: no user input
-            "<strong>Completion</strong> time is when the form is completed on the phone.")
+        completion_help = mark_safe_lazy(gettext_lazy(  # nosec: no user input
+            "<strong>Completion</strong> time is when the form is completed on the phone."))
 
-        submission_help = gettext_lazy(  # nosec: no user input
+        submission_help = mark_safe_lazy(gettext_lazy(  # nosec: no user input
             "<strong>Submission</strong> time is when {hq_name} receives the form.".format(
-                hq_name=commcare_hq_names()['commcare_hq_names']['COMMCARE_HQ_NAME']))
+                hq_name=commcare_hq_names()['commcare_hq_names']['COMMCARE_HQ_NAME'])))
 
         return format_html_lazy("{}<br />{}", completion_help, submission_help)
 

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -4,13 +4,16 @@ from django.utils.translation import gettext_lazy, gettext_noop
 from couchdbkit.exceptions import ResourceNotFound
 from memoized import memoized
 
-from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS_MAP
 from couchforms.analytics import (
     get_all_xmlns_app_id_pairs_submitted_to_in_domain,
 )
 
 from corehq.apps.app_manager.models import Application
-from corehq.apps.hqwebapp.utils.translation import format_html_lazy, mark_safe_lazy
+from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS_MAP
+from corehq.apps.hqwebapp.utils.translation import (
+    format_html_lazy,
+    mark_safe_lazy,
+)
 from corehq.apps.reports.analytics.couchaccessors import (
     get_all_form_definitions_grouped_by_app_and_xmlns,
     get_all_form_details,

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -1,4 +1,3 @@
-from django.utils.html import format_html
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
 
@@ -11,7 +10,7 @@ from couchforms.analytics import (
 )
 
 from corehq.apps.app_manager.models import Application
-from corehq.apps.hqwebapp.utils.translation import mark_safe_lazy
+from corehq.apps.hqwebapp.utils.translation import format_html_lazy
 from corehq.apps.reports.analytics.couchaccessors import (
     get_all_form_definitions_grouped_by_app_and_xmlns,
     get_all_form_details,
@@ -618,14 +617,14 @@ class CompletionOrSubmissionTimeFilter(BaseSingleOptionFilter):
     default_text = gettext_lazy("Completion Time")
 
     def _generate_help_message():
-        completion_help = mark_safe_lazy(gettext_lazy(  # nosec: no user input
-            "<strong>Completion</strong> time is when the form is completed on the phone."))
+        completion_help = gettext_lazy(  # nosec: no user input
+            "<strong>Completion</strong> time is when the form is completed on the phone.")
 
-        submission_help = mark_safe_lazy(gettext_lazy(  # nosec: no user input
+        submission_help = gettext_lazy(  # nosec: no user input
             "<strong>Submission</strong> time is when {hq_name} receives the form.".format(
-                hq_name=commcare_hq_names()['commcare_hq_names']['COMMCARE_HQ_NAME'])))
+                hq_name=commcare_hq_names()['commcare_hq_names']['COMMCARE_HQ_NAME']))
 
-        return format_html("{}<br />{}", completion_help, submission_help)
+        return format_html_lazy("{}<br />{}", completion_help, submission_help)
 
     help_text = _generate_help_message()
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -1,7 +1,5 @@
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
-from django.utils.functional import lazy
-from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
 
@@ -12,6 +10,7 @@ from corehq.apps.enterprise.models import EnterprisePermissions
 from corehq.apps.es import filters
 from corehq.apps.es import users as user_es
 from corehq.apps.groups.models import Group
+from corehq.apps.hqwebapp.utils.translation import mark_safe_lazy
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import user_can_access_other_user
 from corehq.apps.reports.extension_points import customize_user_query
@@ -32,9 +31,6 @@ from .base import (
     BaseReportFilter,
     BaseSingleOptionFilter,
 )
-
-#TODO: replace with common code
-mark_safe_lazy = lazy(mark_safe, str)
 
 
 class UserOrGroupFilter(BaseSingleOptionFilter):

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -5,7 +5,6 @@ from django.utils.safestring import mark_safe
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy, gettext
-from django.utils.functional import lazy
 
 from corehq.apps.export.const import DEID_ID_TRANSFORM, DEID_DATE_TRANSFORM
 
@@ -25,9 +24,6 @@ from corehq.apps.reports.filters.base import (
     BaseSingleOptionFilter,
 )
 from corehq import privileges
-
-
-mark_safe_lazy = lazy(mark_safe, str)  # TODO: Replace with library method
 
 
 class CaseSearchFilter(BaseSimpleFilter):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15376

As detailed in the ticket, this error is encountered when attempting to startup django on 4.2:
```  File "/home/gherceg/dimagi/code/commcare-hq/corehq/apps/reports/filters/forms.py", line 618, in <module>
    class CompletionOrSubmissionTimeFilter(BaseSingleOptionFilter):
  File "/home/gherceg/dimagi/code/commcare-hq/corehq/apps/reports/filters/forms.py", line 634, in CompletionOrSubmissionTimeFilter
    help_text = _generate_help_message()
  File "/home/gherceg/dimagi/code/commcare-hq/corehq/apps/reports/filters/forms.py", line 632, in _generate_help_message
    return format_html("{}<br />{}", completion_help, submission_help)
  File "/home/gherceg/.pyenv/versions/hq-3.9.18/lib/python3.9/site-packages/django/utils/html.py", line 105, in format_html
    return mark_safe(format_string.format(*args_safe, **kwargs_safe))
  File "/home/gherceg/.pyenv/versions/hq-3.9.18/lib/python3.9/site-packages/django/utils/html.py", line 90, in conditional_escape
    text = str(text)
TypeError: __str__ returned non-string (type __proxy__)
```

After some investigation, I noticed that `mark_safe` had been updated to [support lazy arguments](https://github.com/django/django/commit/659d2421c7adbbcd205604002d521d82d6b0b465#diff-0055b8a5c4cf5ca5c592b8528257cf915ba07858e37074d2cc5c81cb9933138cL45) in 4.1.

I was able to reproduce this issue in a django shell a couple of different ways.
```
In [130]: from django.utils.functional import lazy
In [131]: def format_str(s):
     ...:     return f"Formatted: {s}"
In [132]: lazy_format_str = lazy(format_str, str)
In [133]: doubly_lazy_format_str = lazy(lazy_format_str, str)
In [134]: result = lazy_format_str("test")
In [135]: type(result.__str__())
Out[135]: str
In [136]: result = doubly_lazy_format_str("test")
In [137]: type(result.__str__())
Out[137]: django.utils.functional.lazy.<locals>.__proxy__
In [138]: str(result)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[138], line 1
----> 1 str(result)

TypeError: __str__ returned non-string (type __proxy__)
```
and then more analogous to the error encountered here:
```
In [166]: from django.utils.translation import gettext_lazy
In [167]: from django.utils.functional import keep_lazy
In [168]: @keep_lazy(str)
     ...: def format_str(s):
     ...:     return f"Formatted: {s}"
In [169]: lazy_format_str = lazy(format_str, str)
In [170]: result = lazy_format_str(gettext_lazy("test"))
In [171]: type(result)
Out[171]: django.utils.functional.lazy.<locals>.__proxy__
In [172]: type(result.__str__())
Out[172]: django.utils.functional.lazy.<locals>.__proxy__
In [173]: str(result)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[173], line 1
----> 1 str(result)
TypeError: __str__ returned non-string (type __proxy__)
```

It is a bit tough to explain, but the basic summary is that when converting a callable to a lazy callable using `lazy`, you also specify the expected "resultclass" for that callable. In our case, we made `mark_safe` a lazy callable by defining `mark_safe_lazy = lazy(mark_safe, str)` with `str` as the result class. So `lazy` then sets up a __proxy__ object that is aware of `str` methods and will evaluate the callable when a str method is invoked on the __proxy__ object.

The issue is that on Django 4.2, `mark_safe` supports lazy arguments. So we are attempting to convert what is effectively already a lazy callable into a lazy callable, and still expect it to return a str as a result class, which is just not true. So we would either need to update the result class to be a `Promise` class (what __proxy__ inherits from) when defining our `mark_safe_lazy` method, or just avoid converting `mark_safe` into a lazy callable on Django 4.2 since it already supports lazy arguments (I went with this approach).

Commits:
- 45ac6a273486866b07acb8cdec4df53d21769d70: general refactor to reference `mark_safe_lazy` in one place only. Notably, this can be removed once we are on Django 4.2
- 1740f72eb4d3c3dd5474253ec9c1e013bf99266a: allows for support of `mark_safe_lazy` as we transition to Django 4.2. Avoids converting `mark_safe` to a lazy function if on Django>=4.1 since `mark_safe` supports lazy args on that version and above.
- aa0ded3409f96b9084fa75bc4a09010253b34f9f: use lazy version of `format_html` to avoid translated text from being immediately rendered.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
- corehq.apps.hqwebapp.tests.utils.test_translation:TestLazyMarkSafe
- corehq.apps.hqwebapp.tests.utils.test_translation:TestLazyFormatHTML

I thought about adding some "clever" test to test the behavior of `mark_safe_lazy` on different versions, but realistically the "proper" way to do this would be to run our test build against a version running Django 4.2. This will happen on a separate PR.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
