### PR TITLE
Repeat Records Couch to SQL back-fill migration fixes

### DIFF
--- a/corehq/apps/cleanup/tests/test_populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/tests/test_populate_sql_model_from_couch_model.py
@@ -40,7 +40,6 @@ class TestPopulateSQLCommand(TestCase):
             output = call_command(log_path=log.path.parent)
             self.assertIn(f"log output file: {log.path}\n", output)
             self.assertIn(" 5/5 100%", output)
-            self.assertIn("Created model for TestDoc with id 3", log.content)
             self.assertIn("Ignored model for TestDoc with id 4", log.content)
             self.assertEqual(log.content.count("Created model for TestDoc with id 1"), 1)
             resume = Command._resume_iter_couch_view()

--- a/corehq/motech/repeaters/tests/test_couchsqlmigration.py
+++ b/corehq/motech/repeaters/tests/test_couchsqlmigration.py
@@ -462,6 +462,32 @@ class TestRepeatRecordCouchToSQLMigration(BaseRepeatRecordCouchToSQLTest):
         obj = SQLRepeatRecord.objects.get(couch_id=doc_id)
         self.assertFalse(obj.attempts)
 
+    def test_fixup_failed_record_with_no_attempts(self):
+        when = datetime.utcnow().replace(year=2017, microsecond=0)
+        doc, _ = self.create_repeat_record()
+        doc.pop("attempts")
+        doc.pop("registered_on")
+        doc["succeeded"] = False
+        doc["next_check"] = json_format_datetime(when)
+        doc["failure_reason"] = "A tree fell in the forest"
+        doc_id = self.db.save_doc(doc)["id"]
+
+        with templog() as log:
+            from ..management.commands import populate_repeatrecords as mod
+            with patch.object(mod, "_attempt_to_preserve_failure_reason"):  # produces diff
+                call_command('populate_repeatrecords', log_path=log.path)
+            self.assertIn(f'Doc "{doc_id}" has differences:\n', log.content)
+            self.assertIn("failure_reason: couch value 'A tree fell", log.content)
+
+            fixup_log = log.path.parent / "fixup.log"
+            call_command('populate_repeatrecords', log_path=fixup_log, fixup_diffs=log.path)
+            with open(fixup_log) as fh:
+                self.assertNotIn("has differences:", fh.read())
+
+        obj = SQLRepeatRecord.objects.get(couch_id=doc_id)
+        attempt, = obj.attempts
+        self.assertEqual(attempt.created_at, when)
+
     def test_migrate_record_erroneous_next_check(self):
         doc, _ = self.create_repeat_record()
         doc.update(succeeded=True, next_check=datetime.utcnow().isoformat() + 'Z')


### PR DESCRIPTION
:blowfish: Review by commit.

## Safety Assurance

### Safety story

Only affects a management command. Automated tests have been added for non-trivial changes.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations