### PR TITLE
USH-4354: login-as web user

### DIFF
--- a/corehq/apps/cloudcare/esaccessors.py
+++ b/corehq/apps/cloudcare/esaccessors.py
@@ -1,4 +1,5 @@
 from corehq.apps.es import UserES
+from corehq.apps.es.users import web_users, mobile_users
 from corehq.apps.locations.models import SQLLocation
 
 
@@ -43,7 +44,7 @@ def login_as_user_query(
         if couch_user.has_permission(domain, 'access_default_login_as_user'):
             login_as_users.append('default')
         user_es = user_es.login_as_user(login_as_users)
-    return user_es.mobile_users()
+    return user_es.OR(web_users(), mobile_users())
 
 
 def _limit_login_as(couch_user, domain):

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -79,7 +79,7 @@ from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.formdetails import readable
 from corehq.apps.users.decorators import require_can_login_as
 from corehq.apps.users.models import CouchUser
-from corehq.apps.users.util import format_username
+from corehq.apps.users.util import get_complete_username
 from corehq.apps.users.views import BaseUserSettingsView
 from corehq.apps.integration.util import integration_contexts
 from corehq.util.metrics import metrics_histogram
@@ -146,10 +146,7 @@ class FormplayerMain(View):
         username = request.COOKIES.get(cookie_name)
         if username:
             username = urllib.parse.unquote(username)
-            # mobile workers do not have special characters in their name
-            # and web user usernames are email addresses
-            if '@' not in username:
-                username = format_username(username, domain)
+            username = get_complete_username(username, domain)
             user = CouchUser.get_by_username(username)
             if user:
                 return user, set_cookie

--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -14,7 +14,7 @@ from corehq.apps.users.util import (
     bulk_auto_deactivate_commcare_users,
     cached_user_id_to_user_display,
     generate_mobile_username,
-    get_complete_mobile_username,
+    get_complete_username,
     is_username_available,
     user_display_string,
     user_id_to_username,
@@ -261,11 +261,11 @@ class TestIsUsernameAvailable(TestCase):
 class TestGetCompleteMobileUsername(SimpleTestCase):
 
     def test_returns_unchanged_username_if_already_complete(self):
-        username = get_complete_mobile_username('test@test-domain.commcarehq.org', 'test-domain')
+        username = get_complete_username('test@test-domain.commcarehq.org', 'test-domain')
         self.assertEqual(username, 'test@test-domain.commcarehq.org')
 
     def test_returns_complete_username_if_incomplete(self):
-        username = get_complete_mobile_username('test', 'test-domain')
+        username = get_complete_username('test', 'test-domain')
         self.assertEqual(username, 'test@test-domain.commcarehq.org')
 
 

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -56,12 +56,12 @@ def generate_mobile_username(username, domain, is_unique=True):
     Example use: generate_mobile_username('username', 'domain') -> 'username@domain.commcarehq.org'
     """
     from .validation import validate_mobile_username
-    username = get_complete_mobile_username(username, domain)
+    username = get_complete_username(username, domain)
     validate_mobile_username(username, domain, is_unique)
     return username
 
 
-def get_complete_mobile_username(username, domain):
+def get_complete_username(username, domain):
     """
     :param username: accepts both incomplete ('example-user') or complete ('example-user@domain.commcarehq.org')
     :param domain: domain associated with the mobile user


### PR DESCRIPTION
## Product Description

Add web users to the list of users available in the log in as view.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-4354

## Feature Flag

None

## Safety Assurance

### Safety story

Tested locally and on staging.

* Web users are listed in the login as view
* Can login as web user
* Can submit a form as web user
* "Submitted by Web User abc on behalf of Web User xyz" shows up in case details

### Automated test coverage

unsure

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
