### PR TITLE
Default altText to blank

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -426,7 +426,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
             const appId = formplayerUtils.currentUrlToObject().appId;
             return {
                 data: this.options.model.get('data'),
-                altText: this.options.model.get('altText'),
+                altText: this.options.model.get('altText') || '',
                 styles: this.options.styles,
                 isMultiSelect: this.options.isMultiSelect,
                 renderMarkdown: markdown.render,


### PR DESCRIPTION
## Technical Summary
I'm running into issues with an app that I copied from staging to my local environment. I think it's generally a reasonable change to make UI code less prone to crashing when data isn't available (right now this blanks out the whole case list, because underscore errors rendering the template [here](https://github.com/dimagi/commcare-hq/blob/78bd36b8daa3be7a07e87d3e1cbfdf1b789fc35e/corehq/apps/cloudcare/templates/formplayer/case_list.html#L145) and [here](https://github.com/dimagi/commcare-hq/blob/78bd36b8daa3be7a07e87d3e1cbfdf1b789fc35e/corehq/apps/cloudcare/templates/formplayer/case_list.html#L149)), but I'm open to hearing "this is too hacky."

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

doubt it

### QA Plan

not requesting QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
