### PR TITLE
[B5] Migration Tooling Improvements

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
@@ -22,7 +22,10 @@ from corehq.apps.hqwebapp.utils.bootstrap.paths import (
     TRACKED_JS_FOLDERS,
     get_app_name_and_slug,
 )
-from corehq.apps.hqwebapp.utils.management_commands import get_confirmation
+from corehq.apps.hqwebapp.utils.management_commands import (
+    get_confirmation,
+    enter_to_continue,
+)
 
 DIFF_CONFIG_FILE = "apps/hqwebapp/tests/data/bootstrap5_diff_config.json"
 DIFF_STORAGE_FOLDER = "apps/hqwebapp/tests/data/bootstrap5_diffs/"
@@ -154,7 +157,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(
                 "You have un-committed changes. Please commit these changes before proceeding...\n"
             ))
-            self.enter_to_continue()
+            enter_to_continue()
 
         if update_app:
             self.update_configuration_file_for_app(update_app)
@@ -249,10 +252,6 @@ class Command(BaseCommand):
             self.stdout.write("\nto rebuild the diffs.")
 
         self.stdout.write("\n\nThank you! <3\n\n")
-
-    @staticmethod
-    def enter_to_continue():
-        input("\nENTER to continue...")
 
     def make_commit(self, message):
         self.stdout.write("\nNow would be a good time to review changes with git and commit.")

--- a/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_bootstrap5_diffs.py
@@ -154,6 +154,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(
                 "You have un-committed changes. Please commit these changes before proceeding...\n"
             ))
+            self.enter_to_continue()
 
         if update_app:
             self.update_configuration_file_for_app(update_app)
@@ -248,6 +249,10 @@ class Command(BaseCommand):
             self.stdout.write("\nto rebuild the diffs.")
 
         self.stdout.write("\n\nThank you! <3\n\n")
+
+    @staticmethod
+    def enter_to_continue():
+        input("\nENTER to continue...")
 
     def make_commit(self, message):
         self.stdout.write("\nNow would be a good time to review changes with git and commit.")

--- a/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
+++ b/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
@@ -13,6 +13,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.paths import (
 )
 from corehq.apps.hqwebapp.utils.management_commands import (
     get_confirmation,
+    enter_to_continue,
 )
 from corehq.apps.hqwebapp.utils.bootstrap.references import (
     get_references,
@@ -45,7 +46,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(
                 "You have un-committed changes. Please commit these changes before proceeding...\n"
             ))
-            self.enter_to_continue()
+            enter_to_continue()
 
         template = options.get('template')
         if template:
@@ -251,10 +252,6 @@ class Command(BaseCommand):
             self.stdout.write("\n\n")
             self.stdout.write("\n".join(list_to_display))
             self.stdout.write("\n\n")
-
-    @staticmethod
-    def enter_to_continue():
-        input("\nENTER to continue...")
 
     def suggest_commit_message(self, message, show_apply_commit=False):
         self.stdout.write("\nNow would be a good time to review changes with git and commit.")

--- a/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
+++ b/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
@@ -58,6 +58,7 @@ class Command(BaseCommand):
         self.mark_app_as_complete(app_name)
 
     def mark_app_as_complete(self, app_name):
+        has_changes = has_pending_git_changes()
         split_paths = [get_short_path(app_name, path, True)
                        for path in get_split_paths(get_all_template_paths_for_app(app_name))]
         split_paths.extend([get_short_path(app_name, path, False)
@@ -73,6 +74,10 @@ class Command(BaseCommand):
             f"\nMarking '{app_name}' as complete!\n\n"
         ))
         mark_app_as_complete(app_name)
+        self.suggest_commit_message(
+            f"Marked '{app_name}' as complete",
+            show_apply_commit=not has_changes
+        )
 
     def mark_file_as_complete(self, app_name, filename, is_template):
         has_changes = has_pending_git_changes()

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -440,11 +440,18 @@ class Command(BaseCommand):
 
         with open(bootstrap5_path, 'w') as bootstrap5_file:
             bootstrap5_file.writelines(bootstrap5_lines)
-        self.stdout.write("\nChanges saved.")
-        self.suggest_commit_message(
-            f"re-ran migration for {bootstrap3_short_path}",
-            show_apply_commit=not has_changes
-        )
+
+        if has_pending_git_changes():
+            self.stdout.write(
+                f"\nChanges applied to {bootstrap5_short_path}."
+            )
+            self.suggest_commit_message(
+                f"re-ran migration for {bootstrap3_short_path}",
+                show_apply_commit=not has_changes
+            )
+        else:
+            self.stdout.write("\nNo changes were necessary!\n")
+            self.enter_to_continue()
 
     def split_files_and_refactor(self, app_name, file_path, bootstrap3_lines, bootstrap5_lines, is_template):
         short_path = get_short_path(app_name, file_path, is_template)

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -142,6 +142,12 @@ class Command(BaseCommand):
             )
             return
 
+        if self.skip_all and (js_name or template_name):
+            self.stderr.write(
+                "\n--skip-all cannot be used with --template-name or --js-name\n"
+            )
+            return
+
         if self.skip_all:
             confirm = get_confirmation("You have elected to skip all the confirmation prompts. "
                                        "Are you sure?")

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -46,6 +46,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.status import (
 from corehq.apps.hqwebapp.utils.management_commands import (
     get_break_line,
     get_confirmation,
+    enter_to_continue,
 )
 
 
@@ -320,7 +321,7 @@ class Command(BaseCommand):
                 changelog.append(self.format_guidance(flag))
                 if review_changes:
                     self.display_flag_summary(changelog)
-                    self.enter_to_continue()
+                    enter_to_continue()
                     self.clear_screen()
                     self.stdout.write(self.format_header(
                         f"Additional changes to line {line_number} will be made..."
@@ -418,7 +419,7 @@ class Command(BaseCommand):
         self.stdout.write(
             "See: https://www.commcarehq.org/styleguide/b5/migration/#migrating-views"
         )
-        self.enter_to_continue()
+        enter_to_continue()
         if has_pending_git_changes():
             self.stdout.write(self.style.WARNING(
                 "\n\nDon't forget to commit these changes!"
@@ -459,7 +460,7 @@ class Command(BaseCommand):
             )
         else:
             self.stdout.write("\nNo changes were necessary!\n")
-            self.enter_to_continue()
+            enter_to_continue()
 
     def split_files_and_refactor(self, app_name, file_path, bootstrap3_lines, bootstrap5_lines, is_template):
         short_path = get_short_path(app_name, file_path, is_template)
@@ -626,10 +627,6 @@ class Command(BaseCommand):
         self.stdout.write(f'\n{response_text}')
         time.sleep(2)
 
-    @staticmethod
-    def enter_to_continue():
-        input("\nENTER to continue...")
-
     def prompt_user_to_commit_changes(self):
         self.stdout.write(self.style.ERROR(
             "\nYou have un-committed changes! Please commit these changes before proceeding. Thank you!"
@@ -651,4 +648,4 @@ class Command(BaseCommand):
         self.stdout.write("\n\nSuggested command:\n")
         self.stdout.write(self.style.MIGRATE_HEADING(commit_string))
         self.stdout.write("\n")
-        self.enter_to_continue()
+        enter_to_continue()

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -131,26 +131,11 @@ class Command(BaseCommand):
             )
             return
 
-        if self.skip_all:
-            confirm = get_confirmation("You have elected to skip all the confirmation prompts. "
-                                       "Are you sure?")
-            if not confirm:
-                return
-
         if self.skip_all and has_pending_git_changes():
             self.stdout.write(self.style.ERROR(
                 "You have un-committed changes. Please commit these changes before proceeding...\n"
             ))
             ensure_no_pending_changes_before_continuing()
-
-        if self.no_split:
-            self.stdout.write(self.style.WARNING(
-                "\n\nYou have elected to skip the split files step and will apply migration "
-                "changes directly to each un-migrated file.\n"
-            ))
-            confirm = get_confirmation("Are you sure?")
-            if not confirm:
-                return
 
         spec = get_spec('bootstrap_3_to_5')
         verify_references = options.get('verify_references')

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -189,7 +189,12 @@ class Command(BaseCommand):
     @staticmethod
     def _get_files_for_migration(files, file_name):
         if file_name:
-            return [path for path in files if file_name in str(path)]
+            files = [path for path in files if file_name in str(path)]
+            if len(files) > 1 and not is_bootstrap5_path(file_name):
+                files = [
+                    path for path in files if not is_bootstrap5_path(path)
+                ]
+            return files
         return [path for path in files if not is_split_path(path)]
 
     def get_templates_for_migration(self, app_name, selected_filename):

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -131,12 +131,6 @@ class Command(BaseCommand):
             )
             return
 
-        if self.skip_all and selected_filename:
-            self.stderr.write(
-                "\n--skip-all cannot be used with --filename\n"
-            )
-            return
-
         if self.skip_all:
             confirm = get_confirmation("You have elected to skip all the confirmation prompts. "
                                        "Are you sure?")

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -86,6 +86,9 @@ class Command(BaseCommand):
         if not settings.BOOTSTRAP_MIGRATION_LOGS_DIR:
             self.stderr.write("\nPlease make sure BOOTSTRAP_MIGRATION_LOGS_DIR is "
                               "set in your localsettings.py before continuing...\n\n")
+            self.stdout.write(self.style.MIGRATE_LABEL(
+                "TIP: path should be outside of this repository\n\n"
+            ))
             return
 
         template_name = options.get('template_name')

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -297,7 +297,8 @@ class Command(BaseCommand):
                 self.record_file_changes(file_path, app_name, file_changelog, is_template)
                 if self.no_split:
                     self.migrate_file_in_place(app_name, file_path, new_lines, is_template)
-                    self.show_next_steps_after_migrating_file_in_place(short_path)
+                    if is_template:
+                        self.show_next_steps_after_migrating_file_in_place(short_path)
                 elif '/bootstrap3/' in str(file_path):
                     self.migrate_file_again(app_name, file_path, new_lines, is_template)
                 else:

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -137,9 +137,9 @@ class Command(BaseCommand):
         self.no_split = options.get('no_split')
         self.skip_all = options.get('skip_all')
         if self.skip_all and self.no_split:
-            self.stderr.write((
+            self.stderr.write(
                 "\n--skip-all and --no-split cannot be used at the same time.\n"
-            ))
+            )
             return
 
         if self.skip_all:

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -401,7 +401,7 @@ class Command(BaseCommand):
 
     def migrate_file_in_place(self, app_name, file_path, bootstrap5_lines, is_template):
         short_path = get_short_path(app_name, file_path, is_template)
-        confirm = get_confirmation(f"Apply changes to '{short_path}'?")
+        confirm = get_confirmation(f"Apply changes to '{short_path}'?", default='y')
         if not confirm:
             self.write_response("ok, discarding changes...")
 

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -419,6 +419,13 @@ class Command(BaseCommand):
             "See: https://www.commcarehq.org/styleguide/b5/migration/#migrating-views"
         )
         self.enter_to_continue()
+        if has_pending_git_changes():
+            self.stdout.write(self.style.WARNING(
+                "\n\nDon't forget to commit these changes!"
+            ))
+            self.suggest_commit_message(
+                f"added use_bootstrap5 decorator to views referencing {short_path}"
+            )
 
     def migrate_file_again(self, app_name, bootstrap3_path, bootstrap5_lines, is_template):
         bootstrap5_path = self.get_bootstrap5_path(bootstrap3_path)

--- a/corehq/apps/hqwebapp/management/commands/show_invalid_bootstrap3_files.py
+++ b/corehq/apps/hqwebapp/management/commands/show_invalid_bootstrap3_files.py
@@ -145,16 +145,15 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.MIGRATE_LABEL(
                     "Issues with templates:\n"
                 ))
-                self.show_app_issue_summary(app_name, template_issues, is_template=True)
+                self.show_app_issue_summary(app_name, template_issues)
             javascript_issues = summary[1].get('javascript', [])
             if javascript_issues:
                 self.stdout.write(self.style.MIGRATE_LABEL(
-                    "Issues with javascript:"
+                    "Issues with javascript:\n"
                 ))
-                self.show_app_issue_summary(app_name, javascript_issues, is_template=False)
+                self.show_app_issue_summary(app_name, javascript_issues)
 
-    def show_app_issue_summary(self, app_name, issues, is_template):
-        argument = "--template-name" if is_template else "--js-name"
+    def show_app_issue_summary(self, app_name, issues):
         for issue in issues:
             path = issue[0]
             self.stdout.write(self.style.WARNING(
@@ -166,7 +165,7 @@ class Command(BaseCommand):
                 self.stdout.write(f"\t{flag_list}")
             self.stdout.write("\nto fix this, run:")
             self.stdout.write(self.style.MIGRATE_HEADING(
-                f"./manage.py migrate_app_to_bootstrap5 {app_name} {argument} {path}\n"
+                f"./manage.py migrate_app_to_bootstrap5 {app_name} --filename {path}\n"
             ))
             self.enter_to_continue()
 

--- a/corehq/apps/hqwebapp/management/commands/show_invalid_bootstrap3_files.py
+++ b/corehq/apps/hqwebapp/management/commands/show_invalid_bootstrap3_files.py
@@ -8,6 +8,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.paths import (
     get_all_template_paths_for_app,
     get_all_javascript_paths_for_app,
     get_short_path,
+    is_split_path,
 )
 from corehq.apps.hqwebapp.utils.bootstrap.status import (
     get_apps_completed_or_in_progress,
@@ -44,13 +45,8 @@ IGNORED_FILES = [
 ]
 
 
-def _is_split_path(path):
-    path = str(path)
-    return "/bootstrap3/" in path or "/bootstrap5/" in path
-
-
 def _is_relevant_path(path, completed_paths):
-    return not (_is_split_path(path) or str(path) in completed_paths)
+    return not (is_split_path(path) or str(path) in completed_paths)
 
 
 def _get_bootstrap3_flags_from_file(file_path, is_template):

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -65,6 +65,15 @@ def test_make_javascript_dependency_renames():
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
+def test_make_javascript_dependency_renames_hqdefine():
+    line = """hqDefine("hqwebapp/js/bootstrap3/prepaid_modal", [\n"""
+    final_line, renames = make_javascript_dependency_renames(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    eq(final_line, """hqDefine("hqwebapp/js/bootstrap5/prepaid_modal", [\n""")
+    eq(renames, ['renamed bootstrap3 to bootstrap5'])
+
+
 def test_flag_changed_css_classes_bootstrap5():
     line = """        <dl class="dl-horizontal">\n"""
     flags = flag_changed_css_classes(

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -51,7 +51,7 @@ def _get_template_reference_regex(tag, reference):
 
 
 def _get_javascript_reference_regex(reference):
-    return r"(['\"][\w/.\-]+/)(" + reference + r")(/[\w/.\-]+['\"],?)$"
+    return r"(['\"][\w/.\-]+/)(" + reference + r")(/[\w/.\-]+['\"],?)"
 
 
 def _do_rename(line, change_map, regex_fn, replacement_fn):

--- a/corehq/apps/hqwebapp/utils/bootstrap/paths.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/paths.py
@@ -14,6 +14,11 @@ PARENT_PATHS = {
 }
 
 
+def is_split_path(path):
+    path = str(path)
+    return "/bootstrap3/" in path or "/bootstrap5/" in path
+
+
 def get_app_name_and_slug(app_name):
     app_parts = app_name.split(".")
     if len(app_parts) == 2:

--- a/corehq/apps/hqwebapp/utils/bootstrap/paths.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/paths.py
@@ -19,6 +19,10 @@ def is_split_path(path):
     return "/bootstrap3/" in path or "/bootstrap5/" in path
 
 
+def is_bootstrap5_path(path):
+    return '/bootstrap5/' in str(path)
+
+
 def get_app_name_and_slug(app_name):
     app_parts = app_name.split(".")
     if len(app_parts) == 2:

--- a/corehq/apps/hqwebapp/utils/bootstrap/status.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status.py
@@ -71,7 +71,7 @@ def mark_javascript_as_complete(app_name, js_short_path):
 def _mark_file_as_complete(app_name, short_path, file_type):
     app_summary = get_app_status_summary(app_name)
     app_summary.setdefault(file_type, []).append(
-        short_path.lstrip(f"{app_name}/")
+        short_path.removeprefix(f"{app_name}/")
     )
     apply_app_summary_changes(app_name, app_summary)
 

--- a/corehq/apps/hqwebapp/utils/management_commands.py
+++ b/corehq/apps/hqwebapp/utils/management_commands.py
@@ -24,3 +24,7 @@ def select_option_from_prompt(prompt, options, default=None):
 def get_confirmation(prompt, default=None):
     option = select_option_from_prompt(prompt, ['y', 'n'], default=default)
     return option == 'y'
+
+
+def enter_to_continue():
+    input("\nENTER to continue...")

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
@@ -15,10 +15,14 @@
       <li><a href="#overview">Overview</a></li>
       <li><a href="#prepare-local-environment">Prepare Local Environment</a></li>
       <li><a href="#announce-migration">Step 1: Announce Migration</a></li>
-      <li><a href="#split-files">Step 2: Split Files</a>
+      <li><a href="#split-files">Step 2: Auto-Migrate &amp; Split Files</a>
         <ul>
+          <li><a href="#pre-work">Pre-Work: Lint</a></li>
+          <li><a href="#large-apps">Migrating Large Apps</a></li>
           <li><a href="#update-diffs">Configure &amp; Update Diffs</a></li>
           <li><a href="#verify-references">Verify References</a></li>
+          <li><a href="#re-migrate">Re-Migrate Files</a></li>
+          <li><a href="#small-apps">Migrating Smaller Apps</a></li>
         </ul>
       </li>
       <li><a href="#update-stylesheets">Step 2B: Migrate Stylesheets</a></li>
@@ -118,13 +122,25 @@
   </div>
 
   <h2 id="split-files" class="pt-4">
-    Step 2: Split Files
+    Step 2: Auto-Migrate &amp; Split Files
   </h2>
   <p>
     The next step is to split affected template and javascript files into <code>bootstrap3</code> and
     <code>bootstrap5</code> versions. This is an automated process that uses a management command to find and
     replace the straightforward changes, while flagging more complex changes to be addressed later.
   </p>
+  <p>
+    Once the migration changes are staged, the file and split into the two bootstrap versions, with the
+    migration changes saved to the <code>bootstrap5</code> version. The two files are then saved to separate
+    <code>bootstrap3</code> and <code>bootstrap5</code> directories under the original parent directory.
+  </p>
+  <p>
+    The command will then find references to the original filepath and replace them with the filepath to the
+    <code>bootstrap3</code> version.
+  </p>
+  <h3 id="pre-work" class="pt-3">
+    Pre-Work: Lint JavaScript
+  </h3>
   <p>
     Pre-work: Your life will be easier if you lint the app's JavaScript <em>before</em> the migration script
     duplicates every js file. This is usually not arduous. To find lint errors, make sure you have
@@ -144,12 +160,16 @@
     <strong>Important:</strong> Avoid including lint fixes and split-files changes in the SAME commit.
     These changes MUST be separated.
   </div>
+
+  <h3 id="large-apps" class="pt-3">
+    Step 2.1A: Migrating Large Apps
+  </h3>
   <p>
-    Now, on to the migration.
     Please set aside focused time to PR these changes as soon as possible to avoid any migration conflicts or
     missed renamed references, especially in parts of the codebase that are undergoing frequent front-end changes. This
     initial "split file" Pull Request should <strong>only</strong> contain changes automatically made by the management command.
     Additional changes should be made in subsequent PRs.
+    <a href="https://github.com/dimagi/commcare-hq/pull/34345" target="_blank">Here is an example Pull Request</a> of this step.
   </p>
   <p>
     Use the management command below with <code>&lt;app_name&gt;</code> being the
@@ -157,7 +177,7 @@
   </p>
   <div class="card text-bg-light mb-3">
     <div class="card-body">
-      <pre class="m-0">./manage.py migrate_app_to_bootstrap5 &lt;app_name&gt;</pre>
+      <pre class="m-0">./manage.py migrate_app_to_bootstrap5 &lt;app_name&gt; --skip-all</pre>
     </div>
   </div>
   <p>
@@ -165,23 +185,20 @@
     <code>&lt;app_name&gt;</code>.
   </p>
   <p>
-    The management command will iterate through all template and javascript files in the app. You have the option to
-    review and accept each change line-by-line or review the diff for each file at the end.
-    A changelog for each file will be saved to a markdown file in <code>BOOTSTRAP_MIGRATION_LOGS_DIR</code>.
-  </p>
-  <div class="alert alert-primary">
-    Due to potential merge conflict issues, the markdown files outputted to <code>BOOTSTRAP_MIGRATION_LOGS_DIR</code>
-    are not version controlled. If you want to work on migrating an application with multiple people, you can zip
-    these markdown files and share with your collaborators for future reference.
-  </div>
-  <p>
-    Once a file is updated and split into the two bootstrap versions, the command will
-    find references to the original filepath and replace them with the filepath to the <code>bootstrap3</code> version.
+    The option <code>--skip-all</code> is optional, but recommended unless you have a particularly tricky app
+    as it speeds up the migration process by auto-committing the split files changes for each template and
+    javascript file in the app.
   </p>
   <p>
-    After applying all the actions related to splitting a file, it is recommended to commit those changes before
-    moving on to the next file. The management command will prompt you to do this with a suggested commit message.
-    Formatting our commits this way is important to maintain a clean git history.
+    If <code>--skip-all</code> is not used, the management command will iterate through all template and javascript
+    files in the app. You have the option to review and accept each change line-by-line or review
+    the diff for each file at the end.
+  </p>
+  <p>
+    Regardless of what route you take, a changelog for each file will be saved to a markdown file in
+    <code>BOOTSTRAP_MIGRATION_LOGS_DIR</code> (ouside of repository).
+    If you want to work on migrating an application with multiple people, you can zip these markdown files and
+    share with your collaborators for future reference.
   </p>
   <div class="alert alert-primary">
     <p>
@@ -205,10 +222,10 @@
   </div>
 
   <h3 id="update-diffs" class="pt-3">
-    Configure &amp; Update Diffs
+    Step 2.2: Configure &amp; Update Diffs
   </h3>
   <p>
-    Since an app migration usually takes several weeks, we need to ensure that any changes
+    Since a large app migration usually takes several weeks, we need to ensure that any changes
     made to <code>bootstrap3</code> templates during this time are kept in sync with their <code>bootstrap5</code>
     counterparts. We do this by saving diffs of the split files and running tests against them to ensure diffs stay the
     same. Once changes are made to both split files, the diffs can be regenerated so that tests continue to pass.
@@ -243,7 +260,7 @@
   </div>
 
   <h3 id="verify-references" class="pt-3">
-    Verify References
+    Step 2.3: Verify References
   </h3>
   <p>
     Right before submitting the "split files" Pull Request, it is important to rebase the latest <code>master</code>
@@ -263,6 +280,72 @@
   <p>
     After verifying references, it might be necessary to run <code>build_bootstrap5_diffs</code> again before finally
     opening the Pull Request.
+  </p>
+
+  <h3 id="re-migrate" class="pt-3">
+    Step 2.4: Re-Migrate Files
+  </h3>
+  <p>
+    There is a chance that during the time your split-files PR was open, someone might have added a new template or
+    javascript file, or made a change to one of the <code>bootstrap3</code> versions of an already split file.
+    If you merge <code>master</code> into your split files branch and find that the diffs have diverged for a file,
+    please run the following command to re-migrate the <code>bootstrap3</code> version of that file.
+  </p>
+  <p>
+    If the file is a template, please run:
+  </p>
+  <div class="card text-bg-light mb-3">
+    <div class="card-body">
+      <pre class="m-0">./manage.py migrate_app_to_bootstrap5 &lt;app_name&gt; --template-name &lt;file_path&gt;</pre>
+    </div>
+  </div>
+  <p>
+    If the file is a javascript file, please run:
+  </p>
+  <div class="card text-bg-light mb-3">
+    <div class="card-body">
+      <pre class="m-0">./manage.py migrate_app_to_bootstrap5 &lt;app_name&gt; --js-name &lt;file_path&gt;</pre>
+    </div>
+  </div>
+  <p>
+    In this usage, <code>&lt;file_path&gt;</code> can either be the file name of the diverged file or the relative path.
+    For example, if <code>builds/bootstrap3/edit_menu.html</code> diverged, you can specify <code>edit_menu.html</code>
+    or <code>builds/bootstrap3/edit_menu.html</code> as the <code>&lt;file_path&gt;</code>.
+  </p>
+  <p>
+    This command will then re-apply the migration changes to the <code>bootstrap3</code> file and then save those
+    changes to the <code>bootstrap5</code> version. You can then commit those changes and then run
+    <code>build_bootstrap5_diffs</code> to rebuild the diffs.
+  </p>
+
+  <h3 id="small-apps" class="pt-3">
+    Step 2.1B: Migrating Smaller Apps
+  </h3>
+  <p>
+    Some apps only have a handful of templates and javascript files, and it's possible to run the auto-migration
+    on the templates in-place and migrate the views to Bootstrap 5 all within the same Pull Request. In this case,
+    you can make use of the <code>--no-split</code> option for <code>migrate_app_to_bootstrap5</code>.
+  </p>
+  <div class="card text-bg-light mb-3">
+    <div class="card-body">
+      <pre class="m-0">./manage.py migrate_app_to_bootstrap5 &lt;app_name&gt; --no-split</pre>
+    </div>
+  </div>
+  <p>
+    This option will iterate through all the templates and javascript files in <code>&lt;app_name&gt;</code>. After
+    staging the changes to each file, you will have the option to auto-commit those changes.
+  </p>
+  <p>
+    For each migrated template, the command will wait for you to apply the <code>@use_bootstrap5</code> decorator
+    to the relevant views (see <a href="#migrating-views">Migrating Views</a>) before moving on to the next template.
+  </p>
+  <p>
+    Once all the files are migrated in-place, you can then make additional manual changes to each template and view.
+    When the views are fully migrated, you can then create your pull request.
+  </p>
+  <p>
+    This option is useful for smaller apps, because it avoids the split-files and reference renames. Please only
+    choose this option if you are confident you can migrate all the views and javascript files within 1 to 2 weeks.
   </p>
 
   <h2 id="update-stylesheets" class="pt-4">

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
@@ -291,20 +291,9 @@
     If you merge <code>master</code> into your split files branch and find that the diffs have diverged for a file,
     please run the following command to re-migrate the <code>bootstrap3</code> version of that file.
   </p>
-  <p>
-    If the file is a template, please run:
-  </p>
   <div class="card text-bg-light mb-3">
     <div class="card-body">
-      <pre class="m-0">./manage.py migrate_app_to_bootstrap5 &lt;app_name&gt; --template-name &lt;file_path&gt;</pre>
-    </div>
-  </div>
-  <p>
-    If the file is a javascript file, please run:
-  </p>
-  <div class="card text-bg-light mb-3">
-    <div class="card-body">
-      <pre class="m-0">./manage.py migrate_app_to_bootstrap5 &lt;app_name&gt; --js-name &lt;file_path&gt;</pre>
+      <pre class="m-0">./manage.py migrate_app_to_bootstrap5 &lt;app_name&gt; --filename &lt;file_path&gt;</pre>
     </div>
   </div>
   <p>


### PR DESCRIPTION
## Technical Summary
Some tweaks and improvements to the migration tool `migrate_app_to_bootstrap5` and cleanups in related tools.

🐟  Review commit-by-commit. Commits are very small and individually easy to digest.

highlights:
- ⭐ adds a `--no-split` option in `migrate_app_to_bootstrap5` for smaller app migration workflows, allowing migrations of templates and javascript IN PLACE (no file splitting). The command then pauses after the migration changes are made and prompts you to add the `@use_bootstrap5` decorator to the relevant views before moving to the next file.
- ⭐ Updates the `--template-name` and `--js-name` options so that if a `bootstrap3` path is specified, it will re-migrate that `bootstrap3` file and then update the associated `bootstrap5` file, allowing quick resolutions of situations where other folks have made changes to the split templates while the split files PR was in progress. It also allows for re-migrating files that were previously migrated to apply new automation/improvements from `migrate_app_to_bootstrap5` if it's been a while since that file has been migrated.
- 📄 Docs have been updated for the above options
- 🐞 fixes the issue in `complete_bootstrap5_migration` where `case_search/case_search.html` got stored as `.html` in the completed file list 🤦‍♀️ 
- 🧹  cleanup / tidying of small things here and there.
- 🚫 removes the `--re-check` option from `migrate_app_to_bootstrap5` as the changes to `--template-name` and `--js-name` are much better solutions for the original intention of that option. I don't think we want to apply migrations again to `bootstrap5` templates ever, as that will not be valid for things like `col-<size>` updates, and will involve actually having to go through things change-by-change.


## Safety Assurance

### Safety story
Only touches internal tools. Important parts have tests. :)

### Automated test coverage
Yes, the important bits are tested

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
