### PR TITLE
Add padding to sidebar elements

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/query.less
@@ -23,16 +23,23 @@
     table-layout: fixed;
     background: white;
   }
+
   .query-input-group {
-    margin-right: 8px;
-    margin-bottom: 4px;
-    margin-left: 8px;
+    margin-right: 18px;
+    margin-bottom: 10px;
+    margin-left: 18px;
   }
   .query-caption {
-    margin-top: 4px;
-    margin-right: 8px;
+    margin-top: 8px;
+    margin-right: 10px;
     margin-left: 8px;
   }
+
+  .query-caption > div {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+
   .mapboxgl-ctrl-geocoder {
     min-width: 100%;
     font-size: 1em;


### PR DESCRIPTION
Reverts dimagi/commcare-hq#34182 which reverted the original PR. It had to be reverted because it was merged during the code freeze for USH on highly visible web apps features. Nothing has changes from the original PR

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Add more padding to the SSCS sidebar: [USH-4124](https://dimagi.atlassian.net/browse/USH-4124)

Before:
![image](https://github.com/dimagi/commcare-hq/assets/36681924/101c6697-9385-4221-953d-ec91bdd6ad8c)


After:
<img width="333" alt="image" src="https://github.com/dimagi/commcare-hq/assets/36681924/35242803-3153-4edc-870f-d7fcfb3bc9a3">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Query-caption needed a bit more fine-tuning to not mess with the ? icons, while that was not needed for the input group

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
SSCS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Visual change only and does not affect the functionality of the search. This will be tested via the app on staging that is connected to the production app that uses this feature.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
I am not requesting QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4124]: https://dimagi.atlassian.net/browse/USH-4124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ