### PR TITLE
Update Data Dictionary Delete Confirmation Modals

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("data_dictionary/js/data_dictionary", [
     "jquery",
     "knockout",
@@ -172,6 +173,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
         self.confirmDeleteProperty = function () {
             const $modal = $("#delete-case-prop-modal").modal('show');
+            $("#delete-case-prop-name").text(self.name);
             $("#delete-case-prop-btn").off("click").on("click", () => {
                 self.deleted(true);
                 $modal.modal('hide');

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
@@ -107,7 +107,11 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
                 <h4 class="modal-title">
-                    {% trans 'Delete Case Property' %}
+                    {% blocktrans %}
+                        Delete
+                        '<span id="delete-case-prop-name"></span>'
+                        Case Property
+                    {% endblocktrans %}
                 </h4>
             </div>
             <div class="modal-body">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
@@ -113,7 +113,16 @@
             <div class="modal-body">
                 <p>
                     {% blocktrans %}
-                        There are currently no cases that store data with this case property, and so it is safe to delete.
+                        There are currently no cases that store data with this case property, so it is safe to delete.
+                    {% endblocktrans %}
+                </p>
+                <p>
+                    {% blocktrans %}
+                        Please note that there may be a lag of up to 10 minutes associated with this action. If a new form
+                        or case is updated to the server during this time that makes this property unsafe to delete, this will
+                        only be reflected in the Data Dictionary after the expected time. Please refer to
+                        <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary" target="_blank">the documentation</a>
+                        for additional information about this action.
                     {% endblocktrans %}
                 </p>
                 <p>
@@ -162,6 +171,11 @@
                 <p>
                     {% blocktrans %}
                     Please note however, that all case properties for this case type will also be deleted.
+                    Furthermore, there may be a lag of up to 10 minutes associated with this action. If a new form
+                    or case is updated to the server during this time that makes this property unsafe to delete, this will
+                    only be reflected in the Data Dictionary after the expected time. Please refer to
+                    <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary" target="_blank">the documentation</a>
+                    for additional information about this action.
                     {% endblocktrans %}
                 </p>
                 <p>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
@@ -118,7 +118,7 @@
                 </p>
                 <p>
                     {% blocktrans %}
-                        Please note that there may be a lag of up to 10 minutes associated with this action. If a new form
+                        Please note that there may be a delay of up to 10 minutes associated with this action. If a new form
                         or case is updated to the server during this time that makes this property unsafe to delete, this will
                         only be reflected in the Data Dictionary after the expected time. Please refer to
                         <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary" target="_blank">the documentation</a>
@@ -171,7 +171,7 @@
                 <p>
                     {% blocktrans %}
                     Please note however, that all case properties for this case type will also be deleted.
-                    Furthermore, there may be a lag of up to 10 minutes associated with this action. If a new form
+                    Furthermore, there may be a delay of up to 10 minutes associated with this action. If a new form
                     or case is updated to the server during this time that makes this property unsafe to delete, this will
                     only be reflected in the Data Dictionary after the expected time. Please refer to
                     <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary" target="_blank">the documentation</a>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
@@ -122,11 +122,11 @@
                 </p>
                 <p>
                     {% blocktrans %}
-                        Please note that there may be a delay of up to 10 minutes associated with this action. If a new form
-                        or case is updated to the server during this time that makes this property unsafe to delete, this will
-                        only be reflected in the Data Dictionary after the expected time. Please refer to
-                        <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary" target="_blank">the documentation</a>
-                        for additional information about this action.
+                    Please note that if a new form or case was updated to the server recently that makes this property
+                    unsafe to delete, this will only be reflected in the Data Dictionary after a short while. This is not
+                    a blocking action and the case property can be created again if needed in the future. Please refer to
+                    <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary" target="_blank">the documentation</a>
+                    for additional information about this action.
                     {% endblocktrans %}
                 </p>
                 <p>
@@ -174,10 +174,10 @@
                 </p>
                 <p>
                     {% blocktrans %}
-                    Please note however, that all case properties for this case type will also be deleted.
-                    Furthermore, there may be a delay of up to 10 minutes associated with this action. If a new form
-                    or case is updated to the server during this time that makes this property unsafe to delete, this will
-                    only be reflected in the Data Dictionary after the expected time. Please refer to
+                    Please note that all case properties for this case type will also be deleted.
+                    Furthermore, if a new form or case was updated to the server recently that makes this case type
+                    unsafe to delete, this will only be reflected in the Data Dictionary after a short while. This is not
+                    a blocking action and the case type can be created again if needed in the future. Please refer to
                     <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary" target="_blank">the documentation</a>
                     for additional information about this action.
                     {% endblocktrans %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The case property delete confirmation modal has been updated to reflect that there is a cache which might delay showing up-to-date results.
**Old:**
![Screenshot from 2024-03-13 15-24-01](https://github.com/dimagi/commcare-hq/assets/122617251/a538e63d-4992-4c97-b394-fafef33d1f5f)

**New:**
![Screenshot from 2024-03-19 15-28-38](https://github.com/dimagi/commcare-hq/assets/122617251/fa94f6a7-4a58-45d1-9b23-4c5fcafa6e94)

Additionally, the confirmation modal for deleting a case type has also been updated in a similar fashion.
**Old:**
![Screenshot from 2024-03-13 15-25-08](https://github.com/dimagi/commcare-hq/assets/122617251/9544b6c4-47da-4ab8-917c-a663ca944bc0)

**New:**
![Screenshot from 2024-03-19 15-28-44](https://github.com/dimagi/commcare-hq/assets/122617251/bf0cfaab-b0b0-450d-b241-5ae57f864c90)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3485).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Wording only change
- Local testing

This change is only applicable to users that have access to the Data Dictionary privilege.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
