### PR TITLE
Prep to use only DD for case exports

### DIFF
--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -41,7 +41,7 @@ def _get_all_case_properties(domain):
 
     for case_type in get_case_types_from_apps(domain):
         properties = set()
-        schema = CaseExportDataSchema.generate_schema_from_builds(domain, None, case_type)
+        schema = CaseExportDataSchema.generate_schema(domain, None, case_type)
 
         # only the first schema contains case properties. The others contain meta info
         group_schema = schema.group_schemas[0]

--- a/corehq/apps/export/management/commands/rebuild_schemas_subase_repeat_bug.py
+++ b/corehq/apps/export/management/commands/rebuild_schemas_subase_repeat_bug.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             print("Rebuilding {} schemas for domain '{}'".format(len(schema_keys), domain))
             for app_id, xmlns in schema_keys:
                 print("    rebuilding ('{}', '{}')".format(app_id, xmlns))
-                FormExportDataSchema.generate_schema_from_builds(domain, app_id, xmlns, force_rebuild=True)
+                FormExportDataSchema.generate_schema(domain, app_id, xmlns, force_rebuild=True)
 
 
 def _latest_form_schema_ids():

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -2508,7 +2508,7 @@ class SMSExportDataSchema(ExportDataSchema):
 
     @classmethod
     def generate_schema(cls, domain, app_id, identifier, force_rebuild=False,
-            only_process_current_builds=False, task=None):
+                        only_process_current_builds=False, task=None):
         return cls(domain=domain)
 
     @classmethod

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1774,7 +1774,7 @@ class ExportDataSchema(Document):
         else:
             current_schema = cls()
 
-        if only_use_data_dictionary:
+        if cls == CaseExportDataSchema and only_use_data_dictionary:
             current_schema = cls._update_schema_from_data_dictionary(
                 domain, current_schema, identifier, task)
         else:

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1743,7 +1743,7 @@ class ExportDataSchema(Document):
         identifier,
         force_rebuild=False,
         only_process_current_builds=False,
-        only_use_data_dictionary=False,
+        only_use_data_dictionary=True,
         task=None,
     ):
         """

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1733,7 +1733,7 @@ class ExportDataSchema(Document):
         return current_schema
 
     @classmethod
-    def generate_schema_from_builds(
+    def generate_schema(
         cls,
         domain,
         app_id,
@@ -2507,7 +2507,7 @@ class SMSExportDataSchema(ExportDataSchema):
         return SMS_EXPORT
 
     @classmethod
-    def generate_schema_from_builds(cls, domain, app_id, identifier, force_rebuild=False,
+    def generate_schema(cls, domain, app_id, identifier, force_rebuild=False,
             only_process_current_builds=False, task=None):
         return cls(domain=domain)
 

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -215,7 +215,7 @@ def _cached_add_inferred_export_properties(sender, domain, case_type, properties
 def generate_schema_for_all_builds(self, export_type, domain, app_id, identifier):
     from .views.utils import GenerateSchemaFromAllBuildsView
     export_cls = GenerateSchemaFromAllBuildsView.export_cls(export_type)
-    export_cls.generate_schema_from_builds(
+    export_cls.generate_schema(
         domain,
         app_id,
         identifier,
@@ -240,7 +240,7 @@ def process_populate_export_tables(export_id, progress_id=None):
     if progress_id:
         cache.set(progress_id, progress_data)
 
-    schema = CaseExportDataSchema.generate_schema_from_builds(export.domain, None, export.case_type)
+    schema = CaseExportDataSchema.generate_schema(export.domain, None, export.case_type)
     if progress_id:
         progress_data['progress'] = 50
         cache.set(progress_id, progress_data)

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -5,7 +5,6 @@ from django.test import SimpleTestCase, TestCase
 from unittest.mock import patch
 
 from corehq.apps.app_manager.models import (
-    AdvancedModule,
     AdvancedOpenCaseAction,
     Application,
     CaseIndex,

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -624,7 +624,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
     def test_basic_application_schema(self):
         app = self.current_app
 
-        schema = FormExportDataSchema.generate_schema_from_builds(
+        schema = FormExportDataSchema.generate_schema(
             app.domain,
             app._id,
             'my_sweet_xmlns'
@@ -641,7 +641,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
         with patch(
                 'corehq.apps.export.models.new.FormExportDataSchema._process_app_build',
                 side_effect=Exception('boom')):
-            FormExportDataSchema.generate_schema_from_builds(
+            FormExportDataSchema.generate_schema(
                 self.current_app.domain,
                 self.current_app._id,
                 'my_sweet_xmlns'
@@ -650,7 +650,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
     def test_build_from_saved_schema(self):
         app = self.current_app
 
-        schema = FormExportDataSchema.generate_schema_from_builds(
+        schema = FormExportDataSchema.generate_schema(
             app.domain,
             app._id,
             'my_sweet_xmlns'
@@ -668,7 +668,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
         second_build.save()
         self.addCleanup(second_build.delete)
 
-        new_schema = FormExportDataSchema.generate_schema_from_builds(
+        new_schema = FormExportDataSchema.generate_schema(
             app.domain,
             app._id,
             'my_sweet_xmlns'
@@ -681,7 +681,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
     def test_build_with_inferred_schema(self):
         app = self.current_app
 
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             app.domain,
             app._id,
             self.case_type,
@@ -696,7 +696,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
     def test_build_with_advanced_app(self):
         app = self.advanced_app
 
-        schema = FormExportDataSchema.generate_schema_from_builds(
+        schema = FormExportDataSchema.generate_schema(
             app.domain,
             app._id,
             "repeat-xmlns",
@@ -756,7 +756,7 @@ class TestAppCasePropertyReferences(TestCase, TestXmlMixin):
         super(TestAppCasePropertyReferences, cls).tearDownClass()
 
     def testCaseReferencesMakeItToCaseSchema(self):
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             self.domain,
             self.current_app._id,
             self.case_type,
@@ -792,13 +792,13 @@ class TestExportDataSchemaVersionControl(TestCase, TestXmlMixin):
     def test_rebuild_version_control(self):
         app = self.current_app
 
-        schema = FormExportDataSchema.generate_schema_from_builds(
+        schema = FormExportDataSchema.generate_schema(
             app.domain,
             app._id,
             'my_sweet_xmlns'
         )
 
-        existing_schema = FormExportDataSchema.generate_schema_from_builds(
+        existing_schema = FormExportDataSchema.generate_schema(
             app.domain,
             app._id,
             'my_sweet_xmlns'
@@ -808,7 +808,7 @@ class TestExportDataSchemaVersionControl(TestCase, TestXmlMixin):
         with patch(
                 'corehq.apps.export.models.new.FORM_DATA_SCHEMA_VERSION',
                 FORM_DATA_SCHEMA_VERSION + 1):
-            rebuilt_schema = FormExportDataSchema.generate_schema_from_builds(
+            rebuilt_schema = FormExportDataSchema.generate_schema(
                 app.domain,
                 app._id,
                 'my_sweet_xmlns'
@@ -862,7 +862,7 @@ class TestDelayedSchema(TestCase, TestXmlMixin):
         delete_all_export_data_schemas()
 
     def test_basic_delayed_schema(self):
-        schema = FormExportDataSchema.generate_schema_from_builds(
+        schema = FormExportDataSchema.generate_schema(
             self.domain,
             self.current_app._id,
             self.xmlns,
@@ -873,7 +873,7 @@ class TestDelayedSchema(TestCase, TestXmlMixin):
         group_schema = schema.group_schemas[0]
         self.assertEqual(len(group_schema.items), 2)
 
-        schema = FormExportDataSchema.generate_schema_from_builds(
+        schema = FormExportDataSchema.generate_schema(
             self.domain,
             self.current_app._id,
             self.xmlns,
@@ -933,7 +933,7 @@ class TestCaseDelayedSchema(TestCase, TestXmlMixin):
         delete_all_export_data_schemas()
 
     def test_basic_delayed_schema(self):
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             self.domain,
             self.current_app._id,
             self.case_type,
@@ -944,7 +944,7 @@ class TestCaseDelayedSchema(TestCase, TestXmlMixin):
         group_schema = schema.group_schemas[0]
         self.assertEqual(len(group_schema.items), 2)
 
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             self.domain,
             self.current_app._id,
             self.case_type,
@@ -991,7 +991,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
         delete_all_export_data_schemas()
 
     def test_basic_application_schema(self):
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             self.domain,
             self.current_app._id,
             self.case_type,
@@ -1007,7 +1007,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
     def test_build_from_saved_schema(self):
         app = self.current_app
 
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             app.domain,
             app._id,
             self.case_type,
@@ -1031,7 +1031,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
             second_build.save()
         self.addCleanup(second_build.delete)
 
-        new_schema = CaseExportDataSchema.generate_schema_from_builds(
+        new_schema = CaseExportDataSchema.generate_schema(
             app.domain,
             app._id,
             self.case_type,
@@ -1047,7 +1047,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
     def test_build_with_inferred_schema(self):
         app = self.current_app
 
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             app.domain,
             app._id,
             self.case_type,
@@ -1063,7 +1063,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
             ['question2', 'new-property'],
         )
 
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             app.domain,
             app._id,
             self.case_type,
@@ -1076,7 +1076,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
 
     @patch('corehq.apps.export.models.new.get_case_types_for_domain', return_value=(case_type,))
     def test_build_with_bulk_schema(self, _):
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             self.domain,
             self.current_app._id,
             ALL_CASE_TYPE_EXPORT
@@ -1133,7 +1133,7 @@ class TestBuildingCaseSchemaFromMultipleApplications(TestCase, TestXmlMixin):
         delete_all_export_data_schemas()
 
     def test_multiple_app_schema_generation(self):
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             self.domain,
             self.current_app._id,
             self.case_type,
@@ -1184,7 +1184,7 @@ class TestBuildingParentCaseSchemaFromApplication(TestCase, TestXmlMixin):
         Ensures that the child case generates a parent case table and indices
         columns in main table
         """
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             self.domain,
             self.current_app._id,
             'child-case',
@@ -1205,7 +1205,7 @@ class TestBuildingParentCaseSchemaFromApplication(TestCase, TestXmlMixin):
 
     def test_parent_case_table_generation_for_parent_case(self):
         """Ensures that the parent case doesn't have a parent case table"""
-        schema = CaseExportDataSchema.generate_schema_from_builds(
+        schema = CaseExportDataSchema.generate_schema(
             self.domain,
             self.current_app._id,
             self.case_type,

--- a/corehq/apps/export/tests/test_export_form_subcases.py
+++ b/corehq/apps/export/tests/test_export_form_subcases.py
@@ -61,7 +61,7 @@ class TestFormExportSubcases(TestCase, TestXmlMixin):
         super(TestFormExportSubcases, cls).tearDownClass()
 
     def test(self):
-        schema = FormExportDataSchema.generate_schema_from_builds(
+        schema = FormExportDataSchema.generate_schema(
             self.domain,
             self.app._id,
             self.form_xmlns,

--- a/corehq/apps/export/tests/test_export_form_subcases.py
+++ b/corehq/apps/export/tests/test_export_form_subcases.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from django.test import TestCase

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -297,7 +297,7 @@ class BaseExportView(BaseProjectDataView):
 
     @memoized
     def get_export_schema(self, domain, app_id, identifier):
-        return self.export_schema_cls.generate_schema_from_builds(
+        return self.export_schema_cls.generate_schema(
             domain,
             app_id,
             identifier,

--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -456,7 +456,7 @@ def case_property_names(request, domain, case_id):
     # We need to look at the export schema in order to remove any case properties that
     # have been deleted from the app. When the data dictionary is fully public, we can use that
     # so that users may deprecate those properties manually
-    export_schema = CaseExportDataSchema.generate_schema_from_builds(domain, None, case.type)
+    export_schema = CaseExportDataSchema.generate_schema(domain, None, case.type)
     property_schema = export_schema.group_schemas[0]
     last_app_ids = get_latest_app_ids_and_versions(domain)
     all_property_names = {

--- a/corehq/apps/userreports/app_manager/helpers.py
+++ b/corehq/apps/userreports/app_manager/helpers.py
@@ -37,7 +37,11 @@ def get_case_data_source(app, case_type):
     # the first two (row number and case id) are redundant/export specific,
     meta_properties_to_use = MAIN_CASE_TABLE_PROPERTIES[2:]
     # anything with a transform should also be removed
-    meta_properties_to_use = [property_def for property_def in meta_properties_to_use if property_def.item.transform is None]
+    meta_properties_to_use = [
+        property_def
+        for property_def in meta_properties_to_use
+        if property_def.item.transform is None
+    ]
     meta_indicators = [_export_column_to_ucr_indicator(c) for c in meta_properties_to_use]
     dynamic_indicators = _get_dynamic_indicators_from_export_schema(schema)
     # filter out any duplicately defined columns from dynamic indicators

--- a/corehq/apps/userreports/app_manager/helpers.py
+++ b/corehq/apps/userreports/app_manager/helpers.py
@@ -28,7 +28,7 @@ def get_case_data_sources(app):
 
 
 def get_case_data_source(app, case_type):
-    schema = CaseExportDataSchema.generate_schema_from_builds(
+    schema = CaseExportDataSchema.generate_schema(
         app.domain,
         app._id,
         case_type,
@@ -71,7 +71,7 @@ def get_form_data_sources(app):
 
 def get_form_data_source(app, form):
     xform = XForm(form.source, domain=app.domain)
-    schema = FormExportDataSchema.generate_schema_from_builds(
+    schema = FormExportDataSchema.generate_schema(
         app.domain,
         app._id,
         xform.data_node.tag_xmlns,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Currently when we create or edit a case export, we pull columns from apps, data dictionary and form other places like imports.
Iterating apps in the project space puts a considerable load. Since now we have data dictionary on all projects that already have all the case types & properties available, it makes iterating apps redundant.

So, we can now change case exports to only use data dictionary to generate columns for case export. 
We will still include information from areas other than apps and just avoid iterating apps.

This PR just adds code changes to make it possible to skip app iterations for case exports but these changes won't be used right now and will be taken in a follow up PR. So, there will be no user facing change as a result of this PR.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3449
https://docs.google.com/document/d/1ovZMTQsBoVYrXj1LRnfdSkhA-9GgJh0rkbDqdnqn_eY/edit
This PR just sets up to make it possible to limit case schemas to be generated from DD only.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally that new case export can be created just fine when apps are skipped.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests will be added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA Planned since there is no functional change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
