### PR TITLE
Renamed undefined var in build_bootstrap5_diffs

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
@@ -223,7 +223,7 @@ class Command(BaseCommand):
                 "No changes were necessary. Thank you!"
             ))
 
-        self.show_next_steps_after_config_update(show_build_notice=not has_no_changes)
+        self.show_next_steps_after_config_update(show_build_notice=has_changes)
 
     def show_next_steps_after_config_update(self, show_build_notice=False):
         self.stdout.write(self.style.MIGRATE_LABEL(


### PR DESCRIPTION
## Technical Summary
Minor followup for https://github.com/dimagi/commcare-hq/pull/34378 - looks like the linter flagged it in that PR.

## Safety Assurance

### Safety story
Small fix to an internal engineering tool.

### Automated test coverage

I think this command has tests.

### QA Plan

no

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
