### PR TITLE
Web Apps Case Search Geocoder Bug Fix

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -878,16 +878,21 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", [
 
         onBeforeDetach: function () {
             this.smallScreenListener.stopListening();
+            for (const topic of this.geocoderTopics) {
+                $.unsubscribe(topic);
+            }
         },
 
         initGeocoders: function () {
             var self = this;
+            self.geocoderTopics = new Set();
             _.each(self._getChildModels(), function (model, i) {
                 var $field = $($(".query-field")[i]);
 
                 // Set geocoder receivers to subscribe
                 if (model.get('receive')) {
                     var topic = model.get('receive').split("-")[0];
+                    self.geocoderTopics.add(topic);
                     $.subscribe(topic, updateReceiver($field));
                 }
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Should improve performance for case search inputs for geocoder fields for situations where this bug was present.

With the bug, navigating out and back into the case search screen "n" times would result in "n" number of `navigate_menu` requests whenever a geocoder case search field is changed.

https://github.com/dimagi/commcare-hq/assets/88759246/ea0b4bfb-59e5-4f7f-a005-2c7653d87bd1

With the fix, `navigate_menu` request is sent only once.

https://github.com/dimagi/commcare-hq/assets/88759246/312a96b1-f1b5-466b-b037-f1cd94a1738a

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira Ticket
](https://dimagi.atlassian.net/browse/USH-4499)

The "[Tiny Pub/Sub](https://github.com/cowboy/jquery-tiny-pubsub?tab=readme-ov-file)" Jquery Plugin is used. The subscription persists even after view is detached. When the view is attached again, geocoder is initialized again and creates another subscription to that topic. The subscription is not overwritten. This results in multiple subscriptions to coexist for the same topic.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Geocoder for Web apps requires:
  - [Case Claim & Autolaunch](https://www.commcarehq.org/hq/flags/edit/case_claim_autolaunch/)
  - domain Geocoder privileges

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally reproduced bug and locally tested fix. The change is limited to domains with those feature flags enabled and using Geocoder. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
