### PR TITLE
bug: Correct handling of hasAnyNestedQuestions for Form Question

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -699,9 +699,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
 
         self.hasAnyNestedQuestions = function () {
             return _.any(self.children(), function (d) {
-                if (d.type() === constants.REPEAT_TYPE) {
-                    return true;
-                } else if (d.type() === constants.GROUPED_ELEMENT_TILE_ROW_TYPE) {
+                if (d.type() === constants.GROUPED_ELEMENT_TILE_ROW_TYPE) {
                     return d.hasAnyNestedQuestions();
                 }
             });
@@ -775,7 +773,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
 
         self.hasAnyNestedQuestions = function () {
             return _.any(self.children(), function (d) {
-                if (d.type() === constants.QUESTION_TYPE) {
+                if (d.type() === constants.QUESTION_TYPE || d.type() === constants.REPEAT_TYPE) {
                     return true;
                 } else if (d.type() === constants.GROUP_TYPE) {
                     return d.hasAnyNestedQuestions();

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
@@ -397,6 +397,11 @@ hqDefine("cloudcare/js/form_entry/spec/form_ui_spec", function () {
             var form = formUI.Form(nestedGroupJSON);
             assert.isTrue(form.children()[0].children()[0].hasAnyNestedQuestions());
             assert.isFalse(form.children()[1].children()[0].hasAnyNestedQuestions());
+
+            groupJSON.children = [repeatJSON];
+            formJSON.tree = [groupJSON];
+            let form2 = formUI.Form(formJSON);
+            assert.isTrue(form2.children()[0].hasAnyNestedQuestions());
         });
 
         it('Should not reconcile outdated data', function () {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
`gr-has-no-nested-questions` now correctly evaluates as `true` if the group contains only Repeat Group questions.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Bug as part of https://github.com/dimagi/commcare-hq/pull/33979

Group is expected to contain only `GROUPED_ELEMENT_TILE_ROW_TYPE`. Since `GroupedElementTileRow` now can contain `REPEAT_TYPE`, it needs to be handled.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No feature flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
tests exists that `hasAnyNestedQuestions` evaluates true for groups containing only questions or only another group.
Added test that `hasAnyNestedQuestions` evaluates true for groups containing only repeat groups
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-6171

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
