### PR TITLE
`user` can be `None`

### DIFF
--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -69,10 +69,13 @@ def _get_latest_enabled_build(domain, username, app_id, profile_id, location_fla
     latest_enabled_build = None
     if location_flag_enabled:
         user = CommCareUser.get_by_username(normalize_username(username, domain))
-        user_location_id = user.location_id
-        if user_location_id:
+        if user and user.location_id:
             parent_app_id = get_app(domain, app_id).copy_of
-            latest_enabled_build = get_latest_app_release_by_location(domain, user_location_id, parent_app_id)
+            latest_enabled_build = get_latest_app_release_by_location(
+                domain,
+                user.location_id,
+                parent_app_id,
+            )
     if not latest_enabled_build:
         # Fall back to the old logic to support migration
         # ToDo: Remove this block once migration is complete

--- a/corehq/apps/app_manager/tests/test_apps.py
+++ b/corehq/apps/app_manager/tests/test_apps.py
@@ -10,6 +10,7 @@ from memoized import memoized
 from unittest.mock import patch
 
 from corehq.apps.app_manager.dbaccessors import get_app, get_build_ids
+from corehq.apps.app_manager.decorators import _get_latest_enabled_build
 from corehq.apps.app_manager.models import (
     Application,
     ApplicationBase,
@@ -401,3 +402,13 @@ class AppManagerTest(TestCase, TestXmlMixin):
         unlinked_doc = linked_app.convert_to_application().to_json()
         self.assertEqual(unlinked_doc['doc_type'], 'Application')
         self.assertFalse(hasattr(unlinked_doc, 'linked_app_attrs'))
+
+    def test_get_latest_enabled_build_with_loc_flag(self):
+        build = _get_latest_enabled_build(
+            self.domain,
+            'no-such-user',
+            self.app._id,
+            None,
+            location_flag_enabled=True,
+        )
+        self.assertIsNone(build)


### PR DESCRIPTION
## Technical Summary

Fixes [this Sentry error](https://dimagi.sentry.io/issues/5278522287/?project=136860&referrer=github-pr-bot).

## Safety Assurance

### Safety story

The problem is obvious when you see that `CommCareUser.get_by_username()` can return `None`.

### Automated test coverage

Test added

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
