### PR TITLE
Fix flaky test

### DIFF
--- a/corehq/apps/events/tests/test_models.py
+++ b/corehq/apps/events/tests/test_models.py
@@ -55,20 +55,20 @@ class TestAttendeeCaseManager(TestCase):
             'Clarence Closedcase',
         ) as closed_case:
             self.factory.close_case(closed_case.case_id)
-            yield open_case, closed_case
+            yield open_case.case_id, closed_case.case_id
 
     def test_manager_returns_open_cases(self):
-        with self.get_attendee_cases() as (open_case, closed_case):
-            cases = [m.case for m in AttendeeModel.objects.by_domain(DOMAIN)]
-            self.assertEqual(cases, [open_case])
+        with self.get_attendee_cases() as (open_case_id, closed_case_id):
+            case_ids = [m.case_id for m in AttendeeModel.objects.by_domain(DOMAIN)]
+            self.assertCountEqual(case_ids, [open_case_id])
 
     def test_manager_returns_closed_cases_as_well(self):
-        with self.get_attendee_cases() as (open_case, closed_case):
-            cases = [m.case for m in AttendeeModel.objects.by_domain(
+        with self.get_attendee_cases() as (open_case_id, closed_case_id):
+            case_ids = [m.case_id for m in AttendeeModel.objects.by_domain(
                 DOMAIN,
                 include_closed=True,
             )]
-            self.assertEqual(cases, [open_case, closed_case])
+            self.assertCountEqual(case_ids, [open_case_id, closed_case_id])
 
 
 @es_test(requires=[case_search_adapter], setup_class=True)


### PR DESCRIPTION
## Product Description


## Technical Summary

Cherry-picking this out of https://github.com/dimagi/commcare-hq/pull/34429, which might not be merged right away.  It removes an order dependency that I suspect is causing intermittent test failures.  Also switched from comparing cases to comparing case IDs since it doesn't seem to matter to the test and this should be a bit faster and failures are easier to read.

## Feature Flag


## Safety Assurance
tests only

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
