### PR TITLE
If couch user does not exist for export.owner_id, use unknown placeholder

### DIFF
--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -212,6 +212,11 @@ class ExportListHelper(object):
         :return dict
         """
         from corehq.apps.export.views.new import DeleteNewCustomExportView
+
+        def get_export_owner_username(owner_id):
+            user = CouchUser.get_by_user_id(owner_id) if owner_id else None
+            return user.username if user else UNKNOWN_EXPORT_OWNER
+
         formname = export.formname if isinstance(export, FormExportInstance) else None
         return {
             'id': export.get_id,
@@ -219,7 +224,7 @@ class ExportListHelper(object):
             'name': export.name,
             'description': export.description,
             'sharing': export.sharing,
-            'owner_username': self._get_owner_username(export),
+            'owner_username': get_export_owner_username(export.owner_id),
             'can_edit': export.can_edit(self.request.couch_user),
             'exportType': export.type,
             'filters': self._get_filters(export),
@@ -329,12 +334,6 @@ class ExportListHelper(object):
             'showExpiredWarning': (last_accessed and last_accessed < cutoff_datetime),
             'downloadUrl': download_url,
         }
-
-    def _get_owner_username(export):
-        user = None
-        if export.owner_id:
-            user = CouchUser.get_by_user_id(export.owner_id)
-        return user.username if user else UNKNOWN_EXPORT_OWNER
 
 
 class DailySavedExportListHelper(ExportListHelper):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -219,10 +219,7 @@ class ExportListHelper(object):
             'name': export.name,
             'description': export.description,
             'sharing': export.sharing,
-            'owner_username': (
-                CouchUser.get_by_user_id(export.owner_id).username
-                if export.owner_id else UNKNOWN_EXPORT_OWNER
-            ),
+            'owner_username': self._get_owner_username(export),
             'can_edit': export.can_edit(self.request.couch_user),
             'exportType': export.type,
             'filters': self._get_filters(export),
@@ -332,6 +329,10 @@ class ExportListHelper(object):
             'showExpiredWarning': (last_accessed and last_accessed < cutoff_datetime),
             'downloadUrl': download_url,
         }
+
+    def _get_owner_username(export):
+        user = CouchUser.get_by_user_id(export.owner_id)
+        return user.username if user else UNKNOWN_EXPORT_OWNER
 
 
 class DailySavedExportListHelper(ExportListHelper):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -331,6 +331,8 @@ class ExportListHelper(object):
         }
 
     def _get_owner_username(export):
+        if not export.owner_id:
+            return UNKNOWN_EXPORT_OWNER
         user = CouchUser.get_by_user_id(export.owner_id)
         return user.username if user else UNKNOWN_EXPORT_OWNER
 

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -331,9 +331,9 @@ class ExportListHelper(object):
         }
 
     def _get_owner_username(export):
-        if not export.owner_id:
-            return UNKNOWN_EXPORT_OWNER
-        user = CouchUser.get_by_user_id(export.owner_id)
+        user = None
+        if export.owner_id:
+            user = CouchUser.get_by_user_id(export.owner_id)
         return user.username if user else UNKNOWN_EXPORT_OWNER
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Simple change to handle the case where an export.owner_id no longer points to a valid couch user, in which case the export should display the unknown user placeholder in the UI.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
