### PR TITLE
"CommCare HQ" spelling

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -35,7 +35,7 @@ if you have questions or need feedback.
 
 Useful Tools
 ------------
-Here are some tools widely used by CommCareHQ developers
+Here are some tools widely used by CommCare HQ developers
 
 flake8
     Flake8 is run on all PRs automatically. You can run it locally to ensure your

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -173,4 +173,4 @@ class ExternalIdTooLong(CaseRowError):
 
 class UnexpectedError(CaseRowError):
     title = gettext_noop('Unexpected error')
-    message = gettext_lazy('Could not process case. If this persists, Please report an issue to CommCareHQ')
+    message = gettext_lazy('Could not process case. If this persists, please report an issue to CommCare HQ')

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -246,7 +246,7 @@ class PopulateSQLCommand(BaseCommand):
         if not migrated:
             print(f"""
 A migration must be performed before this environment can be upgraded to the latest version
-of CommCareHQ. This migration is run using the management command {command_name}.
+of CommCare HQ. This migration is run using the management command {command_name}.
             """)
             if cls.commit_adding_migration():
                 print(f"""

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/errors.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/errors.js
@@ -8,7 +8,7 @@ hqDefine("cloudcare/js/form_entry/errors", function () {
         JS_ERROR: gettext("An unknown error occurred. " +
             "If you have problems filling in the rest of your form please submit an issue. " +
             "Technical Details: "),
-        TIMEOUT_ERROR: gettext("CommCareHQ has detected a possible network connectivity problem. " +
+        TIMEOUT_ERROR: gettext("CommCare HQ has detected a possible network connectivity problem. " +
             "Please make sure you are connected to the " +
             "Internet in order to submit your form."),
         LOCK_TIMEOUT_ERROR: gettext('Another process prevented us from servicing your request. ' +

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -67,7 +67,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", function () {
             if (urlObject.appId === undefined || urlObject.appId === null) {
                 if (menuResponse.appId === null || menuResponse.appId === undefined) {
                     FormplayerFrontend.trigger('showError', "Response did not contain appId even though it was" +
-                        "required. If this persists, please report an issue to CommCareHQ");
+                        "required. If this persists, please report an issue to CommCare HQ");
                     FormplayerFrontend.trigger("apps:list");
                     return;
                 }

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -555,7 +555,7 @@ def _message_to_tag_value(message, allowed_chars=string.ascii_lowercase + string
     >>> _message_to_tag_value(
     ... 'EntityScreen EntityScreen [Detail=org.commcare.suite.model.Detail@1f984e3c, '
     ... 'selection=null] could not select case 8854f3583f6f46e69af59fddc9f9428d. '
-    ... 'If this error persists please report a bug to CommCareHQ.')
+    ... 'If this error persists please report a bug to CommCare HQ.')
     'entityscreen_entityscreen_detail_org'
     """
     message_tag = unidecode(message)
@@ -569,8 +569,8 @@ def _message_to_sentry_thread_topic(message):
     >>> _message_to_sentry_thread_topic(
     ... 'EntityScreen EntityScreen [Detail=org.commcare.suite.model.Detail@1f984e3c, '
     ... 'selection=null] could not select case 8854f3583f6f46e69af59fddc9f9428d. '
-    ... 'If this error persists please report a bug to CommCareHQ.')
-    'EntityScreen EntityScreen [Detail=org.commcare.suite.model.Detail@[...], selection=null] could not select case [...]. If this error persists please report a bug to CommCareHQ.'
+    ... 'If this error persists please report a bug to CommCare HQ.')
+    'EntityScreen EntityScreen [Detail=org.commcare.suite.model.Detail@[...], selection=null] could not select case [...]. If this error persists please report a bug to CommCare HQ.'
     """  # noqa: E501
     return re.sub(r'[a-f0-9-]{7,}', '[...]', message)
 

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -110,68 +110,76 @@ class DomainDashboardView(LoginAndDomainMixin, BillingModalsMixin, BasePageView,
 
 def _get_default_tiles(request):
 
-    def can_edit_users(request):
+    def can_edit_users(req):
         return (
-            request.couch_user.can_edit_commcare_users()
-            or request.couch_user.can_edit_web_users()
+            req.couch_user.can_edit_commcare_users()
+            or req.couch_user.can_edit_web_users()
         )
 
-    def can_view_apps(request):
-        return request.couch_user.can_view_apps() and has_privilege(request, privileges.PROJECT_ACCESS)
+    def can_view_apps(req):
+        return (
+            req.couch_user.can_view_apps()
+            and has_privilege(req, privileges.PROJECT_ACCESS)
+        )
 
-    def can_view_users(request):
+    def can_view_users(req):
         can_do_something = (
-            request.couch_user.can_edit_commcare_users()
-            or request.couch_user.can_view_commcare_users()
-            or request.couch_user.can_edit_groups()
-            or request.couch_user.can_view_groups()
-            or request.couch_user.can_view_roles()
-        ) and has_privilege(request, privileges.PROJECT_ACCESS)
+            req.couch_user.can_edit_commcare_users()
+            or req.couch_user.can_view_commcare_users()
+            or req.couch_user.can_edit_groups()
+            or req.couch_user.can_view_groups()
+            or req.couch_user.can_view_roles()
+        ) and has_privilege(req, privileges.PROJECT_ACCESS)
         return (
             can_do_something
-            or request.couch_user.can_edit_web_users()
-            or request.couch_user.can_view_web_users()
+            or req.couch_user.can_edit_web_users()
+            or req.couch_user.can_view_web_users()
         )
 
-    def can_view_reports(request):
-        return (user_can_view_reports(request.project, request.couch_user)
-                and has_privilege(request, privileges.PROJECT_ACCESS))
-
-    def can_view_data(request):
-        return ((request.couch_user.can_edit_data() or request.couch_user.can_access_any_exports())
-                and has_privilege(request, privileges.PROJECT_ACCESS))
-
-    def can_edit_locations_not_users(request):
-        if not has_privilege(request, privileges.LOCATIONS):
-            return False
-        user = request.couch_user
-        return not can_edit_users(request) and (
-            user.can_edit_locations() or user_can_edit_location_types(user, request.domain)
-        )
-
-    def can_view_commtrack_setup(request):
-        return request.project.commtrack_enabled
-
-    def _can_access_sms(request):
-        return has_privilege(request, privileges.OUTBOUND_SMS)
-
-    def _can_access_reminders(request):
-        return has_privilege(request, privileges.REMINDERS_FRAMEWORK)
-
-    def can_use_messaging(request):
+    def can_view_reports(req):
         return (
-            (_can_access_reminders(request) or _can_access_sms(request))
-            and not request.couch_user.is_commcare_user()
-            and request.couch_user.can_edit_messaging()
+            user_can_view_reports(req.project, req.couch_user)
+            and has_privilege(req, privileges.PROJECT_ACCESS)
         )
 
-    def is_billing_admin(request):
-        return request.couch_user.can_edit_billing()
+    def can_view_data(req):
+        return ((
+            req.couch_user.can_edit_data()
+            or req.couch_user.can_access_any_exports()
+        ) and has_privilege(req, privileges.PROJECT_ACCESS))
+
+    def can_edit_locations_not_users(req):
+        if not has_privilege(req, privileges.LOCATIONS):
+            return False
+        user = req.couch_user
+        return not can_edit_users(req) and (
+            user.can_edit_locations()
+            or user_can_edit_location_types(user, req.domain)
+        )
+
+    def can_view_commtrack_setup(req):
+        return req.project.commtrack_enabled
+
+    def _can_access_sms(req):
+        return has_privilege(req, privileges.OUTBOUND_SMS)
+
+    def _can_access_reminders(req):
+        return has_privilege(req, privileges.REMINDERS_FRAMEWORK)
+
+    def can_use_messaging(req):
+        return (
+            (_can_access_reminders(req) or _can_access_sms(req))
+            and not req.couch_user.is_commcare_user()
+            and req.couch_user.can_edit_messaging()
+        )
+
+    def is_billing_admin(req):
+        return req.couch_user.can_edit_billing()
 
     def apps_link(urlname, req):
         return (
-            '' if domain_has_apps(request.domain)
-            else reverse(urlname, args=[request.domain])
+            '' if domain_has_apps(req.domain)
+            else reverse(urlname, args=[req.domain])
         )
 
     commcare_name = commcare_hq_names(request)['commcare_hq_names']['COMMCARE_NAME']

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -232,7 +232,7 @@ def _get_default_tiles(request):
             icon='fcc fcc-users',
             urlname=DefaultProjectUserSettingsView.urlname,
             visibility_check=can_view_users,
-            help_text=_('Manage accounts for mobile workers and CommCareHQ users'),
+            help_text=_('Manage accounts for mobile workers and CommCare HQ users'),
         ),
         Tile(
             request,

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -366,7 +366,7 @@ class DomainGlobalSettingsForm(forms.Form):
     call_center_enabled = BooleanField(
         label=gettext_lazy("Call Center Application"),
         required=False,
-        help_text=gettext_lazy("Call Center mode is a CommCareHQ module for managing "
+        help_text=gettext_lazy("Call Center mode is a CommCare HQ module for managing "
                     "call center workflows. It is still under "
                     "active development. Do not enable for your domain unless "
                     "you're actively piloting it.")
@@ -1035,7 +1035,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
             "Please rate the technical competency of the partner on a scale from "
             "1 to 5. 1 means low-competency, and we should expect LOTS of basic "
             "hand-holding. 5 means high-competency, so if they report a bug it's "
-            "probably a real issue with CommCareHQ or a really good idea."
+            "probably a real issue with CommCare HQ or a really good idea."
         ),
     )
     support_prioritization = IntegerField(
@@ -2298,7 +2298,7 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
                         crispy.HTML(
                             _('<p><i class="fa fa-info-circle"></i> '
                               'Clicking "Update" will set up the '
-                              'subscription in CommCareHQ to one of our '
+                              'subscription in CommCare HQ to one of our '
                               'standard contracted plans.<br/> If you '
                               'need to set up a non-standard plan, '
                               'please email {}.</p>').format(settings.ACCOUNTS_EMAIL)

--- a/corehq/apps/es/REINDEX_PROCESS.md
+++ b/corehq/apps/es/REINDEX_PROCESS.md
@@ -344,7 +344,7 @@ When there isn't enough space to accomodate duplicate data for all the indices, 
 ```
 cchq <env> django-manage elastic_sync_multiplexed remove_residual_indices
 ```
-These indices are safe to delete and are not used in any functionality of CommCareHQ.
+These indices are safe to delete and are not used in any functionality of CommCare HQ.
 
 3. Congratulations :tada: You have successfully created new indexes that are active on CommcareHQ.
 

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -596,7 +596,7 @@ class ESQuerySet(object):
 
 class HQESQuery(ESQuery):
     """
-    Query logic specific to CommCareHQ
+    Query logic specific to CommCare HQ
     """
     @property
     def builtin_filters(self):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -751,7 +751,7 @@ class DashboardFeedListView(DailySavedExportListView, DashboardFeedListHelper):
     page_title = gettext_lazy("Excel Dashboard Integration")
 
     lead_text = gettext_lazy('''
-        Excel dashboard feeds allow Excel to directly connect to CommCareHQ to download data.
+        Excel dashboard feeds allow Excel to directly connect to CommCare HQ to download data.
         Data is updated daily.
     ''')
 

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -200,7 +200,7 @@ class Command(BaseCommand):
                          'from a secure dropzone'),
         Role(slug=privileges.ATTENDANCE_TRACKING,
              name='Attendance Tracking',
-             description='Supports using CommCareHQ for attendance tracking'),
+             description='Supports using CommCare HQ for attendance tracking'),
         Role(slug=privileges.REGEX_FIELD_VALIDATION,
              name='Regular Field Validation',
              description='Regular field validation for custom data fields'),
@@ -237,7 +237,7 @@ class Command(BaseCommand):
              description='Support for finding duplicate cases'),
         Role(slug=privileges.CUSTOM_DOMAIN_ALERTS,
              name='Custom Domain Banners',
-             description='Allow projects to add banners for their users on CommCareHQ'),
+             description='Allow projects to add banners for their users on CommCare HQ'),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/apps/hqadmin/management/commands/export_domain_forms_raw.py
+++ b/corehq/apps/hqadmin/management/commands/export_domain_forms_raw.py
@@ -21,7 +21,7 @@ class FormMetadata(JsonObject):
 
 class Command(BaseCommand):
     help = "Save all form XML documents and attachments for a domain to a folder on disk. " \
-           "Use ``import_domain_forms_raw`` to reload the forms into CommCareHQ."
+           "Use ``import_domain_forms_raw`` to reload the forms into CommCare HQ."
 
     def add_arguments(self, parser):
         parser.add_argument('domain')


### PR DESCRIPTION
## Technical Summary

This is why it's bad to make me wait for local monolith deploys. I fixed a few spellings of "CommCare HQ". (It has a space. If you're a little skeptical, take a quick look at [commcarehq.org](https://www.commcarehq.org/).)

This change includes a single code change: There was a lambda function that took a param named "req" but internally used a variable named "request", which shadowed an outer variable with that name. I changed the code to what it seems the original developer intended based on the other functions nearby.

Other than that,
* the first commit fixes lint errors, 
* the second commit resolves shadow variable names, 
* and the third commit is the point of this distraction from monolith deploys: correcting the spelling of "CommCare HQ". 

The changes are all in strings or documentation. There are more "CommCareHQ"s in commcare-hq, but I'll save those for the next monolith deploy. :)

## Feature Flag
N/A

## Safety Assurance

### Safety story

The changes are all in strings or documentation.

### Automated test coverage

Maybe there are tests that check for an affected string. I'll fix those if the test run fails.

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
