### PR TITLE
Fix report error rendering on UI 

### DIFF
--- a/corehq/apps/reports_core/static/reports_core/js/base_template_new.js
+++ b/corehq/apps/reports_core/static/reports_core/js/base_template_new.js
@@ -50,8 +50,9 @@ hqDefine('reports_core/js/base_template_new', function () {
         };
 
         var successCallback = function (data) {
-            if (data.error) {
-                $('#error-message').html(data.error);
+            if (data.error || data.error_message) {
+                const message = data.error || data.error_message;
+                $('#error-message').html(message);
                 $('#report-error').removeClass('hide');
             } else {
                 $('#report-error').addClass('hide');

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -454,7 +454,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             if settings.DEBUG:
                 raise
             return self.render_json_response({
-                'error': str(e),
+                'error_message': str(e),
                 'aaData': [],
                 'iTotalRecords': 0,
                 'iTotalDisplayRecords': 0,


### PR DESCRIPTION
## Product Description
An issue was picked up with regards to report rendering when there's an error during the request for fetching the report data. Whenever something goes wrong during the request not resulting in a request failure (eg status code > 400), we return a custom error in the response that should be rendered as feedback for the user. The problem is that this error was never shown to the user because javascript complained in the console (see the console error below) resulting in a page that hangs (see below). This has caused confusion as to what is really happening, since it looks like the report is loading but it's not.

Hanging page:
![image](https://github.com/dimagi/commcare-hq/assets/44245062/0c56fe5a-3ad6-46e5-8481-046c654c1fdb)


Console error:
![image](https://github.com/dimagi/commcare-hq/assets/44245062/2b72c322-2b44-45c1-a914-ae74a372bd85)

I made a small change in the code and now it works as intended. See the simulated error below:

Simulated error:
![image](https://github.com/dimagi/commcare-hq/assets/44245062/77a706b7-a5d1-4c0a-b395-a931a1a06788)

(I simulated the error by simply raising the error that we catch in code during the try block)

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3627)

It seems like ajax is not happy when the "error" key is specified in the json response, hence I changed the key from "error" -> "error_message" and handled it appropriately in javascript, whilst keeping it backwards compatible.

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
No automated tests

### QA Plan
No QA to be done

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
