### PR TITLE
[B5] migration tool: if migrating a single file, always return that file

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -154,7 +154,7 @@ class Command(BaseCommand):
 
     def _get_files_for_migration(self, files, file_name, do_re_check):
         if file_name is not None:
-            files = [t for t in files if file_name in str(t)]
+            return [t for t in files if file_name in str(t)]
 
         # filter out already split bootstrap3 templates
         files = [t for t in files if '/bootstrap3/' not in str(t)]


### PR DESCRIPTION
## Technical Summary
If the user passes a specific file, migrate that file.

I've been doing this locally to get the flags for files that are "migrated" in the sense that they're in a B5 directory, so the automated changes are made, but they still have compatibility issues.

Open to suggestions on other ways to approach this. I'm not totally in love with this workflow: basically I run the migration tool just for the sake of generating the output file, then don't save the changes. I'm thinking about doing a standalone command that would just check a given file for flags, so the output file wouldn't be cluttered with the automated changes, just haven't gotten there yet.

## Safety Assurance

### Safety story
Minor change to an internal engineering tool

### Automated test coverage

Tool has test coverage, I don't know if this line is covered but am not concerned about it.

### QA Plan

no


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
