### PR TITLE
Fix a flicker issue with the API key expiration warning message

### DIFF
--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -880,7 +880,7 @@ class SsoSamlEnterpriseSettingsForm(BaseSsoEnterpriseSettingsForm):
             ]
 
         self.helper = FormHelper()
-        self.helper.form_class = 'form form-horizontal'
+        self.helper.form_class = 'form form-horizontal ko-template'
         self.helper.label_class = 'col-sm-3 col-md-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
         layout = crispy.Layout(
@@ -1085,7 +1085,7 @@ class SsoOidcEnterpriseSettingsForm(BaseSsoEnterpriseSettingsForm):
             client_secret_toggles = crispy.Div()
 
         self.helper = FormHelper()
-        self.helper.form_class = 'form form-horizontal'
+        self.helper.form_class = 'form form-horizontal ko-template'
         self.helper.label_class = 'col-sm-3 col-md-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
         self.helper.layout = crispy.Layout(

--- a/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
+++ b/corehq/apps/sso/static/sso/js/enterprise_edit_identity_provider.js
@@ -110,6 +110,6 @@ hqDefine('sso/js/enterprise_edit_identity_provider', [
         };
         const showAPIFields = initialPageData.get('show_api_fields');
         let formManager = new editEnterpriseIdPFormManager(showAPIFields);
-        $('#idp').koApplyBindings(formManager);
+        $('#idp form').koApplyBindings(formManager);
     });
 });


### PR DESCRIPTION
## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15455
I was seeing a brief flicker with the Max API Key Expiration warning message. If you scrolled quickly to the bottom, you would see the warning message displayed, even  for IDP that did not enforce key expiration. This seems to be caused by the HTML being displayed before knockout has a chance to apply itself. We've fixed this in the past by applying the `ko-template` class. I ended up applying that to the form and changing the object we applied bindings to, as applying it to the tab did not appear to work (I'm guessing tabs get transformed through a JQuery binding or something)

## Safety Assurance

### Safety story
Locally verified

### Automated test coverage

None

### QA Plan

None


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
