### PR TITLE
Update CODEOWNERS to replace ush-tech with individual devs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,10 +37,10 @@
 /corehq/apps/analytics/ @biyeun
 /corehq/apps/app_manager/ @orangejenny
 /corehq/apps/callcenter/ @snopoke
-/corehq/apps/case_search/ @dimagi/ush-tech
+/corehq/apps/case_search/ @orangejenny @MartinRiese @esoergel @AddisonDunn @stephherbers @Robert-Costello @Jtang-1 @nospame
 /corehq/apps/change_feed/ @dannyroberts
 /corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py @millerdev
-/corehq/apps/cloudcare/ @dimagi/ush-tech @orangejenny
+/corehq/apps/cloudcare/ @orangejenny @MartinRiese @esoergel @AddisonDunn @stephherbers @Robert-Costello @Jtang-1 @nospame
 /corehq/apps/commtrack/ @esoergel
 /corehq/apps/data_dictionary/ @esoergel @orangejenny @zandre-eng
 /corehq/apps/domain/decorators.py @esoergel


### PR DESCRIPTION
Different approach to https://github.com/dimagi/commcare-hq/pull/34385, following a long talk with @ctsims about how we use permissions and GitHub teams.