### PR TITLE
Add preference as query parameter in ES adapter

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -649,7 +649,8 @@ class ElasticDocumentAdapter(BaseAdapter):
         if ES_QUERY_PREFERENCE.enabled(domain):
             # Use domain as key to route to a consistent set of shards.kwargs
             # See https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-preference.html
-            kw['preference'] = domain
+            if 'preference' not in kw:
+                kw['preference'] = domain
 
         with metrics_histogram_timer(
                 'commcare.elasticsearch.search.timing',

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -92,9 +92,7 @@ import textwrap
 
 from memoized import memoized
 
-from corehq.toggles import ES_QUERY_PREFERENCE
 from corehq.util.files import TransientTempfile
-from corehq.util.global_request import get_request_domain
 
 from . import aggregations, filters, queries
 from .const import SCROLL_SIZE, SIZE_LIMIT
@@ -152,16 +150,6 @@ class ESQuery(object):
                 }
             }
         }
-        self._set_preference()
-
-    def _set_preference(self):
-        """
-        If the specified domain has ES_QUERY_PREFERENCE enabled, use domain as key to route to a consistent set
-        of shards. See https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-preference.html
-        """
-        domain = get_request_domain()
-        if ES_QUERY_PREFERENCE.enabled(domain):
-            self.es_query['preference'] = domain
 
     def clone(self):
         adapter = self.adapter


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Followup to fix https://github.com/dimagi/commcare-hq/pull/34486

I should read docs better as the `preference` option is very clearly a query parameter, not something that should be included in the body of the request. I moved the logic down into the ES adapter since we already had a check for the current domain in the `_search` method. It should also be easy to set this option based on the index if we want to do that.

I thought about what the behavior should be if `preference` is already specified in the keyword argument dictionary, and decided to only set it if the `preference` option were not already set on the kwargs.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
ES_QUERY_PREFERENCE

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Still just behind a feature flag, only impacting domains with the feature flag enabled.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
