### PR TITLE
Added linked_domain as a dependency to accounting migration

### DIFF
--- a/corehq/apps/accounting/migrations/0063_replace_linked_projects_ff_with_erm.py
+++ b/corehq/apps/accounting/migrations/0063_replace_linked_projects_ff_with_erm.py
@@ -12,6 +12,7 @@ def _migrate_linked_projects_ff_to_erm(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         ('accounting', '0062_add_release_management_to_enterprise'),
+        ('linked_domain', '0001_initial'),
     ]
 
     operations = [


### PR DESCRIPTION
## Technical Summary
Minor, ran into this while setting up a new local environment, since `accounting` gets migrated before `linked_domain`.

## Safety Assurance

### Safety story
Minor change to an old migration. Should only affect new installations.

### Automated test coverage

no

### QA Plan

no

### Migrations
Migration-only PR.
- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
