### PR TITLE
Added new flag for multi-view API keys

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1120,6 +1120,14 @@ HIDE_SYNC_BUTTON = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
+MULTI_VIEW_API_KEYS = StaticToggle(
+    'multi_view_api_keys',
+    "Multi-View API Keys",
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="Allows users to view and copy API keys after creation",
+)
+
 
 def _ensure_search_index_is_enabled(domain, enabled):
     from corehq.apps.case_search.tasks import reindex_case_search_for_domain


### PR DESCRIPTION
## Technical Summary
An offshoot from https://github.com/dimagi/commcare-hq/pull/34245, just separated out the feature flag so that this can be merged and we can avoid future conflicts as work continues on that PR

## Feature Flag
Introduces the `MULTI_VIEW_API_KEYS` flag

## Safety Assurance

### Safety story
This only introduces the flag. No new code was added that leverages the flag

### Automated test coverage
None

### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
