### PR TITLE
Keep Selected Area on Refresh + Warning for Long URL Length (Geospatial)

### DIFF
--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -284,7 +284,7 @@ class CaseGroupingReport(BaseCaseMapReport):
         features_json = self.request.GET.get('features')
         if features_json:
             try:
-                features |= json.loads(features_json)
+                features = json.loads(features_json)
             except json.JSONDecodeError:
                 raise ValueError(f'{features_json!r} parameter is not valid JSON')
         return features

--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -557,9 +557,11 @@ hqDefine("geospatial/js/case_grouping_map",[
                 $("#lock-groups-controls").koApplyBindings(groupLockModelInstance);
                 initMap();
                 $("#clusterStats").koApplyBindings(clusterStatsInstance);
-                polygonFilterInstance = new models.PolygonFilter(mapModel, true, false);
-                polygonFilterInstance.loadPolygons(initialPageData.get('saved_polygons'));
-                $("#polygon-filters").koApplyBindings(polygonFilterInstance);
+                mapModel.mapInstance.on('load', () => {
+                    polygonFilterInstance = new models.PolygonFilter(mapModel, true, false);
+                    polygonFilterInstance.loadPolygons(initialPageData.get('saved_polygons'));
+                    $("#polygon-filters").koApplyBindings(polygonFilterInstance);
+                });
 
                 $("#caseGroupSelect").koApplyBindings(caseGroupsInstance);
                 return;

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -14,6 +14,7 @@ hqDefine('geospatial/js/models', [
 ) {
     const DOWNPLAY_OPACITY = 0.2;
     const FEATURE_QUERY_PARAM = 'features';
+    const MAX_URL_LENGTH = 4500;
     const DEFAULT_CENTER_COORD = [-20.0, -0.0];
     const DISBURSEMENT_LAYER_PREFIX = 'route-';
 
@@ -514,6 +515,7 @@ hqDefine('geospatial/js/models', [
 
         self.polygons = {};
         self.shouldRefreshPage = ko.observable(false);
+        self.hasUrlError = ko.observable(false);
 
         self.savedPolygons = ko.observableArray([]);
         self.selectedSavedPolygonId = ko.observable('');
@@ -543,13 +545,24 @@ hqDefine('geospatial/js/models', [
 
         function updatePolygonQueryParam() {
             const url = new URL(window.location.href);
-            if (Object.keys(self.polygons).length) {
+            if (Object.keys(self.polygons)) {
                 url.searchParams.set(FEATURE_QUERY_PARAM, JSON.stringify(self.polygons));
             } else {
                 url.searchParams.delete(FEATURE_QUERY_PARAM);
             }
-            window.history.replaceState({ path: url.href }, '', url.href);
-            self.shouldRefreshPage(true);
+            updateUrl(url);
+        }
+
+        function updateUrl(url) {
+            if (url.href.length <= MAX_URL_LENGTH) {
+                window.history.replaceState({ path: url.href }, '', url.href);
+                self.shouldRefreshPage(true);
+                self.hasUrlError(false);
+            } else {
+                self.shouldRefreshPage(false);
+                self.hasUrlError(true);
+            }
+        }
         }
 
         self.loadPolygonFromQueryParam = function () {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -14,6 +14,7 @@ hqDefine('geospatial/js/models', [
 ) {
     const DOWNPLAY_OPACITY = 0.2;
     const FEATURE_QUERY_PARAM = 'features';
+    const SELECTED_FEATURE_ID_QUERY_PARAM = 'selected_feature_id';
     const MAX_URL_LENGTH = 4500;
     const DEFAULT_CENTER_COORD = [-20.0, -0.0];
     const DISBURSEMENT_LAYER_PREFIX = 'route-';
@@ -563,6 +564,21 @@ hqDefine('geospatial/js/models', [
                 self.hasUrlError(true);
             }
         }
+
+        function updateSelectedSavedPolygonParam() {
+            const url = new URL(window.location.href);
+            const prevSelectedId = url.searchParams.get(SELECTED_FEATURE_ID_QUERY_PARAM);
+            if (prevSelectedId === self.selectedSavedPolygonId()) {
+                // If the user refreshes the page, we shouldn't prompt another refresh
+                return;
+            }
+
+            if (self.selectedSavedPolygonId()) {
+                url.searchParams.set(SELECTED_FEATURE_ID_QUERY_PARAM, self.selectedSavedPolygonId());
+            } else {
+                url.searchParams.delete(SELECTED_FEATURE_ID_QUERY_PARAM);
+            }
+            updateUrl(url);
         }
 
         self.loadPolygonFromQueryParam = function () {
@@ -604,12 +620,12 @@ hqDefine('geospatial/js/models', [
 
         self.clearActivePolygon = function () {
             if (self.activeSavedPolygon) {
-                // self.selectedSavedPolygonId('');
-                self.removePolygonsFromFilterList(self.activeSavedPolygon.geoJson.features);
+                self.selectedSavedPolygonId('');
                 removeActivePolygonLayer();
                 self.activeSavedPolygon = null;
                 self.btnSaveDisabled(false);
                 self.btnExportDisabled(true);
+                updateSelectedSavedPolygonParam();
             }
         };
 
@@ -657,7 +673,7 @@ hqDefine('geospatial/js/models', [
             createActivePolygonLayer(polygonObj);
 
             self.activeSavedPolygon = polygonObj;
-            self.addPolygonsToFilterList(polygonObj.geoJson.features);
+            updateSelectedSavedPolygonParam();
             self.btnExportDisabled(false);
             self.btnSaveDisabled(true);
             if (self.shouldSelectAfterFilter) {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -628,12 +628,10 @@ hqDefine('geospatial/js/models', [
 
         self.clearActivePolygon = function () {
             if (self.activeSavedPolygon) {
-                self.selectedSavedPolygonId('');
                 removeActivePolygonLayer();
                 self.activeSavedPolygon = null;
                 self.btnSaveDisabled(false);
                 self.btnExportDisabled(true);
-                updateSelectedSavedPolygonParam();
             }
         };
 

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -594,6 +594,14 @@ hqDefine('geospatial/js/models', [
             }
         };
 
+        self.loadSelectedPolygonFromQueryParam = function () {
+            const url = new URL(window.location.href);
+            const selectedFeatureParam = url.searchParams.get(SELECTED_FEATURE_ID_QUERY_PARAM);
+            if (selectedFeatureParam) {
+                self.selectedSavedPolygonId(selectedFeatureParam);
+            }
+        };
+
         function removeActivePolygonLayer() {
             if (self.activeSavedPolygon) {
                 self.mapObj.mapInstance.removeLayer(self.activeSavedPolygon.id);
@@ -695,6 +703,7 @@ hqDefine('geospatial/js/models', [
                 }
                 self.savedPolygons.push(new SavedPolygon(polygon));
             });
+            self.loadSelectedPolygonFromQueryParam();
         };
 
         self.exportGeoJson = function (exportButtonId) {

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -53,6 +53,12 @@
       to apply the polygon filtering changes.
     {% endblocktrans %}
   </div>
+  <div class="alert alert-warning" data-bind="visible: hasUrlError">
+    {% blocktrans %}
+      There are too many polygons on the map. Please remove some before refreshing the page, otherwise the
+      newly added polygons will be ignored when filtering.
+    {% endblocktrans %}
+  </div>
 </div>
 <div id="case-grouping-map" style="height: 500px"></div>
 

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -56,7 +56,7 @@
   <div class="alert alert-warning" data-bind="visible: hasUrlError">
     {% blocktrans %}
       There are too many polygons on the map. Please remove some before refreshing the page, otherwise the
-      newly added polygons will be ignored when filtering.
+      newly added polygons will be lost.
     {% endblocktrans %}
   </div>
 </div>

--- a/corehq/apps/geospatial/tests/test_reports.py
+++ b/corehq/apps/geospatial/tests/test_reports.py
@@ -7,6 +7,7 @@ from nose.tools import assert_equal, assert_raises
 
 from corehq.apps.es import case_search_adapter
 from corehq.apps.es.tests.utils import es_test
+from corehq.apps.geospatial.models import GeoPolygon
 from corehq.apps.geospatial.reports import (
     CaseGroupingReport,
     geojson_to_es_geoshape,
@@ -59,6 +60,27 @@ def test_validate_geometry_schema():
 @flag_enabled('GEOSPATIAL')
 @es_test(requires=[case_search_adapter], setup_class=True)
 class TestCaseGroupingReport(BaseReportTest):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestCaseGroupingReport, cls).setUpClass()
+        cls.poly_obj_features = [
+            {
+                'type': 'Feature',
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': []
+                }
+            }
+        ]
+        cls.poly_obj = GeoPolygon.objects.create(
+            name='foobar', domain=DOMAIN, geo_json={'features': cls.poly_obj_features}
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.poly_obj.delete()
+        super(TestCaseGroupingReport, cls).tearDownClass()
 
     def _get_request(self, **kwargs):
         request = self.factory.get('/some/url', **kwargs)
@@ -123,6 +145,39 @@ class TestCaseGroupingReport(BaseReportTest):
 
         self.assertEqual(len(json_data), 1)
         self.assertIn(porto_novo.case_id, case_ids)
+
+    def test_features_from_request(self):
+        poly_feature = {
+            'id': '1234',
+            'type': 'Feature',
+            'properties': {},
+            'geometry': {
+                'type': 'Polygon',
+                'coordinates': [
+                    [
+                        [1.1, 2.2],
+                        [3.3, 3.3],
+                        [1.1, 2.2]
+                    ]
+                ]
+            }
+        }
+        feature_params = {
+            'selected_feature_id': self.poly_obj.id,
+            'features': json.dumps({
+                '1234': poly_feature
+            })
+        }
+        request = self._get_request(data=feature_params)
+        report_obj = CaseGroupingReport(request, domain=DOMAIN)
+        request_features = report_obj.features_from_request
+        self.assertEqual(request_features['1234'], poly_feature)
+
+        # Selected feature ID is a random ID, so we need to retrieve it
+        feature_ids = list(request_features)
+        feature_ids.remove('1234')
+        selected_feature_id = feature_ids[0]
+        self.assertEqual([request_features[selected_feature_id]], self.poly_obj_features)
 
     @contextmanager
     def get_cases(self):
@@ -363,8 +418,7 @@ def test_filter_for_two_polygons():
             )
         }
     }
-    features_json = json.dumps(two_polygons)
-    actual_filter = CaseGroupingReport._get_filter_for_features(features_json)
+    actual_filter = CaseGroupingReport._get_filter_for_features(two_polygons)
     assert_equal(actual_filter, expected_filter)
 
 
@@ -473,8 +527,7 @@ def test_one_polygon_with_hole():
             )
         }
     }
-    features_json = json.dumps(polygon_with_hole)
-    actual_filter = CaseGroupingReport._get_filter_for_features(features_json)
+    actual_filter = CaseGroupingReport._get_filter_for_features(polygon_with_hole)
     assert_equal(actual_filter, expected_filter)
 
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When a saved polygon is selected for filtering it will now continue to be selected after a page refresh. Previously, upon refreshing the page the selected saved polygon would be added to the map, however the selection dropdown would show no saved polygon selected.

Additionally, if a user adds too many polygons to the map and causes the URL length to be too long, a warning will be displayed to the user:
![url-length-warning](https://github.com/dimagi/commcare-hq/assets/122617251/18e7dcaa-f238-4e62-acd2-5eb604184c9f)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to tickets here:
- [BadRequestError](https://dimagi.atlassian.net/browse/SC-3272)
- [Filtered Saved Area is not displayed after refresh](https://dimagi.atlassian.net/browse/SC-3271)

This PR addresses an issue on the Geospatial Case Grouping page where users could potentially have a URL length that too long (>4500 characters). This is because when polygons for filtering are added to the map, their JSON gets added into the URL to be sent to the back-end. If a user adds too many polygons to the map then they will receive a `BadRequestError`. This has been addressed by not adding additional polygon JSON to the URL if it will result in the URL being too long. Instead, a relevant warning is given to the user.

Additionally, since every map polygon's JSON is stored in the URL in a single param, there was no easy way to identify and re-select the selected saved polygon on a page refresh. This PR addresses the issue by saving only the selected polygon ID in the URL (not its entire JSON). The selected polygon JSON gets retrieved in the back-end by looking for the correct `GeoPolygon` instance using the given selected polygon ID.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Unit tests

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests exist for `CaseGroupingReport` class, including the new `features_from_request` class property that was added in this PR.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
