### PR TITLE
Revert Application Error Report from GA (Migration)

### DIFF
--- a/corehq/apps/accounting/migrations/0092_revert_application_error_report_priv.py
+++ b/corehq/apps/accounting/migrations/0092_revert_application_error_report_priv.py
@@ -1,0 +1,58 @@
+from django.db import migrations
+
+from django_prbac.models import Grant, Role
+
+from corehq import privileges, toggles
+from corehq.apps.accounting.utils import (
+    get_all_roles_by_slug,
+    get_granted_privs_for_grantee,
+)
+from corehq.util.django_migrations import skip_on_fresh_install
+
+ENTERPRISE_PLAN_ROLE_SLUG = 'enterprise_plan_v0'
+
+
+@skip_on_fresh_install
+def _remove_privilege_from_plan(apps, schema_editor):
+    try:
+        Role.objects.get(slug=privileges.APPLICATION_ERROR_REPORT).delete()
+    except Role.DoesNotExist:
+        pass
+
+
+@skip_on_fresh_install
+def _grant_privilege_to_plans(*args, **kwargs):
+    # This adds the removed privilege back to the Enterprise plan and
+    # is modelled after the ensure_grants function
+    try:
+        priv_role = Role.objects.get(slug=privileges.APPLICATION_ERROR_REPORT)
+    except Role.DoesNotExist:
+        priv_role = Role(
+            slug=privileges.APPLICATION_ERROR_REPORT,
+            name=toggles.APPLICATION_ERROR_REPORT.label,
+            description=toggles.APPLICATION_ERROR_REPORT.description,
+        )
+        priv_role.save()
+
+    grantee_privileges = get_granted_privs_for_grantee()[ENTERPRISE_PLAN_ROLE_SLUG]
+    if privileges.APPLICATION_ERROR_REPORT not in grantee_privileges:
+        grantee_role = get_all_roles_by_slug()[ENTERPRISE_PLAN_ROLE_SLUG]
+        Role.get_cache().clear()
+        Grant.objects.create(
+            from_role=grantee_role,
+            to_role=priv_role,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0091_remove_custom_banner_alerts_feature_flag'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _remove_privilege_from_plan,
+            reverse_code=_grant_privilege_to_plans,
+        ),
+    ]

--- a/corehq/apps/accounting/migrations/0092_revert_application_error_report_priv.py
+++ b/corehq/apps/accounting/migrations/0092_revert_application_error_report_priv.py
@@ -2,7 +2,7 @@ from django.db import migrations
 
 from django_prbac.models import Grant, Role
 
-from corehq import privileges, toggles
+from corehq import toggles
 from corehq.apps.accounting.utils import (
     get_all_roles_by_slug,
     get_granted_privs_for_grantee,
@@ -10,12 +10,13 @@ from corehq.apps.accounting.utils import (
 from corehq.util.django_migrations import skip_on_fresh_install
 
 ENTERPRISE_PLAN_ROLE_SLUG = 'enterprise_plan_v0'
+APPLICATION_ERROR_REPORT = 'application_error_report'
 
 
 @skip_on_fresh_install
 def _remove_privilege_from_plan(apps, schema_editor):
     try:
-        Role.objects.get(slug=privileges.APPLICATION_ERROR_REPORT).delete()
+        Role.objects.get(slug=APPLICATION_ERROR_REPORT).delete()
     except Role.DoesNotExist:
         pass
 
@@ -25,17 +26,17 @@ def _grant_privilege_to_plans(*args, **kwargs):
     # This adds the removed privilege back to the Enterprise plan and
     # is modelled after the ensure_grants function
     try:
-        priv_role = Role.objects.get(slug=privileges.APPLICATION_ERROR_REPORT)
+        priv_role = Role.objects.get(slug=APPLICATION_ERROR_REPORT)
     except Role.DoesNotExist:
         priv_role = Role(
-            slug=privileges.APPLICATION_ERROR_REPORT,
+            slug=APPLICATION_ERROR_REPORT,
             name=toggles.APPLICATION_ERROR_REPORT.label,
             description=toggles.APPLICATION_ERROR_REPORT.description,
         )
         priv_role.save()
 
     grantee_privileges = get_granted_privs_for_grantee()[ENTERPRISE_PLAN_ROLE_SLUG]
-    if privileges.APPLICATION_ERROR_REPORT not in grantee_privileges:
+    if APPLICATION_ERROR_REPORT not in grantee_privileges:
         grantee_role = get_all_roles_by_slug()[ENTERPRISE_PLAN_ROLE_SLUG]
         Role.get_cache().clear()
         Grant.objects.create(

--- a/migrations.lock
+++ b/migrations.lock
@@ -111,6 +111,7 @@ accounting
  0089_dedupe_priv
  0090_custom_domain_alerts_priv
  0091_remove_custom_banner_alerts_feature_flag
+ 0092_revert_application_error_report_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3591).

The Application Error Report is being moved back into a feature flag. This is because the report has no useful function on production (due to mobile logs being sent to Sumologic).

This PR is one of two and contains the migration for reverting the feature to a feature flag. The PR containing the necessary code changes can be found [here](https://github.com/dimagi/commcare-hq/pull/34514).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing of migration (as well as migration revert)
- Tested on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [X] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->
This PR includes a migration to delete the Role associated with the `APPLICATION_ERROR_REPORT` privilege. Upon reverting this migration, the Role object will be re-created.

This PR reverts what was done in the migration from https://github.com/dimagi/commcare-hq/pull/33078 which moved the `APPLICATION_ERROR_REPORT` feature flag to a privilege.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
