### PR TITLE
Remove unnecessary teardown that is causing error on Django 4.2

### DIFF
--- a/corehq/apps/events/tests/test_models.py
+++ b/corehq/apps/events/tests/test_models.py
@@ -554,12 +554,6 @@ class EventCaseTests(TestCase):
         )
         self.event.save()  # Creates case
 
-    def tearDown(self):
-        try:
-            self.event.delete()
-        except AssertionError:
-            pass  # self.event is already deleted
-
     def test_delete_closes_case(self):
         case = CommCareCase.objects.get_case(self.event.case_id, DOMAIN)
         self.assertFalse(case.closed)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This raised an error on Django 4.2
> ValueError: Event object can't be deleted because its event_id attribute is set to None.

It is unnecessary since SQL objects are created within a transaction that is rolled back at the end of tests (the beauty of TestCase), so I just removed the cleanup entirely.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just a test change.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
