### PR TITLE
[B5] migration config: Added renames for grid offset columns

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
@@ -60,7 +60,6 @@
         "col-md-<num>": "col-lg-<num>",
         "col-sm-<num>": "col-md-<num>",
         "col-xs-<num>": "col-sm-<num>",
-        "col-xs-<num>": "col-sm-<num>",
         "col-xl-offset-<num>": "offset-xxl-<num>",
         "col-lg-offset-<num>": "offset-xl-<num>",
         "col-md-offset-<num>": "offset-lg-<num>",

--- a/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
@@ -59,7 +59,13 @@
         "col-lg-<num>": "col-xl-<num>",
         "col-md-<num>": "col-lg-<num>",
         "col-sm-<num>": "col-md-<num>",
-        "col-xs-<num>": "col-sm-<num>"
+        "col-xs-<num>": "col-sm-<num>",
+        "col-xs-<num>": "col-sm-<num>",
+        "col-xl-offset-<num>": "offset-xxl-<num>",
+        "col-lg-offset-<num>": "offset-xl-<num>",
+        "col-md-offset-<num>": "offset-lg-<num>",
+        "col-sm-offset-<num>": "offset-md-<num>",
+        "col-xs-offset-<num>": "offset-sm-<num>"
     },
     "data_attribute_renames": {
         "data-toggle": "data-bs-toggle",


### PR DESCRIPTION
## Technical Summary
These have been renamed.
B3: https://getbootstrap.com/docs/3.4/css/#grid-offsetting
B5: https://getbootstrap.com/docs/5.0/layout/columns/#offsetting-columns

## Safety Assurance

### Safety story
Config change to an internal engineering tool

### Automated test coverage

The migration tool has test coverage. I don't think it's necessary to add tests specific to these additional renames, which follow an existing pattern.

### QA Plan
not requesting QA


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
