### PR TITLE
Support Expand Checkbox Questions option for geojson form exports

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -375,6 +375,12 @@ def write_export_instance(writer, export_instance, documents,
                 if ALL_CASE_TYPE_TABLE in table.path and doc['type'] not in path_names:
                     continue
 
+                # For geojson exports it is important to reliably know whether
+                # the split_multiselects setting is enabled at the point when the
+                # table's rows are handled
+                if writer.format == "geojson":
+                    table.split_multiselects = export_instance.split_multiselects
+
                 try:
                     rows = table.get_rows(
                         doc,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -124,6 +124,10 @@ from corehq.apps.userreports.util import get_indicator_adapter
 
 DAILY_SAVED_EXPORT_ATTACHMENT_NAME = "payload"
 
+GPS_SPLIT_COLUMN_LATITUDE_TEMPLATE = '{}: latitude (degrees)'
+GPS_SPLIT_COLUMN_LONGITUDE_TEMPLATE = '{}: longitude (degrees)'
+GPS_SPLIT_COLUMN_ALTITUDE_TEMPLATE = '{}: altitude (meters)'
+GPS_SPLIT_COLUMN_ACCURACY_TEMPLATE = '{}: accuracy (meters)'
 
 ExcelFormatValue = namedtuple('ExcelFormatValue', 'format value')
 
@@ -2753,14 +2757,18 @@ class SplitGPSExportColumn(ExportColumn):
     def get_headers(self, split_column=False):
         if not split_column:
             return super(SplitGPSExportColumn, self).get_headers()
+
         header = self.label
-        header_templates = [
-            _('{}: latitude (degrees)'),
-            _('{}: longitude (degrees)'),
-            _('{}: altitude (meters)'),
-            _('{}: accuracy (meters)'),
+        return [header_template.format(header) for header_template in self.split_column_header_templates]
+
+    @property
+    def split_column_header_templates(self):
+        return [
+            _(GPS_SPLIT_COLUMN_LATITUDE_TEMPLATE),
+            _(GPS_SPLIT_COLUMN_LONGITUDE_TEMPLATE),
+            _(GPS_SPLIT_COLUMN_ALTITUDE_TEMPLATE),
+            _(GPS_SPLIT_COLUMN_ACCURACY_TEMPLATE),
         ]
-        return [header_template.format(header) for header_template in header_templates]
 
     def get_value(self, domain, doc_id, doc, base_path, split_column=False, **kwargs):
         coord_string = super().get_value(

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -832,12 +832,6 @@ class ExportInstance(BlobMixin, Document):
     @classmethod
     def wrap(cls, data):
         from corehq.apps.export.views.utils import clean_odata_columns
-        # This is a temporary solution to make sure geojson exports have split_multiselects set to false,
-        # otherwise it won't work. Ticket SC-3569 is for making geojson form exports compatible with
-        # the split_multiselects option.
-        if data.get('export_format', '') == 'geojson':
-            data['split_multiselects'] = False
-
         export_instance = super(ExportInstance, cls).wrap(data)
         if export_instance.is_odata_config:
             clean_odata_columns(export_instance)

--- a/corehq/apps/export/static/export/js/customize_export_new.js
+++ b/corehq/apps/export/static/export/js/customize_export_new.js
@@ -37,20 +37,14 @@ hqDefine('export/js/customize_export_new', [
             const exportFormat = initialPageData.get('export_instance').export_format;
             if (exportFormat === constants.EXPORT_FORMATS.GEOJSON) {
                 $("#select-geo-property").show();
-                $("#split-multiselects-checkbox-div").hide();
-                $("#split-multiselects-checkbox").prop("checked", false);
             }
 
             $('#format-select').change(function () {
                 const selectedValue = $(this).val();
                 if (selectedValue === constants.EXPORT_FORMATS.GEOJSON) {
                     $("#select-geo-property").show();
-                    // Hiding and unchecking this checkbox is a temporary measure
-                    $("#split-multiselects-checkbox-div").hide();
-                    $("#split-multiselects-checkbox").prop("checked", false);
                 } else {
                     $("#select-geo-property").hide();
-                    $("#split-multiselects-checkbox-div").show();
                 }
             });
         }

--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -414,6 +414,7 @@ class TestGeoJSONWriter(SimpleTestCase):
         table = self.geopoint_table_configuration(
             selected_geo_property="form.home",
         )
+        table.split_multiselects = True
         features = GeoJSONWriter().get_features(table, self._table_data(table=table, multi_column=True))
 
         feature_coordinates = [feature['geometry']['coordinates'] for feature in features]
@@ -428,6 +429,7 @@ class TestGeoJSONWriter(SimpleTestCase):
         table = self.geopoint_table_configuration(
             selected_geo_property="form.meta.location",
         )
+        table.split_multiselects = True
         features = GeoJSONWriter().get_features(table, self._table_data(table=table, multi_column=True))
 
         feature_coordinates = [feature['geometry']['coordinates'] for feature in features]

--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -18,7 +18,7 @@ from couchexport.writers import (
     GeoJSONWriter,
 )
 from corehq.apps.export.models import TableConfiguration
-from corehq.apps.export.models import SplitGPSExportColumn, GeopointItem, PathNode
+from corehq.apps.export.models import SplitGPSExportColumn, GeopointItem, PathNode, ExportColumn, ExportItem
 
 
 class ZippedExportWriterTests(SimpleTestCase):
@@ -239,145 +239,169 @@ class HeaderNameTest(SimpleTestCase):
 
 
 class TestGeoJSONWriter(SimpleTestCase):
-    GEO_PROPERTY = 'geo-prop'
 
     def test_get_features(self):
-        table = TableConfiguration(selected_geo_property=self.GEO_PROPERTY)
-        features = GeoJSONWriter().get_features(table, self._table_data())
+        table = self.geopoint_table_configuration(
+            selected_geo_property="form.home",
+        )
+        features = GeoJSONWriter().get_features(table, self._table_data(table=table))
 
         expected_features = [
             {
-                'type': 'Feature',
-                'geometry': {'type': 'Point', 'coordinates': ['-71.057083', '42.361145']},
-                'properties': {'name': 'Boston', 'country': 'United States'}
+                'geometry': {'coordinates': ['-71.057083', '42.361145'], 'type': 'Point'},
+                'properties': {
+                    'form.country': 'United States',
+                    'form.city': 'Boston',
+                    'location': '42.361146 -71.057084 100 0',
+                },
+                'type': 'Feature'
             },
             {
-                'type': 'Feature',
-                'geometry': {'type': 'Point', 'coordinates': ['18.423300', '-33.918861']},
-                'properties': {'name': 'Cape Town', 'country': 'South Africa'}
+                'geometry': {'coordinates': ['18.423300', '-33.918861'], 'type': 'Point'},
+                'properties': {
+                    'form.country': 'South Africa',
+                    'form.city': 'Cape Town',
+                    'location': '-33.918862 18.423301 100 0',
+                },
+                'type': 'Feature'
             },
             {
-                'type': 'Feature',
-                'geometry': {'type': 'Point', 'coordinates': ['77.2300', '28.6100']},
-                'properties': {'name': 'Delhi', 'country': 'India'}
+                'geometry': {'coordinates': ['77.2300', '28.6100'], 'type': 'Point'},
+                'properties': {
+                    'form.country': 'India',
+                    'form.city': 'Delhi',
+                    'location': '28.6101 77.2301 100 0',
+                },
+                'type': 'Feature'
             },
         ]
         self.assertEqual(features, expected_features)
 
     def test_get_features__other_geo_property_configured(self):
-        table = TableConfiguration(selected_geo_property="some-other-property")
-        features = GeoJSONWriter().get_features(table, self._table_data())
+        table = self.geopoint_table_configuration(
+            selected_geo_property="form.not_home",
+        )
+        features = GeoJSONWriter().get_features(table, self._table_data(table=table))
         self.assertEqual(features, [])
 
     def test_get_features__invalid_geo_property_column_value(self):
-        table = TableConfiguration(selected_geo_property=self.GEO_PROPERTY)
+        table = self.geopoint_table_configuration(
+            selected_geo_property="form.home",
+        )
+        data = self._table_data(table=table)
 
-        data = self._table_data()
         data[1][1] = "not-a-geo-coordinate-value"
+        corrupt_country = data[1][2]
+
         features = GeoJSONWriter().get_features(table, data)
+        features_names = [feature['properties']['form.country'] for feature in features]
 
-        features_names = [feature['properties']['name'] for feature in features]
-        self.assertTrue(data[1][2] not in features_names)
-
-    def test_get_features_from_path(self):
-        table = self.geopoint_table_configuration(
-            selected_geo_property="some.path",
-            path_string='some.path',
-        )
-        features = GeoJSONWriter().get_features(table, self._table_data(geo_property_header='some.path'))
-
-        expected_features = [
-            {
-                'geometry': {'coordinates': ['-71.057083', '42.361145'], 'type': 'Point'},
-                'properties': {'country': 'United States', 'name': 'Boston'},
-                'type': 'Feature'
-            },
-            {
-                'geometry': {'coordinates': ['18.423300', '-33.918861'], 'type': 'Point'},
-                'properties': {'country': 'South Africa', 'name': 'Cape Town'},
-                'type': 'Feature'
-            },
-            {
-                'geometry': {'coordinates': ['77.2300', '28.6100'], 'type': 'Point'},
-                'properties': {'country': 'India', 'name': 'Delhi'},
-                'type': 'Feature'
-            },
-        ]
-        self.assertEqual(features, expected_features)
-
-    def test_get_features_from_path__invalid_path(self):
-        table = self.geopoint_table_configuration(
-            selected_geo_property="some.other.path",
-            path_string='some.path',
-        )
-        features = GeoJSONWriter().get_features(table, self._table_data(geo_property_header='some.path'))
-
-        expected_features = []
-        self.assertEqual(features, expected_features)
+        self.assertTrue(corrupt_country not in features_names)
 
     def test_get_features_from_path__location_metadata(self):
         table = self.geopoint_table_configuration(
             selected_geo_property="form.meta.location",
-            path_string="form.meta.location",
-            header_name='location',
         )
-        features = GeoJSONWriter().get_features(table, self._table_data(geo_property_header='location'))
-
+        features = GeoJSONWriter().get_features(table, self._table_data(table=table))
         expected_features = [
             {
-                'geometry': {'coordinates': ['-71.057083', '42.361145'], 'type': 'Point'},
-                'properties': {'country': 'United States', 'name': 'Boston'},
+                'geometry': {'coordinates': ['-71.057084', '42.361146'], 'type': 'Point'},
+                'properties': {
+                    'form.country': 'United States',
+                    'form.city': 'Boston',
+                    'form.home': '42.361145 -71.057083 0 0'
+                },
                 'type': 'Feature'
             },
             {
-                'geometry': {'coordinates': ['18.423300', '-33.918861'], 'type': 'Point'},
-                'properties': {'country': 'South Africa', 'name': 'Cape Town'},
+                'geometry': {'coordinates': ['18.423301', '-33.918862'], 'type': 'Point'},
+                'properties': {
+                    'form.country': 'South Africa',
+                    'form.city': 'Cape Town',
+                    'form.home': '-33.918861 18.423300 0 0',
+                },
                 'type': 'Feature'
             },
             {
-                'geometry': {'coordinates': ['77.2300', '28.6100'], 'type': 'Point'},
-                'properties': {'country': 'India', 'name': 'Delhi'},
+                'geometry': {'coordinates': ['77.2301', '28.6101'], 'type': 'Point'},
+                'properties': {
+                    'form.country': 'India',
+                    'form.city': 'Delhi',
+                    'form.home': '28.6100 77.2300 0 0',
+                },
                 'type': 'Feature'
             },
         ]
         self.assertEqual(features, expected_features)
 
-    def _table_data(self, geo_property_header=None):
-        data = [self._table_header(geo_property_header)]
-        table_data_rows = self._table_data_rows
+    def _table_data(self, table, multi_column=False):
+        data = [table.get_headers(split_columns=multi_column)]
+        table_data_rows = self._table_data_rows(multi_column=multi_column)
         [data.append(row) for row in table_data_rows]
         return data
 
-    def _table_header(self, geo_property_header=None):
-        geo_property_header = self.GEO_PROPERTY if geo_property_header is None else geo_property_header
+    def _table_data_rows(self, multi_column):
+        def row_data(city, home, country, location_meta):
+            home_data = home.split(" ") if multi_column else [home]
+            location_meta_data = location_meta.split(" ") if multi_column else [location_meta]
+
+            return [
+                city,
+                *home_data,
+                country,
+                *location_meta_data
+            ]
+
         return [
-            'name',
-            geo_property_header,
-            'country',
+            row_data("Boston", "42.361145 -71.057083 0 0", "United States", "42.361146 -71.057084 100 0"),
+            row_data("Cape Town", "-33.918861 18.423300 0 0", "South Africa", "-33.918862 18.423301 100 0"),
+            row_data("Delhi", "28.6100 77.2300 0 0", "India", "28.6101 77.2301 100 0")
         ]
 
-    @property
-    def _table_data_rows(self):
-        return [
-            ['Boston', '42.361145 -71.057083 0 0', 'United States'],
-            ['Cape Town', '-33.918861 18.423300 0 0', 'South Africa'],
-            ['Delhi', '28.6100 77.2300 0 0', 'India']
-        ]
-
-    def geopoint_table_configuration(self, selected_geo_property, path_string, header_name=None):
-        path = [PathNode(name=node) for node in path_string.split('.')]
-        header_name = header_name if header_name is not None else 'MyGPSProperty'
+    def geopoint_table_configuration(self, selected_geo_property):
+        location_metadata_column = self.create_export_column(
+            label='location',
+            path_string='form.meta.location',
+            column_class=SplitGPSExportColumn,
+            column_item=GeopointItem,
+        )
+        other_location_column = self.create_export_column(
+            label='form.home',
+            path_string="form.home",
+            column_class=SplitGPSExportColumn,
+            column_item=GeopointItem,
+        )
+        city_column = self.create_export_column(
+            label='form.city',
+            path_string='form.name',
+            column_class=ExportColumn,
+            column_item=ExportItem,
+        )
+        country_column = self.create_export_column(
+            label='form.country',
+            path_string='form.country',
+            column_class=ExportColumn,
+            column_item=ExportItem,
+        )
 
         return TableConfiguration(
             selected=True,
             selected_geo_property=selected_geo_property,
             columns=[
-                SplitGPSExportColumn(
-                    label=header_name,
-                    item=GeopointItem(
-                        path=path,
-                    ),
-                    selected=True,
-                )
+                city_column,
+                other_location_column,
+                country_column,
+                location_metadata_column,
             ]
+        )
+
+    @staticmethod
+    def create_export_column(label, path_string, column_class, column_item):
+        path = [PathNode(name=node) for node in path_string.split('.')]
+        return column_class(
+            label=label,
+            item=column_item(
+                path=path,
+            ),
+            selected=True,
         )

--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -334,6 +334,34 @@ class TestGeoJSONWriter(SimpleTestCase):
         ]
         self.assertEqual(features, expected_features)
 
+    def test_get_features_multiple_columns(self):
+        table = self.geopoint_table_configuration(
+            selected_geo_property="form.home",
+        )
+        features = GeoJSONWriter().get_features(table, self._table_data(table=table, multi_column=True))
+
+        feature_coordinates = [feature['geometry']['coordinates'] for feature in features]
+        expected_coordinates = [
+            ["-71.057083", "42.361145"],
+            ["18.423300", "-33.918861"],
+            ["77.2300", "28.6100"],
+        ]
+        self.assertEqual(feature_coordinates, expected_coordinates)
+
+    def test_get_features_from_path_multiple_columns(self):
+        table = self.geopoint_table_configuration(
+            selected_geo_property="form.meta.location",
+        )
+        features = GeoJSONWriter().get_features(table, self._table_data(table=table, multi_column=True))
+
+        feature_coordinates = [feature['geometry']['coordinates'] for feature in features]
+        expected_coordinates = [
+            ["-71.057084", "42.361146"],
+            ["18.423301", "-33.918862"],
+            ["77.2301", "28.6101"],
+        ]
+        self.assertEqual(feature_coordinates, expected_coordinates)
+
     def _table_data(self, table, multi_column=False):
         data = [table.get_headers(split_columns=multi_column)]
         table_data_rows = self._table_data_rows(multi_column=multi_column)
@@ -344,13 +372,7 @@ class TestGeoJSONWriter(SimpleTestCase):
         def row_data(city, home, country, location_meta):
             home_data = home.split(" ") if multi_column else [home]
             location_meta_data = location_meta.split(" ") if multi_column else [location_meta]
-
-            return [
-                city,
-                *home_data,
-                country,
-                *location_meta_data
-            ]
+            return [city, *home_data, country, *location_meta_data]
 
         return [
             row_data("Boston", "42.361145 -71.057083 0 0", "United States", "42.361146 -71.057084 100 0"),

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -655,6 +655,8 @@ class GeoJSONWriter(JsonExportWriter):
                 for i, header in enumerate(table_headers)
                 if i not in geo_data_column_indices
             }
+            if not (lng and lat):
+                continue
 
             features.append(self.parse_feature(
                 coordinates=[lng, lat],
@@ -682,6 +684,7 @@ class GeoJSONWriter(JsonExportWriter):
     def _close(self):
         feature_collections = []
         for table, data in self.tables.items():
+            breakpoint()
             feature_collections.append(
                 self.get_features(table, data)
             )

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -584,14 +584,6 @@ class GeoJSONWriter(JsonExportWriter):
 
         return table.selected_geo_property
 
-    @staticmethod
-    def _is_multiselect_split(table, data_table_headers):
-        """
-        Since we can't directly check whether the columns are split or not we're
-        deducing it from the number of columns.
-        """
-        return table.get_headers(split_columns=True) == data_table_headers
-
     def build_geo_features_from_data(
         self, data, geo_property_name, geo_column_index_func, geo_data_collector_func
     ):
@@ -673,7 +665,7 @@ class GeoJSONWriter(JsonExportWriter):
         geo_column_index_func = self.find_geo_data_column
         geo_data_collector_func = self.collect_geo_data
 
-        if self._is_multiselect_split(table, table_headers):
+        if getattr(table, 'split_multiselects', False):
             geo_column_index_func = self.find_geo_data_columns
             geo_data_collector_func = self.collect_geo_data_multi_column
 


### PR DESCRIPTION
This PR might be easier to review as a whole, as [this commit](https://github.com/dimagi/commcare-hq/commit/2794d7d7d3a4c1d899608eb487ef6f55f60f9abc) will change significantly as part of d573529ad512f70a1a1dccf22f781fe7e24ea512.

## Product Description
This PR adds the ability to use the `Expand Checkbox Questions` option with form exports. Previously this setting was disabled.

![image](https://github.com/dimagi/commcare-hq/assets/44245062/603adb12-0161-4ad9-a40e-13f5fa70f127)


## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3569)

For geojson exports it's important that at the point of generation we know whether or not the `export_instance.split_multiselects` option is selected, hence it's explicitly being put on the `table` object [here](https://github.com/dimagi/commcare-hq/blob/499a2f90ce25bbfe18c8d5f7443b23fa8d7127d4/corehq/apps/export/export.py#L381-L382). 

The `split_multiselects` option splits for example the geo data column into multiple columns (so instead of having one column containing "`<lat> <lng>`" you have 2 columns, one containing "`<lat>`" and the other "`<lng>`"), hence it's necessary to determine which columns those are in order to obtain their values. Based on this `split_multiselects` value there's two methods given to the `build_geo_features_from_data` method:
1. method for determining which columns contain the relevant info
2. method for collecting the data from those columns

These methods above differ based on `split_multiselects`, since the process is different for handling one column vs multiple columns in such a way that it warrants different methods. 

## Feature Flag
`SUPPORT_GEO_JSON_EXPORT`

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
Various tests have been added

### QA Plan
[QA ticket](https://dimagi.atlassian.net/browse/QA-6423)

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
