### PR TITLE
Fixed build_requirejs to update resource version for requirejs_config

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -190,10 +190,10 @@ class Command(ResourceStaticCommand):
         logger.info(f"{log_prefix}r.js complete, bundle config output written to staticfiles/build.txt")
 
         # Copy requirejs_config.js back into corehq, since r.js added all of the bundles to it
+        bootstrap_dir = f'bootstrap{bootstrap_version}'
+        self._update_resource_hash(f"hqwebapp/js/{bootstrap_dir}/requirejs_config.js", filename)
         if self.local:
-            bootstrap_dir = f'bootstrap{bootstrap_version}'
             filename = self._staticfiles_path('hqwebapp', 'js', bootstrap_dir, 'requirejs_config.js')
-            self._update_resource_hash(f"hqwebapp/js/{bootstrap_dir}/requirejs_config.js", filename)
             dest = os.path.join(settings.BASE_DIR, 'corehq', 'apps', 'hqwebapp', 'static',
                                 'hqwebapp', 'js', bootstrap_dir, 'requirejs_config.js')
             logger.info(f"{log_prefix}Copying {bootstrap_dir}/requirejs_config.js back to {os.path.relpath(dest)}")


### PR DESCRIPTION
## Technical Summary
Introduced in https://github.com/dimagi/commcare-hq/pull/34346

Because running `r.js` overwrites the `requirejs_config.js` file (both the B3 and B5 versions), its hash in resource versions must be updated, regardless of whether or not you're running in local mode. Really, updating resource versions only matters when you're not running locally, since locally we don't serve files from the CDN.

Ran into this upon realizing that staging was serving an outdated version of the B5 requirejs config. So far as I can tell, this isn't currently a problem on prod. It would potentially become a problem the next time something gets deployed that affects the js dependency tree.

## Safety Assurance

### Safety story
Bug fix for a deploy step. The fix is low risk. Tested on staging.

### Automated test coverage

no

### QA Plan

no


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
