### PR TITLE
Fix group header image style

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -138,11 +138,9 @@
       float: left;
       margin-right: 10px;
     }
-    span,.caption {
-      img {
-        height: 1em;
-        vertical-align: baseline;
-      }
+    .webapp-markdown-output img {
+      height: 1em;
+      vertical-align: baseline;
     }
   }
 

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -138,6 +138,12 @@
       float: left;
       margin-right: 10px;
     }
+    span,.caption {
+      img {
+        height: 1em;
+        vertical-align: baseline;
+      }
+    }
   }
 
   .panel-heading {


### PR DESCRIPTION
## Product Description

* Fix height to 1em
* Align with font baseline

## Technical Summary

https://dimagi.atlassian.net/browse/USH-4119

## Feature Flag

None

## Safety Assurance

This is a very small change for the size and alignment of specific icons. The biggest issue is coordinating the release of a new BHA version with updated icons.

### Safety story

Tested locally and with a copy of the BHA app on staging.

### Automated test coverage

None

### QA Plan

Tested as part ofhttps://dimagi.atlassian.net/browse/QA-6171

Use a display text like `# ![image](http://localhost:8000/hq/multimedia/file/CommCareImage/15f73346f41201a20f2a6117c40015b8/?thumb=50) Hospital name (something)` in a group (collapsible or not).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
