### PR TITLE
Added global use strict throughout web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/config.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/config.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/config", [
     'jquery',
     'underscore',

--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals ace, Clipboard */
 hqDefine('cloudcare/js/debugger/debugger', function () {
     var kissmetrics = hqImport("analytix/js/kissmetrix"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/form_entry/const", function () {
     return {
         GROUP_TYPE: 'sub-group',

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals moment, SignaturePad, DOMPurify */
 hqDefine("cloudcare/js/form_entry/entries", function () {
     var kissmetrics = hqImport("analytix/js/kissmetrix"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/errors.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/errors.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/form_entry/errors", function () {
     return {
         GENERIC_ERROR: gettext("Something unexpected went wrong on that request. " +

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global DOMPurify */
 hqDefine("cloudcare/js/form_entry/form_ui", function () {
     var markdown = hqImport("cloudcare/js/markdown"),
@@ -546,7 +547,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", function () {
                 if (document.visibilityState === "hidden") {
                     self.showSubmitButton = false;
                 }
-             };
+            };
             self.hasSubmitAttempted(true);
             $.publish('formplayer.' + constants.SUBMIT, self);
         };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 /* globals moment */
 hqDefine("cloudcare/js/form_entry/spec/entries_spec", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/fixtures.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/fixtures.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/form_entry/spec/fixtures", function () {
     return {
         textJSON: (options = {}) => (_.defaults(options, {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 hqDefine("cloudcare/js/form_entry/spec/form_ui_spec", function () {
     describe('Fullform formUI', function () {
@@ -176,11 +177,11 @@ hqDefine("cloudcare/js/form_entry/spec/form_ui_spec", function () {
             assert.equal(form.children()[0].children()[0].children()[0].children()[0].children().length, 1); // [ge]
             assert.equal(form.children()[0].children()[0].children()[0].children()[0].children()[0].children().length, 2); // [q,q]
 
-             assert.equal(form.children()[0].children()[1].children().length, 1); // [ge]
-             assert.equal(form.children()[0].children()[1].children()[0].children().length, 1); // [group]
-             assert.equal(form.children()[0].children()[1].children()[0].children()[0].children().length, 2); // [ge,ge]
-             assert.equal(form.children()[0].children()[1].children()[0].children()[0].children()[0].children().length, 1); // [q]
-             assert.equal(form.children()[0].children()[1].children()[0].children()[0].children()[1].children().length, 1); // [q]
+            assert.equal(form.children()[0].children()[1].children().length, 1); // [ge]
+            assert.equal(form.children()[0].children()[1].children()[0].children().length, 1); // [group]
+            assert.equal(form.children()[0].children()[1].children()[0].children()[0].children().length, 2); // [ge,ge]
+            assert.equal(form.children()[0].children()[1].children()[0].children()[0].children()[0].children().length, 1); // [q]
+            assert.equal(form.children()[0].children()[1].children()[0].children()[0].children()[1].children().length, 1); // [q]
         });
 
         it('Should add n-per-row style to Repeat that are direct children of n-per-row-repeat Group and group the Repeat', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/integration_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/integration_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 hqDefine("cloudcare/js/form_entry/spec/integration_spec", function () {
     describe('Integration', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/utils_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/form_entry/spec/utils_spec", function () {
     describe('Formplayer utils', function () {
         var fixtures = hqImport("cloudcare/js/form_entry/spec/fixtures"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/web_form_session_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/web_form_session_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global affix */
 /* eslint-env mocha */
 hqDefine("cloudcare/js/form_entry/spec/web_form_session_spec", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/task_queue.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/task_queue.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  * Executes the queue in a FIFO action. When a task is added, it will be immediately
  * executed if the queue was previously empty.

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global MapboxGeocoder*/
 hqDefine("cloudcare/js/form_entry/utils", function () {
     var errors = hqImport("cloudcare/js/form_entry/errors"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/web_form_session.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/form_entry/web_form_session", function () {
     var cloudcareUtils = hqImport("cloudcare/js/utils"),
         constants = hqImport("cloudcare/js/form_entry/const"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Marionette, Backbone */
 
 /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/api.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * Backbone model and functions for listing and selecting CommCare apps
  */

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/collections.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone */
 
 hqDefine("cloudcare/js/formplayer/apps/collections", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone */
 
 hqDefine("cloudcare/js/formplayer/apps/controller", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/models.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/models.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone */
 
 hqDefine("cloudcare/js/formplayer/apps/models", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Marionette */
 
 hqDefine("cloudcare/js/formplayer/apps/views", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/constants", function () {
     return {
         ALLOWED_SAVED_OPTIONS: ['oneQuestionPerScreen', 'language'],

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq_events.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq_events.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * hq_events.js
  *

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/progress_bar.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/progress_bar.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Marionette */
 
 hqDefine("cloudcare/js/formplayer/layout/views/progress_bar", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Marionette */
 
 hqDefine("cloudcare/js/formplayer/layout/views/settings", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/main", function () {
 
     $(function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global Sentry */
 /**
  * Backbone model for listing and selecting CommCare menus (modules, forms, and cases)

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone, Sentry */
 
 /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone */
 
 hqDefine("cloudcare/js/formplayer/menus/controller", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone */
 
 hqDefine("cloudcare/js/formplayer/menus/utils", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1,3 +1,4 @@
+'use strict';
 /*globals Marionette */
 
 hqDefine("cloudcare/js/formplayer/menus/views", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone, DOMPurify, Marionette */
 
 hqDefine("cloudcare/js/formplayer/menus/views/query", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/middleware.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/middleware", function () {
     var FormplayerFrontend = hqImport("cloudcare/js/formplayer/app");
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global Backbone, Marionette */
 hqDefine("cloudcare/js/formplayer/router", function () {
     var utils = hqImport("cloudcare/js/formplayer/utils/utils");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/api.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * Backbone model for listing and selecting FormEntrySessions
  */

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/collections.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone */
 
 hqDefine("cloudcare/js/formplayer/sessions/collections", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/controller.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/sessions/controller", function () {
     var constants = hqImport("cloudcare/js/formplayer/constants"),
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/models.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/models.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone */
 
 hqDefine("cloudcare/js/formplayer/sessions/models", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone, Marionette, moment */
 
 hqDefine("cloudcare/js/formplayer/sessions/views", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/case_list_pagination_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/case_list_pagination_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/spec/case_list_pagination_spec", function () {
     describe('#paginateOptions', function () {
         var paginateItems = hqImport("cloudcare/js/formplayer/utils/utils");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/debugger_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/debugger_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 hqDefine("cloudcare/js/formplayer/spec/debugger_spec", function () {
     describe('Debugger', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fake_formplayer.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fake_formplayer.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * Generates mock formplayer responses. Use as a fake for queryFormplayer.
  *

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fixtures/case_grid_list.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fixtures/case_grid_list.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/spec/fixtures/case_grid_list", function () {
     let FakeFormplayer = hqImport("cloudcare/js/formplayer/spec/fake_formplayer");
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fixtures/case_list.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fixtures/case_list.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/spec/fixtures/case_list", function () {
     let FakeFormplayer = hqImport("cloudcare/js/formplayer/spec/fake_formplayer");
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fixtures/case_tile_list.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fixtures/case_tile_list.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/spec/fixtures/case_tile_list", function () {
     let FakeFormplayer = hqImport("cloudcare/js/formplayer/spec/fake_formplayer");
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fixtures/menu_list.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fixtures/menu_list.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/spec/fixtures/menu_list", function () {
     let FakeFormplayer = hqImport("cloudcare/js/formplayer/spec/fake_formplayer");
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fixtures/split_screen_case_list.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/fixtures/split_screen_case_list.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/spec/fixtures/split_screen_case_list", function () {
     const FakeFormplayer = hqImport("cloudcare/js/formplayer/spec/fake_formplayer");
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq_events_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/hq_events_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 hqDefine("cloudcare/js/formplayer/spec/hq_events_spec", function () {
     describe('HQ Events', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/integration_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/integration_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global Backbone */
 /* eslint-env mocha */
 hqDefine("cloudcare/js/formplayer/spec/integration_spec", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global Backbone */
 /* eslint-env mocha */
 hqDefine("cloudcare/js/formplayer/spec/menu_list_spec", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_utils_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 hqDefine("cloudcare/js/formplayer/spec/menu_utils_spec", function () {
     describe('Menu Utils', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/query_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/query_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 /* global Backbone */
 hqDefine("cloudcare/js/formplayer/spec/query_spec", function () {
@@ -28,7 +29,7 @@ hqDefine("cloudcare/js/formplayer/spec/query_spec", function () {
                 const keyQueryListView = QueryListView.queryListView({
                     collection: keyViewCollection,
                     groupHeaders: {
-                        "test": "Test"
+                        "test": "Test",
                     },
                 });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/session_middleware_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/session_middleware_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 hqDefine("cloudcare/js/formplayer/spec/session_middleware_spec", function () {
     describe('SessionMiddle', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 /* global Backbone, Marionette */
 hqDefine("cloudcare/js/formplayer/spec/split_screen_case_search_spec", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/user_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/user_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 hqDefine("cloudcare/js/formplayer/spec/user_spec", function () {
     describe('User', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/utils_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 /* global Backbone */
 hqDefine("cloudcare/js/formplayer/spec/utils_spec", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/collections.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone */
 
 hqDefine("cloudcare/js/formplayer/users/collections", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/controller.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/formplayer/users/controller", function () {
     var Collections = hqImport("cloudcare/js/formplayer/users/collections"),
         FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/models.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/models.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone */
 
 hqDefine("cloudcare/js/formplayer/users/models", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/utils.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global Sentry */
 hqDefine("cloudcare/js/formplayer/users/utils", function () {
     var FormplayerFrontend = hqImport("cloudcare/js/formplayer/app"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone, Marionette */
 
 hqDefine("cloudcare/js/formplayer/users/views", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/calendar-picker-translations.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/calendar-picker-translations.js
@@ -1,3 +1,4 @@
+'use strict';
 (function ($) {
     // English
     $.calendarsPicker.regionalOptions[''] = { // Default regional settings - English/US

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -1,3 +1,4 @@
+'use strict';
 /*global Backbone, DOMPurify */
 hqDefine("cloudcare/js/formplayer/utils/utils", function () {
     var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
@@ -426,7 +427,6 @@ hqDefine("cloudcare/js/formplayer/utils/utils", function () {
 
     if (!String.prototype.includes) {
         String.prototype.includes = function (search, start) {
-            'use strict';
             if (typeof start !== 'number') {
                 start = 0;
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/markdown.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/markdown.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global DOMPurify */
 hqDefine('cloudcare/js/markdown', [
     'jquery',

--- a/corehq/apps/cloudcare/static/cloudcare/js/preview_app/dragscroll.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/preview_app/dragscroll.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * NOTE: MONKEYPATCHED to support form clicks and other actions
  *

--- a/corehq/apps/cloudcare/static/cloudcare/js/preview_app/main.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/preview_app/main.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("cloudcare/js/preview_app/main", function () {
     var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         previewApp = hqImport("cloudcare/js/preview_app/preview_app"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/preview_app/preview_app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/preview_app/preview_app.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine('cloudcare/js/preview_app/preview_app', function () {
     var FormplayerFrontend = hqImport("cloudcare/js/formplayer/app");
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/sentry.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/sentry.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global Sentry */
 hqDefine('cloudcare/js/sentry', [
     'hqwebapp/js/initial_page_data',

--- a/corehq/apps/cloudcare/static/cloudcare/js/spec/markdown_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/spec/markdown_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 hqDefine("cloudcare/js/spec/markdown_spec", function () {
     describe('Markdown', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 hqDefine("cloudcare/js/spec/utils_spec", function () {
     describe("Cloudcare Utils", function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global moment, NProgress, Sentry */
 hqDefine('cloudcare/js/utils', [
     'jquery',


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/34117

People adding these in ad hoc as they edit files in web apps is leading to numerous conflicts with the web apps requirejs migration, which edits the first few lines of every js file in web apps. So let's just do them all.

## Safety Assurance

### Safety story
Innocent linting changes.

### Automated test coverage

There's a fair amount of web apps js coverage, though it's also far from comprehensive.

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
