### PR TITLE
Replace django conf url imports

### DIFF
--- a/corehq/apps/accounting/urls.py
+++ b/corehq/apps/accounting/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.accounting.dispatcher import (
     AccountingAdminInterfaceDispatcher,

--- a/corehq/apps/accounting/urls.py
+++ b/corehq/apps/accounting/urls.py
@@ -57,7 +57,8 @@ urlpatterns = [
     url(r'^accounts/new_subscription/(\d+)/$', NewSubscriptionView.as_view(), name=NewSubscriptionView.urlname),
     url(r'^software_plans/new/$', NewSoftwarePlanView.as_view(), name=NewSoftwarePlanView.urlname),
     url(r'^software_plans/(\d+)/$', EditSoftwarePlanView.as_view(), name=EditSoftwarePlanView.urlname),
-    url(r'^software_plan_versions/(\d+)/(\d+)/$', SoftwarePlanVersionView.as_view(), name=SoftwarePlanVersionView.urlname),
+    url(r'^software_plan_versions/(\d+)/(\d+)/$', SoftwarePlanVersionView.as_view(),
+        name=SoftwarePlanVersionView.urlname),
     url(r'^invoices/(\d+)/$', InvoiceSummaryView.as_view(), name=InvoiceSummaryView.urlname),
     url(r'^wire_invoices/(\d+)/$', WireInvoiceSummaryView.as_view(), name=WireInvoiceSummaryView.urlname),
     url(r'^customer_invoices/(\d+)/$', CustomerInvoiceSummaryView.as_view(),
@@ -71,4 +72,3 @@ urlpatterns = [
     url(AccountingAdminInterfaceDispatcher.pattern(), AccountingAdminInterfaceDispatcher.as_view(),
         name=AccountingAdminInterfaceDispatcher.name()),
 ]
-

--- a/corehq/apps/aggregate_ucrs/urls.py
+++ b/corehq/apps/aggregate_ucrs/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from . import views
 

--- a/corehq/apps/analytics/urls.py
+++ b/corehq/apps/analytics/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.analytics.views import (
     GreenhouseCandidateView,

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -7,7 +7,7 @@ from dataclasses import InitVar, dataclass
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db.models import Max, Min, Q

--- a/corehq/apps/app_manager/download_urls.py
+++ b/corehq/apps/app_manager/download_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.app_manager.views import (
     download_app_strings,

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -103,10 +103,13 @@ from ..hqwebapp.decorators import waf_allow
 
 app_urls = [
     url(r'^languages/$', view_app, name='app_languages'),
-    url(r'^languages/translations/download/$', download_bulk_ui_translations, name='download_bulk_ui_translations'),
+    url(r'^languages/translations/download/$', download_bulk_ui_translations,
+        name='download_bulk_ui_translations'),
     url(r'^languages/translations/upload/$', upload_bulk_ui_translations, name='upload_bulk_ui_translations'),
-    url(r'^languages/bulk_app_translations/download/$', download_bulk_app_translations, name='download_bulk_app_translations'),
-    url(r'^languages/bulk_app_translations/upload/$', upload_bulk_app_translations, name='upload_bulk_app_translations'),
+    url(r'^languages/bulk_app_translations/download/$', download_bulk_app_translations,
+        name='download_bulk_app_translations'),
+    url(r'^languages/bulk_app_translations/upload/$', upload_bulk_app_translations,
+        name='upload_bulk_app_translations'),
     url(r'^multimedia_ajax/$', multimedia_ajax, name='app_multimedia_ajax'),
     url(r'^multimedia_sizes/$', get_multimedia_sizes, name='get_multimedia_sizes'),
     url(r'^multimedia_sizes/(?P<build_profile_id>[\w-]+)/$', get_multimedia_sizes,
@@ -269,7 +272,8 @@ urlpatterns = [
     url(r'^download/(?P<app_id>[\w-]+)/',
         include('corehq.apps.app_manager.download_urls')),
 
-    url(r'^diff/(?P<first_app_id>[\w-]+)/(?P<second_app_id>[\w-]+)/$', AppDiffView.as_view(), name=AppDiffView.urlname),
+    url(r'^diff/(?P<first_app_id>[\w-]+)/(?P<second_app_id>[\w-]+)/$', AppDiffView.as_view(),
+        name=AppDiffView.urlname),
     url(r'existing_case_types', ExistingCaseTypesView.as_view(), name=ExistingCaseTypesView.urlname),
 
     url(r'^', include('custom.ucla.urls')),

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.app_manager.views import (
     AppCaseSummaryView,

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -1,4 +1,3 @@
-import json
 import pytz
 import re
 from collections import OrderedDict, defaultdict
@@ -408,21 +407,24 @@ def validate_form_for_build(request, domain, app_id, form_unique_id, ajax=True):
 
 
 def download_index_files(app, build_profile_id=None):
+    def needed_for_ccz(path):
+        if profiles:
+            return path.startswith(prefix) and path.split('/')[1] not in profiles
+        else:
+            return path.startswith(prefix)
+
     if app.copy_of:
         prefix = 'files/'
         if build_profile_id is not None:
             prefix += build_profile_id + '/'
-            needed_for_CCZ = lambda path: path.startswith(prefix)
         else:
             profiles = set(app.build_profiles)
-            needed_for_CCZ = lambda path: (path.startswith(prefix) and
-                                           path.split('/')[1] not in profiles)
         if not (prefix + 'profile.ccpr') in app.blobs:
             # profile hasnt been built yet
             app.create_build_files(build_profile_id=build_profile_id)
             app.save()
         files = [(path[len(prefix):], app.fetch_attachment(path))
-                 for path in app.blobs if needed_for_CCZ(path)]
+                 for path in app.blobs if needed_for_ccz(path)]
     else:
         files = list(app.create_all_files().items())
     files = [
@@ -434,14 +436,10 @@ def download_index_files(app, build_profile_id=None):
 
 def source_files(app):
     """
-    Return the app's source files, including the app json.
+    Return the app's source files
     Return format is a list of tuples where the first item in the tuple is a
     file name and the second is the file contents.
     """
     if not app.copy_of:
         app.set_media_versions()
-    files = download_index_files(app)
-    app_json = json.dumps(
-        app.to_json(), sort_keys=True, indent=4, separators=(',', ': ')
-    )
-    return sorted(files)
+    return download_index_files(app)

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -3,7 +3,7 @@ import pytz
 import re
 from collections import OrderedDict, defaultdict
 
-from django.conf.urls import re_path as url, include
+from django.urls import re_path as url, include
 from django.contrib import messages
 from django.http import Http404, HttpResponse
 from django.shortcuts import render

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -407,14 +407,15 @@ def validate_form_for_build(request, domain, app_id, form_unique_id, ajax=True):
 
 
 def download_index_files(app, build_profile_id=None):
-    def needed_for_ccz(path):
-        if profiles:
-            return path.startswith(prefix) and path.split('/')[1] not in profiles
-        else:
-            return path.startswith(prefix)
-
     if app.copy_of:
+        def needed_for_ccz(path):
+            if profiles:
+                return path.startswith(prefix) and path.split('/')[1] not in profiles
+            else:
+                return path.startswith(prefix)
+
         prefix = 'files/'
+        profiles = None
         if build_profile_id is not None:
             prefix += build_profile_id + '/'
         else:

--- a/corehq/apps/auditcare/urls.py
+++ b/corehq/apps/auditcare/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from .views import export_all
 

--- a/corehq/apps/builds/urls.py
+++ b/corehq/apps/builds/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from .views import EditMenuView, get, get_all, import_build, post
 

--- a/corehq/apps/case_importer/urls.py
+++ b/corehq/apps/case_importer/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.case_importer.tracking.views import (
     case_upload_case_ids,

--- a/corehq/apps/case_search/urls.py
+++ b/corehq/apps/case_search/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.case_search.views import CaseSearchView
 

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.cloudcare.views import (
     EditCloudcareUserPermissionsView,

--- a/corehq/apps/commtrack/urls.py
+++ b/corehq/apps/commtrack/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.commtrack.views import (
     CommTrackSettingsView,

--- a/corehq/apps/dashboard/urls.py
+++ b/corehq/apps/dashboard/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.dashboard.views import (
     DomainDashboardView,

--- a/corehq/apps/data_dictionary/urls.py
+++ b/corehq/apps/data_dictionary/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.data_dictionary.views import (
     DataDictionaryView,

--- a/corehq/apps/data_interfaces/urls.py
+++ b/corehq/apps/data_interfaces/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.data_interfaces.dispatcher import (
     EditDataInterfaceDispatcher,

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 from django.contrib.auth.views import (
     PasswordChangeDoneView,
     PasswordChangeView,

--- a/corehq/apps/dropbox/urls.py
+++ b/corehq/apps/dropbox/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from .views import DropboxAuthCallback, DropboxAuthInitiate
 

--- a/corehq/apps/email/urls.py
+++ b/corehq/apps/email/urls.py
@@ -1,5 +1,5 @@
 from corehq.apps.email.views import EmailSMTPSettingsView
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.messaging.scheduling.views import MessagingDashboardView
 

--- a/corehq/apps/enterprise/urls.py
+++ b/corehq/apps/enterprise/urls.py
@@ -1,5 +1,5 @@
 from corehq.apps.enterprise.dispatcher import EnterpriseReportDispatcher
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.enterprise.views import (
     add_enterprise_permissions_domain,

--- a/corehq/apps/events/urls.py
+++ b/corehq/apps/events/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from .views import (
     AttendeeEditView,

--- a/corehq/apps/export/urls.py
+++ b/corehq/apps/export/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.export.views.download import (
     BulkDownloadNewFormExportView,

--- a/corehq/apps/fixtures/urls.py
+++ b/corehq/apps/fixtures/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from django.views.generic import RedirectView
 
 from corehq.apps.fixtures.dispatcher import FixtureInterfaceDispatcher

--- a/corehq/apps/geospatial/urls.py
+++ b/corehq/apps/geospatial/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from .dispatchers import CaseManagementMapDispatcher
 from .views import (

--- a/corehq/apps/groups/urls.py
+++ b/corehq/apps/groups/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.groups.views import (
     add_group,

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.api.urls import admin_urlpatterns as admin_api_urlpatterns
 from corehq.apps.domain.views.tombstone import TombstoneManagement, create_tombstone

--- a/corehq/apps/hqcase/urls.py
+++ b/corehq/apps/hqcase/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.hqcase.views import ExplodeCasesView
 

--- a/corehq/apps/hqmedia/urls.py
+++ b/corehq/apps/hqmedia/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.hqmedia.views import (
     BulkUploadMultimediaView,

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
 from two_factor.urls import urlpatterns as tf_urls

--- a/corehq/apps/integration/urls.py
+++ b/corehq/apps/integration/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.integration.views import (
     BiometricIntegrationView,

--- a/corehq/apps/linked_domain/urls.py
+++ b/corehq/apps/linked_domain/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.linked_domain.views import (
     DomainLinkRMIView,

--- a/corehq/apps/locations/urls.py
+++ b/corehq/apps/locations/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.hqwebapp.decorators import waf_allow
 

--- a/corehq/apps/mobile_auth/urls.py
+++ b/corehq/apps/mobile_auth/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.mobile_auth.views import (
     admin_fetch_key_records,

--- a/corehq/apps/mocha/urls.py
+++ b/corehq/apps/mocha/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from .views import MochaView
 

--- a/corehq/apps/notifications/urls.py
+++ b/corehq/apps/notifications/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.notifications.views import (
     ManageNotificationView,

--- a/corehq/apps/oauth_integrations/urls.py
+++ b/corehq/apps/oauth_integrations/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.oauth_integrations.views.google import (
     redirect_oauth_view,

--- a/corehq/apps/ota/urls.py
+++ b/corehq/apps/ota/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.hqadmin.views.users import DomainAdminRestoreView
 from corehq.apps.ota.views import (

--- a/corehq/apps/products/urls.py
+++ b/corehq/apps/products/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.products.views import (
     EditProductView,

--- a/corehq/apps/programs/urls.py
+++ b/corehq/apps/programs/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.programs.views import (
     EditProgramView,

--- a/corehq/apps/receiverwrapper/urls.py
+++ b/corehq/apps/receiverwrapper/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.receiverwrapper.views import post, post_api, secure_post
 

--- a/corehq/apps/registration/urls.py
+++ b/corehq/apps/registration/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.registration.views import (
     ProcessRegistrationView,

--- a/corehq/apps/reminders/urls.py
+++ b/corehq/apps/reminders/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.reminders.views import (
     AddNormalKeywordView,

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -227,7 +227,7 @@ class ReportDispatcher(View):
 
     @classmethod
     def url_pattern(cls):
-        from django.conf.urls import re_path as url
+        from django.urls import re_path as url
         return url(cls.pattern(), cls.as_view(), name=cls.name())
 
 

--- a/corehq/apps/reports/filters/urls.py
+++ b/corehq/apps/reports/filters/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from .api import (
     CaseListFilterOptions,

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.reports.standard.forms.reports import ReprocessXFormErrorView

--- a/corehq/apps/reports/v2/urls.py
+++ b/corehq/apps/reports/v2/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.reports.v2.views import endpoint_data, endpoint_options
 

--- a/corehq/apps/settings/urls.py
+++ b/corehq/apps/settings/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.cloudcare.urls import settings_urls as cloudcare_settings
 from corehq.apps.commtrack.urls import settings_urls as commtrack_settings

--- a/corehq/apps/sms/urls.py
+++ b/corehq/apps/sms/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.sms.views import (
     AddDomainGatewayView,

--- a/corehq/apps/sms/urls.py
+++ b/corehq/apps/sms/urls.py
@@ -36,11 +36,13 @@ urlpatterns = [
     url(r'^compose/$', ComposeMessageView.as_view(), name=ComposeMessageView.urlname),
     url(r'^message_test/$', TestSMSMessageView.as_view(), name=TestSMSMessageView.urlname),
     url(r'^api/send_sms/$', api_send_sms, name='api_send_sms'),
-    url(r'^add_gateway/(?P<hq_api_id>[\w-]+)/$',
-        AddDomainGatewayView.as_view(), name=AddDomainGatewayView.urlname
+    url(
+        r"^add_gateway/(?P<hq_api_id>[\w-]+)/$", AddDomainGatewayView.as_view(), name=AddDomainGatewayView.urlname
     ),
-    url(r'^edit_gateway/(?P<hq_api_id>[\w-]+)/(?P<backend_id>[\w-]+)/$',
-        EditDomainGatewayView.as_view(), name=EditDomainGatewayView.urlname
+    url(
+        r"^edit_gateway/(?P<hq_api_id>[\w-]+)/(?P<backend_id>[\w-]+)/$",
+        EditDomainGatewayView.as_view(),
+        name=EditDomainGatewayView.urlname,
     ),
     url(r'^gateways/$', DomainSmsGatewayListView.as_view(), name=DomainSmsGatewayListView.urlname),
     url(r'^chat_contacts/$', ChatOverSMSView.as_view(), name=ChatOverSMSView.urlname),

--- a/corehq/apps/sso/urls.py
+++ b/corehq/apps/sso/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.sso.views.oidc import (
     sso_oidc_login,

--- a/corehq/apps/styleguide/examples/bootstrap5/example_urls.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/example_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.styleguide.examples.bootstrap5.class_view import (
     ExampleCenteredPageView,

--- a/corehq/apps/styleguide/examples/simple_crispy_form/urls.py
+++ b/corehq/apps/styleguide/examples/simple_crispy_form/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.styleguide.examples.simple_crispy_form.views import (
     DefaultSimpleCrispyFormSectionView,

--- a/corehq/apps/styleguide/urls.py
+++ b/corehq/apps/styleguide/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.styleguide.examples.bootstrap5.example_urls import urlpatterns as example_urlpatterns
 from corehq.apps.styleguide.views import (

--- a/corehq/apps/toggle_ui/urls.py
+++ b/corehq/apps/toggle_ui/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.toggle_ui.views import (
     ToggleEditView,

--- a/corehq/apps/translations/urls.py
+++ b/corehq/apps/translations/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.translations.integrations.transifex.views import (
     AppTranslations,

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -489,7 +489,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
 
     @classmethod
     def url_pattern(cls):
-        from django.conf.urls import re_path as url
+        from django.urls import re_path as url
         pattern = r'^{slug}/(?P<subreport_slug>[\w\-:]+)/$'.format(slug=cls.slug)
         return url(pattern, cls.as_view(), name=cls.slug)
 
@@ -636,7 +636,7 @@ class CustomConfigurableReportDispatcher(ReportDispatcher):
 
     @classmethod
     def url_pattern(cls):
-        from django.conf.urls import re_path as url
+        from django.urls import re_path as url
         pattern = r'^{slug}/(?P<subreport_slug>[\w\-:]+)/$'.format(slug=cls.slug)
         return url(pattern, cls.as_view(), name=cls.slug)
 

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.domain.utils import grandfathered_domain_re
 from corehq.apps.reports.dispatcher import UserManagementReportDispatcher

--- a/corehq/apps/zapier/urls.py
+++ b/corehq/apps/zapier/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.api.urls import CommCareHqApi
 from corehq.apps.zapier.api.v0_5 import (

--- a/corehq/ex-submodules/casexml/apps/case/urls.py
+++ b/corehq/ex-submodules/casexml/apps/case/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, re_path as url
+from django.urls import re_path as url
+
 from .views import reference_case_attachment_view
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^casexml/attachment/(?P<domain>[\w\.:-]+)/(?P<case_id>[\w\-]+)/(?P<attachment_id>.*)$',
         reference_case_attachment_view, name="api_case_attachment")
-)
-
+]

--- a/corehq/ex-submodules/soil/urls.py
+++ b/corehq/ex-submodules/soil/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from soil.views import (
     ajax_job_poll,

--- a/corehq/messaging/scheduling/urls.py
+++ b/corehq/messaging/scheduling/urls.py
@@ -1,5 +1,5 @@
 from corehq.apps.hqwebapp.decorators import waf_allow
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.messaging.scheduling.views import (
     BroadcastListView,

--- a/corehq/messaging/smsbackends/amazon_pinpoint/urls.py
+++ b/corehq/messaging/smsbackends/amazon_pinpoint/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from corehq.messaging.smsbackends.amazon_pinpoint.views import PinpointIncomingMessageView
 
 

--- a/corehq/messaging/smsbackends/apposit/urls.py
+++ b/corehq/messaging/smsbackends/apposit/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from corehq.messaging.smsbackends.apposit.views import AppositIncomingView
 
 

--- a/corehq/messaging/smsbackends/grapevine/urls.py
+++ b/corehq/messaging/smsbackends/grapevine/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 
 from corehq.apps.hqwebapp.decorators import waf_allow
 from .models import GrapevineResource

--- a/corehq/messaging/smsbackends/infobip/urls.py
+++ b/corehq/messaging/smsbackends/infobip/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from corehq.messaging.smsbackends.infobip.views import InfobipIncomingMessageView
 
 

--- a/corehq/messaging/smsbackends/push/urls.py
+++ b/corehq/messaging/smsbackends/push/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from corehq.messaging.smsbackends.push.views import PushIncomingView
 
 

--- a/corehq/messaging/smsbackends/sislog/urls.py
+++ b/corehq/messaging/smsbackends/sislog/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.messaging.smsbackends.sislog.views import SislogIncomingSMSView
 

--- a/corehq/messaging/smsbackends/smsgh/urls.py
+++ b/corehq/messaging/smsbackends/smsgh/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from corehq.messaging.smsbackends.smsgh.views import SMSGHIncomingView
 
 urlpatterns = [

--- a/corehq/messaging/smsbackends/starfish/urls.py
+++ b/corehq/messaging/smsbackends/starfish/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from corehq.messaging.smsbackends.starfish.views import StarfishIncomingView
 
 

--- a/corehq/messaging/smsbackends/start_enterprise/urls.py
+++ b/corehq/messaging/smsbackends/start_enterprise/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from corehq.messaging.smsbackends.start_enterprise.views import StartEnterpriseDeliveryReceiptView
 
 

--- a/corehq/messaging/smsbackends/telerivet/urls.py
+++ b/corehq/messaging/smsbackends/telerivet/urls.py
@@ -1,5 +1,5 @@
 from corehq.messaging.smsbackends.telerivet.views import TelerivetSetupView, incoming_message, message_status
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from .views import create_backend, get_last_inbound_sms, send_sample_sms
 
 

--- a/corehq/messaging/smsbackends/tropo/urls.py
+++ b/corehq/messaging/smsbackends/tropo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.messaging.smsbackends.tropo.views import TropoIncomingSMSView, TropoIncomingIVRView
 

--- a/corehq/messaging/smsbackends/trumpia/urls.py
+++ b/corehq/messaging/smsbackends/trumpia/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.messaging.smsbackends.trumpia.views import TrumpiaIncomingView

--- a/corehq/messaging/smsbackends/turn/urls.py
+++ b/corehq/messaging/smsbackends/turn/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from corehq.messaging.smsbackends.turn.views import TurnIncomingSMSView
 
 

--- a/corehq/messaging/smsbackends/twilio/urls.py
+++ b/corehq/messaging/smsbackends/twilio/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from corehq.messaging.smsbackends.twilio.views import (TwilioIncomingSMSView,
     TwilioIncomingIVRView)
 

--- a/corehq/messaging/smsbackends/unicel/urls.py
+++ b/corehq/messaging/smsbackends/unicel/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.messaging.smsbackends.unicel.views import UnicelIncomingSMSView
 

--- a/corehq/messaging/smsbackends/yo/urls.py
+++ b/corehq/messaging/smsbackends/yo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.messaging.smsbackends.yo.views import YoIncomingSMSView
 

--- a/corehq/motech/dhis2/urls.py
+++ b/corehq/motech/dhis2/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 from corehq.apps.hqwebapp.decorators import waf_allow
 
 from corehq.motech.dhis2.views import (

--- a/corehq/motech/fhir/urls.py
+++ b/corehq/motech/fhir/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.motech.fhir.views import (
     get_view,

--- a/corehq/motech/openmrs/urls.py
+++ b/corehq/motech/openmrs/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.motech.openmrs.views import (
     OpenmrsImporterView,

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.motech.dhis2.views import (
     AddDhis2EntityRepeaterView,

--- a/corehq/util/metrics/urls.py
+++ b/corehq/util/metrics/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from corehq.util.metrics.views import prometheus_metrics
 

--- a/custom/champ/urls.py
+++ b/custom/champ/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from custom.champ.views import PrevisionVsAchievementsView, DistrictFilterPrevView, \
     CBOFilterView, PrevisionVsAchievementsTableView, ServiceUptakeView, UserGroupsFilter, OrganizationsFilter, \

--- a/custom/ucla/urls.py
+++ b/custom/ucla/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from custom.ucla.views import task_creation
 

--- a/custom/up_nrhm/urls.py
+++ b/custom/up_nrhm/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from custom.up_nrhm.views import asha_af_report
 

--- a/urls.py
+++ b/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, re_path as url
+from django.urls import include, re_path as url
 from django.contrib import admin
 from django.shortcuts import render
 from django.views.generic import RedirectView, TemplateView


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Easiest to review by commit.

The first two commits are straightforward changes since django 4.0 removed support for the import path we are currently using. `patterns` was deprecated in [v1.8 of django](https://docs.djangoproject.com/en/5.0/releases/1.8/#django-conf-urls-patterns), but I guess wasn't removed until at least Django 4.0. The docs for that do a good job of explaining the evolution of `patterns`, why it eventually became useless, and why the change made here is safe.

Notably, the flake8 changes in 3900f3558313cc88850bd0f2e4a2e5c9936e404d are more significant than usual. Specifically, the change to `download_index_files` and `source_files`. It looks like we no longer needed to serialize the app to json in `source_files`, because we only did this previously to append these results to the `files` variable (201e380c1f6c). Additionally, the returned list of files is already sorted in `download_index_files`, so the sort in `source_files` was redundant.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
