### PR TITLE
Add ID to HTML Elements in the Geospatial Feature

### DIFF
--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -8,7 +8,7 @@
   <div class="col col-md-2">
     <span id="lock-groups-controls">
       <div class="controls">
-        <button id="lock-case-grouping-btn" data-bind="visible: !groupsLocked(), click: toggleGroupLock" class="btn-default form-control">
+        <button id="gtm-lock-case-grouping-btn" data-bind="visible: !groupsLocked(), click: toggleGroupLock" class="btn-default form-control">
           <i class="fa fa-lock"></i>
           {% trans "Lock Case Grouping for Me" %}
         </button>
@@ -22,7 +22,7 @@
   <div class="col col-md-2">
     <span id="export-controls">
       <div class="controls">
-        <button id="export-groups-btn" class="btn-default form-control" data-bind="click: downloadCSV, disable: !groupsReady()">
+        <button id="gtm-export-groups-btn" class="btn-default form-control" data-bind="click: downloadCSV, disable: !groupsReady()">
           {% trans "Export Groups" %}
         </button>
       </div>

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -8,7 +8,7 @@
   <div class="col col-md-2">
     <span id="lock-groups-controls">
       <div class="controls">
-        <button data-bind="visible: !groupsLocked(), click: toggleGroupLock" class="btn-default form-control">
+        <button id="lock-case-grouping-btn" data-bind="visible: !groupsLocked(), click: toggleGroupLock" class="btn-default form-control">
           <i class="fa fa-lock"></i>
           {% trans "Lock Case Grouping for Me" %}
         </button>
@@ -22,7 +22,7 @@
   <div class="col col-md-2">
     <span id="export-controls">
       <div class="controls">
-        <button class="btn-default form-control" data-bind="click: downloadCSV, disable: !groupsReady()">
+        <button id="export-groups-btn" class="btn-default form-control" data-bind="click: downloadCSV, disable: !groupsReady()">
           {% trans "Export Groups" %}
         </button>
       </div>

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -92,7 +92,7 @@
                             <button type="button" class="btn btn-default" data-bind="event: {click: $root.captureLocationForItem.bind($data)}, disable: $root.isCreatingCase">
                                 {% trans "Capture on Map" %}
                             </button>
-                            <button id="save-row-btn" type="button" class="btn btn-primary" data-bind="enable: canSaveRow, event: {click: $root.saveDataRow.bind($data)}">
+                            <button id="gtm-save-row-btn" type="button" class="btn btn-primary" data-bind="enable: canSaveRow, event: {click: $root.saveDataRow.bind($data)}">
                                 {% trans "Save" %}
                             </button>
                         </td>

--- a/corehq/apps/geospatial/templates/gps_capture.html
+++ b/corehq/apps/geospatial/templates/gps_capture.html
@@ -92,7 +92,7 @@
                             <button type="button" class="btn btn-default" data-bind="event: {click: $root.captureLocationForItem.bind($data)}, disable: $root.isCreatingCase">
                                 {% trans "Capture on Map" %}
                             </button>
-                            <button type="button" class="btn btn-primary" data-bind="enable: canSaveRow, event: {click: $root.saveDataRow.bind($data)}">
+                            <button id="save-row-btn" type="button" class="btn btn-primary" data-bind="enable: canSaveRow, event: {click: $root.saveDataRow.bind($data)}">
                                 {% trans "Save" %}
                             </button>
                         </td>


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3595).

Very small PR that only adds an `id` attribute to a few HTML elements of the Geospatial feature. This is being done so that these elements can be uniquely identified and tracked in product analytics tooling such as Kissmetrics and Google Analytics.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Only attribute changes to HTML elements.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
