### PR TITLE
Fuzzy Search - fixed prefix length

### DIFF
--- a/corehq/apps/case_search/admin.py
+++ b/corehq/apps/case_search/admin.py
@@ -1,0 +1,11 @@
+from django.contrib import admin
+
+from .models import CaseSearchConfig
+
+
+@admin.register(CaseSearchConfig)
+class CaseSearchConfigAdmin(admin.ModelAdmin):
+    list_display = ['domain', 'enabled']
+    list_filter = ['domain', 'enabled']
+    search_fields = ['domain']
+    exclude = ['fuzzy_properties', 'ignore_patterns']

--- a/corehq/apps/case_search/dsl_utils.py
+++ b/corehq/apps/case_search/dsl_utils.py
@@ -6,12 +6,12 @@ from corehq.apps.case_search.exceptions import (
     CaseFilterError,
     XPathFunctionException,
 )
-from corehq.apps.case_search.xpath_functions import XPATH_VALUE_FUNCTIONS
 
 
 def unwrap_value(value, context):
     """Returns the value of the node if it is wrapped in a function, otherwise just returns the node
     """
+    from corehq.apps.case_search.xpath_functions import XPATH_VALUE_FUNCTIONS
     if isinstance(value, Step):
         raise CaseFilterError(
             _("You cannot reference a case property on the right side "

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -30,9 +30,11 @@ class SearchFilterContext:
     fuzzy: bool = False
     request_domain: str = None
     profiler: 'corehq.apps.case_search.utils.CaseSearchProfiler' = None
+    config: 'corehq.apps.case_search.models.CaseSearchConfig' = None
 
     def __post_init__(self):
         from corehq.apps.case_search.utils import CaseSearchProfiler
+        from corehq.apps.case_search.models import CaseSearchConfig
         if self.request_domain is None:
             if isinstance(self.domain, str):
                 self.request_domain = self.domain
@@ -42,6 +44,8 @@ class SearchFilterContext:
                 raise ValueError("When domain is a list with more than one item, request_domain cannot be None.")
         if self.profiler is None:
             self.profiler = CaseSearchProfiler()
+        if self.config is None:
+            self.config = CaseSearchConfig(domain=self.request_domain)
 
 
 def print_ast(node):

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -130,7 +130,7 @@ def build_filter_from_ast(node, context):
     return visit(node)
 
 
-def build_filter_from_xpath(query_domain, xpath, fuzzy=False, request_domain=None, profiler=None):
+def build_filter_from_xpath(xpath, *, domain=None, context=None):
     """Given an xpath expression this function will generate an Elasticsearch
     filter"""
     error_message = _(
@@ -138,7 +138,10 @@ def build_filter_from_xpath(query_domain, xpath, fuzzy=False, request_domain=Non
         "Please try reformatting your query. "
         "The operators we accept are: {}"
     )
-    context = SearchFilterContext(query_domain, fuzzy, request_domain, profiler)
+    if bool(context) == bool(domain):
+        raise TypeError("build_filter_from_xpath takes either a context or a domain, but not both")
+    if not context:
+        context = SearchFilterContext(domain)
     try:
         return build_filter_from_ast(parse_xpath(xpath), context)
     except TypeError as e:

--- a/corehq/apps/case_search/migrations/0013_casesearchconfig_fuzzy_prefix_length.py
+++ b/corehq/apps/case_search/migrations/0013_casesearchconfig_fuzzy_prefix_length.py
@@ -1,0 +1,20 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('case_search', '0012_casesearchconfig_sync_cases_on_form_entry'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='casesearchconfig',
+            name='fuzzy_prefix_length',
+            field=models.SmallIntegerField(blank=True, null=True, validators=[
+                django.core.validators.MinValueValidator(0),
+                django.core.validators.MaxValueValidator(10),
+            ]),
+        ),
+    ]

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -1,11 +1,13 @@
 import re
 
-import attr
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.forms import model_to_dict
 from django.utils.translation import gettext as _
+
+import attr
 
 from corehq.apps.case_search.exceptions import CaseSearchUserError
 from corehq.apps.case_search.filter_dsl import CaseFilterError
@@ -288,6 +290,9 @@ class CaseSearchConfig(models.Model):
     sync_cases_on_form_entry = models.BooleanField(blank=False, null=False, default=False)
     fuzzy_properties = models.ManyToManyField(FuzzyProperties)
     ignore_patterns = models.ManyToManyField(IgnorePatterns)
+    fuzzy_prefix_length = models.SmallIntegerField(blank=True, null=True, validators=[
+        MinValueValidator(0), MaxValueValidator(10),
+    ])
 
     objects = GetOrNoneManager()
 

--- a/corehq/apps/case_search/tests/test_case_search_filters.py
+++ b/corehq/apps/case_search/tests/test_case_search_filters.py
@@ -9,8 +9,11 @@ from corehq.apps.es.tests.utils import es_test
 
 @es_test
 class TestCaseSearchLookups(BaseCaseSearchTest):
+    def setUp(self):
+        super().setUp()
+        self.config = self._create_case_search_config()
+
     def test_date_range_criteria(self):
-        self._create_case_search_config()
         self._assert_query_runs_correctly(
             self.domain,
             [
@@ -34,13 +37,12 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             {'_id': 'c2', 'case_type': 'song', 'description': 'Neu York'},
             {'_id': 'c3', 'case_type': 'show', 'description': 'Boston'},
         ]
-        config = self._create_case_search_config()
         fuzzy_properties = FuzzyProperties.objects.create(
             domain=self.domain,
             case_type='song',
             properties=['description'],
         )
-        config.fuzzy_properties.add(fuzzy_properties)
+        self.config.fuzzy_properties.add(fuzzy_properties)
         self.addCleanup(fuzzy_properties.delete)
         self._assert_query_runs_correctly(
             self.domain,
@@ -55,10 +57,9 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             {'_id': 'c1', 'case_type': 'person', 'phone_number': '8675309'},
             {'_id': 'c2', 'case_type': 'person', 'phone_number': '9045555555'},
         ]
-        config = self._create_case_search_config()
         pattern = IgnorePatterns.objects.create(
             domain=self.domain, case_type='person', case_property='phone_number', regex="+1")
-        config.ignore_patterns.add(pattern)
+        self.config.ignore_patterns.add(pattern)
         self.addCleanup(pattern.delete)
         self._assert_query_runs_correctly(
             self.domain,
@@ -75,7 +76,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             {'_id': 'c3', 'case_type': 'show', 'description': 'New York'},
             {'_id': 'c4', 'case_type': 'show', 'description': 'Boston'},
         ]
-        self._create_case_search_config()
         self._assert_query_runs_correctly(
             self.domain,
             cases,
@@ -86,7 +86,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
 
     def test_blank_case_search(self):
         # foo = '' should match all cases where foo is empty or absent
-        self._create_case_search_config()
         self._bootstrap_cases_in_es_for_domain(self.domain, [
             {'_id': 'c1', 'foo': 'redbeard'},
             {'_id': 'c2', 'foo': 'blackbeard'},
@@ -102,7 +101,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             self.assertItemsEqual(actual, expected, msg=msg)
 
     def test_blank_case_search_parent(self):
-        self._create_case_search_config()
         self._bootstrap_cases_in_es_for_domain(self.domain, [
             {'_id': 'c1', 'foo': 'redbeard'},
             {'_id': 'c2', 'case_type': 'child', 'index': {'parent': (self.case_type, 'c1')}},
@@ -119,7 +117,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
         self.assertItemsEqual(actual, ['c4', 'c6', 'c8'])
 
     def test_selected_any_function(self):
-        self._create_case_search_config()
         cases = [
             {'_id': 'c1', 'case_type': 'song', 'description': 'New York'},
             {'_id': 'c2', 'case_type': 'song', 'description': 'Manchester'},
@@ -138,7 +135,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
         )
 
     def test_selected_all_function(self):
-        self._create_case_search_config()
         cases = [
             {'_id': 'c1', 'case_type': 'song', 'description': 'New York'},
             {'_id': 'c2', 'case_type': 'song', 'description': 'Manchester'},
@@ -159,7 +155,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
         )
 
     def test_selected_any_function_string_prop_name(self):
-        self._create_case_search_config()
         cases = [
             {'_id': 'c1', 'case_type': 'song', 'description': 'New York'},
             {'_id': 'c2', 'case_type': 'song', 'description': 'Manchester'},
@@ -186,7 +181,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             )
 
     def test_index_case_search(self):
-        self._create_case_search_config()
         self._bootstrap_cases_in_es_for_domain(self.domain, [
             {'_id': 'c1', 'foo': 'redbeard'},
             {'_id': 'c2', 'case_type': 'child', 'index': {'parent': (self.case_type, 'c1')}},
@@ -204,7 +198,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
         self.assertItemsEqual(actual, ['c4'])
 
     def test_match_all(self):
-        self._create_case_search_config()
         cases = [
             {'_id': 'c1', 'case_type': 'song', 'description': 'New York'},
             {'_id': 'c2', 'case_type': 'song', 'description': 'Manchester'},
@@ -223,7 +216,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
         )
 
     def test_match_none(self):
-        self._create_case_search_config()
         cases = [
             {'_id': 'c1', 'case_type': 'song', 'description': 'New York'},
             {'_id': 'c2', 'case_type': 'song', 'description': 'Manchester'},

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -14,6 +14,7 @@ from corehq.apps.case_search.filter_dsl import (
     SearchFilterContext,
     build_filter_from_ast,
 )
+from corehq.apps.case_search.models import CaseSearchConfig
 from corehq.apps.es import filters
 from corehq.apps.es.case_search import (
     CaseSearchES,
@@ -202,6 +203,14 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         self._test_xpath_query(
             "fuzzy-match(name, 'jimmy')",
             case_property_query("name", "jimmy", fuzzy=True)
+        )
+
+    def test_fuzzy_match_with_prefix(self):
+        context = SearchFilterContext("domain", config=CaseSearchConfig(domain="domain", fuzzy_prefix_length=2))
+        self._test_xpath_query(
+            "fuzzy-match(name, 'jimmy')",
+            case_property_query("name", "jimmy", fuzzy=True, fuzzy_prefix_length=2),
+            context=context,
         )
 
     def _test_xpath_query(self, query_string, expected_filter, context=None):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -321,7 +321,7 @@ class CaseSearchQueryBuilder:
 
     def _build_filter_from_xpath(self, xpath, fuzzy=False):
         context = SearchFilterContext(self.query_domains, fuzzy, self.request_domain,
-                                      self.profiler)
+                                      self.profiler, self.config)
         with self.profiler.timing_context('_build_filter_from_xpath'):
             return build_filter_from_xpath(xpath, context=context)
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -365,7 +365,8 @@ class CaseSearchQueryBuilder:
         elif criteria.is_index_query:
             return reverse_index_case_query(value, criteria.index_query_identifier)
         else:
-            return case_property_query(criteria.key, value, fuzzy=fuzzy)
+            return case_property_query(criteria.key, value, fuzzy=fuzzy,
+                                       fuzzy_prefix_length=self.config.fuzzy_prefix_length)
 
     def _remove_ignored_patterns(self, case_property, value):
         for to_remove in self._patterns_to_remove[case_property]:

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -24,7 +24,7 @@ from corehq.apps.case_search.exceptions import (
     CaseSearchUserError,
     TooManyRelatedCasesError,
 )
-from corehq.apps.case_search.filter_dsl import build_filter_from_xpath
+from corehq.apps.case_search.filter_dsl import build_filter_from_xpath, SearchFilterContext
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     CASE_SEARCH_XPATH_QUERY_KEY,
@@ -320,9 +320,10 @@ class CaseSearchQueryBuilder:
         return search_es
 
     def _build_filter_from_xpath(self, xpath, fuzzy=False):
+        context = SearchFilterContext(self.query_domains, fuzzy, self.request_domain,
+                                      self.profiler)
         with self.profiler.timing_context('_build_filter_from_xpath'):
-            return build_filter_from_xpath(self.query_domains, xpath, fuzzy,
-                                           self.request_domain, self.profiler)
+            return build_filter_from_xpath(xpath, context=context)
 
     def _get_daterange_query(self, criteria):
         startdate, enddate = criteria.get_date_range()

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -3,6 +3,7 @@ from eulxml.xpath import serialize
 from eulxml.xpath.ast import BinaryExpression, FunctionCall, Step
 
 from corehq.apps.case_search.const import OPERATOR_MAPPING, EQ
+from corehq.apps.case_search.dsl_utils import unwrap_value
 from corehq.apps.case_search.exceptions import CaseFilterError, TooManyRelatedCasesError
 from corehq.apps.case_search.xpath_functions.utils import confirm_args_count
 from corehq.apps.case_search.const import MAX_RELATED_CASES
@@ -150,9 +151,8 @@ def _validate_ancestor_exists_filter(node):
 
 
 def _get_case_ids_from_ast_filter(context, filter_node):
-    from corehq.apps.case_search.dsl_utils import unwrap_value
     if (isinstance(filter_node, BinaryExpression)
-    and serialize(filter_node.left) == "@case_id" and filter_node.op == EQ):
+            and serialize(filter_node.left) == "@case_id" and filter_node.op == EQ):
         # case id is provided in query i.e @case_id="b9eaf791-e427-482d-add4-2a60acf0362e"
         case_ids = unwrap_value(filter_node.right, context)
         return [case_ids] if isinstance(case_ids, str) else case_ids

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -6,6 +6,7 @@ from jsonobject.exceptions import BadValueError
 
 from couchforms.geopoint import GeoPoint
 
+from corehq.apps.case_search.dsl_utils import unwrap_value
 from corehq.apps.case_search.exceptions import XPathFunctionException
 from corehq.apps.es import filters
 from corehq.apps.es.queries import DISTANCE_UNITS
@@ -87,8 +88,6 @@ def phonetic_match(node, context):
 
 def fuzzy_match(node, context):
     """fuzzy-match(alias, 'pinky')"""
-    from corehq.apps.case_search.dsl_utils import unwrap_value
-
     confirm_args_count(node, 2)
     property_name = _property_name_to_string(node.args[0], node)
     value = unwrap_value(node.args[1], context)

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -92,7 +92,8 @@ def fuzzy_match(node, context):
     property_name = _property_name_to_string(node.args[0], node)
     value = unwrap_value(node.args[1], context)
 
-    return case_property_query(property_name, value, fuzzy=True)
+    return case_property_query(property_name, value, fuzzy=True,
+                               fuzzy_prefix_length=context.config.fuzzy_prefix_length)
 
 
 def _property_name_to_string(value, node):

--- a/corehq/apps/case_search/xpath_functions/value_functions.py
+++ b/corehq/apps/case_search/xpath_functions/value_functions.py
@@ -10,6 +10,7 @@ from eulxml.xpath.ast import serialize
 
 from dimagi.utils.parsing import ISO_DATE_FORMAT
 
+from corehq.apps.case_search.dsl_utils import unwrap_value
 from corehq.apps.case_search.exceptions import XPathFunctionException
 from corehq.apps.domain.models import Domain
 
@@ -17,8 +18,6 @@ from .utils import confirm_args_count
 
 
 def date(node, context):
-    from corehq.apps.case_search.dsl_utils import unwrap_value
-
     assert node.name == 'date'
     confirm_args_count(node, 1)
     arg = node.args[0]
@@ -62,8 +61,6 @@ def today(node, context):
 
 
 def date_add(node, context):
-    from corehq.apps.case_search.dsl_utils import unwrap_value
-
     assert node.name == 'date-add'
 
     confirm_args_count(node, 3)

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -183,7 +183,8 @@ case_search_adapter = create_document_adapter(
 )
 
 
-def case_property_query(case_property_name, value, fuzzy=False, multivalue_mode=None):
+def case_property_query(case_property_name, value, fuzzy=False, multivalue_mode=None,
+                        fuzzy_prefix_length=None):
     """
     Search for all cases where case property with name `case_property_name`` has text value `value`
     """
@@ -194,12 +195,15 @@ def case_property_query(case_property_name, value, fuzzy=False, multivalue_mode=
     if value == '':
         return case_property_missing(case_property_name)
     if fuzzy:
+        kwargs = {'fuzziness': 'AUTO'}
+        if fuzzy_prefix_length:
+            kwargs['prefix_length'] = fuzzy_prefix_length
         return _base_property_query(
             case_property_name,
             filters.OR(
                 # fuzzy match. This portion of this query OR's together multi-word case
                 # property values and doesn't respect multivalue_mode
-                queries.fuzzy(value, PROPERTY_VALUE, fuzziness='AUTO'),
+                queries.fuzzy(value, PROPERTY_VALUE, **kwargs),
                 # non-fuzzy match. added to improve the score of exact matches
                 queries.match(value, PROPERTY_VALUE, operator=multivalue_mode)
             ),

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -93,8 +93,9 @@ class CaseSearchES(CaseES):
 
         If fuzzy is true, all equality checks will be treated as fuzzy.
         """
-        from corehq.apps.case_search.filter_dsl import build_filter_from_xpath
-        return self.filter(build_filter_from_xpath(domain, xpath, fuzzy=fuzzy))
+        from corehq.apps.case_search.filter_dsl import build_filter_from_xpath, SearchFilterContext
+        context = SearchFilterContext(domain, fuzzy=fuzzy)
+        return self.filter(build_filter_from_xpath(xpath, context=context))
 
     def get_child_cases(self, case_ids, identifier):
         """Returns all cases that reference cases with ids: `case_ids`

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -99,13 +99,14 @@ def match(search_string, field, operator=None):
     }
 
 
-def fuzzy(search_string, field, fuzziness="AUTO"):
+def fuzzy(search_string, field, fuzziness="AUTO", **kwargs):
     return {
         "fuzzy": {
             field: {
                 "value": f"{search_string}".lower(),
                 "fuzziness": fuzziness,
-                "max_expansions": 100
+                "max_expansions": 100,
+                **kwargs
             }
         }
     }
@@ -117,13 +118,12 @@ def nested(path, query, *args, **kwargs):
 
     Keyword arguments such as score_mode and others can be added.
     """
-    nested = {
-        "path": path,
-        "query": query
-    }
-    nested.update(kwargs)
     return {
-        "nested": nested
+        "nested": {
+            "path": path,
+            "query": query,
+            **kwargs
+        }
     }
 
 
@@ -133,13 +133,12 @@ def nested_filter(path, filter_, *args, **kwargs):
 
     Keyword arguments such as score_mode and others can be added.
     """
-    nested = {
-        "path": path,
-        "filter": filter_
-    }
-    nested.update(kwargs)
     return {
-        "nested": nested
+        "nested": {
+            "path": path,
+            "filter": filter_,
+            **kwargs,
+        }
     }
 
 

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -183,6 +183,6 @@ def _get_filter(domain, key, val):
 
 def _get_query_filter(domain, query):
     try:
-        return build_filter_from_xpath(domain, query)
+        return build_filter_from_xpath(query, domain=domain)
     except CaseFilterError as e:
         raise UserError(f'Bad query: {e}')

--- a/migrations.lock
+++ b/migrations.lock
@@ -225,6 +225,7 @@ case_search
  0010_casesearchconfig_synchronous_web_apps
  0011_domainsnotincasesearchindex
  0012_casesearchconfig_sync_cases_on_form_entry
+ 0013_casesearchconfig_fuzzy_prefix_length
 cleanup
  0001_convert_change_feed_checkpoint_to_sql
  0002_convert_mc_checkpoint_to_sql


### PR DESCRIPTION
## Product Description

Adds a superuser-only setting to specify a fixed prefix length to fuzzy queries in case search.  When set to `2`, for example, fuzzy queries will no longer match on strings where either of the first two characters is wrong.  Likewise for whatever value is specified.

## Technical Summary
This PR adds a new field to the `CaseSearchConfig` called `fuzzy_prefix_length`.  When set, this will be passed as the `prefix_length` [parameter](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-fuzzy-query.html#_parameters_6) to fuzzy queries made via the case search endpoint.

Steps to activate:
1. Go to /admin/case_search/casesearchconfig/
2. Search for the domain in question
3. Open the case search config admin page
4. Set the "Fuzzy prefix length" field to 1 or 2, as desired (I wouldn't go higher than that)
5. Click "Save"

This can be deactivated by deleting the stored value through the same interface.

![image](https://github.com/dimagi/commcare-hq/assets/2367539/bcfe5101-e7c6-418f-b6f3-981ca0142240)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Added a few test cases for this new setting

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

This PR has a migration that introduces a new field.  Reverting the PR would leave that field orphaned.  If it came to it, the best bet would probably be to revert the other commits.  The goal with making this a configurable setting is to easily test it out while preserving the ability to easily roll back or tweak the change if its effects are undesirable (without a deploy)

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
