### PR TITLE
Investigate null values in calculated properties

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -71,9 +71,8 @@ def update_calculated_properties_for_domains(domains):
             for key in ['cp_first_form', 'cp_last_form', 'cp_300th_form']:
                 if props.get(key) is None:
                     del props[key]
-            for key, value in props.items():
-                if value is None:
-                    raise ValueError(f"Null value detected for {key} in domain {domain['name']}")
+            if props.get('cp_n_forms') is None:
+                raise ValueError(f"Null value detected for {key} in domain {domain['name']}")
             domain_adapter.update(domain['_id'], props)
         except Exception as e:
             notify_exception(

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -72,7 +72,7 @@ def update_calculated_properties_for_domains(domains):
                 if props.get(key) is None:
                     del props[key]
             if props.get('cp_n_forms') is None:
-                raise ValueError(f"Null value detected for {key} in domain {domain['name']}")
+                raise ValueError(f"Null value detected for 'cp_n_forms' in domain {domain['name']}")
             domain_adapter.update(domain['_id'], props)
         except Exception as e:
             notify_exception(

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -68,12 +68,9 @@ def update_calculated_properties_for_domains(domains):
         try:
             props = calced_props(domain_obj, domain['_id'], all_stats)
             active_users_by_domain[domain['name']] = props['cp_n_active_cc_users']
-            if props['cp_first_form'] is None:
-                del props['cp_first_form']
-            if props['cp_last_form'] is None:
-                del props['cp_last_form']
-            if props['cp_300th_form'] is None:
-                del props['cp_300th_form']
+            for key in ['cp_first_form', 'cp_last_form', 'cp_300th_form']:
+                if props.get(key) is None:
+                    del props[key]
             domain_adapter.update(domain['_id'], props)
         except Exception as e:
             notify_exception(

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -67,6 +67,9 @@ def update_calculated_properties_for_domains(domains):
             continue
         try:
             props = calced_props(domain_obj, domain['_id'], all_stats)
+            for key, value in props.items():
+                if value is None:
+                    raise ValueError(f"Null value detected for {key} in domain {domain['name']}")
             active_users_by_domain[domain['name']] = props['cp_n_active_cc_users']
             for key in ['cp_first_form', 'cp_last_form', 'cp_300th_form']:
                 if props.get(key) is None:

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -67,13 +67,13 @@ def update_calculated_properties_for_domains(domains):
             continue
         try:
             props = calced_props(domain_obj, domain['_id'], all_stats)
-            for key, value in props.items():
-                if value is None:
-                    raise ValueError(f"Null value detected for {key} in domain {domain['name']}")
             active_users_by_domain[domain['name']] = props['cp_n_active_cc_users']
             for key in ['cp_first_form', 'cp_last_form', 'cp_300th_form']:
                 if props.get(key) is None:
                     del props[key]
+            for key, value in props.items():
+                if value is None:
+                    raise ValueError(f"Null value detected for {key} in domain {domain['name']}")
             domain_adapter.update(domain['_id'], props)
         except Exception as e:
             notify_exception(


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15315

Salesforce sometimes would get null values from the hq, but in the next day, they can get the correct value again. I have no clue at all. So I add a`ValueError` exception to monitor when `cp_n_forms` 's value is `None`, and sent it to sentry. 
Hopefully I can get a traceback and some information regarding this.

I have deployed this branch to staging 2 weeks ago and the cp never be `None`. I will monitor sentry for production to find if we can catch anything.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe as I think `cp_n_forms` should never be `None`, it can be 0, but if it is `None`, then we raise an exception and look into it.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
