### PR TITLE
Set tags for former India Division FFs

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2399,7 +2399,7 @@ EMBED_TABLEAU_REPORT_BY_USER = StaticToggle(
 APPLICATION_RELEASE_LOGS = StaticToggle(
     'application_release_logs',
     'Show Application release logs',
-    TAG_PRODUCT,
+    TAG_SOLUTIONS_OPEN,
     namespaces=[NAMESPACE_DOMAIN],
     description='This feature provides the release logs for application.'
 )

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2486,7 +2486,7 @@ LOCATION_RESTRICTED_SCHEDULED_REPORTS = StaticToggle(
     'Allows access to report scheduling views for location restricted users',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
-    description='Provides access to views for resport scheduling '
+    description='Provides access to views for report scheduling '
                 'such as schedule creation and deletion.'
 )
 


### PR DESCRIPTION
## Technical Summary

Context: [SC-3529](https://dimagi.atlassian.net/browse/SC-3529)

This change sets the correct tags for former India Division feature flags. Only one feature flag needed to be changed.

This is a non-code change.

## Feature Flag

"Show Application release logs"

## Safety Assurance

### Safety story

This is a non-code change.

### Automated test coverage

Not applicable

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3529]: https://dimagi.atlassian.net/browse/SC-3529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ