### PR TITLE
Changed bootstrap migration tool to rename js dependencies rather tha…

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -10,10 +10,10 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     make_direct_css_renames,
     make_numbered_css_renames,
     make_data_attribute_renames,
+    make_javascript_dependency_renames,
     flag_changed_css_classes,
     flag_stateful_button_changes_bootstrap5,
     flag_changed_javascript_plugins,
-    flag_path_references_to_split_javascript_files,
     flag_bootstrap3_references_in_template,
     flag_crispy_forms_in_template,
 )
@@ -181,8 +181,7 @@ class Command(BaseCommand):
                     new_line, renames = self.make_template_line_changes(old_line, spec)
                     flags = self.get_flags_in_template_line(old_line, spec)
                 else:
-                    new_line = old_line  # no replacement changes yet for js files
-                    renames = []
+                    new_line, renames = self.make_javascript_line_changes(old_line, spec)
                     flags = self.get_flags_in_javascript_line(old_line, spec)
 
                 saved_line, line_changelog = self.confirm_and_get_line_changes(
@@ -396,10 +395,13 @@ class Command(BaseCommand):
         return flags
 
     @staticmethod
+    def make_javascript_line_changes(old_line, spec):
+        new_line, renames = make_javascript_dependency_renames(old_line, spec)
+        return new_line, renames
+
+    @staticmethod
     def get_flags_in_javascript_line(javascript_line, spec):
         flags = flag_changed_javascript_plugins(javascript_line, spec)
-        reference_flags = flag_path_references_to_split_javascript_files(javascript_line, "bootstrap3")
-        flags.extend(reference_flags)
         return flags
 
     @staticmethod

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -4,10 +4,10 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     make_direct_css_renames,
     make_numbered_css_renames,
     make_data_attribute_renames,
+    make_javascript_dependency_renames,
     flag_changed_css_classes,
     flag_stateful_button_changes_bootstrap5,
     flag_changed_javascript_plugins,
-    flag_path_references_to_split_javascript_files,
     file_contains_reference_to_path,
     replace_path_references,
     flag_bootstrap3_references_in_template,
@@ -16,7 +16,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
 
 
 def test_make_direct_css_renames_bootstrap5():
-    line = """        <button class="btn-xs btn btn-default context-right btn-xs" id="prepaid-snooze"></button>\n"""
+    line = """        <button class="btn-xs btn btn-default context-right btn-xs" id="prepaid-snooze"></button>\n"""  # noqa E501
     final_line, renames = make_direct_css_renames(
         line, get_spec('bootstrap_3_to_5')
     )
@@ -41,6 +41,15 @@ def test_make_data_attribute_renames_bootstrap5():
     )
     eq(final_line, """        <button data-bs-toggle="modal">\n""")
     eq(renames, ['renamed data-toggle to data-bs-toggle'])
+
+
+def test_make_javascript_dependency_renames():
+    line = """        "hqwebapp/js/bootstrap3/widgets",\n"""
+    final_line, renames = make_javascript_dependency_renames(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    eq(final_line, """        "hqwebapp/js/bootstrap5/widgets",\n""")
+    eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
 def test_flag_changed_css_classes_bootstrap5():
@@ -109,14 +118,6 @@ def test_flag_extended_changed_javascript_plugins_bootstrap5():
                'plugin. Thanks!\n\nOld docs: https://getbootstrap.com/docs/3.4/'
                'javascript/#popovers\nNew docs: https://getbootstrap.com/docs/5.3/'
                'components/popovers/\n'])
-
-
-def test_flag_path_references_to_split_javascript_files_bootstrap5():
-    line = """    'hqwebapp/js/bootstrap3/crud_paginated_list',\n"""
-    flags = flag_path_references_to_split_javascript_files(
-        line, "bootstrap3"
-    )
-    eq(flags, ['Found reference to a split file (bootstrap3)'])
 
 
 def test_file_contains_reference_to_path():

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -93,6 +93,15 @@ def make_data_attribute_renames(line, spec):
     )
 
 
+def make_javascript_dependency_renames(line, spec):
+    return _do_rename(
+        line,
+        spec['javascript_dependency_renames'],
+        lambda x: r"(['\"][\w/.\-]+/)(" + x + r")(/[\w/.\-]+['\"],?)$",
+        lambda x: r"\1" + spec['javascript_dependency_renames'][x] + r"\3"
+    )
+
+
 def flag_changed_css_classes(line, spec):
     flags = []
     for css_class in spec['flagged_css_changes']:
@@ -109,13 +118,6 @@ def flag_changed_javascript_plugins(line, spec):
         extension_regex = _get_extension_regex(plugin)
         if re.search(plugin_regex, line) or re.search(extension_regex, line):
             flags.append(_get_change_guide(f"js-{plugin}"))
-    return flags
-
-
-def flag_path_references_to_split_javascript_files(line, reference):
-    flags = []
-    if "/" + reference + "/" in line:
-        flags.append(f"Found reference to a split file ({reference})")
     return flags
 
 

--- a/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
@@ -71,6 +71,9 @@
         "data-target": "data-bs-target",
         "data-dismiss": "data-bs-dismiss"
     },
+    "javascript_dependency_renames": {
+        "bootstrap3": "bootstrap5"
+    },
     "flagged_css_changes": [
         "breadcrumb",
         "close",


### PR DESCRIPTION
…n flagging

This is for convenience, but also because I'm realizing that mixing B3 and B5 javascript can interfere with the js build process. As soon as files are split into B3 and B5 versions, `build_requirejs` will find the B5 HTML template files and needs to be able to properly build their dependency trees.

Prior to this PR, the migration tool has been making new B5 HTML and js files and also updating the `requirejs_main` in the new HTML templates to point to the new js files. But the new B5 js files still have B3 dependencies, which can result in dependency trees that mix B3 and B5 and break the build. This PR updates the migration tool to rename those dependencies, which is currently a manual step later in the migration.

The build errors I'm seeing are typically because a B5 dependency tree includes B5 bootstrap, which requires the ES6 plugin, which isn't part of out B3 requirejs config. I'm open to adding ES6 to the B3 config, but even if we do that, this PR is a good change since saves us doing the renames manually.

## Safety Assurance

### Safety story
Low risk change to an internal engineering tool.

### Automated test coverage

In PR

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
