### PR TITLE
Removed unused dependency in view-table.js

### DIFF
--- a/corehq/apps/fixtures/static/fixtures/js/view-table.js
+++ b/corehq/apps/fixtures/static/fixtures/js/view-table.js
@@ -1,6 +1,5 @@
 hqDefine("fixtures/js/view-table", [
     "jquery",
-    "hqwebapp/js/django",
     "hqwebapp/js/initial_page_data",
     "reports/js/standard_hq_report",
     "reports/js/config.dataTables.bootstrap",
@@ -8,7 +7,6 @@ hqDefine("fixtures/js/view-table", [
     "datatables.fixedColumns",
 ], function (
     $,
-    django,
     initialPageData,
     standardHQReportModule,
     datatablesConfig,


### PR DESCRIPTION
## Technical Summary
This gets included in all requirejs contexts ([see here](https://github.com/dimagi/commcare-hq/blob/2a4d964ee9f5b38cf7e11d7a7c45527abc924a4d/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html#L36)), and re-importing it can cause trouble.

It also isn't used in this file.

## Safety Assurance

### Safety story
Pretty trivial change, code review can verify its safety.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
