### PR TITLE
[B5] builds app: migrate EditMenuView

### DIFF
--- a/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
@@ -1,4 +1,4 @@
-{% extends 'hqwebapp/bootstrap3/base_page.html' %}
+{% extends 'hqwebapp/bootstrap5/base_page.html' %}
 {% load hq_shared_tags %}
 {% load compress %}
 {% load i18n %}

--- a/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
@@ -19,7 +19,7 @@
   <div class="card-body">
     <h5 class="card-title">{% trans "Menu Options" %}</h5>
     <div class="card-text">
-      <form id="menu-form" class="form-horizontal" action="." method="POST">{% csrf_token %}
+      <form id="menu-form" method="POST">{% csrf_token %}
         <table id="menu-table" class="table table-striped">
           <thead>
           <tr>
@@ -51,44 +51,34 @@
             </td>
           </tr>
           </tbody>
-          <tr>
-            <td colspan="5">
-              <button data-bind="click: addVersion" class="btn btn-outline-primary">
-                <i class="fa fa-plus"></i>
-                {% trans "Add a Version" %}
-              </button>
-            </td>
-          </tr>
         </table>
+        <button data-bind="click: addVersion" class="btn btn-outline-primary">
+          <i class="fa fa-plus"></i>
+          {% trans "Add a Version" %}
+        </button>
 
         <hr/>
 
         <fieldset>
           <legend>Defaults</legend>
-          <div class="form-group">
-            <label class="form-label col-md-3" for="select-default-1">
+          <div class="mb-3">
+            <label class="form-label" for="select-default-1">
               {% trans "Default 1.x Build" %}
             </label>
-            <div class="col-md-8">
-              <select class="form-control" id="select-default-1" data-bind="
-                                  options: available_ones,
-                                  value: default_one"></select>
-            </div>
+            <select class="form-control" id="select-default-1" data-bind="
+                                options: available_ones,
+                                value: default_one"></select>
           </div>
-          <div class="form-group">
-            <label class="form-label col-md-3" for="select-default-2">
+          <div class="mb-3">
+            <label class="form-label" for="select-default-2">
               {% trans "Default 2.x Build" %}
             </label>
-            <div class="col-md-8">
-              <select class="form-control" id="select-default-2" data-bind="
-                                      options: available_twos,
-                                      value: default_two"></select>
-            </div>
+            <select class="form-control" id="select-default-2" data-bind="
+                                    options: available_twos,
+                                    value: default_two"></select>
           </div>
-          <div class="form-actions">
-            <div class="col-sm-offset-3">
-              <button class="btn btn-primary" type="button">Update Menu Options</button>
-            </div>
+          <div class="mb-3">
+            <button class="btn btn-primary" type="button">{% trans "Update Menu Options" %}</button>
           </div>
         </fieldset>
       </form>
@@ -104,36 +94,29 @@
       {% trans "Import a new build from the build server" %}
     </h5>
     <div class="card-text">
-      <form class="form-horizontal" action="{% url 'import_build' %}" method="post">
+      <form action="{% url 'import_build' %}" method="post">
         {% csrf_token %}
-        <div class="form-group">
-          <label class="form-label col-md-3" for="import_build_version">
+        <div class="mb-3">
+          <label class="form-label" for="import_build_version">
             {% trans "Version" %}
           </label>
-          <div class="col-md-8">
-            <input id="import_build_version" type="text" name="version" class="form-control"/>
-            <ol class="help-block">
-              <li>
-                <a href="https://github.com/dimagi/commcare-android/releases" target="_blank">
-                  {% trans "Browse versions" %}
-                </a>
-              </li>
-              <li>{% trans "Paste the latest version in the box above in the format x.y.z" %}</li>
-              <li>{% trans "Click Import Build" %}</li>
-              <li>
-                {% blocktrans %}
-                You can also automatically fetch the latest build from GitHub using the following management command:
-                <b>./manage.py add_commcare_build --latest </b>
-                {% endblocktrans %}
-              </li>
-            </ol>
-          </div>
-        </div>
-        <div class="form-actions">
-          <div class="col-sm-offset-3">
-            <button type="submit" class="btn btn-primary">{% trans "Import Build" %}</button>
-          </div>
-        </div>
+          <input id="import_build_version" type="text" name="version" class="form-control"/>
+          <ol class="help-block">
+            <li>
+              <a href="https://github.com/dimagi/commcare-android/releases" target="_blank">
+                {% trans "Browse versions" %}
+              </a>
+            </li>
+            <li>{% trans "Paste the latest version in the box above in the format x.y.z" %}</li>
+            <li>{% trans "Click Import Build" %}</li>
+            <li>
+              {% blocktrans %}
+              You can also automatically fetch the latest build from GitHub using the following management command:
+              <b>./manage.py add_commcare_build --latest </b>
+              {% endblocktrans %}
+            </li>
+          </ol>
+          <button type="submit" class="btn btn-primary">{% trans "Import Build" %}</button>
       </form>
     </div>
   </div>

--- a/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
@@ -15,7 +15,7 @@
 <div class="alert alert-info"><strong>{% trans "Editing" %} {{ doc.ID }}</strong></div>
 
 
-<div class="card">
+<div class="card mb-4">
   <div class="card-header">{% trans "Menu Options" %}</div>
   <div class="card-body">
     <div class="card-text">
@@ -88,7 +88,7 @@
     </div>
   </div>
 </div>
-<div class="card">
+<div class="card mb-4">
   <div class="card-header">{% trans "Import a new build from the build server" %}</div>
   <div class="card-body">
     <div class="card-text">

--- a/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
@@ -40,7 +40,7 @@
             </select>
           </td>
           <td>
-            <input class="form-control" type="text" data-bind="value: badge">
+            <input class="form-control" type="text" data-bind="value: label">
           </td>
           <td>
             <input type="checkbox" value="superuser-only" data-bind="checked: superuser_only"/>

--- a/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
@@ -16,8 +16,8 @@
 
 
 <div class="card">
+  <div class="card-header">{% trans "Menu Options" %}</div>
   <div class="card-body">
-    <h5 class="card-title">{% trans "Menu Options" %}</h5>
     <div class="card-text">
       <form id="menu-form" method="POST">{% csrf_token %}
         <table id="menu-table" class="table table-striped">
@@ -89,10 +89,8 @@
   </div>
 </div>
 <div class="card">
+  <div class="card-header">{% trans "Import a new build from the build server" %}</div>
   <div class="card-body">
-    <h5 class="card-title">
-      {% trans "Import a new build from the build server" %}
-    </h5>
     <div class="card-text">
       <form action="{% url 'import_build' %}" method="post">
         {% csrf_token %}

--- a/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/bootstrap5/edit_menu.html
@@ -15,127 +15,127 @@
 <div class="alert alert-info"><strong>{% trans "Editing" %} {{ doc.ID }}</strong></div>
 
 
-<div class="card card-default">
-  <div class="card-header">
-    <h3 class="card-title">{% trans "Menu Options" %}</h3>
-  </div>
+<div class="card">
   <div class="card-body">
-    <form id="menu-form" class="form-horizontal" action="." method="POST">{% csrf_token %}
-      <table id="menu-table" class="table table-striped">
-        <thead>
-        <tr>
-          <th>{% trans "Version" %}</th>
-          <th>{% trans "Label" %}</th>
-          <th>{% trans "Superuser Only" %}</th>
-          <th></th>
-        </tr>
-        </thead>
-        <tbody data-bind="foreach: versions">
-        <tr>
-          <td>
-            <select class="form-control" data-bind="
-                                    options: $root.available_versions,
-                                    value: version
-                                ">
-            </select>
-          </td>
-          <td>
-            <input class="form-control" type="text" data-bind="value: label">
-          </td>
-          <td>
-            <input type="checkbox" value="superuser-only" data-bind="checked: superuser_only"/>
-          </td>
-          <td>
-            <button type="button" class="btn btn-outline-danger" data-bind="click: $root.removeVersion">
-              <i class="fa fa-remove"></i>
-            </button>
-          </td>
-        </tr>
-        </tbody>
-        <tr>
-          <td colspan="5">
-            <button data-bind="click: addVersion" class="btn btn-outline-primary">
-              <i class="fa fa-plus"></i>
-              {% trans "Add a Version" %}
-            </button>
-          </td>
-        </tr>
-      </table>
+    <h5 class="card-title">{% trans "Menu Options" %}</h5>
+    <div class="card-text">
+      <form id="menu-form" class="form-horizontal" action="." method="POST">{% csrf_token %}
+        <table id="menu-table" class="table table-striped">
+          <thead>
+          <tr>
+            <th>{% trans "Version" %}</th>
+            <th>{% trans "Label" %}</th>
+            <th>{% trans "Superuser Only" %}</th>
+            <th></th>
+          </tr>
+          </thead>
+          <tbody data-bind="foreach: versions">
+          <tr>
+            <td>
+              <select class="form-control" data-bind="
+                                      options: $root.available_versions,
+                                      value: version
+                                  ">
+              </select>
+            </td>
+            <td>
+              <input class="form-control" type="text" data-bind="value: label">
+            </td>
+            <td>
+              <input type="checkbox" value="superuser-only" data-bind="checked: superuser_only"/>
+            </td>
+            <td>
+              <button type="button" class="btn btn-outline-danger" data-bind="click: $root.removeVersion">
+                <i class="fa fa-remove"></i>
+              </button>
+            </td>
+          </tr>
+          </tbody>
+          <tr>
+            <td colspan="5">
+              <button data-bind="click: addVersion" class="btn btn-outline-primary">
+                <i class="fa fa-plus"></i>
+                {% trans "Add a Version" %}
+              </button>
+            </td>
+          </tr>
+        </table>
 
-      <hr/>
+        <hr/>
 
-      <fieldset>
-        <legend>Defaults</legend>
-        <div class="form-group">
-          <label class="form-label col-md-3" for="select-default-1">
-            {% trans "Default 1.x Build" %}
-          </label>
-          <div class="col-md-8">
-            <select class="form-control" id="select-default-1" data-bind="
-                                options: available_ones,
-                                value: default_one"></select>
+        <fieldset>
+          <legend>Defaults</legend>
+          <div class="form-group">
+            <label class="form-label col-md-3" for="select-default-1">
+              {% trans "Default 1.x Build" %}
+            </label>
+            <div class="col-md-8">
+              <select class="form-control" id="select-default-1" data-bind="
+                                  options: available_ones,
+                                  value: default_one"></select>
+            </div>
           </div>
-        </div>
+          <div class="form-group">
+            <label class="form-label col-md-3" for="select-default-2">
+              {% trans "Default 2.x Build" %}
+            </label>
+            <div class="col-md-8">
+              <select class="form-control" id="select-default-2" data-bind="
+                                      options: available_twos,
+                                      value: default_two"></select>
+            </div>
+          </div>
+          <div class="form-actions">
+            <div class="col-sm-offset-3">
+              <button class="btn btn-primary" type="button">Update Menu Options</button>
+            </div>
+          </div>
+        </fieldset>
+      </form>
+      <form id="submit-menu-form" method="POST">
+        {% csrf_token %}
+      </form>
+    </div>
+  </div>
+</div>
+<div class="card">
+  <div class="card-body">
+    <h5 class="card-title">
+      {% trans "Import a new build from the build server" %}
+    </h5>
+    <div class="card-text">
+      <form class="form-horizontal" action="{% url 'import_build' %}" method="post">
+        {% csrf_token %}
         <div class="form-group">
-          <label class="form-label col-md-3" for="select-default-2">
-            {% trans "Default 2.x Build" %}
+          <label class="form-label col-md-3" for="import_build_version">
+            {% trans "Version" %}
           </label>
           <div class="col-md-8">
-            <select class="form-control" id="select-default-2" data-bind="
-                                    options: available_twos,
-                                    value: default_two"></select>
+            <input id="import_build_version" type="text" name="version" class="form-control"/>
+            <ol class="help-block">
+              <li>
+                <a href="https://github.com/dimagi/commcare-android/releases" target="_blank">
+                  {% trans "Browse versions" %}
+                </a>
+              </li>
+              <li>{% trans "Paste the latest version in the box above in the format x.y.z" %}</li>
+              <li>{% trans "Click Import Build" %}</li>
+              <li>
+                {% blocktrans %}
+                You can also automatically fetch the latest build from GitHub using the following management command:
+                <b>./manage.py add_commcare_build --latest </b>
+                {% endblocktrans %}
+              </li>
+            </ol>
           </div>
         </div>
         <div class="form-actions">
           <div class="col-sm-offset-3">
-            <button class="btn btn-primary" type="button">Update Menu Options</button>
+            <button type="submit" class="btn btn-primary">{% trans "Import Build" %}</button>
           </div>
         </div>
-      </fieldset>
-    </form>
-    <form id="submit-menu-form" method="POST">
-      {% csrf_token %}
-    </form>
-  </div>
-</div>
-<div class="card card-default">
-  <div class="card-header">
-    <h3 class="card-title">
-      {% trans "Import a new build from the build server" %}
-    </h3>
-  </div>
-  <div class="card-body">
-    <form class="form-horizontal" action="{% url 'import_build' %}" method="post">
-      {% csrf_token %}
-      <div class="form-group">
-        <label class="form-label col-md-3" for="import_build_version">
-          {% trans "Version" %}
-        </label>
-        <div class="col-md-8">
-          <input id="import_build_version" type="text" name="version" class="form-control"/>
-          <ol class="help-block">
-            <li>
-              <a href="https://github.com/dimagi/commcare-android/releases" target="_blank">
-                {% trans "Browse versions" %}
-              </a>
-            </li>
-            <li>{% trans "Paste the latest version in the box above in the format x.y.z" %}</li>
-            <li>{% trans "Click Import Build" %}</li>
-            <li>
-              {% blocktrans %}
-              You can also automatically fetch the latest build from GitHub using the following management command:
-              <b>./manage.py add_commcare_build --latest </b>
-              {% endblocktrans %}
-            </li>
-          </ol>
-        </div>
-      </div>
-      <div class="form-actions">
-        <div class="col-sm-offset-3">
-          <button type="submit" class="btn btn-primary">{% trans "Import Build" %}</button>
-        </div>
-      </div>
-    </form>
+      </form>
+    </div>
   </div>
 </div>
 

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -13,6 +13,7 @@ from dimagi.utils.web import json_request, json_response
 
 from corehq.apps.api.models import require_api_user
 from corehq.apps.domain.decorators import require_superuser
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.util.view_utils import json_error
 
@@ -56,11 +57,12 @@ def get_all(request):
 
 
 class EditMenuView(BasePageView):
-    template_name = "builds/bootstrap3/edit_menu.html"
+    template_name = "builds/bootstrap5/edit_menu.html"
     urlname = 'edit_menu'
     doc_id = "config--commcare-builds"
     page_title = gettext_lazy("Edit CommCare Builds")
 
+    @use_bootstrap5
     @method_decorator(require_superuser)
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/builds/edit_menu.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/builds/edit_menu.html.diff.txt
@@ -62,7 +62,7 @@
 -          </td>
 -        </tr>
 -      </table>
-+<div class="card">
++<div class="card mb-4">
 +  <div class="card-header">{% trans "Menu Options" %}</div>
 +  <div class="card-body">
 +    <div class="card-text">
@@ -173,7 +173,7 @@
 -          {% trans "Version" %}
 -        </label>
 -        <div class="col-sm-8">
-+<div class="card">
++<div class="card mb-4">
 +  <div class="card-header">{% trans "Import a new build from the build server" %}</div>
 +  <div class="card-body">
 +    <div class="card-text">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/builds/edit_menu.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/builds/edit_menu.html.diff.txt
@@ -12,7 +12,7 @@
  
  {% block page_title %}
  {% trans "Editing CommCare Builds" %}
-@@ -15,103 +15,91 @@
+@@ -15,103 +15,89 @@
  <div class="alert alert-info"><strong>{% trans "Editing" %} {{ doc.ID }}</strong></div>
  
  
@@ -63,8 +63,8 @@
 -        </tr>
 -      </table>
 +<div class="card">
++  <div class="card-header">{% trans "Menu Options" %}</div>
 +  <div class="card-body">
-+    <h5 class="card-title">{% trans "Menu Options" %}</h5>
 +    <div class="card-text">
 +      <form id="menu-form" method="POST">{% csrf_token %}
 +        <table id="menu-table" class="table table-striped">
@@ -162,10 +162,7 @@
 -<div class="panel panel-default">
 -  <div class="panel-heading">
 -    <h3 class="panel-title">
-+<div class="card">
-+  <div class="card-body">
-+    <h5 class="card-title">
-       {% trans "Import a new build from the build server" %}
+-      {% trans "Import a new build from the build server" %}
 -    </h3>
 -  </div>
 -  <div class="panel-body">
@@ -176,7 +173,9 @@
 -          {% trans "Version" %}
 -        </label>
 -        <div class="col-sm-8">
-+    </h5>
++<div class="card">
++  <div class="card-header">{% trans "Import a new build from the build server" %}</div>
++  <div class="card-body">
 +    <div class="card-text">
 +      <form action="{% url 'import_build' %}" method="post">
 +        {% csrf_token %}
@@ -187,7 +186,7 @@
            <input id="import_build_version" type="text" name="version" class="form-control"/>
            <ol class="help-block">
              <li>
-@@ -128,14 +116,9 @@
+@@ -128,14 +114,9 @@
                {% endblocktrans %}
              </li>
            </ol>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/builds/edit_menu.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/builds/edit_menu.html.diff.txt
@@ -1,6 +1,9 @@
 --- 
 +++ 
-@@ -3,7 +3,7 @@
+@@ -1,9 +1,9 @@
+-{% extends 'hqwebapp/bootstrap3/base_page.html' %}
++{% extends 'hqwebapp/bootstrap5/base_page.html' %}
+ {% load hq_shared_tags %}
  {% load compress %}
  {% load i18n %}
  
@@ -9,96 +12,195 @@
  
  {% block page_title %}
  {% trans "Editing CommCare Builds" %}
-@@ -15,11 +15,11 @@
+@@ -15,103 +15,91 @@
  <div class="alert alert-info"><strong>{% trans "Editing" %} {{ doc.ID }}</strong></div>
  
  
 -<div class="panel panel-default">
 -  <div class="panel-heading">
 -    <h3 class="panel-title">{% trans "Menu Options" %}</h3>
-+<div class="card card-default">
-+  <div class="card-header">
-+    <h3 class="card-title">{% trans "Menu Options" %}</h3>
-   </div>
+-  </div>
 -  <div class="panel-body">
-+  <div class="card-body">
-     <form id="menu-form" class="form-horizontal" action="." method="POST">{% csrf_token %}
-       <table id="menu-table" class="table table-striped">
-         <thead>
-@@ -40,13 +40,13 @@
-             </select>
-           </td>
-           <td>
+-    <form id="menu-form" class="form-horizontal" action="." method="POST">{% csrf_token %}
+-      <table id="menu-table" class="table table-striped">
+-        <thead>
+-        <tr>
+-          <th>{% trans "Version" %}</th>
+-          <th>{% trans "Label" %}</th>
+-          <th>{% trans "Superuser Only" %}</th>
+-          <th></th>
+-        </tr>
+-        </thead>
+-        <tbody data-bind="foreach: versions">
+-        <tr>
+-          <td>
+-            <select class="form-control" data-bind="
+-                                    options: $root.available_versions,
+-                                    value: version
+-                                ">
+-            </select>
+-          </td>
+-          <td>
 -            <input class="form-control" type="text" data-bind="value: label">
-+            <input class="form-control" type="text" data-bind="value: badge">
-           </td>
-           <td>
-             <input type="checkbox" value="superuser-only" data-bind="checked: superuser_only"/>
-           </td>
-           <td>
+-          </td>
+-          <td>
+-            <input type="checkbox" value="superuser-only" data-bind="checked: superuser_only"/>
+-          </td>
+-          <td>
 -            <button type="button" class="btn btn-danger" data-bind="click: $root.removeVersion">
-+            <button type="button" class="btn btn-outline-danger" data-bind="click: $root.removeVersion">
-               <i class="fa fa-remove"></i>
-             </button>
-           </td>
-@@ -54,7 +54,7 @@
-         </tbody>
-         <tr>
-           <td colspan="5">
+-              <i class="fa fa-remove"></i>
+-            </button>
+-          </td>
+-        </tr>
+-        </tbody>
+-        <tr>
+-          <td colspan="5">
 -            <button data-bind="click: addVersion" class="btn btn-default">
-+            <button data-bind="click: addVersion" class="btn btn-outline-primary">
-               <i class="fa fa-plus"></i>
-               {% trans "Add a Version" %}
-             </button>
-@@ -67,20 +67,20 @@
-       <fieldset>
-         <legend>Defaults</legend>
-         <div class="form-group">
+-              <i class="fa fa-plus"></i>
+-              {% trans "Add a Version" %}
+-            </button>
+-          </td>
+-        </tr>
+-      </table>
++<div class="card">
++  <div class="card-body">
++    <h5 class="card-title">{% trans "Menu Options" %}</h5>
++    <div class="card-text">
++      <form id="menu-form" method="POST">{% csrf_token %}
++        <table id="menu-table" class="table table-striped">
++          <thead>
++          <tr>
++            <th>{% trans "Version" %}</th>
++            <th>{% trans "Label" %}</th>
++            <th>{% trans "Superuser Only" %}</th>
++            <th></th>
++          </tr>
++          </thead>
++          <tbody data-bind="foreach: versions">
++          <tr>
++            <td>
++              <select class="form-control" data-bind="
++                                      options: $root.available_versions,
++                                      value: version
++                                  ">
++              </select>
++            </td>
++            <td>
++              <input class="form-control" type="text" data-bind="value: label">
++            </td>
++            <td>
++              <input type="checkbox" value="superuser-only" data-bind="checked: superuser_only"/>
++            </td>
++            <td>
++              <button type="button" class="btn btn-outline-danger" data-bind="click: $root.removeVersion">
++                <i class="fa fa-remove"></i>
++              </button>
++            </td>
++          </tr>
++          </tbody>
++        </table>
++        <button data-bind="click: addVersion" class="btn btn-outline-primary">
++          <i class="fa fa-plus"></i>
++          {% trans "Add a Version" %}
++        </button>
+ 
+-      <hr/>
++        <hr/>
+ 
+-      <fieldset>
+-        <legend>Defaults</legend>
+-        <div class="form-group">
 -          <label class="control-label col-sm-3" for="select-default-1">
-+          <label class="form-label col-md-3" for="select-default-1">
-             {% trans "Default 1.x Build" %}
-           </label>
+-            {% trans "Default 1.x Build" %}
+-          </label>
 -          <div class="col-sm-8">
-+          <div class="col-md-8">
++        <fieldset>
++          <legend>Defaults</legend>
++          <div class="mb-3">
++            <label class="form-label" for="select-default-1">
++              {% trans "Default 1.x Build" %}
++            </label>
              <select class="form-control" id="select-default-1" data-bind="
                                  options: available_ones,
                                  value: default_one"></select>
            </div>
-         </div>
-         <div class="form-group">
+-        </div>
+-        <div class="form-group">
 -          <label class="control-label col-sm-3" for="select-default-2">
-+          <label class="form-label col-md-3" for="select-default-2">
-             {% trans "Default 2.x Build" %}
-           </label>
+-            {% trans "Default 2.x Build" %}
+-          </label>
 -          <div class="col-sm-8">
-+          <div class="col-md-8">
++          <div class="mb-3">
++            <label class="form-label" for="select-default-2">
++              {% trans "Default 2.x Build" %}
++            </label>
              <select class="form-control" id="select-default-2" data-bind="
                                      options: available_twos,
                                      value: default_two"></select>
-@@ -98,20 +98,20 @@
-     </form>
+           </div>
+-        </div>
+-        <div class="form-actions">
+-          <div class="col-sm-offset-3">
+-            <button class="btn btn-primary" type="button">Update Menu Options</button>
++          <div class="mb-3">
++            <button class="btn btn-primary" type="button">{% trans "Update Menu Options" %}</button>
+           </div>
+-        </div>
+-      </fieldset>
+-    </form>
+-    <form id="submit-menu-form" method="POST">
+-      {% csrf_token %}
+-    </form>
++        </fieldset>
++      </form>
++      <form id="submit-menu-form" method="POST">
++        {% csrf_token %}
++      </form>
++    </div>
    </div>
  </div>
 -<div class="panel panel-default">
 -  <div class="panel-heading">
 -    <h3 class="panel-title">
-+<div class="card card-default">
-+  <div class="card-header">
-+    <h3 class="card-title">
-       {% trans "Import a new build from the build server" %}
-     </h3>
-   </div>
--  <div class="panel-body">
++<div class="card">
 +  <div class="card-body">
-     <form class="form-horizontal" action="{% url 'import_build' %}" method="post">
-       {% csrf_token %}
-       <div class="form-group">
++    <h5 class="card-title">
+       {% trans "Import a new build from the build server" %}
+-    </h3>
+-  </div>
+-  <div class="panel-body">
+-    <form class="form-horizontal" action="{% url 'import_build' %}" method="post">
+-      {% csrf_token %}
+-      <div class="form-group">
 -        <label class="control-label col-sm-3" for="import_build_version">
-+        <label class="form-label col-md-3" for="import_build_version">
-           {% trans "Version" %}
-         </label>
+-          {% trans "Version" %}
+-        </label>
 -        <div class="col-sm-8">
-+        <div class="col-md-8">
++    </h5>
++    <div class="card-text">
++      <form action="{% url 'import_build' %}" method="post">
++        {% csrf_token %}
++        <div class="mb-3">
++          <label class="form-label" for="import_build_version">
++            {% trans "Version" %}
++          </label>
            <input id="import_build_version" type="text" name="version" class="form-control"/>
            <ol class="help-block">
              <li>
+@@ -128,14 +116,9 @@
+               {% endblocktrans %}
+             </li>
+           </ol>
+-        </div>
+-      </div>
+-      <div class="form-actions">
+-        <div class="col-sm-offset-3">
+           <button type="submit" class="btn btn-primary">{% trans "Import Build" %}</button>
+-        </div>
+-      </div>
+-    </form>
++      </form>
++    </div>
+   </div>
+ </div>
+ 


### PR DESCRIPTION
## Product Summary

before
<img width="1050" alt="Screenshot 2024-03-11 at 2 42 47 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/ad0b6ac6-de94-4b7d-a331-810b217de787">
<img width="1052" alt="Screenshot 2024-03-11 at 2 43 01 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/e874cbcf-921b-4796-8623-f73734cd7a16">

after

<img width="1088" alt="Screenshot 2024-03-12 at 11 33 52 AM" src="https://github.com/dimagi/commcare-hq/assets/1486591/387ff69d-023d-44af-9d34-c6704df2ca4c">
<img width="1088" alt="Screenshot 2024-03-12 at 11 33 57 AM" src="https://github.com/dimagi/commcare-hq/assets/1486591/fafcf674-a8c2-4d7f-85e1-3c6ad626a912">

Initial migration PR: https://github.com/dimagi/commcare-hq/pull/34258

## Safety Assurance

### Safety story
This is a superuser-only view and not used often. Tested changes locally and on staging.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
