### PR TITLE
Increase Location API max limit

### DIFF
--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -20,6 +20,7 @@ class LocationResource(v0_5.LocationResource):
     patch_limit = 100
 
     class Meta:
+        max_limit = 5000
         queryset = SQLLocation.active_objects.all()
         detail_uri_name = 'location_id'
         authentication = RequirePermissionAuthentication(HqPermissions.edit_locations)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Allows API users to specify a limit greater than 1000 for pagination.

We are concerned there are issues with the API that are caused by pagination. This is a just in case quick fix that will remove the need for pagination if a project has < 5000 locations.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Simple change.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Test coverage is good
- Tested locally
- one line change
- Blast radius should be limited to projects using the location API

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
