### PR TITLE
Change every id field as keyword in Elasticsearch mappings

### DIFF
--- a/corehq/apps/es/mappings/app_mapping.py
+++ b/corehq/apps/es/mappings/app_mapping.py
@@ -138,7 +138,7 @@ APP_MAPPING = {
             "type": "text"
         },
         "family_id": {
-            "type": "text"
+            "type": "keyword"
         },
         "force_http": {
             "type": "boolean"
@@ -416,7 +416,7 @@ APP_MAPPING = {
                                             "type": "keyword"
                                         },
                                         "external_id": {
-                                            "type": "text"
+                                            "type": "keyword"
                                         },
                                         "name_path": {
                                             "type": "text"
@@ -523,7 +523,7 @@ APP_MAPPING = {
                                             "type": "keyword"
                                         },
                                         "reference_id": {
-                                            "type": "text"
+                                            "type": "keyword"
                                         },
                                         "repeat_context": {
                                             "type": "text"
@@ -638,7 +638,7 @@ APP_MAPPING = {
                             "type": "keyword"
                         },
                         "module_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "relationship": {
                             "type": "text"
@@ -684,7 +684,7 @@ APP_MAPPING = {
                     }
                 },
                 "unique_id": {
-                    "type": "text"
+                    "type": "keyword"
                 }
             }
         },
@@ -699,10 +699,10 @@ APP_MAPPING = {
                     "type": "text"
                 },
                 "multimedia_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "unique_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "version": {
                     "type": "long"
@@ -757,7 +757,7 @@ APP_MAPPING = {
             "type": "object"
         },
         "upstream_app_id": {
-            "type": "text"
+            "type": "keyword"
         },
         "upstream_version": {
             "type": "long"

--- a/corehq/apps/es/mappings/case_mapping.py
+++ b/corehq/apps/es/mappings/case_mapping.py
@@ -36,7 +36,7 @@ CASE_MAPPING = {
                             "type": "text"
                         },
                         "referenced_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "referenced_type": {
                             "type": "text"
@@ -48,13 +48,13 @@ CASE_MAPPING = {
                     "type": "date"
                 },
                 "sync_log_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "user_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "xform_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "xform_name": {
                     "type": "text"
@@ -124,7 +124,7 @@ CASE_MAPPING = {
                     "type": "text"
                 },
                 "referenced_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "referenced_type": {
                     "type": "text"
@@ -139,7 +139,7 @@ CASE_MAPPING = {
             "type": "date"
         },
         "location_id": {
-            "type": "text"
+            "type": "keyword"
         },
         "modified_on": {
             "format": DATE_FORMATS_STRING,
@@ -184,7 +184,7 @@ CASE_MAPPING = {
             "type": "text"
         },
         "user_id": {
-            "type": "text"
+            "type": "keyword"
         },
         "version": {
             "type": "text"

--- a/corehq/apps/es/mappings/domain_mapping.py
+++ b/corehq/apps/es/mappings/domain_mapping.py
@@ -39,7 +39,7 @@ DOMAIN_MAPPING = {
             "type": "object",
             "properties": {
                 "case_owner_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "case_type": {
                     "type": "text"
@@ -93,7 +93,7 @@ DOMAIN_MAPPING = {
                     "type": "keyword"
                 },
                 "user_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "user_ip": {
                     "type": "text"
@@ -381,10 +381,10 @@ DOMAIN_MAPPING = {
                     "type": "boolean"
                 },
                 "sf_account_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "sf_contract_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "sub_area": {
                     "fields": {
@@ -495,13 +495,13 @@ DOMAIN_MAPPING = {
             "type": "boolean"
         },
         "sms_case_registration_owner_id": {
-            "type": "text"
+            "type": "keyword"
         },
         "sms_case_registration_type": {
             "type": "text"
         },
         "sms_case_registration_user_id": {
-            "type": "text"
+            "type": "keyword"
         },
         "sms_mobile_worker_registration_enabled": {
             "type": "boolean"
@@ -537,7 +537,7 @@ DOMAIN_MAPPING = {
             "type": "boolean"
         },
         "yt_id": {
-            "type": "text"
+            "type": "keyword"
         },
         Tombstone.PROPERTY_NAME: {
             "type": "boolean"

--- a/corehq/apps/es/mappings/sms_mapping.py
+++ b/corehq/apps/es/mappings/sms_mapping.py
@@ -18,7 +18,7 @@ SMS_MAPPING = {
             "type": "text"
         },
         "backend_id": {
-            "type": "text"
+            "type": "keyword"
         },
         "base_doc": {
             "type": "text"
@@ -60,7 +60,7 @@ SMS_MAPPING = {
             "type": "boolean"
         },
         "reminder_id": {
-            "type": "text"
+            "type": "keyword"
         },
         "text": {
             "type": "text"
@@ -69,7 +69,7 @@ SMS_MAPPING = {
             "type": "text"
         },
         "xforms_session_couch_id": {
-            "type": "text"
+            "type": "keyword"
         },
         Tombstone.PROPERTY_NAME: {
             "type": "boolean"

--- a/corehq/apps/es/mappings/user_mapping.py
+++ b/corehq/apps/es/mappings/user_mapping.py
@@ -16,7 +16,7 @@ USER_MAPPING = {
             "type": "text"
         },
         "__group_ids": {
-            "type": "text"
+            "type": "keyword"
         },
         "__group_names": {
             "fields": {
@@ -30,7 +30,7 @@ USER_MAPPING = {
             "type": "boolean"
         },
         "assigned_location_ids": {
-            "type": "text"
+            "type": "keyword"
         },
         "base_doc": {
             "type": "text"
@@ -146,7 +146,7 @@ USER_MAPPING = {
                     "type": "boolean"
                 },
                 "role_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "timezone": {
                     "type": "text"
@@ -158,7 +158,7 @@ USER_MAPPING = {
             "type": "object",
             "properties": {
                 "assigned_location_ids": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "doc_type": {
                     "type": "keyword"
@@ -181,7 +181,7 @@ USER_MAPPING = {
                     "type": "boolean"
                 },
                 "role_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "timezone": {
                     "type": "text"
@@ -206,7 +206,7 @@ USER_MAPPING = {
                     "type": "text"
                 },
                 "user_id": {
-                    "type": "text"
+                    "type": "keyword"
                 },
                 "user_ip": {
                     "type": "text"
@@ -304,7 +304,7 @@ USER_MAPPING = {
             "type": "text"
         },
         "registering_device_id": {
-            "type": "text"
+            "type": "keyword"
         },
         "reporting_metadata": {
             "dynamic": False,
@@ -315,7 +315,7 @@ USER_MAPPING = {
                     "type": "object",
                     "properties": {
                         "app_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "build_version": {
                             "type": "integer"
@@ -331,7 +331,7 @@ USER_MAPPING = {
                     "type": "nested",
                     "properties": {
                         "app_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "build_version": {
                             "type": "integer"
@@ -347,10 +347,10 @@ USER_MAPPING = {
                     "type": "object",
                     "properties": {
                         "app_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "build_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "build_version": {
                             "type": "integer"
@@ -359,7 +359,7 @@ USER_MAPPING = {
                             "type": "text"
                         },
                         "device_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "submission_date": {
                             "format": DATE_FORMATS_STRING,
@@ -372,10 +372,10 @@ USER_MAPPING = {
                     "type": "nested",
                     "properties": {
                         "app_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "build_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "build_version": {
                             "type": "integer"
@@ -384,7 +384,7 @@ USER_MAPPING = {
                             "type": "text"
                         },
                         "device_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "submission_date": {
                             "format": DATE_FORMATS_STRING,
@@ -397,7 +397,7 @@ USER_MAPPING = {
                     "type": "object",
                     "properties": {
                         "app_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "build_version": {
                             "type": "integer"
@@ -413,7 +413,7 @@ USER_MAPPING = {
                     "type": "nested",
                     "properties": {
                         "app_id": {
-                            "type": "text"
+                            "type": "keyword"
                         },
                         "build_version": {
                             "type": "integer"


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
We have most of the fields marked as `text` fields and we run aggregations on some of them. Running aggregations on `text` fields was supported till ES2 and it is also supported in ES 5 for indices brought from ES 2. But for newer indices it is not supported. 
If you want to run aggregations on `text` fields you would have to enable `fielddata` which again is expensive. Since we would never run fuzzy queries on id based field we should be marking them as `keyword` fields. 
This is the best time to do it as we are creating new indices for upgrading to ES 6.
Some discussion on it happened on [#gtd-elasticsearch](https://dimagi.slack.com/archives/C4Q5D8ZDZ/p1710752801017969)

Ticket - https://dimagi.atlassian.net/browse/SAAS-15422
## Safety Assurance
Does not affect anything and the changes will only come into play after new indices have been created which will come in the following PR.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Pretty safe. Changes does not affect anything in HQ.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
