### PR TITLE
Added script to grant web apps access to default mobile worker roles

### DIFF
--- a/corehq/apps/users/analytics.py
+++ b/corehq/apps/users/analytics.py
@@ -82,7 +82,7 @@ def get_search_users_in_domain_es_query(domain, search_string, limit, offset):
     return user_es.start(offset).size(limit).sort('username.exact')
 
 
-def get_role_user_count(domain, role_id, web_users_only=True):
+def get_role_user_count(domain, role_id, web_users_only=False):
     from corehq.apps.es.users import UserES
     query = UserES().is_active().domain(domain).role_id(role_id)
     if web_users_only:

--- a/corehq/apps/users/analytics.py
+++ b/corehq/apps/users/analytics.py
@@ -82,8 +82,11 @@ def get_search_users_in_domain_es_query(domain, search_string, limit, offset):
     return user_es.start(offset).size(limit).sort('username.exact')
 
 
-def get_role_user_count(domain, role_id):
+def get_role_user_count(domain, role_id, web_users_only=True):
     from corehq.apps.es.users import UserES
-    users_count = UserES().is_active().domain(domain).role_id(role_id).count()
+    query = UserES().is_active().domain(domain).role_id(role_id)
+    if web_users_only:
+        query = query.web_users()
+    users_count = query.count()
     users_count += Invitation.objects.filter(role="user-role:" + role_id, is_accepted=False).count()
     return users_count

--- a/corehq/apps/users/management/commands/grant_web_apps_to_default_mobile_worker_role.py
+++ b/corehq/apps/users/management/commands/grant_web_apps_to_default_mobile_worker_role.py
@@ -12,11 +12,10 @@ class Command(BaseCommand):
         roles_to_update = UserRole.objects.filter(is_commcare_user_default=True)
         for role in roles_to_update:
             permissions = role.permissions
-            if not permissions.access_web_apps:
+            if not permissions.access_web_apps and not permissions.web_apps_list:
                 count = get_role_user_count(role.domain, role.couch_id, web_users_only=True)
                 if count == 0:
                     # Only update if role is limited to mobile workers, who already have access to web apps
-                    if not permissions.web_apps_list:
-                        permissions.access_web_apps = True
-                        permissions.normalize(previous=role.permissions)
-                        role.set_permissions(permissions.to_list())
+                    permissions.access_web_apps = True
+                    permissions.normalize(previous=role.permissions)
+                    role.set_permissions(permissions.to_list())

--- a/corehq/apps/users/management/commands/grant_web_apps_to_default_mobile_worker_role.py
+++ b/corehq/apps/users/management/commands/grant_web_apps_to_default_mobile_worker_role.py
@@ -1,0 +1,22 @@
+from django.core.management.base import BaseCommand
+
+from corehq.apps.users.analytics import get_role_user_count
+from corehq.apps.users.models_role import Permission, UserRole
+
+
+class Command(BaseCommand):
+    help = "Add access_web_apps permission to default mobile worker roles"
+
+    def handle(self, **options):
+        permission, created = Permission.objects.get_or_create(value='access_web_apps')
+        roles_to_update = UserRole.objects.filter(is_commcare_user_default=True)
+        for role in roles_to_update:
+            permissions = role.permissions
+            if not permissions.access_web_apps:
+                count = get_role_user_count(role.domain, role.couch_id, web_users_only=True)
+                if count == 0:
+                    # Only update if role is limited to mobile workers, who already have access to web apps
+                    if not permissions.web_apps_list:
+                        permissions.access_web_apps = True
+                        permissions.normalize(previous=role.permissions)
+                        role.set_permissions(permissions.to_list())


### PR DESCRIPTION
## Technical Summary
A similar migration was part of https://github.com/dimagi/commcare-hq/pull/34421, but I removed it before finishing that PR up.

This adds `web_apps_access` to all default mobile worker roles. https://github.com/dimagi/commcare-hq/pull/34421 is already adding that permission to default mobile worker roles for new domains ([here](https://github.com/dimagi/commcare-hq/pull/34421/files#diff-1bcb69f341aa947ebf047999dc27ad7c2e241e244adc52466c87b42fba49240fR30)).

This permission is not checked for mobile workers (see [here](https://github.com/dimagi/commcare-hq/blob/fcbab9a35c990127c5d4eeb740c1c87ae5faf199/corehq/apps/cloudcare/views.py#L122-L123)). Therefore, this change does not have user-facing impact. It does get roles and permissions closer to reflecting the platform's actual behavior.

There is some possibility that projects have assigned **web** users to default mobile worker roles, so the script does not update any roles with web users assigned. Once this is run, it should be easy to query for default mobile worker roles where `access_web_apps` is False, which are presumably roles with web users assigned.

This change doesn't quite go far enough to make it quite safe to remove the code (linked above) that skips checking the web apps permission for mobile users. There may be mobile workers who are assigned to other roles that do not have the web apps permission enabled. To safely remove that check, we'd need to audit existing mobile workers to determine if anyone would be affected, and if so, decide how to handle that. I'm not including that in this PR, although I'm curious if we'll discuss doing that as part of the retrospective for https://github.com/dimagi/commcare-hq/pull/34535/

## Safety Assurance

### Safety story
This is a migration that affects ~all domains' permissions, so moderate risk. On the other hand, it should not affect any role that includes web users, and it grants access that mobile workers already have.

### Automated test coverage

no

### QA Plan

Not requesting QA.

### Migrations
- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
