### PR TITLE
Migrate records for soft-deleted repeaters

### DIFF
--- a/corehq/motech/repeaters/management/commands/create_missing_repeaters.py
+++ b/corehq/motech/repeaters/management/commands/create_missing_repeaters.py
@@ -1,0 +1,118 @@
+from uuid import UUID
+
+from memoized import memoized
+from django.core.management.base import BaseCommand
+
+from dimagi.utils.chunked import chunked
+from dimagi.utils.couch.database import iter_docs
+
+from corehq.apps.domain.dbaccessors import domain_exists
+from corehq.util.couchdb_management import couch_config
+
+from ...models import Repeater, ConnectionSettings
+from ...views.repeat_record_display import MISSING_VALUE
+
+
+class Command(BaseCommand):
+    help = """
+    Migrate deleted repeaters from Couch to SQL.
+
+    The new SQL repeaters are for repeat record display purposes
+    only, and therefore have a minimal set of fields with meaningful
+    values. Notably, they do not have related connection settings,
+    and therefore may cause errors if referenced elsewhere. All new
+    repeaters are created with a soft-deleted state.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, dry_run, **options):
+        couch = couch_config.get_db("receiverwrapper")
+        domain_by_repeater_id = dict(iter_missing_repeaters(couch))
+        missing_repeaters = iter_docs(couch, list(domain_by_repeater_id))
+        mode = " (dry run)" if dry_run else ""
+
+        # recreate soft-deleted repeaters in SQL
+        soft_migrated = []
+        for docs in chunked(missing_repeaters, 100, list):
+            for doc in docs:
+                domain_name = domain_by_repeater_id[doc["_id"]]
+                if domain_name != doc["domain"]:
+                    print(f"Repeat record domain '{domain_name}' != "
+                          f"'{doc['domain']}' of repeater {doc['_id']}")
+            soft_migrated.extend(create_sql_repeaters(docs, dry_run))
+        print_summary(soft_migrated, "soft", mode)
+
+        # recreate hard-deleted repeaters in SQL
+        soft_ids = {r.id for r in soft_migrated}
+        remaining = [
+            {"_id": x, "domain": d}
+            for x, d in domain_by_repeater_id.items() if UUID(x) not in soft_ids
+        ]
+        hard_migrated = []
+        for docs in chunked(remaining, 100, list):
+            hard_migrated.extend(create_sql_repeaters(docs, dry_run))
+        print()
+        print_summary(hard_migrated, "hard", mode)
+
+
+def print_summary(repeaters, category, mode):
+    print(f"Migrated {len(repeaters)} {category}-deleted repeaters to SQL{mode}")
+    for repeater in repeaters:
+        print(f"  {repeater.domain} {repeater.id.hex} {repeater.name}")
+
+
+def iter_missing_repeaters(couch):
+    """Yield (id, domain) pairs of repeaters that do not exist in SQL"""
+    @memoized
+    def is_not_deleted(domain_name):
+        return domain_exists(domain_name)
+
+    couch_results = couch.view(
+        'repeaters/repeat_records',
+        startkey=[],
+        endkey=[{}],
+        reduce=True,
+        group_level=2,
+    ).all()
+    sql_repeater_ids = set(Repeater.all_objects.order_by().values_list("id", flat=True))
+    for result in couch_results:
+        domain, repeater_id = result['key']
+        if (
+            repeater_id is not None  # view emits twice per record, skip the second
+            and UUID(repeater_id) not in sql_repeater_ids
+            and is_not_deleted(domain)
+        ):
+            yield repeater_id, domain
+
+
+def create_sql_repeaters(docs, dry_run):
+    objs = [make_deleted_sql_repeater(doc) for doc in docs]
+    domains = {doc['domain'] for doc in docs}
+    settings = {d: make_deleted_connection_settings(d) for d in domains}
+    if not dry_run:
+        ConnectionSettings.objects.bulk_create(settings.values())
+        for obj in objs:
+            assert settings[obj.domain].id is not None
+            obj.connection_settings = settings[obj.domain]
+        Repeater.objects.bulk_create(objs)
+    return objs
+
+
+def make_deleted_sql_repeater(doc):
+    return Repeater(
+        id=UUID(doc["_id"]),
+        domain=doc["domain"],
+        name=doc.get('name') or doc.get('url'),
+        is_deleted=True,
+    )
+
+
+def make_deleted_connection_settings(domian):
+    return ConnectionSettings(
+        domain=domian,
+        name=MISSING_VALUE,
+        url="",
+        is_deleted=True,
+    )

--- a/corehq/motech/repeaters/management/commands/populate_repeatrecords.py
+++ b/corehq/motech/repeaters/management/commands/populate_repeatrecords.py
@@ -119,7 +119,7 @@ class Command(PopulateSQLCommand):
         rare condition, it is not handled. It should be sufficient to
         rerun the migration to recover from that error.
         """
-        existing_ids = {id_.hex for id_ in Repeater.objects.filter(
+        existing_ids = {id_.hex for id_ in Repeater.all_objects.filter(
             id__in=list({d["repeater_id"] for d in docs})
         ).values_list("id", flat=True)}
         return {d["_id"] for d in docs if d["repeater_id"] not in existing_ids}

--- a/corehq/motech/repeaters/management/commands/populate_repeatrecords.py
+++ b/corehq/motech/repeaters/management/commands/populate_repeatrecords.py
@@ -99,6 +99,9 @@ class Command(PopulateSQLCommand):
                 sql.attempts,
                 transforms,
             ))
+        if any(d for d in diffs) and '_rev' in couch:
+            # possibly useful for detecting Couch data corruption
+            diffs.append(f"couch['_rev']: {couch['_rev']}")
         return diffs
 
     def get_ids_to_ignore(self, docs):

--- a/corehq/motech/repeaters/tests/test_couchsqlmigration.py
+++ b/corehq/motech/repeaters/tests/test_couchsqlmigration.py
@@ -199,6 +199,7 @@ class TestRepeatRecordCouchToSQLDiff(BaseRepeatRecordCouchToSQLTest):
 
     def test_diff_attempts(self):
         doc, obj = self.create_repeat_record()
+        doc["_rev"] = "v0-fake"
         doc["attempts"][0]["succeeded"] = True
         doc["attempts"][0]["failure_reason"] = None
         doc["attempts"][1]["datetime"] = "2020-01-01T00:00:00.000000Z"
@@ -211,12 +212,14 @@ class TestRepeatRecordCouchToSQLDiff(BaseRepeatRecordCouchToSQLTest):
                 "attempts[0].state: couch value State.Success != sql value State.Fail",
                 "attempts[0].message: couch value '' != sql value 'something bad happened'",
                 f"attempts[1].created_at: couch value {couch_datetime} != sql value {sql_created_at}",
+                "couch['_rev']: v0-fake",
             ]
         else:
             expected_diff = [
                 "attempts[0].state: couch value <State.Success: 4> != sql value <State.Fail: 2>",
                 "attempts[0].message: couch value '' != sql value 'something bad happened'",
                 f"attempts[1].created_at: couch value {couch_datetime} != sql value {sql_created_at}",
+                "couch['_rev']: v0-fake",
             ]
         self.assertEqual(self.diff(doc, obj), expected_diff)
 


### PR DESCRIPTION
An analysis of records in Couch that were not being migrated to SQL showed that some records were not being migrated even though the corresponding repeater does exist in SQL. `get_ids_to_ignore` should have been using `Repeater.all_objects` instead of `Repeater.objects`.

The [other commit](https://github.com/dimagi/commcare-hq/commit/b29558bcd246b10c34b99256a9e1b64eeb4a40dd) in this PR adds a bit more detail about the Couch record to diffs in the log.

## Safety Assurance

### Safety story

Changes a management command only.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations