### PR TITLE
Added knockout_bindings as a dependency of entries.js

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -14,6 +14,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
     'cloudcare/js/form_entry/utils',
     'signature_pad/dist/signature_pad.umd.min',
     'mapbox.js/dist/mapbox.uncompressed',
+    'hqwebapp/js/bootstrap3/knockout_bindings.ko',  // fadeVisible
     'cloudcare/js/formplayer/utils/calendar-picker-translations',   // EthiopianDateEntry
     'select2/dist/js/select2.full.min',
 ], function (


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SUPPORT-19569

Fixes a bug where "Clear" buttons were showing for checkbox questions. They should only show for questions using radio buttons.

## Technical Summary
Introduced in https://github.com/dimagi/commcare-hq/pull/34271 when we started using expicit dependencies.

The `fadeVisible` binding that controls the "Clear" button for multiselect questions (see [here](https://github.com/dimagi/commcare-hq/blob/9de16994bca831babb78ad5b31c23a5e393bb4b2/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_select.html#L25-L27)) is defined in `knockout_bindings.ko.js`, so that needs to be added as a dependency.

## Safety Assurance

### Safety story
Local testing should be sufficient for this. Tiny, very low-risk change.

### Automated test coverage

not really

### QA Plan

no

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
