### PR TITLE
Add View Cases Column to Raw Forms Report

### DIFF
--- a/corehq/apps/reports/standard/forms/reports.py
+++ b/corehq/apps/reports/standard/forms/reports.py
@@ -125,7 +125,6 @@ class SubmissionErrorReport(DeploymentsReport):
                     view_name = 'render_form_data'
                 else:
                     view_name = 'download_form'
-                view_name = 'download_form'
                 try:
                     url = reverse(view_name, args=[self.domain, doc_id])
                     if tab_link:

--- a/corehq/apps/reports/standard/forms/reports.py
+++ b/corehq/apps/reports/standard/forms/reports.py
@@ -44,7 +44,8 @@ class SubmissionErrorReport(DeploymentsReport):
                                    DataTablesColumn(_("Submit Time"), prop_name="received_on"),
                                    DataTablesColumn(_("Form Type"), sortable=False),
                                    DataTablesColumn(_("Error Type"), sortable=False),
-                                   DataTablesColumn(_("Error Message"), sortable=False))
+                                   DataTablesColumn(_("Error Message"), sortable=False),
+                                   DataTablesColumn(_("View Cases"), sortable=False))
         if self.support_toggle_enabled:
             headers.add_column(DataTablesColumn(_("Re-process Form")))
         headers.custom_sort = [[2, "desc"]]

--- a/corehq/apps/reports/standard/forms/reports.py
+++ b/corehq/apps/reports/standard/forms/reports.py
@@ -116,7 +116,7 @@ class SubmissionErrorReport(DeploymentsReport):
         EMPTY_FORM = _("Unknown Form")
 
         def _to_row(xform_dict):
-            def _fmt_url(doc_id):
+            def _fmt_url(doc_id, link_text, tab_link=None):
                 if xform_dict['doc_type'] in [
                         "XFormInstance",
                         "XFormArchived",
@@ -125,11 +125,15 @@ class SubmissionErrorReport(DeploymentsReport):
                     view_name = 'render_form_data'
                 else:
                     view_name = 'download_form'
+                view_name = 'download_form'
                 try:
+                    url = reverse(view_name, args=[self.domain, doc_id])
+                    if tab_link:
+                        url += tab_link
                     return format_html(
                         "<a class='ajax_dialog' href='{url}'>{text}</a>",
-                        url=reverse(view_name, args=[self.domain, doc_id]),
-                        text=_("View Form")
+                        url=url,
+                        text=link_text,
                     )
                 except NoReverseMatch:
                     return 'unable to view form'
@@ -161,12 +165,13 @@ class SubmissionErrorReport(DeploymentsReport):
                         date=_fmt_date(string_to_utc_datetime(archive_operations[-1].get('date'))),
                     )
             return [
-                _fmt_url(xform_dict['_id']),
+                _fmt_url(xform_dict['_id'], link_text=_("View Form")),
                 form_username,
                 _fmt_date(string_to_utc_datetime(xform_dict['received_on'])),
                 form_name,
                 error_type,
                 xform_dict.get('problem', EMPTY_ERROR),
+                _fmt_url(xform_dict['_id'], link_text=_("View Cases"), tab_link='#form-case-data'),
                 self._make_reproces_button(xform_dict) if self.support_toggle_enabled else '',
             ]
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A new "View Cases" column is added to the "Raw Forms, Duplicates, and Errors" report:
![view-cases-column](https://github.com/dimagi/commcare-hq/assets/122617251/f8d0d1e4-93d8-478a-a27a-f4b55811cf2c)

Clicking on the link in this column for a row will take the user to the cases tab on the relevant form page:
![cases-tab-form-page](https://github.com/dimagi/commcare-hq/assets/122617251/6698fa82-4c57-4662-bf26-2753768ee99a)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3420).

The new column on the raw forms report allows users to see all the cases that are impacted by a particular form.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- QA done

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA is completed. Ticket available [here](https://dimagi.atlassian.net/browse/QA-6255).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
