### PR TITLE
Update Mapbox Streets Layers

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -148,9 +148,33 @@ hqDefine('geospatial/js/models', [
                 });
 
                 self.mapInstance.addLayer({
-                    id: 'landuse_overlay',
+                    id: 'Landuse',
                     source: 'mapbox-streets',
-                    'source-layer': 'landuse_overlay',
+                    'source-layer': 'landuse',
+                    type: 'line',
+                    paint: {
+                        'line-color': '#695447', // brown land color
+                    },
+                    layout: {
+                        'visibility': 'none',
+                    },
+                });
+                self.mapInstance.addLayer({
+                    id: 'Road',
+                    source: 'mapbox-streets',
+                    'source-layer': 'road',
+                    type: 'line',
+                    paint: {
+                        'line-color': '#000000', // black
+                    },
+                    layout: {
+                        'visibility': 'none',
+                    },
+                });
+                self.mapInstance.addLayer({
+                    id: 'Admin',
+                    source: 'mapbox-streets',
+                    'source-layer': 'admin',
                     type: 'line',
                     paint: {
                         'line-color': '#800080', // purple
@@ -159,36 +183,16 @@ hqDefine('geospatial/js/models', [
                         'visibility': 'none',
                     },
                 });
-                self.mapInstance.addLayer({
-                    id: 'road',
-                    source: 'mapbox-streets',
-                    'source-layer': 'road',
-                    type: 'line',
-                    paint: {
-                        'line-color': '#000000', // black
-                    },
-                    'layout': {
-                        'visibility': 'none',
-                    },
-                });
-                self.mapInstance.addLayer({
-                    id: 'admin',
-                    source: 'mapbox-streets',
-                    'source-layer': 'admin',
-                    type: 'line',
-                    paint: {
-                        'line-color': '#800080', // purple
-                    },
-                    'layout': {
-                        'visibility': 'none',
-                    },
-                });
             });
         }
 
         function addLayersToPanel() {
             self.mapInstance.on('idle', () => {
-                const toggleableLayerIds = ['landuse_overlay', 'admin', 'road'];
+                const toggleableLayerIds = [
+                    'Landuse',
+                    'Admin',
+                    'Road',
+                ];
                 const menuElement = document.getElementById('layer-toggle-menu');
                 for (const layerId of toggleableLayerIds) {
                     // Skip if layer doesn't exist or button is already present

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -183,6 +183,30 @@ hqDefine('geospatial/js/models', [
                         'visibility': 'none',
                     },
                 });
+                self.mapInstance.addLayer({
+                    id: 'Building',
+                    source: 'mapbox-streets',
+                    'source-layer': 'building',
+                    type: 'fill',
+                    paint: {
+                        'fill-color': '#808080', // grey
+                    },
+                    layout: {
+                        'visibility': 'none',
+                    },
+                });
+                self.mapInstance.addLayer({
+                    id: 'Waterway',
+                    source: 'mapbox-streets',
+                    'source-layer': 'waterway',
+                    type: 'line',
+                    paint: {
+                        'line-color': '#00008b', // darkblue
+                    },
+                    layout: {
+                        'visibility': 'none',
+                    },
+                });
             });
         }
 
@@ -192,6 +216,8 @@ hqDefine('geospatial/js/models', [
                     'Landuse',
                     'Admin',
                     'Road',
+                    'Building',
+                    'Waterway',
                 ];
                 const menuElement = document.getElementById('layer-toggle-menu');
                 for (const layerId of toggleableLayerIds) {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine('geospatial/js/models', [
     'jquery',
     'knockout',
@@ -29,7 +30,6 @@ hqDefine('geospatial/js/models', [
     };
 
     var MapItem = function (itemId, itemData, marker, markerColors) {
-        'use strict';
         var self = this;
         self.itemId = itemId;
         self.itemData = itemData;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Two new Mapbox Streets layers have been added: Building and Waterway. Additionally, the landuse_overlay layer has been replaced with the Landuse layer:
![Screenshot from 2024-03-14 09-41-19](https://github.com/dimagi/commcare-hq/assets/122617251/e671a5dd-962a-4178-91bd-688d440020ff)

Apart from the layer changes, the names for all existing layers have been capitalized to make them more readable in the UI.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3497).



## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
