### PR TITLE
Remove unnecessary initialization in makemigrations override

### DIFF
--- a/hqscripts/management/commands/makemigrations.py
+++ b/hqscripts/management/commands/makemigrations.py
@@ -51,9 +51,6 @@ class Command(makemigrations.Command):
 
     @no_translations
     def handle(self, *app_labels, **options):
-        # used in super().write_migration_files
-        self.written_files = []
-
         def assert_exclusive_options(opt_name, extra=[]):
             prevent = extra + ["dry_run", "merge", "empty", "name", "check_changes"]
             enforce = ["interactive", "include_header"]  # default=True


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
In https://github.com/dimagi/commcare-hq/pull/34390 I added this initialization for both `make_elastic_migration` and `makemigrations` because of a related test failure for `make_elastic_migration`. I didn't look closely enough at `makemigrations` to see that we do call `super().handle(...)` which means we do not need to initialize this variable as @millerdev pointed out.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I tested running this `makemigrations` on 4.2 to ensure it was unnecessary. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
