### PR TITLE
remove service name from datadog trace decorators

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -84,7 +84,7 @@ PROFILE_LIMIT = os.getenv('COMMCARE_PROFILE_RESTORE_LIMIT')
 PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 
 
-@tracer.wrap(name="ota.restore", service='hqtraces')
+@tracer.wrap(name="ota.restore")
 @location_safe
 @handle_401_response
 @mobile_auth_or_formplayer
@@ -102,7 +102,7 @@ def restore(request, domain, app_id=None):
     return response
 
 
-@tracer.wrap(name="ota.search", service='hqtraces')
+@tracer.wrap(name="ota.search")
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
@@ -112,7 +112,7 @@ def search(request, domain):
     return app_aware_search(request, domain, None)
 
 
-@tracer.wrap(name="ota.app_aware_search", service='hqtraces')
+@tracer.wrap(name="ota.app_aware_search")
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
@@ -166,7 +166,7 @@ def _log_search_timing(start_time, request_dict, domain, app_id):
         })
 
 
-@tracer.wrap(name="ota.claim", service='hqtraces')
+@tracer.wrap(name="ota.claim")
 @location_safe_bypass
 @csrf_exempt
 @require_POST
@@ -490,7 +490,7 @@ def recovery_measures(request, domain, build_id):
     return JsonResponse(response)
 
 
-@tracer.wrap(name="ota.case_fixture", service='hqtraces')
+@tracer.wrap(name="ota.case_fixture")
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
@@ -566,7 +566,7 @@ def _data_registry_case_fixture(request, domain, app_id, case_types, case_ids, r
     return helper.get_multi_domain_case_hierarchy(request.couch_user, cases)
 
 
-@tracer.wrap(name="ota.case_restore", service='hqtraces')
+@tracer.wrap(name="ota.case_restore")
 @formplayer_auth
 def case_restore(request, domain, case_id):
     """Restore endpoint used for SMS forms where the 'user' is a case.


### PR DESCRIPTION
## Technical Summary
When adding the decorators in https://github.com/dimagi/commcare-hq/pull/34442 the `service` argument was supplied.

The `service` argument is used to tag the trace with a different service name from the parent (https://ddtrace.readthedocs.io/en/stable/api.html#ddtrace.Tracer.wrap). Since these are not tracing separate services we don't need to include the service name.

Having the service name makes the APM analysis confusing since it treats all activity in the function as a separate service.

## Safety Assurance

### Safety story
Datadog tracing change only

### QA Plan
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
