### PR TITLE
Update update_fields arg in custom save methods if specified

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -292,7 +292,7 @@ def sync_supply_point(location, is_deletion=False, update_fields=None):
         updated_supply_point = _reopen_or_create_supply_point(location)
         location.supply_point_id = updated_supply_point.case_id
 
-    if update_fields:
+    if update_fields is not None:
         update_fields.append('supply_point_id')
 
 

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -277,7 +277,7 @@ def _reopen_or_create_supply_point(location):
         return SupplyInterface.create_from_location(location.domain, location)
 
 
-def sync_supply_point(location, is_deletion=False):
+def sync_supply_point(location, is_deletion=False, update_fields=None):
     """Called on location save() or delete().  Updates the supply_point_id if appropriate"""
     domain_obj = Domain.get_by_name(location.domain)
     if not domain_obj.commtrack_enabled:
@@ -291,6 +291,9 @@ def sync_supply_point(location, is_deletion=False):
     else:
         updated_supply_point = _reopen_or_create_supply_point(location)
         location.supply_point_id = updated_supply_point.case_id
+
+    if update_fields:
+        update_fields.append('supply_point_id')
 
 
 @receiver(xform_archived)

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -161,10 +161,8 @@ class LocationType(models.Model):
         self.emergency_level = config.emergency_level
         self.understock_threshold = config.understock_threshold
         self.overstock_threshold = config.overstock_threshold
-        if update_fields:
-            update_fields.append('emergency_level')
-            update_fields.append('understock_threshold')
-            update_fields.append('overstock_threshold')
+        if update_fields is not None:
+            update_fields.extend(['emergency_level', 'understock_threshold', 'overstock_threshold'])
 
     def save(self, *args, **kwargs):
         additional_update_fields = []
@@ -181,7 +179,7 @@ class LocationType(models.Model):
             self._populate_stock_levels(config, update_fields=additional_update_fields)
 
         is_not_first_save = self.pk is not None
-        if 'update_fields' in kwargs.keys():
+        if 'update_fields' in kwargs:
             kwargs['update_fields'].extend(additional_update_fields)
         super(LocationType, self).save(*args, **kwargs)
 
@@ -411,7 +409,7 @@ class SQLLocation(AdjListModel):
         with transaction.atomic():
             set_site_code_if_needed(self, update_fields=additional_update_fields)
             sync_supply_point(self, update_fields=additional_update_fields)
-            if 'update_fields' in kwargs.keys():
+            if 'update_fields' in kwargs:
                 kwargs['update_fields'].extend(additional_update_fields)
             super(SQLLocation, self).save(*args, **kwargs)
 

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -179,7 +179,7 @@ class LocationType(models.Model):
             self._populate_stock_levels(config, update_fields=additional_update_fields)
 
         is_not_first_save = self.pk is not None
-        if 'update_fields' in kwargs:
+        if kwargs.get('update_fields') is not None:
             kwargs['update_fields'].extend(additional_update_fields)
         super(LocationType, self).save(*args, **kwargs)
 
@@ -409,7 +409,7 @@ class SQLLocation(AdjListModel):
         with transaction.atomic():
             set_site_code_if_needed(self, update_fields=additional_update_fields)
             sync_supply_point(self, update_fields=additional_update_fields)
-            if 'update_fields' in kwargs:
+            if kwargs.get('update_fields') is not None:
                 kwargs['update_fields'].extend(additional_update_fields)
             super(SQLLocation, self).save(*args, **kwargs)
 

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -770,7 +770,7 @@ def set_site_code_if_needed(location, update_fields=None):
                                 .values_list('site_code', flat=True))
         ]
         location.site_code = generate_code(location.name, all_codes)
-        if update_fields:
+        if update_fields is not None:
             update_fields.append('site_code')
 
 

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -179,7 +179,7 @@ class LocationType(models.Model):
             self._populate_stock_levels(config, update_fields=additional_update_fields)
 
         is_not_first_save = self.pk is not None
-        if kwargs.get('update_fields') is not None:
+        if 'update_fields' in kwargs:
             kwargs['update_fields'].extend(additional_update_fields)
         super(LocationType, self).save(*args, **kwargs)
 
@@ -409,7 +409,7 @@ class SQLLocation(AdjListModel):
         with transaction.atomic():
             set_site_code_if_needed(self, update_fields=additional_update_fields)
             sync_supply_point(self, update_fields=additional_update_fields)
-            if kwargs.get('update_fields') is not None:
+            if 'update_fields' in kwargs:
                 kwargs['update_fields'].extend(additional_update_fields)
             super(SQLLocation, self).save(*args, **kwargs)
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3025,6 +3025,8 @@ class HQApiKey(models.Model):
     def save(self, *args, **kwargs):
         if not self.key:
             self.key = self.generate_key()
+            if 'update_fields' in kwargs.keys():
+                kwargs['update_fields'].append('key')
 
         return super().save(*args, **kwargs)
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3025,7 +3025,7 @@ class HQApiKey(models.Model):
     def save(self, *args, **kwargs):
         if not self.key:
             self.key = self.generate_key()
-            if kwargs.get('update_fields') is not None:
+            if 'update_fields' in kwargs:
                 kwargs['update_fields'].append('key')
 
         return super().save(*args, **kwargs)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3025,7 +3025,7 @@ class HQApiKey(models.Model):
     def save(self, *args, **kwargs):
         if not self.key:
             self.key = self.generate_key()
-            if 'update_fields' in kwargs:
+            if kwargs.get('update_fields') is not None:
                 kwargs['update_fields'].append('key')
 
         return super().save(*args, **kwargs)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3025,7 +3025,7 @@ class HQApiKey(models.Model):
     def save(self, *args, **kwargs):
         if not self.key:
             self.key = self.generate_key()
-            if 'update_fields' in kwargs.keys():
+            if 'update_fields' in kwargs:
                 kwargs['update_fields'].append('key')
 
         return super().save(*args, **kwargs)

--- a/corehq/motech/generic_inbound/models.py
+++ b/corehq/motech/generic_inbound/models.py
@@ -57,7 +57,7 @@ class ConfigurableAPI(models.Model):
             if self.url_key:
                 raise FieldError("'url_key' is auto-assigned")
             self.url_key = make_url_key()
-            if 'update_fields' in kwargs:
+            if kwargs.get('update_fields') is not None:
                 kwargs['update_fields'].append('url_key')
             self.__original_url_key = self.url_key
         elif self.url_key != self.__original_url_key:

--- a/corehq/motech/generic_inbound/models.py
+++ b/corehq/motech/generic_inbound/models.py
@@ -57,7 +57,7 @@ class ConfigurableAPI(models.Model):
             if self.url_key:
                 raise FieldError("'url_key' is auto-assigned")
             self.url_key = make_url_key()
-            if kwargs.get('update_fields') is not None:
+            if 'update_fields' in kwargs:
                 kwargs['update_fields'].append('url_key')
             self.__original_url_key = self.url_key
         elif self.url_key != self.__original_url_key:

--- a/corehq/motech/generic_inbound/models.py
+++ b/corehq/motech/generic_inbound/models.py
@@ -57,7 +57,7 @@ class ConfigurableAPI(models.Model):
             if self.url_key:
                 raise FieldError("'url_key' is auto-assigned")
             self.url_key = make_url_key()
-            if 'update_fields' in kwargs.keys():
+            if 'update_fields' in kwargs:
                 kwargs['update_fields'].append('url_key')
             self.__original_url_key = self.url_key
         elif self.url_key != self.__original_url_key:

--- a/corehq/motech/generic_inbound/models.py
+++ b/corehq/motech/generic_inbound/models.py
@@ -1,4 +1,3 @@
-import enum
 from functools import cached_property
 from uuid import uuid4
 
@@ -58,6 +57,8 @@ class ConfigurableAPI(models.Model):
             if self.url_key:
                 raise FieldError("'url_key' is auto-assigned")
             self.url_key = make_url_key()
+            if 'update_fields' in kwargs.keys():
+                kwargs['update_fields'].append('url_key')
             self.__original_url_key = self.url_key
         elif self.url_key != self.__original_url_key:
             raise FieldError("'url_key' can not be changed")

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -195,7 +195,7 @@ class RepeaterSuperProxy(models.Model):
         self.clear_caches()
         self.repeater_type = self._repeater_type
         self.name = self.name or self.connection_settings.name
-        if kwargs.get('update_fields') is not None:
+        if 'update_fields' in kwargs:
             kwargs['update_fields'].extend(['repeater_type', 'name'])
         return super().save(*args, **kwargs)
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -195,6 +195,8 @@ class RepeaterSuperProxy(models.Model):
         self.clear_caches()
         self.repeater_type = self._repeater_type
         self.name = self.name or self.connection_settings.name
+        if 'update_fields' in kwargs.keys():
+            kwargs['update_fields'].extend(['repeater_type', 'name'])
         return super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -195,7 +195,7 @@ class RepeaterSuperProxy(models.Model):
         self.clear_caches()
         self.repeater_type = self._repeater_type
         self.name = self.name or self.connection_settings.name
-        if 'update_fields' in kwargs:
+        if kwargs.get('update_fields') is not None:
             kwargs['update_fields'].extend(['repeater_type', 'name'])
         return super().save(*args, **kwargs)
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -195,7 +195,7 @@ class RepeaterSuperProxy(models.Model):
         self.clear_caches()
         self.repeater_type = self._repeater_type
         self.name = self.name or self.connection_settings.name
-        if 'update_fields' in kwargs.keys():
+        if 'update_fields' in kwargs:
             kwargs['update_fields'].extend(['repeater_type', 'name'])
         return super().save(*args, **kwargs)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15436

In reviewing changes in Django 4.2, I came across [this one](https://docs.djangoproject.com/en/5.0/releases/4.2/#setting-update-fields-in-model-save-may-now-be-required)

> In order to avoid updating unnecessary columns, [QuerySet.update_or_create()](https://docs.djangoproject.com/en/5.0/ref/models/querysets/#django.db.models.query.QuerySet.update_or_create) now passes update_fields to the [Model.save()](https://docs.djangoproject.com/en/5.0/ref/models/instances/#django.db.models.Model.save) calls. As a consequence, any fields modified in the custom save() methods should be added to the update_fields keyword argument before calling super()

This actually didn't immediately apply to us as I didn't find any current uses of `update_or_create` on models with custom saves that modify fields. However to future proof against what I think would be unexpected behavior if using `update_or_create` on a model that does have a custom save method, I've identified the current custom save methods that modify fields and therefore should update the `update_fields` kwarg if specified.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Realistically this should have no impact on existing code since there aren't places where we pass `update_fields` into these custom save methods. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
