### PR TITLE
Performance: Update Elasticsearch queries for direct ID match to reduce per request latency

### DIFF
--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -13,10 +13,14 @@ from corehq.apps.case_search.filter_dsl import (
     SearchFilterContext,
     build_filter_from_ast,
 )
+from corehq.apps.es import filters
 from corehq.apps.es.case_search import (
     CaseSearchES,
     case_property_geo_distance,
+    case_property_missing,
     case_property_query,
+    case_property_range_query,
+    case_property_starts_with,
     case_search_adapter,
 )
 from corehq.apps.es.tests.utils import ElasticTestMixin, es_test
@@ -28,37 +32,7 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
 
     def test_simple_filter(self):
         parsed = parse_xpath("name = 'farid'")
-
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "bool": {
-                                    "filter": (
-                                        {
-                                            "term": {
-                                                "case_properties.key.exact": "name"
-                                            }
-                                        },
-                                        {
-                                            "term": {
-                                                "case_properties.value.exact": "farid"
-                                            }
-                                        }
-                                    )
-                                }
-                            }
-                        ],
-                        "must": {
-                            "match_all": {}
-                        }
-                    }
-                }
-            }
-        }
+        expected_filter = case_property_query('name', 'farid')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
@@ -66,37 +40,7 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
            return_value=pytz.timezone('America/Los_Angeles'))
     def test_simple_filter_with_date(self, mock_get_timezone):
         parsed = parse_xpath("dob = '2023-06-03'")
-
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "bool": {
-                                    "filter": (
-                                        {
-                                            "term": {
-                                                "case_properties.key.exact": "dob"
-                                            }
-                                        },
-                                        {
-                                            "term": {
-                                                "case_properties.value.exact": "2023-06-03"
-                                            }
-                                        }
-                                    )
-                                }
-                            }
-                        ],
-                        "must": {
-                            "match_all": {}
-                        }
-                    }
-                }
-            }
-        }
+        expected_filter = case_property_query('dob', '2023-06-03')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         mock_get_timezone.assert_not_called()
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
@@ -105,547 +49,95 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
            return_value=pytz.timezone('America/Los_Angeles'))
     def test_datetime_special_case_property_equality_comparison(self, mock_get_timezone):
         parsed = parse_xpath("last_modified='2023-01-10'")
-
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "last_modified"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "range": {
-                                "case_properties.value.date": {
-                                    "gte": "2023-01-10T08:00:00",
-                                    "lt": "2023-01-11T08:00:00"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        expected_filter = case_property_range_query(
+            'last_modified', gte='2023-01-10T08:00:00', lt='2023-01-11T08:00:00')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         mock_get_timezone.assert_called_once()
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_not_filter(self):
         parsed = parse_xpath("not(name = 'farid')")
-
-        expected_filter = {
-            "bool": {
-                "must_not": {
-                    "nested": {
-                        "path": "case_properties",
-                        "query": {
-                            "bool": {
-                                "filter": [
-                                    {
-                                        "bool": {
-                                            "filter": (
-                                                {
-                                                    "term": {
-                                                        "case_properties.key.exact": "name"
-                                                    }
-                                                },
-                                                {
-                                                    "term": {
-                                                        "case_properties.value.exact": "farid"
-                                                    }
-                                                }
-                                            )
-                                        }
-                                    }
-                                ],
-                                "must": {
-                                    "match_all": {}
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        expected_filter = filters.NOT(case_property_query('name', 'farid'))
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_starts_with(self):
         parsed = parse_xpath("starts-with(ssn, '100')")
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": (
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "ssn"
-                                }
-                            },
-                            {
-                                "prefix": {
-                                    "case_properties.value.exact": "100"
-                                }
-                            }
-                        )
-                    }
-                }
-            }
-        }
-
+        expected_filter = case_property_starts_with('ssn', '100')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_date_comparison(self):
         parsed = parse_xpath("dob >= '2017-02-12'")
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "dob"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "range": {
-                                "case_properties.value.date": {
-                                    "gte": "2017-02-12"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        expected_filter = case_property_range_query('dob', gte='2017-02-12')
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, query, is_raw_query=True)
 
     @freeze_time('2021-08-02')
     def test_date_comparison__today(self):
         parsed = parse_xpath("dob >= today()")
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "dob"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "range": {
-                                "case_properties.value.date": {
-                                    "gte": "2021-08-02"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        expected_filter = case_property_range_query('dob', gte='2021-08-02')
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, query, is_raw_query=True)
 
     def test_numeric_comparison(self):
         parsed = parse_xpath("number <= '100.32'")
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "number"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "range": {
-                                "case_properties.value.numeric": {
-                                    "lte": 100.32
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        expected_filter = case_property_range_query('number', lte=100.32)
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, query, is_raw_query=True)
 
     def test_numeric_comparison_negative(self):
         parsed = parse_xpath("number <= -100.32")
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "number"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "range": {
-                                "case_properties.value.numeric": {
-                                    "lte": -100.32
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        expected_filter = case_property_range_query('number', lte=-100.32)
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, query, is_raw_query=True)
 
     def test_numeric_equality_negative(self):
         parsed = parse_xpath("number = -100.32")
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "bool": {
-                                    "filter": (
-                                        {
-                                            "term": {
-                                                "case_properties.key.exact": "number"
-                                            }
-                                        },
-                                        {
-                                            "term": {
-                                                "case_properties.value.exact": -100.32
-                                            }
-                                        }
-                                    )
-                                }
-                            }
-                        ],
-                        "must": {
-                            "match_all": {}
-                        }
-                    }
-                }
-            }
-        }
+        expected_filter = case_property_query('number', -100.32)
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_case_property_existence(self):
         parsed = parse_xpath("property != ''")
-        expected_filter = {
-            "bool": {
-                "must_not": {
-                    "bool": {
-                        "should": [
-                            {
-                                "bool": {
-                                    "must_not": {
-                                        "nested": {
-                                            "path": "case_properties",
-                                            "query": {
-                                                "term": {
-                                                    "case_properties.key.exact": "property"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "nested": {
-                                    "path": "case_properties",
-                                    "query": {
-                                        "bool": {
-                                            "filter": [
-                                                {
-                                                    "bool": {
-                                                        "filter": [
-                                                            {
-                                                                "term": {
-                                                                    "case_properties.key.exact": "property"
-                                                                }
-                                                            },
-                                                            {
-                                                                "term": {
-                                                                    "case_properties.value.exact": ""
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ],
-                                            "must": {
-                                                "match_all": {}
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                }
-            }
-        }
-
+        expected_filter = filters.NOT(case_property_missing('property'))
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(query, expected_filter, is_raw_query=True)
 
     def test_nested_filter(self):
         parsed = parse_xpath("(name = 'farid' or name = 'leila') and dob <= '2017-02-11'")
-        expected_filter = {
-            "bool": {
-                "filter": [
-                    {
-                        "bool": {
-                            "should": [
-                                {
-                                    "nested": {
-                                        "path": "case_properties",
-                                        "query": {
-                                            "bool": {
-                                                "filter": [
-                                                    {
-                                                        "bool": {
-                                                            "filter": [
-                                                                {
-                                                                    "term": {
-                                                                        "case_properties.key.exact": "name"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "term": {
-                                                                        "case_properties.value.exact": "farid"
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    }
-                                                ],
-                                                "must": {
-                                                    "match_all": {}
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                {
-                                    "nested": {
-                                        "path": "case_properties",
-                                        "query": {
-                                            "bool": {
-                                                "filter": [
-                                                    {
-                                                        "bool": {
-                                                            "filter": [
-                                                                {
-                                                                    "term": {
-                                                                        "case_properties.key.exact": "name"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "term": {
-                                                                        "case_properties.value.exact": "leila"
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    }
-                                                ],
-                                                "must": {
-                                                    "match_all": {}
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "nested": {
-                            "path": "case_properties",
-                            "query": {
-                                "bool": {
-                                    "filter": [
-                                        {
-                                            "term": {
-                                                "case_properties.key.exact": "dob"
-                                            }
-                                        }
-                                    ],
-                                    "must": {
-                                        "range": {
-                                            "case_properties.value.date": {
-                                                "lte": "2017-02-11"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                ]
-            }
-        }
+        expected_filter = filters.AND(
+            filters.OR(
+                case_property_query('name', 'farid'),
+                case_property_query('name', 'leila'),
+            ),
+            case_property_range_query('dob', lte='2017-02-11'),
+        )
 
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_selected(self):
         parsed = parse_xpath("selected(first_name, 'Jon')")
-        expected_filter_single = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "first_name"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "match": {
-                                "case_properties.value": {
-                                    "query": "Jon",
-                                    "operator": "or",
-                                    "fuzziness": "0"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
+        expected_filter_single = case_property_query('first_name', 'Jon', multivalue_mode='or')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter_single, is_raw_query=True)
 
         parsed = parse_xpath("selected(first_name, 'Jon John Jhon')")
-        expected_filter_many = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "first_name"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "match": {
-                                "case_properties.value": {
-                                    "query": "Jon John Jhon",
-                                    "operator": "or",
-                                    "fuzziness": "0"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
+        expected_filter_many = case_property_query('first_name', 'Jon John Jhon', multivalue_mode='or')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter_many, is_raw_query=True)
 
     def test_selected_any(self):
         parsed = parse_xpath("selected-any(first_name, 'Jon John Jhon')")
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "first_name"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "bool": {
-                                "should": [
-                                    {
-                                        "fuzzy": {
-                                            "case_properties.value": {
-                                                "value": "jon john jhon",
-                                                "fuzziness": "AUTO",
-                                                "max_expansions": 100
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "match": {
-                                            "case_properties.value": {
-                                                "query": "Jon John Jhon",
-                                                "operator": "or",
-                                                "fuzziness": "0"
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
+        expected_filter = case_property_query('first_name', 'Jon John Jhon', fuzzy=True)
         # Note fuzzy is on for this one
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain", fuzzy=True))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_selected_all(self):
         parsed = parse_xpath("selected-all(first_name, 'Jon John Jhon')")
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "first_name"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "match": {
-                                "case_properties.value": {
-                                    "query": "Jon John Jhon",
-                                    "operator": "and",
-                                    "fuzziness": "0"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
+        expected_filter = case_property_query('first_name', 'Jon John Jhon', multivalue_mode='and')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
@@ -662,60 +154,14 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
     @freeze_time('2021-08-02')
     def test_filter_today(self):
         parsed = parse_xpath("age > today()")
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "age"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "range": {
-                                "case_properties.value.date": {
-                                    "gt": "2021-08-02"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
+        expected_filter = case_property_range_query('age', gt='2021-08-02')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     @freeze_time('2021-08-02')
     def test_filter_date_today(self):
         parsed = parse_xpath("age > date(today())")
-        expected_filter = {
-            "nested": {
-                "path": "case_properties",
-                "query": {
-                    "bool": {
-                        "filter": [
-                            {
-                                "term": {
-                                    "case_properties.key.exact": "age"
-                                }
-                            }
-                        ],
-                        "must": {
-                            "range": {
-                                "case_properties.value.date": {
-                                    "gt": "2021-08-02"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
+        expected_filter = case_property_range_query('age', gt='2021-08-02')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
@@ -739,17 +185,13 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
 
     def test_match_all(self):
         parsed = parse_xpath("match-all()")
-        expected_filter = {
-            "match_all": {}
-        }
+        expected_filter = filters.match_all()
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_match_none(self):
         parsed = parse_xpath("match-none()")
-        expected_filter = {
-            "match_none": {}
-        }
+        expected_filter = filters.match_none()
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
@@ -922,49 +364,49 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
     def test_subcase_exists(self):
         parsed = parse_xpath("subcase-exists('father', name='Margaery')")
-        expected_filter = {"terms": {"_id": [self.parent_case_id]}}
+        expected_filter = filters.doc_id([self.parent_case_id])
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_exists__filter_no_match(self):
         parsed = parse_xpath("subcase-exists('father', name='Mace')")
-        expected_filter = {"terms": {"_id": []}}
+        expected_filter = filters.doc_id([])
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_exists__no_subase_filter(self):
         parsed = parse_xpath("subcase-exists('father')")
-        expected_filter = {"terms": {"_id": [self.parent_case_id]}}
+        expected_filter = filters.doc_id([self.parent_case_id])
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_exists_inverted(self):
         parsed = parse_xpath("not(subcase-exists('father', name='Margaery'))")
-        expected_filter = {"bool": {"must_not": {"terms": {"_id": [self.parent_case_id]}}}}
+        expected_filter = filters.NOT(filters.doc_id([self.parent_case_id]))
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_count__no_subcase_filter(self):
         parsed = parse_xpath("subcase-count('father') > 1")
-        expected_filter = {"terms": {"_id": [self.parent_case_id]}}
+        expected_filter = filters.doc_id([self.parent_case_id])
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_count__filter_no_match(self):
         parsed = parse_xpath("subcase-count('father', house='Martel') > 0")
-        expected_filter = {"terms": {"_id": []}}
+        expected_filter = filters.doc_id([])
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_count_gt(self):
         parsed = parse_xpath("subcase-count('father', house='Tyrell') > 1")
-        expected_filter = {"terms": {"_id": [self.parent_case_id]}}
+        expected_filter = filters.doc_id([self.parent_case_id])
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_count_lt(self):
         parsed = parse_xpath("subcase-count('father', house='Tyrell') < 1")
-        expected_filter = {"bool": {"must_not": {"terms": {"_id": [self.parent_case_id]}}}}
+        expected_filter = filters.NOT(filters.doc_id([self.parent_case_id]))
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
@@ -978,24 +420,24 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
     def test_subcase_count_no_match(self):
         parsed = parse_xpath("subcase-count('father', house='Tyrell') > 2")
-        expected_filter = {"terms": {"_id": []}}
+        expected_filter = filters.doc_id([])
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_count_eq(self):
         parsed = parse_xpath("subcase-count('father', house='Tyrell') = 2")
-        expected_filter = {"terms": {"_id": [self.parent_case_id]}}
+        expected_filter = filters.doc_id([self.parent_case_id])
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_filter_relationship(self):
         parsed = parse_xpath("subcase-count('grandmother', house='Tyrell') >= 1")
-        expected_filter = {"terms": {"_id": [self.grandparent_case_id]}}
+        expected_filter = filters.doc_id([self.grandparent_case_id])
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_subcase_filter_relationship_no_hits(self):
         parsed = parse_xpath("subcase-count('grandmother', house='Tyrell') > 1")
-        expected_filter = {"terms": {"_id": []}}
+        expected_filter = filters.doc_id([])
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -299,23 +299,16 @@ def case_property_starts_with(case_property_name, value):
 
 
 def case_property_range_query(case_property_name, gt=None, gte=None, lt=None, lte=None):
-    """Returns cases where case property `key` fall into the range provided.
-
-    """
+    """Returns cases where case property `key` fall into the range provided."""
     kwargs = {'gt': gt, 'gte': gte, 'lt': lt, 'lte': lte}
-    # if its a number, use it
     try:
-        # numeric range
+        # if its a number, use it
         kwargs = {key: float(value) for key, value in kwargs.items() if value is not None}
-        return _base_property_query(
-            case_property_name,
-            queries.range_query("{}.{}.numeric".format(CASE_PROPERTIES_PATH, VALUE), **kwargs)
-        )
     except (TypeError, ValueError):
         pass
+    else:
+        return case_property_numeric_range(case_property_name, **kwargs)
 
-    # if its a date or datetime, use it
-    # date range
     kwargs = {
         key: value if isinstance(value, (date, datetime)) else _parse_date_or_datetime(value)
         for key, value in kwargs.items()
@@ -323,7 +316,19 @@ def case_property_range_query(case_property_name, gt=None, gte=None, lt=None, lt
     }
     if not kwargs:
         raise TypeError()       # Neither a date nor number was passed in
+    return case_property_date_range(case_property_name, **kwargs)
 
+
+def case_property_numeric_range(case_property_name, gt=None, gte=None, lt=None, lte=None):
+    kwargs = {'gt': gt, 'gte': gte, 'lt': lt, 'lte': lte}
+    return _base_property_query(
+        case_property_name,
+        queries.range_query("{}.{}.numeric".format(CASE_PROPERTIES_PATH, VALUE), **kwargs)
+    )
+
+
+def case_property_date_range(case_property_name, gt=None, gte=None, lt=None, lte=None):
+    kwargs = {'gt': gt, 'gte': gte, 'lt': lt, 'lte': lte}
     return _base_property_query(
         case_property_name,
         queries.date_range("{}.{}.date".format(CASE_PROPERTIES_PATH, VALUE), **kwargs)

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -330,11 +330,6 @@ class ESQuery(object):
         self._legacy_fields = True
         return self.source(fields)
 
-    def ids_query(self, doc_ids):
-        return self.set_query(
-            queries.ids_query(doc_ids)
-        )
-
     def source(self, include, exclude=None):
         """
             Restrict the output of _source in the queryset. This can be used to return an object in a queryset

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -93,7 +93,7 @@ def doc_type(doc_type):
 
 def doc_id(doc_id):
     """Filter by doc_id.  Also accepts a list of doc ids"""
-    return term("_id", doc_id)
+    return {"ids": {"values": doc_id}}
 
 
 def missing(field):

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -84,10 +84,6 @@ def search_string_query(search_string, default_fields):
     }
 
 
-def ids_query(doc_ids):
-    return {"ids": {"values": doc_ids}}
-
-
 def match(search_string, field, operator=None):
     if operator not in [None, 'and', 'or']:
         raise ValueError(" 'operator' argument should be one of: 'and', 'or' ")

--- a/corehq/apps/es/tests/test_filters.py
+++ b/corehq/apps/es/tests/test_filters.py
@@ -333,10 +333,10 @@ class TestFiltersRun(SimpleTestCase):
         )
         self.assertEqual(query.run().doc_ids, ['doc3'])
 
-    def test_ids_query(self):
+    def test_doc_ids_filter(self):
         self._setup_data()
         ids = ['doc1', 'doc2']
         self.assertEqual(
-            FormES().remove_default_filters().ids_query(ids).exclude_source().run().doc_ids,
+            FormES().remove_default_filters().doc_id(ids).exclude_source().run().doc_ids,
             ids
         )


### PR DESCRIPTION
## Product Description
Performance improvement with no user facing changes.

## Technical Summary
For Elasticsearch requests, this change eliminates the use of `_id` as a direct scalar query match in favor of the already available `ids` vector match. This pattern is now the canonical way recommended by Elastic to perform direct ID matches.

This has high potential for improving latency in individual retrieval traversals, because the `_id` field under the hood is part of the ES `stored_fields` record instead of the `doc_values` record, and the latter is significantly more optimized for read overheads. 

![image](https://github.com/dimagi/commcare-hq/assets/155066/c7f741e2-3e54-4cd9-a6e9-605257ee6772)

## Feature Flag


## Safety Assurance


### Safety story
This will be piloted through staging and evaluated for performance in tranche 3, along with #34429, to be measured through the nightly load against the baseline. 

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
