### PR TITLE
Updated openModal binding to set aria-labelledby

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
@@ -375,23 +375,28 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
          */
         init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
             let value = valueAccessor(),
-                templateID = value,
+                templateId = value,
                 ifValue = true;
             if (typeof value === 'object') {
-                templateID = value.templateId;
+                templateId = value.templateId;
                 ifValue = _.has(value, 'if') ? value.if : true;
             }
-            let modalElement = $('<div></div>').addClass('modal fade').attr("tabindex", "-1").appendTo('body'),
+            let modalElement = $('<div></div>')
+                    .addClass('modal fade')
+                    .attr("id", templateId)
+                    .attr("aria-labelledby", templateId + "-title")
+                    .attr("tabindex", "-1")
+                    .appendTo('body'),
                 newValueAccessor = function () {
                     let clickAction = function () {
                         if (!ifValue) {
                             return;
                         }
                         ko.bindingHandlers.template.init(modalElement.get(0), function () {
-                            return templateID;
+                            return templateId;
                         }, allBindingsAccessor, viewModel, bindingContext);
                         ko.bindingHandlers.template.update(modalElement.get(0), function () {
-                            return templateID;
+                            return templateId;
                         }, allBindingsAccessor, viewModel, bindingContext);
 
                         let modal = new bootstrap.Modal(modalElement.get(0));

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
@@ -41,12 +41,25 @@
              }
          },
      };
-@@ -383,19 +381,21 @@
-                 templateID = value.templateId;
+@@ -377,25 +375,32 @@
+          */
+         init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+             let value = valueAccessor(),
+-                templateID = value,
++                templateId = value,
+                 ifValue = true;
+             if (typeof value === 'object') {
+-                templateID = value.templateId;
++                templateId = value.templateId;
                  ifValue = _.has(value, 'if') ? value.if : true;
              }
 -            var modal = $('<div></div>').addClass('modal fade').appendTo('body'),
-+            let modalElement = $('<div></div>').addClass('modal fade').attr("tabindex", "-1").appendTo('body'),
++            let modalElement = $('<div></div>')
++                    .addClass('modal fade')
++                    .attr("id", templateId)
++                    .attr("aria-labelledby", templateId + "-title")
++                    .attr("tabindex", "-1")
++                    .appendTo('body'),
                  newValueAccessor = function () {
 -                    var clickAction = function () {
 +                    let clickAction = function () {
@@ -54,12 +67,14 @@
                              return;
                          }
 -                        ko.bindingHandlers.template.init(modal.get(0), function () {
+-                            return templateID;
 +                        ko.bindingHandlers.template.init(modalElement.get(0), function () {
-                             return templateID;
++                            return templateId;
                          }, allBindingsAccessor, viewModel, bindingContext);
 -                        ko.bindingHandlers.template.update(modal.get(0), function () {
+-                            return templateID;
 +                        ko.bindingHandlers.template.update(modalElement.get(0), function () {
-                             return templateID;
++                            return templateId;
                          }, allBindingsAccessor, viewModel, bindingContext);
 -                        modal.modal('show');
 +
@@ -68,7 +83,7 @@
                      };
                      return clickAction;
                  };
-@@ -405,11 +405,13 @@
+@@ -405,11 +410,13 @@
  
      ko.bindingHandlers.openRemoteModal = {
          init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {


### PR DESCRIPTION
## Product Description
https://getbootstrap.com/docs/5.0/components/modal/#accessibility

This is a little bit magical. The binding requires a template id, and this assumes the markup contains a title with the id `<template id>-title`. An alternative would be to explicitly pass a param like `labelledById` to the binding.

Not fixing pre-existing lint errors.

## Safety Assurance

### Safety story
Accessibility change affecting screen readers. Slight risk of javascript errors. Tested locally.

### Automated test coverage

no

### QA Plan

not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
