### PR TITLE
Handle Missing Headers in Data Dictionary Upload

### DIFF
--- a/corehq/apps/data_dictionary/bulk.py
+++ b/corehq/apps/data_dictionary/bulk.py
@@ -103,11 +103,11 @@ def _process_multichoice_sheets(domain, workbook, allowed_value_info, prop_row_i
             if len(row) < 1:
                 continue
 
-            row_vals, error = map_row_values_to_column_names(
+            row_vals, row_val_errors = map_row_values_to_column_names(
                 row, column_headings, sheet_name=worksheet.title, default_val=''
             )
-            if error:
-                errors.append(error)
+            if len(row_val_errors):
+                errors.extend(row_val_errors)
                 break
             (allowed_value, prop_name, description) = (
                 row_vals['allowed_value'], row_vals['prop_name'], row_vals['description'])
@@ -171,9 +171,9 @@ def _process_sheets(domain, workbook, allowed_value_info):
             if len(row) < 1:
                 continue
 
-            row_vals, error = map_row_values_to_column_names(row, column_headings, sheet_name=case_type)
-            if error:
-                errors.append(error)
+            row_vals, row_val_errors = map_row_values_to_column_names(row, column_headings, sheet_name=case_type)
+            if len(row_val_errors):
+                errors.extend(row_val_errors)
                 break
             error, fhir_resource_prop_path, fhir_resource_type, remove_path = None, None, None, None
             (name, description, label, group, deprecated) = (
@@ -227,9 +227,11 @@ def _process_fhir_resource_type_mapping_sheet(domain, worksheet):
         if len(row) < 3:
             errors.append(_('Not enough columns in \"{}\" sheet').format(FHIR_RESOURCE_TYPE_MAPPING_SHEET))
         else:
-            row_vals, error = map_row_values_to_column_names(row, column_headings, sheet_name=worksheet.title)
-            if error:
-                errors.append(error)
+            row_vals, row_val_errors = map_row_values_to_column_names(
+                row, column_headings, sheet_name=worksheet.title
+            )
+            if len(row_val_errors):
+                errors.extend(row_val_errors)
                 break
             (case_type, remove_resource_type, fhir_resource_type) = (
                 row_vals['case_type'], row_vals['remove_resource_type'], row_vals['fhir_resource_type'])

--- a/corehq/apps/data_dictionary/bulk.py
+++ b/corehq/apps/data_dictionary/bulk.py
@@ -103,8 +103,12 @@ def _process_multichoice_sheets(domain, workbook, allowed_value_info, prop_row_i
             if len(row) < 1:
                 continue
 
-            row_vals = map_row_values_to_column_names(
+            row_vals, error = map_row_values_to_column_names(
                 row, column_headings, sheet_name=worksheet.title, default_val=''
+            )
+            if error:
+                errors.append(error)
+                break
             (allowed_value, prop_name, description) = (
                 row_vals['allowed_value'], row_vals['prop_name'], row_vals['description'])
 
@@ -167,7 +171,10 @@ def _process_sheets(domain, workbook, allowed_value_info):
             if len(row) < 1:
                 continue
 
-            row_vals = map_row_values_to_column_names(row, column_headings, sheet_name=case_type)
+            row_vals, error = map_row_values_to_column_names(row, column_headings, sheet_name=case_type)
+            if error:
+                errors.append(error)
+                break
             error, fhir_resource_prop_path, fhir_resource_type, remove_path = None, None, None, None
             (name, description, label, group, deprecated) = (
                 row_vals['name'], row_vals['description'], row_vals['label'], row_vals['group'],
@@ -220,7 +227,10 @@ def _process_fhir_resource_type_mapping_sheet(domain, worksheet):
         if len(row) < 3:
             errors.append(_('Not enough columns in \"{}\" sheet').format(FHIR_RESOURCE_TYPE_MAPPING_SHEET))
         else:
-            row_vals = map_row_values_to_column_names(row, column_headings, sheet_name=worksheet.title)
+            row_vals, error = map_row_values_to_column_names(row, column_headings, sheet_name=worksheet.title)
+            if error:
+                errors.append(error)
+                break
             (case_type, remove_resource_type, fhir_resource_type) = (
                 row_vals['case_type'], row_vals['remove_resource_type'], row_vals['fhir_resource_type'])
 

--- a/corehq/apps/data_dictionary/bulk.py
+++ b/corehq/apps/data_dictionary/bulk.py
@@ -103,7 +103,8 @@ def _process_multichoice_sheets(domain, workbook, allowed_value_info, prop_row_i
             if len(row) < 1:
                 continue
 
-            row_vals = map_row_values_to_column_names(row, column_headings, default_val='')
+            row_vals = map_row_values_to_column_names(
+                row, column_headings, sheet_name=worksheet.title, default_val=''
             (allowed_value, prop_name, description) = (
                 row_vals['allowed_value'], row_vals['prop_name'], row_vals['description'])
 
@@ -166,7 +167,7 @@ def _process_sheets(domain, workbook, allowed_value_info):
             if len(row) < 1:
                 continue
 
-            row_vals = map_row_values_to_column_names(row, column_headings)
+            row_vals = map_row_values_to_column_names(row, column_headings, sheet_name=case_type)
             error, fhir_resource_prop_path, fhir_resource_type, remove_path = None, None, None, None
             (name, description, label, group, deprecated) = (
                 row_vals['name'], row_vals['description'], row_vals['label'], row_vals['group'],
@@ -219,7 +220,7 @@ def _process_fhir_resource_type_mapping_sheet(domain, worksheet):
         if len(row) < 3:
             errors.append(_('Not enough columns in \"{}\" sheet').format(FHIR_RESOURCE_TYPE_MAPPING_SHEET))
         else:
-            row_vals = map_row_values_to_column_names(row, column_headings)
+            row_vals = map_row_values_to_column_names(row, column_headings, sheet_name=worksheet.title)
             (case_type, remove_resource_type, fhir_resource_type) = (
                 row_vals['case_type'], row_vals['remove_resource_type'], row_vals['fhir_resource_type'])
 

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -223,6 +223,10 @@ class MiscUtilTest(TestCase):
         self.assertEqual(len(errors), 0)
         for key, val in expected_output.items():
             self.assertEqual(row_vals[key], val)
+
+    def test_map_row_values_to_column_names_errors(self):
+        sheet_name = 'foobar'
+        column_headings, _ = get_column_headings(self.valid_header_row, self.valid_values, sheet_name)
         row_vals, errors = map_row_values_to_column_names(self.row, column_headings[0:1], sheet_name=sheet_name)
         self.assertEqual(errors[0], f'Column 2 in "{sheet_name}" sheet is missing a header')
 

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -210,15 +210,21 @@ class MiscUtilTest(TestCase):
         self.assertEqual(errors, expected_errors)
 
     def test_map_row_values_to_column_names(self):
-        column_headings, _ = get_column_headings(self.valid_header_row, self.valid_values)
-        row_vals = map_row_values_to_column_names(self.row, column_headings, default_val='empty')
+        sheet_name = 'foobar'
+        column_headings, _ = get_column_headings(self.valid_header_row, self.valid_values, sheet_name)
+        row_vals, errors = map_row_values_to_column_names(
+            self.row, column_headings, sheet_name, default_val='empty'
+        )
         expected_output = {
             'col_1': 'a',
             'col_2': 'b',
             'col_3': 'empty',
         }
+        self.assertEqual(len(errors), 0)
         for key, val in expected_output.items():
             self.assertEqual(row_vals[key], val)
+        row_vals, errors = map_row_values_to_column_names(self.row, column_headings[0:1], sheet_name=sheet_name)
+        self.assertEqual(errors[0], f'Column 2 in "{sheet_name}" sheet is missing a header')
 
     def test_is_case_type_deprecated(self):
         is_deprecated = is_case_type_deprecated(self.domain, self.deprecated_case_type_name)

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -348,15 +348,17 @@ def get_column_headings(row, valid_values, sheet_name, case_prop_name=None):
 
 def map_row_values_to_column_names(row, column_headings, sheet_name, default_val=None):
     row_vals = defaultdict(lambda: default_val)
-    error = None
+    errors = []
     for index, cell in enumerate(row):
         try:
             column_name = column_headings[index]
         except IndexError:
-            error = _('Column {} in "{}" sheet is missing a header').format(index + 1, sheet_name)
+            errors.append(
+                _('Column {} in "{}" sheet is missing a header').format(index + 1, sheet_name)
+            )
         cell_val = '' if cell.value is None else str(cell.value)
         row_vals[column_name] = cell_val
-    return row_vals, error
+    return row_vals, errors
 
 
 def is_case_type_deprecated(domain, case_type):

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -320,19 +320,14 @@ def get_gps_properties(domain, case_type):
     ).values_list('name', flat=True))
 
 
-def get_column_headings(row, valid_values, sheet_name=None, case_prop_name=None):
+def get_column_headings(row, valid_values, sheet_name, case_prop_name=None):
     column_headings = []
     errors = []
     for index, cell in enumerate(row, start=1):
         if not cell.value:
-            if sheet_name:
-                errors.append(
-                    _("Column {} in \"{}\" sheet has an empty header").format(index, sheet_name)
-                )
-            else:
-                errors.append(
-                    _("Column {} has an empty header").format(index)
-                )
+            errors.append(
+                _("Column {} in \"{}\" sheet has an empty header").format(index, sheet_name)
+            )
             continue
 
         cell_value = cell.value.lower()
@@ -340,21 +335,13 @@ def get_column_headings(row, valid_values, sheet_name=None, case_prop_name=None)
             column_headings.append(valid_values[cell_value])
         else:
             formatted_valid_values = ', '.join(list(valid_values.keys())).title()
-            if sheet_name:
-                error = _("Invalid column \"{}\" in \"{}\" sheet. Valid column names are: {}").format(
-                    cell.value, sheet_name, formatted_valid_values)
-                errors.append(error)
-            else:
-                error = _("Invalid column \"{}\". Valid column names are: {}").format(
-                    cell.value, formatted_valid_values)
-                errors.append(error)
+            error = _("Invalid column \"{}\" in \"{}\" sheet. Valid column names are: {}").format(
+                cell.value, sheet_name, formatted_valid_values)
+            errors.append(error)
     if case_prop_name and case_prop_name not in column_headings:
-        if sheet_name:
-            errors.append(
-                _("Missing \"Case Property\" column header in \"{}\" sheet").format(sheet_name)
-            )
-        else:
-            errors.append(_("Missing \"Case Property\" column header"))
+        errors.append(
+            _("Missing \"Case Property\" column header in \"{}\" sheet").format(sheet_name)
+        )
 
     return column_headings, errors
 

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -346,13 +346,17 @@ def get_column_headings(row, valid_values, sheet_name, case_prop_name=None):
     return column_headings, errors
 
 
-def map_row_values_to_column_names(row, column_headings, default_val=None):
+def map_row_values_to_column_names(row, column_headings, sheet_name, default_val=None):
     row_vals = defaultdict(lambda: default_val)
+    error = None
     for index, cell in enumerate(row):
-        column_name = column_headings[index]
+        try:
+            column_name = column_headings[index]
+        except IndexError:
+            error = _('Column {} in "{}" sheet is missing a header').format(index + 1, sheet_name)
         cell_val = '' if cell.value is None else str(cell.value)
         row_vals[column_name] = cell_val
-    return row_vals
+    return row_vals, error
 
 
 def is_case_type_deprecated(domain, case_type):

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -326,7 +326,7 @@ def get_column_headings(row, valid_values, sheet_name, case_prop_name=None):
     for index, cell in enumerate(row, start=1):
         if not cell.value:
             errors.append(
-                _("Column {} in \"{}\" sheet has an empty header").format(index, sheet_name)
+                _('Column {} in "{}" sheet has an empty header').format(index, sheet_name)
             )
             continue
 
@@ -335,12 +335,12 @@ def get_column_headings(row, valid_values, sheet_name, case_prop_name=None):
             column_headings.append(valid_values[cell_value])
         else:
             formatted_valid_values = ', '.join(list(valid_values.keys())).title()
-            error = _("Invalid column \"{}\" in \"{}\" sheet. Valid column names are: {}").format(
+            error = _('Invalid column "{}" in "{}" sheet. Valid column names are: {}').format(
                 cell.value, sheet_name, formatted_valid_values)
             errors.append(error)
     if case_prop_name and case_prop_name not in column_headings:
         errors.append(
-            _("Missing \"Case Property\" column header in \"{}\" sheet").format(sheet_name)
+            _('Missing "Case Property" column header in "{}" sheet').format(sheet_name)
         )
 
     return column_headings, errors


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
If there are any blank header cells that don't get loaded when processing a DD upload then the following error will be shown:
![Screenshot from 2024-04-02 12-53-22](https://github.com/dimagi/commcare-hq/assets/122617251/796f95ad-c1de-4e86-85d1-523ca9bde312)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3581).

An issue ([ticket](https://dimagi.atlassian.net/browse/QA-6279) for ref) was picked up where a Data Dictionary Excel upload resulted in an `IndexError` exception. Specifically, this occurred because the length of the `column_headings` list in `map_row_values_to_column_names()` was less than the length of a row that contained data. Normally, this shouldn't happen as `column_headings` should have `None` values for blank header cells.

This is a very specific error which I was unable to reproduce either locally or on the production environment. Leaving the header cells blank for columns that contained data resulted in the correct UI error being thrown. This seems to be a very special case where the Excel file got corrupted and so some of the blank header cells weren't being loaded with `worksheet.iter_rows()`.

This PR adds in an additional safety precaution by correctly catching the exception and raising a UI error for the user.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Unit tests

This change will only impact domains that have the Data Dictionary privilege.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests exist for both the `map_row_values_to_column_names()` and `get_column_headings()` util functions.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
