### PR TITLE
Only include mobile reports from accessible apps in web apps restores

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -109,7 +109,7 @@ class ReportFixturesProvider(FixtureProvider):
 
     def _get_apps(self, restore_state, restore_user):
         app_aware_sync_app = restore_state.params.app
-        web_apps_restore = restore_state.params.device_id.startswith('WebAppsLogin')
+        web_apps_restore = restore_state.params.is_webapps
 
         if app_aware_sync_app:
             apps = [app_aware_sync_app]
@@ -117,7 +117,9 @@ class ReportFixturesProvider(FixtureProvider):
             apps = get_apps_in_domain(restore_user.domain, include_remote=False)
             if web_apps_restore and toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY:
                 # use couch_user to determine app access
-                apps = filter_available_web_apps(apps, restore_user.domain, restore_user._couch_user, False)
+                apps = filter_available_web_apps(
+                    apps, restore_user.domain, restore_user._couch_user, is_preview=False
+                )
 
         return apps
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -25,7 +25,7 @@ from corehq.apps.app_manager.dbaccessors import (
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     is_valid_mobile_select_filter_type,
 )
-from corehq.apps.app_manager.util import get_correct_app_class
+from corehq.apps.app_manager.util import get_correct_app_class, is_remote_app
 from corehq.apps.cloudcare.utils import fetch_build, filter_available_web_apps
 from corehq.apps.userreports.exceptions import (
     ReportConfigurationNotFoundError,
@@ -120,14 +120,12 @@ class ReportFixturesProvider(FixtureProvider):
             apps = [
                 fetch_build(restore_user.domain, restore_user._couch_user.username, app_id) for app_id in app_ids
             ]
-            if web_apps_restore and toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY:
-                # use couch_user to determine app access
-                apps = filter_available_web_apps(
-                    apps, restore_user.domain, restore_user._couch_user, is_preview=False
-                )
+            apps = [app for app in apps if not is_remote_app(app)]
+            # use couch_user to determine app access
+            apps = filter_available_web_apps(apps, restore_user.domain, restore_user._couch_user, is_preview=False)
             apps = [get_correct_app_class(app).wrap(app) for app in apps]
         else:
-            apps = get_apps_in_domain(restore_user.domain)
+            apps = get_apps_in_domain(restore_user.domain, include_remote=False)
 
         return apps
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -115,7 +115,7 @@ class ReportFixturesProvider(FixtureProvider):
             apps = [app_aware_sync_app]
         else:
             apps = get_apps_in_domain(restore_user.domain, include_remote=False)
-            if web_apps_restore:
+            if web_apps_restore and toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY:
                 # use couch_user to determine app access
                 apps = filter_available_web_apps(apps, restore_user.domain, restore_user._couch_user, False)
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -1,6 +1,5 @@
 import logging
 import numbers
-import uuid
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -439,7 +438,9 @@ def generate_rows_and_filters(report_data_cache, report_config, restore_user, ro
     return row_elements, filters_elem
 
 
-def get_report_element(report_data_cache, report_config, data_source, deferred_fields, filter_options_by_field, row_to_element):
+def get_report_element(
+    report_data_cache, report_config, data_source, deferred_fields, filter_options_by_field, row_to_element
+):
     """
     :param row_to_element: function (
                 deferred_fields, filter_options_by_field, row, index, is_total_row

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -25,6 +25,7 @@ from corehq.apps.app_manager.dbaccessors import (
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     is_valid_mobile_select_filter_type,
 )
+from corehq.apps.cloudcare.utils import filter_available_web_apps
 from corehq.apps.userreports.exceptions import (
     ReportConfigurationNotFoundError,
     UserReportsError,
@@ -109,11 +110,15 @@ class ReportFixturesProvider(FixtureProvider):
 
     def _get_apps(self, restore_state, restore_user):
         app_aware_sync_app = restore_state.params.app
+        web_apps_restore = restore_state.params.device_id.startswith('WebAppsLogin')
 
         if app_aware_sync_app:
             apps = [app_aware_sync_app]
         else:
             apps = get_apps_in_domain(restore_user.domain, include_remote=False)
+            if web_apps_restore:
+                # use couch_user to determine app access
+                apps = filter_available_web_apps(apps, restore_user.domain, restore_user._couch_user, False)
 
         return apps
 

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -47,9 +47,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_app_ids_in_domain,
     get_current_app,
     get_current_app_doc,
-    get_latest_build_doc,
     get_latest_build_id,
-    get_latest_released_app_doc,
     get_latest_released_build_id,
 )
 
@@ -62,6 +60,7 @@ from corehq.apps.cloudcare.decorators import require_cloudcare_access
 from corehq.apps.cloudcare.esaccessors import login_as_user_query
 from corehq.apps.cloudcare.models import SQLAppGroup
 from corehq.apps.cloudcare.utils import (
+    fetch_build,
     filter_available_web_apps,
     get_mobile_ucr_count,
     should_restrict_web_apps_usage,
@@ -110,7 +109,7 @@ class FormplayerMain(View):
         return super(FormplayerMain, self).dispatch(request, *args, **kwargs)
 
     def fetch_app(self, domain, app_id):
-        return _fetch_build(domain, self.request.couch_user.username, app_id)
+        return fetch_build(domain, self.request.couch_user.username, app_id)
 
     def get_web_apps_available_to_user(self, domain, user):
         app_ids = get_app_ids_in_domain(domain)
@@ -225,13 +224,6 @@ class FormplayerMain(View):
         return set_cookie(
             render(request, "cloudcare/bootstrap3/formplayer_home.html", context)
         )
-
-
-def _fetch_build(domain, username, app_id):
-    if (toggles.CLOUDCARE_LATEST_BUILD.enabled(domain) or toggles.CLOUDCARE_LATEST_BUILD.enabled(username)):
-        return get_latest_build_doc(domain, app_id)
-    else:
-        return get_latest_released_app_doc(domain, app_id)
 
 
 def _fetch_build_id(domain, username, app_id):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2561,6 +2561,17 @@ ES_QUERY_PREFERENCE = StaticToggle(
     """
 )
 
+RESTORE_ACCESSIBLE_REPORTS_ONLY = StaticToggle(
+    'restore_accessible_reports_only',
+    'Only restore reports in apps that are accessible to the restoring user',
+    tag=TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    This is an optimization for web apps restores that limits the number of mobile reports included in the restore
+    based on which apps the user can access.
+    """
+)
+
 
 class FrozenPrivilegeToggle(StaticToggle):
     """


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I tried to minimize changes as much as possible to isolate the intended change, which is to limit the apps used when building reports in restores. Generating mobile reports is an expensive part of a restore, so limiting the reports built to the apps that the restoring user has access to is a straightforward way to reduce the number of reports included in the restore.

I plan to add tests to the new filter utility as well, but wanted to put up a draft of the PR in case others had suggestions on better ways to achieve this. I'm pretty sure that the current implementation is sufficient to ensure that when a user's access to a specific app changes, those changes will be reflected in the next sync. If the user is added to an app, that app will be included in the list of apps referenced when collecting reports to sync. On the flip side, if a user's access is revoked, that app will not be included, and if a previous restore state exists, the relevant report fixture ids will be purged from the user's db.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
