### PR TITLE
Profiling case search - more detail

### DIFF
--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -32,6 +32,7 @@ class SearchFilterContext:
     profiler: 'corehq.apps.case_search.utils.CaseSearchProfiler' = None
 
     def __post_init__(self):
+        from corehq.apps.case_search.utils import CaseSearchProfiler
         if self.request_domain is None:
             if isinstance(self.domain, str):
                 self.request_domain = self.domain
@@ -39,6 +40,8 @@ class SearchFilterContext:
                 self.request_domain = self.domain[0]
             else:
                 raise ValueError("When domain is a list with more than one item, request_domain cannot be None.")
+        if self.profiler is None:
+            self.profiler = CaseSearchProfiler()
 
 
 def print_ast(node):

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -28,6 +28,7 @@ class SearchFilterContext:
     domain: Union[str, List[str]]  # query domain
     fuzzy: bool = False
     request_domain: str = None
+    profiler: 'corehq.apps.case_search.utils.CaseSearchProfiler' = None
 
     def __post_init__(self):
         if self.request_domain is None:
@@ -125,7 +126,7 @@ def build_filter_from_ast(node, context):
     return visit(node)
 
 
-def build_filter_from_xpath(query_domain, xpath, fuzzy=False, request_domain=None):
+def build_filter_from_xpath(query_domain, xpath, fuzzy=False, request_domain=None, profiler=None):
     """Given an xpath expression this function will generate an Elasticsearch
     filter"""
     error_message = _(
@@ -133,7 +134,7 @@ def build_filter_from_xpath(query_domain, xpath, fuzzy=False, request_domain=Non
         "Please try reformatting your query. "
         "The operators we accept are: {}"
     )
-    context = SearchFilterContext(query_domain, fuzzy, request_domain)
+    context = SearchFilterContext(query_domain, fuzzy, request_domain, profiler)
     try:
         return build_filter_from_ast(parse_xpath(xpath), context)
     except TypeError as e:

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -10,6 +10,7 @@ from eulxml.xpath.ast import (
     serialize,
 )
 
+import corehq
 from corehq.apps.case_search.const import OPERATOR_MAPPING, COMPARISON_OPERATORS, ALL_OPERATORS
 from corehq.apps.case_search.exceptions import (
     CaseFilterError,

--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -62,6 +62,18 @@
       </li>
     </script>
 
+    <div class="panel-group" id="queries-accordion" data-bind="foreach: results().queries">
+      <div class="panel panel-default">
+        <div class="panel-heading clickable" data-toggle="collapse" data-parent="#queries-accordion"
+          data-bind="attr: { href: '#query-' + $index() }">
+          Elasticsearch query: <code data-bind="text: slug"></code>
+        </div>
+        <div class="panel-body panel-collapse collapse" data-bind="attr: { id: 'query-' + $index() }">
+          <pre data-bind="text: JSON.stringify(query, null, 4)"></pre>
+        </div>
+      </div>
+    </div>
+
   </div>
 
 </div>

--- a/corehq/apps/case_search/tests/utils.py
+++ b/corehq/apps/case_search/tests/utils.py
@@ -1,8 +1,12 @@
 from corehq.apps.case_search.models import criteria_dict_to_criteria_list
-from corehq.apps.case_search.utils import CaseSearchQueryBuilder
+from corehq.apps.case_search.utils import (
+    CaseSearchProfiler,
+    CaseSearchQueryBuilder,
+)
 
 
 def get_case_search_query(domain, case_types, criteria_dict, commcare_sort=None):
     """Helper function for tests"""
     criteria = criteria_dict_to_criteria_list(criteria_dict)
-    return CaseSearchQueryBuilder(domain, case_types).build_query(criteria, commcare_sort=commcare_sort)
+    builder = CaseSearchQueryBuilder(domain, case_types, CaseSearchProfiler())
+    return builder.build_query(criteria, commcare_sort=commcare_sort)

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -140,8 +140,8 @@ def get_primary_case_search_results(helper, domain, case_types, criteria, commca
         raise CaseSearchUserError(str(e))
 
     try:
+        helper.profiler.add_query('main', search_es)
         with helper.profiler.timing_context('run query'):
-            helper.profiler.add_query('main', search_es)
             hits = search_es.run().raw_hits
     except Exception as e:
         notify_exception(None, str(e), details=dict(

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -118,5 +118,6 @@ class ProfileCaseSearchView(_BaseCaseSearchView):
             'primary_count': profiler.primary_count,
             'related_count': profiler.related_count,
             'timing_data': profiler.timing_context.to_dict(),
+            'queries': profiler.queries,
             'runtime': runtime,
         })

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -111,12 +111,12 @@ class ProfileCaseSearchView(_BaseCaseSearchView):
         app_id = data.get('app_id', request.POST.get('app_id'))  # may be in either place
         start = datetime.now()
         config = extract_search_request_config(request_dict)
-        timing_context, primary_count, related_count = profile_case_search(
+        profiler = profile_case_search(
             self.domain, request.couch_user, app_id, config)
         runtime = (datetime.now() - start).total_seconds()
         return json_response({
-            'primary_count': primary_count,
-            'related_count': related_count,
+            'primary_count': profiler.primary_count,
+            'related_count': profiler.related_count,
+            'timing_data': profiler.timing_context.to_dict(),
             'runtime': runtime,
-            'timing_data': timing_context.to_dict(),
         })

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -89,7 +89,9 @@ def _is_ancestor_path_expression(node):
 def _child_case_lookup(context, case_ids, identifier):
     """returns a list of all case_ids who have parents `case_id` with the relationship `identifier`
     """
-    return CaseSearchES().domain(context.domain).get_child_cases(case_ids, identifier).scroll_ids()
+    es_query = CaseSearchES().domain(context.domain).get_child_cases(case_ids, identifier)
+    context.profiler.add_query('_child_case_lookup', es_query)
+    return es_query.scroll_ids()
 
 
 def ancestor_exists(node, context):
@@ -144,6 +146,7 @@ def _get_case_ids_from_ast_filter(context, filter_node):
         es_filter = build_filter_from_ast(filter_node, context)
 
         es_query = CaseSearchES().domain(context.domain).filter(es_filter)
+        context.profiler.add_query('_get_case_ids_from_ast_filter', es_query)
         if es_query.count() > MAX_RELATED_CASES:
             new_query = serialize(filter_node)
             raise TooManyRelatedCasesError(

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -120,11 +120,8 @@ def _run_subcase_query(subcase_query, context):
         .source(['indices.referenced_id', 'indices.identifier'])
     )
 
-    if context.profiler:
-        context.profiler.add_query('subcase_query', es_query)
-        with context.profiler.timing_context('subcase_query'):
-            return es_query.run().hits
-    else:
+    context.profiler.add_query('subcase_query', es_query)
+    with context.profiler.timing_context('subcase_query'):
         return es_query.run().hits
 
 

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -98,9 +98,12 @@ def _get_parent_case_ids_matching_subcase_query(subcase_query, context):
         .source(['indices.referenced_id', 'indices.identifier'])
     )
 
+    context.profiler.add_query('subcase_query', es_query)
+    with context.profiler.timing_context('subcase_query'):
+        results = es_query.run()
     counts_by_parent_id = Counter(
         index['referenced_id']
-        for subcase in es_query.run().hits
+        for subcase in results.hits
         for index in subcase['indices']
         if index['identifier'] == subcase_query.index_identifier
     )

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -72,7 +72,29 @@ def _get_parent_case_ids_matching_subcase_query(subcase_query, context):
 
     Only cases with `[>,=] case_count_gt` subcases will be returned.
     """
-    # TODO: validate that the subcase filter doesn't contain any ancestor filtering
+
+    counts_by_parent_id = Counter(
+        index['referenced_id']
+        for subcase in _run_subcase_query(subcase_query, context)
+        for index in subcase['indices']
+        if index['identifier'] == subcase_query.index_identifier
+    )
+    if len(counts_by_parent_id) > MAX_RELATED_CASES:
+        from ..exceptions import TooManyRelatedCasesError
+        raise TooManyRelatedCasesError(
+            _("The related case lookup you are trying to perform would return too many cases"),
+            serialize(subcase_query.subcase_filter)
+        )
+
+    if subcase_query.op == '>' and subcase_query.count <= 0:
+        return list(counts_by_parent_id)
+
+    return [
+        case_id for case_id, count in counts_by_parent_id.items() if subcase_query.filter_count(count)
+    ]
+
+
+def _run_subcase_query(subcase_query, context):
     from corehq.apps.case_search.filter_dsl import (
         build_filter_from_ast,
     )
@@ -98,28 +120,12 @@ def _get_parent_case_ids_matching_subcase_query(subcase_query, context):
         .source(['indices.referenced_id', 'indices.identifier'])
     )
 
-    context.profiler.add_query('subcase_query', es_query)
-    with context.profiler.timing_context('subcase_query'):
-        results = es_query.run()
-    counts_by_parent_id = Counter(
-        index['referenced_id']
-        for subcase in results.hits
-        for index in subcase['indices']
-        if index['identifier'] == subcase_query.index_identifier
-    )
-    if len(counts_by_parent_id) > MAX_RELATED_CASES:
-        from ..exceptions import TooManyRelatedCasesError
-        raise TooManyRelatedCasesError(
-            _("The related case lookup you are trying to perform would return too many cases"),
-            serialize(subcase_query.subcase_filter)
-        )
-
-    if subcase_query.op == '>' and subcase_query.count <= 0:
-        return list(counts_by_parent_id)
-
-    return [
-        case_id for case_id, count in counts_by_parent_id.items() if subcase_query.filter_count(count)
-    ]
+    if context.profiler:
+        context.profiler.add_query('subcase_query', es_query)
+        with context.profiler.timing_context('subcase_query'):
+            return es_query.run().hits
+    else:
+        return es_query.run().hits
 
 
 def _parse_normalize_subcase_query(node) -> SubCaseQuery:


### PR DESCRIPTION
## Product Description
Builds off of https://github.com/dimagi/commcare-hq/pull/34373 to add more detail.
The main things this does is:
* Logs each separate elasticsearch query performed
* Shows timing information for evaluating `_xpath_query` expressions

![image](https://github.com/dimagi/commcare-hq/assets/2367539/e2d70e04-d565-4667-b84e-405ff729b044)

## Technical Summary

Certainly open to feedback or contributions if you've got 'em.  Here are some things I'd like to improve, if the implementation would be worth it:
* Make the profiling/logging code less obtrusive (I don't love littering the code with it)
* There are various classes to hold state or context in case search, but nothing end-to-end - I'm kinda wondering if something like that would be useful.
* It'd be handy to store the profiler object in the DB so we can view it retroactively for real case search requests
* I'd like to run the elasticsearch profiler on the ES queries saved here, though the output is pretty painful to interpret.  Might look into tooling there eventually.  This incurs overhead, so we wouldn't want to do it for real case searches.

The big thing I'd like reviewers to think about is how this code affects the real case search workflows.  I don't want to add notable overhead or risk.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

Local and automated testing.  Will pilot on staging too.

### Automated test coverage

There are tests for most of this

### QA Plan

n/a


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
