### PR TITLE
Specify IntegerField for depth value in CTE query

### DIFF
--- a/corehq/apps/locations/adjacencylist.py
+++ b/corehq/apps/locations/adjacencylist.py
@@ -58,13 +58,13 @@ class AdjListManager(models.Manager):
 
         def make_cte_query(cte):
             return self.filter(where).order_by().annotate(
-                _depth=Value(0, output_field=models.Field()),
+                _depth=Value(0, output_field=models.IntegerField()),
             ).union(
                 cte.join(
                     self.all().order_by(),
                     id=cte.col.parent_id,
                 ).annotate(
-                    _depth=cte.col._depth + Value(1, output_field=models.Field()),
+                    _depth=cte.col._depth + Value(1, output_field=models.IntegerField()),
                 ),
             )
 

--- a/corehq/apps/locations/adjacencylist.py
+++ b/corehq/apps/locations/adjacencylist.py
@@ -5,26 +5,24 @@ from django.db.models.query import Q, QuerySet
 
 from django_cte import With
 
-field = models.Field()  # generic output field type
-
 
 class str_array(Func):
     function = "Array"
     # HACK fool postgres with concat
     # https://stackoverflow.com/a/12488455/10840 (see comment by KajMagnus)
     template = "%(function)s[%(expressions)s || '']::varchar[]"
-    output_field = field
+    output_field = models.Field()
 
 
 class array_append(Func):
     function = "array_append"
-    output_field = field
+    output_field = models.Field()
 
 
 class array_length(Func):
     function = "array_length"
     template = "%(function)s(%(expressions)s, 1)"
-    output_field = field
+    output_field = models.Field()
 
 
 class AdjListManager(models.Manager):
@@ -60,13 +58,13 @@ class AdjListManager(models.Manager):
 
         def make_cte_query(cte):
             return self.filter(where).order_by().annotate(
-                _depth=Value(0, output_field=field),
+                _depth=Value(0, output_field=models.Field()),
             ).union(
                 cte.join(
                     self.all().order_by(),
                     id=cte.col.parent_id,
                 ).annotate(
-                    _depth=cte.col._depth + Value(1, output_field=field),
+                    _depth=cte.col._depth + Value(1, output_field=models.Field()),
                 ),
             )
 
@@ -136,7 +134,7 @@ class AdjListManager(models.Manager):
                 cte.queryset().annotate(
                     max_len=array_length(
                         F("_cte_ordering"),
-                        output_field=field
+                        output_field=models.Field()
                     ),
                 ).distinct("id").order_by(
                     "id",


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The first commit is a prefactor that removes the global definition of `field` in favor of explicitly specifying the Field class where used. In my opinion, this just makes it easier to read since you don't have to figure our where `field` is defined.

The second commit replaces `Field()` with `IntegerField()` when used in the CTE query to set the `_depth` option. This is because in Django 4.1, changes were made to prevent Django from inferring output types of combinator expressions that impacted our use of `Field` + `Field`. Comparing the `_resolve_output_field` method in [3.2](https://github.com/django/django/blob/stable/3.2.x/django/db/models/expressions.py#L464C9-L475) vs [4.2](https://github.com/django/django/blob/stable/4.2.x/django/db/models/expressions.py#L667-L682), 3.2 called the super (BaseExpression) [_resolve_output_field](https://github.com/django/django/blob/stable/3.2.x/django/db/models/expressions.py#L283-L308) method, which attempts to infer the output type. The change in 4.2 removes this call to super, and calls [_resolve_combined_type](https://github.com/django/django/blob/stable/4.2.x/django/db/models/expressions.py#L638-L645) directly. This relies on [_connector_combinations](https://github.com/django/django/blob/stable/4.2.x/django/db/models/expressions.py#L520-L615) which specify the left side field, right side field, and expected output of different combinations, none of which include the `Field` type since it is ambiguous.

This is safe to make since our expression between two IntegerFields does not contain mixed types, and should behave the same as previously.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This was raised in a PR that runs tests against Django 4.2, and the test `corehq.apps.callcenter.tests.test_location_owners:CallCenterLocationOwnerTest.test_ancestor_location_sync
` failed. This test passes with this change on both 3.2 and 4.2.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
