### PR TITLE
[B5] diff tool: flip branches and allow staged changes

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
@@ -161,13 +161,13 @@ class Command(BaseCommand):
 
         if has_pending_git_changes():
             self.stdout.write(self.style.SUCCESS(
-                "\nDone! Diffs are already up-to-date, no changes needed.\n\n"
-            ))
-        else:
-            self.stdout.write(self.style.SUCCESS(
                 "\n\nDiffs have been rebuilt. Thank you!\n"
             ))
             self.make_commit("Rebuilt diffs")
+        else:
+            self.stdout.write(self.style.SUCCESS(
+                "\nDone! Diffs are already up-to-date, no changes needed.\n\n"
+            ))
 
     def update_config(self, config, app_name, js_folder=None):
         parent_path = get_parent_path(app_name, js_folder)

--- a/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
@@ -7,7 +7,6 @@ from django.core.management import BaseCommand
 
 from corehq.apps.hqwebapp.utils.bootstrap.git import (
     has_pending_git_changes,
-    ensure_no_pending_changes_before_continuing,
     apply_commit,
     get_commit_string,
 )
@@ -147,7 +146,6 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(
                 "You have un-committed changes. Please commit these changes before proceeding...\n"
             ))
-            ensure_no_pending_changes_before_continuing()
 
         if update_app:
             self.update_configuration_file_for_app(update_app)


### PR DESCRIPTION
Two minor followups for https://github.com/dimagi/commcare-hq/pull/34378/, both in the diff tool:

1. Flip an if that was missed when renaming & reversing some flag values
2. Don't block if the user has pending changes. As we talked about the other day, this is reasonable if the user is in the migration tool, doing skip-all and auto-committing. But in the diff tool, there's no way to avoid it, and there's no auto-commit option anyway.

## Safety Assurance

### Safety story
minor changes to internal engineering tool

### Automated test coverage

yes

### QA Plan

no

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
