### PR TITLE
Patch schema editor prevent db access

### DIFF
--- a/corehq/sql_db/tests/test_fields.py
+++ b/corehq/sql_db/tests/test_fields.py
@@ -64,7 +64,7 @@ def schema_editor():
 
 def assert_no_pattern_ops_index(editor):
     statements = editor.collected_sql + editor.deferred_sql
-    assert editor.collected_sql, "expected at least one SQL statement"
+    assert statements, "expected at least one SQL statement"
     assert not has_pattern_ops_index(statements), \
         "\n".join(str(s) for s in statements)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Paired on this with Daniel. A change was made in 4.2 that resulted in this test accessing the db when we didn't want it to. We patched the `execute` function on the schema editor object to prevent it to from doing so, and appended the passed in sql to the `collected_sql` property on the editor so that this continues to behave similarly to how it did before.  
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
