### PR TITLE
[B5] Mark completed apps as complete

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -58,5 +58,8 @@
   },
   "user_importer": {
     "is_complete": true
+  },
+  "dropbox": {
+    "is_complete": true
   }
 }

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -61,5 +61,8 @@
   },
   "dropbox": {
     "is_complete": true
+  },
+  "casexml": {
+    "is_complete": true
   }
 }

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -67,5 +67,8 @@
   },
   "programs": {
     "is_complete": true
+  },
+  "products": {
+    "is_complete": true
   }
 }

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -64,5 +64,8 @@
   },
   "casexml": {
     "is_complete": true
+  },
+  "programs": {
+    "is_complete": true
   }
 }

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -46,5 +46,8 @@
   },
   "corehq.tabs": {
     "in_progress": true
+  },
+  "ota": {
+    "is_complete": true
   }
 }

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -52,5 +52,8 @@
   },
   "commtrack": {
     "is_complete": true
+  },
+  "registry": {
+    "is_complete": true
   }
 }

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -55,5 +55,8 @@
   },
   "registry": {
     "is_complete": true
+  },
+  "user_importer": {
+    "is_complete": true
   }
 }

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -49,5 +49,8 @@
   },
   "ota": {
     "is_complete": true
+  },
+  "commtrack": {
+    "is_complete": true
   }
 }


### PR DESCRIPTION
## Technical Summary
A few apps that were completed in the google sheet were not marked as complete in the `json` status file, so our completeness tests are ignoring these applications. This PR ensures that those apps are not missed by our Bootstrap 5 completion tests, in case new templates/javascript are added to these apps.

## Safety Assurance

### Safety story
Safe change. just modifies an internally used javascript file.

### Automated test coverage
Yes. The modified file determines what apps will be tested for bootstrap 5 migration completeness

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
