### PR TITLE
Grandfather in mobile workers without web apps

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -118,7 +118,9 @@ class FormplayerMain(View):
         ))
         apps = filter(None, apps)
         apps = filter(lambda app: app.get('cloudcare_enabled') or self.preview, apps)
-        apps = filter(lambda app: user.can_access_web_app(domain, app.get('copy_of', app.get('_id'))), apps)
+        # Backwards-compatibility - mobile users haven't historically required this permission
+        if user.is_web_user() or user.can_access_any_web_apps(domain):
+            apps = filter(lambda app: user.can_access_web_app(domain, app.get('copy_of', app.get('_id'))), apps)
         apps = filter(lambda app: app_access.user_can_access_app(user, app), apps)
         apps = [_format_app_doc(app) for app in apps]
         apps = sorted(apps, key=lambda app: app['name'].lower())

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1596,7 +1596,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         if domain:
             try:
                 role = self.get_role(domain)
-                return role.permissions.web_apps_list
+                return bool(role.permissions.web_apps_list)
             except DomainMembershipError:
                 pass
         return False


### PR DESCRIPTION
## Product Description
Fix web apps access for mobile workers

## Technical Summary
The problem was the introduction of this line into the code that filters which apps are available to users:
```python
    def access_web_app(self, app_id):
        return self.access_web_apps or app_id in self.web_apps_list
```
The old behavior was that the `access_web_apps` permission was needed to access web apps (EXCEPT for mobile workers, who got access no matter their role/permissions).  The new behavior was a parameterized permission list, so if you didn't allow access to _all_ web apps, you could provide access to some.

The expectation with this change was that all existing roles that needed it would have `access_web_apps` enabled, and going forward, projects could disable that permission and grant only specific apps that their users needed access to.  However, this didn't take into account that (I'd argue incorrect) behavior that there might be mobile workers accessing web apps even without the explicit permission to do so.

This fix works by only applying this filter if the user is a web user (who have always needed the permission) or someone whose role does provide explicit permissions for web apps.


## Feature Flag


## Safety Assurance


### Safety story
Local testing and discussion with other developers

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
