### PR TITLE
Reorder case properties for case schema

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -2408,11 +2408,13 @@ class CaseExportDataSchema(ExportDataSchema):
         case_properties_indices = {}
 
         filter_kwargs = {'case_type__domain': domain, 'case_type__name': case_type}
-        for case_property_name, case_property_index in (
+
+        for case_property_index, case_property_name in enumerate(
             CaseProperty.objects
                 .filter(**filter_kwargs)
-                .select_related('case_type')
-                .values_list('name', 'index')
+                .select_related('case_type').select_related('group')
+                .order_by('group__index', 'index')
+                .values_list('name', flat=True)
         ):
             case_properties_indices[case_property_name] = case_property_index
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -38,7 +38,8 @@ from dimagi.ext.couchdbkit import (
 from dimagi.utils.couch.database import iter_docs
 from soil.progress import set_task_progress
 
-from corehq import feature_previews
+from corehq import feature_previews, privileges
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.app_schemas.case_properties import (
     ParentCasePropertyBuilder,
 )
@@ -57,6 +58,7 @@ from corehq.apps.app_manager.models import (
     OpenSubCaseAction,
     RemoteApp,
 )
+from corehq.apps.data_dictionary.models import CaseProperty
 from corehq.apps.domain.models import Domain
 from corehq.apps.export.const import (
     ALL_CASE_TYPE_EXPORT,
@@ -2357,6 +2359,11 @@ class CaseExportDataSchema(ExportDataSchema):
         )
         case_property_mapping = builder.get_case_property_map([case_type])
 
+        if domain_has_privilege(app.domain, privileges.DATA_DICTIONARY):
+            case_property_mapping[case_type] = cls._reorder_case_properties_from_data_dictionary(
+                app.domain, case_type, case_property_mapping[case_type]
+            )
+
         parent_types = builder.get_case_relationships_for_case_type(case_type)
         case_schemas = []
         case_schemas.append(cls._generate_schema_from_case_property_mapping(
@@ -2379,6 +2386,35 @@ class CaseExportDataSchema(ExportDataSchema):
         case_schemas.append(current_schema)
 
         return cls._merge_schemas(*case_schemas)
+
+    @classmethod
+    def _reorder_case_properties_from_data_dictionary(cls, domain, case_type, case_properties):
+        """
+        Reorders the list of case properties passed according to ordering of case properties for the case type
+        in Data Dictionary.
+        Deprecated properties are included as well since they could be present in the export.
+
+        :param: domain - domain name
+        :param: case_type - name of case type
+        :param: case_properties - list of case properties corresponding to the case type
+        """
+        case_properties_indices = {}
+
+        filter_kwargs = {'case_type__domain': domain, 'case_type__name': case_type}
+        for case_property_name, case_property_index in (
+            CaseProperty.objects
+                .filter(**filter_kwargs)
+                .select_related('case_type')
+                .values_list('name', 'index')
+        ):
+            case_properties_indices[case_property_name] = case_property_index
+
+        ordered_case_properties = sorted(
+            case_properties,
+            key=lambda prop: case_properties_indices.get(prop, 0)
+        )
+
+        return ordered_case_properties
 
     @classmethod
     def _generate_schema_from_case_property_mapping(cls, case_property_mapping, parent_types, app_id, app_version):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -2310,13 +2310,15 @@ class FormExportDataSchema(ExportDataSchema):
         return items
 
     @classmethod
-    def _process_apps_for_export(cls, domain, schema, identifier, app_build_ids, task):
+    def _process_apps_for_export(cls, domain, schema, identifier, app_build_ids, task,
+                                 for_new_export_instance=False):
         return super(FormExportDataSchema, cls)._process_apps_for_export(
             domain,
             schema,
             identifier,
             app_build_ids,
-            task
+            task,
+            for_new_export_instance=for_new_export_instance
         )
 
 
@@ -2506,7 +2508,8 @@ class CaseExportDataSchema(ExportDataSchema):
         return schema
 
     @classmethod
-    def _process_apps_for_export(cls, domain, schema, identifier, app_build_ids, task):
+    def _process_apps_for_export(cls, domain, schema, identifier, app_build_ids, task,
+                                 for_new_export_instance=False):
         if identifier == ALL_CASE_TYPE_EXPORT:
             return cls._process_apps_for_bulk_export(domain, schema, app_build_ids, task)
         else:
@@ -2515,7 +2518,8 @@ class CaseExportDataSchema(ExportDataSchema):
                 schema,
                 identifier,
                 app_build_ids,
-                task
+                task,
+                for_new_export_instance=for_new_export_instance
             )
 
     @classmethod
@@ -2583,13 +2587,15 @@ class SMSExportDataSchema(ExportDataSchema):
     def get_latest_export_schema(domain, include_metadata, identifier=None):
         return SMSExportDataSchema(domain=domain, include_metadata=include_metadata)
 
-    def _process_apps_for_export(cls, domain, schema, identifier, app_build_ids, task):
-        return super(FormExportDataSchema, cls)._process_apps_for_export(
+    def _process_apps_for_export(cls, domain, schema, identifier, app_build_ids, task,
+                                 for_new_export_instance=False):
+        return super(SMSExportDataSchema, cls)._process_apps_for_export(
             domain,
             schema,
             identifier,
             app_build_ids,
-            task
+            task,
+            for_new_export_instance=for_new_export_instance
         )
 
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -2576,7 +2576,7 @@ class SMSExportDataSchema(ExportDataSchema):
 
     @classmethod
     def generate_schema_from_builds(cls, domain, app_id, identifier, force_rebuild=False,
-            only_process_current_builds=False, task=None):
+                                    only_process_current_builds=False, task=None, for_new_export_instance=False):
         return cls(domain=domain)
 
     @classmethod

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -1423,11 +1423,14 @@ class TestOrderingOfCaseSchemaItemsFromDataDictionary(TestCase, TestXmlMixin):
         data_dictionary_case_types = CaseType.objects.filter(domain=self.domain).all()
         self.assertEqual(len(data_dictionary_case_types), 1)
 
-        case_type = data_dictionary_case_types[0]
-        case_properties = list(CaseProperty.objects.filter(case_type=case_type.pk).values_list('name', flat=True))
-        self.assertEqual(
-            set(case_properties),
-            {'name', 'age', 'height', 'weight', 'address'}
+        self.assertListEqual(
+            list(CaseProperty.objects.order_by('name').values_list('name', 'index')),
+            [('address', 0), ('age', 0), ('height', 1), ('name', 0), ('weight', 0)]
+        )
+
+        self.assertListEqual(
+            list(CasePropertyGroup.objects.order_by('name').values_list('name', 'index')),
+            [('details', 1), ('location', 2)]
         )
 
     @patch('corehq.apps.data_dictionary.util.get_case_types_from_apps')

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -324,12 +324,13 @@ class BaseExportView(BaseProjectDataView):
             return HttpResponseRedirect(url)
 
     @memoized
-    def get_export_schema(self, domain, app_id, identifier):
+    def get_export_schema(self, domain, app_id, identifier, for_new_export_instance=False):
         return self.export_schema_cls.generate_schema_from_builds(
             domain,
             app_id,
             identifier,
             only_process_current_builds=True,
+            for_new_export_instance=for_new_export_instance
         )
 
     @memoized
@@ -432,7 +433,7 @@ class CreateNewCustomCaseExportView(BaseExportView):
         if case_type == ALL_CASE_TYPE_EXPORT:
             schema = self.get_empty_export_schema(self.domain, case_type)
         else:
-            schema = self.get_export_schema(self.domain, None, case_type)
+            schema = self.get_export_schema(self.domain, None, case_type, for_new_export_instance=True)
 
         export_settings = get_default_export_settings_if_available(self.domain)
         self.export_instance = self.create_new_export_instance(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
For domains with access to Data Dictionary, when creating a new case export, the columns for the export will be ordered based on the ordering of case properties in data dictionary.

When editing existing exports, their original ordering is retained because we allow users to set the order of columns when they create exports & so we won't want to change that order for existing exports.

This change is limited to new case exports only.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3451

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.
We are just changing the ordering for only new case exports for domains with access to Data Dictionary, so the impact is to limited users/projects.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added new tests. Old tests should help verify any changes to existing code which is mostly an addition of an optional argument to existing methods.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will go through QA. https://dimagi.atlassian.net/browse/QA-6447

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
