### PR TITLE
Javascript lint for builds app, and removing sorting

### DIFF
--- a/corehq/apps/builds/static/builds/js/edit-builds.js
+++ b/corehq/apps/builds/static/builds/js/edit-builds.js
@@ -1,4 +1,4 @@
-/* globals hqDefine */
+"use strict";
 hqDefine('builds/js/edit-builds', [
     'jquery',
     'underscore',
@@ -37,8 +37,8 @@ hqDefine('builds/js/edit-builds', [
                 version.build.version, version.label
             ));
         });
-        _.each(doc.defaults, function (version_doc) {
-            var version = version_doc.version;
+        _.each(doc.defaults, function (versionDoc) {
+            var version = versionDoc.version;
             if (version[0] === '1') {
                 self.default_one(version);
             } else if (version[0] === '2') {

--- a/corehq/apps/builds/static/builds/js/edit_builds.js
+++ b/corehq/apps/builds/static/builds/js/edit_builds.js
@@ -4,7 +4,6 @@ hqDefine('builds/js/edit_builds', [
     'underscore',
     'knockout',
     'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/bootstrap3/knockout_bindings.ko',
 ], function ($, _, ko, initialPageData) {
     var doc = initialPageData.get('doc');
 

--- a/corehq/apps/builds/static/builds/js/edit_builds.js
+++ b/corehq/apps/builds/static/builds/js/edit_builds.js
@@ -1,5 +1,5 @@
 "use strict";
-hqDefine('builds/js/edit-builds', [
+hqDefine('builds/js/edit_builds', [
     'jquery',
     'underscore',
     'knockout',

--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -3,7 +3,7 @@
 {% load compress %}
 {% load i18n %}
 
-{% requirejs_main 'builds/js/edit-builds' %}
+{% requirejs_main 'builds/js/edit_builds' %}
 
 {% block page_title %}
 {% trans "Editing CommCare Builds" %}

--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -24,18 +24,14 @@
       <table id="menu-table" class="table table-striped">
         <thead>
         <tr>
-          <th></th>
           <th>{% trans "Version" %}</th>
           <th>{% trans "Label" %}</th>
           <th>{% trans "Superuser Only" %}</th>
           <th></th>
         </tr>
         </thead>
-        <tbody data-bind="sortable: versions">
+        <tbody data-bind="foreach: versions">
         <tr>
-          <td class="sortable-handle">
-            <i class="fa-solid fa-up-down"></i>
-          </td>
           <td>
             <select class="form-control" data-bind="
                                     options: $root.available_versions,

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -13,7 +13,6 @@ from dimagi.utils.web import json_request, json_response
 
 from corehq.apps.api.models import require_api_user
 from corehq.apps.domain.decorators import require_superuser
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.util.view_utils import json_error
 
@@ -63,7 +62,6 @@ class EditMenuView(BasePageView):
     page_title = gettext_lazy("Edit CommCare Builds")
 
     @method_decorator(require_superuser)
-    @use_jquery_ui
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 


### PR DESCRIPTION
## Technical Summary
Fix lint errors before splitting these files for B5 migration, which will otherwise generate double the lint errors.

## Safety Assurance

### Safety story
Minor lint changes to admin-only page. Verified the page still loads locally.

### Automated test coverage

no

### QA Plan
no
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
