### PR TITLE
Performance: Migrate Case Search fixture envelope generation to lxml

### DIFF
--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -293,7 +293,7 @@ class CaseClaimEndpointTests(TestCase):
 
     def _assert_empty_search_result(self, response, message=None):
         self.assertEqual(response.status_code, 200, message)
-        self.assertEqual('<results id="case" />', response.content.decode('utf-8'), message)
+        self.assertEqual('<results id="case"/>', response.content.decode('utf-8'), message)
 
     def test_duplicate_claim_after_case_changes(self):
         """

--- a/corehq/ex-submodules/casexml/apps/case/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/case/fixtures.py
@@ -1,6 +1,6 @@
 from casexml.apps.case.xml.generator import safe_element
 from casexml.apps.phone.xml import get_casedb_element
-from xml.etree import cElementTree as ElementTree
+from lxml import etree as ElementTree
 
 
 class CaseDBFixture(object):


### PR DESCRIPTION
## Product Description
Performance improvement with no user facing changes.

## Technical Summary
Changes the xml serialization library used to generate case search payloads from the built-in cElementTree to the existing lxml dependency.

This follows through on the performance updates which were identified and previously rolled out in #28285 for sync payload generation, but never applied to the case XML generated from the case search endpoints. In previous application migrating this library reduced the round-trip latency of end-to-end restores with moderate to large payloads by nearly 50%. Our load testing has identified slow queries from Sentry reviews with similar ratios of unexpected time spend in serialization (35% v. 50%). 

This was initially identified as part of the same performance investigation as #34429, and further investigation from assessing the Locust test results indicates the XML payload serialization as the source of the premature CPU saturation in Case Search bound Web Apps scaleups. This should have benefits on both efficiency of resource utilization at scale and on case search latency. 

Additional information in the [detailed Case Search investigation narrative](https://docs.google.com/document/d/1PYtT93X-8oE9uMNwoWKHA0NaQtA2Akn54vYh9LTbxUU/edit)
## Safety Assurance

### Safety story
The library is a drop in replacement and we have made the same replacement in other parts of the code base.

This will be piloted for performance in tranche 2 to be evaluated primarily for impact on load test peaks. 

### Automated test coverage

Existing test coverage is strong for this fixture generation

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
