### PR TITLE
Reset Project Alerts Permission on Role Save

### DIFF
--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -268,10 +268,6 @@ class TestUpdateRoleFromView(TestCase):
         role_data['permissions']['manage_domain_alerts'] = True
         self.assertFalse(self.role.permissions.to_json()['manage_domain_alerts'])
 
-        _update_role_from_view(self.domain, role_data)
-        self.role.refresh_from_db()
-        self.assertFalse(self.role.permissions.to_json()['manage_domain_alerts'])
-
         role_data['permissions']['manage_domain_alerts'] = True
         with patch('corehq.apps.users.views.domain_has_privilege', side_effect=patch_privilege_check):
             _update_role_from_view(self.domain, role_data)

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -268,9 +268,11 @@ class TestUpdateRoleFromView(TestCase):
         role_data['permissions']['manage_domain_alerts'] = True
         self.assertFalse(self.role.permissions.to_json()['manage_domain_alerts'])
 
-        with self.assertRaisesMessage(ValueError, "Update subscription to set access for custom domain alerts"):
-            _update_role_from_view(self.domain, role_data)
+        _update_role_from_view(self.domain, role_data)
+        self.role.refresh_from_db()
+        self.assertFalse(self.role.permissions.to_json()['manage_domain_alerts'])
 
+        role_data['permissions']['manage_domain_alerts'] = True
         with patch('corehq.apps.users.views.domain_has_privilege', side_effect=patch_privilege_check):
             _update_role_from_view(self.domain, role_data)
         self.role.refresh_from_db()

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -279,12 +279,13 @@ class BaseEditUserView(BaseUserSettingsView):
     @property
     def can_change_user_roles(self):
         return (
-            bool(self.editable_role_choices) and
-            self.request.couch_user.user_id != self.editable_user_id and
-            (
-                self.request.couch_user.is_domain_admin(self.domain) or
-                not self.existing_role or
-                self.existing_role in [choice[0] for choice in self.editable_role_choices]
+            bool(self.editable_role_choices)
+            and self.request.couch_user.user_id != self.editable_user_id
+            and (
+                self.request.couch_user.is_domain_admin(self.domain)
+                or not self.existing_role
+                or self.existing_role
+                in [choice[0] for choice in self.editable_role_choices]
             )
         )
 
@@ -428,8 +429,10 @@ class EditWebUserView(BaseEditUserView):
         }
         if self.request.is_view_only:
             make_form_readonly(self.commtrack_form)
-        if (self.request.project.commtrack_enabled or
-                self.request.project.uses_locations):
+        if (
+            self.request.project.commtrack_enabled
+            or self.request.project.uses_locations
+        ):
             ctx.update({'update_form': self.commtrack_form})
         if TABLEAU_USER_SYNCING.enabled(self.domain):
             ctx.update({'tableau_form': self.tableau_form})
@@ -909,8 +912,8 @@ def undo_remove_web_user(request, domain, record_id):
 
 
 # If any permission less than domain admin were allowed here, having that permission would give you the permission
-# to change the permissions of your own role such that you could do anything, and would thus be equivalent to having
-# domain admin permissions.
+# to change the permissions of your own role such that you could do anything, and would thus be equivalent to
+# having domain admin permissions.
 @json_error
 @domain_admin_required
 @require_POST

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -950,12 +950,6 @@ def _update_role_from_view(domain, role_data):
         # This shouldn't be possible through the UI, but as a safeguard...
         role_data['permissions']['access_all_locations'] = True
 
-    if (
-        not domain_has_privilege(domain, privileges.CUSTOM_DOMAIN_ALERTS)
-        and 'manage_domain_alerts' in role_data['permissions']
-    ):
-        role_data['permissions']['manage_domain_alerts'] = False
-
     if "_id" in role_data:
         try:
             role = UserRole.objects.by_couch_id(role_data["_id"])

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -954,7 +954,7 @@ def _update_role_from_view(domain, role_data):
         not domain_has_privilege(domain, privileges.CUSTOM_DOMAIN_ALERTS)
         and 'manage_domain_alerts' in role_data['permissions']
     ):
-        raise ValueError(_("Update subscription to set access for custom domain alerts"))
+        role_data['permissions']['manage_domain_alerts'] = False
 
     if "_id" in role_data:
         try:


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3546).

This PR fixes a bug where domains that do not have access to the `CUSTOM_DOMAIN_ALERTS` privilege receive an error when trying to save a user role. Currently an error gets thrown if the `manage_domain_alerts` permission for this privilege exists in a role, regardless of whether it is enabled or not. This permission is a field of the `HqPermissions` model which would be present for all roles. We should not throw an error if the domain doesn't have the necessary privilege but rather simply default to disabling this permission on role save.

For additional context, please refer to the [original PR](https://github.com/dimagi/commcare-hq/pull/33874) which added this permission.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned. This would be good to raise with QA as it is something that slipped past when doing the QA for the `CUSTOM_DOMAIN_ALERTS` feature.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
