### PR TITLE
Web Apps Restore User Bug

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -164,7 +164,7 @@ class FormplayerMain(View):
             ).run()
             if login_as_users.total == 1:
                 def set_cookie(response):
-                    response.set_cookie(cookie_name, user.raw_username)
+                    response.set_cookie(cookie_name, urllib.parse.quote(user.raw_username))
                     return response
 
                 user = CouchUser.get_by_username(login_as_users.hits[0]['username'])


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Existing behavior: When a web user has only one available option to "login as", that "login as" user is automatically chosen.

This PR resolves a bug where if that "login as" user contains a "+", the "+" is replaced by a space, resulting in the wrong "restore as" username when attempting to navigate to an app or performing any action that requires a "restore as" username.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4513)

The "restore_as" username is set in cookies and is fetched from the cookie whenever needed. However, in the logic flow where only one "login_as" option exists, the stored cookie value for "restore_as" is not encoded. [Jquery's cookie library ](https://github.com/carhartl/jquery-cookie?tab=readme-ov-file#raw)by default encodes/decodes values when writing/reading. So upon reading the cookie value [here](https://github.com/dimagi/commcare-hq/blob/bf313afaf838312250a087dffde3f706ca7cf75b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/utils.js#L49-L51), the "+" is decoded as a space.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Not specific to a feature flag.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally reproduced bug and tested. The change area is specific to scenarios where only one "login_as" user is avaiaible. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
