### PR TITLE
[B5]Update b5 migration doc

### DIFF
--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
@@ -322,10 +322,7 @@
   </p>
   <p>
     Finally, you should make sure any javascript files needed to render that view also inherit from <code>bootstrap5</code>
-    dependencies. As you migrate a view's requirejs module, it is important to update the
-    <a href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/management/commands/build_requirejs.py#L147-L149"
-       target="_blank">split_bundles</a>
-    map in <code>build_requirejs</code>.
+    dependencies.
   </p>
   <p>
     Once a view's template and javascript files updated, it is now time to load that view make visual observations and


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
In this [PR](https://github.com/dimagi/commcare-hq/pull/34346), `split_bundles` manual config is dropped. So I update the document to remove the line ask us to update `split_bundles`


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Doc update, and this doc is for internal use

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
