### PR TITLE
Add a feature flag to remove scroll queries in case search

### DIFF
--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -154,4 +154,4 @@ def _get_case_ids_from_ast_filter(context, filter_node):
                 new_query
             )
 
-        return es_query.scroll_ids()
+        return es_query.get_ids()

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -103,7 +103,7 @@ def _child_case_lookup(context, case_ids, identifier):
     """
     es_query = CaseSearchES().domain(context.domain).get_child_cases(case_ids, identifier)
     context.profiler.add_query('_child_case_lookup', es_query)
-    if _should_scroll(context.domain):
+    if _should_scroll(context):
         return es_query.scroll_ids()
     else:
         return es_query.get_ids()
@@ -169,7 +169,7 @@ def _get_case_ids_from_ast_filter(context, filter_node):
                 new_query
             )
 
-        if _should_scroll(context.domain):
+        if _should_scroll(context):
             return es_query.scroll_ids()
         else:
             return es_query.get_ids()

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -91,7 +91,7 @@ def _child_case_lookup(context, case_ids, identifier):
     """
     es_query = CaseSearchES().domain(context.domain).get_child_cases(case_ids, identifier)
     context.profiler.add_query('_child_case_lookup', es_query)
-    return es_query.scroll_ids()
+    return es_query.get_ids()
 
 
 def ancestor_exists(node, context):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1008,6 +1008,17 @@ USH_CASE_CLAIM_UPDATES = StaticToggle(
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
 )
 
+NO_SCROLL_IN_CASE_SEARCH = StaticToggle(
+    'no_scroll_in_case_search',
+    "Do not use scroll queries in case search elasticsearch queries",
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    This toggle replaces scroll queries in case search ancestor functions with
+    normal search queries.
+    """
+)
+
 GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
     "geocoder_my_location_button",
     "USH: Add button to geocoder to populate search with the user's current location",


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Scroll queries appear to bypass elasticsearch caching. Running queries without scroll speeds these up in example domains from consistently over 10 seconds to around 1 second.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`NO_SCROLL_IN_CASE_SEARCH`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
These queries are tested, and the query parameters are unchanged.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
