### PR TITLE
[B5] Updates to migration tool, add #todo comments for flags

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -18,6 +18,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     flag_changed_javascript_plugins,
     flag_crispy_forms_in_template,
     flag_inline_styles,
+    add_todo_comments_for_flags,
 )
 from corehq.apps.hqwebapp.utils.bootstrap.git import (
     has_pending_git_changes,
@@ -255,6 +256,7 @@ class Command(BaseCommand):
                 saved_line, line_changelog = self.confirm_and_get_line_changes(
                     line_number, old_line, new_line, renames, flags, review_changes
                 )
+                saved_line = add_todo_comments_for_flags(flags, saved_line, is_template)
 
                 new_lines.append(saved_line)
                 if saved_line != old_line or flags:
@@ -289,9 +291,10 @@ class Command(BaseCommand):
             self.clear_screen()
             self.stdout.write(changelog[-1])
             for flag in flags:
+                guidance = flag[1]
                 changelog.append("\nFlagged Code:")
                 changelog.append(self.format_code(old_line, break_length=len(old_line) + 5))
-                changelog.append(self.format_guidance(flag))
+                changelog.append(self.format_guidance(guidance))
                 if review_changes:
                     self.display_flag_summary(changelog)
                     enter_to_continue()

--- a/corehq/apps/hqwebapp/management/commands/show_invalid_bootstrap3_files.py
+++ b/corehq/apps/hqwebapp/management/commands/show_invalid_bootstrap3_files.py
@@ -1,7 +1,7 @@
 from django.core.management import BaseCommand
 
 from corehq.apps.hqwebapp.utils.bootstrap.changes import (
-    flag_bootstrap3_references_in_template,
+    check_bootstrap3_references_in_template,
     flag_bootstrap3_references_in_javascript, get_spec,
 )
 from corehq.apps.hqwebapp.utils.bootstrap.paths import (
@@ -55,7 +55,7 @@ def _get_bootstrap3_flags_from_file(file_path, is_template):
         lines = current_file.readlines()
         for line_number, line in enumerate(lines):
             if is_template:
-                flags = flag_bootstrap3_references_in_template(
+                flags = check_bootstrap3_references_in_template(
                     line, get_spec('bootstrap_3_to_5')
                 )
             else:

--- a/corehq/apps/hqwebapp/management/commands/show_invalid_bootstrap3_files.py
+++ b/corehq/apps/hqwebapp/management/commands/show_invalid_bootstrap3_files.py
@@ -2,7 +2,7 @@ from django.core.management import BaseCommand
 
 from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     check_bootstrap3_references_in_template,
-    flag_bootstrap3_references_in_javascript, get_spec,
+    check_bootstrap3_references_in_javascript, get_spec,
 )
 from corehq.apps.hqwebapp.utils.bootstrap.paths import (
     get_all_template_paths_for_app,
@@ -59,7 +59,7 @@ def _get_bootstrap3_flags_from_file(file_path, is_template):
                     line, get_spec('bootstrap_3_to_5')
                 )
             else:
-                flags = flag_bootstrap3_references_in_javascript(line)
+                flags = check_bootstrap3_references_in_javascript(line)
             if flags:
                 flagged_lines.append([
                     line_number, flags

--- a/corehq/apps/hqwebapp/management/commands/show_invalid_bootstrap3_files.py
+++ b/corehq/apps/hqwebapp/management/commands/show_invalid_bootstrap3_files.py
@@ -49,22 +49,22 @@ def _is_relevant_path(path, completed_paths):
     return not (is_split_path(path) or str(path) in completed_paths)
 
 
-def _get_bootstrap3_flags_from_file(file_path, is_template):
-    flagged_lines = []
+def _get_bootstrap3_references_from_file(file_path, is_template):
+    problem_lines = []
     with open(file_path, 'r') as current_file:
         lines = current_file.readlines()
         for line_number, line in enumerate(lines):
             if is_template:
-                flags = check_bootstrap3_references_in_template(
+                issues = check_bootstrap3_references_in_template(
                     line, get_spec('bootstrap_3_to_5')
                 )
             else:
-                flags = check_bootstrap3_references_in_javascript(line)
-            if flags:
-                flagged_lines.append([
-                    line_number, flags
+                issues = check_bootstrap3_references_in_javascript(line)
+            if issues:
+                problem_lines.append([
+                    line_number, issues
                 ])
-    return flagged_lines
+    return problem_lines
 
 
 def _get_flagged_files(app_name, paths, is_template):
@@ -73,7 +73,7 @@ def _get_flagged_files(app_name, paths, is_template):
         short_path = get_short_path(app_name, path, is_template)
         if short_path in IGNORED_FILES:
             continue
-        flagged_lines = _get_bootstrap3_flags_from_file(path, is_template)
+        flagged_lines = _get_bootstrap3_references_from_file(path, is_template)
         if flagged_lines:
             flagged_files.append([
                 short_path,

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -16,6 +16,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     flag_bootstrap3_references_in_javascript,
     flag_inline_styles,
     make_template_dependency_renames,
+    add_todo_comments_for_flags,
 )
 
 
@@ -88,17 +89,21 @@ def test_flag_changed_css_classes_bootstrap5():
     flags = flag_changed_css_classes(
         line, get_spec('bootstrap_3_to_5')
     )
-    eq(flags, ['`dl-horizontal` has been dropped.\nInstead, use `.row` on `<dl>` and use grid column classes '
-               '(or mixins) on its `<dt>` and `<dd>` children.\n\nAn EXAMPLE for how to apply this change is '
-               'provided below.\nPlease see docs for further details.\n\nPreviously:\n```\n<dl class='
-               '"dl-horizontal">\n    <dt>foo</dt>\n    <dd>foo</dd>\n</dl>\n```\n\nNow:\n```\n<dl class='
-               '"row">\n    <dt class="col-3">foo</dt>\n    <dd class="col-9">foo</dd>\n</dl>\n```\n'])
+    eq(flags, [[
+        'css:dl-horizontal',
+        '`dl-horizontal` has been dropped.\nInstead, use `.row` on `<dl>` and use grid column classes '
+        '(or mixins) on its `<dt>` and `<dd>` children.\n\nAn EXAMPLE for how to apply this change is '
+        'provided below.\nPlease see docs for further details.\n\nPreviously:\n```\n<dl class='
+        '"dl-horizontal">\n    <dt>foo</dt>\n    <dd>foo</dd>\n</dl>\n```\n\nNow:\n```\n<dl class='
+        '"row">\n    <dt class="col-3">foo</dt>\n    <dd class="col-9">foo</dd>\n</dl>\n```\n'
+    ]])
 
 
 def test_flag_stateful_button_changes_bootstrap5():
     line = """        <button data-loading-text="foo>\n"""
     flags = flag_stateful_button_changes_bootstrap5(line)
-    eq(flags, ['You are using stateful buttons here, which are no longer supported in Bootstrap 5.'])
+    eq(flags, [['stateful button',
+                'You are using stateful buttons here, which are no longer supported in Bootstrap 5.']])
 
 
 def test_make_template_dependency_renames_no_change():
@@ -208,15 +213,17 @@ def test_flag_inline_styles():
     line = """method="post" style="float: left; margin-right: 5px;">"""
     flags = flag_inline_styles(line)
     eq(len(flags), 1)
-    eq(flags[0].startswith('This template uses inline styles.'), True)
+    eq(flags[0][0], "inline style")
+    eq(flags[0][1].startswith('This template uses inline styles.'), True)
 
 
 def test_flag_crispy_forms_in_template():
     line = """    {% crispy form %}\n"""
     flags = flag_crispy_forms_in_template(line)
-    eq(flags, ["This template uses crispy forms. "
-               "Please ensure the form looks good after migration, and refer to "
-               "the updated Style Guide for current best practices, especially with checkbox fields."])
+    eq(flags, [["check crispy",
+                "This template uses crispy forms. "
+                "Please ensure the form looks good after migration, and refer to "
+                "the updated Style Guide for current best practices, especially with checkbox fields."]])
 
 
 def test_flag_changed_javascript_plugins_bootstrap5():
@@ -224,15 +231,16 @@ def test_flag_changed_javascript_plugins_bootstrap5():
     flags = flag_changed_javascript_plugins(
         line, get_spec('bootstrap_3_to_5')
     )
-    eq(flags, ["The `modal` plugin has been restructured since the removal of jQuery.\n\nThere is now a new way "
-               "of triggering modal events and interacting with modals in javascript.\nFor instance, if we "
-               "wanted to hide a modal with id `#bugReport` before, we would now do the\nfollowing..."
-               "\n\nAn EXAMPLE for how to apply this change is provided below.\nPlease see docs for "
-               "further details.\n\npreviously\n```\n$('#bugReport').modal('hide');\n```\n\nnow\n```\n"
-               "const bugReportModal = new bootstrap.Modal($('#bugReport'));\nbugReportModal.hide();\n```\n\n"
-               "Hint: make sure to list `hqwebapp/js/bootstrap5_loader` as a js dependency in the file where\n"
-               "bootstrap is referenced.\n\nOld docs: https://getbootstrap.com/docs/3.4/javascript/#modals\n"
-               "New docs: https://getbootstrap.com/docs/5.3/components/modal/#via-javascript\n"])
+    eq(flags, [["plugin:modal",
+                "The `modal` plugin has been restructured since the removal of jQuery.\n\nThere is now a new way "
+                "of triggering modal events and interacting with modals in javascript.\nFor instance, if we "
+                "wanted to hide a modal with id `#bugReport` before, we would now do the\nfollowing..."
+                "\n\nAn EXAMPLE for how to apply this change is provided below.\nPlease see docs for "
+                "further details.\n\npreviously\n```\n$('#bugReport').modal('hide');\n```\n\nnow\n```\n"
+                "const bugReportModal = new bootstrap.Modal($('#bugReport'));\nbugReportModal.hide();\n```\n\n"
+                "Hint: make sure to list `hqwebapp/js/bootstrap5_loader` as a js dependency in the file where\n"
+                "bootstrap is referenced.\n\nOld docs: https://getbootstrap.com/docs/3.4/javascript/#modals\n"
+                "New docs: https://getbootstrap.com/docs/5.3/components/modal/#via-javascript\n"]])
 
 
 def test_flag_extended_changed_javascript_plugins_bootstrap5():
@@ -240,13 +248,14 @@ def test_flag_extended_changed_javascript_plugins_bootstrap5():
     flags = flag_changed_javascript_plugins(
         line, get_spec('bootstrap_3_to_5')
     )
-    eq(flags, ['The `popover` plugin has been restructured since the removal of jQuery.\n'
-               '\nThere is now a new way of triggering popover events and interacting '
-               'with popovers in javascript.\n\nPlease feel free to update this help text'
-               ' as you find common replacements/restructuring\nfor our usage of this '
-               'plugin. Thanks!\n\nOld docs: https://getbootstrap.com/docs/3.4/'
-               'javascript/#popovers\nNew docs: https://getbootstrap.com/docs/5.3/'
-               'components/popovers/\n'])
+    eq(flags, [['plugin:popover',
+                'The `popover` plugin has been restructured since the removal of jQuery.\n'
+                '\nThere is now a new way of triggering popover events and interacting '
+                'with popovers in javascript.\n\nPlease feel free to update this help text'
+                ' as you find common replacements/restructuring\nfor our usage of this '
+                'plugin. Thanks!\n\nOld docs: https://getbootstrap.com/docs/3.4/'
+                'javascript/#popovers\nNew docs: https://getbootstrap.com/docs/5.3/'
+                'components/popovers/\n']])
 
 
 def test_file_contains_reference_to_path():
@@ -340,3 +349,55 @@ def test_replace_path_references_javascript():
     // nothing to do, this is just to define the dependencies for foobarapp/base.html
 });"""
     eq(result, expected_result)
+
+
+def test_add_todo_comments_for_flags_template():
+    line = """          <div class="form-inline nav"\n"""
+    flags = flag_changed_css_classes(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    line = add_todo_comments_for_flags(flags, line, is_template=True)
+    eq(line, """          <div class="form-inline nav"  {# todo B5: css:form-inline, css:nav #}\n""")
+
+
+def test_add_todo_comments_for_flags_template_replace():
+    line = """          {% crispy form %}  {# todo B5: css:form-inline, css:nav #}\n"""
+    flags = flag_crispy_forms_in_template(line)
+    line = add_todo_comments_for_flags(flags, line, is_template=True)
+    eq(line, """          {% crispy form %}  {# todo B5: check crispy #}\n""")
+
+
+def test_add_todo_comments_for_flags_template_noop():
+    line = """          <div class="form"\n"""
+    flags = flag_changed_css_classes(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    line = add_todo_comments_for_flags(flags, line, is_template=True)
+    eq(line, line)
+
+
+def test_add_todo_comments_for_flags_javascript():
+    line = """            $modal.modal({\n"""
+    flags = flag_changed_javascript_plugins(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    line = add_todo_comments_for_flags(flags, line, is_template=False)
+    eq(line, """            $modal.modal({  /* todo B5: plugin:modal */\n""")
+
+
+def test_add_todo_comments_for_flags_javascript_replace():
+    line = """            $popover.popover({  /* todo B5: plugin:modal */\n"""
+    flags = flag_changed_javascript_plugins(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    line = add_todo_comments_for_flags(flags, line, is_template=False)
+    eq(line, """            $popover.popover({  /* todo B5: plugin:popover */\n""")
+
+
+def test_add_todo_comments_for_flags_javascript_noop():
+    line = """        return "snooze_" + slug + "_" + domain;\n"""
+    flags = flag_changed_javascript_plugins(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    line = add_todo_comments_for_flags(flags, line, is_template=False)
+    eq(line, line)

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -11,7 +11,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     flag_changed_javascript_plugins,
     file_contains_reference_to_path,
     replace_path_references,
-    flag_bootstrap3_references_in_template,
+    check_bootstrap3_references_in_template,
     flag_crispy_forms_in_template,
     flag_bootstrap3_references_in_javascript,
     flag_inline_styles,
@@ -115,9 +115,9 @@ def test_make_template_dependency_renames_no_change():
     eq(renames, [])
 
 
-def test_flag_bootstrap3_references_in_template_extends():
+def test_check_bootstrap3_references_in_template_extends():
     line = """{% extends "hqwebapp/bootstrap3/base_section.html" %}\n"""
-    flags = flag_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
     eq(flags, ['This template extends a bootstrap 3 template.'])
 
 
@@ -130,9 +130,9 @@ def test_make_template_dependency_renames_extends():
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
-def test_flag_bootstrap3_references_in_template_requirejs():
+def test_check_bootstrap3_references_in_template_requirejs():
     line = """    {% requirejs_main 'hqwebapp/bootstrap3/foo' %}\n"""
-    flags = flag_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
     eq(flags, ["This template references a bootstrap 3 requirejs file. "
                "It should also use requirejs_main_b5 instead of requirejs_main."])
 
@@ -146,9 +146,9 @@ def test_make_template_dependency_renames_requirejs():
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
-def test_flag_bootstrap3_references_in_template_requirejs_b5():
+def test_check_bootstrap3_references_in_template_requirejs_b5():
     line = """    {% requirejs_main_b5 'hqwebapp/js-test/bootstrap3/foo' %}\n"""
-    flags = flag_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
     eq(flags, ['This template references a bootstrap 3 requirejs file.'])
 
 
@@ -161,9 +161,9 @@ def test_make_template_dependency_renames_requirejs_b5():
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
-def test_flag_bootstrap3_references_in_template_static():
+def test_check_bootstrap3_references_in_template_static():
     line = """    <link rel="stylesheet" href="{% static 'test/js/bootstrap3/foo' %}"></link>\n"""
-    flags = flag_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
     eq(flags, ['This template references a bootstrap 3 static file.'])
 
 
@@ -176,9 +176,9 @@ def test_make_template_dependency_renames_static():
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
-def test_flag_bootstrap3_references_in_template_include():
+def test_check_bootstrap3_references_in_template_include():
     line = """    {% include "some_app/bootstrap3/some_thing.html" %}\n"""
-    flags = flag_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
     eq(flags, ['This template includes a bootstrap 3 template.'])
 
 
@@ -193,13 +193,13 @@ def test_make_template_dependency_renames_include():
 
 def test_flag_requirejs_main_references_in_template():
     line = """    {% requirejs_main 'hqwebapp/js/foo' %}\n"""
-    flags = flag_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
     eq(flags, ['This template should use requirejs_main_b5 instead of requirejs_main.'])
 
 
 def test_flag_any_bootstrap3_references_in_template():
     line = """<link src='sms/js/bootstrap3/compose.js' >\n"""
-    flags = flag_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
     eq(flags, ['This template references a bootstrap 3 file.'])
 
 

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -117,8 +117,8 @@ def test_make_template_dependency_renames_no_change():
 
 def test_check_bootstrap3_references_in_template_extends():
     line = """{% extends "hqwebapp/bootstrap3/base_section.html" %}\n"""
-    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
-    eq(flags, ['This template extends a bootstrap 3 template.'])
+    issues = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    eq(issues, ['This template extends a bootstrap 3 template.'])
 
 
 def test_make_template_dependency_renames_extends():
@@ -132,9 +132,9 @@ def test_make_template_dependency_renames_extends():
 
 def test_check_bootstrap3_references_in_template_requirejs():
     line = """    {% requirejs_main 'hqwebapp/bootstrap3/foo' %}\n"""
-    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
-    eq(flags, ["This template references a bootstrap 3 requirejs file. "
-               "It should also use requirejs_main_b5 instead of requirejs_main."])
+    issues = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    eq(issues, ["This template references a bootstrap 3 requirejs file. "
+                "It should also use requirejs_main_b5 instead of requirejs_main."])
 
 
 def test_make_template_dependency_renames_requirejs():
@@ -148,8 +148,8 @@ def test_make_template_dependency_renames_requirejs():
 
 def test_check_bootstrap3_references_in_template_requirejs_b5():
     line = """    {% requirejs_main_b5 'hqwebapp/js-test/bootstrap3/foo' %}\n"""
-    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
-    eq(flags, ['This template references a bootstrap 3 requirejs file.'])
+    issues = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    eq(issues, ['This template references a bootstrap 3 requirejs file.'])
 
 
 def test_make_template_dependency_renames_requirejs_b5():
@@ -163,8 +163,8 @@ def test_make_template_dependency_renames_requirejs_b5():
 
 def test_check_bootstrap3_references_in_template_static():
     line = """    <link rel="stylesheet" href="{% static 'test/js/bootstrap3/foo' %}"></link>\n"""
-    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
-    eq(flags, ['This template references a bootstrap 3 static file.'])
+    issues = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    eq(issues, ['This template references a bootstrap 3 static file.'])
 
 
 def test_make_template_dependency_renames_static():
@@ -178,8 +178,8 @@ def test_make_template_dependency_renames_static():
 
 def test_check_bootstrap3_references_in_template_include():
     line = """    {% include "some_app/bootstrap3/some_thing.html" %}\n"""
-    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
-    eq(flags, ['This template includes a bootstrap 3 template.'])
+    issues = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    eq(issues, ['This template includes a bootstrap 3 template.'])
 
 
 def test_make_template_dependency_renames_include():
@@ -193,20 +193,20 @@ def test_make_template_dependency_renames_include():
 
 def test_flag_requirejs_main_references_in_template():
     line = """    {% requirejs_main 'hqwebapp/js/foo' %}\n"""
-    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
-    eq(flags, ['This template should use requirejs_main_b5 instead of requirejs_main.'])
+    issues = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    eq(issues, ['This template should use requirejs_main_b5 instead of requirejs_main.'])
 
 
 def test_flag_any_bootstrap3_references_in_template():
     line = """<link src='sms/js/bootstrap3/compose.js' >\n"""
-    flags = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
-    eq(flags, ['This template references a bootstrap 3 file.'])
+    issues = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
+    eq(issues, ['This template references a bootstrap 3 file.'])
 
 
 def test_check_bootstrap3_references_in_javascript():
     line = """    "hqwebapp/js/bootstrap3/foo",\n"""
-    flags = check_bootstrap3_references_in_javascript(line)
-    eq(flags, ['This javascript file references a bootstrap 3 file.'])
+    issues = check_bootstrap3_references_in_javascript(line)
+    eq(issues, ['This javascript file references a bootstrap 3 file.'])
 
 
 def test_flag_inline_styles():

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -13,7 +13,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     replace_path_references,
     check_bootstrap3_references_in_template,
     flag_crispy_forms_in_template,
-    flag_bootstrap3_references_in_javascript,
+    check_bootstrap3_references_in_javascript,
     flag_inline_styles,
     make_template_dependency_renames,
     add_todo_comments_for_flags,
@@ -203,9 +203,9 @@ def test_flag_any_bootstrap3_references_in_template():
     eq(flags, ['This template references a bootstrap 3 file.'])
 
 
-def test_flag_bootstrap3_references_in_javascript():
+def test_check_bootstrap3_references_in_javascript():
     line = """    "hqwebapp/js/bootstrap3/foo",\n"""
-    flags = flag_bootstrap3_references_in_javascript(line)
+    flags = check_bootstrap3_references_in_javascript(line)
     eq(flags, ['This javascript file references a bootstrap 3 file.'])
 
 

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -196,37 +196,37 @@ def flag_stateful_button_changes_bootstrap5(line):
 
 
 def check_bootstrap3_references_in_template(line, spec):
-    flags = []
+    issues = []
     for tag in spec['template_tags_with_dependencies']:
         b3_ref_regex = _get_template_reference_regex(tag, 'bootstrap3')
         tag_only_regex = r"(\{% " + tag + r" ['\"][\w/.\-]+)"
         if re.search(b3_ref_regex, line):
             if tag == "extends":
-                flags.append("This template extends a bootstrap 3 template.")
+                issues.append("This template extends a bootstrap 3 template.")
             if tag == "static":
-                flags.append("This template references a bootstrap 3 static file.")
+                issues.append("This template references a bootstrap 3 static file.")
             if tag == "include":
-                flags.append("This template includes a bootstrap 3 template.")
+                issues.append("This template includes a bootstrap 3 template.")
             if tag == "requirejs_main":
-                flags.append("This template references a bootstrap 3 requirejs file. "
+                issues.append("This template references a bootstrap 3 requirejs file. "
                              "It should also use requirejs_main_b5 instead of requirejs_main.")
             if tag == "requirejs_main_b5":
-                flags.append("This template references a bootstrap 3 requirejs file.")
+                issues.append("This template references a bootstrap 3 requirejs file.")
         elif re.search(tag_only_regex, line):
             if tag == "requirejs_main":
-                flags.append("This template should use requirejs_main_b5 instead of requirejs_main.")
+                issues.append("This template should use requirejs_main_b5 instead of requirejs_main.")
     regex = r"(=[\"\'][\w\/]+)(\/bootstrap3\/)"
     if re.search(regex, line):
-        flags.append("This template references a bootstrap 3 file.")
-    return flags
+        issues.append("This template references a bootstrap 3 file.")
+    return issues
 
 
 def check_bootstrap3_references_in_javascript(line):
-    flags = []
+    issues = []
     regex = _get_javascript_reference_regex('bootstrap3')
     if re.search(regex, line):
-        flags.append("This javascript file references a bootstrap 3 file.")
-    return flags
+        issues.append("This javascript file references a bootstrap 3 file.")
+    return issues
 
 
 def flag_inline_styles(line):

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -195,7 +195,7 @@ def flag_stateful_button_changes_bootstrap5(line):
     return flags
 
 
-def flag_bootstrap3_references_in_template(line, spec):
+def check_bootstrap3_references_in_template(line, spec):
     flags = []
     for tag in spec['template_tags_with_dependencies']:
         b3_ref_regex = _get_template_reference_regex(tag, 'bootstrap3')

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -221,7 +221,7 @@ def check_bootstrap3_references_in_template(line, spec):
     return flags
 
 
-def flag_bootstrap3_references_in_javascript(line):
+def check_bootstrap3_references_in_javascript(line):
     flags = []
     regex = _get_javascript_reference_regex('bootstrap3')
     if re.search(regex, line):


### PR DESCRIPTION
## Technical Summary
This updates the `migrate_app_to_bootstrap5_tool` to write `{# todo B5: ... #}` or `/* todo B5: .... */` comments at the ends of lines that have been flagged by the migration tool. I had to rewrite how we do flags to return in the `[slug, guidance_text]` format. I also renamed the checks we are only using in the `show_invalid_bootstrap3_files` tool so that there's no confusion on what the return format should be.

## Safety Assurance

### Safety story
Safe change, only updates internal tools

### Automated test coverage
Yes

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
