### PR TITLE
Removed jasmine-fixture dependency

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/web_form_session_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/web_form_session_spec.js
@@ -1,5 +1,4 @@
 'use strict';
-/* global affix */
 /* eslint-env mocha */
 hqDefine("cloudcare/js/form_entry/spec/web_form_session_spec", function () {
     describe('WebForm', function () {
@@ -83,15 +82,6 @@ hqDefine("cloudcare/js/form_entry/spec/web_form_session_spec", function () {
             );
 
             beforeEach(function () {
-                // Setup HTML
-                try {
-                    affix('input#submit');
-                    affix('#content');
-                } catch (e) {
-                    // temporarily catch this error while we work out issues running
-                    // mocha tests with grunt-mocha. this passes fine in browser
-                }
-
                 // Setup Params object
                 params = {
                     form_url: window.location.host,
@@ -280,15 +270,6 @@ hqDefine("cloudcare/js/form_entry/spec/web_form_session_spec", function () {
             );
 
             beforeEach(function () {
-                // Setup HTML
-                try {
-                    affix('input#submit');
-                    affix('#content');
-                } catch (e) {
-                    // temporarily catch this error while we work out issues running
-                    // mocha tests with grunt-mocha. this passes fine in browser
-                }
-
                 formJSON = {
                     form_url: window.location.host,
                     onerror: sinon.spy(),

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/form_entry/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/form_entry/mocha.html
@@ -11,7 +11,6 @@
 {% block dependencies %}
   {% include "formplayer/dependencies.html" %}
   <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
-  <script src="{% static 'jasmine-fixture/dist/jasmine-fixture.js' %}"></script>
 {% endblock %}
 
 {% block mocha_tests %}

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
         "grunt-cli": "1.4.3",
         "grunt-contrib-watch": "1.1.0",
         "grunt-mocha": "1.2.0",
-        "jasmine-fixture": "2.0.0",
         "lodash": "4.17.21",
         "mocha": "9.2.2",
         "mocha-headless-chrome": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3012,11 +3012,6 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-jasmine-fixture@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jasmine-fixture/-/jasmine-fixture-2.0.0.tgz#b6d0c5a3bb4834d23dd137464ef96f04f93bbd60"
-  integrity sha1-ttDFo7tINNI90TdGTvlvBPk7vWA=
-
 jquery-color@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jquery-color/-/jquery-color-2.2.0.tgz#2596bb782b69d9368b7840e6b3fe1e70fdd821c3"


### PR DESCRIPTION
## Technical Summary
Troubleshooting requirejs test issues, realized tests pass without this dependency, which has also been enclosed in a try/catch [since 2020](https://github.com/dimagi/commcare-hq/pull/27651). I'm just going to remove it.

## Safety Assurance

### Safety story
Test code only.

### Automated test coverage
yes

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
