### PR TITLE
Updated alert_user library styling to work in B5

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/alert_user.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/alert_user.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
     This is the knockout-based, javascript analog of messages in Django.
 
@@ -40,7 +41,7 @@ function (
                 clearTimeout(self.timer);
                 self.timer = setTimeout(removeAlertTimerFunc(self), 5000);
             }
-        }
+        };
         return self;
     };
 
@@ -88,11 +89,11 @@ function (
             viewModel.removeAlert(ko.dataFor(this));
         });
 
-        var message_element = $("#message-alerts").get(0);
+        var messageElement = $("#message-alerts").get(0);
         // this element is not available on templates like iframe_domain_login.html
-        if (message_element) {
-            ko.cleanNode(message_element);
-            $(message_element).koApplyBindings(viewModel);
+        if (messageElement) {
+            ko.cleanNode(messageElement);
+            $(messageElement).koApplyBindings(viewModel);
         }
     });
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/alert_user.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/alert_user.js
@@ -26,7 +26,7 @@ function (
         var self = {
             "message": ko.observable(message),
             "alert_class": ko.observable(
-                "alert fade in message-alert"
+                "alert alert-dismissible message-alert"
             ),
         };
         if (tags) {

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -106,9 +106,8 @@
              class="ko-template"
              data-bind="foreach: {data: alerts, beforeRemove: fadeOut}">
           <div data-bind="attr: {'class': alert_class}">
-            <a class="close"
-               data-dismiss="alert" href="#">&times;</a>
             <span data-bind="html: message"></span>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans_html_attr "Close" %}"></button>
           </div>
         </div>
       </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
@@ -128,7 +128,18 @@
  {% endblock post_navigation_content %}
  
  
-@@ -126,7 +119,7 @@
+@@ -113,9 +106,8 @@
+              class="ko-template"
+              data-bind="foreach: {data: alerts, beforeRemove: fadeOut}">
+           <div data-bind="attr: {'class': alert_class}">
+-            <a class="close"
+-               data-dismiss="alert" href="#">&times;</a>
+             <span data-bind="html: message"></span>
++            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans_html_attr "Close" %}"></button>
+           </div>
+         </div>
+       </div>
+@@ -126,7 +118,7 @@
  
  {% block footer %}
    {% if not enterprise_mode %}
@@ -137,7 +148,7 @@
    {% endif %}
  {% endblock footer %}
  
-@@ -134,9 +127,9 @@
+@@ -134,9 +126,9 @@
  {% block modals %}
    {% if domain and not enterprise_mode %}
      {% if show_overdue_invoice_modal %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/alert_user.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/alert_user.js.diff.txt
@@ -1,6 +1,11 @@
 --- 
 +++ 
-@@ -13,10 +13,10 @@
+@@ -1,3 +1,4 @@
++"use strict";
+ /*
+     This is the knockout-based, javascript analog of messages in Django.
+ 
+@@ -13,10 +14,10 @@
         (success < info < warning < danger).
      fadeOut: Set to 'true' to have the message automatically removed from the UI after 5s.
  */
@@ -13,3 +18,37 @@
  ],
  function (
      $,
+@@ -26,7 +27,7 @@
+         var self = {
+             "message": ko.observable(message),
+             "alert_class": ko.observable(
+-                "alert fade in message-alert"
++                "alert alert-dismissible message-alert"
+             ),
+         };
+         if (tags) {
+@@ -40,7 +41,7 @@
+                 clearTimeout(self.timer);
+                 self.timer = setTimeout(removeAlertTimerFunc(self), 5000);
+             }
+-        }
++        };
+         return self;
+     };
+ 
+@@ -88,11 +89,11 @@
+             viewModel.removeAlert(ko.dataFor(this));
+         });
+ 
+-        var message_element = $("#message-alerts").get(0);
++        var messageElement = $("#message-alerts").get(0);
+         // this element is not available on templates like iframe_domain_login.html
+-        if (message_element) {
+-            ko.cleanNode(message_element);
+-            $(message_element).koApplyBindings(viewModel);
++        if (messageElement) {
++            ko.cleanNode(messageElement);
++            $(messageElement).koApplyBindings(viewModel);
+         }
+     });
+ 


### PR DESCRIPTION
## Product Description
Small tweaks to make the alerts created by the `alert_user` library dismissable in B5.

See https://getbootstrap.com/docs/5.0/components/alerts/#dismissing

Cherry picked from an app migration.

## Safety Assurance

### Safety story
Pretty tiny bug fix. I doubt there are B5 pages using this code in production yet.

### Automated test coverage

unlikely

### QA Plan

not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
