### PR TITLE
Support Django 4.2 updates to makemigrations

### DIFF
--- a/corehq/apps/es/management/commands/make_elastic_migration.py
+++ b/corehq/apps/es/management/commands/make_elastic_migration.py
@@ -68,6 +68,9 @@ class Command(makemigrations.Command):
 
         self.target_versions = options['target_versions']
 
+        # used in super().write_migration_files
+        self.written_files = []
+
         # abort early if a migration name is provided but is invalid
         if self.migration_name and not self.migration_name.isidentifier():
             raise CommandError("The migration name must be a valid Python identifier.")

--- a/corehq/apps/es/management/commands/make_elastic_migration.py
+++ b/corehq/apps/es/management/commands/make_elastic_migration.py
@@ -34,13 +34,13 @@ class Command(makemigrations.Command):
             ),
         )
         parser.add_argument(
-            "-u", "--update", metavar="CNAME[:PROPERTY[,PROPERTY ...]]",
+            "-u", "--update-index", metavar="CNAME[:PROPERTY[,PROPERTY ...]]",
             dest="updates", default=[], type=self.adapter_and_properties_type,
             action="append", help=(
                 "Add an UpdateIndexMapping operation for index with canonical "
                 "name CNAME. Use the optional ':PROPERTY,...' suffix to "
                 "specify which properties to update, omitting this suffix will "
-                "update all properties. The -u/--update option may be "
+                "update all properties. The -u/--update-index option may be "
                 "specified multiple times."
             ),
         )

--- a/hqscripts/management/commands/makemigrations.py
+++ b/hqscripts/management/commands/makemigrations.py
@@ -51,6 +51,8 @@ class Command(makemigrations.Command):
 
     @no_translations
     def handle(self, *app_labels, **options):
+        # used in super().write_migration_files
+        self.written_files = []
 
         def assert_exclusive_options(opt_name, extra=[]):
             prevent = extra + ["dry_run", "merge", "empty", "name", "check_changes"]


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
In Django 4.2, an `--update` option was added to the `makemigrations` management command (see ticket [here](https://code.djangoproject.com/ticket/24870)), which now conflicts with our `--update` option in `make_elastic_migration`. I updated our option to be `--update-index`, but kept the shorthand version to be `-u` since Django doesn't specify a shorthand. However I think this might still be confusing and am open to changing that as well.

Additionally, as part of a change to run [generated migration files through a black formatter](https://github.com/django/django/pull/15412/files), a `written_files` instance variable is expected when calling `write_migration_files` on the base `makemigrations` command. The second commit adds this variable in `def handle(...)` for both of our commands that inherit from `makemigrations`. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
