### PR TITLE
Remove ops email from sso alert

### DIFF
--- a/corehq/apps/sso/templates/sso/email/api_secret_expiring_reminder.html
+++ b/corehq/apps/sso/templates/sso/email/api_secret_expiring_reminder.html
@@ -10,17 +10,10 @@
 
 <p>
   {% blocktrans %}
-    To change or renew your subscription, please reach out to {{ sales_email }}.
-  {% endblocktrans %}
-</p>
-
-<p>
-  {% blocktrans %}
     If you have any questions, please don’t hesitate to contact
     {{ contact_email }}. Thank you for your use and support of CommCare.
   {% endblocktrans %}
 </p>
-
 
 <p>
   {% blocktrans %}

--- a/corehq/apps/sso/utils/context_helpers.py
+++ b/corehq/apps/sso/utils/context_helpers.py
@@ -66,31 +66,6 @@ def get_idp_cert_expiration_email_context(idp):
     return email_context
 
 
-def get_graph_api_connection_issue_email_context(idp, error):
-    subject = _("CommCare HQ Alert: SSO Remote User Management - Issue Connecting to Microsoft Graph API")
-    template_context = {
-        "error": error,
-        "contact_email": settings.ACCOUNTS_EMAIL,
-        "base_url": get_site_domain(),
-    }
-    body_html, body_txt = render_multiple_to_strings(
-        template_context,
-        "sso/email/microsoft_graph_api_connection_issue_notification.html",
-        "sso/email/microsoft_graph_api_connection_issue_notification.txt",
-    )
-    email_context = {
-        "subject": subject,
-        "from": _(f"Dimagi CommCare Accounts <{settings.ACCOUNTS_EMAIL}>"),
-        "to": idp.owner.enterprise_admin_emails or [idp.owner.dimagi_contact] or [settings.ACCOUNT_EMAIL],
-        "bcc": [settings.ACCOUNTS_EMAIL],
-        "html": body_html,
-        "plaintext": body_txt,
-    }
-    if idp.owner.dimagi_contact:
-        email_context["bcc"].append(idp.owner.dimagi_contact)
-    return email_context
-
-
 def get_sso_deactivation_skip_email_context(idp, failure_reason):
     subject = _("CommCare HQ Alert: Temporarily skipped automatic deactivation of SSO Web Users"
                 " (Remote User Management)")

--- a/corehq/apps/sso/utils/context_helpers.py
+++ b/corehq/apps/sso/utils/context_helpers.py
@@ -82,7 +82,7 @@ def get_sso_deactivation_skip_email_context(idp, failure_reason):
     email_context = {
         "subject": subject,
         "from": _(f"Dimagi CommCare Accounts <{settings.ACCOUNTS_EMAIL}>"),
-        "to": idp.owner.enterprise_admin_emails or [idp.owner.dimagi_contact] or [settings.ACCOUNT_EMAIL],
+        "to": idp.owner.enterprise_admin_emails or [idp.owner.dimagi_contact] or [settings.ACCOUNTS_EMAIL],
         "bcc": [],
         "html": body_html,
         "plaintext": body_txt,

--- a/corehq/apps/sso/utils/context_helpers.py
+++ b/corehq/apps/sso/utils/context_helpers.py
@@ -83,7 +83,7 @@ def get_sso_deactivation_skip_email_context(idp, failure_reason):
         "subject": subject,
         "from": _(f"Dimagi CommCare Accounts <{settings.ACCOUNTS_EMAIL}>"),
         "to": idp.owner.enterprise_admin_emails or [idp.owner.dimagi_contact] or [settings.ACCOUNT_EMAIL],
-        "bcc": [settings.ACCOUNTS_EMAIL],
+        "bcc": [],
         "html": body_html,
         "plaintext": body_txt,
     }
@@ -130,7 +130,7 @@ def get_api_secret_expiration_email_context(idp):
         "subject": subject,
         "from": _(f"Dimagi CommCare Accounts <{settings.ACCOUNTS_EMAIL}>"),
         "to": idp.owner.enterprise_admin_emails,
-        "bcc": [settings.ACCOUNTS_EMAIL],
+        "bcc": [],
         "html": body_html,
         "plaintext": body_txt,
     }


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Sending email to Ops will create a SALES ticket in this case. But we don't expect ops or support team to take any action at this stage. So it is meaningless to send those email to accounts@dimagi.com. 
This ticket removing Ops email from those sso alert.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe as we remove the email.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
