### PR TITLE
[B5] Ensure that if spec files were split, Gruntfile.js is updated

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -244,6 +244,15 @@ class Command(BaseCommand):
         return set(available_js_files).difference(completed_js_files)
 
     def migrate_files(self, files, app_name, spec, is_template):
+        """
+        Migrates a list of files if there are changes.
+
+        :param app_name: string (app name that's being migrated)
+        :param files: list(Path) (object)
+        :param spec: dict
+        :param is_template: boolean (whether the file is a template or javascript file)
+        :return: list(Path) (list of all Paths that had changes)
+        """
         migrated_files = []
         for index, file_path in enumerate(files):
             short_path = get_short_path(app_name, file_path, is_template)
@@ -270,6 +279,17 @@ class Command(BaseCommand):
         return migrated_files
 
     def migrate_single_file(self, app_name, file_path, spec, is_template, review_changes):
+        """
+        This runs through each line in a file and obtains flagged todos and changes for each line
+        and applies them, depending on user input (if skip-all isn't active).
+
+        :param app_name: string (app name that's being migrated)
+        :param file_path: Path (object)
+        :param spec: dict
+        :param is_template: boolean (whether the file is a template or javascript file)
+        :param review_changes: boolean (option of whether the user should review line-by-line)
+        :return: boolean (True if changes were made, False if no changes)
+        """
         is_fresh_migration = not is_bootstrap5_path(file_path)
         with open(file_path, 'r') as current_file:
             old_lines = current_file.readlines()

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -148,7 +148,7 @@ class Command(BaseCommand):
             return
 
         app_templates = self.get_templates_for_migration(app_name, selected_filename)
-        self.migrate_files(app_templates, app_name, spec, is_template=True)
+        migrated_templates = self.migrate_files(app_templates, app_name, spec, is_template=True)
 
         app_javascript = self.get_js_files_for_migration(app_name, selected_filename)
         self.migrate_files(app_javascript, app_name, spec, is_template=False)
@@ -215,6 +215,7 @@ class Command(BaseCommand):
         return set(available_js_files).difference(completed_js_files)
 
     def migrate_files(self, files, app_name, spec, is_template):
+        migrated_files = []
         for index, file_path in enumerate(files):
             short_path = get_short_path(app_name, file_path, is_template)
             self.clear_screen()
@@ -235,7 +236,9 @@ class Command(BaseCommand):
                 )
             else:
                 review_changes = False
-            self.migrate_single_file(app_name, file_path, spec, is_template, review_changes)
+            if self.migrate_single_file(app_name, file_path, spec, is_template, review_changes):
+                migrated_files.append(file_path)
+        return migrated_files
 
     def migrate_single_file(self, app_name, file_path, spec, is_template, review_changes):
         is_fresh_migration = not is_bootstrap5_path(file_path)
@@ -281,8 +284,10 @@ class Command(BaseCommand):
                     self.split_files_and_refactor(
                         app_name, file_path, old_lines, new_lines, is_template
                     )
+                return True
             else:
                 self.write_response(f"\nNo changes were needed for {short_path}. Skipping...\n\n")
+        return False
 
     def confirm_and_get_line_changes(self, line_number, old_line, new_line, renames, flags, review_changes):
         changelog = []

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -17,6 +17,7 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     flag_inline_styles,
     make_template_dependency_renames,
     add_todo_comments_for_flags,
+    update_gruntfile,
 )
 
 
@@ -401,3 +402,39 @@ def test_add_todo_comments_for_flags_javascript_noop():
     )
     line = add_todo_comments_for_flags(flags, line, is_template=False)
     eq(line, line)
+
+
+def test_update_gruntfile():
+    filedata = """
+    var apps = [
+        'app_manager',
+        'export/ko',
+        'notifications',
+        'reports_core/choiceListUtils',
+        'locations',
+        'userreports',
+        'cloudcare',
+        'cloudcare/form_entry',
+        'hqwebapp',
+        'case_importer',
+    ];
+    """
+    mocha_paths = ["cloudcare/spec/mocha.html", "cloudcare/spec/form_entry/mocha.html"]
+    result = update_gruntfile(filedata, mocha_paths)
+    expected_result = """
+    var apps = [
+        'app_manager',
+        'export/ko',
+        'notifications',
+        'reports_core/choiceListUtils',
+        'locations',
+        'userreports',
+        'cloudcare/bootstrap3',
+        'cloudcare/bootstrap5',
+        'cloudcare/form_entry/bootstrap3',
+        'cloudcare/form_entry/bootstrap5',
+        'hqwebapp',
+        'case_importer',
+    ];
+    """
+    eq(result, expected_result)

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -54,6 +54,10 @@ def _get_javascript_reference_regex(reference):
     return r"(['\"][\w/.\-]+/)(" + reference + r")(/[\w/.\-]+['\"],?)"
 
 
+def _get_mocha_app_regex(app):
+    return r"([ ]+[\"\'])(" + app + r")([\"\'],\n)"
+
+
 def _get_todo_regex(is_template):
     open_comment = r"\{#" if is_template else r"\/\*"
     close_comment = r"#\}" if is_template else r"\*\/"
@@ -267,3 +271,16 @@ def replace_path_references(filedata, old_reference, new_reference):
         repl=r"\1" + new_reference + r"\3",
         string=filedata
     )
+
+
+def update_gruntfile(filedata, mocha_paths):
+    mocha_apps = [path.replace('/spec', '').replace('/mocha.html', '')
+                  for path in mocha_paths]
+    for app in mocha_apps:
+        regex = _get_mocha_app_regex(app)
+        filedata = re.sub(
+            pattern=regex,
+            repl=r"\1" + f"{app}/bootstrap3" + r"\3\1" + f"{app}/bootstrap5" + r"\3",
+            string=filedata
+        )
+    return filedata

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -274,7 +274,7 @@ def replace_path_references(filedata, old_reference, new_reference):
 
 
 def update_gruntfile(filedata, mocha_paths):
-    mocha_apps = [path.replace('/spec', '').replace('/mocha.html', '')
+    mocha_apps = [path.replace('/spec/', '/').removesuffix('/mocha.html')
                   for path in mocha_paths]
     for app in mocha_apps:
         regex = _get_mocha_app_regex(app)

--- a/corehq/apps/hqwebapp/utils/bootstrap/paths.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/paths.py
@@ -12,6 +12,7 @@ PARENT_PATHS = {
     "casexml": COREHQ_BASE_DIR / "ex-submodules/casexml/apps",
     "ex-submodules": COREHQ_BASE_DIR / "ex-submodules",
 }
+GRUNTFILE_PATH = COREHQ_BASE_DIR.parent / "Gruntfile.js"
 
 
 def is_split_path(path):


### PR DESCRIPTION
## Technical Summary
I noticed when splitting an app, if `spec` templates were split, eg `hqwebapp/spec/mocha.html` became `hqwebapp/spec/bootstrap3/mocha.html` and `hqwebapp/spec/bootstrap5/mocha.html`, the javascript tests failed. This is because `Gruntfile.js` was not properly updated. Jenny had taken care of updating the views [here](https://github.com/dimagi/commcare-hq/pull/34521/commits/de437e34d01863223ae4f42e79203e8e318d9e80) when splitting web apps. Since a simple update to `Gruntfile.js` is all that's needed moving forward, I decided to automate these changes.

## Safety Assurance

### Safety story
Only updates a particular tool. tests are present

### Automated test coverage
yes

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
