### PR TITLE
[B5] Added support for HQ help templates

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
@@ -3,11 +3,13 @@ hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
     'knockout',
     'underscore',
     'analytix/js/google',
+    'es6!hqwebapp/js/bootstrap5_loader',
 ], function (
     $,
     ko,
     _,
-    googleAnalytics
+    googleAnalytics,
+    bootstrap
 ) {
     // disable-on-submit is a class for form submit buttons so they're automatically disabled when the form is submitted
     $(document).on('submit', 'form', function (ev) {
@@ -75,18 +77,10 @@ hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
             if (opts) {
                 options = _.extend(options, opts);
             }
-            if (!$link.data('content')) {
-                options.content = function () {
-                    return $('#popover_content_wrapper').html();
-                };
-            }
-            if (!$link.data("title")) {
-                options.template = '<div class="popover"><div class="arrow"></div><div class="popover-inner"><div class="popover-content"><p></p></div></div></div>';
-            }
-            $link.popover(options);
+            new bootstrap.Popover($link, options);
 
             // Prevent jumping to the top of the page when link is clicked
-            $helpElem.find('a').click(function (event) {
+            $link.click(function (event) {
                 googleAnalytics.track.event("Clicked Help Bubble", $(this).data('title'), '-');
                 event.preventDefault();
             });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
@@ -46,11 +46,11 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
         wrap = wrap === undefined ? true : wrap;
         var el = $(
             '<div class="hq-help">' +
-                '<a href="#" tabindex="-1">' +
+                '<a href="#" tabindex="-1" data-bs-toggle="popover">' +
                     '<i class="fa fa-question-circle icon-question-sign"></i></a></div>'
         );
         _.each(['content', 'title', 'html', 'placement', 'container'], function (attr) {
-            $('a', el).data(attr, opts[attr]);
+            $('a', el).attr('data-bs-' + attr, opts[attr]);
         });
         if (wrap) {
             el.hqHelp();

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
@@ -1,12 +1,24 @@
 --- 
 +++ 
-@@ -1,4 +1,4 @@
+@@ -1,13 +1,15 @@
 -hqDefine("hqwebapp/js/bootstrap3/hq.helpers", [
 +hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
      'jquery',
      'knockout',
      'underscore',
-@@ -59,19 +59,6 @@
+     'analytix/js/google',
++    'es6!hqwebapp/js/bootstrap5_loader',
+ ], function (
+     $,
+     ko,
+     _,
+-    googleAnalytics
++    googleAnalytics,
++    bootstrap
+ ) {
+     // disable-on-submit is a class for form submit buttons so they're automatically disabled when the form is submitted
+     $(document).on('submit', 'form', function (ev) {
+@@ -59,19 +61,6 @@
          return false; // let default handler run
      };
  
@@ -26,7 +38,25 @@
      $.fn.hqHelp = function (opts) {
          var self = this;
          self.each(function (i) {
-@@ -104,6 +91,11 @@
+@@ -88,22 +77,19 @@
+             if (opts) {
+                 options = _.extend(options, opts);
+             }
+-            if (!$link.data('content')) {
+-                options.content = function () {
+-                    return $('#popover_content_wrapper').html();
+-                };
+-            }
+-            if (!$link.data("title")) {
+-                options.template = '<div class="popover"><div class="arrow"></div><div class="popover-inner"><div class="popover-content"><p></p></div></div></div>';
+-            }
+-            $link.popover(options);
++            new bootstrap.Popover($link, options);
+ 
+             // Prevent jumping to the top of the page when link is clicked
+-            $helpElem.find('a').click(function (event) {
++            $link.click(function (event) {
+                 googleAnalytics.track.event("Clicked Help Bubble", $(this).data('title'), '-');
                  event.preventDefault();
              });
          });

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
@@ -25,6 +25,20 @@
  ) {
      var eventize = function (that) {
          'use strict';
+@@ -44,11 +46,11 @@
+         wrap = wrap === undefined ? true : wrap;
+         var el = $(
+             '<div class="hq-help">' +
+-                '<a href="#" tabindex="-1">' +
++                '<a href="#" tabindex="-1" data-bs-toggle="popover">' +
+                     '<i class="fa fa-question-circle icon-question-sign"></i></a></div>'
+         );
+         _.each(['content', 'title', 'html', 'placement', 'container'], function (attr) {
+-            $('a', el).data(attr, opts[attr]);
++            $('a', el).attr('data-bs-' + attr, opts[attr]);
+         });
+         if (wrap) {
+             el.hqHelp();
 @@ -115,8 +117,6 @@
              $.postGo(action, $.unparam(data));
          });


### PR DESCRIPTION
## Technical Summary
Cherry picked from the products migration, since this is a broader change. Marked invisible since this won't affect any live pages.

https://getbootstrap.com/docs/5.3/components/popovers/

## Safety Assurance

### Safety story
Doesn't affect live pages.

### Automated test coverage

no

### QA Plan

Not requesting formal QA. I've tested this locally as part of the products migration.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
