### PR TITLE
Updated .flake8 to ignore B5 diffs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,4 @@ max-line-length = 115
 ignore = E128, E265, F403, W503
 per-file-ignores =
     **/migrations/*.py: E501, E303
+extend-exclude = corehq/apps/hqwebapp/tests/data/bootstrap5_diffs

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
@@ -1,5 +1,5 @@
---- 
-+++ 
+---  
++++  
 @@ -2,26 +2,37 @@
  requirejs.config({
      baseUrl: '/static/',

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
@@ -1,5 +1,5 @@
----  
-+++  
+--- 
++++ 
 @@ -2,26 +2,37 @@
  requirejs.config({
      baseUrl: '/static/',


### PR DESCRIPTION
## Technical Summary
Flake throws a lot of trailing whitespace errors on B5 diff files. It doesn't need to be linting those files in the first place.

More discussion in https://github.com/dimagi/commcare-hq/pull/34298

## Safety Assurance

### Safety story
Change to lint config. No user-facing risk.

### Automated test coverage

not really

### QA Plan

Tested locally, see commit history.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
