### PR TITLE
Add timing metrics for case seach

### DIFF
--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -197,7 +197,7 @@ class CaseSearchRequestConfig:
 
 
 def extract_search_request_config(request_dict):
-    params = dict(request_dict.lists())
+    params = request_dict.copy()
     for param_name in CASE_SEARCH_TAGS_MAPPING:
         params.pop(param_name, None)
     kwargs_from_params = {

--- a/corehq/apps/case_search/static/case_search/js/case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/case_search.js
@@ -1,3 +1,5 @@
+'use strict';
+
 hqDefine('case_search/js/case_search', [
     'jquery',
     'underscore',
@@ -11,7 +13,6 @@ hqDefine('case_search/js/case_search', [
     alertUser,
     initialPageData
 ) {
-    'use strict';
     var caseSearchModel = function (caseDataUrl) {
         var self = {};
         self.type = ko.observable();
@@ -23,8 +24,8 @@ hqDefine('case_search/js/case_search', [
         self.query = ko.observable();
         self.profile = ko.observable();
         self.case_data_url = caseDataUrl;
-        self.xpath = ko.observable();
         self.parameters = ko.observableArray();
+        self.xpath_expressions = ko.observableArray();
 
         self.addParameter = function () {
             self.parameters.push({
@@ -37,6 +38,13 @@ hqDefine('case_search/js/case_search', [
         };
         self.removeParameter = function () {
             self.parameters.remove(this);
+        };
+
+        self.addXPath = function () {
+            self.xpath_expressions.push({xpath: ""});
+        };
+        self.removeXPath = function () {
+            self.xpath_expressions.remove(this);
         };
 
         self.showResults = ko.computed(function () {
@@ -62,7 +70,7 @@ hqDefine('case_search/js/case_search', [
                     owner_id: self.owner_id(),
                     parameters: self.parameters(),
                     customQueryAddition: self.customQueryAddition(),
-                    xpath: self.xpath(),
+                    xpath_expressions: _.pluck(self.xpath_expressions(), 'xpath'),
                 }
                 )}),
                 success: function (data) {

--- a/corehq/apps/case_search/static/case_search/js/profile_case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/profile_case_search.js
@@ -13,6 +13,7 @@ hqDefine('case_search/js/profile_case_search', [
 ) {
     var caseSearchModel = function () {
         var self = {};
+        self.appId = ko.observable();
         self.requestDict = ko.observable();
         self.results = ko.observable();
         self.browserTime = ko.observable();
@@ -29,7 +30,7 @@ hqDefine('case_search/js/profile_case_search', [
             let start = Date.now();
             $.post({
                 url: window.location.href,
-                data: {q: self.requestDict()},
+                data: {q: self.requestDict(), app_id: self.appId()},
                 success: function (data) {
                     self.results(data);
                     self.searchButtonIcon("fa fa-search");

--- a/corehq/apps/case_search/static/case_search/js/profile_case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/profile_case_search.js
@@ -1,0 +1,50 @@
+'use strict';
+
+hqDefine('case_search/js/profile_case_search', [
+    'jquery',
+    'underscore',
+    'knockout',
+    'hqwebapp/js/bootstrap3/alert_user',
+], function (
+    $,
+    _,
+    ko,
+    alertUser
+) {
+    var caseSearchModel = function () {
+        var self = {};
+        self.requestDict = ko.observable();
+        self.results = ko.observable();
+        self.browserTime = ko.observable();
+        self.searchButtonIcon = ko.observable("fa fa-search");
+        self.exampleRequestDict = JSON.stringify({
+            "request_dict": {
+                "_xpath_query": ["name: 'Ethan'", "subcase-exists(parent, name='Matilda')"],
+                "case_type": ["patient"],
+            },
+        });
+
+        self.search = function () {
+            self.searchButtonIcon("fa fa-spin fa-refresh");
+            let start = Date.now();
+            $.post({
+                url: window.location.href,
+                data: {q: self.requestDict()},
+                success: function (data) {
+                    self.results(data);
+                    self.searchButtonIcon("fa fa-search");
+                    self.browserTime((Date.now() - start) / 1000);
+                },
+                error: function (response) {
+                    alertUser.alert_user(response.responseJSON.message, 'danger');
+                },
+            });
+        };
+
+        return self;
+    };
+
+    $(function () {
+        $("#profile-case-search").koApplyBindings(caseSearchModel());
+    });
+});

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -87,9 +87,16 @@
                 <strong>XPath Expression</strong>
               </div>
               <div class="panel-body">
-                <div class="form-group" style="width:100%">
-                  <textarea style="min-width: 50%" spellcheck="false" class="form-control vertical-resize" name="xpath" type="text" placeholder="e.g: name = 'tyrion' or nickname='the imp'" data-bind="value: xpath"> </textarea>
+                <div class="form-group" style="width:100%" data-bind="foreach: xpath_expressions" >
+                  <textarea style="min-width: 50%" spellcheck="false" class="form-control vertical-resize"
+                    name="xpath" type="text" placeholder="e.g: name = 'tyrion' or nickname='the imp'" data-bind="value: xpath"> </textarea>
+                  <span class='btn btn-danger' data-bind="click: $parent.removeXPath">
+                    <i class="fa-regular fa-trash-can"></i> {% trans "Delete" %}
+                  </span>
                 </div>
+                <button class="btn btn-default" id="add-xpath" data-bind="click: addXPath">
+                  <i class="fa fa-plus"></i> {% trans "Add XPath" %}
+                </button>
               </div>
             </div>
             <button type="button" class="btn btn-primary" data-bind="click: search">

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -92,21 +92,6 @@
                 </div>
               </div>
             </div>
-            {% if query_additions %}
-              <div class="panel panel-default">
-                <div class="panel-heading">
-                  <strong>{% trans "Custom Query Addition" %}</strong>
-                </div>
-                <div class="panel-body">
-                  <select data-bind="value: customQueryAddition">
-                    <option></option>
-                    {% for query_addition in query_additions %}
-                      <option value="{{ query_addition.id }}">{{ query_addition.name }}</option>
-                    {% endfor %}
-                  </select>
-                </div>
-              </div>
-            {% endif %}
             <button type="button" class="btn btn-primary" data-bind="click: search">
               <i data-bind="attr: {class: searchButtonIcon}"></i> {% trans "Search" %}
             </button>

--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -33,7 +33,8 @@
   <div class="spacer"></div>
 
   <div data-bind="if: results">
-    <p>Total number of results: <span data-bind="text: results().count"></span></p>
+    <p>Number of primary results: <span data-bind="text: results().primary_count"></span></p>
+    <p>Number of related cases: <span data-bind="text: results().related_count"></span></p>
     <p>Total browser runtime: <span data-bind="text: browserTime"></span> seconds</p>
     <p>Total server runtime: <span data-bind="text: results().runtime"></span> seconds</p>
 

--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -16,7 +16,7 @@
   <div>
     <form>
       <div class="form-group">
-        <label for="appId">App ID</label>
+        <label for="appId">App ID (if not already in the request dict)</label>
         <input data-bind="value: appId" type="text" class="form-control">
       </div>
       <div class="form-group">

--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -16,6 +16,10 @@
   <div>
     <form>
       <div class="form-group">
+        <label for="appId">App ID</label>
+        <input data-bind="value: appId" type="text" class="form-control">
+      </div>
+      <div class="form-group">
         <label for="requestDict">request_dict</label>
         <textarea id="requestDict" spellcheck="false" class="form-control vertical-resize" name="request_dict"
           type="json" data-bind="value: requestDict, attr: {placeholder: exampleRequestDict}"></textarea>

--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -32,8 +32,34 @@
     <p>Total number of results: <span data-bind="text: results().count"></span></p>
     <p>Total browser runtime: <span data-bind="text: browserTime"></span> seconds</p>
     <p>Total server runtime: <span data-bind="text: results().runtime"></span> seconds</p>
+
+    <ul data-bind="template: {name: 'timingRow', foreach: results().timing_data }"
+      class="list-group"></ul>
+
+    <script id="timingRow" type="text/html">
+      <li class="list-group-item">
+        <div class="container-fluid">
+          <div class="row">
+            <div class="col-xs-3" data-bind="text: name"></div>
+            <div class="col-xs-3">
+              <strong data-bind="text: duration ? duration.toFixed(3) : '-'"></strong> seconds;
+            </div>
+            <div class="col-xs-3">
+              <strong data-bind="text: percent_total ? percent_total.toFixed(3) : '-'"></strong>% of total;
+            </div>
+            <div class="col-xs-3">
+              <strong data-bind="text: percent_parent ? percent_parent.toFixed(3) : '-'"></strong>% of parent
+            </div>
+          </div>
+          <ul data-bind="template: { name: 'timingRow', foreach: subs }"
+          class="list-group"></ul>
+        </div>
+      </li>
+    </script>
+
   </div>
 
 </div>
+
 
 {% endblock %}

--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -1,0 +1,39 @@
+{% extends 'hqwebapp/bootstrap3/base_section.html' %}
+{% load hq_shared_tags %}
+{% load compress %}
+{% load i18n %}
+
+{% requirejs_main 'case_search/js/profile_case_search' %}
+
+{% block page_content %}
+
+<div id="profile-case-search">
+  <h3>Profile Slow Case Searches</h3>
+  <p>
+    Paste in a JSON representation of the request dict made to case search, such
+    as that found in 'LongCaseSearchRequest' error logs
+  </p>
+  <div>
+    <form>
+      <div class="form-group">
+        <label for="requestDict">request_dict</label>
+        <textarea id="requestDict" spellcheck="false" class="form-control vertical-resize" name="request_dict"
+          type="json" data-bind="value: requestDict, attr: {placeholder: exampleRequestDict}"></textarea>
+      </div>
+      <button class="btn btn-primary" data-bind="click: search">
+        <i data-bind="attr: {class: searchButtonIcon}"></i> {% trans "Search" %}
+      </button>
+    </form>
+  </div>
+
+  <div class="spacer"></div>
+
+  <div data-bind="if: results">
+    <p>Total number of results: <span data-bind="text: results().count"></span></p>
+    <p>Total browser runtime: <span data-bind="text: browserTime"></span> seconds</p>
+    <p>Total server runtime: <span data-bind="text: results().runtime"></span> seconds</p>
+  </div>
+
+</div>
+
+{% endblock %}

--- a/corehq/apps/case_search/tests/test_models.py
+++ b/corehq/apps/case_search/tests/test_models.py
@@ -1,7 +1,6 @@
 from unittest.mock import call, patch
 
 from django.test import TestCase
-from django.utils.datastructures import MultiValueDict
 
 from testil import assert_raises, eq
 
@@ -85,15 +84,10 @@ def test_extract_criteria_config(self, case_type, data_registry, custom_related_
 def _make_request_dict(params):
     """All values must be a list to match what we get from Django during a request.
     """
-    request_dict = MultiValueDict()
-    for key, value in params.items():
-        if value is None:
-            continue
-        if isinstance(value, list):
-            request_dict.setlist(key, value)
-        else:
-            request_dict[key] = value
-    return request_dict
+    return {
+        key: (value if isinstance(value, list) else [value])
+        for key, value in params.items() if value is not None
+    }
 
 
 @generate_cases([

--- a/corehq/apps/case_search/urls.py
+++ b/corehq/apps/case_search/urls.py
@@ -1,7 +1,8 @@
 from django.urls import re_path as url
 
-from corehq.apps.case_search.views import CaseSearchView
+from corehq.apps.case_search.views import CaseSearchView, ProfileCaseSearchView
 
 urlpatterns = [
     url(r'^search/$', CaseSearchView.as_view(), name=CaseSearchView.urlname),
+    url(r'^profile/$', ProfileCaseSearchView.as_view(), name=ProfileCaseSearchView.urlname),
 ]

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -396,6 +396,7 @@ def get_related_cases_result(helper, app, case_types, source_cases, include_all_
         return results
 
 
+@time_function()
 def _get_all_related_cases(helper, source_cases):
     results = []
     results.extend(helper.get_all_related_live_cases(source_cases))
@@ -416,6 +417,7 @@ def _get_search_detail_path_defined_cases(helper, app, case_types, source_cases)
     return result
 
 
+@time_function()
 def _get_child_cases_referenced_in_app(helper, app, case_types, source_case_ids):
     child_case_types = [
         _type for types in [get_child_case_types(app, case_type) for case_type in case_types]
@@ -446,6 +448,7 @@ def get_search_detail_relationship_paths(app, case_type):
     return paths
 
 
+@time_function()
 def get_path_related_cases_results(helper, cases, paths):
     """
     Given a set of cases and a set of case property paths,
@@ -492,6 +495,7 @@ def get_child_case_types(app, case_type):
     return child_case_types
 
 
+@time_function()
 def get_child_case_results(helper, parent_case_ids, child_case_types=None):
     filter = helper.get_base_queryset().get_child_cases(parent_case_ids, "parent")
     if child_case_types:
@@ -510,6 +514,7 @@ def get_expanded_case_results(helper, custom_related_case_property, cases):
     return _get_case_search_cases(helper, expanded_case_ids)
 
 
+@time_function()
 def _get_case_search_cases(helper, case_ids):
     results = helper.get_base_queryset().case_ids(case_ids).run().hits
     return [helper.wrap_case(result) for result in results]

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -6,6 +6,7 @@ from functools import wraps
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
+from casexml.apps.case.fixtures import CaseDBFixture
 from dimagi.utils.logging import notify_exception
 
 from corehq import toggles
@@ -94,11 +95,16 @@ def profile_case_search(domain, couch_user, app_id, config):
     with helper.timing_context:
         cases = get_primary_case_search_results(helper, domain, config.case_types,
                                                 config.criteria, config.commcare_sort)
+        primary_count = len(cases)
         if app_id:
             cases.extend(get_and_tag_related_cases(
                 helper, app_id, config.case_types, cases, config.custom_related_case_property,
                 config.include_all_related_cases))
-    return helper.timing_context, len(cases)
+        related_count = len(cases) - primary_count
+
+        with helper.timing_context('CaseDBFixture.fixture'):
+            CaseDBFixture(cases).fixture
+    return helper.timing_context, primary_count, related_count
 
 
 @time_function()
@@ -351,7 +357,8 @@ def get_and_tag_related_cases(helper, app_id, case_types, cases,
     if not cases:
         return []
 
-    app = get_app_cached(helper.domain, app_id)
+    with helper.timing_context('get_app_cached'):
+        app = get_app_cached(helper.domain, app_id)
 
     expanded_case_results = []
     if custom_related_case_property:
@@ -366,8 +373,9 @@ def get_and_tag_related_cases(helper, app_id, case_types, cases,
     results = list({
         case.case_id: case for case in unfiltered_results if case.case_id not in initial_case_ids
     }.values())
-    for case in results:
-        _tag_is_related_case(case)
+    with helper.timing_context('_tag_is_related_case'):
+        for case in results:
+            _tag_is_related_case(case)
     return results
 
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -1,13 +1,14 @@
+import json
 import re
 from collections import defaultdict
-import json
+from functools import wraps
 
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
-from corehq import toggles
 
 from dimagi.utils.logging import notify_exception
 
+from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app_cached
 from corehq.apps.app_manager.util import module_offers_search
 from corehq.apps.case_search.const import (
@@ -15,10 +16,12 @@ from corehq.apps.case_search.const import (
     COMMCARE_PROJECT,
     IS_RELATED_CASE,
 )
-from corehq.apps.case_search.exceptions import CaseSearchUserError, CaseFilterError, TooManyRelatedCasesError
-from corehq.apps.case_search.filter_dsl import (
-    build_filter_from_xpath,
+from corehq.apps.case_search.exceptions import (
+    CaseFilterError,
+    CaseSearchUserError,
+    TooManyRelatedCasesError,
 )
+from corehq.apps.case_search.filter_dsl import build_filter_from_xpath
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     CASE_SEARCH_XPATH_QUERY_KEY,
@@ -32,14 +35,29 @@ from corehq.apps.es.case_search import (
     case_property_missing,
     case_property_query,
     case_property_range_query,
-    wrap_case_search_hit,
     reverse_index_case_query,
+    wrap_case_search_hit,
 )
 from corehq.apps.registry.exceptions import (
     RegistryAccessException,
     RegistryNotFound,
 )
 from corehq.apps.registry.helper import DataRegistryHelper
+from corehq.util.timer import TimingContext
+
+
+def time_function():
+    """Decorator to get timing information on a case search function that has `helper` as the first arg"""
+    def decorator(fn):
+        @wraps(fn)
+        def _inner(helper, *args, **kwargs):
+            tag = fn.__name__
+            if helper:
+                with helper.timing_context(tag):
+                    return fn(helper, *args, **kwargs)
+            return fn(helper, *args, **kwargs)
+        return _inner
+    return decorator
 
 
 def get_case_search_results_from_request(domain, app_id, couch_user, request_dict):
@@ -70,10 +88,25 @@ def get_case_search_results(domain, case_types, criteria,
     return cases
 
 
+def profile_case_search(domain, couch_user, app_id, config):
+    helper = _get_helper(couch_user, domain, config.case_types, config.data_registry)
+
+    with helper.timing_context:
+        cases = get_primary_case_search_results(helper, domain, config.case_types,
+                                                config.criteria, config.commcare_sort)
+        if app_id:
+            cases.extend(get_and_tag_related_cases(
+                helper, app_id, config.case_types, cases, config.custom_related_case_property,
+                config.include_all_related_cases))
+    return helper.timing_context, len(cases)
+
+
+@time_function()
 def get_primary_case_search_results(helper, domain, case_types, criteria, commcare_sort=None):
     builder = CaseSearchQueryBuilder(domain, case_types, helper.query_domains)
     try:
-        search_es = builder.build_query(criteria, commcare_sort)
+        with helper.timing_context('build_query'):
+            search_es = builder.build_query(criteria, commcare_sort)
     except TooManyRelatedCasesError:
         raise CaseSearchUserError(_('Search has too many results. Please try a more specific search.'))
     except CaseFilterError as e:
@@ -84,14 +117,16 @@ def get_primary_case_search_results(helper, domain, case_types, criteria, commca
         raise CaseSearchUserError(str(e))
 
     try:
-        hits = search_es.run().raw_hits
+        with helper.timing_context('run query'):
+            hits = search_es.run().raw_hits
     except Exception as e:
         notify_exception(None, str(e), details=dict(
             exception_type=type(e),
         ))
         raise
 
-    cases = [helper.wrap_case(hit, include_score=True) for hit in hits]
+    with helper.timing_context('wrap_cases'):
+        cases = [helper.wrap_case(hit, include_score=True) for hit in hits]
     return cases
 
 
@@ -112,6 +147,7 @@ class _QueryHelper:
     def __init__(self, domain):
         self.domain = domain
         self.query_domains = [self.domain]
+        self.timing_context = TimingContext('Case Search')
 
     def get_base_queryset(self):
         return CaseSearchES().domain(self.query_domains)
@@ -131,6 +167,7 @@ class _RegistryQueryHelper:
         self.couch_user = couch_user
         self.registry_helper = registry_helper
         self.query_domains = self.registry_helper.visible_domains
+        self.timing_context = TimingContext('Case Search')
 
     def get_base_queryset(self):
         return CaseSearchES().domain(self.query_domains)
@@ -302,6 +339,7 @@ class CaseSearchQueryBuilder:
         ]
 
 
+@time_function()
 def get_and_tag_related_cases(helper, app_id, case_types, cases,
                             custom_related_case_property, include_all_related_cases):
     """
@@ -333,6 +371,7 @@ def get_and_tag_related_cases(helper, app_id, case_types, cases,
     return results
 
 
+@time_function()
 def get_related_cases_result(helper, app, case_types, source_cases, include_all_related_cases):
     """
     Gets parent, child, and extension cases through sync algorithm if configured.
@@ -357,6 +396,7 @@ def _get_all_related_cases(helper, source_cases):
     return results
 
 
+@time_function()
 def _get_search_detail_path_defined_cases(helper, app, case_types, source_cases):
     paths = [
         rel for rels in [get_search_detail_relationship_paths(app, case_type) for case_type in case_types]
@@ -453,6 +493,7 @@ def get_child_case_results(helper, parent_case_ids, child_case_types=None):
     return [helper.wrap_case(result) for result in results]
 
 
+@time_function()
 def get_expanded_case_results(helper, custom_related_case_property, cases):
     expanded_case_ids = {
         case.get_case_property(custom_related_case_property, dynamic_only=True) for case in cases

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -111,10 +111,12 @@ class ProfileCaseSearchView(_BaseCaseSearchView):
         app_id = data.get('app_id', request.POST.get('app_id'))  # may be in either place
         start = datetime.now()
         config = extract_search_request_config(request_dict)
-        timing_context, num_cases = profile_case_search(self.domain, request.couch_user, app_id, config)
+        timing_context, primary_count, related_count = profile_case_search(
+            self.domain, request.couch_user, app_id, config)
         runtime = (datetime.now() - start).total_seconds()
         return json_response({
-            'count': num_cases,
+            'primary_count': primary_count,
+            'related_count': related_count,
             'runtime': runtime,
             'timing_data': timing_context.to_dict(),
         })

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -106,11 +106,11 @@ class ProfileCaseSearchView(_BaseCaseSearchView):
     @json_error
     @cls_require_superuser_or_contractor
     def post(self, request, *args, **kwargs):
+        app_id = request.POST.get('app_id')
         data = json.loads(request.POST.get('q'))
         request_dict = data.get('request_dict', data)
         start = datetime.now()
         config = extract_search_request_config(request_dict)
-        app_id = None  # TODO add to UI
         timing_context, num_cases = profile_case_search(self.domain, request.couch_user, app_id, config)
         runtime = (datetime.now() - start).total_seconds()
         return json_response({

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -106,9 +106,9 @@ class ProfileCaseSearchView(_BaseCaseSearchView):
     @json_error
     @cls_require_superuser_or_contractor
     def post(self, request, *args, **kwargs):
-        app_id = request.POST.get('app_id')
         data = json.loads(request.POST.get('q'))
         request_dict = data.get('request_dict', data)
+        app_id = data.get('app_id', request.POST.get('app_id'))  # may be in either place
         start = datetime.now()
         config = extract_search_request_config(request_dict)
         timing_context, num_cases = profile_case_search(self.domain, request.couch_user, app_id, config)

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -53,7 +53,7 @@ class CaseSearchView(BaseDomainView):
         case_type = query.get('type')
         owner_id = query.get('owner_id')
         search_params = query.get('parameters', [])
-        xpath = query.get("xpath")
+        xpath_expressions = query.get("xpath_expressions", [])
         search = CaseSearchES()
         search = search.domain(self.domain).size(10)
         if case_type:
@@ -73,7 +73,7 @@ class CaseSearchView(BaseDomainView):
                     fuzzy=param.get('fuzzy'),
                 )
 
-        if xpath:
+        for xpath in filter(None, xpath_expressions):
             search = search.xpath_query(self.domain, xpath)
 
         include_profile = request.POST.get("include_profile", False)

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -130,11 +130,11 @@ def app_aware_search(request, domain, app_id):
     except CaseSearchUserError as e:
         return HttpResponse(str(e), status=400)
     fixtures = CaseDBFixture(cases).fixture
-    _log_search_timing(start_time, request_dict, domain)
+    _log_search_timing(start_time, request_dict, domain, app_id)
     return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
 
 
-def _log_search_timing(start_time, request_dict, domain):
+def _log_search_timing(start_time, request_dict, domain, app_id):
     for key, value in request_dict.items():
         if isinstance(value, str):
             request_dict[key] = value.replace('\t', '')
@@ -158,6 +158,7 @@ def _log_search_timing(start_time, request_dict, domain):
     if elapsed >= 10 and limit_domains(domain) != "__other__":
         notify_exception(None, "LongCaseSearchRequest", details={
             'request_dict': request_dict,
+            'app_id': app_id,
         })
 
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -972,14 +972,20 @@ class ProjectDataTab(UITab):
                 case_search_enabled_for_domain,
             )
             if case_search_enabled_for_domain(self.domain):
-                from corehq.apps.case_search.views import CaseSearchView
-                explore_data_views.append({
+                from corehq.apps.case_search.views import CaseSearchView, ProfileCaseSearchView
+                explore_data_views.extend([{
                     'title': _(CaseSearchView.page_title),
                     'url': reverse(CaseSearchView.urlname, args=(self.domain,)),
                     'icon': 'fa fa-search',
                     'show_in_dropdown': False,
                     'subpages': [],
-                })
+                }, {
+                    'title': _(ProfileCaseSearchView.page_title),
+                    'url': reverse(ProfileCaseSearchView.urlname, args=(self.domain,)),
+                    'icon': 'fa fa-clock',
+                    'show_in_dropdown': False,
+                    'subpages': [],
+                }])
         return explore_data_views
 
     def _get_geospatial_views(self):


### PR DESCRIPTION
## Product Description
Admin-only view to see case search performance breakdown.  Works best with the `LongCaseSearchRequest` log in sentry

![image](https://github.com/dimagi/commcare-hq/assets/2367539/5c930b58-6315-4307-8c78-fd625bd88626)

## Technical Summary
This initializes a `TimingContext` object when executing a case search request and keeps track of various sections of the process.  Turns out at least in some instances it's not just the ES query that's slow, but also building the query (and executing secondary queries), wrapping cases, serializing cases, fetching an app (seems like that shouldn't be happening here), and enriching the data with related cases.  I want to see what this looks like on production, since the circumstances there are pretty different than staging.

The timing code is not necessary in normal case search queries, only when initiating through this admin view, but I don't know of a better way to do this, and I can't imagine this having an appreciable performance impact.  It does add a bit of boilerplate to the code, which I don't like, and I'd support removing this when we are no longer as focused on case search performance.

## Feature Flag


## Safety Assurance


### Safety story
The parts of this that involve production code is relatively small, and that's the critical part.  The bulk of the changeset is admin-only, and I'm not concerned about errors there.  This has been on staging for about a week and I've tested it there without issue.

### Automated test coverage


### QA Plan



### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
