### PR TITLE
Don't check web apps group-based permissions unless flag is on

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -121,7 +121,8 @@ class FormplayerMain(View):
         # Backwards-compatibility - mobile users haven't historically required this permission
         if user.is_web_user() or user.can_access_any_web_apps(domain):
             apps = filter(lambda app: user.can_access_web_app(domain, app.get('copy_of', app.get('_id'))), apps)
-        apps = filter(lambda app: app_access.user_can_access_app(user, app), apps)
+        if toggles.WEB_APPS_PERMISSIONS_VIA_GROUPS.enabled(domain):
+            apps = filter(lambda app: app_access.user_can_access_app(user, app), apps)
         apps = [_format_app_doc(app) for app in apps]
         apps = sorted(apps, key=lambda app: app['name'].lower())
         return apps
@@ -266,8 +267,9 @@ class FormplayerPreviewSingleApp(View):
 
         app = get_current_app(domain, app_id)
 
-        if not app_access.user_can_access_app(request.couch_user, app):
-            raise Http404()
+        if toggles.WEB_APPS_PERMISSIONS_VIA_GROUPS.enabled(domain):
+            if not app_access.user_can_access_app(request.couch_user, app):
+                raise Http404()
 
         if not request.couch_user.can_access_web_app(domain, app.origin_id):
             raise Http404()


### PR DESCRIPTION
## Product Description
Followup for https://github.com/dimagi/commcare-hq/pull/34421/

## Technical Summary
Previous PR added a flag to gate groups-based permissions, which are legacy functionality now that access to specific web apps can be controlled via roles and permissions.

That PR used the flag to limit access to the configuration UI for this functionality. However, the flag was not checked when determining which apps to show to a user, so if a project turned off the flag but still had group access configured, it would still be used. This PR fixes that.

## Feature Flag
WEB_APPS_PERMISSIONS_VIA_GROUPS

## Safety Assurance

### Safety story
Impact limited to domains using this flag. Tested locally.

### Automated test coverage

I don't think there's view-level testing.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
