### PR TITLE
Make geojson daily saved export downloadable

### DIFF
--- a/corehq/ex-submodules/couchexport/models.py
+++ b/corehq/ex-submodules/couchexport/models.py
@@ -45,7 +45,7 @@ class Format(object):
                                   "download": True},
                    GEOJSON: {"mimetype": "application/geo+json",
                           "extension": "geojson",
-                          "download": False},
+                          "download": True},
                    }
 
     VALID_FORMATS = list(FORMAT_DICT)


### PR DESCRIPTION
## Product Description
A geojson export is now downloadable, whereas previously it only opened the file in the browser.

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3428)

This only involves specifying that the export format is downloadable. Nothing major.

## Feature Flag
Support geojson export in case exporter

## Safety Assurance

### Safety story
Tested localy

### Automated test coverage
No automated tests needed.

### QA Plan
No QA needed for this simple change.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
