### PR TITLE
Add link to download ES profiler data

### DIFF
--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -47,17 +47,17 @@
           <div class="row">
             <div class="col-sm-3" data-bind="text: name"></div>
             <div class="col-sm-3">
-              <strong data-bind="text: duration ? duration.toFixed(3) : '-'"></strong> seconds;
+              <strong data-bind="text: duration ? duration.toFixed(3) : '-'"></strong> seconds
             </div>
             <div class="col-sm-3">
-              <strong data-bind="text: percent_total ? percent_total.toFixed(3) : '-'"></strong>% of total;
+              <strong data-bind="text: percent_total ? percent_total.toFixed(3) : '-'"></strong>% of total
             </div>
             <div class="col-sm-3">
               <strong data-bind="text: percent_parent ? percent_parent.toFixed(3) : '-'"></strong>% of parent
             </div>
           </div>
           <ul data-bind="template: { name: 'timingRow', foreach: subs }"
-          class="list-group"></ul>
+            class="list-group"></ul>
         </div>
       </li>
     </script>
@@ -66,7 +66,9 @@
       <div class="card card-default my-1">
         <div class="card-header clickable" data-bs-toggle="collapse" data-parent="#queries-accordion"
           data-bind="attr: { href: '#query-' + $index() }">
-          Elasticsearch query: <code data-bind="text: slug"></code>
+          Elasticsearch query #<span data-bind="text: query_number"></span>:
+          <code data-bind="text: slug"></code> -
+          <strong data-bind="text: duration ? duration.toFixed(3) : '-'"></strong> seconds
         </div>
         <div class="card-body panel-collapse collapse" data-bind="attr: { id: 'query-' + $index() }">
           <pre data-bind="text: JSON.stringify(query, null, 4)"></pre>

--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -71,6 +71,9 @@
           <strong data-bind="text: duration ? duration.toFixed(3) : '-'"></strong> seconds
         </div>
         <div class="card-body panel-collapse collapse" data-bind="attr: { id: 'query-' + $index() }">
+          <!-- ko if: profile_url -->
+            <a class="btn btn-info" data-bind="attr: {href: profile_url}">Download Profile JSON</a>
+          <!-- /ko -->
           <pre data-bind="text: JSON.stringify(query, null, 4)"></pre>
         </div>
       </div>

--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -72,7 +72,7 @@
         </div>
         <div class="card-body panel-collapse collapse" data-bind="attr: { id: 'query-' + $index() }">
           <!-- ko if: profile_url -->
-            <a class="btn btn-info" data-bind="attr: {href: profile_url}">Download Profile JSON</a>
+            <a class="btn btn-info float-end" data-bind="attr: {href: profile_url}">Download Profile JSON</a>
           <!-- /ko -->
           <pre data-bind="text: JSON.stringify(query, null, 4)"></pre>
         </div>

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -3,6 +3,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import wraps
+from io import BytesIO
 
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
@@ -40,11 +41,13 @@ from corehq.apps.es.case_search import (
     reverse_index_case_query,
     wrap_case_search_hit,
 )
+from corehq.apps.hqadmin.utils import get_download_url
 from corehq.apps.registry.exceptions import (
     RegistryAccessException,
     RegistryNotFound,
 )
 from corehq.apps.registry.helper import DataRegistryHelper
+from corehq.util.dates import get_timestamp_for_filename
 from corehq.util.quickcache import quickcache
 from corehq.util.timer import TimingContext
 
@@ -75,16 +78,29 @@ class CaseSearchProfiler:
                 'query_number': self._query_number,
                 'query': es_query.raw_query,
                 'duration': timer.duration,
-                'profile': results.raw.get('profile'),
+                'profile_url': self._get_profile_url(slug, self._query_number, results.raw.get('profile')),
             })
         return results
 
     def add_query(self, slug, es_query):
         self._query_number += 1
         if self.debug_mode:
-            self.queries.append({'slug': slug,
-                                 'query_number': self._query_number,
-                                 'query': es_query.raw_query})
+            self.queries.append({
+                'slug': slug,
+                'query_number': self._query_number,
+                'query': es_query.raw_query,
+                'duration': None,
+                'profile_url': None,
+            })
+
+    @staticmethod
+    def _get_profile_url(slug, query_number, profile_json):
+        timestamp = get_timestamp_for_filename()
+        name = f'es_profile_{query_number}_{slug}_{timestamp}.json'
+        io = BytesIO()
+        io.write(json.dumps(profile_json).encode('utf-8'))
+        io.seek(0)
+        return get_download_url(io, name, content_type='application/json')
 
 
 def time_function():

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -116,5 +116,4 @@ class ProfileCaseSearchView(_BaseCaseSearchView):
             'related_count': profiler.related_count,
             'timing_data': profiler.timing_context.to_dict(),
             'queries': profiler.queries,
-            'profile_results': profiler.profile_results,
         })


### PR DESCRIPTION
## Product Description

This builds off the case search profiler util introduced in  https://github.com/dimagi/commcare-hq/pull/34373

It does a few things:
* Numbers ES queries so you can cross reference between the timing data and the query details
* Adds query duration in-line with query details
* Adds a link to download the profiler output for each query

This screenshot shows all of that:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/3784c509-1cc9-4b58-8281-9ac93716cb89)


## Technical Summary


## Feature Flag


## Safety Assurance
All of the functionality changes except the `_query_number` counter are gated behind a `debug_mode` flag, and so should only affect usages of this utility, not general case search

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change