### PR TITLE
Use match_none filter in subcase query if no ids

### DIFF
--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -372,7 +372,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
     def test_subcase_exists__filter_no_match(self):
         parsed = parse_xpath("subcase-exists('father', name='Mace')")
-        expected_filter = filters.doc_id([])
+        expected_filter = filters.match_none()
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
@@ -396,7 +396,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
     def test_subcase_count__filter_no_match(self):
         parsed = parse_xpath("subcase-count('father', house='Martel') > 0")
-        expected_filter = filters.doc_id([])
+        expected_filter = filters.match_none()
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
@@ -422,7 +422,7 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
     def test_subcase_count_no_match(self):
         parsed = parse_xpath("subcase-count('father', house='Tyrell') > 2")
-        expected_filter = filters.doc_id([])
+        expected_filter = filters.match_none()
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
@@ -440,6 +440,6 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
 
     def test_subcase_filter_relationship_no_hits(self):
         parsed = parse_xpath("subcase-count('grandmother', house='Tyrell') > 1")
-        expected_filter = filters.doc_id([])
+        expected_filter = filters.match_none()
         built_filter = build_filter_from_ast(parsed, SearchFilterContext(self.domain))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -57,13 +57,8 @@ def subcase(node, context):
     subcase_query = _parse_normalize_subcase_query(node)
     ids = _get_parent_case_ids_matching_subcase_query(subcase_query, context)
     if subcase_query.invert:
-        if not ids:
-            return filters.match_all()
-        return filters.NOT(filters.doc_id(ids))
-    # uncomment once we are on ES > 2.4
-    # if not ids:
-    #     return filters.match_none()
-    return filters.doc_id(ids)
+        return filters.NOT(filters.doc_id(ids)) if ids else filters.match_all()
+    return filters.doc_id(ids) if ids else filters.match_none()
 
 
 def _get_parent_case_ids_matching_subcase_query(subcase_query, context):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[match_none](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-match-all-query.html#query-dsl-match-none-query) is a query that was added in ES 5 and is useful when we know the query would not return any results like the scenario in this PR.

I was curious what impact this would actually have, if any, and first came across an issue in the ES repo asking for better descriptions when queries are rewritten to use a match none query where appropriate. I didn't see any references to the `ids` query there, but it seems like I just missed it since when I actually tested profiling basic ES queries, the `ids` query was rewritten to use a MatchNoDocsQuery when the list was empty, with the description `'MatchNoDocsQuery("Missing ids in "ids" query.")'`. For reference, the same query is run when using `match_none` with the description `MatchNoDocsQuery("User requested "match_none" query.")`. I also timed these basic queries on the case search index, and saw virtually no difference. For the sake of clarity, it still seems worth making the change, but I have no reason to believe this will result in any significant difference in the event that we happen to run a subcase query that comes up empty.
 
Also for the record, we are now on ES 5 and [past the window](https://forum.dimagi.com/t/commcare-changelog-on-readthedocs-no-longer-being-updated/10478) where we need to support ES 2 to self hosters so this change is safe to make.
> CommCare HQ releases after March 1, 2024 will not support Elasticsearch 2.x. So we strongly recommend applying this change before then.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
As evidenced by the profiling I spoke to up above, this is effectively running the exact same ES query as before, so I don't see any risk here outside of verifying the slight logic change is correct, which the automated tests cover.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There are case search tests that cover this `subcase` method and have been updated in this PR to expect the `match_none` query to be used instead of an empty `ids` query.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
