### PR TITLE
Added .hide to direct CSS renames in bootstrap_3_to_5.json

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
@@ -8,6 +8,7 @@
         "badge-warning": "text-bg-warning",
         "badge-info": "text-bg-info",
         "badge-light": "text-bg-light",
+        "hide": "d-none",
         "label": "badge",
         "label-default": "text-bg-secondary",
         "label-primary": "text-bg-primary",


### PR DESCRIPTION
## Technical Summary
`hide` is no longer available in B5.

## Safety Assurance

### Safety story
Essentially a config change. Only affects an internal engineering tool.

### Automated test coverage

The tool in general has coverage.

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
