### PR TITLE
Repeat Record Couch to SQL fixes

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import pdb
 import sys
 import traceback
 from collections import defaultdict
@@ -336,8 +337,13 @@ Run the following commands to run the migration and get up to date:
                 remove override.
             """
         )
+        parser.add_argument(
+            '--debug',
+            action='store_true',
+            help="Debug uncaught exceptions.",
+        )
 
-    def handle(self, chunk_size, fixup_diffs, override_is_completed, **options):
+    def handle(self, chunk_size, fixup_diffs, override_is_completed, debug, **options):
         if override_is_completed:
             return self.handle_override_is_completed(override_is_completed)
 
@@ -419,6 +425,11 @@ Run the following commands to run the migration and get up to date:
                 traceback.print_exc(file=logfile)
                 aborted = True
                 print("Aborted.")
+            except Exception as exc:
+                if not debug:
+                    raise
+                traceback.print_exception(type(exc), exc, exc.__traceback__)
+                pdb.post_mortem(exc.__traceback__)
 
         if not is_bulk:
             print(f"Processed {doc_index} documents")

--- a/corehq/motech/repeaters/management/commands/populate_repeatrecords.py
+++ b/corehq/motech/repeaters/management/commands/populate_repeatrecords.py
@@ -220,6 +220,8 @@ def get_state(doc):
 
 ATTEMPT_TRANSFORMS = {
     "state": get_state,
-    "message": (lambda doc: (doc["success_response"] if doc["succeeded"] else doc["failure_reason"]) or ''),
+    "message": (lambda doc: (
+        doc.get("success_response") if doc.get("succeeded") else doc.get("failure_reason")
+    ) or ''),
     "created_at": (lambda doc: string_to_utc_datetime(doc["datetime"])),
 }

--- a/corehq/motech/repeaters/management/commands/populate_repeatrecords.py
+++ b/corehq/motech/repeaters/management/commands/populate_repeatrecords.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from django.db.models import Count
 
 from dimagi.utils.parsing import json_format_datetime, string_to_utc_datetime
@@ -148,7 +150,7 @@ class Command(PopulateSQLCommand):
         return count_docs()
 
     def _get_all_couch_docs_for_model(self, chunk_size):
-        yield from iter_docs(chunk_size)
+        yield from iter_docs(chunk_size, self.__logfile)
 
     def _get_couch_doc_count_for_domains(self, domains):
         def count_domain_docs(domain):
@@ -157,9 +159,17 @@ class Command(PopulateSQLCommand):
 
     def _iter_couch_docs_for_domains(self, domains, chunk_size):
         def iter_domain_docs(domain):
-            return iter_docs(chunk_size, startkey=[domain], endkey=[domain, {}])
+            return iter_docs(chunk_size, self.__logfile, startkey=[domain], endkey=[domain, {}])
         for domain in domains:
             yield from iter_domain_docs(domain)
+
+    def open_log(self, *args, **kw):
+        @contextmanager
+        def grab_log(ctx):
+            with ctx as log:
+                self.__logfile = log
+                yield log
+        return grab_log(super().open_log(*args, **kw))
 
 
 def count_docs(**params):
@@ -178,7 +188,7 @@ def count_docs(**params):
     return int(result['value'] / 2)
 
 
-def iter_docs(chunk_size, **params):
+def iter_docs(chunk_size, logfile, **params):
     from ...models import RepeatRecord
     # repeaters/repeat_records_by_payload_id's map emits once per document
     for result in paginate_view(
@@ -189,6 +199,9 @@ def iter_docs(chunk_size, **params):
         reduce=False,
         **params,
     ):
+        if result['doc'] is None:
+            logfile.write(f"Ignored null document: {result['id']}\n")
+            continue
         yield result['doc']
 
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1018,10 +1018,12 @@ class RepeatRecord(SyncCouchToSQLMixin, Document):
 
     @classmethod
     def _migration_get_fields(cls):
-        return ["domain", "payload_id", "registered_at", "next_check", "state"]
+        return ["domain", "payload_id", "registered_at", "state"]
 
     def _migration_sync_to_sql(self, sql_object, save=True):
         sql_object.repeater_id = uuid.UUID(self.repeater_id)
+        if not (self.succeeded or self.cancelled):
+            sql_object.next_check = self.next_check
         return super()._migration_sync_to_sql(sql_object, save=save)
 
     @classmethod

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1022,8 +1022,7 @@ class RepeatRecord(SyncCouchToSQLMixin, Document):
 
     def _migration_sync_to_sql(self, sql_object, save=True):
         sql_object.repeater_id = uuid.UUID(self.repeater_id)
-        if not (self.succeeded or self.cancelled):
-            sql_object.next_check = self.next_check
+        sql_object.next_check = None if self.succeeded or self.cancelled else self.next_check
         return super()._migration_sync_to_sql(sql_object, save=save)
 
     @classmethod


### PR DESCRIPTION
For bugs encountered while migrating data. Also adds a new `--debug` option to the migration command to more easily get detailed information about migration errors.

:fish: Review by commit.

## Safety Assurance

### Safety story

These changes only affect the management command that is being used to migrate repeat records from Couch to SQL.

### Automated test coverage

Some.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations