### PR TITLE
Performance: Independent cache for app context values in Case Search

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4531,12 +4531,14 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
 
     def save(self, response_json=None, increment_version=None, **params):
         from corehq.apps.analytics.tasks import track_workflow, send_hubspot_form, HUBSPOT_SAVED_APP_FORM_ID
+        from corehq.apps.case_search.utils import get_app_context_by_case_type
         self.last_modified = datetime.datetime.utcnow()
         if not self._rev and not domain_has_apps(self.domain):
             domain_has_apps.clear(self.domain)
         if self.get_id:
             # expire cache unless new application
             self.global_app_config.clear_version_caches()
+            get_app_context_by_case_type.clear(self.domain, self.get_id)
         get_all_case_properties.clear(self)
         expire_case_properties_caches(self.domain)
         get_usercase_properties.clear(self)

--- a/corehq/apps/case_search/tests/test_get_related_cases.py
+++ b/corehq/apps/case_search/tests/test_get_related_cases.py
@@ -56,8 +56,11 @@ class TestCaseSearchAppStuff(TestCase):
         )
 
     def test_get_search_detail_relationship_paths(self):
-        self.assertEqual(get_search_detail_relationship_paths(self.app, "patient"), {"parent/parent", "host"})
-        self.assertEqual(get_search_detail_relationship_paths(self.app, "monster"), set())
+        self.assertEqual(get_search_detail_relationship_paths(self.app, ["patient"]),
+                         {"parent/parent", "host"})
+        self.assertEqual(get_search_detail_relationship_paths(self.app, ["monster"]), set())
+        self.assertEqual(get_search_detail_relationship_paths(self.app, ["patient", "monster"]),
+                         {"parent/parent", "host"})
 
     def test_get_child_case_types(self):
         self.assertEqual(get_child_case_types(self.app, "patient"), {'child'})

--- a/corehq/apps/case_search/tests/test_get_related_cases.py
+++ b/corehq/apps/case_search/tests/test_get_related_cases.py
@@ -275,9 +275,6 @@ class TestGetRelatedCases(BaseCaseSearchTest):
     def test_get_related_cases_result(self):
         """Test that `get_related_cases_result` includes all cases when include_all_related_cases
         is True. And includes only child and path related cases when include_all_related_cases is False"""
-        app = Application.new_app(self.domain, "Case Search App")
-        module = app.add_module(Module.new_module("Search Module", "en"))
-        module.case_type = "teacher"
 
         # a1>b1
         # c1>a2
@@ -308,10 +305,12 @@ class TestGetRelatedCases(BaseCaseSearchTest):
         }
 
         def get_related_cases_result_helper(include_all_related_cases):
-            with patch("corehq.apps.case_search.utils.get_child_case_types", return_value={'c'}), \
-                    patch("corehq.apps.case_search.utils.get_search_detail_relationship_paths",
-                        return_value={"parent"}):
-                return get_related_cases_result(_QueryHelper(self.domain), app, {'teacher'},
+            with (patch("corehq.apps.case_search.utils.get_child_case_types", return_value={'c'}),
+                  patch("corehq.apps.case_search.utils.get_search_detail_relationship_paths",
+                        return_value={"parent"}),
+                  patch("corehq.apps.case_search.utils.get_app_cached",
+                        return_value=None)):
+                return get_related_cases_result(_QueryHelper(self.domain), 'app_id', {'teacher'},
                     source_cases, include_all_related_cases)
 
         EXPECTED_PARTIAL_RELATED_CASES = (source_cases_related["PATH_RELATED_CASE_ID"]

--- a/corehq/apps/case_search/tests/test_get_related_cases.py
+++ b/corehq/apps/case_search/tests/test_get_related_cases.py
@@ -63,8 +63,10 @@ class TestCaseSearchAppStuff(TestCase):
                          {"parent/parent", "host"})
 
     def test_get_child_case_types(self):
-        self.assertEqual(get_child_case_types(self.app, "patient"), {'child'})
-        self.assertEqual(get_child_case_types(self.app, "monster"), set())
+        self.assertEqual(get_child_case_types(self.app, ["patient"]), {'child'})
+        self.assertEqual(get_child_case_types(self.app, ["monster"]), set())
+        self.assertEqual(get_child_case_types(self.app, ["patient", "monster"]), {'child'})
+
 
 @es_test
 class TestGetRelatedCases(BaseCaseSearchTest):

--- a/corehq/apps/case_search/tests/test_get_related_cases.py
+++ b/corehq/apps/case_search/tests/test_get_related_cases.py
@@ -56,6 +56,7 @@ class TestCaseSearchAppStuff(TestCase):
             DetailColumn(header={"en": "zz"}, model="case", field="parent/zz", format="plain"),
         )
         cls.app.save()
+        cls.addClassCleanup(cls.app.delete)
 
     def test_get_app_context(self):
         paths, child_case_types = get_app_context(self.domain, self.app._id, ['patient'])

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -474,17 +474,13 @@ def get_path_related_cases_results(helper, cases, paths):
 
 @time_function()
 def _get_child_cases_referenced_in_app(helper, app, case_types, source_case_ids):
-    child_case_types = [
-        _type for types in [get_child_case_types(app, case_type) for case_type in case_types]
-        for _type in types
-    ]
-    result = []
+    child_case_types = get_child_case_types(app, case_types)
     if child_case_types:
-        result.extend(get_child_case_results(helper, source_case_ids, child_case_types))
-    return result
+        return get_child_case_results(helper, source_case_ids, child_case_types)
+    return []
 
 
-def get_child_case_types(app, case_type):
+def get_child_case_types(app, case_types):
     """
     Get child case types used by search detail tab nodesets in any modules
     that match the given case type and are configured for case search.
@@ -493,7 +489,7 @@ def get_child_case_types(app, case_type):
     """
     child_case_types = set()
     for module in app.get_modules():
-        if module.case_type == case_type and module_offers_search(module):
+        if module.case_type in case_types and module_offers_search(module):
             for tab in module.search_detail("long").tabs:
                 if tab.has_nodeset and tab.nodeset_case_type:
                     child_case_types.add(tab.nodeset_case_type)

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -367,16 +367,14 @@ def get_and_tag_related_cases(helper, app_id, case_types, cases,
     if not cases:
         return []
 
-    with helper.profiler.timing_context('get_app_cached'):
-        app = get_app_cached(helper.domain, app_id)
-
     expanded_case_results = []
     if custom_related_case_property:
         expanded_case_results.extend(get_expanded_case_results(helper, custom_related_case_property, cases))
 
     unfiltered_results = expanded_case_results
     top_level_cases = cases + expanded_case_results
-    related_cases = get_related_cases_result(helper, app, case_types, top_level_cases, include_all_related_cases)
+    related_cases = get_related_cases_result(
+        helper, app_id, case_types, top_level_cases, include_all_related_cases)
     if related_cases:
         unfiltered_results.extend(related_cases)
     initial_case_ids = {case.case_id for case in cases}
@@ -390,7 +388,7 @@ def get_and_tag_related_cases(helper, app_id, case_types, cases,
 
 
 @time_function()
-def get_related_cases_result(helper, app, case_types, source_cases, include_all_related_cases):
+def get_related_cases_result(helper, app_id, case_types, source_cases, include_all_related_cases):
     """
     Gets parent, child, and extension cases through sync algorithm if configured.
     Otherwise, gets case property path defined in search details and child case types
@@ -400,10 +398,34 @@ def get_related_cases_result(helper, app, case_types, source_cases, include_all_
         return _get_all_related_cases(helper, source_cases)
     else:
         results = []
-        results.extend(_get_search_detail_path_defined_cases(helper, app, case_types, source_cases))
-        source_case_ids = {case.case_id for case in source_cases}
-        results.extend(_get_child_cases_referenced_in_app(helper, app, case_types, source_case_ids))
+        with helper.profiler.timing_context('get_app_context'):
+            paths, child_case_types = get_app_context(helper.domain, app_id, case_types)
+        if paths:
+            results.extend(get_path_related_cases_results(helper, source_cases, paths))
+        if child_case_types:
+            source_case_ids = {case.case_id for case in source_cases}
+            results.extend(get_child_case_results(helper, source_case_ids, child_case_types))
         return results
+
+
+def get_app_context(domain, app_id, case_types):
+    """
+    for the provided case types, return paths to required case types, plus child case types
+    """
+    all_paths, all_child_case_types = _get_app_context_by_case_type(domain, app_id)
+    paths = set().union(*(all_paths[ct] for ct in case_types if ct in all_paths))
+    child_case_types = set().union(*(
+        all_child_case_types[ct] for ct in case_types if ct in all_child_case_types))
+    return paths, child_case_types
+
+
+# TODO quickcache
+def _get_app_context_by_case_type(domain, app_id):
+    app = get_app_cached(domain, app_id)
+    return (
+        get_search_detail_relationship_paths(app),
+        get_child_case_types(app),
+    )
 
 
 @time_function()
@@ -415,30 +437,22 @@ def _get_all_related_cases(helper, source_cases):
     return results
 
 
-@time_function()
-def _get_search_detail_path_defined_cases(helper, app, case_types, source_cases):
-    paths = get_search_detail_relationship_paths(app, case_types)
-    if paths:
-        return get_path_related_cases_results(helper, source_cases, paths)
-    return []
-
-
-def get_search_detail_relationship_paths(app, case_types):
+def get_search_detail_relationship_paths(app):
     """
-    Get unique case relationships used by search details in any modules that
-    match the given case types and are configured for case search.
+    Get unique case relationships used by search details for each case type
+    that has a module that uses case search
 
     Returns a set of relationships, e.g. {"parent", "host", "parent/parent"}
     """
-    paths = set()
+    paths = defaultdict(set)
     for module in app.get_modules():
-        if module.case_type in case_types and module_offers_search(module):
+        if module_offers_search(module):
             for column in module.search_detail("short").columns + module.search_detail("long").columns:
                 if not column.useXpathExpression:
                     parts = column.field.split("/")
                     if len(parts) > 1:
                         parts.pop()     # keep only the relationship: "parent", "parent/parent", etc.
-                        paths.add("/".join(parts))
+                        paths[module.case_type].add("/".join(parts))
     return paths
 
 
@@ -472,28 +486,19 @@ def get_path_related_cases_results(helper, cases, paths):
     return results
 
 
-@time_function()
-def _get_child_cases_referenced_in_app(helper, app, case_types, source_case_ids):
-    child_case_types = get_child_case_types(app, case_types)
-    if child_case_types:
-        return get_child_case_results(helper, source_case_ids, child_case_types)
-    return []
-
-
-def get_child_case_types(app, case_types):
+def get_child_case_types(app):
     """
     Get child case types used by search detail tab nodesets in any modules
     that match the given case type and are configured for case search.
 
     Returns a set of case types
     """
-    child_case_types = set()
+    child_case_types = defaultdict(set)
     for module in app.get_modules():
-        if module.case_type in case_types and module_offers_search(module):
+        if module_offers_search(module):
             for tab in module.search_detail("long").tabs:
                 if tab.has_nodeset and tab.nodeset_case_type:
-                    child_case_types.add(tab.nodeset_case_type)
-
+                    child_case_types[module.case_type].add(tab.nodeset_case_type)
     return child_case_types
 
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -423,18 +423,6 @@ def _get_search_detail_path_defined_cases(helper, app, case_types, source_cases)
     return []
 
 
-@time_function()
-def _get_child_cases_referenced_in_app(helper, app, case_types, source_case_ids):
-    child_case_types = [
-        _type for types in [get_child_case_types(app, case_type) for case_type in case_types]
-        for _type in types
-    ]
-    result = []
-    if child_case_types:
-        result.extend(get_child_case_results(helper, source_case_ids, child_case_types))
-    return result
-
-
 def get_search_detail_relationship_paths(app, case_types):
     """
     Get unique case relationships used by search details in any modules that
@@ -482,6 +470,18 @@ def get_path_related_cases_results(helper, cases, paths):
         results.extend(results_cache[path])
 
     return results
+
+
+@time_function()
+def _get_child_cases_referenced_in_app(helper, app, case_types, source_case_ids):
+    child_case_types = [
+        _type for types in [get_child_case_types(app, case_type) for case_type in case_types]
+        for _type in types
+    ]
+    result = []
+    if child_case_types:
+        result.extend(get_child_case_results(helper, source_case_ids, child_case_types))
+    return result
 
 
 def get_child_case_types(app, case_type):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -45,6 +45,7 @@ from corehq.apps.registry.exceptions import (
     RegistryNotFound,
 )
 from corehq.apps.registry.helper import DataRegistryHelper
+from corehq.util.quickcache import quickcache
 from corehq.util.timer import TimingContext
 
 
@@ -419,8 +420,10 @@ def get_app_context(domain, app_id, case_types):
     return paths, child_case_types
 
 
-# TODO quickcache
+@quickcache(['domain', 'app_id'], timeout=24 * 60 * 60)
 def _get_app_context_by_case_type(domain, app_id):
+    # Loading and parsing a whole app is actually pretty expensive
+    # This fn extracts what we need and caches only that
     app = get_app_cached(domain, app_id)
     return (
         get_search_detail_relationship_paths(app),

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -417,14 +417,10 @@ def _get_all_related_cases(helper, source_cases):
 
 @time_function()
 def _get_search_detail_path_defined_cases(helper, app, case_types, source_cases):
-    paths = [
-        rel for rels in [get_search_detail_relationship_paths(app, case_type) for case_type in case_types]
-        for rel in rels
-    ]
-    result = []
+    paths = get_search_detail_relationship_paths(app, case_types)
     if paths:
-        result.extend(get_path_related_cases_results(helper, source_cases, paths))
-    return result
+        return get_path_related_cases_results(helper, source_cases, paths)
+    return []
 
 
 @time_function()
@@ -439,16 +435,16 @@ def _get_child_cases_referenced_in_app(helper, app, case_types, source_case_ids)
     return result
 
 
-def get_search_detail_relationship_paths(app, case_type):
+def get_search_detail_relationship_paths(app, case_types):
     """
     Get unique case relationships used by search details in any modules that
-    match the given case type and are configured for case search.
+    match the given case types and are configured for case search.
 
     Returns a set of relationships, e.g. {"parent", "host", "parent/parent"}
     """
     paths = set()
     for module in app.get_modules():
-        if module.case_type == case_type and module_offers_search(module):
+        if module.case_type in case_types and module_offers_search(module):
             for column in module.search_detail("short").columns + module.search_detail("long").columns:
                 if not column.useXpathExpression:
                     parts = column.field.split("/")

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -413,7 +413,7 @@ def get_app_context(domain, app_id, case_types):
     """
     for the provided case types, return paths to required case types, plus child case types
     """
-    all_paths, all_child_case_types = _get_app_context_by_case_type(domain, app_id)
+    all_paths, all_child_case_types = get_app_context_by_case_type(domain, app_id)
     paths = set().union(*(all_paths[ct] for ct in case_types if ct in all_paths))
     child_case_types = set().union(*(
         all_child_case_types[ct] for ct in case_types if ct in all_child_case_types))
@@ -421,7 +421,7 @@ def get_app_context(domain, app_id, case_types):
 
 
 @quickcache(['domain', 'app_id'], timeout=24 * 60 * 60)
-def _get_app_context_by_case_type(domain, app_id):
+def get_app_context_by_case_type(domain, app_id):
     # Loading and parsing a whole app is actually pretty expensive
     # This fn extracts what we need and caches only that
     app = get_app_cached(domain, app_id)

--- a/corehq/apps/events/tests/test_models.py
+++ b/corehq/apps/events/tests/test_models.py
@@ -55,20 +55,20 @@ class TestAttendeeCaseManager(TestCase):
             'Clarence Closedcase',
         ) as closed_case:
             self.factory.close_case(closed_case.case_id)
-            yield open_case, closed_case
+            yield open_case.case_id, closed_case.case_id
 
     def test_manager_returns_open_cases(self):
-        with self.get_attendee_cases() as (open_case, closed_case):
-            cases = [m.case for m in AttendeeModel.objects.by_domain(DOMAIN)]
-            self.assertEqual(cases, [open_case])
+        with self.get_attendee_cases() as (open_case_id, closed_case_id):
+            case_ids = [m.case_id for m in AttendeeModel.objects.by_domain(DOMAIN)]
+            self.assertCountEqual(case_ids, [open_case_id])
 
     def test_manager_returns_closed_cases_as_well(self):
-        with self.get_attendee_cases() as (open_case, closed_case):
-            cases = [m.case for m in AttendeeModel.objects.by_domain(
+        with self.get_attendee_cases() as (open_case_id, closed_case_id):
+            case_ids = [m.case_id for m in AttendeeModel.objects.by_domain(
                 DOMAIN,
                 include_closed=True,
             )]
-            self.assertEqual(cases, [open_case, closed_case])
+            self.assertCountEqual(case_ids, [open_case_id, closed_case_id])
 
 
 @es_test(requires=[case_search_adapter], setup_class=True)


### PR DESCRIPTION
## Product Description
Performance improvement with no user facing changes.

## Technical Summary
Targeted improvement identified from deeper profiling of the Sentry queue of [non-performant queries](https://dimagi.sentry.io/issues/4886583636/events/46d6dab92bb0457eb6607f86f75f102a/?project=136860)

Multiple phases of a case search require retrieving the metadata about case types and relationships from the app document to construct the raw query. Since app docs are quite large, repeating this processing multiple times per query (and in between queries) is still significant even though the object itself is cached. 

In testing, I've seen requests spend 0.1s up to over 1s on loading the app, so the likely impact here could be significant. This would improve performance even for limited scope queries, since it's part off the baseline query construction process and bound by the performance characteristics of the app definition and not the request data.

Additional information in the [detailed Case Search investigation narrative](https://docs.google.com/document/d/1PYtT93X-8oE9uMNwoWKHA0NaQtA2Akn54vYh9LTbxUU/edit)

## Feature Flag


## Safety Assurance
This will be piloted through stating and evaluated for performance in tranche 3, along with #34433, to be measured through the nightly load against the baseline. 

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
