### PR TITLE
Adds App filter to the Project Performance Report

### DIFF
--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -266,6 +266,7 @@ class ProjectHealthDashboard(ProjectReport):
     fields = [
         'corehq.apps.reports.filters.location.LocationGroupFilter',
         'corehq.apps.reports.filters.dates.HiddenLastMonthDateFilter',
+        'corehq.apps.reports.filters.select.SelectApplicationFilter',
     ]
 
     exportable = True

--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -17,6 +17,7 @@ from corehq.apps.es.groups import GroupES
 from corehq.apps.es.users import UserES
 from corehq.apps.hqwebapp.decorators import use_nvd3
 from corehq.apps.locations.models import SQLLocation
+from corehq.apps.reports.filters.select import SelectApplicationFilter
 from corehq.apps.reports.standard import ProjectReport
 from corehq.apps.users.util import raw_username
 
@@ -79,6 +80,7 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
         previous_summary=None,
         delta_high_performers=0,
         delta_low_performers=0,
+        app_id=None,
     ):
         self._previous_summary = previous_summary
         self._next_summary = None
@@ -94,6 +96,9 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
             base_queryset = base_queryset.filter(
                 user_id__in=selected_users,
             )
+
+        if app_id:
+            base_queryset = base_queryset.filter(app_id=app_id)
 
         self._user_stat_from_malt = (base_queryset
                                      .values('user_id', 'username')
@@ -283,6 +288,10 @@ class ProjectHealthDashboard(ProjectReport):
     def decorator_dispatcher(self, request, *args, **kwargs):
         super(ProjectHealthDashboard, self).decorator_dispatcher(request, *args, **kwargs)
 
+    @property
+    def selected_app_id(self):
+        return self.request_params.get(SelectApplicationFilter.slug, None)
+
     def get_number_of_months(self):
         try:
             return int(self.request.GET.get('months', 6))
@@ -348,6 +357,7 @@ class ProjectHealthDashboard(ProjectReport):
                 previous_summary=last_month_summary,
                 selected_users=filtered_users,
                 active_not_deleted_users=active_not_deleted_users,
+                app_id=self.selected_app_id,
             )
             six_month_summary.append(this_month_summary)
             if last_month_summary is not None:

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -168,6 +168,18 @@ class MonthlyPerformanceSummaryTests(SetupProjectPerformanceMixin, TestCase):
         self.assertEqual(month_summary.number_of_active_users, 1)
         self.assertEqual(month_summary.number_of_performing_users, 1)
 
+    def test_filter_by_app_id(self):
+        prev_month_summary, month_summary = self.get_summary_for_two_months(
+            self.users_in_group,
+            self.active_not_deleted_users,
+            self.APP_ID,
+        )
+
+        self.assertEqual(prev_month_summary.number_of_active_users, 1)
+        self.assertEqual(prev_month_summary.number_of_performing_users, 1)
+        self.assertEqual(month_summary.number_of_active_users, 1)
+        self.assertEqual(month_summary.number_of_performing_users, 1)
+
 
 @mock.patch('corehq.apps.reports.standard.project_health.GroupES', GroupESFake)
 class ProjectHealthDashboardTest(SetupProjectPerformanceMixin, TestCase):

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -157,6 +157,17 @@ class MonthlyPerformanceSummaryTests(SetupProjectPerformanceMixin, TestCase):
         """
         self.assertEqual(len(list(self.month._get_all_user_stubs())), 2)
 
+    def test_filter_by_selected_users(self):
+        prev_month_summary, month_summary = self.get_summary_for_two_months(
+            [self.user1._id],
+            self.active_not_deleted_users,
+        )
+
+        self.assertEqual(prev_month_summary.number_of_active_users, 0)
+        self.assertEqual(prev_month_summary.number_of_performing_users, 0)
+        self.assertEqual(month_summary.number_of_active_users, 1)
+        self.assertEqual(month_summary.number_of_performing_users, 1)
+
 
 @mock.patch('corehq.apps.reports.standard.project_health.GroupES', GroupESFake)
 class ProjectHealthDashboardTest(SetupProjectPerformanceMixin, TestCase):

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -1,9 +1,8 @@
 import datetime
 import uuid
+from unittest import mock
 
 from django.test import RequestFactory, TestCase
-
-from unittest import mock
 
 from dimagi.utils.dates import add_months
 

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 from django.test import RequestFactory, TestCase
 
@@ -27,10 +28,11 @@ class SetupProjectPerformanceMixin(object):
     USERNAME2 = "testuser2"
     WEB_USER = "webuser"
     USER_TYPE = "CommCareUser"
+    APP_ID = uuid.uuid4().hex
     now = datetime.datetime.utcnow()
-    year, month = add_months(now.year, now.month, 1)
-    month_as_date = datetime.date(year, month, 1)
-    prev_month_as_date = datetime.date(now.year, now.month, 1)
+    month_as_date = datetime.date(now.year, now.month, 1)
+    prev_year, prev_month = add_months(now.year, now.month, -1)
+    prev_month_as_date = datetime.date(prev_year, prev_month, 1)
 
     @classmethod
     def class_setup(cls):
@@ -72,7 +74,7 @@ class SetupProjectPerformanceMixin(object):
             domain_name=cls.DOMAIN_NAME,
             user_type=cls.USER_TYPE,
             num_of_forms=16,
-            app_id=MISSING_APP_ID,
+            app_id=cls.APP_ID,
         )
         malt_user.save()
         malt_user1 = MALTRow.objects.create(
@@ -92,7 +94,7 @@ class SetupProjectPerformanceMixin(object):
             domain_name=cls.DOMAIN_NAME,
             user_type=cls.USER_TYPE,
             num_of_forms=15,
-            app_id=MISSING_APP_ID,
+            app_id=cls.APP_ID,
         )
         malt_user_prev.save()
 
@@ -103,24 +105,33 @@ class MonthlyPerformanceSummaryTests(SetupProjectPerformanceMixin, TestCase):
     def setUpClass(cls):
         super(MonthlyPerformanceSummaryTests, cls).setUpClass()
         cls.class_setup()
-        users_in_group = []
-        active_not_deleted_users = [cls.user._id, cls.user1._id, cls.user2._id]
-        cls.prev_month = MonthlyPerformanceSummary(
+        cls.users_in_group = []
+        cls.active_not_deleted_users = [cls.user._id, cls.user1._id, cls.user2._id]
+        cls.prev_month, cls.month = cls.get_summary_for_two_months(
+            cls.users_in_group, cls.active_not_deleted_users
+        )
+
+    @classmethod
+    def get_summary_for_two_months(cls, users_in_group, active_not_deleted_users, app_id=None):
+        prev_month_summary = MonthlyPerformanceSummary(
             domain=cls.DOMAIN_NAME,
             performance_threshold=15,
             month=cls.prev_month_as_date,
             previous_summary=None,
             selected_users=users_in_group,
             active_not_deleted_users=active_not_deleted_users,
+            app_id=app_id,
         )
-        cls.month = MonthlyPerformanceSummary(
+        month_summary = MonthlyPerformanceSummary(
             domain=cls.DOMAIN_NAME,
             performance_threshold=15,
             month=cls.month_as_date,
-            previous_summary=cls.prev_month,
+            previous_summary=prev_month_summary,
             selected_users=users_in_group,
             active_not_deleted_users=active_not_deleted_users,
+            app_id=app_id,
         )
+        return prev_month_summary, month_summary
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds application filter to the Project Performance Report.

![image](https://github.com/dimagi/commcare-hq/assets/125016806/debd5c4f-683b-4884-a1a6-92dc56a46b64)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-3416)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local Testing completed.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test Case added for app filter and user filter.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA ticket - [QA-6249](https://dimagi.atlassian.net/browse/QA-6249)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[QA-6249]: https://dimagi.atlassian.net/browse/QA-6249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ