### PR TITLE
Added test_make_direct_css_renames_in_knockout

### DIFF
--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -29,6 +29,15 @@ def test_make_direct_css_renames_bootstrap5():
     eq(renames, ['renamed btn-default to btn-outline-primary', 'renamed btn-xs to btn-sm'])
 
 
+def test_make_direct_css_renames_in_knockout():
+    line = """    <td data-bind="css: {'badge-success': isSuccess}">"""
+    final_line, renames = make_direct_css_renames(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    eq(final_line, """    <td data-bind="css: {'text-bg-success': isSuccess}">""")
+    eq(renames, ['renamed badge-success to text-bg-success'])
+
+
 def test_make_numbered_css_renames_bootstrap5():
     line = """        <div class="col-xs-6">\n"""
     final_line, renames = make_numbered_css_renames(


### PR DESCRIPTION
## Technical Summary
I made some changes to flag the knockout `css` binding, then realized that the existing code already picks up classes used there. Adding a test to demonstrate this.

## Safety Assurance

### Safety story
Tests only

### Automated test coverage

yes

### QA Plan

no
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
