### PR TITLE
Fix some form UI issues

### DIFF
--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -6,7 +6,6 @@
         class: elementTile,
         css: {
           'gr-no-children': $data.children().length === 0,
-          'gr-has-no-questions': $data.children().every(function(d) { return d.type() !== 'grouped-element-tile-row' }),
           'gr-has-no-nested-questions': !$data.hasAnyNestedQuestions(),
           'panel panel-default': collapsible,
           'repetition': isRepetition,

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -167,7 +167,7 @@
         <div data-bind="
           css: submitClass,
           style: {
-            'bottom':isAnchoredSubmitStyle && {{ request.couch_user.can_edit_data|yesno:'true,false' }} ? '30px' : '' {# data preview bar #}
+            'bottom':isAnchoredSubmitStyle && {{ request.couch_user.can_edit_data|yesno:'true,false' }} {% if environment != "web-apps" %} && false {% endif %} ? '30px' : '' {# data preview bar #}
           }">
           <button class="submit btn btn-primary"
                   type="submit"

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/form.less
@@ -30,17 +30,6 @@ legend {
   border: none;
 }
 
-.gr-has-no-questions legend {
-  margin-bottom: 0px;
-}
-
-.gr-has-no-nested-questions legend {
-  margin-bottom: 0px;
-  > .caption {
-    display: none;
-  }
-}
-
 .gr.repetition:not(:first-child) {
     border-top: @cc-neutral-hi solid 1px;
     padding-top: 20px;

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -1,5 +1,5 @@
 @form-text-indent: 23px;
-@form-text-size: 16px;
+@form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fit
 @group-indent: 15px;
 
 .form-container {
@@ -305,7 +305,6 @@
 
 .checkbox, .radio {
   input[type="checkbox"], input[type="radio"] {
-    // This needs customization any time @form-text-size is updated
     margin-top: 3.15px;
   }
   // Overrides Bootstrap defaults

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -305,7 +305,7 @@
 
 .checkbox, .radio {
   input[type="checkbox"], input[type="radio"] {
-    // This needs customization any time the font size in Web Apps is updated
+    // This needs customization any time @form-text-size is updated
     margin-top: 3.15px;
   }
   // Overrides Bootstrap defaults

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -302,3 +302,13 @@
 .gr-has-no-nested-questions {
   display: none;
 }
+
+.checkbox, .radio {
+  input[type="checkbox"], input[type="radio"] {
+    // This needs customization any time the font size in Web Apps is updated
+    margin-top: 3.15px;
+  }
+  // Overrides Bootstrap defaults
+  padding-top: 0px !important;
+  padding-bottom: 7px;
+}

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -299,8 +299,6 @@
   }
 }
 
-.question-tile-row .gr-no-children.gr-has-no-questions.gr-has-no-nested-questions {
-  // Prevents a priority issue that's happened three times where
-  // a group with hidden values creates whitespace.
+.gr-has-no-nested-questions {
   display: none;
 }

--- a/corehq/apps/hqwebapp/static/preview_app/less/preview_app/form.less
+++ b/corehq/apps/hqwebapp/static/preview_app/less/preview_app/form.less
@@ -32,6 +32,10 @@
   border-top: 3px solid desaturate(@cc-brand-hi, 30);
 }
 
+.form-container .gr-has-no-nested-questions {
+  display: none;
+}
+
 .form-container .gr.gr-no-children {
   background-color: transparent;
   border-bottom: none;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->




Fixes two issues with checkbox/radio question padding/alignment, and one issue where groups without any questions in them causing visible whitespace.

In Jira: 
- [USH-4240](https://dimagi.atlassian.net/browse/USH-4240) (whitespace issue)
- [USH-4116](https://dimagi.atlassian.net/browse/USH-4116) (multiple choice padding/alignment)
- [SUPPORT-18977](https://dimagi.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/81/SUPPORT-18977) (also multiple choice padding/alignment)

In regards to multiple choice padding/alignment, see these screenshots...

Before:
![Screenshot 2024-03-04 at 4 43 13 PM](https://github.com/dimagi/commcare-hq/assets/6729291/cd654b17-f20f-4cb0-929b-71b961f2f656)
![Screenshot 2024-03-04 at 4 43 38 PM](https://github.com/dimagi/commcare-hq/assets/6729291/f8b75cc0-12ff-480c-94af-0ccd4e963eb8)

After:
![Screenshot 2024-03-04 at 4 42 08 PM](https://github.com/dimagi/commcare-hq/assets/6729291/d4a7e3bb-5c62-4059-aef4-3c8d06273a4d)
![Screenshot 2024-03-04 at 4 45 15 PM](https://github.com/dimagi/commcare-hq/assets/6729291/f9885362-714d-4de5-9ce5-47b9cda00ee3)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

In regards to the whitespace issue:

I did some research, and the classes `.gr-has-no-nested-questions` and `.gr-has-no-questions` seem primarily like remnants of [a long ago time](https://github.com/dimagi/commcare-hq/pull/15622). It also seems to me from some research that groups that don't have questions in them shouldn't display _at all_. And so this PR attempts to make that blanket fix.

Relates to Jonathan's bug fix: #34220.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Changes specific to Web Apps forms
- Biggest possible risk is a group that we actually want to display coming under the `.gr-has-no-nested-questions` umbrella
- This will go through both client-specific apps and regular web apps forms QA, I think

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Some existing JS tests work with `hasAnyNestedQuestions()`, but otherwise this PR is just CSS.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

https://dimagi.atlassian.net/browse/QA-6171

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4240]: https://dimagi.atlassian.net/browse/USH-4240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-4116]: https://dimagi.atlassian.net/browse/USH-4116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUPPORT-18977]: https://dimagi.atlassian.net/browse/SUPPORT-18977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ