### PR TITLE
Split web apps templates: users.html

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -137,7 +137,10 @@
   {% include 'cloudcare/partials/case_detail.html' %}
   {% include 'cloudcare/partials/case_list.html' %}
   {% include 'cloudcare/partials/menu_list.html' %}
-  {% include 'cloudcare/partials/users.html' %}
+  {% include 'cloudcare/partials/users/restore_as.html' %}
+  {% include 'cloudcare/partials/users/restore_as_banner.html' %}
+  {% include 'cloudcare/partials/users/user_data.html' %}
+  {% include 'cloudcare/partials/users/user_row.html' %}
   {% include 'cloudcare/partials/session_list.html' %}
   {% include 'cloudcare/partials/query_view.html' %}
   {% include 'cloudcare/partials/confirmation_modal.html' %}

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users.html
@@ -1,37 +1,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<script type="text/template" id="restore-as-view-template">
-  <div class="module-menu-container">
-    <div class="page-header menu-header">
-      <h1 class="page-title">Log in as user</h1>
-    </div>
-    <form class="module-search-container js-user-search">
-      <div class="input-group input-group-lg">
-        <input
-          type="text"
-          class="js-user-query form-control"
-          value="<%- query %>"
-          placeholder="Filter workers" />
-        <div class="input-group-btn">
-          <button class="btn btn-default" type="submit">
-            <i class="fa fa-search" aria-hidden="true"></i>
-          </button>
-        </div>
-      </div>
-    </form>
-    <table class="table module-table">
-      <tbody>
-      </tbody>
-    </table>
-    <% if (endPage) { %>
-      {% block pagination_templates %}
-        {% include 'cloudcare/partials/pagination.html' %}
-      {% endblock %}
-    <% } %>
-  </div>
-</script>
-
 <script type="text/template" id="user-row-view-template">
   <td class="module-column module-column-icon">
     <div class="module-icon-container module-icon-user">

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users.html
@@ -1,39 +1,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<script type="text/template" id="user-data-template">
-  <table class="table module-table module-table-case-detail">
-    <tbody>
-    <tr>
-      <th>{% trans "Name" %}</th>
-      <td><%- user.first_name + ' ' + user.last_name %></td>
-    </tr>
-    <% if (user.location) { %>
-    <tr>
-      <th>{% trans "Organization" %}</th>
-      <td><%- user.location.name %></td>
-    </tr>
-    <tr>
-      <th>{% trans "Organization Type" %}</th>
-      <td><%- user.location.location_type %></td>
-    </tr>
-    <% } %>
-    <tr>
-      <th>{% trans "Date Registered" %}</th>
-      <td><%- user.dateRegistered %></td>
-    </tr>
-    <% _.each(user.customFields, function(value, key) { %>
-    <% if (!key.startsWith('commcare_') && !key.startsWith('commtrack') && value) { %>
-    <tr>
-      <th><%- key %></th>
-      <td><%- value %></td>
-    </tr>
-    <% } %>
-    <% }) %>
-    </tbody>
-  </table>
-
-</script>
 <script type="text/template" id="restore-as-banner-template">
   {% if request|can_use_restore_as %}
     <% if (restoreAs) { %>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users.html
@@ -1,21 +1,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<script type="text/template" id="user-row-view-template">
-  <td class="module-column module-column-icon">
-    <div class="module-icon-container module-icon-user">
-      <i class="fa fa-user module-icon" aria-hidden="true"></i>
-    </div>
-  </td>
-  <td class="module-column module-column-name">
-    <h3>
-      <b><%- username %></b>
-      <span><%- first_name + ' ' + last_name %></span>
-      <i><small><%- location ? location.name + ' (' + location.location_type + ')' : '' %></small></i>
-    </h3>
-  </td>
-</script>
-
 <script type="text/template" id="user-data-template">
   <table class="table module-table module-table-case-detail">
     <tbody>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users/restore_as.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users/restore_as.html
@@ -1,0 +1,30 @@
+<script type="text/template" id="restore-as-view-template">
+  <div class="module-menu-container">
+    <div class="page-header menu-header">
+      <h1 class="page-title">Log in as user</h1>
+    </div>
+    <form class="module-search-container js-user-search">
+      <div class="input-group input-group-lg">
+        <input
+          type="text"
+          class="js-user-query form-control"
+          value="<%- query %>"
+          placeholder="Filter workers" />
+        <div class="input-group-btn">
+          <button class="btn btn-default" type="submit">
+            <i class="fa fa-search" aria-hidden="true"></i>
+          </button>
+        </div>
+      </div>
+    </form>
+    <table class="table module-table">
+      <tbody>
+      </tbody>
+    </table>
+    <% if (endPage) { %>
+      {% block pagination_templates %}
+        {% include 'cloudcare/partials/pagination.html' %}
+      {% endblock %}
+    <% } %>
+  </div>
+</script>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users/restore_as.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users/restore_as.html
@@ -1,7 +1,10 @@
+{% load hq_shared_tags %}
+{% load i18n %}
+
 <script type="text/template" id="restore-as-view-template">
   <div class="module-menu-container">
     <div class="page-header menu-header">
-      <h1 class="page-title">Log in as user</h1>
+      <h1 class="page-title">{% trans "Log in as user" %}</h1>
     </div>
     <form class="module-search-container js-user-search">
       <div class="input-group input-group-lg">
@@ -9,7 +12,7 @@
           type="text"
           class="js-user-query form-control"
           value="<%- query %>"
-          placeholder="Filter workers" />
+          placeholder="{% trans_html_attr "Filter workers" %}" />
         <div class="input-group-btn">
           <button class="btn btn-default" type="submit">
             <i class="fa fa-search" aria-hidden="true"></i>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users/restore_as_banner.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users/restore_as_banner.html
@@ -1,5 +1,4 @@
 {% load hq_shared_tags %}
-{% load i18n %}
 
 <script type="text/template" id="restore-as-banner-template">
   {% if request|can_use_restore_as %}

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users/user_data.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users/user_data.html
@@ -1,0 +1,34 @@
+{% load i18n %}
+
+<script type="text/template" id="user-data-template">
+  <table class="table module-table module-table-case-detail">
+    <tbody>
+    <tr>
+      <th>{% trans "Name" %}</th>
+      <td><%- user.first_name + ' ' + user.last_name %></td>
+    </tr>
+    <% if (user.location) { %>
+    <tr>
+      <th>{% trans "Organization" %}</th>
+      <td><%- user.location.name %></td>
+    </tr>
+    <tr>
+      <th>{% trans "Organization Type" %}</th>
+      <td><%- user.location.location_type %></td>
+    </tr>
+    <% } %>
+    <tr>
+      <th>{% trans "Date Registered" %}</th>
+      <td><%- user.dateRegistered %></td>
+    </tr>
+    <% _.each(user.customFields, function(value, key) { %>
+    <% if (!key.startsWith('commcare_') && !key.startsWith('commtrack') && value) { %>
+    <tr>
+      <th><%- key %></th>
+      <td><%- value %></td>
+    </tr>
+    <% } %>
+    <% }) %>
+    </tbody>
+  </table>
+</script>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users/user_row.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users/user_row.html
@@ -1,0 +1,14 @@
+<script type="text/template" id="user-row-view-template">
+  <td class="module-column module-column-icon">
+    <div class="module-icon-container module-icon-user">
+      <i class="fa fa-user module-icon" aria-hidden="true"></i>
+    </div>
+  </td>
+  <td class="module-column module-column-name">
+    <h3>
+      <b><%- username %></b>
+      <span><%- first_name + ' ' + last_name %></span>
+      <i><small><%- location ? location.name + ' (' + location.location_type + ')' : '' %></small></i>
+    </h3>
+  </td>
+</script>

--- a/corehq/apps/cloudcare/templates/cloudcare/preview_app_base.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/preview_app_base.html
@@ -76,7 +76,10 @@
 {% include 'cloudcare/partials/menu_list.html' %}
 {% include 'cloudcare/partials/session_list.html' %}
 {% include 'cloudcare/partials/confirmation_modal.html' %}
-{% include 'cloudcare/partials/users.html' %}
+{% include 'cloudcare/partials/users/restore_as.html' %}
+{% include 'cloudcare/partials/users/restore_as_banner.html' %}
+{% include 'cloudcare/partials/users/user_data.html' %}
+{% include 'cloudcare/partials/users/user_row.html' %}
 {% include 'cloudcare/partials/progress.html' %}
 {% include 'cloudcare/partials/query_view.html' %}
 

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
@@ -44,7 +44,10 @@
   {% include 'cloudcare/partials/case_detail.html' %}
   {% include 'cloudcare/partials/case_list.html' %}
   {% include 'cloudcare/partials/menu_list.html' %}
-  {% include 'cloudcare/partials/users.html' %}
+  {% include 'cloudcare/partials/users/restore_as.html' %}
+  {% include 'cloudcare/partials/users/restore_as_banner.html' %}
+  {% include 'cloudcare/partials/users/user_data.html' %}
+  {% include 'cloudcare/partials/users/user_row.html' %}
   {% include 'cloudcare/partials/session_list.html' %}
   {% include 'cloudcare/partials/query_view.html' %}
   {% include 'cloudcare/partials/confirmation_modal.html' %}


### PR DESCRIPTION
## Technical Summary
This is primarily about code organization, but I'm motivated to do it now because if I split these files for the bootstrap migration, the diff process makes it advantageous to have more small files rather then fewer large ones.

## Safety Assurance

### Safety story
Mechanical changes. The main risk is missing an include reference, or missing loading a template tag. But since web apps loads all of its templates on the same page, this is easy to test. Tested locally.

### Automated test coverage

I suppose some, since one of the updated files is the mocha template.

### QA Plan

not requesting QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
