### PR TITLE
Updated CKEDITOR_BASEPATH assignment

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -99,7 +99,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
             },
         });
 
-        CKEDITOR_BASEPATH = initialPageData('CKEDITOR_BASEPATH');     // eslint-disable-line no-unused-vars, no-undef
+        window.CKEDITOR_BASEPATH = initialPageData('CKEDITOR_BASEPATH');     // eslint-disable-line no-unused-vars, no-undef
 
         // This unfortunate chain of import callbacks was required because
         // appcues appears to make an attempt to use the same requirejs


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Fixes a bug in javascript that caused app builder to not load.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15401
Fix taken from https://github.com/dimagi/commcare-hq/commit/4bff9f8d498e03d532229cba1f4e6201fb8bdace and likely caused by https://github.com/dimagi/commcare-hq/pull/34257 which got into action due to js compression [here](https://github.com/dimagi/commcare-hq/blob/463acdd187fd0fc3d76117459efd58bac6a66102/corehq/apps/app_manager/templates/app_manager/form_designer.html#L44) that included this file with other files that had "use strict" added.

We were able to confirm the fix locally during our deploy to India.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
We were unable to test this fix standalone locally, even after running collectstatic due to multiple issues being faced though from code that seemed like the right fix and mainly it was working on staging as a part of [another branch](https://github.com/dimagi/commcare-hq/pull/34271/commits/4bff9f8d498e03d532229cba1f4e6201fb8bdace) that was already deployed on staging.
The blast radius of this is limited to app manager which is currently not working due to the failure in javascript, so this change won't make it worse.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
