### PR TITLE
Improve Data Forwarding view load time

### DIFF
--- a/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
@@ -8,22 +8,22 @@
     </td>
     <td>
         <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=PENDING">
-            {{ repeater.get_pending_record_count }}
+            {{ repeater.count_State.Pending }}
         </a>
     </td>
     <td>
         <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=FAIL">
-            {{ repeater.get_failure_record_count }}
+            {{ repeater.count_State.Fail }}
         </a>
     </td>
     <td>
         <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=CANCELLED">
-            {{ repeater.get_cancelled_record_count }}
+            {{ repeater.count_State.Cancelled }}
         </a>
     </td>
     <td>
         <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=SUCCESS">
-            {{ repeater.get_success_record_count }}
+            {{ repeater.count_State.Success }}
         </a>
     </td>
     <td>

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -612,16 +612,24 @@ class TestFormRepeaterAllowedToForward(RepeaterTestCase):
 class TestRepeatRecordManager(RepeaterTestCase):
     before_now = datetime.utcnow() - timedelta(days=1)
 
-    def test_count_pending_records_for_domain(self):
-        now = datetime.utcnow()
-        self.new_record(next_check=now - timedelta(hours=1))
-        self.new_record(next_check=now - timedelta(minutes=15))
-        self.new_record(next_check=now - timedelta(minutes=5))
-        self.new_record(next_check=now + timedelta(minutes=5))
-        self.new_record(next_check=None, state=State.Success)
-        self.new_record(next_check=now - timedelta(hours=1), domain="other")
-        pending = SQLRepeatRecord.objects.count_pending_records_for_domain("test")
-        self.assertEqual(pending, 4)
+    def test_count_by_repeater_and_state(self):
+        self.make_records(1, state=State.Pending)
+        self.make_records(2, state=State.Fail)
+        self.make_records(3, state=State.Cancelled)
+        self.make_records(5, state=State.Success)
+        counts = SQLRepeatRecord.objects.count_by_repeater_and_state(domain="test")
+
+        rid = self.repeater.id
+        self.assertEqual(counts[rid][State.Pending], 1)
+        self.assertEqual(counts[rid][State.Fail], 2)
+        self.assertEqual(counts[rid][State.Cancelled], 3)
+        self.assertEqual(counts[rid][State.Success], 5)
+
+        missing_id = uuid.uuid4()
+        self.assertEqual(counts[missing_id][State.Pending], 0)
+        self.assertEqual(counts[missing_id][State.Fail], 0)
+        self.assertEqual(counts[missing_id][State.Cancelled], 0)
+        self.assertEqual(counts[missing_id][State.Success], 0)
 
     def test_count_overdue(self):
         now = datetime.utcnow()
@@ -690,14 +698,16 @@ class TestRepeatRecordManager(RepeaterTestCase):
             state=state,
         )
 
-    def make_records(self, n):
+    def make_records(self, n, state=State.Pending):
         now = timezone.now() - timedelta(seconds=10)
+        is_pending = state in [State.Pending, State.Fail]
         records = SQLRepeatRecord.objects.bulk_create(SQLRepeatRecord(
             domain="test",
             repeater=self.repeater,
             payload_id="c0ffee",
             registered_at=now,
-            next_check=now,
+            next_check=(now if is_pending else None),
+            state=state,
         ) for i in range(n))
         return {r.id for r in records}
 

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -23,6 +23,7 @@ from corehq.apps.users.models import HqPermissions
 from corehq.motech.const import PASSWORD_PLACEHOLDER
 from corehq.motech.models import ConnectionSettings
 
+from ..const import State
 from ..forms import CaseRepeaterForm, FormRepeaterForm, GenericRepeaterForm
 from ..models import (
     Repeater,
@@ -44,14 +45,20 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 
-    @property
-    def repeater_types_info(self):
+    def get_repeater_types_info(self, state_counts):
+        def get_repeaters_with_state_counts(repeater_class):
+            repeaters = repeater_class.objects.by_domain(self.domain)
+            for repeater in repeaters:
+                assert not hasattr(repeater, "count_State"), repeater.count_State
+                repeater.count_State = {s.name: state_counts[repeater.id][s] for s in State}
+            return repeaters
+
         return [
             RepeaterTypeInfo(
                 class_name=r._repeater_type,
                 friendly_name=r.friendly_name,
                 has_config=r._has_config,
-                instances=r.objects.by_domain(self.domain),
+                instances=get_repeaters_with_state_counts(r),
             )
             for r in get_all_repeater_types().values()
             if r.available_for_domain(self.domain)
@@ -59,10 +66,15 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
 
     @property
     def page_context(self):
+        state_counts = SQLRepeatRecord.objects.count_by_repeater_and_state(domain=self.domain)
         return {
             'report': 'repeat_record_report',
-            'repeater_types_info': self.repeater_types_info,
-            'pending_record_count': SQLRepeatRecord.objects.count_pending_records_for_domain(self.domain),
+            'repeater_types_info': self.get_repeater_types_info(state_counts),
+            'pending_record_count': sum(
+                count for repeater_id, states in state_counts.items()
+                for state, count in states.items()
+                if state == State.Pending or state == State.Fail
+            ),
             'user_can_configure': (
                 self.request.couch_user.is_superuser
                 or self.request.couch_user.can_edit_motech()


### PR DESCRIPTION
Get repeat record counts with a single query rather than running a separate query for each state of each repeater.

Count queries on repeat record states are not particularly efficient when there are many records. Further optimization may be possible by adding another SQL index.

https://dimagi.atlassian.net/browse/QA-6334

## Safety Assurance

### Safety story

Affects the Data Forwarding view only. Tested on staging.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations