### PR TITLE
Include location site code in Location API v0.6 error messaging

### DIFF
--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -81,7 +81,7 @@ class LocationResource(v0_5.LocationResource):
     def _update(self, bundle, domain, is_new_location=False):
         data = bundle.data
         if 'parent_location_id' in data:
-            parent = self._get_parent_location(data.pop('parent_location_id'), data)
+            parent = self._get_parent_location(data.pop('parent_location_id'), data.get('site_code', None))
             if not is_new_location and 'location_type_code' not in data:
                 # Otherwise validation of new parent will effectively be done under 'location_type_code'
                 self._validate_new_parent(domain, bundle.obj, parent,
@@ -117,12 +117,12 @@ class LocationResource(v0_5.LocationResource):
 
         bundle.obj.save()
 
-    def _get_parent_location(self, id, data):
+    def _get_parent_location(self, id, site_code):
         try:
             return SQLLocation.objects.get(location_id=id)
         except SQLLocation.DoesNotExist:
             raise LocationAPIError(_("Could not find parent location with the given ID."),
-                                   site_code=data.get('site_code', None))
+                                   site_code=site_code)
 
     def _validate_unique_among_siblings(self, location, name, parent, location_site_code):
         if has_siblings_with_name(location, name, parent.location_id):

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -15,6 +15,13 @@ from django.utils.translation import gettext as _
 from tastypie.exceptions import BadRequest
 
 
+class LocationAPIError(BadRequest):
+    def __init__(self, message="", errors=None, code=None, site_code=None):
+        if site_code:
+            message = message + " " + f"Location site code: {site_code}."
+        super(LocationAPIError, self).__init__(message, errors, code)
+
+
 class LocationResource(v0_5.LocationResource):
     resource_name = 'location'
     patch_limit = 100
@@ -54,7 +61,8 @@ class LocationResource(v0_5.LocationResource):
     def obj_create(self, bundle, **kwargs):
         domain = kwargs['domain']
         if 'name' not in bundle.data or 'location_type_code' not in bundle.data:
-            raise BadRequest("'name' and 'location_type_code' are required fields when creating a new location.")
+            raise LocationAPIError("'name' and 'location_type_code' are required fields when creating "
+                                   "a new location.", site_code=bundle.data.get('site_code', None))
         bundle.obj = SQLLocation(domain=domain)
         self._update(bundle, domain, is_new_location=True)
         return bundle
@@ -64,66 +72,73 @@ class LocationResource(v0_5.LocationResource):
         try:
             bundle.obj = SQLLocation.objects.get(location_id=location_id, domain=kwargs['domain'])
         except SQLLocation.DoesNotExist:
-            raise BadRequest(_("Could not update: could not find location with"
-                               f" given ID {location_id} on the domain."))
+            raise LocationAPIError(_("Could not update: could not find location with"
+                                    f" given ID {location_id} on the domain."),
+                                    site_code=bundle.data.get('site_code', None))
         self._update(bundle, kwargs['domain'], is_new_location=False)
         return bundle
 
     def _update(self, bundle, domain, is_new_location=False):
         data = bundle.data
         if 'parent_location_id' in data:
-            parent = self._get_parent_location(data.pop('parent_location_id'))
+            parent = self._get_parent_location(data.pop('parent_location_id'), data)
             if not is_new_location and 'location_type_code' not in data:
                 # Otherwise validation of new parent will effectively be done under 'location_type_code'
-                self._validate_new_parent(domain, bundle.obj, parent)
+                self._validate_new_parent(domain, bundle.obj, parent,
+                                          location_site_code=data.get('site_code', None))
             bundle.obj.parent = parent
         if 'name' in data:
-            self._validate_unique_among_siblings(bundle.obj, data['name'], bundle.obj.parent)
+            self._validate_unique_among_siblings(bundle.obj, data['name'], bundle.obj.parent,
+                                                 data.get('site_code', None))
             bundle.obj.name = data.pop('name')
             if 'site_code' not in data:
                 bundle.obj.site_code = generate_site_code(domain, bundle.obj.location_id, bundle.obj.name)
         if 'site_code' in data:
-            site_code = validate_site_code(domain, bundle.obj.location_id, data.pop('site_code'), BadRequest)
+            site_code = validate_site_code(domain, bundle.obj.location_id, data.pop('site_code'), LocationAPIError)
             bundle.obj.site_code = site_code
         if 'location_data' in data:
             validator = LocationFieldsView.get_validator(domain)
             errors = validator(data['location_data'])
             if errors:
-                raise BadRequest(errors)
+                raise LocationAPIError(errors, site_code=data.get('site_code', None))
             setattr(bundle.obj, 'metadata', data.pop('location_data'))
         if 'location_type_code' in data or is_new_location:
             bundle.obj.location_type = get_location_type(domain, bundle.obj, bundle.obj.parent,
                                                          data.pop('location_type_code', None),
-                                                         BadRequest, is_new_location)
+                                                         LocationAPIError, is_new_location)
         if 'latitude' in data:
             bundle.obj.latitude = data.pop('latitude')
         if 'longitude' in data:
             bundle.obj.longitude = data.pop('longitude')
 
         if len(data):
-            raise BadRequest(_(f"Invalid fields were included in request: {list(data.keys())}"))
+            raise LocationAPIError(_(f"Invalid fields were included in request: {list(data.keys())}."),
+                                   site_code=data.get('site_code', None))
 
         bundle.obj.save()
 
-    def _get_parent_location(self, id):
+    def _get_parent_location(self, id, data):
         try:
             return SQLLocation.objects.get(location_id=id)
         except SQLLocation.DoesNotExist:
-            raise Exception(_("Could not find parent location with the given ID."))
+            raise LocationAPIError(_("Could not find parent location with the given ID."),
+                                   site_code=data.get('site_code', None))
 
-    def _validate_unique_among_siblings(self, location, name, parent):
+    def _validate_unique_among_siblings(self, location, name, parent, location_site_code):
         if has_siblings_with_name(location, name, parent.location_id):
-            raise BadRequest(
-                _("Location with same name and parent already exists.")
+            raise LocationAPIError(
+                _("Location with same name and parent already exists."), site_code=location_site_code
             )
 
-    def _validate_new_parent(self, domain, location, parent):
+    def _validate_new_parent(self, domain, location, parent, location_site_code=None):
         parent_allowed_types = LocationForm.get_allowed_types(domain, parent)
         if not parent_allowed_types:
-            raise BadRequest(_("The selected parent location cannot have child locations!"))
+            raise LocationAPIError(_("The selected parent location cannot have child locations!"),
+                                   site_code=location_site_code)
         if location.location_type not in parent_allowed_types:
-            raise BadRequest(_("Parent cannot have children of this location's type."))
-        self._validate_unique_among_siblings(location, location.name, parent)
+            raise LocationAPIError(_("Parent cannot have children of this location's type."),
+                                   site_code=location_site_code)
+        self._validate_unique_among_siblings(location, location.name, parent, location_site_code)
 
     @atomic
     def patch_list(self, request, **kwargs):

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -18,7 +18,7 @@ from tastypie.exceptions import BadRequest
 class LocationAPIError(BadRequest):
     def __init__(self, message="", errors=None, code=None, site_code=None):
         if site_code:
-            message = message + " " + f"Location site code: {site_code}."
+            message = message + " " + _(f"Location site code: {site_code}.")
         super(LocationAPIError, self).__init__(message, errors, code)
 
 

--- a/corehq/apps/locations/tests/test_api_v6.py
+++ b/corehq/apps/locations/tests/test_api_v6.py
@@ -206,15 +206,17 @@ class LocationV6Test(APIResourceTest):
     def test_invalid_parent(self):
         put_data = {
             "parent_location_id": self.south_park.location_id,
+            "site_code": "denver"
         }
         response = self._assert_auth_post_resource(self.single_endpoint(self.location2.location_id),
                                                    put_data, method='PUT')
         self.assertEqual(response.json(),
-                         {'error': 'The selected parent location cannot have child locations!'})
+                         {'error': 'The selected parent location cannot have child locations! '
+                                   'Location site code: denver.'})
         self.assertEqual(response.status_code, 400)
 
     def test_name_unique_among_siblings(self):
-        post_data = post_data = {
+        post_data = {
             "location_type_code": "city",
             "name": "Denver",
             "parent_location_id": "1",
@@ -223,7 +225,8 @@ class LocationV6Test(APIResourceTest):
         response = self._assert_auth_post_resource(self.list_endpoint, post_data, method='POST')
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(),
-                         {'error': 'Location with same name and parent already exists.'})
+                         {'error': 'Location with same name and parent already exists. '
+                                   'Location site code: second_denver.'})
 
     def test_site_code_special_chars(self):
         put_data = {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

I got feedback that Location API v0.6 could add the site code in its API error messaging to make the problematic location easier to find when doing a PATCH.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I created a new exception that extends `BadRequest` and takes a `site_code`.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Test coverage is pretty good
- If there is a problem with the code, it should only cause an `Exception` to be raised where an API error was occurring anyways, so only negative effect would be that the error is reported to Sentry and appears as a blank 500 to the API user instead of a 400 with an error message

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Test changes included. Most of the API errors are tested.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
