### PR TITLE
Decorate OTA views with @tracer.wrap to enable tracing

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -84,7 +84,7 @@ PROFILE_LIMIT = os.getenv('COMMCARE_PROFILE_RESTORE_LIMIT')
 PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 
 
-@tracer.wrap(name="restore", service='hqtraces')
+@tracer.wrap(name="ota.restore", service='hqtraces')
 @location_safe
 @handle_401_response
 @mobile_auth_or_formplayer
@@ -102,7 +102,7 @@ def restore(request, domain, app_id=None):
     return response
 
 
-@tracer.wrap(name="search", service='hqtraces')
+@tracer.wrap(name="ota.search", service='hqtraces')
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
@@ -112,7 +112,7 @@ def search(request, domain):
     return app_aware_search(request, domain, None)
 
 
-@tracer.wrap(name="app_aware_search", service='hqtraces')
+@tracer.wrap(name="ota.app_aware_search", service='hqtraces')
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
@@ -166,7 +166,7 @@ def _log_search_timing(start_time, request_dict, domain, app_id):
         })
 
 
-@tracer.wrap(name="claim_case", service='hqtraces')
+@tracer.wrap(name="ota.claim", service='hqtraces')
 @location_safe_bypass
 @csrf_exempt
 @require_POST
@@ -490,7 +490,7 @@ def recovery_measures(request, domain, build_id):
     return JsonResponse(response)
 
 
-@tracer.wrap(name="case_fixture", service='hqtraces')
+@tracer.wrap(name="ota.case_fixture", service='hqtraces')
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
@@ -566,7 +566,7 @@ def _data_registry_case_fixture(request, domain, app_id, case_types, case_ids, r
     return helper.get_multi_domain_case_hierarchy(request.couch_user, cases)
 
 
-@tracer.wrap(name="case_restore", service='hqtraces')
+@tracer.wrap(name="ota.case_restore", service='hqtraces')
 @formplayer_auth
 def case_restore(request, domain, case_id):
     """Restore endpoint used for SMS forms where the 'user' is a case.

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -16,6 +16,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 
 from couchdbkit import ResourceConflict
+from ddtrace import tracer
 from iso8601 import iso8601
 from looseversion import LooseVersion
 from memoized import memoized
@@ -83,6 +84,7 @@ PROFILE_LIMIT = os.getenv('COMMCARE_PROFILE_RESTORE_LIMIT')
 PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 
 
+@tracer.wrap(name="restore", service='hqtraces')
 @location_safe
 @handle_401_response
 @mobile_auth_or_formplayer
@@ -100,6 +102,7 @@ def restore(request, domain, app_id=None):
     return response
 
 
+@tracer.wrap(name="search", service='hqtraces')
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
@@ -109,6 +112,7 @@ def search(request, domain):
     return app_aware_search(request, domain, None)
 
 
+@tracer.wrap(name="app_aware_search", service='hqtraces')
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
@@ -162,6 +166,7 @@ def _log_search_timing(start_time, request_dict, domain, app_id):
         })
 
 
+@tracer.wrap(name="claim_case", service='hqtraces')
 @location_safe_bypass
 @csrf_exempt
 @require_POST
@@ -485,6 +490,7 @@ def recovery_measures(request, domain, build_id):
     return JsonResponse(response)
 
 
+@tracer.wrap(name="case_fixture", service='hqtraces')
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
@@ -560,6 +566,7 @@ def _data_registry_case_fixture(request, domain, app_id, case_types, case_ids, r
     return helper.get_multi_domain_case_hierarchy(request.couch_user, cases)
 
 
+@tracer.wrap(name="case_restore", service='hqtraces')
 @formplayer_auth
 def case_restore(request, domain, case_id):
     """Restore endpoint used for SMS forms where the 'user' is a case.


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-15465

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This PR tags the traces from OTA views with a name and separate service `hq_traces` that can be used to filter the traces on datadog.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Should be pretty safe. Just adds tracing. This branch is also added on staging, so we should be able to see these traces for staging as well.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Ran HQ locally after running the changes
### Automated test coverage
NA
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions


### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
