### PR TITLE
Add no-op migrations in preparation for 4.2

### DIFF
--- a/corehq/apps/data_interfaces/migrations/0038_alter_caseduplicate_potential_duplicates.py
+++ b/corehq/apps/data_interfaces/migrations/0038_alter_caseduplicate_potential_duplicates.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("data_interfaces", "0037_add_dedupe_update_toggle"),
+    ]
+
+    state_operations = [
+        migrations.AlterField(
+            model_name="caseduplicate",
+            name="potential_duplicates",
+            field=models.ManyToManyField(to="data_interfaces.caseduplicate"),
+        ),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(state_operations=state_operations)
+    ]

--- a/corehq/apps/data_interfaces/migrations/0038_alter_caseduplicate_potential_duplicates.py
+++ b/corehq/apps/data_interfaces/migrations/0038_alter_caseduplicate_potential_duplicates.py
@@ -1,4 +1,12 @@
+from django import VERSION as django_version
 from django.db import migrations, models
+
+# Django < 4 specifies related_name in ManyToManyField, whereas Django >= 4 does not.
+# This results in a new migration being created on 4. This m2m_kwargs is designed to enable
+# upgrading to Django 4.2 from 3.2 smoothly.
+m2m_kwargs = {}
+if django_version[0] < 4:
+    m2m_kwargs['related_name'] = '_caseduplicate_potential_duplicates_+'
 
 
 class Migration(migrations.Migration):
@@ -11,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="caseduplicate",
             name="potential_duplicates",
-            field=models.ManyToManyField(to="data_interfaces.caseduplicate"),
+            field=models.ManyToManyField(to="data_interfaces.caseduplicate", **m2m_kwargs),
         ),
     ]
 

--- a/corehq/blobs/migrations/0014_alter_deletedblobmeta_id.py
+++ b/corehq/blobs/migrations/0014_alter_deletedblobmeta_id.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("blobs", "0013_drop_icds_cas_index"),
+    ]
+
+    state_operations = [
+        migrations.AlterField(
+            model_name="deletedblobmeta",
+            name="id",
+            field=models.IntegerField(primary_key=True, serialize=False),
+        ),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(state_operations=state_operations),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -195,6 +195,7 @@ blobs
  0011_blobmeta_compressed
  0012_rename_indexes
  0013_drop_icds_cas_index
+ 0014_alter_deletedblobmeta_id
 case_importer
  0001_initial
  0002_auto_20161206_1937
@@ -344,6 +345,7 @@ data_interfaces
  0035_add_case_duplicate_new
  0036_backfill_dedupe_match_values
  0037_add_dedupe_update_toggle
+ 0038_alter_caseduplicate_potential_duplicates
 dhis2
  0001_initial
  0002_auto_20170322_1323


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://docs.djangoproject.com/en/5.0/releases/4.0/#migrations-autodetector-changes

No-op migrations in preparation for upgrading to Django 4.2.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
