### PR TITLE
Add Default Case Geo-Location Property as Selectable Option

### DIFF
--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -40,7 +40,7 @@ from corehq.form_processor.models import CommCareCase
 from corehq.util.timezones.utils import get_timezone
 from corehq.util.view_utils import json_error
 
-from .const import POLYGON_COLLECTION_GEOJSON_SCHEMA
+from .const import POLYGON_COLLECTION_GEOJSON_SCHEMA, GPS_POINT_CASE_PROPERTY
 from .models import GeoConfig, GeoPolygon
 from .routing_solvers.mapbox_optimize import (
     routing_status,
@@ -231,11 +231,12 @@ class GeospatialConfigPage(BaseConfigView):
             case_type__domain=self.domain,
             data_type=CaseProperty.DataType.GPS,
         )
+        gps_case_props_deprecated_state = {prop.name: prop.deprecated for prop in gps_case_props}
+        if GPS_POINT_CASE_PROPERTY not in gps_case_props_deprecated_state:
+            gps_case_props_deprecated_state[GPS_POINT_CASE_PROPERTY] = False
         context.update({
             'config': self.config.as_dict(fields=GeospatialConfigForm.Meta.fields),
-            'gps_case_props_deprecated_state': {
-                prop.name: prop.deprecated for prop in gps_case_props
-            },
+            'gps_case_props_deprecated_state': gps_case_props_deprecated_state,
             'target_grouping_name': GeoConfig.TARGET_SIZE_GROUPING,
             'min_max_grouping_name': GeoConfig.MIN_MAX_GROUPING,
             'road_network_algorithm_slug': GeoConfig.ROAD_NETWORK_ALGORITHM,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The default case geolocation property (currently `gps_point`) will now always be available as a selectable option in the settings dropdown:
![default-selectable-option](https://github.com/dimagi/commcare-hq/assets/122617251/11288ff2-92f1-449c-bc26-36b2f508cca0)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3489).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Small UI change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
