### PR TITLE
Re-enable throttling for static tokens

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1091,11 +1091,8 @@ SESSION_BYPASS_URLS = [
     r'^/a/{domain}/apps/download/',
 ]
 
-# Disable builtin throttling for two factor backup tokens, since we have our own
-# See corehq.apps.hqwebapp.signals and corehq.apps.hqwebapp.forms for details
-OTP_STATIC_THROTTLE_FACTOR = 0
-# Adding OTP_TOTP_THROTTLE_FACTOR and TWO_FACTOR_PHONE_THROTTLE_FACTOR to preserve behavior after upgrading
-# past version 1.15.4 of django-two-factor-auth, which changed the factor to 10.
+# Preserves behavior after upgrading past version 1.15.4 of django-two-factor-auth, which changed the factor to 10
+OTP_STATIC_THROTTLE_FACTOR = 1
 OTP_TOTP_THROTTLE_FACTOR = 1
 TWO_FACTOR_PHONE_THROTTLE_FACTOR = 1
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15398

Due to a bug in django-two-factor-auth, failed login attempts were incorrectly set on 2FA devices including backup tokens. For this reason, we disabled the built-in throttling in https://github.com/dimagi/commcare-hq/pull/28483 and fell back on our custom max try limit of 5.

Since then, django-two-factor-auth has resolved this issue in 1.15.4, and now that we have upgraded past this version (https://github.com/dimagi/commcare-hq/pull/33918), we can safely re-enable throttling on backup tokens.

The only remaining step prior to merging this PR is to ensure we safely reset the `throttling_failure_count` on 2FA devices to ensure users are not unfairly locked out from attempting logins for unreasonably long times. I've written up https://docs.google.com/document/d/1CsrytwTjq1IQddfLIigi-jl9t-9IvG51djftqwTyZ84/edit#heading=h.ecke3242zj9r to address this, and once we agree upon a solution there and run that on SaaS environments, I believe we can safely merge this PR.
- [x] reset throttling_failure_count on backup token devices
 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The bug that Cal described in the PR when this was disabled is the exact bug that was resolved in 1.15.4 of django-two-factor-auth. As long as we adequately reset the now inaccurate throttling_failure_count values before rolling this out, throttling backup token attempts makes our system safer.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests for this behavior. This is functionality that comes with django-otp/django-two-factor-auth.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
