### PR TITLE
[B5] Web apps permissions page

### DIFF
--- a/corehq/apps/cloudcare/decorators.py
+++ b/corehq/apps/cloudcare/decorators.py
@@ -1,9 +1,9 @@
 from functools import wraps
 
-from django.http import HttpResponse
 from django.shortcuts import render
 
 from corehq.apps.domain.decorators import login_and_domain_required
+from corehq.apps.hqwebapp.utils.bootstrap import set_bootstrap_version5
 from corehq import toggles
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
@@ -32,10 +32,12 @@ def require_cloudcare_access_ex():
                     "app_or_domain_name": app_or_domain_name,
                     "is_superuser": hasattr(request, "couch_user") and request.couch_user.is_superuser
                 }
+                set_bootstrap_version5()
                 return render(request, "cloudcare/web_apps_disabled.html", context)
             if hasattr(request, "couch_user"):
                 if request.couch_user.is_web_user():
-                    return require_permission(HqPermissions.access_web_apps)(view_func)(request, domain, *args, **kwargs)
+                    return require_permission(HqPermissions.access_web_apps)(view_func)(request, domain,
+                        *args, **kwargs)
                 else:
                     assert request.couch_user.is_commcare_user(), \
                         "user was neither a web user or a commcare user!"
@@ -43,5 +45,6 @@ def require_cloudcare_access_ex():
             return login_and_domain_required(view_func)(request, domain, *args, **kwargs)
         return _inner
     return decorator
+
 
 require_cloudcare_access = require_cloudcare_access_ex()

--- a/corehq/apps/cloudcare/static/cloudcare/js/config.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/config.js
@@ -4,7 +4,7 @@ hqDefine("cloudcare/js/config", [
     'underscore',
     'knockout',
     'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/bootstrap3/main',
+    'hqwebapp/js/bootstrap5/main',
 ], function (
     $,
     _,

--- a/corehq/apps/cloudcare/templates/cloudcare/config.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/config.html
@@ -1,21 +1,8 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "cloudcare/js/config" %}
-
-{% block stylesheets %}
-  <style>
-    #cloudcare-app-settings-form label.radio {
-      padding-left: 2em;
-      width: 20%;
-    }
-
-    #cloudcare-app-settings-form select {
-      width: 20%;
-    }
-  </style>
-{% endblock %}
+{% requirejs_main_b5 "cloudcare/js/config" %}
 
 {% block page_content %}
   {% initial_page_data 'access' access %}
@@ -26,22 +13,25 @@
   <h2>{% trans 'Manage Web Apps Permissions' %}</h2>
   <section id="cloudcare-app-settings" style="display: none">
     <div data-bind="saveButton: saveButton"></div>
-    <div id="cloudcare-app-settings-form" data-bind="with: applicationAccess">
-      <label class="radio">
-        <input type="radio" value="false" data-bind="checked: restrict.JSON"/>
-        {% blocktrans %}Allow all mobile workers to see all Web Apps applications.{% endblocktrans %}
-      </label>
-      <label class="radio">
-        <input type="radio" value="true" data-bind="checked: restrict.JSON"/>
-        {% blocktrans %}Customize each mobile worker's access to Web Apps{% endblocktrans %}
-        <code data-bind="visible: !restrict()">...</code>
-      </label>
+    <div data-bind="with: applicationAccess">
+      <div class="form-check">
+        <input class="form-check-input" type="radio" value="false" data-bind="checked: restrict.JSON" id="radioFalse"/>
+        <label class="form-check-label" for="radioFalse">
+          {% blocktrans %}Allow all mobile workers to see all Web Apps applications.{% endblocktrans %}
+        </label>
+      </div>
+      <div class="form-check">
+        <input class="form-check-input" type="radio" value="true" data-bind="checked: restrict.JSON" id="radioTrue"/>
+        <label class="form-check-label" for="radioTrue">
+          {% blocktrans %}Customize each mobile worker's access to Web Apps{% endblocktrans %}
+        </label>
+      </div>
       <div data-bind="visible: restrict">
-        <table class="table table-bordered table-striped" data-bind="if: app_groups().length">
+        <table class="table table-bordered table-striped mt-3" data-bind="if: app_groups().length">
           <thead>
             <tr>
-              <th class="col-sm-6">{% trans 'Application' %}</th>
-              <th class="col-sm-6">{% trans 'Group' %}</th>
+              <th class="col-md-6">{% trans 'Application' %}</th>
+              <th class="col-md-6">{% trans 'Group' %}</th>
             </tr>
           </thead>
           <tbody data-bind="foreach: app_groups">
@@ -61,28 +51,30 @@
           </tr>
           </tbody>
         </table>
-        <div class="well">
-          <h4>{% trans "Here's what this means" %}</h4>
-          <ul data-bind="foreach: $root.appsByGroup">
-            <li>
-              <span></span>
-              <span data-bind="if: group">
-                                {% blocktrans %}Mobile workers in group
-                                  <strong data-bind="text: group.name"></strong>
-                                  have access to{% endblocktrans %}
-                            </span>
-              <span data-bind="if: !group">
-                                {% blocktrans %}<strong>No Mobile Workers</strong> have access to{% endblocktrans %}
-                            </span>
-              <ul data-bind="foreach: apps">
-                <li data-bind="text: name"></li>
-              </ul>
-            </li>
-          </ul>
-          <p>{% blocktrans %}...and all other mobile workers do not have access to any Web Apps applications.{% endblocktrans %}</p>
-        </div>
-        <div data-bind="if: !app_groups().length">
-          {% trans 'No Web Apps applications available' %}
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">{% trans "Here's what this means" %}</h5>
+            <ul data-bind="foreach: $root.appsByGroup">
+              <li>
+                <span></span>
+                <span data-bind="if: group">
+                                  {% blocktrans %}Mobile workers in group
+                                    <strong data-bind="text: group.name"></strong>
+                                    have access to{% endblocktrans %}
+                              </span>
+                <span data-bind="if: !group">
+                                  {% blocktrans %}<strong>No Mobile Workers</strong> have access to{% endblocktrans %}
+                              </span>
+                <ul data-bind="foreach: apps">
+                  <li data-bind="text: name"></li>
+                </ul>
+              </li>
+            </ul>
+            <p>{% blocktrans %}...and all other mobile workers do not have access to any Web Apps applications.{% endblocktrans %}</p>
+          </div>
+          <div data-bind="if: !app_groups().length">
+            {% trans 'No Web Apps applications available' %}
+          </div>
         </div>
       </div>
     </div>

--- a/corehq/apps/cloudcare/templates/cloudcare/web_apps_disabled.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/web_apps_disabled.html
@@ -1,4 +1,4 @@
-{% extends "hqwebapp/bootstrap3/base_page.html" %}
+{% extends "hqwebapp/bootstrap5/base_page.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
 

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -69,6 +69,7 @@ from corehq.apps.domain.decorators import (
 )
 from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.decorators import (
+    use_bootstrap5,
     use_daterangepicker,
     use_jquery_ui,
     waf_allow,
@@ -442,6 +443,7 @@ class EditCloudcareUserPermissionsView(BaseUserSettingsView):
     def page_title(self):
         return _("Web Apps Permissions")
 
+    @use_bootstrap5
     @method_decorator(domain_admin_required)
     @method_decorator(requires_privilege_with_fallback(privileges.CLOUDCARE))
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
@@ -161,7 +161,7 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
                     }).addClass(cssClass),
                     $saving: $('<div/>').text(SaveButton.message.SAVING).addClass('btn btn-primary disabled'),
                     $saved: $('<div/>').text(SaveButton.message.SAVED).addClass('btn btn-primary disabled'),
-                    ui: $('<div/>').addClass('pull-right savebtn-bar ' + barClass),
+                    ui: $('<div/>').addClass('float-end savebtn-bar ' + barClass),
                     setStateWhenReady: function (state) {
                         if (this.state === 'saving') {
                             this.nextState = state;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
@@ -57,6 +57,15 @@
                  $(key).text(update[key]).val(update[key]);
              }
          }
+@@ -161,7 +161,7 @@
+                     }).addClass(cssClass),
+                     $saving: $('<div/>').text(SaveButton.message.SAVING).addClass('btn btn-primary disabled'),
+                     $saved: $('<div/>').text(SaveButton.message.SAVED).addClass('btn btn-primary disabled'),
+-                    ui: $('<div/>').addClass('pull-right savebtn-bar ' + barClass),
++                    ui: $('<div/>').addClass('float-end savebtn-bar ' + barClass),
+                     setStateWhenReady: function (state) {
+                         if (this.state === 'saving') {
+                             this.nextState = state;
 @@ -179,7 +179,7 @@
                          this.$saved.detach();
                          this.$retry.detach();


### PR DESCRIPTION
## Product Description
before
![Screenshot 2024-04-02 at 4 41 17 PM](https://github.com/dimagi/commcare-hq/assets/1486591/8c01569b-71cd-4f3e-836c-75b0ac88b0c6)

after
![Screenshot 2024-04-02 at 4 39 40 PM](https://github.com/dimagi/commcare-hq/assets/1486591/ebb6dab8-898c-4984-8a77-6837fb68a9e7)

## Safety Assurance

### Safety story
These are pretty minor styling & js changes, on a page that doesn't get much traffic.

### Automated test coverage

no

### QA Plan

Not requesting QA. I tested the save logic and the page-specific js, which is minimal (showing/hiding the table based on the radio selection). I also smoke tested the web apps disable page, which is pretty trivial.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
