### PR TITLE
Updated build_bootstrap5_diffs to skip hidden files

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
@@ -53,7 +53,10 @@ def get_bootstrap5_filepaths(full_diff_config):
             path_bootstrap5 = COREHQ_BASE_DIR / parent_path / directory_bootstrap5
 
             if compare_all_files:
-                migrated_files = [[x.name, x.name] for x in path_bootstrap3.glob('**/*') if x.is_file()]
+                migrated_files = [
+                    [x.name, x.name] for x in path_bootstrap3.glob('**/*')
+                    if x.is_file() and not x.name.startswith(".")
+                ]
 
             for filename_bootstrap3, filename_bootstrap5 in migrated_files:
                 diff_filename = get_diff_filename(filename_bootstrap3, filename_bootstrap5, file_type)


### PR DESCRIPTION
## Technical Summary
Skip Unix-style hidden files. I keep hitting errors with this command due to it trying to diff vim swap files.

## Safety Assurance

### Safety story
Only affects an internal management command.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
