### PR TITLE
Use natural key for Permission table

### DIFF
--- a/corehq/apps/dump_reload/tests/test_serialization.py
+++ b/corehq/apps/dump_reload/tests/test_serialization.py
@@ -11,6 +11,7 @@ from corehq.apps.users.models import SQLUserData
 from corehq.apps.users.models_role import Permission, RolePermission, UserRole
 from corehq.form_processor.models.cases import CaseTransaction, CommCareCase
 from corehq.form_processor.models.forms import XFormInstance, XFormOperation
+from corehq.apps.registry.models import DataRegistry, RegistryGrant
 
 
 class TestJSONFieldSerialization(SimpleTestCase):
@@ -58,6 +59,20 @@ class TestForeignKeyFieldSerialization(SimpleTestCase):
         self.assertEqual(fk_field, ['testuser'])
 
     def test_foreign_key_on_model_without_natural_key_returns_primary_key_when_serialized(self):
+        data_registry = DataRegistry(pk=500, domain='test', name='test-registry')
+        registry_grant = RegistryGrant(pk=10, registry=data_registry, from_domain='test', to_domains=['to-test'])
+
+        output_stream = StringIO()
+        with patch('corehq.apps.dump_reload.sql.dump.get_objects_to_dump', return_value=[registry_grant]):
+            SqlDataDumper('test', [], []).dump(output_stream)
+
+        deserialized_model = json.loads(output_stream.getvalue())
+        pk_field = deserialized_model['pk']
+        self.assertEqual(pk_field, 10)
+        registry_field = deserialized_model['fields']['registry']
+        self.assertEqual(registry_field, 500)
+
+    def test_natural_foreign_key_for_Permission_returns_tuple_when_serialized(self):
         role = UserRole(pk=10, domain='test', name='test-role')
         permission = Permission(pk=500, value='test')
         role_permission = RolePermission(role=role, permission_fk=permission)
@@ -70,7 +85,7 @@ class TestForeignKeyFieldSerialization(SimpleTestCase):
         role_field = deserialized_model['fields']['role']
         self.assertEqual(role_field, 10)
         permission_field = deserialized_model['fields']['permission_fk']
-        self.assertEqual(permission_field, 500)
+        self.assertEqual(permission_field, ['test'])
 
     def test_natural_foreign_key_for_CommCareCase_returns_str_when_serialized(self):
         cc_case = CommCareCase(domain='test', case_id='abc123')

--- a/corehq/apps/dump_reload/tests/test_sql_data_loader.py
+++ b/corehq/apps/dump_reload/tests/test_sql_data_loader.py
@@ -63,7 +63,12 @@ class TestSqlDataLoader(TestCase):
         model = {
             "model": "users.rolepermission",
             "pk": 1,
-            "fields": {"role": role.pk, "permission_fk": permission.pk, "allow_all": True, "allowed_items": []},
+            "fields": {
+                "role": role.pk,
+                "permission_fk": [permission.value],
+                "allow_all": True,
+                "allowed_items": [],
+            },
         }
         serialized_model = json.dumps(model)
 

--- a/corehq/apps/users/models_role.py
+++ b/corehq/apps/users/models_role.py
@@ -295,11 +295,18 @@ class RolePermission(models.Model):
         return PermissionInfo(self.permission, allow=allow)
 
 
+class PermissionManager(AuditingManager):
+
+    def get_by_natural_key(self, value):
+        # Useful when serializing data that foreign keys to this table for a migration (e.g., RolePermission)
+        return self.get(value=value)
+
+
 @audit_fields("value", audit_special_queryset_writes=True)
 class Permission(models.Model):
     value = models.CharField(max_length=255, unique=True)
 
-    objects = AuditingManager()
+    objects = PermissionManager()
 
     class Meta:
         db_table = "users_permission"
@@ -312,6 +319,10 @@ class Permission(models.Model):
         from corehq.apps.users.models import HqPermissions
         for name in HqPermissions.permission_names():
             Permission.objects.get_or_create(value=name)
+
+    def natural_key(self):
+        # Useful when serializing data that foreign keys to this table for a migration (e.g., RolePermission)
+        return (self.value,)
 
 
 @audit_fields("role", "assignable_by_role", audit_special_queryset_writes=True)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
We don't include Permissions in data dumps, so using the natural key ensures that when loading data into a new environment, the correct Permission is referenced in a foreign key relationship.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added an automated test to ensure this object is serialized as expected.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
