### PR TITLE
Add test to verify a deactivated user cannot login using api

### DIFF
--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -131,6 +131,17 @@ class LoginAuthenticationTest(AuthenticationTestBase):
         self.api_key.refresh_from_db()
         self.assertIsNotNone(self.api_key.last_used)
 
+    def test_login_with_deactivated_user(self):
+        def reactivate_user():
+            self.user.is_active = True
+            self.user.save()
+        self.user.is_active = False
+        self.user.save()
+        self.addCleanup(reactivate_user)
+        self.assertAuthenticationFail(LoginAuthentication(), self._get_request_with_api_key())
+        self.api_key.refresh_from_db()
+        self.assertIsNone(self.api_key.last_used)
+
 
 class LoginAndDomainAuthenticationTest(AuthenticationTestBase):
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When is_active is set to False on a WebUser, that user should no longer be able to use their API keys to access API endpoints on CommCare HQ.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Tech Sepc: https://docs.google.com/document/d/1LOF1lCl3wTsEQkEEsHtZi3u4N6kvjXaLv-Lu6e9aYjo/edit#heading=h.ll7lzqwsaw9w
Ticket: https://dimagi.atlassian.net/browse/SAAS-15236

Verified [we will check if user is active](https://github.com/dimagi/commcare-hq/blob/8c6c0747340a73f7832dafa547a1904da012f4d5/corehq/apps/domain/auth.py#L272-L273)
Also add test in this PR to ensure that.


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just add a test

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
corehq.apps.api.tests.test_auth:LoginAuthenticationTest.test_login_with_deactivated_user

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
