### PR TITLE
Fix tests that fail in Django 4.2 due to accessing reverse foreign key relationship before save

### DIFF
--- a/corehq/apps/linked_domain/tests/test_updates.py
+++ b/corehq/apps/linked_domain/tests/test_updates.py
@@ -1,6 +1,7 @@
 from django.test import SimpleTestCase
-from corehq.apps.users.models import UserRole
+
 from corehq.apps.linked_domain.updates import _copy_role_attributes
+from corehq.apps.users.models import UserRole
 
 
 class RoleCopyTests(SimpleTestCase):

--- a/corehq/apps/linked_domain/tests/test_updates.py
+++ b/corehq/apps/linked_domain/tests/test_updates.py
@@ -6,7 +6,11 @@ from corehq.apps.users.models import UserRole
 
 class RoleCopyTests(SimpleTestCase):
     def test_copy_role_attributes_populates_all_attributes(self):
-        source_role_json = RoleCopyTests._get_source_role_as_json()
+        source_role_json = RoleCopyTests._get_source_role_as_json(
+            name="test",
+            default_landing_page="testpage",
+            is_non_admin_editable=False
+        )
 
         dest_role = UserRole()
 
@@ -32,7 +36,6 @@ class RoleCopyTests(SimpleTestCase):
             "is_non_admin_editable": False,
         }
         # add/override specified kwargs
-        for key, val in kwargs.items():
-            source_role_json[key] = val
+        source_role_json.update(kwargs)
 
         return source_role_json

--- a/corehq/apps/linked_domain/tests/test_updates.py
+++ b/corehq/apps/linked_domain/tests/test_updates.py
@@ -5,23 +5,33 @@ from corehq.apps.linked_domain.updates import _copy_role_attributes
 
 class RoleCopyTests(SimpleTestCase):
     def test_copy_role_attributes_populates_all_attributes(self):
-        source_role = UserRole(
-            name='test',
-            default_landing_page='testpage',
-            is_non_admin_editable=False,
-        )
+        source_role_json = RoleCopyTests._get_source_role_as_json()
 
         dest_role = UserRole()
 
-        _copy_role_attributes(source_role.to_json(), dest_role)
+        _copy_role_attributes(source_role_json, dest_role)
 
         self.assertEqual(dest_role.name, 'test')
         self.assertEqual(dest_role.default_landing_page, 'testpage')
         self.assertFalse(dest_role.is_non_admin_editable)
 
     def test_copy_role_preserves_destination_domain(self):
-        source_role = UserRole(name='test', domain='source')
+        source_role_json = RoleCopyTests._get_source_role_as_json(domain="source")
         dest_role = UserRole(domain='dest')
 
-        _copy_role_attributes(source_role.to_json(), dest_role)
+        _copy_role_attributes(source_role_json, dest_role)
         self.assertEqual(dest_role.domain, 'dest')
+
+    @staticmethod
+    def _get_source_role_as_json(**kwargs):
+        source_role_json = {
+            "_id": "abc123",
+            "name": "test",
+            "default_landing_page": "testpage",
+            "is_non_admin_editable": False,
+        }
+        # add/override specified kwargs
+        for key, val in kwargs.items():
+            source_role_json[key] = val
+
+        return source_role_json

--- a/corehq/apps/users/models_role.py
+++ b/corehq/apps/users/models_role.py
@@ -196,7 +196,12 @@ class UserRole(models.Model):
         _clear_query_cache()
 
     def get_permission_infos(self):
-        return [rp.as_permission_info() for rp in self.rolepermission_set.all()]
+        try:
+            return [rp.as_permission_info() for rp in self.rolepermission_set.all()]
+        except ValueError:
+            # A ValueError is raised if this instance hasn't been saved yet when attempting to access the reverse
+            # foreign key relationship. Return an empty list in this scenario.
+            return []
 
     @property
     def permissions(self):
@@ -249,9 +254,14 @@ class UserRole(models.Model):
 
     @property
     def assignable_by_couch(self):
-        return list(
-            self.roleassignableby_set.values_list('assignable_by_role__couch_id', flat=True)
-        )
+        try:
+            return list(
+                self.roleassignableby_set.values_list('assignable_by_role__couch_id', flat=True)
+            )
+        except ValueError:
+            # A ValueError is raised if this instance hasn't been saved yet when attempting to access the reverse
+            # foreign key relationship. Return an empty list in this scenario.
+            return []
 
     @property
     def assignable_by(self):

--- a/corehq/apps/users/models_role.py
+++ b/corehq/apps/users/models_role.py
@@ -1,15 +1,17 @@
 import uuid
 
-import attr
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models, transaction
+
+import attr
 from field_audit import audit_fields
 from field_audit.models import AuditAction, AuditingManager
 
+from dimagi.utils.logging import notify_error
+
 from corehq.apps.users.landing_pages import ALL_LANDING_PAGES
 from corehq.util.models import ForeignValue, foreign_init
-from dimagi.utils.logging import notify_error
 
 
 @attr.s(frozen=True)

--- a/corehq/apps/users/models_role.py
+++ b/corehq/apps/users/models_role.py
@@ -196,13 +196,7 @@ class UserRole(models.Model):
         _clear_query_cache()
 
     def get_permission_infos(self):
-        try:
-            role_permission_set = self.rolepermission_set.all()
-        except ValueError:
-            # A ValueError is raised if this instance hasn't been saved yet when attempting to access the reverse
-            # foreign key relationship. Return an empty list in this scenario.
-            return []
-        return [rp.as_permission_info() for rp in role_permission_set]
+        return [rp.as_permission_info() for rp in self.rolepermission_set.all()]
 
     @property
     def permissions(self):
@@ -255,15 +249,7 @@ class UserRole(models.Model):
 
     @property
     def assignable_by_couch(self):
-        try:
-            role_assignable_by_set = self.roleassignableby_set.values_list(
-                "assignable_by_role__couch_id", flat=True
-            )
-        except ValueError:
-            # A ValueError is raised if this instance hasn't been saved yet when attempting to access the reverse
-            # foreign key relationship. Return an empty list in this scenario.
-            return []
-        return list(role_assignable_by_set)
+        return list(self.roleassignableby_set.values_list("assignable_by_role__couch_id", flat=True))
 
     @property
     def assignable_by(self):

--- a/corehq/apps/users/models_role.py
+++ b/corehq/apps/users/models_role.py
@@ -197,11 +197,12 @@ class UserRole(models.Model):
 
     def get_permission_infos(self):
         try:
-            return [rp.as_permission_info() for rp in self.rolepermission_set.all()]
+            role_permission_set = self.rolepermission_set.all()
         except ValueError:
             # A ValueError is raised if this instance hasn't been saved yet when attempting to access the reverse
             # foreign key relationship. Return an empty list in this scenario.
             return []
+        return [rp.as_permission_info() for rp in role_permission_set]
 
     @property
     def permissions(self):
@@ -255,13 +256,14 @@ class UserRole(models.Model):
     @property
     def assignable_by_couch(self):
         try:
-            return list(
-                self.roleassignableby_set.values_list('assignable_by_role__couch_id', flat=True)
+            role_assignable_by_set = self.roleassignableby_set.values_list(
+                "assignable_by_role__couch_id", flat=True
             )
         except ValueError:
             # A ValueError is raised if this instance hasn't been saved yet when attempting to access the reverse
             # foreign key relationship. Return an empty list in this scenario.
             return []
+        return list(role_assignable_by_set)
 
     @property
     def assignable_by(self):

--- a/corehq/motech/generic_inbound/models.py
+++ b/corehq/motech/generic_inbound/models.py
@@ -90,12 +90,7 @@ class ConfigurableAPI(models.Model):
         return reverse("generic_inbound_api", args=[self.domain, self.url_key], absolute=True)
 
     def get_validations(self):
-        try:
-            return list(self.validations.all())
-        except ValueError:
-            # A ValueError is raised if this instance hasn't been saved yet when attempting to access the reverse
-            # foreign key relationship. Return an empty list in this scenario.
-            return []
+        return list(self.validations.all())
 
 
 class ConfigurableApiValidation(models.Model):

--- a/corehq/motech/generic_inbound/models.py
+++ b/corehq/motech/generic_inbound/models.py
@@ -1,4 +1,3 @@
-import enum
 from functools import cached_property
 from uuid import uuid4
 
@@ -91,7 +90,12 @@ class ConfigurableAPI(models.Model):
         return reverse("generic_inbound_api", args=[self.domain, self.url_key], absolute=True)
 
     def get_validations(self):
-        return list(self.validations.all())
+        try:
+            return list(self.validations.all())
+        except ValueError:
+            # A ValueError is raised if this instance hasn't been saved yet when attempting to access the reverse
+            # foreign key relationship. Return an empty list in this scenario.
+            return []
 
 
 class ConfigurableApiValidation(models.Model):

--- a/corehq/motech/generic_inbound/tests/test_api_processing.py
+++ b/corehq/motech/generic_inbound/tests/test_api_processing.py
@@ -35,6 +35,8 @@ class TestGenericInboundAPI(SimpleTestCase):
             domain=self.domain_name,
             transform_expression=UCRExpression(definition={})
         )
+        # mock 'get_validations' to prevent reverse foreign key lookup on unsaved obj
+        api_model.get_validations = lambda: []
         user = MockUser()
         context = get_evaluation_context(user, 'post', {}, {}, {})
         with self.assertRaises(BadSpecError):

--- a/corehq/motech/generic_inbound/tests/test_api_processing.py
+++ b/corehq/motech/generic_inbound/tests/test_api_processing.py
@@ -6,7 +6,11 @@ from django.test import SimpleTestCase
 from corehq.apps.userreports.const import UCR_NAMED_FILTER
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.models import UCRExpression
-from corehq.motech.generic_inbound.backend.base import _execute_generic_api, _apply_api_filter, _validate_api_request
+from corehq.motech.generic_inbound.backend.base import (
+    _apply_api_filter,
+    _execute_generic_api,
+    _validate_api_request,
+)
 from corehq.motech.generic_inbound.exceptions import (
     GenericInboundRequestFiltered,
     GenericInboundValidationError,

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -777,7 +777,7 @@ class TestRepeatRecordMethods(TestCase):
 
     def test_requeue(self):
         now = datetime.utcnow()
-        record = SQLRepeatRecord(
+        record = SQLRepeatRecord.objects.create(
             domain="test",
             repeater_id=self.repeater.id.hex,
             payload_id="abc123",


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
From Django 4.1 [release notes](https://docs.djangoproject.com/en/5.0/releases/4.1/#reverse-foreign-key-changes-for-unsaved-model-instances):
> In order to unify the behavior with many-to-many relations for unsaved model instances, a reverse foreign key now raises ValueError when calling [related managers](https://docs.djangoproject.com/en/5.0/ref/models/relations/#django.db.models.fields.related.RelatedManager) for unsaved objects.

This seems to primarily be an issue in tests since it is common practice to create an object but not save it to the db in the test, potentially accessing a reverse fk relationship in that time.

I do still have a todo item which is to find all possible reverse fk relationships and see if where we attempt to access those to confirm the upgrade to 4.2 is safe.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
