### PR TITLE
Cs/sc 3429 geojson form export

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -653,9 +653,6 @@ class TableConfiguration(DocumentSchema, ReadablePathMixin):
 
     def get_column_by_path_str(self, path, doc_type):
         path_nodes = [PathNode(name=node) for node in path.split('.')]
-        if not path_nodes:
-            return None
-
         _, column = self.get_column(item_path=path_nodes, item_doc_type=doc_type, column_transform=None)
         return column
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -651,6 +651,11 @@ class TableConfiguration(DocumentSchema, ReadablePathMixin):
 
         return None, None
 
+    def get_column_by_path_str(self, path, doc_type):
+        path_nodes = [PathNode(name=node) for node in path.split('.')]
+        _, column = self.get_column(item_path=path_nodes, item_doc_type=doc_type, column_transform=None)
+        return column
+
     @memoized
     def get_hyperlink_column_indices(self, split_columns):
         export_column_index = 0
@@ -1277,6 +1282,17 @@ class FormExportInstance(ExportInstance):
                     ):
                         column.label = 'formid'
                         column.selected = True
+
+        if export_instance.export_format == "geojson":
+            for table in export_instance.tables:
+                column = table.get_column_by_path_str(
+                    path=table.selected_geo_property,
+                    doc_type="GeopointItem",
+                )
+                if column and not column.selected:
+                    # ensure the selected_geo_property is selected
+                    column.selected = True
+
         return export_instance
 
     @property

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -832,9 +832,14 @@ class ExportInstance(BlobMixin, Document):
     @classmethod
     def wrap(cls, data):
         from corehq.apps.export.views.utils import clean_odata_columns
+        # This is a temporary solution
+        if data.get('export_format', '') == 'geojson':
+            data['split_multiselects'] = False
+
         export_instance = super(ExportInstance, cls).wrap(data)
         if export_instance.is_odata_config:
             clean_odata_columns(export_instance)
+
         return export_instance
 
     @property

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -653,6 +653,9 @@ class TableConfiguration(DocumentSchema, ReadablePathMixin):
 
     def get_column_by_path_str(self, path, doc_type):
         path_nodes = [PathNode(name=node) for node in path.split('.')]
+        if not path_nodes:
+            return None
+
         _, column = self.get_column(item_path=path_nodes, item_doc_type=doc_type, column_transform=None)
         return column
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -832,7 +832,9 @@ class ExportInstance(BlobMixin, Document):
     @classmethod
     def wrap(cls, data):
         from corehq.apps.export.views.utils import clean_odata_columns
-        # This is a temporary solution
+        # This is a temporary solution to make sure geojson exports have split_multiselects set to false,
+        # otherwise it won't work. Ticket SC-3569 is for making geojson form exports compatible with
+        # the split_multiselects option.
         if data.get('export_format', '') == 'geojson':
             data['split_multiselects'] = False
 

--- a/corehq/apps/export/static/export/js/customize_export_new.js
+++ b/corehq/apps/export/static/export/js/customize_export_new.js
@@ -38,13 +38,16 @@ hqDefine('export/js/customize_export_new', [
             if (exportFormat === constants.EXPORT_FORMATS.GEOJSON) {
                 $("#select-geo-property").show();
                 $("#split-multiselects-checkbox-div").hide();
+                $("#split-multiselects-checkbox").prop("checked", false);
             }
 
             $('#format-select').change(function () {
                 const selectedValue = $(this).val();
                 if (selectedValue === constants.EXPORT_FORMATS.GEOJSON) {
                     $("#select-geo-property").show();
+                    // Hiding and unchecking this checkbox is a temporary measure
                     $("#split-multiselects-checkbox-div").hide();
+                    $("#split-multiselects-checkbox").prop("checked", false);
                 } else {
                     $("#select-geo-property").hide();
                     $("#split-multiselects-checkbox-div").show();

--- a/corehq/apps/export/static/export/js/customize_export_new.js
+++ b/corehq/apps/export/static/export/js/customize_export_new.js
@@ -37,14 +37,17 @@ hqDefine('export/js/customize_export_new', [
             const exportFormat = initialPageData.get('export_instance').export_format;
             if (exportFormat === constants.EXPORT_FORMATS.GEOJSON) {
                 $("#select-geo-property").show();
+                $("#split-multiselects-checkbox-div").hide()
             }
 
             $('#format-select').change(function () {
                 const selectedValue = $(this).val();
                 if (selectedValue === constants.EXPORT_FORMATS.GEOJSON) {
                     $("#select-geo-property").show();
+                    $("#split-multiselects-checkbox-div").hide();
                 } else {
                     $("#select-geo-property").hide();
+                    $("#split-multiselects-checkbox-div").show();
                 }
             });
         }

--- a/corehq/apps/export/static/export/js/customize_export_new.js
+++ b/corehq/apps/export/static/export/js/customize_export_new.js
@@ -37,7 +37,7 @@ hqDefine('export/js/customize_export_new', [
             const exportFormat = initialPageData.get('export_instance').export_format;
             if (exportFormat === constants.EXPORT_FORMATS.GEOJSON) {
                 $("#select-geo-property").show();
-                $("#split-multiselects-checkbox-div").hide()
+                $("#split-multiselects-checkbox-div").hide();
             }
 
             $('#format-select').change(function () {

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -196,7 +196,7 @@
                 </label>
               </div>
 
-              <div class="checkbox">
+              <div id="split-multiselects-checkbox-div" class="checkbox">
                 <label>
                   <input type="checkbox"
                          id="split-multiselects-checkbox"

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -177,9 +177,12 @@ class BaseExportView(BaseProjectDataView):
         format_options = ["xls", "xlsx", "csv"]
 
         should_support_geojson = (
-            self.export_type == CASE_EXPORT
-            and toggles.SUPPORT_GEO_JSON_EXPORT.enabled(self.domain)
-            and not self._is_bulk_export
+            toggles.SUPPORT_GEO_JSON_EXPORT.enabled(self.domain)
+            and (
+                self.export_type == CASE_EXPORT
+                and not self._is_bulk_export
+                or self.export_type == FORM_EXPORT
+            )
         )
         if should_support_geojson:
             format_options.append("geojson")

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -1,5 +1,4 @@
 import json
-
 from django.conf import settings
 from django.contrib import messages
 from django.http import Http404, HttpResponseRedirect, HttpResponse, JsonResponse
@@ -116,7 +115,7 @@ class BaseExportView(BaseProjectDataView):
     def page_context(self):
         owner_id = self.export_instance.owner_id
         number_of_apps_to_process = 0
-        is_all_case_types_export = self._is_bulk_export
+        is_all_case_types_export = self._is_bulk_case_export
         table_count = 0
         if not is_all_case_types_export:
             # Case History table is not a selectable table, so exclude it from count
@@ -156,13 +155,31 @@ class BaseExportView(BaseProjectDataView):
 
     @property
     def _possible_geo_properties(self):
-        if self._is_bulk_export:
+        if not toggles.SUPPORT_GEO_JSON_EXPORT.enabled(self.domain):
+            return []
+        if self._is_bulk_case_export:
             return []
 
         if self.export_type == FORM_EXPORT:
-            # 'location' is the geo-point in the form metadata
-            return ['location']
+            return self._possible_form_geo_properties
+        elif self.export_type == CASE_EXPORT:
+            return self._possible_case_geo_properties
+        return []
 
+    @property
+    def _possible_form_geo_properties(self):
+        export_table = self.export_instance.tables[0]
+        geo_props = []
+
+        for column in export_table.columns:
+            if column.item.doc_type == 'GeopointItem':
+                path_str = '.'.join([f"{node.name}" for node in column.item.path])
+                geo_props.append(path_str)
+
+        return geo_props
+
+    @property
+    def _possible_case_geo_properties(self):
         return list(CaseProperty.objects.filter(
             case_type__domain=self.domain,
             case_type__name=self.export_instance.case_type,
@@ -175,7 +192,7 @@ class BaseExportView(BaseProjectDataView):
 
         should_support_geojson = (
             toggles.SUPPORT_GEO_JSON_EXPORT.enabled(self.domain)
-            and not self._is_bulk_export
+            and not self._is_bulk_case_export
         )
         if should_support_geojson:
             format_options.append("geojson")
@@ -306,10 +323,11 @@ class BaseExportView(BaseProjectDataView):
         return self.export_schema_cls.generate_empty_schema(domain, identifier)
 
     @property
-    def _is_bulk_export(self):
-        if self.export_type is not CASE_EXPORT:
-            return False
-        return self.export_instance.case_type == ALL_CASE_TYPE_EXPORT
+    def _is_bulk_case_export(self):
+        return (
+            self.export_type is CASE_EXPORT
+            and self.export_instance.case_type == ALL_CASE_TYPE_EXPORT
+        )
 
 
 @location_safe

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -173,6 +173,8 @@ class BaseExportView(BaseProjectDataView):
 
         for column in export_table.columns:
             if column.item.doc_type == 'GeopointItem':
+                # show the path to the geo properties, not the column headers, because the
+                # paths do not change.
                 path_str = '.'.join([f"{node.name}" for node in column.item.path])
                 geo_props.append(path_str)
 

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -160,7 +160,8 @@ class BaseExportView(BaseProjectDataView):
     @property
     def _possible_geo_properties(self):
         if self.export_type == FORM_EXPORT:
-            return []
+            # 'location' is the geo-point in the form metadata
+            return ['location']
 
         if self._is_bulk_export:
             return []

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -585,7 +585,7 @@ class GeoJSONWriter(JsonExportWriter):
         geo_property_name = table.selected_geo_property
         table_headers = data[0]
         if geo_property_name not in table_headers:
-            # This might happen for form exports where we store the path to the geo property
+            # This might happen for some form export metadata columns
             geo_property_name = self._find_geo_property_by_path(table)
             if geo_property_name not in table_headers:
                 return []

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -572,14 +572,12 @@ class GeoJSONWriter(JsonExportWriter):
     def _find_geo_property_by_path(table):
         # For form exports we store the path to the geo property, so this is an
         # attempt to find the header by the path specification
-        is_path = len(table.selected_geo_property.split('.')) > 1
-        if is_path:
-            column = table.get_column_by_path_str(
-                path=table.selected_geo_property,
-                doc_type="GeopointItem",
-            )
-            if column:
-                return column.get_headers()[0]
+        column = table.get_column_by_path_str(
+            path=table.selected_geo_property,
+            doc_type="GeopointItem",
+        )
+        if column:
+            return column.get_headers()[0]
 
         return table.selected_geo_property
 

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -568,11 +568,29 @@ class GeoJSONWriter(JsonExportWriter):
             "properties": properties,
         }
 
+    @staticmethod
+    def _find_geo_property_by_path(table):
+        # For form exports we store the path to the geo property, so this is an
+        # attempt to find the header by the path specification
+        is_path = len(table.selected_geo_property.split('.')) > 1
+        if is_path:
+            column = table.get_column_by_path_str(
+                path=table.selected_geo_property,
+                doc_type="GeopointItem",
+            )
+            if column:
+                return column.get_headers()[0]
+
+        return table.selected_geo_property
+
     def get_features(self, table, data):
         geo_property_name = table.selected_geo_property
         table_headers = data[0]
         if geo_property_name not in table_headers:
-            return []
+            # This might happen for form exports where we store the path to the geo property
+            geo_property_name = self._find_geo_property_by_path(table)
+            if geo_property_name not in table_headers:
+                return []
 
         geo_data_index = table_headers.index(geo_property_name)
         features = []


### PR DESCRIPTION
## Product Description
This PR extends the .geojson file export to the form export workflow (case export has been added in [this PR](https://github.com/dimagi/commcare-hq/pull/34000)).

See below for what this looks like...

![form_geojson](https://github.com/dimagi/commcare-hq/assets/44245062/4e99b0d7-f2dc-4156-8dbe-3a9f610edc02)


## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3429)

The "Select geo property" select input **contains the path** to the geo property/attribute on the form. This was decided because using the column header value(s) might be error prone because they can change (the user can change this). Having the user select the path is the best way we can be sure that we know exactly what form property the user is referring to.

Furthermore, the select input will only consider form properties of type "GeopointItem", which is questions which the type set to GPS point (this is also true for the location meta data).

One last thing to note is that if a user selects a geo property, HQ will **always** select it, regardless of the user's choice on the UI. When the user loads the page the column corresponding to the selected geo property will always be checked. (I am still to autoselect it on the UI as soon as the user selects it, but for now it happens in the BE)

## Feature Flag
`SUPPORT_GEO_JSON_EXPORT`

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
I don't think additional automated tests is necessary 

### QA Plan
[QA ticket](https://dimagi.atlassian.net/browse/QA-6203) 

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
