### PR TITLE
Use get_prep_value instead of get_db_prep_value

### DIFF
--- a/corehq/util/tests/test_jsonattrs.py
+++ b/corehq/util/tests/test_jsonattrs.py
@@ -174,7 +174,11 @@ def get_json_value(model, field_name):
     """
     field = model._meta.get_field(field_name)
     value = field.pre_save(model, False)
-    return json.loads(field.get_db_prep_save(value, None))
+    from django import VERSION as django_version
+    if django_version[:2] >= (4, 2):
+        return field.get_prep_value(value)
+    else:
+        return json.loads(field.get_prep_value(value))
 
 
 def set_json_value(model, field_name, value):

--- a/corehq/util/tests/test_jsonattrs.py
+++ b/corehq/util/tests/test_jsonattrs.py
@@ -176,7 +176,8 @@ def get_json_value(model, field_name):
     value = field.pre_save(model, False)
     from django import VERSION as django_version
     if django_version[:2] >= (4, 2):
-        return field.get_prep_value(value)
+        # load as json obj to ensure it serializes properly
+        return json.loads(json.dumps(field.get_prep_value(value)))
     else:
         return json.loads(field.get_prep_value(value))
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This avoids needing to use a db connection in what is otherwise a SimpleTestCase. Given this is just a test helper, the risk is very low. 

I suppose I could have been more clever and inspected the instance type to determine if json.loads needs to be called, but this ensures it is obvious why the two code paths exist and will make it easy for us to remove once upgraded to 4.2.

On 4.2, `get_db_prep_save` and `get_db_prep_value` were implemented on the JSONField class [here](https://github.com/django/django/blob/a76c52b19a221147f3a903848f711daa367e2e20/django/db/models/fields/json.py#L101-L131), which made it so that `get_db_prep_save` now required a db connection to be passed in as well, and is the main motivation for this change.

Notably, there are now two code paths in `get_json_value` because of the change in behavior of `get_prep_value`.

On 3.2, [get_prep_value](https://github.com/django/django/blob/stable/3.2.x/django/db/models/fields/json.py#L90-L93) on JSONField returns a json string. This behavior changed on 4.2, where get_prep_value was removed from JSONField, so the super [Field.get_prep_value](https://github.com/django/django/blob/stable/4.2.x/django/db/models/fields/__init__.py#L934-L938) is now called, which just returns the value passed in, evaluating any promised objects if needed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
