### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,7 @@
 /corehq/apps/domain/auth.py @esoergel
 /corehq/apps/es/ @esoergel @amitphulera
 /corehq/apps/hqcase/ @esoergel
-/corehq/apps/hqwebapp/ @orangejenny
+/corehq/apps/hqwebapp/ @orangejenny @biyeun
 /corehq/apps/linked_domain/ @gherceg
 /corehq/apps/locations/ @esoergel
 /corehq/apps/locations/adjacencylist.py @esoergel @millerdev
@@ -44,7 +44,8 @@
 /corehq/apps/receiverwrapper/ @snopoke
 /corehq/apps/sms*/ @orangejenny @mkangia
 /corehq/apps/smsbillables/ @dannyroberts @biyeun
-/corehq/apps/styleguide/ @orangejenny
+/corehq/apps/sso/ @biyeun
+/corehq/apps/styleguide/ @orangejenny @biyeun
 /corehq/apps/translations/app_translations/ @orangejenny
 /corehq/apps/user_importer/ @stephherbers
 /corehq/apps/userreports/ @calellowitz


### PR DESCRIPTION
## Technical Summary
Adding myself as a code owner to a few places, like `styleguide`, `sso`, and `hqwebapp`

## Safety Assurance

### Safety story
just updating codeowners

### Automated test coverage
n/a

### QA Plan
n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
