### PR TITLE
`LookupTableItemResource` returns data in API v0.6

### DIFF
--- a/corehq/apps/api/tests/lookup_table_resources.py
+++ b/corehq/apps/api/tests/lookup_table_resources.py
@@ -240,7 +240,7 @@ class TestLookupTableResource(APIResourceTest):
 
 class TestLookupTableItemResource(APIResourceTest):
     resource = LookupTableItemResource
-    api_name = 'v0.5'
+    api_name = 'v0.6'
 
     @classmethod
     def setUpClass(cls):
@@ -325,6 +325,12 @@ class TestLookupTableItemResource(APIResourceTest):
 
         response = self._assert_auth_post_resource(
             self.list_endpoint, json.dumps(data_item_json), content_type='application/json')
+        response_json = json.loads(response.content.decode('utf-8'))
+        self.assertIn('id', response_json)
+        self.assertEqual(
+            response_json['fields']['state_name']['field_list'][0]['field_value'],
+            'Massachusetts'
+        )
         self.assertEqual(response.status_code, 201)
         data_item = LookupTableRow.objects.filter(domain=self.domain.name).first()
         self.addCleanup(data_item.delete)
@@ -353,8 +359,13 @@ class TestLookupTableItemResource(APIResourceTest):
 
         response = self._assert_auth_post_resource(
             self.single_endpoint(data_item.id.hex), json.dumps(data_item_update), method="PUT")
+        response_json = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response_json['item_attributes']['attribute1'],
+            'cool_attr_value'
+        )
         data_item = LookupTableRow.objects.get(id=data_item.id)
-        self.assertEqual(response.status_code, 204)
         self.assertEqual(data_item.table_id, self.data_type.id)
         self.assertEqual(len(data_item.fields), 1)
         self.assertEqual(data_item.fields['state_name'][0].value, 'Massachusetts')

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -1,5 +1,6 @@
-from django.urls import path, include, re_path as url
 from django.http import HttpResponseNotFound
+from django.urls import include, path
+from django.urls import re_path as url
 
 from tastypie.api import Api
 
@@ -28,12 +29,7 @@ from corehq.apps.api.resources.v0_5 import (
     UserDomainsResource,
 )
 from corehq.apps.commtrack.resources.v0_1 import ProductResource
-from corehq.apps.fixtures.resources.v0_1 import (
-    FixtureResource,
-    InternalFixtureResource,
-    LookupTableItemResource,
-    LookupTableResource,
-)
+from corehq.apps.fixtures import resources as fixtures
 from corehq.apps.hqcase.views import case_api, case_api_bulk_fetch
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.locations import resources as locations
@@ -52,7 +48,7 @@ API_LIST = (
         v0_4.GroupResource,
         v0_4.XFormInstanceResource,
         v0_4.SingleSignOnResource,
-        FixtureResource,
+        fixtures.v0_1.FixtureResource,
         DomainMetadataResource,
     )),
     ((0, 5), (
@@ -64,8 +60,8 @@ API_LIST = (
         v0_5.WebUserResource,
         v0_5.GroupResource,
         v0_5.BulkUserResource,
-        InternalFixtureResource,
-        FixtureResource,
+        fixtures.v0_1.InternalFixtureResource,
+        fixtures.v0_1.FixtureResource,
         v0_5.DeviceReportResource,
         DomainMetadataResource,
         locations.v0_5.LocationResource,
@@ -79,12 +75,13 @@ API_LIST = (
         locations.v0_1.InternalLocationResource,
         v0_5.ODataCaseResource,
         v0_5.ODataFormResource,
-        LookupTableResource,
-        LookupTableItemResource,
+        fixtures.v0_1.LookupTableResource,
+        fixtures.v0_1.LookupTableItemResource,
         v0_5.NavigationEventAuditResource,
     )),
     ((0, 6), (
         locations.v0_6.LocationResource,
+        fixtures.v0_6.LookupTableItemResource,
     ))
 )
 

--- a/corehq/apps/fixtures/resources/__init__.py
+++ b/corehq/apps/fixtures/resources/__init__.py
@@ -1,0 +1,1 @@
+from . import v0_1, v0_6

--- a/corehq/apps/fixtures/resources/__init__.py
+++ b/corehq/apps/fixtures/resources/__init__.py
@@ -1,1 +1,1 @@
-from . import v0_1, v0_6
+from . import v0_1, v0_6  # noqa: F401

--- a/corehq/apps/fixtures/resources/v0_6.py
+++ b/corehq/apps/fixtures/resources/v0_6.py
@@ -1,0 +1,7 @@
+from . import v0_1
+
+
+class LookupTableItemResource(v0_1.LookupTableItemResource):
+
+    class Meta(v0_1.LookupTableItemResource.Meta):
+        always_return_data = True


### PR DESCRIPTION
## Technical Summary

Context: [Forum](https://forum.dimagi.com/t/need-the-lookup-table-item-api/10677)

Creating and updating a `LookupTableItemResource` now returns the created/updated item in API v0.6.

Behavior in previous API versions is unchanged: Creating/updating an item returns an empty response body.

I am bumping the API version for `LookupTableItemResource` because an update returns a different response code; It used to return "204 No Content", and now returns "200 OK". Users of the current API will most likely be unaffected by the change in response body, because there is nothing in it for them to use.

If you believe that changing the response code on an update from 204 to 200 is too small a change to deserve bumping the API version for this resource, please push back. I went with the most cautious approach, but could be persuaded to leave the API version as-is.

## Feature Flag

Not applicable

## Safety Assurance

### Safety story

I verified this change with automated tests

### Automated test coverage

Updated test included.

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
