### PR TITLE
clear breadcrumbs for smart link responses

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -45,6 +45,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
 
             var urlObject = formplayerUtils.currentUrlToObject();
             if (urlObject.endpointId) {
+                menuResponse.breadcrumbs = [];
                 urlObject.replaceEndpoint(menuResponse.selections);
                 formplayerUtils.setUrlToObject(urlObject);
             }


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
 As described in the ticket, there is some unexpected behavior when clicking breadcrumbs after following a smart link. This removes breadcrumbs when a smart link is used.
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi.atlassian.net/browse/USH-4207
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[SESSION_ENDPOINTS](https://www.commcarehq.org/hq/flags/edit/session_endpoints/)
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging. Only changes what when breadcrumbs are displayed. The risk of unexpected problems is low.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA planned. The thought of some regression testing had occurred to me, but then I decided that the change is so specific/focused that it wasn't needed. I'm open to other thoughts.

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
