### PR TITLE
Updated tempus decorators to support both class-based and function-based views

### DIFF
--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -250,10 +250,16 @@ def use_tempusdominus(view_func):
             ...
     """
     @wraps(view_func)
-    def _inner(request, *args, **kwargs):
+    def _wrapped(*args, **kwargs):
+        if hasattr(args[0], 'META'):
+            # function view
+            request = args[0]
+        else:
+            # class view
+            request = args[1]
         request.use_tempusdominus = True
-        return view_func(request, *args, **kwargs)
-    return _inner
+        return view_func(*args, **kwargs)
+    return _wrapped
 
 
 def waf_allow(kind, hard_code_pattern=None):


### PR DESCRIPTION
## Technical Summary
Like https://github.com/dimagi/commcare-hq/pull/34509, this is datepicker functionality I'm cherry-picking because multiple migrations depend on it.

This decorator needs to be usable for both function-based views like [manage_registry](https://github.com/dimagi/commcare-hq/blob/db7292349df5f58121b1adbd3bcfa0daa029d90f/corehq/apps/registry/views.py#L91-L96) and also class-based views like [ApiKeyView](https://github.com/dimagi/commcare-hq/blob/db7292349df5f58121b1adbd3bcfa0daa029d90f/corehq/apps/settings/views.py#L617-L623).

## Safety Assurance

### Safety story
This follows the same pattern as other decorators in the file, like B3's [use_daterangepicker](https://github.com/dimagi/commcare-hq/blob/db7292349df5f58121b1adbd3bcfa0daa029d90f/corehq/apps/hqwebapp/decorators.py#L7-L29). It also isn't currently being used by any views in production.

### Automated test coverage

doubt it

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
