### PR TITLE
Make web user location IDs available in restore and usercase

### DIFF
--- a/corehq/apps/callcenter/sync_usercase.py
+++ b/corehq/apps/callcenter/sync_usercase.py
@@ -1,9 +1,10 @@
 import uuid
 from collections import namedtuple
 from itertools import chain
-from lxml import etree
 
 from django.core.cache import cache
+
+from lxml import etree
 
 from casexml.apps.case.mock import CaseBlock
 from dimagi.utils.couch import CriticalSection
@@ -14,6 +15,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.export.tasks import add_inferred_export_properties
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.locations.models import SQLLocation
+from corehq.apps.users.util import user_location_data
 from corehq.form_processor.models import CommCareCase
 from corehq.toggles import USH_USERCASES_FOR_WEB_USERS
 
@@ -133,6 +135,11 @@ def _get_user_case_fields(user, case_type, owner_id, domain):
     # remove any keys that aren't valid XML element names
     fields = {k: v for k, v in user.get_user_data(domain).items() if
               valid_element_name(k)}
+
+    if user.is_web_user:
+        fields['commcare_location_id'] = user.get_location_id(domain)
+        fields['commcare_location_ids'] = user_location_data(user.get_location_ids(domain))
+
     # language or phone_number can be null and will break
     # case submission
     fields.update({

--- a/corehq/apps/callcenter/sync_usercase.py
+++ b/corehq/apps/callcenter/sync_usercase.py
@@ -136,9 +136,10 @@ def _get_user_case_fields(user, case_type, owner_id, domain):
     fields = {k: v for k, v in user.get_user_data(domain).items() if
               valid_element_name(k)}
 
-    if user.is_web_user:
+    if user.is_web_user():
         fields['commcare_location_id'] = user.get_location_id(domain)
         fields['commcare_location_ids'] = user_location_data(user.get_location_ids(domain))
+        fields['commcare_primary_case_sharing_id'] = user.get_location_id(domain)
 
     # language or phone_number can be null and will break
     # case submission

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -221,7 +221,6 @@ class CallCenterUtilsTests(TestCase):
 class CallCenterUtilsUsercaseTests(TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.skip_commcareuser_teardown = False
 
     @classmethod
     def setUpClass(cls):
@@ -235,8 +234,7 @@ class CallCenterUtilsUsercaseTests(TestCase):
                                         '***', None, None, commit=False)  # Don't commit yet
 
     def tearDown(self):
-        if not self.skip_commcareuser_teardown:
-            self.user.delete(self.domain.name, deleted_by=None)
+        self.user.delete(self.domain.name, deleted_by=None)
 
     @classmethod
     def tearDownClass(cls):
@@ -403,7 +401,7 @@ class CallCenterUtilsUsercaseTests(TestCase):
 
     @flag_enabled('USH_USERCASES_FOR_WEB_USERS')
     def test_web_user_location_fields_sync(self):
-        self.skip_commcareuser_teardown = True
+        self.user.save()
         web_user = WebUser.create(TEST_DOMAIN, 'user3', '***', None, None)
         self.addCleanup(web_user.delete, TEST_DOMAIN, deleted_by=None)
         lt = LocationType.objects.create(

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1124,12 +1124,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         if self.is_commcare_user() and self.is_demo_user:
             session_data[COMMCARE_USER_TYPE_KEY] = COMMCARE_USER_TYPE_DEMO
 
-        if self.is_web_user():
-            # TODO can we do this for both types of users and remove the fields from user data?
-            session_data['commcare_location_id'] = self.get_location_id(domain)
-            session_data['commcare_location_ids'] = user_location_data(self.get_location_ids(domain))
-            session_data['commcare_primary_case_sharing_id'] = self.get_location_id(domain)
-
         session_data.update({
             f'{SYSTEM_PREFIX}_first_name': self.first_name,
             f'{SYSTEM_PREFIX}_last_name': self.last_name,
@@ -2592,6 +2586,14 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
 
     def get_usercase_by_domain(self, domain):
         return CommCareCase.objects.get_case_by_external_id(domain, self._id, USERCASE_TYPE)
+
+    def get_user_session_data(self, domain):
+        # TODO can we do this for both types of users and remove the fields from user data?
+        session_data = super(WebUser, self).get_user_session_data(domain)
+        session_data['commcare_location_id'] = self.get_location_id(domain)
+        session_data['commcare_location_ids'] = user_location_data(self.get_location_ids(domain))
+        session_data['commcare_primary_case_sharing_id'] = self.get_location_id(domain)
+        return session_data
 
 
 class FakeUser(WebUser):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1124,6 +1124,11 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         if self.is_commcare_user() and self.is_demo_user:
             session_data[COMMCARE_USER_TYPE_KEY] = COMMCARE_USER_TYPE_DEMO
 
+        if self.is_web_user():
+            # TODO can we do this for both types of users and remove the fields from user data?
+            session_data['commcare_location_id'] = self.get_location_id(domain)
+            session_data['commcare_location_ids'] = user_location_data(self.get_location_ids(domain))
+
         session_data.update({
             f'{SYSTEM_PREFIX}_first_name': self.first_name,
             f'{SYSTEM_PREFIX}_last_name': self.last_name,

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1128,6 +1128,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             # TODO can we do this for both types of users and remove the fields from user data?
             session_data['commcare_location_id'] = self.get_location_id(domain)
             session_data['commcare_location_ids'] = user_location_data(self.get_location_ids(domain))
+            session_data['commcare_primary_case_sharing_id'] = self.get_location_id(domain)
 
         session_data.update({
             f'{SYSTEM_PREFIX}_first_name': self.first_name,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
@@ -48,6 +48,7 @@ def dummy_user_xml(user=None):
         user_type,
     )
 
+
 DUMMY_RESTORE_XML_TEMPLATE = ("""
 <OpenRosaResponse xmlns="http://openrosa.org/http/response"%(items_xml)s>
     <message nature="ota_restore_success">%(message)s</message>

--- a/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
@@ -7,6 +7,12 @@ DUMMY_USERNAME = "mclovin"
 DUMMY_PASSWORD = "changeme"
 DUMMY_PROJECT = "domain"
 
+LOCATION_IDS_DATA_FIELDS = """
+                              <data key="commcare_location_id"/>
+                              <data key="commcare_location_ids"/>"""
+COMMCARE_PRIMARY_CASE_SHARING_ID = """
+                                      <data key="commcare_primary_case_sharing_id"/>"""
+
 
 def dummy_user_xml(user=None):
     username = user.username if user else DUMMY_USERNAME
@@ -24,8 +30,8 @@ def dummy_user_xml(user=None):
         <date>{}</date>
         <user_data>
             <data key="commcare_first_name"/>
-            <data key="commcare_last_name"/>
-            <data key="commcare_phone_number"/>
+            <data key="commcare_last_name"/>{}
+            <data key="commcare_phone_number"/>{}
             <data key="commcare_profile"/>
             <data key="commcare_project">{}</data>
             <data key="commcare_user_type">{}</data>
@@ -36,6 +42,8 @@ def dummy_user_xml(user=None):
         password,
         user_id,
         date_to_xml_string(date_joined),
+        LOCATION_IDS_DATA_FIELDS if user_type == 'web' else '',
+        COMMCARE_PRIMARY_CASE_SHARING_ID if user_type == 'web' else '',
         project,
         user_type,
     )

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -1,6 +1,5 @@
 import os
 import uuid
-from datetime import date
 
 from django.test import TestCase
 
@@ -287,8 +286,8 @@ class OtaRestoreTest(BaseOtaRestoreTest):
         )
         all_sync_logs = get_all_syncslogs()
         [even_latest_log] = [log for log in all_sync_logs
-                             if log.get_id != sync_log_id and
-                             log.get_id != latest_log.get_id]
+                             if log.get_id != sync_log_id
+                             and log.get_id != latest_log.get_id]
 
         # case block should come back
         expected_sync_restore_payload = dummy_restore_xml(

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -14,6 +14,8 @@ from casexml.apps.case.tests.util import (
     delete_all_sync_logs,
     delete_all_xforms,
 )
+from corehq.apps.locations.models import LocationType
+from corehq.apps.locations.tests.util import make_loc
 from casexml.apps.phone import xml
 from casexml.apps.phone.models import SyncLogSQL, properly_wrap_sync_log
 from casexml.apps.phone.restore import CachedResponse
@@ -33,6 +35,14 @@ from corehq.util.test_utils import TestFileMixin
 
 def get_registration_xml(restore_user):
     return xml.tostring(xml.get_registration_element(restore_user)).decode('utf-8')
+
+
+def _expected_payload(key, val):
+    if val is None:
+        expected = f'<data key="{key}"/>'
+    else:
+        expected = f'<data key="{key}">{val}</data>'
+    return expected
 
 
 class SimpleOtaRestoreTest(TestCase):
@@ -62,18 +72,10 @@ class SimpleOtaRestoreTest(TestCase):
             phone_number='555555',
         )
         payload = get_registration_xml(user)
-
-        def assertRegistrationData(key, val):
-            if val is None:
-                expected = f'<data key="{key}"/>'
-            else:
-                expected = f'<data key="{key}">{val}</data>'
-            self.assertIn(expected, payload)
-
-        assertRegistrationData("commcare_first_name", "mclovin")
-        assertRegistrationData("commcare_last_name", None)
-        assertRegistrationData("commcare_phone_number", "555555")
-        assertRegistrationData("commcare_user_type", "commcare")
+        self.assertIn(_expected_payload("commcare_first_name", "mclovin"), payload)
+        self.assertIn(_expected_payload("commcare_last_name", None), payload)
+        self.assertIn(_expected_payload("commcare_phone_number", "555555"), payload)
+        self.assertIn(_expected_payload("commcare_user_type", "commcare"), payload)
 
 
 class BaseOtaRestoreTest(TestCase, TestFileMixin):
@@ -385,3 +387,23 @@ class WebUserOtaRestoreTest(OtaRestoreTest):
         super(WebUserOtaRestoreTest, self).setUp()
         delete_all_users()
         self.restore_user = create_restore_user(self.project.name, is_mobile_user=False)
+
+    def test_location_ids_in_restore(self):
+        web_user = self.restore_user._couch_user
+        domain = self.project.name
+
+        # Location setup
+        lt = LocationType.objects.create(
+            domain=domain, name='lt2'
+        )
+        self.loc1 = make_loc('loc1', type=lt.name, domain=domain)
+        self.loc2 = make_loc('loc2', type=lt.name, domain=domain)
+        web_user.set_location(domain, self.loc1)
+        web_user.add_to_assigned_locations(domain, self.loc2)
+
+        payload = get_registration_xml(self.restore_user)
+
+        self.assertIn(_expected_payload("commcare_location_id", self.loc1.location_id), payload)
+        self.assertIn(_expected_payload("commcare_location_ids",
+                                       ' '.join([self.loc1.location_id, self.loc2.location_id])), payload)
+        self.assertIn(_expected_payload("commcare_primary_case_sharing_id", self.loc1.location_id), payload)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Jira: [USH-4317](https://dimagi.atlassian.net/browse/USH-4317?atlOrigin=eyJpIjoiOTNiZjdkNjgwMTc3NGM1M2E4MWI0YmIzYTU1ZTU0YjkiLCJwIjoiaiJ9)

Makes a web user's location IDs available in the restore file (in the registration element) and the usercase.

This missing data was noticed as part of QA on the recent user data modifications. 

## Technical Summary

Nothing fancy. Adding the IDs data XML to the test registration element felt a bit hacky, but this can be seen as [tech debt](https://dimagi.atlassian.net/browse/USH-4317?focusedCommentId=320297) addressed at a later time.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Mostly straightforward change
- Changes should be limited to web users only. Existing tests verify this
- New tests cover expected result pretty well, I think
- Going to do a run-through on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added new tests to see that the IDs are added properly.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None. Going to take a quick look on a client test domain on staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4317]: https://dimagi.atlassian.net/browse/USH-4317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ