### PR TITLE
Allows single date filter to be saved while saving reports

### DIFF
--- a/corehq/apps/reports/static/reports/js/report_config_models.js
+++ b/corehq/apps/reports/static/reports/js/report_config_models.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("reports/js/report_config_models", [
     'jquery',
     'knockout',

--- a/corehq/apps/reports/static/reports/js/report_config_models.js
+++ b/corehq/apps/reports/static/reports/js/report_config_models.js
@@ -164,7 +164,7 @@ hqDefine("reports/js/report_config_models", [
         // edit the config currently being viewed
         self.setConfigBeingEdited = function (config) {
             var filters = {},
-                excludeFilters = ['startdate', 'enddate', 'format', 'date'];
+                excludeFilters = ['startdate', 'enddate', 'format'];
             if (self.filterForm) {
                 self.filterForm.find(":input").each(function () {
                     var el = $(this),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
At present, the SINGLE date filter is excluded from being saved as a filter while saving the report. As a result, the saved report when viewed does not have the originally selected date filter and uses a default date for that report. This change addresses this issue so that the originally selected date is available in the saved report.
See [Ticket](https://dimagi.atlassian.net/browse/QA-6196) for more details and demo of the issue.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Note: The single date filter is at present used only in single report: SimplifiedInventoryReport. The issue persists in this report as well. 
Related PR where this filter is being added: https://github.com/dimagi/commcare-hq/pull/34253
This is being created as a separated PR as changes are independent of original work and should be easier to track/rollback if needed,


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is a minor change that directly affects reports with single date filter which are limited in number. 
Sanity testing was done on local for Saved Reports Functionality.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA will be testing this as it was raised by QA.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
