### PR TITLE
Remove local search bar in web apps when SSCS is enabled

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1035,6 +1035,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", function () {
                 isMultiSelect: false,
                 showMap: this.showMap,
                 sidebarEnabled: this.options.sidebarEnabled,
+                splitScreenToggleEnabled: toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
                 smallScreenEnabled: this.smallScreenEnabled,
                 triggerEmptyCaseList: this.options.triggerEmptyCaseList,
 

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -20,7 +20,7 @@
     </div>
     <% } %>
 
-    <% if (!sidebarEnabled) { %>
+    <% if (!splitScreenToggleEnabled) { %>
     <div class="module-search-container">
       <div class="input-group input-group-lg">
         <input type="text"


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Following the discussion in [USH-4064](https://dimagi.atlassian.net/browse/USH-4064), we want to remove the "local" case search search bar when split-screen case search is enabled.

![Screenshot 2024-03-21 at 3 03 05 PM](https://github.com/dimagi/commcare-hq/assets/6729291/e857ec10-b4be-4f42-aa95-ef3e0812ef23)
->
![Screenshot 2024-03-21 at 3 03 58 PM](https://github.com/dimagi/commcare-hq/assets/6729291/e6e8449a-06ad-417b-a0a9-b817ce25f7c4)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

- I'm pretty sure the SSCS toggle is inclusive of `sidebarEnabled` (see [here](https://github.com/dimagi/commcare-hq/blob/854fb11ca2ec440eb4ebbd81452d4bda9359e738/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js#L164-L165)), so we can just update the search bar to not show if the FF isn't enabled
- I had trouble finding any precedent for checking a FF in a cloudcare template, I thought I went about it in a proper way but lmk if you have thoughts there

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

SPLIT_SCREEN_CASE_SEARCH

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Very small code change
- Tested locally, with the FF on and off
- This will go through the new weekly QA UI cycle

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

This will go through the new weekly QA UI cycle.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4064]: https://dimagi.atlassian.net/browse/USH-4064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ