### PR TITLE
Add URL Param to DHIS2 Metadata Request

### DIFF
--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -249,7 +249,8 @@ def get_api_version(dhis2_version):
         example, the API version for DHIS 2.25 is 25.
 
 
-    .. _DHIS 2 Developer guide: https://docs.dhis2.org/master/en/developer/html/webapi_browsing_the_web_api.html#webapi_api_versions
+    .. _DHIS 2 Developer guide:
+    .. https://docs.dhis2.org/master/en/developer/html/webapi_browsing_the_web_api.html#webapi_api_versions
     """
     try:
         api_version = LooseVersion(dhis2_version).version[1]
@@ -270,7 +271,7 @@ def fetch_metadata(requests):
        one that maps to DHIS2 IDs.
 
     """
-    response = requests.get('/api/metadata', raise_for_status=True)
+    response = requests.get('/api/metadata', raise_for_status=True, params={'assumeTrue': 'false'})
     return response.json()
 
 

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -249,9 +249,8 @@ def get_api_version(dhis2_version):
         example, the API version for DHIS 2.25 is 25.
 
 
-    .. _DHIS 2 Developer guide:
-    .. https://docs.dhis2.org/master/en/developer/html/webapi_browsing_the_web_api.html#webapi_api_versions
-    """
+    .. _DHIS 2 Developer guide: https://docs.dhis2.org/master/en/developer/html/webapi_browsing_the_web_api.html#webapi_api_versions
+    """  # noqa: E501
     try:
         api_version = LooseVersion(dhis2_version).version[1]
     except (AttributeError, IndexError):


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3535).

This PR adds an additional `assumeTrue=false` param when making a request to the `api/metadata` endpoint for a DHIS2 instance. Including this param should reduce the size of the response, since DHIS2 will only include metadata items that are explicitely specified as true based on provided criteria. Given that we are only interested in retrieving the system version from the metadata, it is fine to exclude certain metadata.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`DHIS2_INTEGRATION`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Ran a curl command to `https://play.dhis2.org/2.39.4.1/api/metadata?assumeTrue=false` to ensure that DHIS2 version is still in the response after adding the URL param. Difficult to test otherwise as this requires access to a DHIS2 instance.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
