### PR TITLE
Catch ValueError when accessing UserRole permissions

### DIFF
--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -497,7 +497,6 @@ def _get_synced_role(upstream_role_def, downstream_domain, downstream_roles,
     if conflicting_role:
         role.name = _get_next_free_name(role.name, downstream_roles_by_name)
 
-    role.save()
     return (role, None, is_default_role)
 
 

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -490,7 +490,7 @@ def _get_synced_role(upstream_role_def, downstream_domain, downstream_roles,
         return (None, upstream_role_def['name'], is_default_role)
 
     if not role:
-        role = UserRole(domain=downstream_domain)
+        role = UserRole.create(domain=downstream_domain)
 
     _copy_role_attributes(upstream_role_def, role)
 

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -490,13 +490,14 @@ def _get_synced_role(upstream_role_def, downstream_domain, downstream_roles,
         return (None, upstream_role_def['name'], is_default_role)
 
     if not role:
-        role = UserRole.create(domain=downstream_domain)
+        role = UserRole(domain=downstream_domain)
 
     _copy_role_attributes(upstream_role_def, role)
 
     if conflicting_role:
         role.name = _get_next_free_name(role.name, downstream_roles_by_name)
 
+    role.save()
     return (role, None, is_default_role)
 
 

--- a/corehq/apps/users/models_role.py
+++ b/corehq/apps/users/models_role.py
@@ -198,7 +198,13 @@ class UserRole(models.Model):
         _clear_query_cache()
 
     def get_permission_infos(self):
-        return [rp.as_permission_info() for rp in self.rolepermission_set.all()]
+        try:
+            role_permission_set = self.rolepermission_set.all()
+        except ValueError:
+            # A ValueError is raised if this instance hasn't been saved yet when attempting to access the reverse
+            # foreign key relationship. Return an empty list in this scenario.
+            return []
+        return [rp.as_permission_info() for rp in role_permission_set]
 
     @property
     def permissions(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Sentry Error](https://dimagi.sentry.io/issues/5287248681/?environment=production&project=136860&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+Exception+pushing&referrer=issue-stream&statsPeriod=24h&stream_index=0)

If a UserRole does already exist in the downstream domain, we need to create one to copy the contents of the upstream role into. Rather than waiting to save this newly created role to the db until later in the process, we should save it immediately because accessing reverse foreign key relationships depends on the object being saved to the db (as of Django 4.2). Specifically, we attempt to access the [rolepermission_set](https://github.com/dimagi/commcare-hq/blob/123e28409269c5a4a55e4c0e5cb27b3adadbe75a/corehq/apps/users/models_role.py#L200-L206) on the role [before saving it](https://github.com/dimagi/commcare-hq/blob/123e28409269c5a4a55e4c0e5cb27b3adadbe75a/corehq/apps/linked_domain/updates.py#L442-L445).

This change ensures the role will be saved immediately so that any code that depends on the object being saved to the database runs as expected.

I need to look more into an appropriate test that covers the bug that this attempts to resolve.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
