### PR TITLE
Added requirejs_main_b5 alias

### DIFF
--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -3,7 +3,7 @@
 {% load compress %}
 {% load i18n %}
 
-{% requirejs_main 'builds/js/edit_builds' %}
+{% requirejs_main_b5 'builds/js/edit_builds' %}
 
 {% block page_title %}
 {% trans "Editing CommCare Builds" %}

--- a/corehq/apps/domain/templates/domain/admin/commtrack_settings.html
+++ b/corehq/apps/domain/templates/domain/admin/commtrack_settings.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main "domain/js/commtrack_settings" %}
+{% requirejs_main_b5 "domain/js/commtrack_settings" %}
 
 {% block page_content %}
   {% crispy form %}

--- a/corehq/apps/domain/templates/domain/admin/sms_settings.html
+++ b/corehq/apps/domain/templates/domain/admin/sms_settings.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'commtrack/js/sms' %}
+{% requirejs_main_b5 'commtrack/js/sms' %}
 
 {% block page_content %}
   {% initial_page_data "settings" settings %}

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -9,6 +9,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     get_spec,
     make_direct_css_renames,
     make_numbered_css_renames,
+    make_template_tag_renames,
     make_data_attribute_renames,
     flag_changed_css_classes,
     flag_stateful_button_changes_bootstrap5,
@@ -385,6 +386,8 @@ class Command(BaseCommand):
         renames.extend(numbered_renames)
         new_line, attribute_renames = make_data_attribute_renames(new_line, spec)
         renames.extend(attribute_renames)
+        new_line, template_tag_renames = make_template_tag_renames(new_line, spec)
+        renames.extend(template_tag_renames)
         return new_line, renames
 
     @staticmethod

--- a/corehq/apps/hqwebapp/templates/500.html
+++ b/corehq/apps/hqwebapp/templates/500.html
@@ -5,7 +5,7 @@
   {% trans "500 Error" %}
 {% endblock %}
 
-{% requirejs_main 'hqwebapp/js/500' %}
+{% requirejs_main_b5 'hqwebapp/js/500' %}
 
 {% block page_name %}{% trans "Oh no, something unexpected just happened!" %}{% endblock %}
 {% block page_content %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_paginated_crud.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_paginated_crud.html
@@ -3,13 +3,6 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% block js %}
-  {% if not requirejs_main %}
-    {{ block.super }}
-    <script src="{% static 'hqwebapp/js/bootstrap5/crud_paginated_list.js' %}"></script>
-  {% endif %}
-{% endblock %}
-
 {% block page_content %}
   {% initial_page_data 'total' pagination.total %}
   {% initial_page_data 'limit' pagination.limit %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/soil_status_full.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/soil_status_full.html
@@ -2,7 +2,8 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "hqwebapp/js/soil" %}
+{% requirejs_main_b5 "hqwebapp/js/soil" %}
+
 
 {% block page_content %}
   {% initial_page_data 'download_id' download_id %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/maintenance_alerts.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/maintenance_alerts.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main "hqwebapp/js/maintenance_alerts" %}
+{% requirejs_main_b5 "hqwebapp/js/maintenance_alerts" %}
 
 {% block page_content %}
   {% initial_page_data 'alerts' alerts %}

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -635,6 +635,15 @@ def analytics_ab_test(parser, token):
 
 
 @register.tag
+def requirejs_main_b5(parser, token):
+    """
+    Alias for requirejs_main. The build_requirejs step of deploy, which regexes HTML templates
+    for that tag, uses this alias to determine which version of Bootstrap a template uses.
+    """
+    return requirejs_main(parser, token)
+
+
+@register.tag
 def requirejs_main(parser, token):
     """
     Indicate that a page should be using RequireJS, by naming the
@@ -654,6 +663,11 @@ def requirejs_main(parser, token):
         value = None
     else:
         tag_name, value = bits
+
+    # Treat requirejs_main_b5 identically to requirejs_main
+    # Some templates check for {% if requirejs_main %}
+    tag_name = tag_name.rstrip("_b5")
+
     if getattr(parser, "__saw_requirejs_main", False):
         raise TemplateSyntaxError(
             "multiple '%s' tags not allowed (%s)" % tuple(bits))

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_paginated_crud.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_paginated_crud.html.diff.txt
@@ -1,21 +1,22 @@
 --- 
 +++ 
-@@ -1,4 +1,4 @@
+@@ -1,14 +1,7 @@
 -{% extends 'hqwebapp/bootstrap3/base_section.html' %}
 +{% extends 'hqwebapp/bootstrap5/base_section.html' %}
  {% load i18n %}
  {% load hq_shared_tags %}
  {% load crispy_forms_tags %}
-@@ -6,7 +6,7 @@
- {% block js %}
-   {% if not requirejs_main %}
-     {{ block.super }}
+-
+-{% block js %}
+-  {% if not requirejs_main %}
+-    {{ block.super }}
 -    <script src="{% static 'hqwebapp/js/bootstrap3/crud_paginated_list.js' %}"></script>
-+    <script src="{% static 'hqwebapp/js/bootstrap5/crud_paginated_list.js' %}"></script>
-   {% endif %}
- {% endblock %}
+-  {% endif %}
+-{% endblock %}
  
-@@ -26,7 +26,7 @@
+ {% block page_content %}
+   {% initial_page_data 'total' pagination.total %}
+@@ -26,7 +19,7 @@
  
        <div class="row"
             data-bind="visible: isLoadingVisible">
@@ -24,7 +25,7 @@
            <i class="fa fa-spin fa-spinner"></i>
            {{ pagination.text.loading }}
          </div>
-@@ -37,7 +37,7 @@
+@@ -37,7 +30,7 @@
                        css: {
                          hide: !isAlertVisible()
                        }">
@@ -33,7 +34,7 @@
            <div class="alert alert-danger"
                 data-bind="html: alertHtml"></div>
          </div>
-@@ -51,13 +51,13 @@
+@@ -51,13 +44,13 @@
  
          <div class="row"
               data-bind="visible: isPaginationActive">
@@ -50,7 +51,7 @@
              <table class="table table-striped table-bordered"
                     style="margin-bottom: 0;">
                <thead>
-@@ -147,7 +147,7 @@
+@@ -147,7 +140,7 @@
  
        <div class="row"
             data-bind="visible: isPaginationActive">
@@ -59,7 +60,7 @@
            <div class="form-inline"
                 style="margin: 1.6em 0;">
              <label for="pagination-limit">
-@@ -162,8 +162,8 @@
+@@ -162,8 +155,8 @@
              </select>
            </div>
          </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/soil_status_full.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/soil_status_full.html.diff.txt
@@ -1,12 +1,18 @@
 --- 
 +++ 
-@@ -1,4 +1,4 @@
+@@ -1,8 +1,9 @@
 -{% extends "hqwebapp/bootstrap3/base_section.html" %}
 +{% extends "hqwebapp/bootstrap5/base_section.html" %}
  {% load i18n %}
  {% load hq_shared_tags %}
  
-@@ -11,7 +11,7 @@
+-{% requirejs_main "hqwebapp/js/soil" %}
++{% requirejs_main_b5 "hqwebapp/js/soil" %}
++
+ 
+ {% block page_content %}
+   {% initial_page_data 'download_id' download_id %}
+@@ -11,7 +12,7 @@
  
    <header>
      <div class="row">

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -3,6 +3,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     get_spec,
     make_direct_css_renames,
     make_numbered_css_renames,
+    make_template_tag_renames,
     make_data_attribute_renames,
     flag_changed_css_classes,
     flag_stateful_button_changes_bootstrap5,
@@ -16,7 +17,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
 
 
 def test_make_direct_css_renames_bootstrap5():
-    line = """        <button class="btn-xs btn btn-default context-right btn-xs" id="prepaid-snooze"></button>\n"""
+    line = """        <button class="btn-xs btn btn-default context-right btn-xs" id="prepaid-snooze"></button>\n"""  # noqa: E501
     final_line, renames = make_direct_css_renames(
         line, get_spec('bootstrap_3_to_5')
     )
@@ -32,6 +33,15 @@ def test_make_numbered_css_renames_bootstrap5():
     )
     eq(final_line, """        <div class="col-sm-6">\n""")
     eq(renames, ['renamed col-xs-<num> to col-sm-<num>'])
+
+
+def test_make_template_tag_renames_bootstrap5():
+    line = """        {% requirejs_main "data_dictionary/js/data_dictionary" %}\n"""
+    final_line, renames = make_template_tag_renames(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    eq(final_line, """        {% requirejs_main_b5 "data_dictionary/js/data_dictionary" %}\n""")
+    eq(renames, ['renamed requirejs_main to requirejs_main_b5'])
 
 
 def test_make_data_attribute_renames_bootstrap5():

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -84,6 +84,15 @@ def make_numbered_css_renames(line, spec):
     )
 
 
+def make_template_tag_renames(line, spec):
+    return _do_rename(
+        line,
+        spec['template_tag_renames'],
+        lambda x: r"(\{% )(" + x + r")( [^%]* %})",
+        lambda x: r"\1" + spec['template_tag_renames'][x] + r"\3"
+    )
+
+
 def make_data_attribute_renames(line, spec):
     return _do_rename(
         line,

--- a/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
@@ -66,6 +66,9 @@
         "col-sm-offset-<num>": "offset-md-<num>",
         "col-xs-offset-<num>": "offset-sm-<num>"
     },
+    "template_tag_renames": {
+        "requirejs_main": "requirejs_main_b5"
+    },
     "data_attribute_renames": {
         "data-toggle": "data-bs-toggle",
         "data-target": "data-bs-target",

--- a/corehq/apps/products/templates/products/manage/product.html
+++ b/corehq/apps/products/templates/products/manage/product.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main 'commtrack/js/products_and_programs_main' %}
+{% requirejs_main_b5 'commtrack/js/products_and_programs_main' %}
 
 {% block page_content %}
   <form class="form" name="product" method="post">

--- a/corehq/apps/products/templates/products/manage/products.html
+++ b/corehq/apps/products/templates/products/manage/products.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load compress %}
 
-{% requirejs_main 'commtrack/js/products_and_programs_main' %}
+{% requirejs_main_b5 'commtrack/js/products_and_programs_main' %}
 
 {% block page_content %}
   {% initial_page_data 'program_product_options' program_product_options %}

--- a/corehq/apps/programs/templates/programs/manage/program.html
+++ b/corehq/apps/programs/templates/programs/manage/program.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load compress %}
 
-{% requirejs_main 'commtrack/js/products_and_programs_main' %}
+{% requirejs_main_b5 'commtrack/js/products_and_programs_main' %}
 
 {% block page_content %}
   {% initial_page_data 'program_product_options' program_product_options %}

--- a/corehq/apps/programs/templates/programs/manage/programs.html
+++ b/corehq/apps/programs/templates/programs/manage/programs.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load compress %}
 
-{% requirejs_main 'commtrack/js/products_and_programs_main' %}
+{% requirejs_main_b5 'commtrack/js/products_and_programs_main' %}
 
 {% block page_content %}
   {% initial_page_data 'program_product_options' program_product_options %}


### PR DESCRIPTION
## Technical Summary
Cherry picked from https://github.com/dimagi/commcare-hq/pull/34346

I'd like to get this part merged soon, as I think at least some of the build errors we've been having on staging have to do with the 34346 branch expecting all B5 pages to use the new tag, when there are several migrations in progress or about to begin. Specifically, @biyeun had mentioned problems with the design sprint branch, I've been seeing issues with my case_importer migration, and I'd like to get this taken care of before @jingcheng16 starts her first migration.

It's a fairly low-risk part of that PR, as the new tag is just an alias.

## Safety Assurance

### Safety story
This is pretty low risk code, but I'll re-test it on staging after removing the other changes from https://github.com/dimagi/commcare-hq/pull/34346

### Automated test coverage

not really

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
