### PR TITLE
Set 'preference' option on ES queries

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -304,10 +304,11 @@ class ESQuery(object):
         https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-preference.html
         """
         domain = get_request_domain()
-        query = self.clone()
         if ES_QUERY_PREFERENCE.enabled(domain):
+            query = self.clone()
             query.es_query['preference'] = domain
-        return query
+            return query
+        return self
 
     def add_query(self, new_query, clause):
         """

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -299,16 +299,14 @@ class ESQuery(object):
 
     def set_preference(self):
         """
-        If the specified domain has ES_QUERY_PREFERENCE enabled, route requests to primary shards.
-        Otherwise, route to replica shards. The '*_first' naming scheme ensures requests are still
-        handled if the intended shard is unavailable.
+        If the specified domain has ES_QUERY_PREFERENCE enabled, use domain as key to route to a consistent set
+        of shards.
         https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-preference.html
         """
+        domain = get_request_domain()
         query = self.clone()
-        if ES_QUERY_PREFERENCE.enabled(get_request_domain()):
-            query.es_query['preference'] = '_primary_first'
-        else:
-            query.es_query['preference'] = '_replica_first'
+        if ES_QUERY_PREFERENCE.enabled(domain):
+            query.es_query['preference'] = domain
         return query
 
     def add_query(self, new_query, clause):

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -152,7 +152,16 @@ class ESQuery(object):
                 }
             }
         }
-        self.set_preference()
+        self._set_preference()
+
+    def _set_preference(self):
+        """
+        If the specified domain has ES_QUERY_PREFERENCE enabled, use domain as key to route to a consistent set
+        of shards. See https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-preference.html
+        """
+        domain = get_request_domain()
+        if ES_QUERY_PREFERENCE.enabled(domain):
+            self.es_query['preference'] = domain
 
     def clone(self):
         adapter = self.adapter
@@ -296,19 +305,6 @@ class ESQuery(object):
         query = self.clone()
         query.es_query['profile'] = True
         return query
-
-    def set_preference(self):
-        """
-        If the specified domain has ES_QUERY_PREFERENCE enabled, use domain as key to route to a consistent set
-        of shards.
-        https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-preference.html
-        """
-        domain = get_request_domain()
-        if ES_QUERY_PREFERENCE.enabled(domain):
-            query = self.clone()
-            query.es_query['preference'] = domain
-            return query
-        return self
 
     def add_query(self, new_query, clause):
         """

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2529,6 +2529,17 @@ ALLOW_WEB_APPS_RESTRICTION = StaticToggle(
     """
 )
 
+ES_QUERY_PREFERENCE = StaticToggle(
+    'es_query_preference',
+    'Sets preference option on ES queries',
+    tag=TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    When enabled, ES queries for this domain will be routed to the same shards for every request. This helps
+    ES queries take advantage of caching on ES nodes.
+    """
+)
+
 
 class FrozenPrivilegeToggle(StaticToggle):
     """


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The preference option in ES allows you to specify which shards to route a request to. We primarily care about routing all case search related requests to specific shards for certain domains, but this PR notably does this for all indices.

There were a couple of options for how to obtain the domain to use when deciding what to set `preference` to. This is the safest method to start with, which just ensures that a domain with the `ES_QUERY_PREFERENCE` feature flag enabled will be routed to the same shards.
 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
ES_QUERY_PREFERENCE

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Behavior only changes once the feature flag is enabled so the blast radius is minimal.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
