### PR TITLE
Only include apps that are available for the restoring user when generating reports

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -117,6 +117,7 @@ class ReportFixturesProvider(FixtureProvider):
             # only way to reliably know that this is a web apps restore, not live preview
             and not restore_user.request_user.can_view_apps(restore_user.domain)
         ):
+            apps = []
             for app in get_web_apps_available_to_user(restore_user.domain, restore_user._couch_user):
                 if not is_remote_app(app):
                     apps.append(get_correct_app_class(app).wrap(app))

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -25,6 +25,8 @@ from corehq.apps.app_manager.dbaccessors import (
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     is_valid_mobile_select_filter_type,
 )
+from corehq.apps.app_manager.util import get_correct_app_class, is_remote_app
+from corehq.apps.cloudcare.utils import get_web_apps_available_to_user
 from corehq.apps.userreports.exceptions import (
     ReportConfigurationNotFoundError,
     UserReportsError,
@@ -112,6 +114,11 @@ class ReportFixturesProvider(FixtureProvider):
 
         if app_aware_sync_app:
             apps = [app_aware_sync_app]
+        elif toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY and restore_state.params.is_webapps:
+            apps = []
+            for app in get_web_apps_available_to_user(restore_user.domain, restore_user._couch_user):
+                if not is_remote_app(app):
+                    apps.append(get_correct_app_class(app).wrap(app))
         else:
             apps = get_apps_in_domain(restore_user.domain, include_remote=False)
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -113,9 +113,13 @@ class ReportFixturesProvider(FixtureProvider):
             apps = [app_aware_sync_app]
         elif toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY and restore_state.params.is_webapps:
             apps = []
-            for app in get_web_apps_available_to_user(restore_user.domain, restore_user._couch_user):
-                if not is_remote_app(app):
-                    apps.append(get_correct_app_class(app).wrap(app))
+            if restore_user.request_user.can_edit_apps():
+                # return all apps since we don't know if this is in a live preview or web apps context
+                apps = get_apps_in_domain(restore_user.domain, include_remote=False)
+            else:
+                for app in get_web_apps_available_to_user(restore_user.domain, restore_user._couch_user):
+                    if not is_remote_app(app):
+                        apps.append(get_correct_app_class(app).wrap(app))
         else:
             apps = get_apps_in_domain(restore_user.domain, include_remote=False)
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -113,7 +113,7 @@ class ReportFixturesProvider(FixtureProvider):
             apps = [app_aware_sync_app]
         elif toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY and restore_state.params.is_webapps:
             apps = []
-            if restore_user.request_user.can_edit_apps():
+            if restore_user.request_user.can_view_apps():
                 # return all apps since we don't know if this is in a live preview or web apps context
                 apps = get_apps_in_domain(restore_user.domain, include_remote=False)
             else:

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -111,7 +111,10 @@ class ReportFixturesProvider(FixtureProvider):
 
         if app_aware_sync_app:
             apps = [app_aware_sync_app]
-        elif toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY and restore_state.params.is_webapps:
+        elif (
+            toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY.enabled(restore_user.domain)
+            and restore_state.params.is_webapps
+        ):
             apps = []
             if restore_user.request_user.can_view_apps():
                 # return all apps since we don't know if this is in a live preview or web apps context

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -1,6 +1,5 @@
 import logging
 import numbers
-import uuid
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -19,9 +18,7 @@ from corehq.apps.app_manager.const import (
     MOBILE_UCR_VERSION_1,
     MOBILE_UCR_VERSION_2,
 )
-from corehq.apps.app_manager.dbaccessors import (
-    get_apps_in_domain,
-)
+from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     is_valid_mobile_select_filter_type,
 )
@@ -441,7 +438,9 @@ def generate_rows_and_filters(report_data_cache, report_config, restore_user, ro
     return row_elements, filters_elem
 
 
-def get_report_element(report_data_cache, report_config, data_source, deferred_fields, filter_options_by_field, row_to_element):
+def get_report_element(
+    report_data_cache, report_config, data_source, deferred_fields, filter_options_by_field, row_to_element
+):
     """
     :param row_to_element: function (
                 deferred_fields, filter_options_by_field, row, index, is_total_row

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -115,7 +115,7 @@ class ReportFixturesProvider(FixtureProvider):
             toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY.enabled(restore_user.domain)
             and restore_state.params.is_webapps
             # only way to reliably know that this is a web apps restore, not live preview
-            and not restore_user.can_view_apps(restore_user.domain)
+            and not restore_user.request_user.can_view_apps(restore_user.domain)
         ):
             for app in get_web_apps_available_to_user(restore_user.domain, restore_user._couch_user):
                 if not is_remote_app(app):

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -114,7 +114,8 @@ class ReportFixturesProvider(FixtureProvider):
         elif (
             toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY.enabled(restore_user.domain)
             and restore_state.params.is_webapps
-            and restore_user.can_view_apps()  # only way to be sure this a web apps restore, not live preview
+            # only way to reliably know that this is a web apps restore, not live preview
+            and not restore_user.can_view_apps(restore_user.domain)
         ):
             for app in get_web_apps_available_to_user(restore_user.domain, restore_user._couch_user):
                 if not is_remote_app(app):

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -114,15 +114,11 @@ class ReportFixturesProvider(FixtureProvider):
         elif (
             toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY.enabled(restore_user.domain)
             and restore_state.params.is_webapps
+            and restore_user.can_view_apps()  # only way to be sure this a web apps restore, not live preview
         ):
-            apps = []
-            if restore_user.request_user.can_view_apps():
-                # return all apps since we don't know if this is in a live preview or web apps context
-                apps = get_apps_in_domain(restore_user.domain, include_remote=False)
-            else:
-                for app in get_web_apps_available_to_user(restore_user.domain, restore_user._couch_user):
-                    if not is_remote_app(app):
-                        apps.append(get_correct_app_class(app).wrap(app))
+            for app in get_web_apps_available_to_user(restore_user.domain, restore_user._couch_user):
+                if not is_remote_app(app):
+                    apps.append(get_correct_app_class(app).wrap(app))
         else:
             apps = get_apps_in_domain(restore_user.domain, include_remote=False)
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2561,6 +2561,17 @@ ES_QUERY_PREFERENCE = StaticToggle(
     """
 )
 
+RESTORE_ACCESSIBLE_REPORTS_ONLY = StaticToggle(
+    'restore_accessible_reports_only',
+    'Only restore reports in apps that are accessible to the restoring user',
+    tag=TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    This is an optimization for web apps restores that limits the number of mobile reports included in the restore
+    based on which apps the user can access.
+    """
+)
+
 
 class FrozenPrivilegeToggle(StaticToggle):
     """


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Depends on https://github.com/dimagi/commcare-hq/pull/34546 (currently based off of that branch), and will ultimately replace https://github.com/dimagi/commcare-hq/pull/34532.

It is likely the case that this will become the accepted way of restoring reports since it isn't necessary to include apps that a user does not have access to. However for now this is behind a feature flag for ease of enabling/testing.

For now, because we cannot reliably determine if a restore was triggered by web apps or live preview, we have to check if the underlying web user has permission to view apps. If they do, we cannot safely limit the reports included in a restore since it could be a live preview context where web apps permissions do not apply.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
RESTORE_ACCESSIBLE_REPORTS_ONLY

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The change is entirely behind a feature flag which certainly limits the blast radius and makes it easy to turn off if needed.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
