### PR TITLE
Conditionally Hide Deprecated Filter for Case Exports

### DIFF
--- a/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
@@ -196,7 +196,7 @@
               </button>
 
               <!-- Deprecated Button -->
-              {% if export_instance.type == 'case' %}
+              {% if show_deprecated_filter %}
                 <button type="button"
                         class="btn btn-default btn-xs"
                         data-bind="click: table.toggleShowDeprecated,

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -139,7 +139,10 @@ class BaseExportView(BaseProjectDataView):
         allow_deid = has_privilege(self.request, privileges.DEIDENTIFIED_DATA)
 
         show_deprecated_filter = False
-        if self.export_instance.type == CASE_EXPORT:
+        if (
+            self.export_instance.type == CASE_EXPORT
+            and domain_has_privilege(self.domain, privileges.DATA_DICTIONARY)
+        ):
             show_deprecated_filter = CaseProperty.objects.filter(
                 case_type__domain=self.domain,
                 case_type__name=self.export_instance.case_type,

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -138,6 +138,14 @@ class BaseExportView(BaseProjectDataView):
 
         allow_deid = has_privilege(self.request, privileges.DEIDENTIFIED_DATA)
 
+        show_deprecated_filter = False
+        if self.export_instance.type == CASE_EXPORT:
+            show_deprecated_filter = CaseProperty.objects.filter(
+                case_type__domain=self.domain,
+                case_type__name=self.export_instance.case_type,
+                deprecated=True,
+            ).exists()
+
         return {
             'export_instance': self.export_instance,
             'export_home_url': self.export_home_url,
@@ -155,6 +163,7 @@ class BaseExportView(BaseProjectDataView):
             'is_all_case_types_export': is_all_case_types_export,
             'disable_table_checkbox': (table_count < 2),
             'geo_properties': self._possible_geo_properties,
+            'show_deprecated_filter': show_deprecated_filter,
         }
 
     @property


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

The "Show Deprecated" filter for case exports will now only show if a domain has at least one deprecated case property in the Data Dictionary:

![show-deprecated-filter-case-exports](https://github.com/dimagi/commcare-hq/assets/122617251/0dae85da-489a-449a-a668-ff511f030db5)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3533).

A small UI change to conditionally hide the deprecated filter for case exports if a domain doesn't have any deprecated case properties in the Data Dictionary. This check will only be done if the domain has the Data Dictionary privilege, since domains that do not will not be able to deprecate case properties (no access to Data Dictionary UI).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Small UI change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
