### PR TITLE
Updated saving UI for feature flag page

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -122,15 +122,16 @@
 
           <td class="text-center">
             <div data-bind="visible: hasDomainNamespace">
-              <i class="fa fa-spin fa-refresh" data-bind="visible: setTogglePending"></i>
               <button type="button"
                       class="btn btn-default"
                       data-bind="click: toggleEnabledState,
-                                                   css: {
-                                                       'active': domainEnabled(),
-                                                       'disabled': setTogglePending,
-                                                   }">
-                <i class="fa" data-bind="css: domainEnabled() ? 'fa-rocket' : 'fa-ban'"></i>
+                                 disable: setTogglePending,
+                                 css: {
+                                    'active': domainEnabled(),
+                                    'disabled': setTogglePending,
+                                 }">
+                <i class="fa" data-bind="css: domainEnabled() ? 'fa-rocket' : 'fa-ban', hidden: setTogglePending"></i>
+                <i class="fa fa-spin fa-refresh" data-bind="visible: setTogglePending"></i>
                 <!--ko text: domainEnabled() ? 'Enabled' : 'Not Enabled' --><!--/ko-->
               </button>
             </div>

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -128,7 +128,6 @@
                                  disable: setTogglePending,
                                  css: {
                                     'active': domainEnabled(),
-                                    'disabled': setTogglePending,
                                  }">
                 <i class="fa" data-bind="css: domainEnabled() ? 'fa-rocket' : 'fa-ban', hidden: setTogglePending"></i>
                 <i class="fa fa-spin fa-refresh" data-bind="visible: setTogglePending"></i>


### PR DESCRIPTION
## Product Description
Tiny thing that was bugging me: when you click to enable/disable a feature flag, a spinner icon appears briefly on a new line in the row, making the table rows jump around. Instead, turn the button's icon into a spinner (and disable the button, because we might as well prevent double-click accidents).

<img width="967" alt="Screenshot 2024-03-04 at 4 47 14 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/00d1cca6-385f-4554-9862-708261bb51b8">

## Safety Assurance

### Safety story
Minor UI change to an internal admin page.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
