### PR TITLE
[SSO Accounting Settings] fix misconfigured billing account error

### DIFF
--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -430,10 +430,21 @@ class EditIdentityProviderAdminForm(forms.Form):
         )
 
         if self.idp.is_editable:
+            dashboard_link = url_helpers.get_dashboard_link(self.idp)
             self.fields['is_editable'].help_text = format_html(
                 '<a href="{}">{}</a>',
-                url_helpers.get_dashboard_link(self.idp),
+                dashboard_link,
                 _("Edit Enterprise Settings")
+            ) if dashboard_link else format_html(
+                '<div class="alert alert-warning">'
+                '   <i class="fa-solid fa-warning-sign"></i> {}'
+                '   <a href="{}">{}</a>'
+                '</div>',
+                _("This account has no active Enterprise subscription! Please fix the "
+                  "Billing Account configuration in order to complete the Identity "
+                  "Provider setup."),
+                account_link,
+                _("Manage Billing Account"),
             )
 
         self.helper = FormHelper()

--- a/corehq/apps/sso/utils/url_helpers.py
+++ b/corehq/apps/sso/utils/url_helpers.py
@@ -43,9 +43,13 @@ def get_dashboard_link(identity_provider):
         is_active=True,
         account__is_active=True,
     ).first()
+    try:
+        enterprise_domain = linked_subscription.subscriber.domain
+    except AttributeError:
+        return None
     return reverse(
         EditIdentityProviderEnterpriseView.urlname,
-        args=(linked_subscription.subscriber.domain, identity_provider.slug,)
+        args=(enterprise_domain, identity_provider.slug,)
     )
 
 


### PR DESCRIPTION
## Technical Summary
In the Accounting Admin UI, instead of throwing a 500 on Edit Identity Provider page when a Billing Account has no active subscription, show a more helpful message to get the accounting admin to fix the billing account. This error was previously thrown because a billing account had no active enterprise subscription and, therefore, a valid enterprise dashboard link could not be created.

<img width="938" alt="Screen Shot 2024-03-04 at 8 17 35 AM" src="https://github.com/dimagi/commcare-hq/assets/716573/549a26f5-7790-4e24-b139-c43a2b479162">


## Safety Assurance

### Safety story
Safe change. Tested on staging. Fixes an existing error. Only affects Accounting Admins

### Automated test coverage
No

### QA Plan
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
