### PR TITLE
Remove Django deprecation warnings

### DIFF
--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -21,8 +21,6 @@ WHITELIST = [
     ("nose.importer", "the imp module is deprecated"),
     ("nose.util", "inspect.getargspec() is deprecated"),
     ("pkg_resources", "pkg_resources.declare_namespace"),
-    ("tastypie", "django.conf.urls.url() is deprecated"),
-    ("tastypie", "request.is_ajax() is deprecated"),
     ("nose.suite", "'collections.abc'"),
     ("nose.plugins.collect", "'collections.abc'"),
 

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -22,12 +22,10 @@ WHITELIST = [
     ("couchdbkit.schema.properties", "'collections.abc'"),
     ("django.apps", re.compile(r"'(" + "|".join(re.escape(app) for app in [
         "captcha",
-        "django_celery_results",
         "oauth2_provider",
         "statici18n",
         "two_factor",
     ]) + ")' defines default_app_config"), RemovedInDjango41Warning),
-    ("django_celery_results", "ugettext_lazy() is deprecated"),
     ("nose.importer", "the imp module is deprecated"),
     ("nose.util", "inspect.getargspec() is deprecated"),
     ("pkg_resources", "pkg_resources.declare_namespace"),

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -18,10 +18,8 @@ WHITELIST = [
     # (module_path, message_substring_or_regex, optional_warning_class, override_action)
 
     # warnings that may be resolved with a library upgrade
-    ("captcha.fields", "ugettext_lazy() is deprecated"),
     ("couchdbkit.schema.properties", "'collections.abc'"),
     ("django.apps", re.compile(r"'(" + "|".join(re.escape(app) for app in [
-        "captcha",
         "oauth2_provider",
         "statici18n",
         "two_factor",

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -20,7 +20,6 @@ WHITELIST = [
     # warnings that may be resolved with a library upgrade
     ("couchdbkit.schema.properties", "'collections.abc'"),
     ("django.apps", re.compile(r"'(" + "|".join(re.escape(app) for app in [
-        "statici18n",
         "two_factor",
     ]) + ")' defines default_app_config"), RemovedInDjango41Warning),
     ("nose.importer", "the imp module is deprecated"),

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -20,7 +20,6 @@ WHITELIST = [
     # warnings that may be resolved with a library upgrade
     ("couchdbkit.schema.properties", "'collections.abc'"),
     ("django.apps", re.compile(r"'(" + "|".join(re.escape(app) for app in [
-        "oauth2_provider",
         "statici18n",
         "two_factor",
     ]) + ")' defines default_app_config"), RemovedInDjango41Warning),

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -2,7 +2,6 @@ import os
 import re
 import warnings
 
-from django.utils.deprecation import RemovedInDjango41Warning
 from sqlalchemy.exc import SAWarning
 
 
@@ -19,9 +18,6 @@ WHITELIST = [
 
     # warnings that may be resolved with a library upgrade
     ("couchdbkit.schema.properties", "'collections.abc'"),
-    ("django.apps", re.compile(r"'(" + "|".join(re.escape(app) for app in [
-        "two_factor",
-    ]) + ")' defines default_app_config"), RemovedInDjango41Warning),
     ("nose.importer", "the imp module is deprecated"),
     ("nose.util", "inspect.getargspec() is deprecated"),
     ("pkg_resources", "pkg_resources.declare_namespace"),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15374

All relevant django libraries have been upgraded and are no longer using django features that are removed in Django >= 4. These warnings are all safe to remove from the whitelist, and if not, the tests will fail.
 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
These were added because tests failed when these warnings were raised previously. I assume if tests pass, it reflects that the imports are no longer problematic due to relying on deprecated features.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
