### PR TITLE
Removed showBreadcrumbs from startForm handler

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -177,9 +177,6 @@ hqDefine("cloudcare/js/formplayer/app", function () {
     FormplayerFrontend.on('startForm', function (data) {
         FormplayerFrontend.permitIntervalSync = false;
         FormplayerFrontend.getChannel().request("clearMenu");
-        hqRequire(["cloudcare/js/formplayer/menus/utils"], function (MenusUtils) {
-            MenusUtils.showBreadcrumbs(data.breadcrumbs);
-        });
 
         data.onLoading = CloudcareUtils.formplayerLoading;
         data.onLoadingComplete = CloudcareUtils.formplayerLoadingComplete;


### PR DESCRIPTION
## Product Summary
This is a fix for a bug that happens when we switch to requirejs, but I'm cherry picking it to reduce the size of that PR (https://github.com/dimagi/commcare-hq/pull/34271) and get extra review attention.

Bug report here: https://dimagi.atlassian.net/browse/QA-6193?focusedCommentId=320546

## Technical Summary

The problem is that when requirejs is turned on, `hqRequire` becomess asynchronous, which results in this `showBreadcrumbs` getting called _after_ [this logic](https://github.com/dimagi/commcare-hq/blob/ef722b033b9dfe1dc15b4129915806a7152ea183/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js#L127-L135) shows the breadcrumbs and the menu. `showBreadcrumbs` re-renders the entire breadcrumbs area, so the second call wipes out the dropdown menu. The second call no longer has the language information necessary to re-render the dropdown correctly.

However...so far as I can tell, this `showBreadcrumbs` call ought to be unnecessary. `showBreadcrumbs` already gets called when the user clicks into a menu, via [menu:select](https://github.com/dimagi/commcare-hq/blob/ef722b033b9dfe1dc15b4129915806a7152ea183/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js#L152) `menu:select` gets triggered regardless of whether a user clicks a menu item, picks a case from a case list, or clicks a registration from case list button. It then [calls listMenus](https://github.com/dimagi/commcare-hq/blob/ef722b033b9dfe1dc15b4129915806a7152ea183/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js#L165) which [calls selectMenu](https://github.com/dimagi/commcare-hq/blob/ef722b033b9dfe1dc15b4129915806a7152ea183/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js#L58) which [calls showMenu](https://github.com/dimagi/commcare-hq/blob/ef722b033b9dfe1dc15b4129915806a7152ea183/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js#L79) which runs the logic linked above that calls `showBreadcrumbs`.

The two other scenarios I can think of to enter a form are end of form nav and smart links. I tested end of form nav linking directly to a form, and it still displays breadcrumbs properly. I haven't tested smart links, but I'll ask QA to, and the removed `showBreadcrumbs` call dates back to 2017 (see https://github.com/dimagi/commcare-hq/pull/14390/) so they weren't the reason it was added.

I don't love [removing something without clearly understanding its original purpose](https://en.wikipedia.org/wiki/G._K._Chesterton#Chesterton's_fence). But code reading and testing suggest this call might no longer be necessary.

## Safety Assurance

### Safety story
Web apps UI makes this at least medium risk, and navigation is historically tricky. However, the most likely risk of a bug is that breadcrumbs get displayed improperly, which as bugs go, isn't that bad. Broader js errors are unlikely, given the small scope of the change.

### Automated test coverage

I don't think breadcrumbs have much test coverage.

### QA Plan

I'll ask QA to look at this.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
