### PR TITLE
Fixed split_bundles config in build_requirejs

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -147,7 +147,7 @@ def _r_js(local=False, verbose=False, bootstrap_version=None):
     # These pages depend on bootstrap 5 and must be skipped by the bootstrap3 run of this command.
     # "<bundle directory>": [<js main modules that depend on bootstrap 5>]
     split_bundles = {
-        "commtrack/js": ['commtrack/js/bootstrap5/products_and_programs_main'],
+        "commtrack/js": ['commtrack/js/products_and_programs_main'],
         "hqwebapp/js": ['hqwebapp/js/500'],
     }
 


### PR DESCRIPTION
## Technical Summary
I could have sworn I tested https://github.com/dimagi/commcare-hq/pull/34332, yet the rename  is wrong.

## Safety Assurance

### Safety story
small change to config in a management command

### Automated test coverage

no

### QA Plan

no

### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
