### PR TITLE
Redirect app updates instead of syncs/submissions

### DIFF
--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -19,6 +19,7 @@ from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.decorators import (
+    check_redirect,
     safe_cached_download,
     safe_download,
 )
@@ -55,6 +56,7 @@ def _get_build_profile_id(request):
 
 
 @safe_download
+@check_redirect
 def download_odk_profile(request, domain, app_id):
     """
     See ApplicationBase.create_profile
@@ -73,6 +75,7 @@ def download_odk_profile(request, domain, app_id):
 
 
 @safe_download
+@check_redirect
 def download_odk_media_profile(request, domain, app_id):
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
@@ -87,6 +90,7 @@ def download_odk_media_profile(request, domain, app_id):
 
 
 @safe_cached_download
+@check_redirect
 def download_suite(request, domain, app_id):
     """
     See Application.create_suite
@@ -101,6 +105,7 @@ def download_suite(request, domain, app_id):
 
 
 @safe_cached_download
+@check_redirect
 def download_media_suite(request, domain, app_id):
     """
     See Application.create_media_suite
@@ -115,6 +120,7 @@ def download_media_suite(request, domain, app_id):
 
 
 @safe_cached_download
+@check_redirect
 def download_app_strings(request, domain, app_id, lang):
     """
     See Application.create_app_strings
@@ -128,6 +134,7 @@ def download_app_strings(request, domain, app_id, lang):
 
 
 @safe_cached_download
+@check_redirect
 def download_xform(request, domain, app_id, module_id, form_id):
     """
     See FormBase.render_xform
@@ -166,6 +173,7 @@ class DownloadCCZ(DownloadMultimediaZip):
 
 
 @safe_cached_download
+@check_redirect
 def download_file(request, domain, app_id, path):
     download_target_version = request.GET.get('download_target_version') == 'true'
     if download_target_version:
@@ -273,6 +281,7 @@ def download_file(request, domain, app_id, path):
 
 
 @safe_download
+@check_redirect
 def download_profile(request, domain, app_id):
     """
     See ApplicationBase.create_profile
@@ -290,6 +299,7 @@ def download_profile(request, domain, app_id):
 
 
 @safe_download
+@check_redirect
 def download_media_profile(request, domain, app_id):
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
@@ -303,6 +313,7 @@ def download_media_profile(request, domain, app_id):
 
 
 @safe_cached_download
+@check_redirect
 def download_practice_user_restore(request, domain, app_id):
     if not request.app.copy_of:
         autogenerate_build(request.app, request.user.username)

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -89,8 +89,8 @@ def download_odk_media_profile(request, domain, app_id):
     )
 
 
-@safe_cached_download
 @check_redirect
+@safe_cached_download
 def download_suite(request, domain, app_id):
     """
     See Application.create_suite
@@ -104,8 +104,8 @@ def download_suite(request, domain, app_id):
     )
 
 
-@safe_cached_download
 @check_redirect
+@safe_cached_download
 def download_media_suite(request, domain, app_id):
     """
     See Application.create_media_suite
@@ -119,8 +119,8 @@ def download_media_suite(request, domain, app_id):
     )
 
 
-@safe_cached_download
 @check_redirect
+@safe_cached_download
 def download_app_strings(request, domain, app_id, lang):
     """
     See Application.create_app_strings
@@ -133,8 +133,8 @@ def download_app_strings(request, domain, app_id, lang):
     )
 
 
-@safe_cached_download
 @check_redirect
+@safe_cached_download
 def download_xform(request, domain, app_id, module_id, form_id):
     """
     See FormBase.render_xform
@@ -172,8 +172,8 @@ class DownloadCCZ(DownloadMultimediaZip):
         super(DownloadCCZ, self).check_before_zipping()
 
 
-@safe_cached_download
 @check_redirect
+@safe_cached_download
 def download_file(request, domain, app_id, path):
     download_target_version = request.GET.get('download_target_version') == 'true'
     if download_target_version:
@@ -312,8 +312,8 @@ def download_media_profile(request, domain, app_id):
     )
 
 
-@safe_cached_download
 @check_redirect
+@safe_cached_download
 def download_practice_user_restore(request, domain, app_id):
     if not request.app.copy_of:
         autogenerate_build(request.app, request.user.username)

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -1,6 +1,5 @@
 import logging
 from functools import wraps
-from urllib.parse import urljoin
 
 from django.conf import settings
 from django.contrib import messages
@@ -671,13 +670,6 @@ cls_require_superuser_or_contractor = cls_to_view(additional_decorator=require_s
 
 def check_domain_migration(view_func):
     def wrapped_view(request, domain, *args, **kwargs):
-        domain_obj = Domain.get_by_name(domain)
-        if domain_obj.redirect_url:
-            # IMPORTANT!
-            #     We assume that the domain name is the same on both
-            #     environments.
-            url = urljoin(domain_obj.redirect_url, request.path)
-            return HttpResponseRedirect(url)
         if DATA_MIGRATION.enabled(domain):
             auth_logger.info(
                 "Request rejected domain=%s reason=%s request=%s",

--- a/corehq/apps/domain/management/commands/redirect_url.py
+++ b/corehq/apps/domain/management/commands/redirect_url.py
@@ -8,19 +8,18 @@ from corehq.toggles import DATA_MIGRATION
 
 class Command(BaseCommand):
     help = (
-        'Sets the redirect URL for a "308 Permanent Redirect" response to '
-        'form submissions and syncs. Only valid for domains that have been '
-        'migrated to new environments. Set the schema and hostname only '
-        '(e.g. "https://example.com/"). The rest of the path will be appended '
-        'for redirecting different endpoints. THIS FEATURE ASSUMES THE DOMAIN '
-        'NAME IS THE SAME ON BOTH ENVIRONMENTS.'
+        'Sets the redirect URL for a "302 Found" redirect response to app '
+        'update requests from CommCare Mobile. Set the base URL only '
+        '(e.g. "https://example.com/"). THIS FEATURE ASSUMES THAT THE DOMAIN '
+        'WAS MIGRATED FROM THIS ENVIRONMENT TO THE TARGET ENVIRONMENT: Domain '
+        'names must match; App IDs must match; User IDs must match.'
     )
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
         parser.add_argument(
             '--set',
-            help="The URL to redirect to",
+            help="The base URL to redirect to",
         )
         parser.add_argument(
             '--unset',
@@ -44,8 +43,7 @@ class Command(BaseCommand):
 
         if domain_obj.redirect_url:
             self.stdout.write(
-                'Form submissions and syncs are redirected to '
-                f'{domain_obj.redirect_url}'
+                f'App updates are redirected to {domain_obj.redirect_url}'
             )
         else:
             self.stdout.write('Redirect URL not set')

--- a/corehq/apps/domain/tests/test_redirect_url.py
+++ b/corehq/apps/domain/tests/test_redirect_url.py
@@ -134,10 +134,7 @@ class TestCheckDomainMigration(TestCase):
 
     def test_redirect_response(self):
         with _set_redirect_url():
-            response = self.client.get(reverse(
-                'download_odk_media_profile',
-                args=[DOMAIN, self.app._id],
-            ), {'latest': 'true'})
+            response = self._download_odk_media_profile()
             self.assertEqual(response.status_code, 302)
             self.assertEqual(
                 response.url,
@@ -146,15 +143,27 @@ class TestCheckDomainMigration(TestCase):
             )
 
     def test_normal_response(self):
-        response = self.client.get(reverse(
-            'download_odk_media_profile',
-            args=[DOMAIN, self.app._id],
-        ))
+        response = self._download_odk_media_profile()
         self.assertEqual(response.status_code, 200)
         self.assertRegex(
             response.content.decode('utf-8'),
             r"^<\?xml version='1.0' encoding='UTF-8'\?>"
         )
+
+    @flag_enabled('DATA_MIGRATION')
+    def test_data_migration_doesnt_block_updates(self):
+        response = self._download_odk_media_profile()
+        self.assertEqual(response.status_code, 200)
+        self.assertRegex(
+            response.content.decode('utf-8'),
+            r"^<\?xml version='1.0' encoding='UTF-8'\?>"
+        )
+
+    def _download_odk_media_profile(self):
+        return self.client.get(reverse(
+            'download_odk_media_profile',
+            args=[DOMAIN, self.app._id],
+        ), {'latest': 'true'})
 
 
 @contextmanager

--- a/corehq/apps/domain/tests/test_redirect_url.py
+++ b/corehq/apps/domain/tests/test_redirect_url.py
@@ -140,6 +140,7 @@ class TestCheckDomainMigration(TestCase):
                 response.url,
                 f'https://example.com/a/{DOMAIN}/apps/download/{self.app._id}'
                 '/media_profile.ccpr?latest=true'
+                f'&username=user%40{DOMAIN}.commcarehq.org'
             )
 
     def test_normal_response(self):
@@ -163,7 +164,7 @@ class TestCheckDomainMigration(TestCase):
         return self.client.get(reverse(
             'download_odk_media_profile',
             args=[DOMAIN, self.app._id],
-        ), {'latest': 'true'})
+        ), {'latest': 'true', 'username': f'user@{DOMAIN}.commcarehq.org'})
 
 
 @contextmanager

--- a/corehq/apps/domain/tests/test_redirect_url.py
+++ b/corehq/apps/domain/tests/test_redirect_url.py
@@ -55,8 +55,7 @@ class TestRedirectUrlCommand(TestCase):
         stdout = self._call_redirect_url('--set', 'https://example.com/')
         self.assertEqual(
             stdout,
-            'Form submissions and syncs are redirected to '
-            'https://example.com/\n'
+            'App updates are redirected to https://example.com/\n'
         )
 
     def test_unset_url_data_migration_not_enabled(self):
@@ -75,8 +74,7 @@ class TestRedirectUrlCommand(TestCase):
             stdout = self._call_redirect_url()
             self.assertEqual(
                 stdout,
-                'Form submissions and syncs are redirected to '
-                'https://example.com/\n'
+                'App updates are redirected to https://example.com/\n'
             )
 
     @flag_enabled('DATA_MIGRATION')
@@ -85,8 +83,7 @@ class TestRedirectUrlCommand(TestCase):
             stdout = self._call_redirect_url()
             self.assertEqual(
                 stdout,
-                'Form submissions and syncs are redirected to '
-                'https://example.com/\n'
+                'App updates are redirected to https://example.com/\n'
             )
 
     def test_return_unset_url_data_migration_not_enabled(self):

--- a/corehq/apps/domain/tests/test_redirect_url.py
+++ b/corehq/apps/domain/tests/test_redirect_url.py
@@ -7,11 +7,9 @@ from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 
+from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.users.models import WebUser
-from corehq.const import OPENROSA_VERSION_2
-from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.util.test_utils import flag_enabled
 
 DOMAIN = 'test-redirect-url'
@@ -112,64 +110,51 @@ class TestRedirectUrlCommand(TestCase):
 
 class TestCheckDomainMigration(TestCase):
     """
-    Tests the ``receiver_post`` view, which is wrapped with the
-    ``corehq.apps.domain.decorators.check_domain_migration`` decorator.
+    Tests the ``download_odk_media_profile`` view, which is wrapped with
+    the ``corehq.apps.app_manager.decorators.check_redirect`` decorator.
 
-    All relevant views are protected by that decorator during and after
-    data migration. These tests verify that the decorator returns a 302
-    redirect response when the domain's ``redirect_url`` is set, and a
-    503 service unavailable response when it is not set.
+    All relevant views are protected by that decorator. These tests
+    verify that the decorator returns a 302 redirect response when the
+    domain's ``redirect_url`` is set, and a normal response when it is
+    not set.
     """
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.domain_obj = create_domain(DOMAIN)
-        cls.user = WebUser.create(
-            None, 'admin', 'Passw0rd!',
-            None, None,
-        )
-        cls.user.add_domain_membership(DOMAIN, is_admin=True)
-        cls.user.save()
+        cls.app = Application.new_app(DOMAIN, "TestApp")
+        cls.app.save()
         cls.client = Client()
-        cls.client.login(username='admin', password='Passw0rd!')
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(DOMAIN, deleted_by=None)
         cls.domain_obj.delete()
         super().tearDownClass()
 
-    @flag_enabled('DATA_MIGRATION')
     def test_redirect_response(self):
         with _set_redirect_url():
-            response = self._submit_form()
+            response = self.client.get(reverse(
+                'download_odk_media_profile',
+                args=[DOMAIN, self.app._id],
+            ), {'latest': 'true'})
             self.assertEqual(response.status_code, 302)
             self.assertEqual(
                 response.url,
-                'https://example.com/a/test-redirect-url/receiver/'
+                f'https://example.com/a/{DOMAIN}/apps/download/{self.app._id}'
+                '/media_profile.ccpr?latest=true'
             )
 
-    @flag_enabled('DATA_MIGRATION')
-    def test_service_unavailable_response(self):
-        response = self._submit_form()
-        self.assertEqual(response.status_code, 503)
-        self.assertEqual(
+    def test_normal_response(self):
+        response = self.client.get(reverse(
+            'download_odk_media_profile',
+            args=[DOMAIN, self.app._id],
+        ))
+        self.assertEqual(response.status_code, 200)
+        self.assertRegex(
             response.content.decode('utf-8'),
-            'Service Temporarily Unavailable',
+            r"^<\?xml version='1.0' encoding='UTF-8'\?>"
         )
-
-    def _submit_form(self):
-        form = """<?xml version='1.0' ?>
-        <form>Not a real form</form>
-        """
-        with StringIO(form) as f:
-            response = self.client.post(
-                reverse("receiver_post", args=[DOMAIN]),
-                {"xml_submission_file": f},
-                **{OPENROSA_VERSION_HEADER: OPENROSA_VERSION_2}
-            )
-        return response
 
 
 @contextmanager


### PR DESCRIPTION
## Product Description

This change allows domains that have been migrated to third-party-managed hosts to redirect app updates to their new host.

This avoids problems when deployed CommCare apps are not using a DNS alias prior to the migration.

## Technical Summary

Based on discussions with the Mobile team, we are adopting a slightly different approach from that taken in PR https://github.com/dimagi/commcare-hq/pull/34461

Instead of redirecting restores/syncs and form submissions, we are redirecting app updates instead.

Jira: [SC-3628](https://dimagi.atlassian.net/browse/SC-3628)

Documentation: [Redirect on Data Migration](https://docs.google.com/document/d/1mQxRmboW3CuOkmklUjf5jypgJcv9VX_e26TEiFh1CyI/edit)

FYI @avazirna 

## Feature Flag

Data Migration

## Safety Assurance

### Safety story

HQ behavior verified by unit tests. Tested in collaboration with Mobile team.

### Automated test coverage

Tests included

### QA Plan

QA ticket: [QA-6406](https://dimagi.atlassian.net/browse/QA-6406)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3628]: https://dimagi.atlassian.net/browse/SC-3628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-6406]: https://dimagi.atlassian.net/browse/QA-6406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ