### PR TITLE
Extract function to retrieve web apps available to user into utility

### DIFF
--- a/corehq/apps/cloudcare/tests/test_utils.py
+++ b/corehq/apps/cloudcare/tests/test_utils.py
@@ -1,8 +1,20 @@
 from django.test import TestCase
 
-from corehq.apps.app_manager.models import Application, ReportModule, ReportAppConfig
-from corehq.apps.cloudcare.utils import get_mobile_ucr_count, should_restrict_web_apps_usage
+from corehq.apps.app_manager.models import (
+    Application,
+    ReportAppConfig,
+    ReportModule,
+)
+from corehq.apps.cloudcare.models import ApplicationAccess, SQLAppGroup
+from corehq.apps.cloudcare.utils import (
+    can_user_access_web_app,
+    get_mobile_ucr_count,
+    should_restrict_web_apps_usage,
+)
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.groups.models import Group
+from corehq.apps.users.models import CommCareUser, HqPermissions, WebUser
+from corehq.apps.users.models_role import UserRole
 from corehq.util.test_utils import flag_disabled, flag_enabled
 
 
@@ -107,3 +119,102 @@ class TestGetMobileUCRCount(TestCase):
         super().setUpClass()
         cls.domain = create_domain('mobile-ucr-count-test')
         cls.addClassCleanup(cls.domain.delete)
+
+
+class TestCanUserAccessWebApp(TestCase):
+
+    def test_commcare_user_has_access_if_assigned_role_that_can_access_all_web_apps(self):
+        role = UserRole.create(
+            self.domain, "can-access-all-web-apps", permissions=HqPermissions(access_web_apps=True)
+        )
+        self.commcare_user.set_role(self.domain, role.get_qualified_id())
+
+        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+
+        self.assertTrue(has_access)
+
+    def test_commcare_user_does_not_have_access_if_assigned_role_that_cannot_access_web_apps(self):
+        role = UserRole.create(
+            self.domain, "cannot-access-web-apps", permissions=HqPermissions(access_web_apps=False)
+        )
+        self.commcare_user.set_role(self.domain, role.get_qualified_id())
+
+        can_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+
+        self.assertFalse(can_access)
+
+    def test_commcare_user_has_access_if_assigned_role_that_can_access_specific_app(self):
+        role = UserRole.create(
+            self.domain,
+            "can-access-specific-app",
+            permissions=HqPermissions(web_apps_list=[self.app_doc["copy_of"]]),
+        )
+        self.commcare_user.set_role(self.domain, role.get_qualified_id())
+
+        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+
+        self.assertTrue(has_access)
+
+    def test_web_user_has_access_if_assigned_role_that_can_access_all_web_apps(self):
+        role = UserRole.create(
+            self.domain, "can-access-all-web-apps", permissions=HqPermissions(access_web_apps=True)
+        )
+        self.web_user.set_role(self.domain, role.get_qualified_id())
+
+        has_access = can_user_access_web_app(self.app_doc, self.web_user, self.domain)
+
+        self.assertTrue(has_access)
+
+    def test_web_user_does_not_have_access_if_assigned_role_that_cannot_access_web_apps(self):
+        role = UserRole.create(
+            self.domain, "cannot-access-web-apps", permissions=HqPermissions(access_web_apps=False)
+        )
+        self.web_user.set_role(self.domain, role.get_qualified_id())
+
+        has_access = can_user_access_web_app(self.app_doc, self.web_user, self.domain)
+
+        self.assertFalse(has_access)
+
+    def test_web_user_has_access_if_assigned_role_that_can_access_specific_app(self):
+        role = UserRole.create(
+            self.domain,
+            "can-access-specific-app",
+            permissions=HqPermissions(web_apps_list=[self.app_doc["copy_of"]]),
+        )
+        self.web_user.set_role(self.domain, role.get_qualified_id())
+
+        has_access = can_user_access_web_app(self.app_doc, self.web_user, self.domain)
+
+        self.assertTrue(has_access)
+
+    @flag_enabled("WEB_APPS_PERMISSIONS_VIA_GROUPS")
+    def test_commcare_user_has_access_if_in_group(self):
+        role = UserRole.create(
+            self.domain, "can-access-all-web-apps", permissions=HqPermissions(access_web_apps=True)
+        )
+        self.commcare_user.set_role(self.domain, role.get_qualified_id())
+        group = Group(domain=self.domain, name="web-apps-group")
+        group.add_user(self.commcare_user._id)
+        group.save()
+        self.addCleanup(group.delete)
+        app_access = ApplicationAccess.objects.create(domain=self.domain, restrict=True)
+        SQLAppGroup.objects.create(app_id=self.app_doc['_id'], group_id=group._id, application_access=app_access)
+
+        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+
+        self.assertTrue(has_access)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-user-access-to-web-apps'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+
+    def setUp(self):
+        super().setUp()
+        self.app_doc = {'doc_type': 'Application', '_id': 'abc123', 'copy_of': 'def456'}
+        self.commcare_user = CommCareUser.create(self.domain, 'bob@test.commcarehq.org', 'password', None, None)
+        self.addCleanup(self.commcare_user.delete, None, None)
+        self.web_user = WebUser.create(self.domain, 'bob@test.com', 'password', None, None)
+        self.addCleanup(self.web_user.delete, None, None)

--- a/corehq/apps/cloudcare/tests/test_utils.py
+++ b/corehq/apps/cloudcare/tests/test_utils.py
@@ -133,7 +133,8 @@ class TestCanUserAccessWebApp(TestCase):
 
         self.assertTrue(has_access)
 
-    def test_commcare_user_does_not_have_access_if_assigned_role_that_cannot_access_web_apps(self):
+    def test_commcare_user_has_access_if_assigned_role_that_cannot_access_web_apps(self):
+        # mobile users have not historically required this new permission, so we need to assume they have access
         role = UserRole.create(
             self.domain, "cannot-access-web-apps", permissions=HqPermissions(access_web_apps=False)
         )
@@ -141,7 +142,7 @@ class TestCanUserAccessWebApp(TestCase):
 
         can_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
 
-        self.assertFalse(can_access)
+        self.assertTrue(can_access)
 
     def test_commcare_user_has_access_if_assigned_role_that_can_access_specific_app(self):
         role = UserRole.create(

--- a/corehq/apps/cloudcare/tests/test_utils.py
+++ b/corehq/apps/cloudcare/tests/test_utils.py
@@ -126,7 +126,7 @@ class TestCanUserAccessWebApp(TestCase):
     def test_commcare_user_has_access_if_assigned_role_that_can_access_all_web_apps(self):
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(access_web_apps=True))
 
-        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
 
         self.assertTrue(has_access)
 
@@ -134,37 +134,37 @@ class TestCanUserAccessWebApp(TestCase):
         # mobile users have not historically required this new permission, so we need to assume they have access
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(access_web_apps=False))
 
-        can_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
 
-        self.assertTrue(can_access)
+        self.assertTrue(has_access)
 
     def test_commcare_user_has_access_if_assigned_role_that_can_access_specific_app(self):
         self.set_role_on_user_with_permissions(
             self.commcare_user, HqPermissions(web_apps_list=[self.app_doc["copy_of"]])
         )
 
-        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
 
         self.assertTrue(has_access)
 
     def test_commcare_user_does_not_have_access_if_assigned_role_that_can_access_different_app(self):
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(web_apps_list=["random-app"]))
 
-        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
 
         self.assertFalse(has_access)
 
     def test_web_user_has_access_if_assigned_role_that_can_access_all_web_apps(self):
         self.set_role_on_user_with_permissions(self.web_user, HqPermissions(access_web_apps=True))
 
-        has_access = can_user_access_web_app(self.app_doc, self.web_user, self.domain)
+        has_access = can_user_access_web_app(self.web_user, self.app_doc)
 
         self.assertTrue(has_access)
 
     def test_web_user_does_not_have_access_if_assigned_role_that_cannot_access_web_apps(self):
         self.set_role_on_user_with_permissions(self.web_user, HqPermissions(access_web_apps=False))
 
-        has_access = can_user_access_web_app(self.app_doc, self.web_user, self.domain)
+        has_access = can_user_access_web_app(self.web_user, self.app_doc)
 
         self.assertFalse(has_access)
 
@@ -173,14 +173,14 @@ class TestCanUserAccessWebApp(TestCase):
             self.web_user, HqPermissions(web_apps_list=[self.app_doc["copy_of"]])
         )
 
-        has_access = can_user_access_web_app(self.app_doc, self.web_user, self.domain)
+        has_access = can_user_access_web_app(self.web_user, self.app_doc)
 
         self.assertTrue(has_access)
 
     def test_web_user_does_not_have_access_if_assigned_role_that_can_access_different_app(self):
         self.set_role_on_user_with_permissions(self.web_user, HqPermissions(web_apps_list=["random-app"]))
 
-        has_access = can_user_access_web_app(self.app_doc, self.web_user, self.domain)
+        has_access = can_user_access_web_app(self.web_user, self.app_doc)
 
         self.assertFalse(has_access)
 
@@ -189,7 +189,7 @@ class TestCanUserAccessWebApp(TestCase):
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(access_web_apps=False))
         self.add_user_to_group_for_app_id(self.commcare_user, self.app_doc['_id'])
 
-        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
 
         self.assertTrue(has_access)
 
@@ -199,7 +199,7 @@ class TestCanUserAccessWebApp(TestCase):
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(web_apps_list=["random-app"]))
         self.add_user_to_group_for_app_id(self.commcare_user, self.app_doc['_id'])
 
-        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
 
         self.assertFalse(has_access)
 
@@ -208,7 +208,7 @@ class TestCanUserAccessWebApp(TestCase):
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(web_apps_list=["random-app"]))
         self.add_user_to_group_for_app_id(self.commcare_user, 'random-app')
 
-        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
 
         self.assertFalse(has_access)
 
@@ -219,7 +219,7 @@ class TestCanUserAccessWebApp(TestCase):
         )
         self.add_user_to_group_for_app_id(self.commcare_user, self.app_doc['_id'])
 
-        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
 
         self.assertTrue(has_access)
 
@@ -230,7 +230,7 @@ class TestCanUserAccessWebApp(TestCase):
         )
         self.add_user_to_group_for_app_id(self.commcare_user, "random-app")
 
-        has_access = can_user_access_web_app(self.app_doc, self.commcare_user, self.domain)
+        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
 
         self.assertTrue(has_access)
 
@@ -239,7 +239,7 @@ class TestCanUserAccessWebApp(TestCase):
         # web users always have permission via groups
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(web_apps_list=["random-app"]))
 
-        has_access = can_user_access_web_app(self.app_doc, self.web_user, self.domain)
+        has_access = can_user_access_web_app(self.web_user, self.app_doc)
 
         self.assertFalse(has_access)
 
@@ -252,7 +252,7 @@ class TestCanUserAccessWebApp(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.app_doc = {'doc_type': 'Application', '_id': 'abc123', 'copy_of': 'def456'}
+        self.app_doc = {'doc_type': 'Application', '_id': 'abc123', 'copy_of': 'def456', 'domain': self.domain}
         self.commcare_user = CommCareUser.create(self.domain, 'bob@test.commcarehq.org', 'password', None, None)
         self.addCleanup(self.commcare_user.delete, None, None)
         self.web_user = WebUser.create(self.domain, 'bob@test.com', 'password', None, None)

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -22,11 +22,12 @@ def can_user_access_web_app(user, app):
     :param user: either a WebUser or CommCareUser
     :param app: app doc (not wrapped Application)
     """
-    domain = app.get("domain")
+    domain = app["domain"]
     # Backwards-compatibility - mobile users haven't historically required this permission
     has_access_via_permission = user.is_commcare_user()
     if user.is_web_user() or user.can_access_any_web_apps(domain):
-        has_access_via_permission = user.can_access_web_app(domain, app.get('copy_of', app.get('_id')))
+        app_id = app.get("copy_of", app.get("_id"))
+        has_access_via_permission = user.can_access_web_app(domain, app_id)
 
     has_access_via_group = True  # permission takes precedence over groups, so default to True
     if toggles.WEB_APPS_PERMISSIONS_VIA_GROUPS.enabled(domain):

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -24,7 +24,7 @@ def can_user_access_web_app(app, user, domain):
     :param domain: domain name
     """
     # Backwards-compatibility - mobile users haven't historically required this permission
-    has_access_via_permission = False
+    has_access_via_permission = user.is_commcare_user()
     if user.is_web_user() or user.can_access_any_web_apps(domain):
         has_access_via_permission = user.can_access_web_app(domain, app.get('copy_of', app.get('_id')))
 

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -17,12 +17,12 @@ from corehq.apps.app_manager.dbaccessors import (
 from corehq.util.quickcache import quickcache
 
 
-def can_user_access_web_app(app, user, domain):
+def can_user_access_web_app(user, app):
     """
-    :param app: app doc (not wrapped Application)
     :param user: either a WebUser or CommCareUser
-    :param domain: domain name
+    :param app: app doc (not wrapped Application)
     """
+    domain = app.get("domain")
     # Backwards-compatibility - mobile users haven't historically required this permission
     has_access_via_permission = user.is_commcare_user()
     if user.is_web_user() or user.can_access_any_web_apps(domain):
@@ -64,7 +64,7 @@ def get_web_apps_available_to_user(domain, user, is_preview=False, fetch_app_fn=
     app_ids = get_app_ids_in_domain(domain)
     for app_id in app_ids:
         app = fetch_app_fn(domain, user.username, app_id)
-        if app and is_web_app(app) and can_user_access_web_app(app, user, domain):
+        if app and is_web_app(app) and can_user_access_web_app(user, app):
             apps.append(app)
 
     return apps

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -6,7 +6,13 @@ from django.urls import reverse
 from six.moves.urllib.parse import quote
 
 from corehq import toggles
-from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
+from corehq.apps.app_manager.dbaccessors import (
+    get_apps_in_domain,
+    get_latest_build_doc,
+    get_latest_build_id,
+    get_latest_released_app_doc,
+    get_latest_released_build_id,
+)
 from corehq.util.quickcache import quickcache
 
 
@@ -30,6 +36,20 @@ def can_user_access_web_app(app, user, domain):
         has_access_via_group = app_access.user_can_access_app(user, app)
 
     return has_access_via_permission or has_access_via_group
+
+
+def get_latest_build_for_web_apps(domain, username, app_id):
+    if (toggles.CLOUDCARE_LATEST_BUILD.enabled(domain) or toggles.CLOUDCARE_LATEST_BUILD.enabled(username)):
+        return get_latest_build_doc(domain, app_id)
+    else:
+        return get_latest_released_app_doc(domain, app_id)
+
+
+def get_latest_build_id_for_web_apps(domain, username, app_id):
+    if (toggles.CLOUDCARE_LATEST_BUILD.enabled(domain) or toggles.CLOUDCARE_LATEST_BUILD.enabled(username)):
+        return get_latest_build_id(domain, app_id)
+    else:
+        return get_latest_released_build_id(domain, app_id)
 
 
 def should_show_preview_app(request, app, username):

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -28,7 +28,7 @@ def can_user_access_web_app(app, user, domain):
     if user.is_web_user() or user.can_access_any_web_apps(domain):
         has_access_via_permission = user.can_access_web_app(domain, app.get('copy_of', app.get('_id')))
 
-    has_access_via_group = False
+    has_access_via_group = True  # permission takes precedence over groups, so default to True
     if toggles.WEB_APPS_PERMISSIONS_VIA_GROUPS.enabled(domain):
         from corehq.apps.cloudcare.dbaccessors import (
             get_application_access_for_domain,
@@ -36,7 +36,7 @@ def can_user_access_web_app(app, user, domain):
         app_access = get_application_access_for_domain(domain)
         has_access_via_group = app_access.user_can_access_app(user, app)
 
-    return has_access_via_permission or has_access_via_group
+    return has_access_via_permission and has_access_via_group
 
 
 def get_latest_build_for_web_apps(domain, username, app_id):

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -245,13 +245,14 @@ class FormplayerPreviewSingleApp(View):
 
     def get(self, request, domain, app_id, **kwargs):
         app = get_current_app(domain, app_id)
-        has_access = can_user_access_web_app(request.couch_user, app.to_json())
+        app_json = app.to_json()
+        has_access = can_user_access_web_app(request.couch_user, app_json)
         if not has_access:
             raise Http404()
 
         def _default_lang():
             try:
-                return app['langs'][0]
+                return app_json['langs'][0]
             except Exception:
                 return 'en'
 
@@ -264,7 +265,7 @@ class FormplayerPreviewSingleApp(View):
             "domain": domain,
             "default_geocoder_location": domain_obj.default_geocoder_location,
             "language": language,
-            "apps": [_format_app_doc(app)],
+            "apps": [_format_app_doc(app_json)],
             "mapbox_access_token": settings.MAPBOX_ACCESS_TOKEN,
             "username": request.user.username,
             "formplayer_url": get_formplayer_url(for_js=True),

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -229,7 +229,7 @@ class FormplayerMainPreview(FormplayerMain):
     def fetch_app_fn(self):
         return self.wrap_get_current_app_doc
 
-    def wrap_get_current_app_doc(domain, username, app_id):
+    def wrap_get_current_app_doc(self, domain, username, app_id):
         # ignore username as it is only here to confirm to fetch_app_fn signature
         return get_current_app_doc(domain, app_id)
 

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -61,7 +61,11 @@ from corehq.apps.cloudcare.dbaccessors import get_cloudcare_apps, get_applicatio
 from corehq.apps.cloudcare.decorators import require_cloudcare_access
 from corehq.apps.cloudcare.esaccessors import login_as_user_query
 from corehq.apps.cloudcare.models import SQLAppGroup
-from corehq.apps.cloudcare.utils import get_mobile_ucr_count, should_restrict_web_apps_usage
+from corehq.apps.cloudcare.utils import (
+    can_user_access_web_app,
+    get_mobile_ucr_count,
+    should_restrict_web_apps_usage
+)
 from corehq.apps.domain.decorators import (
     domain_admin_required,
     login_and_domain_required,
@@ -109,21 +113,16 @@ class FormplayerMain(View):
         return _fetch_build(domain, self.request.couch_user.username, app_id)
 
     def get_web_apps_available_to_user(self, domain, user):
-        app_access = get_application_access_for_domain(domain)
-        app_ids = get_app_ids_in_domain(domain)
+        def is_web_app(app):
+            return app.get('cloudcare_enabled') or self.preview
 
-        apps = list(map(
-            lambda app_id: self.fetch_app(domain, app_id),
-            app_ids,
-        ))
-        apps = filter(None, apps)
-        apps = filter(lambda app: app.get('cloudcare_enabled') or self.preview, apps)
-        # Backwards-compatibility - mobile users haven't historically required this permission
-        if user.is_web_user() or user.can_access_any_web_apps(domain):
-            apps = filter(lambda app: user.can_access_web_app(domain, app.get('copy_of', app.get('_id'))), apps)
-        if toggles.WEB_APPS_PERMISSIONS_VIA_GROUPS.enabled(domain):
-            apps = filter(lambda app: app_access.user_can_access_app(user, app), apps)
-        apps = [_format_app_doc(app) for app in apps]
+        apps = []
+        app_ids = get_app_ids_in_domain(domain)
+        for app_id in app_ids:
+            app = self.fetch_app(domain, app_id)
+            if app and is_web_app(app) and can_user_access_web_app(app, user, domain):
+                apps.append(_format_app_doc(app))
+
         apps = sorted(apps, key=lambda app: app['name'].lower())
         return apps
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is somewhat of a prefactor in order to facilitate using the same list of app docs when collecting mobile UCRs to include in a restore. Existing behavior should not have changed at all with this PR.

I added automated tests for what felt like the most complex part of the utility, which was determining if a user is able to access an app or not. 

Commit by commit 🐟 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests in corehq.apps.cloudcare.tests.test_utils:TestCanUserAccessWebApp to ensure `can_access_web_app` behaves as expected.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
