### PR TITLE
Bug Fix Web User Invitation Location

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -66,6 +66,7 @@ from corehq.apps.locations.permissions import (
     location_safe,
     user_can_access_other_user,
 )
+from corehq.apps.locations.models import SQLLocation
 from corehq.apps.registration.forms import (
     AdminInvitesUserForm,
 )
@@ -1081,7 +1082,6 @@ class InviteWebUserView(BaseManageWebUserView):
             'email': domain_request.email if domain_request else None,
         }
         if 'location_id' in self.request.GET:
-            from corehq.apps.locations.models import SQLLocation
             loc = SQLLocation.objects.get(location_id=self.request.GET.get('location_id'))
         if self.request.method == 'POST':
             current_users = [user.username for user in WebUser.by_domain(self.domain)]
@@ -1143,6 +1143,8 @@ class InviteWebUserView(BaseManageWebUserView):
                 data["invited_by"] = request.couch_user.user_id
                 data["invited_on"] = datetime.utcnow()
                 data["domain"] = self.domain
+                location_id = data.pop("location_id", None)
+                data["location"] = SQLLocation.by_location_id(location_id) if location_id else None
                 invite = Invitation(**data)
                 invite.save()
                 invite.send_activation_email()


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Fixes bug for web user invitations when [CommCare Supply](https://dimagi.atlassian.net/wiki/spaces/GS/pages/2144314585/Archived+-+CommCare+Supply+Proposal) FF is enabled 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Sentry Error](https://dimagi.sentry.io/issues/5213693891/?project=136860) and bug was introduced as part of this [PR](https://github.com/dimagi/commcare-hq/pull/34363)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
This is not specific to CommCare Supply, Commtrack FF (especially because adding locations to web user invite will be GA in an upcoming PR) but for now, this bug is present only when [Commtrack](https://www.commcarehq.org/hq/flags/edit/commtrack/) FF is enabled.
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally reproduced bug and verified this fixed the bug
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
