### PR TITLE
Allow filtering by IdP Type / Service Type in the Identity Providers list view

### DIFF
--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext_noop as _
 
 from dateutil.relativedelta import relativedelta
 
+from corehq.apps.sso.models import IdentityProviderType
 from dimagi.utils.dates import DateSpan
 
 from corehq.apps.accounting.async_handlers import (
@@ -74,6 +75,13 @@ class CreditAdjustmentReasonFilter(BaseSingleOptionFilter):
     label = _("Credit Adjustment Reason")
     default_text = _("Any Reason")
     options = CreditAdjustmentReason.CHOICES
+
+
+class IdPServiceTypeFilter(BaseSingleOptionFilter):
+    slug = 'idp_service_type'
+    label = _("Service Type")
+    default_text = _("Any Service")
+    options = IdentityProviderType.CHOICES
 
 
 class CreditAdjustmentLinkFilter(BaseSingleOptionFilter):

--- a/corehq/apps/sso/views/accounting_admin.py
+++ b/corehq/apps/sso/views/accounting_admin.py
@@ -11,6 +11,7 @@ from corehq.apps.accounting.dispatcher import AccountingAdminInterfaceDispatcher
 from corehq.apps.accounting.filters import (
     DateCreatedFilter,
     NameFilter,
+    IdPServiceTypeFilter,
 )
 from corehq.apps.accounting.interface import AddItemInterface
 from corehq.apps.accounting.views import AccountingSectionView
@@ -43,6 +44,7 @@ class IdentityProviderInterface(AddItemInterface):
     fields = [
         'corehq.apps.accounting.interface.DateCreatedFilter',
         'corehq.apps.accounting.interface.NameFilter',
+        'corehq.apps.accounting.filters.IdPServiceTypeFilter',
     ]
 
     @property
@@ -89,6 +91,13 @@ class IdentityProviderInterface(AddItemInterface):
         if name is not None:
             queryset = queryset.filter(
                 owner__name=name,
+            )
+        idp_type = IdPServiceTypeFilter.get_value(
+            self.request, self.domain
+        )
+        if idp_type is not None:
+            queryset = queryset.filter(
+                idp_type=idp_type,
             )
 
         return queryset

--- a/corehq/apps/sso/views/accounting_admin.py
+++ b/corehq/apps/sso/views/accounting_admin.py
@@ -54,6 +54,7 @@ class IdentityProviderInterface(AddItemInterface):
         return DataTablesHeader(
             DataTablesColumn("Name"),
             DataTablesColumn("Slug"),
+            DataTablesColumn("Service"),
             DataTablesColumn("Edit Status"),
             DataTablesColumn("Active Status"),
             DataTablesColumn("Account Owner Name"),
@@ -66,6 +67,7 @@ class IdentityProviderInterface(AddItemInterface):
             return [
                 format_html('<a href="{}">{}</a>', edit_url, idp.name),
                 idp.slug,
+                idp.service_name,
                 "Open" if idp.is_editable else "Closed",
                 "Active" if idp.is_active else "Inactive",
                 idp.owner.name,


### PR DESCRIPTION
## Technical Summary
This adds the ability to filter by `idp_type` / Service Type in the Identity Provider list view in the accounting admin UI. This also adds a column to display the Service Type in this list view. This comes in handy especially on staging when trying to clear up / consolidate multiple Azure / Entra IdP instances

## Safety Assurance

### Safety story
Very safe change. Only affects accounting admin workflow

### Automated test coverage
No

### QA Plan
N/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
