### PR TITLE
[B5] migration too: ensure that the custom directory is also covered by references checks

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/paths.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/paths.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import corehq
 
 COREHQ_BASE_DIR = Path(corehq.__file__).resolve().parent
+CUSTOM_BASE_DIR = COREHQ_BASE_DIR.parent / "custom"
 TRACKED_JS_FOLDERS = ["js", "spec"]
 
 

--- a/corehq/apps/hqwebapp/utils/bootstrap/references.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/references.py
@@ -2,7 +2,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     file_contains_reference_to_path,
     replace_path_references,
 )
-from corehq.apps.hqwebapp.utils.bootstrap.paths import COREHQ_BASE_DIR
+from corehq.apps.hqwebapp.utils.bootstrap.paths import COREHQ_BASE_DIR, CUSTOM_BASE_DIR
 
 
 def update_and_get_references(old_reference, new_reference, is_template=True):
@@ -33,13 +33,14 @@ def get_file_types(is_template=True):
 
 def get_references_data(reference, is_template=True):
     for file_type in get_file_types(is_template):
-        for file_path in COREHQ_BASE_DIR.glob(file_type):
-            if not file_path.is_file():
-                continue
-            with open(file_path, 'r') as file:
-                filedata = file.read()
-            if file_contains_reference_to_path(filedata, reference):
-                yield file_path, filedata
+        for directory in [COREHQ_BASE_DIR, CUSTOM_BASE_DIR]:
+            for file_path in directory.glob(file_type):
+                if not file_path.is_file():
+                    continue
+                with open(file_path, 'r') as file:
+                    filedata = file.read()
+                if file_contains_reference_to_path(filedata, reference):
+                    yield file_path, filedata
 
 
 def get_references(reference, is_template):


### PR DESCRIPTION
## Technical Summary
We were previously overlooking the `custom` directory when searching for template and javascript file references. This fixes that issue and makes sure both the `corehq` directory and `custom` directory are included in the references checks.

## Safety Assurance

### Safety story
safe change made to internal tools that actually fixes an oversight

### Automated test coverage
all important aspects of the tool are already covered by tests

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
