### PR TITLE
Do not attempt to jsonify if value is expression

### DIFF
--- a/corehq/util/jsonattrs.py
+++ b/corehq/util/jsonattrs.py
@@ -81,11 +81,12 @@ Things that may be added in the future:
 - Support for migrating/converting the outer collection of `AttrsDict` and
   `AttrsList`.
 """
-from attrs import asdict, define, field
-
 from django.core.exceptions import ValidationError
 from django.db.models import JSONField
+from django.db.models.expressions import Expression
 from django.utils.translation import gettext_lazy as _
+
+from attrs import asdict, define, field
 
 __all__ = ["AttrsDict", "AttrsList", "dict_of", "list_of"]
 
@@ -100,6 +101,8 @@ class JsonAttrsField(JSONField):
         self.builder = builder
 
     def get_prep_value(self, value):
+        if isinstance(value, Expression):
+            return super().get_prep_value(value)
         return super().get_prep_value(self.builder.jsonify(value))
 
     def to_python(self, value):

--- a/corehq/util/jsonattrs.py
+++ b/corehq/util/jsonattrs.py
@@ -83,7 +83,6 @@ Things that may be added in the future:
 """
 from django.core.exceptions import ValidationError
 from django.db.models import JSONField
-from django.db.models.expressions import Expression
 from django.utils.translation import gettext_lazy as _
 
 from attrs import asdict, define, field
@@ -101,7 +100,8 @@ class JsonAttrsField(JSONField):
         self.builder = builder
 
     def get_prep_value(self, value):
-        if isinstance(value, Expression):
+        # determine if this value is an expression and therefore should not be jsonified
+        if hasattr(value, "resolve_expression"):
             return super().get_prep_value(value)
         return super().get_prep_value(self.builder.jsonify(value))
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
We make use of Django [Func](https://docs.djangoproject.com/en/3.2/ref/models/expressions/#django.db.models.Func) expressions to execute [jsonb_set](https://github.com/dimagi/commcare-hq/blob/7ca7a082a0808afabe0e93beecca3ea845286531/corehq/sql_db/jsonops.py#L75-L75) in SQL (my understanding).

These expressions were impacted by a change to the SQLCompiler classes in Django, where `get_db_prep_save` is [now called](https://github.com/django/django/commit/0ff46591ac3010841c73fd26e0fef93995fedd99#diff-f58de2deaccecd2d53199c5ca29e3e1050ec2adb80fb057cdfc0b4e6accdf14fL1640) for all field values of a query, even if they are expressions. We don't actually want to jsonify an expression, so in our custom JsonAttrsField class where we define `get_prep_value`, which is eventually called by `get_db_prep_value`, we just return the value as is if it is of type Expression.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
