### PR TITLE
Change the APIKeyView to account for users with no time zone

### DIFF
--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -671,7 +671,7 @@ class ApiKeyView(BaseMyAccountView, CRUDPaginatedViewMixin):
 
     def _to_user_time(self, value):
         return (ServerTime(value)
-                .user_time(ZoneInfo(self.request.couch_user.get_time_zone()))
+                .user_time(self.get_user_timezone())
                 .done()
                 .strftime(USER_DATETIME_FORMAT)) if value else '-'
 
@@ -754,6 +754,9 @@ class ApiKeyView(BaseMyAccountView, CRUDPaginatedViewMixin):
 
     create_item_form_class = "form form-horizontal"
 
+    def get_user_timezone(self):
+        return ZoneInfo(self.request.couch_user.get_time_zone() or 'UTC')
+
     def get_create_form(self, is_blank=False):
         if self.managing_idp:
             max_expiration_window = self.managing_idp.max_days_until_user_api_key_expiration
@@ -767,12 +770,12 @@ class ApiKeyView(BaseMyAccountView, CRUDPaginatedViewMixin):
                 self.request.POST,
                 user_domains=user_domains,
                 max_allowed_expiration_days=max_expiration_window,
-                timezone=ZoneInfo(self.request.couch_user.get_time_zone())
+                timezone=self.get_user_timezone(),
             )
         return HQApiKeyForm(
             user_domains=user_domains,
             max_allowed_expiration_days=max_expiration_window,
-            timezone=ZoneInfo(self.request.couch_user.get_time_zone())
+            timezone=self.get_user_timezone(),
         )
 
     def get_create_item_data(self, create_form):


### PR DESCRIPTION
## Technical Summary
A recent PR of mine seems to have caused a rare bug in production when a user has no associated timezone (which is possible when they have no associated domain): https://dimagi.sentry.io/issues/5140108945/?project=136860&referrer=github-pr-bot. This changes the `APIKeyView` to accomodate these users.

I would have preferred to change the root implementation, such that `WebUser.get_time_zone()` could never return `None`, but there were two instances in the code [ScheduleInstance](https://github.com/dimagi/commcare-hq/blob/36daa7a02853c92bc9b8488aa773d8f56da7949a/corehq/messaging/scheduling/scheduling_partitioned/models.py#L143-L158) and [a ScheduleInstance test](https://github.com/dimagi/commcare-hq/blob/36daa7a02853c92bc9b8488aa773d8f56da7949a/corehq/messaging/scheduling/tests/test_recipients.py#L688) that made me nervous to do so.

## Feature Flag
No feature flag

## Safety Assurance

### Safety story
Tested locally. I would have preferred to create a test for this, but creating a view to verify this behavior felt like it would be a confusing test. I think this kind of utility function should be extracted out from this view, but again, I wasn't sure where it should live if we're not comfortable overriding the base `WebUser` behavior.

### Automated test coverage

No tests

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
