### PR TITLE
B5: Fixed width of nested menus

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/navigation_left_sidebar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/navigation_left_sidebar.html
@@ -24,7 +24,7 @@
             {{ nav.title }}
           </a>
           {% if nav.subpage and nav.subpage.title %}
-            <ul class="nav">
+            <ul class="nav flex-column">
               <li class="nav-item">
                 <a href="#" class="nav-link active" aria-current="page">
                   {{ nav.subpage.title }}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/navigation_left_sidebar.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/navigation_left_sidebar.html.diff.txt
@@ -39,8 +39,9 @@
            </a>
 -
            {% if nav.subpage and nav.subpage.title %}
-             <ul class="nav">
+-            <ul class="nav">
 -              <li class="active"><a href="#">{{ nav.subpage.title }}</a></li>
++            <ul class="nav flex-column">
 +              <li class="nav-item">
 +                <a href="#" class="nav-link active" aria-current="page">
 +                  {{ nav.subpage.title }}


### PR DESCRIPTION
## Product Description
Cherry-picking this from the products & programs migration because it's a broader change.

before
<img width="336" alt="Screenshot 2024-03-18 at 5 27 08 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/6a5cb474-e31f-4ef3-9372-51a68362b04e">

after
<img width="471" alt="Screenshot 2024-03-18 at 5 26 50 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/ffcc4b65-3a62-49d8-90bb-2db11fd26eee">

## Safety Assurance

### Safety story
Low risk style change. I don't think there are any B5 pages on prod yet that use the sidebar, but I'm marking this PR "all users / all environments" out of an abundance of caution.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
