### PR TITLE
Add CheckboxField for using checkboxes with labels, inline labels, and help text in horizontal crispy forms

### DIFF
--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -274,6 +274,10 @@ class FieldWithExtras(Field):
         return super(FieldWithExtras, self).render(form, context, template_pack=template_pack, **kwargs)
 
 
+class CheckboxField(Field):
+    template = "bootstrap3to5/layout/prepended_appended_text.html"
+
+
 class FieldWithHelpBubble(FieldWithExtras):
     """Add a help bubble after the field label.
 

--- a/corehq/apps/styleguide/examples/bootstrap5/checkbox_form.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/checkbox_form.py
@@ -44,7 +44,7 @@ class CheckboxDemoForm(forms.Form):
             crispy.Fieldset(
                 _("Basic Information"),
                 'height',  # Functions the same as crispy.Field below
-                twbscrispy.PrependedText('smoking_status', ''),
+                hqcrispy.CheckboxField('smoking_status'),
                 crispy.Field('heart_rate'),
                 'forward_results',
             ),

--- a/corehq/apps/styleguide/examples/bootstrap5/crispy_forms_basic.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/crispy_forms_basic.py
@@ -70,7 +70,7 @@ class BasicCrispyExampleForm(forms.Form):
                 # This is a special component that is best to use
                 # in combination with BootstrapCheckboxInput on a
                 # BooleanField (see Molecules > Checkboxes)
-                twbscrispy.PrependedText('forward_message', ''),
+                hqcrispy.CheckboxField('forward_message'),
             ),
             crispy.Fieldset(
                 _("Advanced Information"),

--- a/corehq/apps/styleguide/examples/bootstrap5/crispy_forms_knockout.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/crispy_forms_knockout.py
@@ -76,7 +76,7 @@ class KnockoutCrispyExampleForm(forms.Form):
                     # data-bind creating select2 (see Molecules > Selections)
                     data_bind="select2: areas, value: area"
                 ),
-                twbscrispy.PrependedText('include_message', ''),
+                hqcrispy.CheckboxField('include_message'),
                 crispy.Div(
                     crispy.Field('message', data_bind="value: message"),
                     # we apply a data-bind on the visibility to a wrapper

--- a/corehq/apps/styleguide/examples/bootstrap5/switch_form.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/switch_form.py
@@ -36,7 +36,7 @@ class SwitchDemoForm(forms.Form):
             crispy.Fieldset(
                 _("Basic Information"),
                 'email',
-                twbscrispy.PrependedText('enable_tracking', ''),
+                hqcrispy.CheckboxField('enable_tracking'),
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(

--- a/corehq/apps/styleguide/examples/simple_crispy_form/forms.py
+++ b/corehq/apps/styleguide/examples/simple_crispy_form/forms.py
@@ -59,8 +59,7 @@ class ExampleUserLoginForm(forms.Form):
             crispy.Fieldset(
                 _("Advanced Information"),
                 'is_staff',
-                twbscrispy.PrependedText('phone_number', '+',
-                                         placeholder='15555555555'),
+                hqcrispy.CheckboxField('phone_number', placeholder='15555555555'),
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(_("Create User"),

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/checkboxes.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/checkboxes.html
@@ -62,7 +62,7 @@
   </p>
   <p>
     To get a label to appear on the left, checkboxes are sometimes displayed as a single-element you must use the
-    <code>BootstrapCheckboxInput</code> <code>widget</code> and the <code>PrependText</code> crispy forms layout element
+    <code>BootstrapCheckboxInput</code> <code>widget</code> and the <code>CheckboxField</code> crispy forms layout element
     as shown below.
   </p>
   <p>
@@ -100,8 +100,8 @@
   </h3>
   <p>
     Switches can also be used in crispy forms for <code>BooleanField</code>s using a combination of the
-    <code>BootstrapSwitchInput</code> <code>widget</code> and the <code>PrependText</code> crispy forms layout element
-    as shown below.
+    <code>BootstrapSwitchInput</code> <code>widget</code> and the <code>CheckboxField</code> crispy
+    forms layout element as shown below.
   </p>
   {% include 'styleguide/bootstrap5/form_example.html' with content=examples.switch_crispy %}
 


### PR DESCRIPTION
## Technical Summary
Instead of co-opting `PrependedText` and leaving out the required second argument (which actually throws a silent error), a new field `CheckboxField` is created that piggy-backs off the `PrependedText` template, without requiring a second argument. This is needed when using checkboxes in horizontal crispy forms if the left-hand label, inline label (text following the checkbox), and the help text are needed for a checkbox in the form. Styleguide has been updated to reflect new usage.

## Safety Assurance

### Safety story
Very safe change and removes an existing silent error thrown when using `PrependedText` without the second argument. References have only been updated in styleguide forms, so nothing in production workflows is currently affected by this change.

### Automated test coverage
No

### QA Plan
none


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
