### PR TITLE
Confirm rebuilding data sources

### DIFF
--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -211,17 +211,17 @@
                 {% trans "Rebuilding this data source will erase all the existing data in the data source and start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data." %}
               {% endif %}
             </p>
-            <p>
-              {% trans "Based on the amount of data to be processed, this can take a considerable amount of time." %}
-            </p>
             {% blocktrans %}
+              <p>
+                Based on the amount of data to be processed, this can take a considerable amount of time.
+              </p>
               <p>
                 Some useful tips around rebuilding can be found <a target="_blank" href="https://dimagi.atlassian.net/wiki/spaces/GS/pages/2250768909/User+Configurable+Reports+Performance+Tips">here.</a>
               </p>
+              <p>
+                Please confirm if you want to proceed.
+              </p>
             {% endblocktrans %}
-            <p>
-              {% trans "Please confirm if you want to proceed." %}
-            </p>
           </div>
           <form method='post' action="{% url 'rebuild_configurable_data_source' domain data_source.get_id %}" >
             {% csrf_token %}

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -30,41 +30,32 @@
           {% endif %}
         </div>
         <div class="btn-group">
-          <form method='post' action="{% url 'rebuild_configurable_data_source' domain data_source.get_id %}" >
-            {% csrf_token %}
-            <div {% if data_source.disable_destructive_rebuild %}style="margin-right: 15px;"{% endif %}>
-              {% if use_updated_ucr_naming %}
-              <button type="submit"
-                class="btn btn-default disable-on-submit"
-                data-toggle="popover"
-                title="Warning"
-                data-container="body"
-                data-content="{% trans_html_attr "Rebuilding report sources erases all the existing data and will start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data" %}"
-                data-trigger="hover"
-                {% if data_source.disable_destructive_rebuild %}disabled{% endif %}>
-                {% trans 'Rebuild Custom Web Report Source' %}
+          {% if data_source.disable_destructive_rebuild %}
+            <div style="margin-right: 15px;">
+              <button class="btn btn-default" disabled>
+                {% if use_updated_ucr_naming %}
+                  {% trans 'Rebuild Custom Web Report Source'%}
+                {% else %}
+                  {% trans 'Rebuild Data Source'%}
+                {% endif %}
               </button>
-              {% else %}
-              <button type="submit"
-                class="btn btn-default disable-on-submit"
-                data-toggle="popover"
-                title="Warning"
-                data-container="body"
-                data-content="{% trans_html_attr "Rebuilding data sources erases all the existing data and will start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data" %}"
-                data-trigger="hover"
-                {% if data_source.disable_destructive_rebuild %}disabled{% endif %}>
-                {% trans 'Rebuild Data Source'%}
-              </button>
-              {% endif %}
               {# janky: can't use a tooltip on a disabled button, so instead add a help icon and force extra space (above) so it's clear which button this is for. Todo: After bootstrap 4 upgrade there is a fix https://getbootstrap.com/docs/4.4/components/tooltips/#disabled-elements #}
-              {% if data_source.disable_destructive_rebuild %}
-                <span class="hq-help-template"
-                  data-title="{% trans_html_attr "Rebuild Unavailable" %}"
-                  data-content="{% trans_html_attr "Fully rebuilding has been disabled for this data source. Please use the in place rebuild if necessary." %}"
-                  data-placement="left"></span>
-              {% endif %}
+              <span class="hq-help-template"
+                data-title="{% trans_html_attr "Rebuild Unavailable" %}"
+                data-content="{% trans_html_attr "Fully rebuilding has been disabled for this data source. Please use the in place rebuild if necessary." %}"
+                data-placement="left"></span>
             </div>
-          </form>
+          {% else %}
+            <div>
+              <a href="#confirm_rebuild" class="btn btn-default" data-toggle="modal">
+                {% if use_updated_ucr_naming %}
+                  {% trans 'Rebuild Custom Web Report Source'%}
+                {% else %}
+                  {% trans 'Rebuild Data Source'%}
+                {% endif %}
+              </a>
+            </div>
+          {% endif %}
       </div>
       <div class="btn-group">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -197,5 +188,48 @@
         </div>
       {% endif %}
     {% endif %}
+    <div id="confirm_rebuild" class="modal fade" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            <h4 class="modal-title">
+              {% if use_updated_ucr_naming %}
+                {% trans 'Are you sure you want to rebuild this custom web report source?'%}
+              {% else %}
+                {% trans 'Are you sure you want to rebuild this data source?'%}
+              {% endif %}
+            </h4>
+          </div>
+          <div class="modal-body">
+            <p>
+              {% if use_updated_ucr_naming %}
+                {% trans "Rebuilding report sources erases all the existing data and will start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data." %}
+              {% else %}
+                {% trans "Rebuilding data sources erases all the existing data and will start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data." %}
+              {% endif %}
+            </p>
+            <p>
+              {% trans "Based on the amount of data to be processed, this can take a considerable amount of time." %}
+            </p>
+          </div>
+          <form method='post' action="{% url 'rebuild_configurable_data_source' domain data_source.get_id %}" >
+            {% csrf_token %}
+            <div class="modal-footer">
+              <button type="button" class="btn btn-default" data-dismiss="modal">
+                {% trans "Cancel" %}
+              </button>
+              {% if use_updated_ucr_naming %}
+                <button type="submit" value="{% trans 'Rebuild Custom Web Report Source'%}" class="disable-on-submit btn btn-danger">{% trans 'Rebuild Custom Web Report Source'%}</button>
+              {% else %}
+                <button type="submit" value="{% trans 'Rebuild Data Source'%}" class="disable-on-submit btn btn-danger">{% trans 'Rebuild Data Source'%}</button>
+              {% endif %}
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
   {% endif %}
 {% endblock %}

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -214,6 +214,9 @@
             <p>
               {% trans "Based on the amount of data to be processed, this can take a considerable amount of time." %}
             </p>
+            <p>
+              {% trans "Please confirm if you want to proceed." %}
+            </p>
           </div>
           <form method='post' action="{% url 'rebuild_configurable_data_source' domain data_source.get_id %}" >
             {% csrf_token %}
@@ -221,11 +224,7 @@
               <button type="button" class="btn btn-default" data-dismiss="modal">
                 {% trans "Cancel" %}
               </button>
-              {% if use_updated_ucr_naming %}
-                <button type="submit" value="{% trans 'Rebuild Custom Web Report Source'%}" class="disable-on-submit btn btn-danger">{% trans 'Rebuild Custom Web Report Source'%}</button>
-              {% else %}
-                <button type="submit" value="{% trans 'Rebuild Data Source'%}" class="disable-on-submit btn btn-danger">{% trans 'Rebuild Data Source'%}</button>
-              {% endif %}
+              <button type="submit" value="{% trans 'Confirm'%}" class="disable-on-submit btn btn-danger">{% trans 'Confirm'%}</button>
             </div>
           </form>
         </div>

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -214,6 +214,11 @@
             <p>
               {% trans "Based on the amount of data to be processed, this can take a considerable amount of time." %}
             </p>
+            {% blocktrans %}
+              <p>
+                Some useful tips around rebuilding can be found <a target="_blank" href="https://dimagi.atlassian.net/wiki/spaces/GS/pages/2250768909/User+Configurable+Reports+Performance+Tips">here.</a>
+              </p>
+            {% endblocktrans %}
             <p>
               {% trans "Please confirm if you want to proceed." %}
             </p>

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -206,9 +206,9 @@
           <div class="modal-body">
             <p>
               {% if use_updated_ucr_naming %}
-                {% trans "Rebuilding report sources erases all the existing data and will start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data." %}
+                {% trans "Rebuilding this report source will erase all the existing data in the report source and start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data." %}
               {% else %}
-                {% trans "Rebuilding data sources erases all the existing data and will start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data." %}
+                {% trans "Rebuilding this data source will erase all the existing data in the data source and start populating it again. While the rebuild is happening, reports based on this data source will show incomplete data." %}
               {% endif %}
             </p>
             <p>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Minor improvements to interactions with the rebuild action for data sources
1. Add a confirmation modal when rebuilding data sources to avoid immediate action & let user confirm.
2. Warn the user that rebuild could take time depending on the data to be processed.
3. Add a [link](https://dimagi.atlassian.net/wiki/spaces/GS/pages/2250768909/User+Configurable+Reports+Performance+Tips) to some helpful information about rebuilds.

Here is how it looks:
![Screenshot from 2024-04-13 00-13-14](https://github.com/dimagi/commcare-hq/assets/3864163/cfac4621-2dcc-42c3-9ff8-30f0a612f273)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
In case the feature flag "UCR_UPDATED_NAMING" is enabled for the project, this looks like this

![image](https://github.com/dimagi/commcare-hq/assets/3864163/236084c7-7831-458f-b591-95c78cca775d)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Some of the text here comes from the tooltip that used to show up on hovering over the button. This tooltip was now redundant with the modal added and hence was removed. Here is how it looked

![Screenshot from 2024-04-13 00-12-08](https://github.com/dimagi/commcare-hq/assets/3864163/f1929708-1b86-49aa-a2a8-aca75748be81)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
If rebuild action is not permitted, we show a disabled button like before

![image](https://github.com/dimagi/commcare-hq/assets/3864163/117c6b72-495e-40c3-9495-7031bc06e7aa)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3539

Mainly moved the content from warning tooltip to the confirmation modal.
In case rebuilt is not allowed, retained the original disabled button.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally that I could initiate a rebuild or cancel from modal if needed.
Also tested for when `use_updated_ucr_naming` was set to True for `UCR_UPDATED_NAMING` feature flag.
Tested for disabled button as well.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-6337

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
