### PR TITLE
Removed datepicker and jquery ui imports on DHIS2 dataset maps pages

### DIFF
--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map_create.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map_create.js
@@ -1,7 +1,6 @@
 hqDefine("dhis2/js/dataset_map_create", [
     "jquery",
     "hqwebapp/js/bootstrap3/widgets",
-    'jquery-ui/ui/widgets/datepicker',
 ], function ($) {
     function showCompleteDateColumnInput(shouldShow) {
         var label = $('label[for="id_complete_date_column"]').hide();

--- a/corehq/motech/dhis2/static/dhis2/js/dataset_map_update.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dataset_map_update.js
@@ -2,7 +2,6 @@ hqDefine("dhis2/js/dataset_map_update", [
     "jquery",
     "hqwebapp/js/bootstrap3/crud_paginated_list_init",
     "hqwebapp/js/bootstrap3/widgets",
-    'jquery-ui/ui/widgets/datepicker',
 ], function ($) {
     function showCompleteDateColumnInput(shouldShow) {
         var label = $('label[for="id_complete_date_column"]').hide();

--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -15,7 +15,6 @@ from django.views.generic.edit import BaseCreateView, BaseUpdateView
 from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views.settings import BaseProjectSettingsView
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
@@ -201,7 +200,6 @@ class DataSetMapCreateView(BaseCreateView, BaseProjectSettingsView):
 
     @method_decorator(require_permission(HqPermissions.edit_motech))
     @method_decorator(toggles.DHIS2_INTEGRATION.required_decorator())
-    @use_jquery_ui  # for datepicker
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 
@@ -234,7 +232,6 @@ class DataSetMapUpdateView(BaseUpdateView, BaseProjectSettingsView,
 
     @method_decorator(require_permission(HqPermissions.edit_motech))
     @method_decorator(toggles.DHIS2_INTEGRATION.required_decorator())
-    @use_jquery_ui  # for datepicker
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/29963, which replaced the datepicker with a different set of inputs. Ran across this while looking at jquery UI usage in HQ.

## Feature Flag
DHIS2

## Safety Assurance

### Safety story
Code review should be sufficient for this. I did verify the page to create a dataset map still loads locally.

### Automated test coverage

unlikely

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
