### PR TITLE
Make Couch to SQL migrations resumable

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,8 +16,10 @@
 /corehq/tests/nose.py @millerdev
 /corehq/tests/noseplugins/ @millerdev
 /corehq/util/ @esoergel
+/corehq/util/couch_helpers.py @millerdev
 /corehq/util/datadog/lockmeter.py @millerdev
 /corehq/util/datadog/tests/test_lockmeter.py @millerdev
+/corehq/util/pagination.py @millerdev
 /corehq/warehouse/ @calellowitz
 /corehq/warnings.py @millerdev
 
@@ -26,6 +28,7 @@
 /corehq/apps/app_manager/ @orangejenny
 /corehq/apps/callcenter/ @snopoke
 /corehq/apps/change_feed/ @dannyroberts
+/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py @millerdev
 /corehq/apps/commtrack/ @esoergel
 /corehq/apps/data_dictionary/ @esoergel @orangejenny @zandre-eng
 /corehq/apps/domain/decorators.py @esoergel
@@ -50,6 +53,7 @@
 /corehq/apps/userreports/ @calellowitz
 /corehq/apps/userreports/reports/builder/ @kaapstorm
 /corehq/apps/users/ @esoergel
+/corehq/ex-submodules/dimagi/utils/couch/migration.py @millerdev
 /corehq/ex-submodules/pillowtop @dannyroberts @calellowitz
 
 /custom/covid/management/commands/ @stephherbers @AddisonDunn

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -11,23 +11,25 @@ from time import sleep
 
 from attrs import define, field
 
-from couchdbkit.exceptions import ResourceNotFound
-
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
-from django.utils.functional import classproperty
 
 from corehq.apps.domain.dbaccessors import iterate_doc_ids_in_domain_by_type
 from corehq.dbaccessors.couchapps.all_docs import (
-    get_all_docs_with_doc_types,
     get_doc_count_by_type,
     get_doc_count_by_domain_type
 )
+from corehq.util.couch_helpers import NoSkipArgsProvider
 from corehq.util.couchdb_management import couch_config
 from corehq.util.django_migrations import skip_on_fresh_install
 from corehq.util.log import with_progress_bar
+from corehq.util.pagination import (
+    PaginationEventHandler,
+    ResumableFunctionIterator,
+    paginate_function,
+)
 from dimagi.utils.chunked import chunked
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch.migration import disable_sync_to_couch
@@ -146,6 +148,8 @@ class PopulateSQLCommand(BaseCommand):
             self._set_migration_completed()
         elif override_is_completed == "no":
             self._override_migration_status(is_completed=False)
+        elif override_is_completed == "discard":
+            self.discard_resume_state()
         else:
             self._avg_items_to_be_migrated()
         print(f"status={self.get_migration_status()}")
@@ -164,14 +168,12 @@ class PopulateSQLCommand(BaseCommand):
         status = self.get_migration_status()
         if is_completed == bool(status.get("is_completed")):
             return
-        if "ignored_count" not in status:
+        if not status.get("is_completed"):
             print("WARNING The command may not have run to completion.")
             if input("Override anyway? [yN] ").lower() != "y":
                 print("Aborted.")
                 return
-        extra = {"is_completed": True} if is_completed else {}
-        self.ignored_count = status.get("ignored_count", 0)
-        self.save_migration_status(**extra)
+        self._resume_iter_couch_view().set_iterator_detail("is_completed", is_completed)
 
     def _avg_items_to_be_migrated(self):
         def get_count():
@@ -192,30 +194,16 @@ class PopulateSQLCommand(BaseCommand):
         sql_count = cls.sql_class().objects.count()
         return couch_count - ignored_count - sql_count
 
-    @classproperty
-    def _migration_status_slug(cls):
-        return f"{cls.couch_doc_type()}-sql-migration-status"
-
-    def save_migration_status(self, fixup_diffs=False, **extra):
-        ignored_count = self.ignored_count
-        if fixup_diffs:
-            status = self.get_migration_status()
-            if "ignored_count" not in status:
-                return
-            ignored_count += status["ignored_count"]
-        self.couch_db().save_doc({
-            "_id": self._migration_status_slug,
-            "doc_type": "PopulateSQLCommandStatus",
-            "ignored_count": ignored_count,
-            **extra
-        }, force_update=True)
-
     @classmethod
     def get_migration_status(cls):
-        try:
-            return cls.couch_db().get(cls._migration_status_slug)
-        except ResourceNotFound:
-            return {}
+        return cls._resume_iter_couch_view().state.progress
+
+    @classmethod
+    def discard_resume_state(cls):
+        resume = cls._resume_iter_couch_view()
+        if hasattr(resume.state, "_rev"):
+            print(f"Discarding resume state: {resume.state}")
+            resume.discard_state()
 
     @classmethod
     def commit_adding_migration(cls):
@@ -310,7 +298,8 @@ Run the following commands to run the migration and get up to date:
         parser.add_argument(
             '--domains',
             nargs='+',
-            help="Only migrate documents in the specified domains",
+            help="Only migrate documents in the specified domains. "
+                 "NOTE: domain migrations are not resumable.",
         )
         parser.add_argument(
             '--chunk-size',
@@ -325,16 +314,16 @@ Run the following commands to run the migration and get up to date:
         )
         parser.add_argument(
             '--override-is-migration-completed',
-            choices=["check", "yes", "no"],
+            choices=["check", "yes", "no", "discard"],
             dest="override_is_completed",
             help="""
                 Check or set migration completion status. Use to override
                 the check performed by `migrate_from_migration` when the number
-                of items to be migrated is volatile. Note that the override will
-                be removed if the command is run again without this option after
-                the override is set. Accepted values: check: check and print
-                status, yes: override `count_items_to_be_migrated` to zero, no:
-                remove override.
+                of items to be migrated is volatile. Accepted values:
+                check: check and print status,
+                yes: set `count_items_to_be_migrated` to zero,
+                no: remove override,
+                discard: discard all migration state.
             """
         )
         parser.add_argument(
@@ -345,6 +334,8 @@ Run the following commands to run the migration and get up to date:
 
     def handle(self, chunk_size, fixup_diffs, override_is_completed, debug, **options):
         if override_is_completed:
+            if options["domains"]:
+                raise CommandError("Cannot override status with --domains")
             return self.handle_override_is_completed(override_is_completed)
 
         log_path = options.get("log_path")
@@ -363,10 +354,10 @@ Run the following commands to run the migration and get up to date:
         if verify_only and skip_verify:
             raise CommandError("verify_only and skip_verify are mutually exclusive")
 
-        self.log_path = log_path
         self.diff_count = 0
         self.ignored_count = 0
         doc_index = 0
+        offset = 0
 
         if fixup_diffs:
             if not os.path.exists(fixup_diffs):
@@ -385,9 +376,24 @@ Run the following commands to run the migration and get up to date:
         else:
             doc_count = self._get_couch_doc_count_for_type()
             sql_doc_count = self.sql_class().objects.count()
-            docs = self._get_all_couch_docs_for_model(chunk_size)
+            results = self._resume_iter_couch_view(chunk_size)
+            if verify_only:
+                # non-resumable iteration
+                results = paginate_function(results.data_function, results.args_provider)
+            else:
+                # resumable iteration
+                state = results.state.progress
+                offset = state.get("doc_count", 0)
+                if state.get("is_completed"):
+                    print(f"Migration is complete. Previously migrated {offset} documents.")
+                    print("Use --override-is-migration-completed to inspect or reset.")
+                    return
+                log_path = state.setdefault("log_path", str(log_path))
+            should = self.should_process
+            docs = (r['doc'] for r in results if should(r))
+        docs = with_progress_bar(docs, doc_count, oneline=False, offset=offset)
 
-        print(f"\n\nDetailed log output file: {log_path}")
+        print("Detailed log output file:", log_path)
         print("Found {} {} docs and {} {} models".format(
             doc_count,
             self.couch_doc_type(),
@@ -410,8 +416,9 @@ Run the following commands to run the migration and get up to date:
 
         aborted = False
         with self.open_log(log_path) as logfile:
+            self.logfile = logfile
             try:
-                for item in iter_items(with_progress_bar(docs, length=doc_count, oneline=False)):
+                for item in iter_items(docs):
                     if not verify_only:
                         migrate(item, logfile)
                     if not skip_verify:
@@ -420,7 +427,6 @@ Run the following commands to run the migration and get up to date:
                         doc_index += 1
                         if doc_index % 1000 == 0:
                             print(f"Diff count: {self.diff_count}")
-                self.save_migration_status(fixup_diffs)
             except KeyboardInterrupt:
                 traceback.print_exc(file=logfile)
                 aborted = True
@@ -430,6 +436,7 @@ Run the following commands to run the migration and get up to date:
                     raise
                 traceback.print_exception(type(exc), exc, exc.__traceback__)
                 pdb.post_mortem(exc.__traceback__)
+                aborted = True
 
         if not is_bulk:
             print(f"Processed {doc_index} documents")
@@ -614,22 +621,63 @@ Run the following commands to run the migration and get up to date:
             for doc in iter_docs(self.couch_db(), doc_id_iter, chunk_size):
                 yield doc
 
-    def _get_all_couch_docs_for_model(self, chunk_size):
-        return get_all_docs_with_doc_types(
-            self.couch_db(), [self.couch_doc_type()], chunk_size)
+    @classmethod
+    def _resume_iter_couch_view(cls, chunk_size=1000):
+        view_name, params = cls.get_couch_view_name_and_parameters()
+        view = partial(cls.couch_db().view, view_name, reduce=False, include_docs=True)
+        args_provider = NoSkipArgsProvider(params | {"limit": chunk_size})
+        iteration_key = f"{cls.couch_doc_type()}-to-sql"
+        rfi = ResumableFunctionIterator(iteration_key, view, args_provider)
+        assert rfi.event_handler is None, rfi
+        rfi.event_handler = IterDocsEvents(rfi)
+        return rfi
+
+    def should_process(self, result):
+        """Return true if Couch result should be processed
+
+        Can be used to filter out results with null document, for
+        example. Note: this is not used for by-domain iterations.
+        """
+        return True
+
+    @classmethod
+    def get_couch_view_name_and_parameters(cls):
+        """Get view name and parameters for all docs iteration
+
+        Override if the all_docs/by_doc_type view does not exist in the
+        target database.
+        """
+        doc_type = cls.couch_doc_type()
+        return 'all_docs/by_doc_type', {
+            'startkey': [doc_type],
+            'endkey': [doc_type, {}],
+        }
 
     @classmethod
     def _get_couch_doc_count_for_type(cls):
         return get_doc_count_by_type(cls.couch_db(), cls.couch_doc_type())
 
     @staticmethod
-    def open_log(log_path, mode="w"):
+    def open_log(log_path, mode="a"):
         if log_path == "-":
             return nullcontext(sys.stdout)
         return open(log_path, mode)
 
 
 DIFF_HEADER = "Doc {} has differences:\n"
+
+
+class IterDocsEvents(PaginationEventHandler):
+
+    def __init__(self, iterator):
+        self.iterator = iterator
+        self.initial_count = iterator.state.progress.get("doc_count", 0)
+
+    def page_start(self, total_emitted, *args, **kwargs):
+        self.iterator.state.progress["doc_count"] = self.initial_count + total_emitted
+
+    def stop(self):
+        self.iterator.set_iterator_detail("is_completed", True)
 
 
 @define

--- a/corehq/apps/cleanup/tests/test_populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/tests/test_populate_sql_model_from_couch_model.py
@@ -1,0 +1,252 @@
+import re
+import sys
+from contextlib import contextmanager
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils.functional import cached_property
+
+from dimagi.ext.couchdbkit import Document
+from dimagi.utils.couch.migration import SyncCouchToSQLMixin, SyncSQLToCouchMixin
+
+from testil import tempdir
+
+from corehq.dbaccessors.couchapps.all_docs import delete_all_docs_by_doc_type
+
+from ..management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
+
+
+class TestPopulateSQLCommand(TestCase):
+
+    def test_resume_migration(self):
+        with templog() as log:
+            create_doc("1")
+            create_doc("2", ignore=True)
+            create_doc("3")
+            with stop_at_diff("3"):
+                call_command(log_path=log.path)
+            self.assertIn("Ignored model for TestDoc with id 2", log.content)
+            self.assertIn("Created model for TestDoc with id 3", log.content)
+            del log.content
+            resume = Command._resume_iter_couch_view()
+            self.assertEqual(resume.state.kwargs["startkey"], ['TestDoc', '2'])
+            self.assertEqual(resume.state.progress["doc_count"], 2)
+            self.assertFalse(resume.state.progress.get("is_completed"))
+
+            create_doc("4", ignore=True)
+            create_doc("5")
+            output = call_command(log_path=log.path.parent)
+            self.assertIn(f"log output file: {log.path}\n", output)
+            self.assertIn(" 5/5 100%", output)
+            self.assertIn("Created model for TestDoc with id 3", log.content)
+            self.assertIn("Ignored model for TestDoc with id 4", log.content)
+            self.assertEqual(log.content.count("Created model for TestDoc with id 1"), 1)
+            resume = Command._resume_iter_couch_view()
+            self.assertEqual(resume.state.progress["doc_count"], 5)
+            self.assertTrue(resume.state.progress.get("is_completed"))
+
+            create_doc("6")
+            output = call_command(log_path=log.path.parent)
+            self.assertEqual(
+                output.strip(),
+                "Migration is complete. Previously migrated 5 documents.\n"
+                "Use --override-is-migration-completed to inspect or reset.",
+            )
+
+    def test_verify_does_not_change_resume_state(self):
+        # bulk_create patch causes diffs
+        with templog() as log, patch.object(FakeModel.objects, "bulk_create"):
+            create_doc("1")
+            create_doc("2", ignore=True)
+            create_doc("3")
+            with stop_at_diff("3"):
+                call_command(log_path=log.path)
+            log1 = log.content
+            del log.content
+
+            create_doc("4")
+            verify_log = Log(log.path.parent, "verify.log")
+            output = call_command(verify_only=True, log_path=verify_log.path)
+            self.assertIn("Found 3 differences", output)
+            self.assertIn('Doc "1" has differences', verify_log.content)
+            self.assertIn('Doc "4" has differences', verify_log.content)
+            self.assertEqual(log.content, log1, "original log should not be modified")
+            resume = Command._resume_iter_couch_view()
+            self.assertEqual(resume.state.progress["log_path"], str(log.path))
+            self.assertEqual(resume.state.progress["doc_count"], 2)
+            self.assertFalse(resume.state.progress.get("is_completed"))
+
+    def test_fixup_diffs_does_not_change_resume_state(self):
+        with templog() as log:
+            create_doc("1")
+            create_doc("2", ignore=True)
+            create_doc("3")
+            # bulk_create patch causes diffs
+            with stop_at_diff("3"), patch.object(FakeModel.objects, "bulk_create"):
+                call_command(log_path=log.path)
+            self.assertIn('Doc "1" has differences', log.content)
+            self.assertIn('Doc "3" has differences', log.content)
+            log1 = log.content
+            del log.content
+
+            db = Command.couch_db()
+            db.save_doc(db.get("3") | {"ignore": True})
+            fixup_log = Log(log.path.parent, "fixup.log")
+            output = call_command(fixup_diffs=log.path, log_path=fixup_log.path)
+            self.assertIn("Found 0 differences", output)
+            self.assertIn("Ignored 1 Couch documents", output)
+            self.assertIn('Created model for TestDoc with id 1', fixup_log.content)
+            self.assertIn("Ignored model for TestDoc with id 3", fixup_log.content)
+            self.assertEqual(log.content, log1, "original log should not be modified")
+            resume = Command._resume_iter_couch_view()
+            self.assertEqual(resume.state.progress["log_path"], str(log.path))
+            self.assertFalse(resume.state.progress.get("is_completed"))
+
+    def test_domains_migration_does_not_change_resume_state(self):
+        with templog() as log:
+            create_doc("1", domain="two")
+            create_doc("2", ignore=True)
+            create_doc("3", domain="two")
+            with stop_at_diff("3"):
+                call_command(log_path=log.path)
+            log1 = log.content
+            del log.content
+
+            create_doc("4", domain="two", ignore=True)
+            create_doc("5")
+            create_doc("6", domain="two")
+            domains_log = Log(log.path.parent, "domains.log")
+            output = call_command(log_path=domains_log.path, domains=["two"])
+            self.assertIn("Ignored 1 Couch documents", output)
+            self.assertIn('Ignored model for TestDoc with id 4', domains_log.content)
+            self.assertIn('Created model for TestDoc with id 6', domains_log.content)
+            self.assertEqual(log.content, log1, "original log should not be modified")
+            resume = Command._resume_iter_couch_view()
+            self.assertEqual(resume.state.progress["log_path"], str(log.path))
+            self.assertFalse(resume.state.progress.get("is_completed"))
+
+    def tearDown(self):
+        delete_all_docs_by_doc_type(Command.couch_db(), [TestDoc.__name__])
+        Command.discard_resume_state()
+        FakeModel._created = []
+
+
+def call_command(*, log_path, **options):
+    options.setdefault("domains", None)
+    options.setdefault("chunk_size", 1)
+    options.setdefault("fixup_diffs", None)
+    options.setdefault("override_is_completed", None)
+    options.setdefault("debug", None)
+    output = StringIO()
+    with patch.object(sys, "stdout", output):
+        try:
+            Command().handle(log_path=log_path, **options)
+        except SystemExit as exc:
+            output.write(f"SystemExit: {exc}\n")
+    outstr = output.getvalue()
+    print(outstr)
+    if "Migration is complete." not in outstr:
+        log = re.search("log output file: ([^\n]+)", outstr).group(1)
+        print(log)
+        with open(log) as fh:
+            print(fh.read())
+    return outstr
+
+
+def stop_at_diff(doc_id):
+    def diff_stop(self, doc, *args):
+        real_diff(self, doc, *args)
+        if doc["_id"] == doc_id:
+            raise KeyboardInterrupt
+    real_diff = Command._do_diff
+    return patch.object(Command, "_do_diff", diff_stop)
+
+
+class Command(PopulateSQLCommand):
+
+    @classmethod
+    def couch_doc_type(cls):
+        return TestDoc.__name__
+
+    @classmethod
+    def sql_class(cls):
+        return FakeModel
+
+    def get_ids_to_ignore(self, docs):
+        return {d['_id'] for d in docs if d.get("ignore")}
+
+    def _sql_query_from_docs(self, docs):
+        ids = {doc["_id"] for doc in docs}
+        return MockQueryset(obj for obj in FakeModel._created if obj._id in ids)
+
+    @classmethod
+    def diff_couch_and_sql(cls, couch, sql):
+        return [cls.diff_attr(name, couch, sql) for name in ["_id", "domain"]]
+
+
+class TestDoc(SyncCouchToSQLMixin, Document):
+    class Meta:
+        app_label = "couch"
+
+    def _migration_get_fields(self):
+        return ["domain"]
+
+
+class FakeModel(SyncSQLToCouchMixin):
+    _created = []
+    _migration_couch_id_name = "_id"
+
+    @classmethod
+    def _migration_get_couch_model_class(cls):
+        return TestDoc
+
+    class objects:
+        def bulk_create(objs, ignore_conflicts=False):
+            FakeModel._created.extend(objs)
+
+        def count():
+            return len(FakeModel._created)
+
+        def filter(**params):
+            (key, val), = params.items()
+            assert key.endswith("__in"), (key, val)
+            attr = key[:-4]
+            objs = [f for f in FakeModel._created if getattr(f, attr) in val]
+            return MockQueryset(objs)
+
+    def __repr__(self):
+        return f"{type(self).__name__}(_id={self._id})"
+
+
+def create_doc(_id, **data):
+    return Command.couch_db().save_doc({
+        "_id": _id,
+        "doc_type": Command.couch_doc_type(),
+        "domain": "one",
+    } | data)
+
+
+class MockQueryset(list):
+    def only(self, *a, **kw):
+        return self
+
+    def count(self):
+        return len(self)
+
+
+@contextmanager
+def templog():
+    with tempdir() as tmp:
+        yield Log(tmp)
+
+
+class Log:
+    def __init__(self, tmp, name="log.txt"):
+        self.path = Path(tmp) / name
+
+    @cached_property
+    def content(self):
+        with self.path.open() as lines:
+            return "".join(lines)

--- a/corehq/motech/dhis2/tests/test_models.py
+++ b/corehq/motech/dhis2/tests/test_models.py
@@ -9,8 +9,11 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from nose.tools import assert_equal
+from testil import tempdir
 
 from corehq.motech.models import ConnectionSettings
+from corehq.motech.dhis2.management.commands.populate_sqldatasetmap import Command
+
 
 from ..const import (
     COMPLETE_DATE_COLUMN,
@@ -235,7 +238,9 @@ class GetInfoForColumnsTests(TestCase):
             }]
         })
         self.dataset_map.save()
-        call_command('populate_sqldatasetmap', log_path=f"sqldatasetmap_{datetime.utcnow().isoformat()}.log")
+        with tempdir() as tmp:
+            call_command('populate_sqldatasetmap', log_path=tmp)
+            Command.discard_resume_state()
         self.sqldataset_map = SQLDataSetMap.objects.get(
             domain=self.domain,
             couch_id=self.dataset_map._id,

--- a/corehq/motech/repeaters/tests/test_couchsqlmigration.py
+++ b/corehq/motech/repeaters/tests/test_couchsqlmigration.py
@@ -226,6 +226,7 @@ class TestRepeatRecordCouchToSQLMigration(BaseRepeatRecordCouchToSQLTest):
 
     def tearDown(self):
         delete_all_repeat_records()
+        Command.discard_resume_state()
         super().tearDown()
 
     def test_sync_to_couch(self):


### PR DESCRIPTION
Make it possible to resume a Couch to SQL backfill operation after a crash or manual interruption. Previously it was necessary to start over and revisit every document each time the migration crashed or was stopped.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Nearly all code changed in this PR (except for `corehq/util/pagination.py`) is used only by Couch to SQL backfill management commands. The changes to `pagination.py` are very minor and should be safe. The only change that potentially could have a negative effect on other code is
```diff
            return DelegatingPaginationEventHandler([
+               self.event_handler,  # first so it can mutate iterator state
                ResumableIteratorEventHandler(self),
-               self.event_handler
            ])
```
It changes the order that event handlers are called in a `ResumableFunctionIterator` with a custom event handler. No existing code that I could find outside of the Couch to SQL migration code uses a custom event handler, so this should be fine.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations