### PR TITLE
Fix ProtectedError when deleting IdentityProvider

### DIFF
--- a/corehq/apps/sso/views/accounting_admin.py
+++ b/corehq/apps/sso/views/accounting_admin.py
@@ -28,7 +28,12 @@ from corehq.apps.sso.async_handlers import (
     SSOExemptUsersAdminAsyncHandler,
     SsoTestUserAdminAsyncHandler,
 )
-from corehq.apps.sso.models import IdentityProvider, IdentityProviderProtocol, AuthenticatedEmailDomain
+from corehq.apps.sso.models import (
+    IdentityProvider,
+    IdentityProviderProtocol,
+    AuthenticatedEmailDomain,
+    TrustedIdentityProvider,
+)
 
 
 class IdentityProviderInterface(AddItemInterface):
@@ -207,6 +212,7 @@ class EditIdentityProviderAdminView(BaseIdentityProviderAdminView, AsyncHandlerM
             )
         elif self.is_deletion_request:
             AuthenticatedEmailDomain.objects.filter(identity_provider=self.identity_provider).delete()
+            TrustedIdentityProvider.objects.filter(identity_provider=self.identity_provider).delete()
             self.identity_provider.delete()
             messages.success(
                 request,


### PR DESCRIPTION
## Technical Summary
This ensures that all related `TrustedIdentityProvider` objects are deleted before deleting an `IdentityProvider` to avoid throwing a `ProtectedError`

## Safety Assurance

### Safety story
Very safe change. Fixes bug. Only affects accounting admin workflow. There's no other way to delete a `TrustedIdentityProvider` object once it's created.

### Automated test coverage
yes

### QA Plan
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
