### PR TITLE
Remove FormplayerPreviewSingleApp view

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
@@ -21,7 +21,7 @@ hqDefine("cloudcare/js/formplayer/main", [
             domain: initialPageData.get('domain'),
             formplayer_url: initialPageData.get('formplayer_url'),
             debuggerEnabled: initialPageData.get('debugger_enabled'),
-            singleAppMode: initialPageData.get('single_app_mode'),
+            singleAppMode: false,
             environment: initialPageData.get('environment'),
         };
         FormplayerFrontEnd.start(options);

--- a/corehq/apps/cloudcare/templates/cloudcare/bootstrap3/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/bootstrap3/formplayer_home.html
@@ -69,7 +69,6 @@
   {% initial_page_data 'language' language %}
   {% initial_page_data 'mapbox_access_token' mapbox_access_token %}
   {% initial_page_data 'default_geocoder_location' default_geocoder_location %}
-  {% initial_page_data 'single_app_mode' single_app_mode %}
   {% initial_page_data 'username' username %}
   {% initial_page_data 'has_geocoder_privs' has_geocoder_privs %}
   {% initial_page_data 'dialer_enabled' integrations.dialer_enabled %}

--- a/corehq/apps/cloudcare/templates/cloudcare/bootstrap5/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/bootstrap5/formplayer_home.html
@@ -68,7 +68,6 @@
   {% initial_page_data 'language' language %}
   {% initial_page_data 'mapbox_access_token' mapbox_access_token %}
   {% initial_page_data 'default_geocoder_location' default_geocoder_location %}
-  {% initial_page_data 'single_app_mode' single_app_mode %}
   {% initial_page_data 'username' username %}
   {% initial_page_data 'has_geocoder_privs' has_geocoder_privs %}
   {% initial_page_data 'dialer_enabled' integrations.dialer_enabled %}

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -4,7 +4,6 @@ from corehq.apps.cloudcare.views import (
     EditCloudcareUserPermissionsView,
     FormplayerMain,
     FormplayerMainPreview,
-    FormplayerPreviewSingleApp,
     LoginAsUsers,
     PreviewAppView,
     ReadableQuestions,
@@ -18,11 +17,6 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5, waf_allow
 app_urls = [
     url(r'^v2/$', FormplayerMain.as_view(), name=FormplayerMain.urlname),
     url(r'^v2/preview/$', FormplayerMainPreview.as_view(), name=FormplayerMainPreview.urlname),
-    url(
-        r'^v2/preview/(?P<app_id>[\w-]+)/$',
-        FormplayerPreviewSingleApp.as_view(),
-        name=FormplayerPreviewSingleApp.urlname,
-    ),
     url(r'^preview_app/(?P<app_id>[\w-]+)/$', PreviewAppView.as_view(), name=PreviewAppView.urlname),
     url(r'^report_formplayer_error', report_formplayer_error, name='report_formplayer_error'),
     url(r'^report_sentry_error', report_sentry_error, name='report_sentry_error'),

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -43,7 +43,6 @@ from corehq.apps.accounting.utils import (
 )
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
-    get_current_app,
     get_current_app_doc,
 )
 from corehq.apps.cloudcare.const import (
@@ -58,7 +57,6 @@ from corehq.apps.cloudcare.decorators import require_cloudcare_access
 from corehq.apps.cloudcare.esaccessors import login_as_user_query
 from corehq.apps.cloudcare.models import SQLAppGroup
 from corehq.apps.cloudcare.utils import (
-    can_user_access_web_app,
     get_latest_build_for_web_apps,
     get_latest_build_id_for_web_apps,
     get_mobile_ucr_count,
@@ -232,51 +230,6 @@ class FormplayerMainPreview(FormplayerMain):
     def wrap_get_current_app_doc(self, domain, username, app_id):
         # ignore username as it is only here to confirm to fetch_app_fn signature
         return get_current_app_doc(domain, app_id)
-
-
-class FormplayerPreviewSingleApp(View):
-
-    urlname = 'formplayer_single_app'
-
-    @method_decorator(require_cloudcare_access)
-    @method_decorator(requires_privilege_for_commcare_user(privileges.CLOUDCARE))
-    def dispatch(self, request, *args, **kwargs):
-        return super(FormplayerPreviewSingleApp, self).dispatch(request, *args, **kwargs)
-
-    def get(self, request, domain, app_id, **kwargs):
-        app = get_current_app(domain, app_id)
-        app_json = app.to_json()
-        has_access = can_user_access_web_app(request.couch_user, app_json)
-        if not has_access:
-            raise Http404()
-
-        def _default_lang():
-            try:
-                return app_json['langs'][0]
-            except Exception:
-                return 'en'
-
-        # default language to user's preference, followed by
-        # first app's default, followed by english
-        language = request.couch_user.language or _default_lang()
-        domain_obj = Domain.get_by_name(domain)
-
-        context = {
-            "domain": domain,
-            "default_geocoder_location": domain_obj.default_geocoder_location,
-            "language": language,
-            "apps": [_format_app_doc(app_json)],
-            "mapbox_access_token": settings.MAPBOX_ACCESS_TOKEN,
-            "username": request.user.username,
-            "formplayer_url": get_formplayer_url(for_js=True),
-            "single_app_mode": True,
-            "home_url": reverse(self.urlname, args=[domain, app_id]),
-            "environment": WEB_APPS_ENVIRONMENT,
-            "integrations": integration_contexts(domain),
-            "has_geocoder_privs": has_geocoder_privs(domain),
-            "valid_multimedia_extensions_map": VALID_ATTACHMENT_FILE_EXTENSION_MAP,
-        }
-        return render(request, "cloudcare/bootstrap3/formplayer_home.html", context)
 
 
 class PreviewAppView(TemplateView):

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -205,7 +205,6 @@ class FormplayerMain(View):
             "mapbox_access_token": settings.MAPBOX_ACCESS_TOKEN,
             "username": request.couch_user.username,
             "formplayer_url": get_formplayer_url(for_js=True),
-            "single_app_mode": False,
             "home_url": reverse(self.urlname, args=[domain]),
             "environment": WEB_APPS_ENVIRONMENT,
             "integrations": integration_contexts(domain),

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/formplayer_home.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/formplayer_home.html.diff.txt
@@ -44,7 +44,7 @@
  
  {% block js %} {{ block.super }}
    {% include "cloudcare/partials/dependencies.html" %}
-@@ -95,7 +94,7 @@
+@@ -94,7 +93,7 @@
    <!-- For now we won't touch this since the form entry code is coupled with it  -->
  
    <div id="cloudcare-main" class="cloudcare-home-content">
@@ -53,7 +53,7 @@
      <section id="cases"></section>
      <div id="menu-container">
        <section id="formplayer-progress-container"></section>
-@@ -130,8 +129,8 @@
+@@ -129,8 +128,8 @@
    {% if not request.session.secure_session %}
      {% include 'hqwebapp/includes/inactivity_modal_data.html' %}
    {% endif %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I can't say for sure, but I think it is the case that this page has been broken since at the very least [this change](https://github.com/dimagi/commcare-hq/commit/d3c18a434c9ce86563958d4aec38a4680937355c#diff-038c798c3fb4d9875e7ae85cb28457af41e60efa0e2e08fa3ed7df90cb8f613eR275), since `_format_app` assumed `app` was app json, not an Application object, and calling `get` on an Application object behaves very differently than on an app json obj. The point being, this view has likely not been working for nearly 4 years, and from what I can tell, is not referenced anywhere in HQ by view name or url name.

Therefore, I'm removing it!
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
View is not accessible and up until [very recently](https://github.com/dimagi/commcare-hq/pull/34546/commits/cb1eed83e93eb67583f43fa90fc71ed19b5b5b72), has had a bug that leads to a 500 when attempting to access it by typing in the url endpoint.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
