### PR TITLE
Restored web apps access to all mobile workers for app preview

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -269,8 +269,9 @@ class FormplayerPreviewSingleApp(View):
         if not app_access.user_can_access_app(request.couch_user, app):
             raise Http404()
 
-        if not request.couch_user.can_access_web_app(domain, app.origin_id):
-            raise Http404()
+        if request.couch_user.is_web_user() or request.couch_user.can_access_any_web_apps(domain):
+            if not request.couch_user.can_access_web_app(domain, app.origin_id):
+                raise Http404()
 
         def _default_lang():
             try:


### PR DESCRIPTION
## Product Description
Followup to https://github.com/dimagi/commcare-hq/pull/34535/: for consistency's sake, make the same adjustment to the app preview view.

This is less urgent, as there are likely few mobile workers using app preview, certainly compared to web apps usage.

## Safety Assurance

### Safety story
This affects permissions, so it's moderate risk. On the other hand, it's applying the same pattern as https://github.com/dimagi/commcare-hq/pull/34535, just to a different view.

### Automated test coverage

No test coverage of this specific code.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
