### PR TITLE
Case search timing breadcrumbs

### DIFF
--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -36,9 +36,9 @@
     <p>Number of primary results: <span data-bind="text: results().primary_count"></span></p>
     <p>Number of related cases: <span data-bind="text: results().related_count"></span></p>
     <p>Total browser runtime: <span data-bind="text: browserTime"></span> seconds</p>
-    <p>Total server runtime: <span data-bind="text: results().runtime"></span> seconds</p>
+    <p>Total server runtime: <span data-bind="text: results().timing_data.duration.toFixed(3)"></span> seconds</p>
 
-    <ul data-bind="template: {name: 'timingRow', foreach: results().timing_data }"
+    <ul data-bind="template: {name: 'timingRow', data: results().timing_data }"
       class="list-group"></ul>
 
     <script id="timingRow" type="text/html">

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -78,7 +78,7 @@ def time_function():
 
 def get_case_search_results_from_request(domain, app_id, couch_user, request_dict):
     config = extract_search_request_config(request_dict)
-    return get_case_search_results(
+    cases = get_case_search_results(
         domain,
         config.case_types,
         config.criteria,
@@ -89,6 +89,8 @@ def get_case_search_results_from_request(domain, app_id, couch_user, request_dic
         include_all_related_cases=config.include_all_related_cases,
         commcare_sort=config.commcare_sort,
     )
+    fixtures = CaseDBFixture(cases).fixture
+    return fixtures
 
 
 def get_case_search_results(domain, case_types, criteria,

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -1,6 +1,5 @@
 import json
 import re
-from datetime import datetime
 
 from django.http import Http404
 from django.urls import reverse
@@ -8,11 +7,8 @@ from django.utils.translation import gettext_lazy
 
 from dimagi.utils.web import json_response
 
-from corehq.apps.case_search.models import (
-    case_search_enabled_for_domain,
-    extract_search_request_config,
-)
-from corehq.apps.case_search.utils import profile_case_search
+from corehq.apps.case_search.models import case_search_enabled_for_domain
+from corehq.apps.case_search.utils import get_case_search_results_from_request
 from corehq.apps.domain.decorators import cls_require_superuser_or_contractor
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.util.view_utils import BadRequest, json_error
@@ -109,15 +105,11 @@ class ProfileCaseSearchView(_BaseCaseSearchView):
         data = json.loads(request.POST.get('q'))
         request_dict = data.get('request_dict', data)
         app_id = data.get('app_id', request.POST.get('app_id'))  # may be in either place
-        start = datetime.now()
-        config = extract_search_request_config(request_dict)
-        profiler = profile_case_search(
-            self.domain, request.couch_user, app_id, config)
-        runtime = (datetime.now() - start).total_seconds()
+        _, profiler = get_case_search_results_from_request(
+            self.domain, app_id, request.couch_user, request_dict, debug=True)
         return json_response({
             'primary_count': profiler.primary_count,
             'related_count': profiler.related_count,
             'timing_data': profiler.timing_context.to_dict(),
             'queries': profiler.queries,
-            'runtime': runtime,
         })

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -129,10 +129,9 @@ def app_aware_search(request, domain, app_id):
         fixtures, profiler = get_case_search_results_from_request(domain, app_id, request.couch_user, request_dict)
     except CaseSearchUserError as e:
         return HttpResponse(str(e), status=400)
+    profiler.timing_context.add_to_sentry_breadcrumbs()
     _log_search_timing(start_time, request_dict, domain, app_id)
-    response = HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
-    response.request_timer = profiler.timing_context  # logged as Sentry breadcrumbs
-    return response
+    return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
 
 
 def _log_search_timing(start_time, request_dict, domain, app_id):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -126,11 +126,13 @@ def app_aware_search(request, domain, app_id):
     request_dict = dict((request.GET if request.method == 'GET' else request.POST).lists())
 
     try:
-        fixtures = get_case_search_results_from_request(domain, app_id, request.couch_user, request_dict)
+        fixtures, profiler = get_case_search_results_from_request(domain, app_id, request.couch_user, request_dict)
     except CaseSearchUserError as e:
         return HttpResponse(str(e), status=400)
     _log_search_timing(start_time, request_dict, domain, app_id)
-    return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
+    response = HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
+    response.request_timer = profiler.timing_context  # logged as Sentry breadcrumbs
+    return response
 
 
 def _log_search_timing(start_time, request_dict, domain, app_id):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -126,10 +126,9 @@ def app_aware_search(request, domain, app_id):
     request_dict = dict((request.GET if request.method == 'GET' else request.POST).lists())
 
     try:
-        cases = get_case_search_results_from_request(domain, app_id, request.couch_user, request_dict)
+        fixtures = get_case_search_results_from_request(domain, app_id, request.couch_user, request_dict)
     except CaseSearchUserError as e:
         return HttpResponse(str(e), status=400)
-    fixtures = CaseDBFixture(cases).fixture
     _log_search_timing(start_time, request_dict, domain, app_id)
     return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
 

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -120,12 +120,17 @@ class LogLongRequestMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         request_timer = getattr(response, 'request_timer', None)
         if request_timer:
-            for sub in request_timer.to_list(exclude_root=True):
-                add_breadcrumb(
-                    category="timing",
-                    message=f"{sub.name}: {sub.duration:0.3f}",
-                    level="info",
-                )
+
+            def visit(element, prefix=""):
+                if element.duration is not None and element.percent_of_total is not None:
+                    message = (f"⏱  {element.percent_of_total:>3.0f}% {prefix} "
+                               f"{element.name or ''}: {element.duration:0.3f}s")
+                    add_breadcrumb(category="timing", message=message, level="info")
+                prefix += "  →"
+                for sub in element.subs:
+                    visit(sub, prefix=prefix)
+
+            visit(request_timer.root)
 
         if hasattr(request, '_profile_starttime'):
             duration = datetime.datetime.utcnow() - request._profile_starttime
@@ -336,7 +341,7 @@ def get_view_func(view_fn, view_kwargs):
         try:
             class_name = dispatcher.get_report_class_name(domain, slug)
             return to_function(class_name) if class_name else None
-        except:
+        except Exception:
             # custom report dispatchers may do things differently
             return
 

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -138,7 +138,7 @@ urlpatterns = [
     ROOT_URLCONF='corehq.tests.test_middleware',
     MIDDLEWARE=('corehq.middleware.LogLongRequestMiddleware',)
 )
-@mock.patch('corehq.middleware.add_breadcrumb')
+@mock.patch('corehq.util.timer.add_breadcrumb')
 @mock.patch('corehq.middleware.notify_exception')
 class TestLogLongRequestMiddleware(SimpleTestCase):
 

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -1,9 +1,10 @@
+import itertools
 import time
 import uuid
-
 from functools import wraps
+
 from memoized import memoized
-import itertools
+from sentry_sdk import add_breadcrumb
 
 from dimagi.utils.logging import notify_exception
 
@@ -204,8 +205,6 @@ class TimingContext(object):
         This must be called before sending to sentry, for instance if using
         notify_exception rather than raising a hard error
         """
-        from sentry_sdk import add_breadcrumb
-
         def visit(element, prefix=""):
             if element.duration is not None and element.percent_of_total is not None:
                 message = (f"⏱  {element.percent_of_total:>3.0f}% {prefix} "
@@ -216,7 +215,6 @@ class TimingContext(object):
                 visit(sub, prefix=prefix)
 
         visit(self.root)
-
 
     def __repr__(self):
         return "TimingContext(root='{}')".format(


### PR DESCRIPTION
## Product Description


## Technical Summary
This PR adds timing context to the "Breadcrumbs" stored in sentry using the existing `LogLongRequestMiddleware` util, and makes some minor tweaks to that display.

This is live on staging:

![image](https://github.com/dimagi/commcare-hq/assets/2367539/f8f365be-53da-4d2d-93a4-dad2f792316a)

## Feature Flag


## Safety Assurance
I'll be testing on staging

### Safety story


### Automated test coverage


### QA Plan

 

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
