### PR TITLE
change `doc_type` from `text` to `keyword` before creating new indices

### DIFF
--- a/corehq/apps/es/mappings/xform_mapping.py
+++ b/corehq/apps/es/mappings/xform_mapping.py
@@ -41,7 +41,12 @@ XFORM_MAPPING = {
             "type": "keyword"
         },
         "doc_type": {
-            "type": "keyword"
+            "fields": {
+                "exact": {
+                    "type": "keyword"
+                }
+            },
+            "type": "text"
         },
         "domain": {
             "fields": {

--- a/corehq/apps/es/mappings/xform_mapping.py
+++ b/corehq/apps/es/mappings/xform_mapping.py
@@ -41,7 +41,7 @@ XFORM_MAPPING = {
             "type": "keyword"
         },
         "doc_type": {
-            "type": "text"
+            "type": "keyword"
         },
         "domain": {
             "fields": {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
`doc_type` field in xform mappings on which we run some aggregations was set as a `text` field. It worked fine in ES 2 but ES 5 does not allow the aggregations on `text` fields. In all other mappings `doc_type` is set as `keyword`. So it makes sense to change it to `keyword` in xform mappings as well before creating new indices for ES 6.
[Context](https://dimagi.slack.com/archives/C4Q5D8ZDZ/p1701178629724779)


## Safety Assurance
Very small change, will only affect mappings for newly created indices. 
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
