### PR TITLE
Adds ID attribute to desired html elements in data dict for no-code-tracking

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -103,7 +103,7 @@
                 css: {disabled: formCreateCaseTypeSent()},
                 attr: {disabled: formCreateCaseTypeSent()}
               ">{% trans 'Cancel' %}</a>
-              <button type="submit" class="btn btn-primary" data-bind="
+              <button type="submit" class="btn btn-primary" id="create-case-type-button" data-bind="
                 css: {disabled: formCreateCaseTypeSent() || !nameValid() || !nameUnique()},
                 attr: {disabled: formCreateCaseTypeSent() || !nameValid() || !nameUnique()}
               ">
@@ -141,7 +141,7 @@
     </p>
   </div>
   {% if not request.is_view_only %}
-    <div data-bind="saveButton: saveButton, visible: $root.activeCaseType()"></div>
+    <div id="save-button" data-bind="saveButton: saveButton, visible: $root.activeCaseType()"></div>
   {% endif %}
   <div class="row">
     <div class="col-md-12">
@@ -176,7 +176,7 @@
         {% trans "Export to Excel" %}
       </a>
       {% if not request.is_view_only %}
-        <a class="btn btn-default" href="{% url "upload_data_dict" domain %}">
+        <a class="btn btn-default" id="upload-dict" href="{% url "upload_data_dict" domain %}">
           <i class="fa-solid fa-cloud-arrow-up"></i>
           {% trans "Import from Excel" %}
         </a>
@@ -348,7 +348,7 @@
               </div>
               <div class="row-item-small m-auto">
                 <!-- ko if: !deprecated() -->
-                <button title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="btn btn-default">
+                <button id="deprecate-case-property" title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="btn btn-default">
                   <i class="fa fa-archive"></i>
                   {% trans 'Deprecate' %}
                 </button>
@@ -369,7 +369,7 @@
         {% if not request.is_view_only %}
           <form class="form-inline" data-bind="css: { 'has-error': !newPropertyNameUnique() || !newPropertyNameValid() }">
             <input class="form-control" placeholder="Case Property" data-bind="value: newPropertyName">
-            <button class="btn btn-default" data-bind="click: $root.newCaseProperty, enable: newPropertyNameUnique() && newPropertyNameValid()">
+            <button class="btn btn-default" id="add-case-property" data-bind="click: $root.newCaseProperty, enable: newPropertyNameUnique() && newPropertyNameValid()">
               <i class="fa fa-plus"></i>
               {% trans "Add Case Property" %}
             </button>
@@ -385,7 +385,7 @@
           <br />
           <form class="form-inline" data-bind="css: {'has-error': !newGroupNameUnique() || !newGroupNameValid()}">
             <input class="form-control" placeholder="Group Name" data-bind="value: newGroupName">
-            <button class="btn btn-default" data-bind="click: $root.newGroup, enable: newGroupNameUnique() && newGroupNameValid()">
+            <button class="btn btn-default" id="add-case-property-group" data-bind="click: $root.newGroup, enable: newGroupNameUnique() && newGroupNameValid()">
               <i class="fa fa-plus"></i>
               {% trans "Add Case Property Group" %}
             </button>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -103,7 +103,7 @@
                 css: {disabled: formCreateCaseTypeSent()},
                 attr: {disabled: formCreateCaseTypeSent()}
               ">{% trans 'Cancel' %}</a>
-              <button type="submit" class="btn btn-primary" id="create-case-type-button" data-bind="
+              <button type="submit" class="btn btn-primary" id="gtm-create-case-type-btn" data-bind="
                 css: {disabled: formCreateCaseTypeSent() || !nameValid() || !nameUnique()},
                 attr: {disabled: formCreateCaseTypeSent() || !nameValid() || !nameUnique()}
               ">
@@ -141,7 +141,7 @@
     </p>
   </div>
   {% if not request.is_view_only %}
-    <div id="save-button" data-bind="saveButton: saveButton, visible: $root.activeCaseType()"></div>
+    <div id="gtm-save-btn" data-bind="saveButton: saveButton, visible: $root.activeCaseType()"></div>
   {% endif %}
   <div class="row">
     <div class="col-md-12">
@@ -176,7 +176,7 @@
         {% trans "Export to Excel" %}
       </a>
       {% if not request.is_view_only %}
-        <a class="btn btn-default" id="upload-dict" href="{% url "upload_data_dict" domain %}">
+        <a class="btn btn-default" id="gtm-upload-dict" href="{% url "upload_data_dict" domain %}">
           <i class="fa-solid fa-cloud-arrow-up"></i>
           {% trans "Import from Excel" %}
         </a>
@@ -348,7 +348,7 @@
               </div>
               <div class="row-item-small m-auto">
                 <!-- ko if: !deprecated() -->
-                <button id="deprecate-case-property" title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="btn btn-default">
+                <button id="gtm-deprecate-case-property" title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="btn btn-default">
                   <i class="fa fa-archive"></i>
                   {% trans 'Deprecate' %}
                 </button>
@@ -369,7 +369,7 @@
         {% if not request.is_view_only %}
           <form class="form-inline" data-bind="css: { 'has-error': !newPropertyNameUnique() || !newPropertyNameValid() }">
             <input class="form-control" placeholder="Case Property" data-bind="value: newPropertyName">
-            <button class="btn btn-default" id="add-case-property" data-bind="click: $root.newCaseProperty, enable: newPropertyNameUnique() && newPropertyNameValid()">
+            <button class="btn btn-default" id="gtm-add-case-property" data-bind="click: $root.newCaseProperty, enable: newPropertyNameUnique() && newPropertyNameValid()">
               <i class="fa fa-plus"></i>
               {% trans "Add Case Property" %}
             </button>
@@ -385,7 +385,7 @@
           <br />
           <form class="form-inline" data-bind="css: {'has-error': !newGroupNameUnique() || !newGroupNameValid()}">
             <input class="form-control" placeholder="Group Name" data-bind="value: newGroupName">
-            <button class="btn btn-default" id="add-case-property-group" data-bind="click: $root.newGroup, enable: newGroupNameUnique() && newGroupNameValid()">
+            <button class="btn btn-default" id="gtm-add-case-property-group" data-bind="click: $root.newGroup, enable: newGroupNameUnique() && newGroupNameValid()">
               <i class="fa fa-plus"></i>
               {% trans "Add Case Property Group" %}
             </button>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
@@ -45,7 +45,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
-          <button type="button" class="btn btn-primary" id="deprecate-case-type-confirm" data-dismiss="modal" data-bind="click: $root.deprecateCaseType">{% trans "Confirm" %}</button>
+          <button type="button" class="btn btn-primary" id="gtm-deprecate-case-type-confirm" data-dismiss="modal" data-bind="click: $root.deprecateCaseType">{% trans "Confirm" %}</button>
         </div>
       </div>
     </div>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
@@ -45,7 +45,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
-          <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: $root.deprecateCaseType">{% trans "Confirm" %}</button>
+          <button type="button" class="btn btn-primary" id="deprecate-case-type-confirm" data-dismiss="modal" data-bind="click: $root.deprecateCaseType">{% trans "Confirm" %}</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds `id` attribute to the desired html elements in data dictionary feature so that they can be used for identification to track clicks
in Kissmetrics and GTM console.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3594

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Changes are safe as it only involves adding `id` attribute 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None



<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
