### PR TITLE
Deprecated Property Warning on Case Management Page

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -1,5 +1,5 @@
+"use strict";
 hqDefine('app_manager/js/forms/case_config_ui', function () {
-    "use strict";
     $(function () {
         var caseConfigUtils = hqImport('app_manager/js/case_config_utils'),
             initial_page_data = hqImport("hqwebapp/js/initial_page_data").get,
@@ -838,11 +838,11 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
         };
 
         if (initial_page_data('has_form_source')) {
-            var caseConfig = caseConfig(_.extend({}, initial_page_data("case_config_options"), {
+            var caseConfigObj = caseConfig(_.extend({}, initial_page_data("case_config_options"), {
                 home: $('#case-config-ko'),
                 requires: ko.observable(initial_page_data("form_requires")),
             }));
-            caseConfig.init();
+            caseConfigObj.init();
         }
     });
 });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -503,6 +503,16 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                     return self.case_transaction.case_type();
                 });
                 self.updatedDescription = ko.observable();
+                self.isDeprecated = ko.computed(function () {
+                    const config = self.case_transaction.caseConfig;
+                    if (self.key() !== 'name' && _(config.deprecatedPropertiesDict).has(self.caseType())) {
+                        const depProps = config.deprecatedPropertiesDict[self.caseType()];
+                        if (_(depProps).has(self.key())) {
+                            return depProps[self.key()];
+                        }
+                    }
+                    return false;
+                });
                 self.description = ko.computed({
                     read: function () {
                         if (self.updatedDescription() !== undefined) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -412,6 +412,15 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 return count;
             });
 
+            self.hasDeprecatedProperties = ko.computed(function () {
+                for (const p of self.case_properties()) {
+                    if (p.isDeprecated()) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+
             self.repeat_context = function () {
                 if (self.case_name) {
                     return caseConfig.get_repeat_context(self.case_name());

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -49,6 +49,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             self.setUsercasePropertiesMap(params.usercasePropertiesMap);
 
             self.descriptionDict = params.propertyDescriptions;
+            self.deprecatedPropertiesDict = params.deprecatedProperties;
 
             self.saveButton = hqImport("hqwebapp/js/bootstrap3/main").initSaveButton({
                 unsavedMessage: gettext("You have unchanged case settings"),

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -520,7 +520,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                         const config = self.case_transaction.caseConfig;
                         const depProps = config.deprecatedPropertiesDict[self.caseType()];
                         if (depProps && self.key() !== 'name') {
-                            return depProps[self.key()];
+                            return depProps.includes(self.key());
                         }
                     }
                     return false;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -3,7 +3,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
     $(function () {
         var caseConfigUtils = hqImport('app_manager/js/case_config_utils'),
             initial_page_data = hqImport("hqwebapp/js/initial_page_data").get,
-            addOnsPrivileges = initial_page_data('add_ons_addOnsPrivileges'),
+            addOnsPrivileges = initial_page_data('add_ons_privileges'),
             privileges = hqImport('hqwebapp/js/privileges'),
             toggles = hqImport("hqwebapp/js/toggles");
         var action_names = ["open_case", "update_case", "close_case", "case_preload",

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -1,5 +1,7 @@
 "use strict";
-hqDefine('app_manager/js/forms/case_config_ui', function () {
+hqDefine('app_manager/js/forms/case_config_ui', [
+    'hqwebapp/js/privileges',
+], function (privileges) {
     $(function () {
         var caseConfigUtils = hqImport('app_manager/js/case_config_utils'),
             initial_page_data = hqImport("hqwebapp/js/initial_page_data").get,
@@ -413,9 +415,11 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             });
 
             self.hasDeprecatedProperties = ko.computed(function () {
-                for (const p of self.case_properties()) {
-                    if (p.isDeprecated()) {
-                        return true;
+                if (privileges.hasPrivilege('data_dictionary')) {
+                    for (const p of self.case_properties()) {
+                        if (p.isDeprecated()) {
+                            return true;
+                        }
                     }
                 }
                 return false;
@@ -513,10 +517,12 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 });
                 self.updatedDescription = ko.observable();
                 self.isDeprecated = ko.computed(function () {
-                    const config = self.case_transaction.caseConfig;
-                    const depProps = config.deprecatedPropertiesDict[self.caseType()];
-                    if (depProps && self.key() !== 'name') {
-                        return depProps[self.key()];
+                    if (privileges.hasPrivilege('data_dictionary')) {
+                        const config = self.case_transaction.caseConfig;
+                        const depProps = config.deprecatedPropertiesDict[self.caseType()];
+                        if (depProps && self.key() !== 'name') {
+                            return depProps[self.key()];
+                        }
                     }
                     return false;
                 });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -514,11 +514,9 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 self.updatedDescription = ko.observable();
                 self.isDeprecated = ko.computed(function () {
                     const config = self.case_transaction.caseConfig;
-                    if (self.key() !== 'name' && _(config.deprecatedPropertiesDict).has(self.caseType())) {
-                        const depProps = config.deprecatedPropertiesDict[self.caseType()];
-                        if (_(depProps).has(self.key())) {
-                            return depProps[self.key()];
-                        }
+                    const depProps = config.deprecatedPropertiesDict[self.caseType()];
+                    if (self.key() !== 'name' && _(depProps).has(self.key())) {
+                        return depProps[self.key()];
                     }
                     return false;
                 });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -727,6 +727,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 return usercaseTransaction({
                     case_properties: case_properties,
                     case_preload: case_preload,
+                    case_type: 'commcare-user', // will get overridden by the default. Set here to check deprecated status for saved properties on initial page load
                     allow: {
                         repeats: function () {
                             // This placeholder function allows us to reuse the "case-config:case-properties:question"

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -515,7 +515,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 self.isDeprecated = ko.computed(function () {
                     const config = self.case_transaction.caseConfig;
                     const depProps = config.deprecatedPropertiesDict[self.caseType()];
-                    if (self.key() !== 'name' && _(depProps).has(self.key())) {
+                    if (depProps && self.key() !== 'name') {
                         return depProps[self.key()];
                     }
                     return false;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -3,7 +3,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
     $(function () {
         var caseConfigUtils = hqImport('app_manager/js/case_config_utils'),
             initial_page_data = hqImport("hqwebapp/js/initial_page_data").get,
-            privileges = initial_page_data('add_ons_privileges'),
+            addOnsPrivileges = initial_page_data('add_ons_addOnsPrivileges'),
             toggles = hqImport("hqwebapp/js/toggles");
         var action_names = ["open_case", "update_case", "close_case", "case_preload",
             // Usercase actions are managed in the User Properties tab.
@@ -238,11 +238,11 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 })
             );
             self.addSubCase = function () {
-                if (!privileges.subcases) return;
+                if (!addOnsPrivileges.subcases) return;
                 self.subcases.push(HQOpenSubCaseAction.to_case_transaction({}, caseConfig));
             };
             self.removeSubCase = function (subcase) {
-                if (!privileges.subcases) return;
+                if (!addOnsPrivileges.subcases) return;
                 self.subcases.remove(subcase);
             };
 
@@ -816,7 +816,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                             return false;
                         },
                     },
-                }, caseConfig, privileges.subcases);
+                }, caseConfig, addOnsPrivileges.subcases);
             },
             from_case_transaction: function (case_transaction) {
                 var o = ko.mapping.toJS(case_transaction, caseTransactionMapping(case_transaction));

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -1,11 +1,10 @@
 "use strict";
-hqDefine('app_manager/js/forms/case_config_ui', [
-    'hqwebapp/js/privileges',
-], function (privileges) {
+hqDefine('app_manager/js/forms/case_config_ui', function () {
     $(function () {
         var caseConfigUtils = hqImport('app_manager/js/case_config_utils'),
             initial_page_data = hqImport("hqwebapp/js/initial_page_data").get,
             addOnsPrivileges = initial_page_data('add_ons_addOnsPrivileges'),
+            privileges = hqImport('hqwebapp/js/privileges'),
             toggles = hqImport("hqwebapp/js/toggles");
         var action_names = ["open_case", "update_case", "close_case", "case_preload",
             // Usercase actions are managed in the User Properties tab.

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -204,6 +204,18 @@
     </h4>
   </div>
   <div class="panel-body">
+    <div class="alert alert-warning" data-bind="visible: hasDeprecatedProperties" >
+      <p>
+        <i class="fa fa-warning"></i>
+        {% blocktrans %}
+          There are one or more form questions that are being saved to deprecated case properties.
+          Please revise and consider changing these case properties. For more information on deprecated
+          case properties, please refer to
+          <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143958252/Deprecating+Case+Types+and+Case+Properties+using+Data+Dictionary" target="_blank">this documentation</a>
+          .
+        {% endblocktrans %}
+      </p>
+    </div>
     <table class="table table-savecaseprops"
            data-bind="visible: case_properties().length">
       <thead>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -234,7 +234,8 @@
       <tr class="form-group"
           data-bind="css: {
                       'has-error': validate,
-                      warning: (!validate() && required() && !path()) || (!validate() && !required() && !path() && key())
+                      warning: (!validate() && required() && !path()) || (!validate() && !required() && !path() && key()),
+                      'has-warning': !validate() && isDeprecated()
                     }">
         <td class="col-sm-1 text-center"
             data-bind="if: $parent.hasPrivilege">
@@ -265,6 +266,11 @@
                         visible: validate"></p>
           <!-- ko if: $parent.hasPrivilege -->
           {% if request|request_has_privilege:"DATA_DICTIONARY" %}
+            <p class="help-block"  data-bind="visible: !validate() && isDeprecated()">
+              {% blocktrans %}
+                Property has been deprecated.
+              {% endblocktrans %}
+            </p>
             <inline-edit params="value: $data.description,
                                 rows: 3,
                                 cols: 30,

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -112,6 +112,7 @@ from corehq.apps.app_manager.xform import (
 from corehq.apps.data_dictionary.util import (
     add_properties_to_data_dictionary,
     get_case_property_description_dict,
+    get_case_property_deprecated_dict,
 )
 from corehq.apps.domain.decorators import (
     LoginAndDomainMixin,
@@ -790,6 +791,7 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
         'moduleCaseTypes': module_case_types,
         'propertiesMap': case_properties_map,
         'propertyDescriptions': get_case_property_description_dict(domain),
+        'deprecatedProperties': get_case_property_deprecated_dict(domain),
         'questions': xform_questions,
         'reserved_words': load_case_reserved_words(),
         'usercasePropertiesMap': usercase_properties_map,

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -20,6 +20,9 @@ from corehq.apps.data_dictionary.util import (
     is_case_type_or_prop_name_valid,
     delete_case_property,
     get_used_props_by_case_type,
+    get_case_property_description_dict,
+    get_case_property_label_dict,
+    get_case_property_deprecated_dict,
 )
 from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.tests.utils import (
@@ -144,14 +147,29 @@ class MiscUtilTest(TestCase):
         super().setUpClass()
         cls.case_type_name = 'caseType'
         cls.deprecated_case_type_name = 'depCaseType'
-        cls.case_type_obj = CaseType(name=cls.case_type_name, domain=cls.domain)
-        cls.case_type_obj.save()
-        cls.dep_case_type_obj = CaseType(
+        cls.case_type_obj = CaseType.objects.create(name=cls.case_type_name, domain=cls.domain)
+        cls.dep_case_type_obj = CaseType.objects.create(
             name=cls.deprecated_case_type_name,
             domain=cls.domain,
             is_deprecated=True
         )
-        cls.dep_case_type_obj.save()
+        CaseProperty.objects.create(
+            name='case_prop_1',
+            case_type=cls.case_type_obj,
+            description='foo',
+        )
+        CaseProperty.objects.create(
+            name='case_prop_2',
+            case_type=cls.case_type_obj,
+            deprecated=True,
+            label='Prop'
+        )
+        CaseProperty.objects.create(
+            name='case_prop_3',
+            case_type=cls.dep_case_type_obj,
+            deprecated=True,
+            description='bar',
+        )
 
         cls.invalid_col = 'barr'
         cls.invalid_header_row = [Cell('Foo'), Cell(cls.invalid_col), Cell('Test Column'), Cell(None)]
@@ -257,6 +275,45 @@ class MiscUtilTest(TestCase):
             self.assertTrue(is_case_type_or_prop_name_valid(valid_name))
         for invalid_name in invalid_names:
             self.assertFalse(is_case_type_or_prop_name_valid(invalid_name))
+
+    def test_get_case_property_description_dict(self):
+        desc_dict = get_case_property_description_dict(self.domain)
+        expected_response = {
+            'caseType': {
+                'case_prop_1': 'foo',
+                'case_prop_2': '',
+            },
+            'depCaseType': {
+                'case_prop_3': 'bar',
+            }
+        }
+        self.assertEqual(desc_dict, expected_response)
+
+    def test_get_case_property_label_dict(self):
+        label_dict = get_case_property_label_dict(self.domain)
+        expected_response = {
+            'caseType': {
+                'case_prop_1': '',
+                'case_prop_2': 'Prop',
+            },
+            'depCaseType': {
+                'case_prop_3': '',
+            }
+        }
+        self.assertEqual(label_dict, expected_response)
+
+    def test_get_case_property_deprecated_dict(self):
+        dep_dict = get_case_property_deprecated_dict(self.domain)
+        expected_response = {
+            'caseType': {
+                'case_prop_1': False,
+                'case_prop_2': True,
+            },
+            'depCaseType': {
+                'case_prop_3': True,
+            }
+        }
+        self.assertEqual(dep_dict, expected_response)
 
 
 @es_test(requires=[case_search_adapter], setup_class=True)

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -305,13 +305,12 @@ class MiscUtilTest(TestCase):
     def test_get_case_property_deprecated_dict(self):
         dep_dict = get_case_property_deprecated_dict(self.domain)
         expected_response = {
-            'caseType': {
-                'case_prop_1': False,
-                'case_prop_2': True,
-            },
-            'depCaseType': {
-                'case_prop_3': True,
-            }
+            'caseType': [
+                'case_prop_2',
+            ],
+            'depCaseType': [
+                'case_prop_3',
+            ]
         }
         self.assertEqual(dep_dict, expected_response)
 

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -151,6 +151,25 @@ def get_case_property_label_dict(domain):
     return labels_dict
 
 
+def get_case_property_deprecated_dict(domain):
+    """
+    This returns a dictionary of the structure
+    {
+        case_type: {
+            case_property: is_deprecated,
+            ...
+        },
+        ...
+    }
+    for each case type and case property in the domain
+    """
+    annotated_types = CaseType.objects.filter(domain=domain).prefetch_related('properties')
+    deprecated_dict = {}
+    for case_type in annotated_types:
+        deprecated_dict[case_type.name] = {prop.name: prop.deprecated for prop in case_type.properties.all()}
+    return deprecated_dict
+
+
 def get_values_hints_dict(domain, case_type_name):
     values_hints_dict = defaultdict(list)
     case_type = CaseType.objects.filter(domain=domain, name=case_type_name).first()

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -155,18 +155,19 @@ def get_case_property_deprecated_dict(domain):
     """
     This returns a dictionary of the structure
     {
-        case_type: {
-            case_property: is_deprecated,
+        case_type: [
+            case_property,
             ...
-        },
+        ],
         ...
     }
-    for each case type and case property in the domain
+    for each case type and case property in the domain. Each case type
+    will contain a list of only deprecated case properties.
     """
     annotated_types = CaseType.objects.filter(domain=domain).prefetch_related('properties')
     deprecated_dict = {}
     for case_type in annotated_types:
-        deprecated_dict[case_type.name] = {prop.name: prop.deprecated for prop in case_type.properties.all()}
+        deprecated_dict[case_type.name] = [prop.name for prop in case_type.properties.all() if prop.deprecated]
     return deprecated_dict
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
If a form question is being saved to a case property that has been deprecated in the DD then the following banner message will be shown on the Case Management/User Properties page:
![Screenshot from 2024-04-12 11-45-56](https://github.com/dimagi/commcare-hq/assets/122617251/24e25980-60a0-49db-9fcd-62cd8e7807d6)

Additionally, each row that is being saved to a deprecated case property will have a warning:
![Screenshot from 2024-04-12 11-46-09](https://github.com/dimagi/commcare-hq/assets/122617251/1e8cc898-4524-4909-8153-e83c093c7f39)

This is to help better notify users as to which case properties should be considered for replacement.

If a row contains an error, then the deprecated warning is hidden to prioritise showing the error instead:
![Screenshot from 2024-04-12 11-47-23](https://github.com/dimagi/commcare-hq/assets/122617251/954f1145-cc4d-48ec-b17e-c9ec03f5b9d5)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3376).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- QA done
- Unit tests exist

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests exist for the DD util functions that retrieve the case property description and deprecated status mappings.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA has been completed. Ticket is available [here](https://dimagi.atlassian.net/browse/QA-6355).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
