### PR TITLE
[B5] Fix tempusDominus usage in requirejs 

### DIFF
--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -234,24 +234,24 @@ def use_bootstrap5(view_func):
     return _inner
 
 
-def use_datetimepicker(view_func):
+def use_tempusdominus(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to include CSS for Tempus Dominus (Date and/or Time picking widget).
     NOTE: Only available for Bootstrap 5 pages!
 
     Example:
-        @use_datetimepicker
+        @use_tempusdominus
         def dispatch(self, request, *args, **kwargs):
             return super().dispatch(request, *args, **kwargs)
 
     Or alternatively:
-        @method_decorator(use_datetimepicker, name='dispatch')
+        @method_decorator(use_tempusdominus, name='dispatch')
         class MyViewClass(MyViewSubclass):
             ...
     """
     @wraps(view_func)
     def _inner(request, *args, **kwargs):
-        request.use_datetimepicker = True
+        request.use_tempusdominus = True
         return view_func(request, *args, **kwargs)
     return _inner
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/requirejs_config.js
@@ -10,7 +10,6 @@ requirejs.config({
         "datatables.bootstrap": "datatables.net-bs5/js/dataTables.bootstrap5.min",
         "datatables.fixedColumns": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
         "datatables.fixedColumns.bootstrap": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
-        "datetimepicker": "@eonasdan/tempus-dominus/dist/js/jQuery-provider.min",  // import this if you need jquery plugin of tempus-dominus
         "es6": "requirejs-babel7/es6",
         "jquery": "jquery/dist/jquery.min",
         "knockout": "knockout/build/output/knockout-latest.debug",
@@ -18,7 +17,7 @@ requirejs.config({
         "popper": "@popperjs/core/dist/umd/popper.min",
         "sentry_browser": "sentry/js/sentry.browser.7.28.0.min",
         "sentry_captureconsole": "sentry/js/sentry.captureconsole.7.28.0.min",
-        "tempus-dominus": "@eonasdan/tempus-dominus/dist/js/tempus-dominus.min",
+        "tempusDominus": "@eonasdan/tempus-dominus/dist/js/tempus-dominus.min",
         "underscore": "underscore/underscore",
     },
     shim: {
@@ -26,8 +25,8 @@ requirejs.config({
         "ace-builds/src-min-noconflict/ace": { exports: "ace" },
         "datatables.bootstrap": { deps: ['datatables'] },
         "datatables.fixedColumns.bootstrap": { deps: ['datatables.fixedColumns'] },
-        "datetimepicker": {
-            deps: ['popper', 'tempus-dominus'],
+        "tempusDominus": {
+            deps: ['popper'],
         },
         "d3/d3.min": {
             "exports": "d3",

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/widgets.js
@@ -4,8 +4,9 @@ hqDefine("hqwebapp/js/bootstrap5/widgets",[
     'underscore',
     '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
     'hqwebapp/js/initial_page_data',
+    'tempusDominus',
     'select2/dist/js/select2.full.min',
-], function ($, _, MapboxGeocoder, initialPageData) {
+], function ($, _, MapboxGeocoder, initialPageData, tempusDominus) {
     var init = function () {
         var MAPBOX_ACCESS_TOKEN = initialPageData.get(
             "mapbox_access_token"
@@ -108,11 +109,9 @@ hqDefine("hqwebapp/js/bootstrap5/widgets",[
         });
 
         _.each($(".date-picker"), function (input) {
-            // datepicker / tempus dominus
-            // This is imported using hqRequire because tempus dominus is not currently working.
-            // This protects other modules that use this module but don't use datepickers.
-            hqRequire(['datetimepicker'], function () {
-                $(input).tempusDominus({
+            new tempusDominus.TempusDominus(
+                input,
+                {
                     display: {
                         theme: 'light',
                         components: {
@@ -123,7 +122,6 @@ hqDefine("hqwebapp/js/bootstrap5/widgets",[
                         format: 'yyyy-MM-dd',
                     },
                 });
-            });
         });
     };
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -71,6 +71,7 @@ function hqDefine(path, dependencies, moduleAccessor) {
             };
             if (window.USE_BOOTSTRAP5) {
                 thirdPartyGlobals['es6!hqwebapp/js/bootstrap5_loader'] = 'bootstrap';
+                thirdPartyGlobals['tempusDominus'] = 'tempusDominus';
             }
             var args = [];
             for (var i = 0; i < dependencies.length; i++) {

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -176,6 +176,13 @@
       {% endcompress %}
     {% endif %}
 
+    {% if request.use_datetimepicker and not requirejs_main and use_bootstrap5 %}
+      {% compress js %}
+        <script src="{% static '@popperjs/core/dist/umd/popper.min.js' %}"></script>
+        <script src="{% static '@eonasdan/tempus-dominus/dist/js/tempus-dominus.min.js' %}"></script>
+      {% endcompress %}
+    {% endif %}
+
     {% block head %}
     {% endblock %}
   </head>
@@ -414,14 +421,6 @@
       {% compress js %}
         <script src="{% static 'bootstrap3-typeahead/bootstrap3-typeahead.min.js' %}"></script>
         <script src="{% static 'hqwebapp/js/bootstrap-multi-typeahead.js' %}"></script>
-      {% endcompress %}
-    {% endif %}
-
-    {% if request.use_datetimepicker and not requirejs_main and use_bootstrap5 %}
-      {% compress js %}
-        <script src="{% static '@popperjs/core/dist/umd/popper.min.js' %}"></script>
-        <script src="{% static '@eonasdan/tempus-dominus/dist/js/tempus-dominus.min.js' %}"></script>
-        <script src="{% static '@eonasdan/tempus-dominus/dist/js/jQuery-provider.min.js' %}"></script>
       {% endcompress %}
     {% endif %}
 

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -128,7 +128,7 @@
       {% endif %}
     {% endif %}
 
-    {% if request.use_datetimepicker and use_bootstrap5 %}
+    {% if request.use_tempusdominus and use_bootstrap5 %}
       {% compress css %}
         <link type="text/css"
               rel="stylesheet"
@@ -176,7 +176,7 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_datetimepicker and not requirejs_main and use_bootstrap5 %}
+    {% if request.use_tempusdominus and not requirejs_main and use_bootstrap5 %}
       {% compress js %}
         <script src="{% static '@popperjs/core/dist/umd/popper.min.js' %}"></script>
         <script src="{% static '@eonasdan/tempus-dominus/dist/js/tempus-dominus.min.js' %}"></script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -2,26 +2,37 @@
+@@ -2,26 +2,36 @@
  requirejs.config({
      baseUrl: '/static/',
      paths: {
@@ -14,7 +14,6 @@
 +        "datatables.bootstrap": "datatables.net-bs5/js/dataTables.bootstrap5.min",
 +        "datatables.fixedColumns": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
 +        "datatables.fixedColumns.bootstrap": "datatables.net-fixedcolumns/js/dataTables.fixedColumns.min",
-+        "datetimepicker": "@eonasdan/tempus-dominus/dist/js/jQuery-provider.min",  // import this if you need jquery plugin of tempus-dominus
 +        "es6": "requirejs-babel7/es6",
          "jquery": "jquery/dist/jquery.min",
          "knockout": "knockout/build/output/knockout-latest.debug",
@@ -22,7 +21,7 @@
 +        "popper": "@popperjs/core/dist/umd/popper.min",
          "sentry_browser": "sentry/js/sentry.browser.7.28.0.min",
          "sentry_captureconsole": "sentry/js/sentry.captureconsole.7.28.0.min",
-+        "tempus-dominus": "@eonasdan/tempus-dominus/dist/js/tempus-dominus.min",
++        "tempusDominus": "@eonasdan/tempus-dominus/dist/js/tempus-dominus.min",
          "underscore": "underscore/underscore",
      },
      shim: {
@@ -31,8 +30,8 @@
 -        "bootstrap": { deps: ['jquery'] },
          "datatables.bootstrap": { deps: ['datatables'] },
 +        "datatables.fixedColumns.bootstrap": { deps: ['datatables.fixedColumns'] },
-+        "datetimepicker": {
-+            deps: ['popper', 'tempus-dominus'],
++        "tempusDominus": {
++            deps: ['popper'],
 +        },
          "d3/d3.min": {
              "exports": "d3",
@@ -42,7 +41,7 @@
          "hqwebapp/js/lib/modernizr": {
              exports: 'Modernizr',
          },
-@@ -47,7 +58,7 @@
+@@ -47,7 +57,7 @@
          },
      },
  

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/widgets.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/widgets.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,11 +1,10 @@
+@@ -1,12 +1,12 @@
  'use strict';
 -hqDefine("hqwebapp/js/bootstrap3/widgets",[
 +hqDefine("hqwebapp/js/bootstrap5/widgets",[
@@ -8,21 +8,22 @@
      'underscore',
      '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.min',
      'hqwebapp/js/initial_page_data',
++    'tempusDominus',
      'select2/dist/js/select2.full.min',
 -    'jquery-ui/ui/widgets/datepicker',
- ], function ($, _, MapboxGeocoder, initialPageData) {
+-], function ($, _, MapboxGeocoder, initialPageData) {
++], function ($, _, MapboxGeocoder, initialPageData, tempusDominus) {
      var init = function () {
          var MAPBOX_ACCESS_TOKEN = initialPageData.get(
-@@ -109,7 +108,22 @@
+             "mapbox_access_token"
+@@ -109,7 +109,19 @@
          });
  
          _.each($(".date-picker"), function (input) {
 -            $(input).datepicker({ dateFormat: "yy-mm-dd" });
-+            // datepicker / tempus dominus
-+            // This is imported using hqRequire because tempus dominus is not currently working.
-+            // This protects other modules that use this module but don't use datepickers.
-+            hqRequire(['datetimepicker'], function () {
-+                $(input).tempusDominus({
++            new tempusDominus.TempusDominus(
++                input,
++                {
 +                    display: {
 +                        theme: 'light',
 +                        components: {
@@ -33,7 +34,6 @@
 +                        format: 'yyyy-MM-dd',
 +                    },
 +                });
-+            });
          });
      };
  

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/base.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/base.html
@@ -48,6 +48,12 @@
     {% endblock %}
 
     {% javascript_libraries hq=True use_bootstrap5=True %}
+
+    {% compress js %}
+      <script src="{% static '@popperjs/core/dist/umd/popper.min.js' %}"></script>
+      <script src="{% static '@eonasdan/tempus-dominus/dist/js/tempus-dominus.min.js' %}"></script>
+    {% endcompress %}
+
     <script src="{% statici18n LANGUAGE_CODE %}"></script>
   </head>
   <body>
@@ -126,9 +132,6 @@
       <script src="{% static 'knockout-validation/dist/knockout.validation.min.js' %}"></script>
       <script src="{% static 'hqwebapp/js/bootstrap5/validators.ko.js' %}"></script>
       <script src="{% static 'hqwebapp/js/password_validators.ko.js' %}"></script>
-      <script src="{% static '@popperjs/core/dist/umd/popper.min.js' %}"></script>
-      <script src="{% static '@eonasdan/tempus-dominus/dist/js/tempus-dominus.min.js' %}"></script>
-      <script src="{% static '@eonasdan/tempus-dominus/dist/js/jQuery-provider.min.js' %}"></script>
     {% endcompress %}
 
     {% block javascript %}

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/date_only.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/date_only.html
@@ -1,8 +1,9 @@
 <input type="text" name="dateonly" class="form-control" id="id_dateonly">
 
 <script>
-  $(function () {
-    $('#id_dateonly').tempusDominus({
+  new tempusDominus.TempusDominus(
+    document.getElementById('id_dateonly'),
+    {
       display: {
         theme: 'light',
         components: {
@@ -12,6 +13,6 @@
       localization: {
         format: 'L',
       },
-    });
-  });
+    }
+    );
 </script>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/date_range.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/date_range.html
@@ -1,8 +1,9 @@
 <input type="text" name="date_range" class="form-control" id="id_date_range">
 
 <script>
-  $(function () {
-    $('#id_date_range').tempusDominus({
+  new tempusDominus.TempusDominus(
+    document.getElementById('id_date_range'),
+    {
       dateRange: true,
       multipleDatesSeparator: " - ",
       display: {
@@ -15,5 +16,4 @@
         format: 'L',
       },
     });
-  });
 </script>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/tempus_dominus.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/tempus_dominus.html
@@ -1,11 +1,11 @@
 <input type="text" name="date_end" class="form-control" id="id_date_end">
 
 <script>
-  $(function () {
-    $('#id_date_end').tempusDominus({
+  new tempusDominus.TempusDominus(
+    document.getElementById('id_date_end'),
+    {
       display: {
           theme: 'light',
       },
     });
-  });
 </script>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/time_only.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/time_only.html
@@ -1,8 +1,9 @@
 <input type="text" name="timpick" class="form-control" id="id_timepicker">
 
 <script>
-  $(function () {
-    $('#id_timepicker').tempusDominus({
+  new tempusDominus.TempusDominus(
+    document.getElementById('id_timepicker'),
+    {
       display: {
         theme: 'light',
         components: {
@@ -13,5 +14,4 @@
         format: 'LT',
       },
     });
-  });
 </script>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/time_only_24.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/time_only_24.html
@@ -1,8 +1,9 @@
 <input type="text" name="timpick24" class="form-control" id="id_timepicker_24">
 
 <script>
-  $(function () {
-    $('#id_timepicker_24').tempusDominus({
+  new tempusDominus.TempusDominus(
+    document.getElementById('id_timepicker_24'),
+    {
       display: {
         theme: 'light',
         components: {
@@ -14,5 +15,4 @@
         format: 'H:mm',
       },
     });
-  });
 </script>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/dates_times.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/dates_times.html
@@ -47,7 +47,7 @@
     <strong>Important Usage Note:</strong> To use Tempus Dominus on a page, you will need to apply the
     <code>@use_tempusdominus</code> decorator to your view to ensure that the CSS (on all views) and javascript
     (on non-requirejs views) are included.
-    If you are using requirejs, make sure that <code>datetimepicker</code> is in your list of dependencies.
+    If you are using requirejs, make sure that <code>tempusDominus</code> is in your list of dependencies.
   </div>
 
   <h2 id="simple-date" class="pt-4">

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/dates_times.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/dates_times.html
@@ -45,7 +45,7 @@
   </p>
   <div class="alert alert-primary">
     <strong>Important Usage Note:</strong> To use Tempus Dominus on a page, you will need to apply the
-    <code>@use_datetimepicker</code> decorator to your view to ensure that the CSS (on all views) and javascript
+    <code>@use_tempusdominus</code> decorator to your view to ensure that the CSS (on all views) and javascript
     (on non-requirejs views) are included.
     If you are using requirejs, make sure that <code>datetimepicker</code> is in your list of dependencies.
   </div>
@@ -57,7 +57,7 @@
     If you are in need of a simple date picker widget that returns a format in <code>YYYY-MM-DD</code>, then
     your best option is to add the <code>date-picker</code> CSS class to any text <code>input</code> and
     make sure that <code>hqwebapp/js/bootstrap5/widgets</code> is included as part of your javascript dependencies.
-    Additionally, you will want to use the <ocde>@use_datetimepicker</ocde> decorator on the view using the widget
+    Additionally, you will want to use the <ocde>@use_tempusdominus</ocde> decorator on the view using the widget
     to ensure the CSS is loaded to the page properly.
   </p>
   <p>


### PR DESCRIPTION
## Technical Summary
It seems as though the maintainer of tempusDominus has a [disapproving opinion](https://github.com/Eonasdan/tempus-dominus/discussions/2839#discussioncomment-6439635) of `jQuery` and isn't interested in supporting legacy systems.

With this in mind, I've fixed our `tempusDominus` usage in `requirejs` and non-`requirejs` pages by removing the `jQuery` plugin, which is obviously not working with `requirejs`. I've also updated the examples in our Style Guide to not use `jQuery`. Lastly, I renamed the `@use_datetimepicker` decorator to `@use_tempusdominus` to avoid confusion.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Deploying to staging and making sure this doesn't break the requirejs build. Tested locally with requirejs and it does work.

### Automated test coverage
staging deploy

### QA Plan
No


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
leaving un-checked due to the eventual diffs that will go in this PR
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
