### PR TITLE
Update Translations UI

### DIFF
--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -219,6 +219,8 @@ class AppTranslationsForm(forms.Form):
             return PushAppTranslationsForm
         elif form_action == 'pull':
             return PullAppTranslationsForm
+        elif form_action == 'backup':
+            return BackUpAppTranslationsForm
         elif form_action == 'delete':
             return DeleteAppTranslationsForm
 
@@ -265,24 +267,19 @@ class PullAppTranslationsForm(AppTranslationsForm):
         help_text=gettext_lazy("Please note that this will lock the resource for all languages"),
         required=False,
         initial=False)
-    pull_all_source_files_and_translations = forms.MultipleChoiceField(
-        choices=[('yes', 'Pull everything from the resource. You can use this to create a backup of a '
-                         'particular resource. If checked, note that selections for the remaining fields '
-                         'below will be ignored.')],
-        widget=forms.CheckboxSelectMultiple(),
-        required=False,
-        initial='no',
-    )
 
     def form_fields(self):
         form_fields = super(PullAppTranslationsForm, self).form_fields()
         form_fields.extend([
-            'pull_all_source_files_and_translations',
             crispy.Field('target_lang', css_class="hqwebapp-select2"),
             'lock_translations',
             'perform_translated_check',
         ])
         return form_fields
+
+
+class BackUpAppTranslationsForm(AppTranslationsForm):
+    form_action = 'backup'
 
 
 class DeleteAppTranslationsForm(AppTranslationsForm):

--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -213,35 +213,40 @@ class AppTranslationsForm(forms.Form):
 
     @classmethod
     def form_for(cls, form_action):
-        if form_action == 'create':
-            return CreateAppTranslationsForm
-        elif form_action == 'update':
-            return UpdateAppTranslationsForm
+        if form_action == 'create_update':
+            return CreateUpdateAppTranslationsForm
         elif form_action == 'push':
             return PushAppTranslationsForm
         elif form_action == 'pull':
             return PullAppTranslationsForm
-        elif form_action == 'backup':
-            return BackUpAppTranslationsForm
         elif form_action == 'delete':
             return DeleteAppTranslationsForm
 
 
-class CreateAppTranslationsForm(AppTranslationsForm):
-    form_action = 'create'
+class CreateUpdateAppTranslationsForm(AppTranslationsForm):
+    form_action = 'create_update'
+    update_existing_resource = forms.MultipleChoiceField(
+        choices=[
+            ('yes', 'Update existing resources'),
+        ],
+        widget=forms.CheckboxSelectMultiple(),
+        required=False,
+        initial='no',
+        help_text=gettext_lazy("Check this if you want to update an existing resource, instead of "
+                               "creating new ones. If you submit this form without this check, "
+                               "duplicate resources may be created.")
+    )
     source_lang = forms.ChoiceField(label=gettext_lazy("Source Language on Transifex"),
                                     choices=langcodes.get_all_langs_for_select(),
                                     initial="en"
                                     )
 
     def form_fields(self):
-        form_fields = super(CreateAppTranslationsForm, self).form_fields()
+        form_fields = super(CreateUpdateAppTranslationsForm, self).form_fields()
+        if self.form_action == 'create_update':
+            form_fields.append('update_existing_resource')
         form_fields.append(crispy.Field('source_lang', css_class="hqwebapp-select2"))
         return form_fields
-
-
-class UpdateAppTranslationsForm(CreateAppTranslationsForm):
-    form_action = 'update'
 
 
 class PushAppTranslationsForm(AppTranslationsForm):
@@ -249,22 +254,32 @@ class PushAppTranslationsForm(AppTranslationsForm):
 
     def form_fields(self):
         form_fields = super(PushAppTranslationsForm, self).form_fields()
+        # for some reason this works only works with both of these lines, not one or the other
         form_fields.append(crispy.Field('target_lang', css_class="hqwebapp-select2"))
+        form_fields.append('target_lang')
         return form_fields
 
 
 class PullAppTranslationsForm(AppTranslationsForm):
     form_action = 'pull'
-    lock_translations = forms.BooleanField(label=gettext_lazy("Lock translations for resources that are being "
-                                                              "pulled"),
-                                           help_text=gettext_lazy("Please note that this will lock the resource"
-                                                                  " for all languages"),
-                                           required=False,
-                                           initial=False)
+    lock_translations = forms.BooleanField(
+        label=gettext_lazy("Lock translations for resources that are being pulled"),
+        help_text=gettext_lazy("Please note that this will lock the resource for all languages"),
+        required=False,
+        initial=False)
+    pull_all_source_files_and_translations = forms.MultipleChoiceField(
+        choices=[('yes', 'Pull everything from the resource. You can use this to create a backup of a '
+                         'particular resource. If checked, note that selections for the remaining fields '
+                         'below will be ignored.')],
+        widget=forms.CheckboxSelectMultiple(),
+        required=False,
+        initial='no',
+    )
 
     def form_fields(self):
         form_fields = super(PullAppTranslationsForm, self).form_fields()
         form_fields.extend([
+            'pull_all_source_files_and_translations',
             crispy.Field('target_lang', css_class="hqwebapp-select2"),
             'lock_translations',
             'perform_translated_check',
@@ -281,14 +296,10 @@ class DeleteAppTranslationsForm(AppTranslationsForm):
         return form_fields
 
 
-class DownloadAppTranslationsForm(CreateAppTranslationsForm):
+class DownloadAppTranslationsForm(CreateUpdateAppTranslationsForm):
     """Used to download the files that are being uploaded to Transifex."""
 
     form_action = 'download'
-
-
-class BackUpAppTranslationsForm(AppTranslationsForm):
-    form_action = 'backup'
 
 
 class TransifexOrganizationForm(forms.ModelForm):

--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -210,7 +210,7 @@ class AppTranslationsForm(forms.Form):
 
     @classmethod
     def form_for(cls, form_action):
-        if form_action == 'create_update':
+        if form_action == 'create_or_update':
             return CreateUpdateAppTranslationsForm
         elif form_action == 'push':
             return PushAppTranslationsForm
@@ -223,7 +223,7 @@ class AppTranslationsForm(forms.Form):
 
 
 class CreateUpdateAppTranslationsForm(AppTranslationsForm):
-    form_action = 'create_update'
+    form_action = 'create_or_update'
     update_existing_resource = forms.MultipleChoiceField(
         choices=[
             ('yes', 'Update existing resources'),
@@ -242,7 +242,7 @@ class CreateUpdateAppTranslationsForm(AppTranslationsForm):
 
     def form_fields(self):
         form_fields = super(CreateUpdateAppTranslationsForm, self).form_fields()
-        if self.form_action == 'create_update':
+        if self.form_action == 'create_or_update':
             form_fields.append('update_existing_resource')
         form_fields.append(crispy.Field('source_lang', css_class="hqwebapp-select2"))
         return form_fields

--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -291,14 +291,11 @@ class BackUpAppTranslationsForm(AppTranslationsForm):
 
 class DeleteAppTranslationsForm(AppTranslationsForm):
     form_action = 'delete'
-    app_id = forms.ChoiceField(label=gettext_lazy("Application"), choices=(), required=False)
 
     def form_fields(self):
-        return [
-            crispy.Field('transifex_project_slug', css_class="hqwebapp-select2"),
-            'action',
-            'perform_translated_check'
-        ]
+        form_fields = super(DeleteAppTranslationsForm, self).form_fields()
+        form_fields.append('perform_translated_check')
+        return form_fields
 
 
 class DownloadAppTranslationsForm(CreateUpdateAppTranslationsForm):

--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -254,9 +254,7 @@ class PushAppTranslationsForm(AppTranslationsForm):
 
     def form_fields(self):
         form_fields = super(PushAppTranslationsForm, self).form_fields()
-        # for some reason this works only works with both of these lines, not one or the other
         form_fields.append(crispy.Field('target_lang', css_class="hqwebapp-select2"))
-        form_fields.append('target_lang')
         return form_fields
 
 
@@ -291,9 +289,11 @@ class DeleteAppTranslationsForm(AppTranslationsForm):
     form_action = 'delete'
 
     def form_fields(self):
-        form_fields = super(DeleteAppTranslationsForm, self).form_fields()
-        form_fields.append('perform_translated_check')
-        return form_fields
+        return [
+            crispy.Field('transifex_project_slug', css_class="hqwebapp-select2"),
+            'action',
+            'perform_translated_check'
+        ]
 
 
 class DownloadAppTranslationsForm(CreateUpdateAppTranslationsForm):

--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -206,9 +206,6 @@ class AppTranslationsForm(forms.Form):
             available_versions = get_available_versions_for_app(self.domain, app_id)
             if version not in available_versions:
                 self.add_error('version', gettext_lazy('Version not available for app'))
-        if (not cleaned_data['target_lang']
-                and (cleaned_data['action'] == "pull" and cleaned_data['perform_translated_check'])):
-            self.add_error('target_lang', gettext_lazy('Target lang required to confirm translation completion'))
         return cleaned_data
 
     @classmethod
@@ -253,6 +250,11 @@ class CreateUpdateAppTranslationsForm(AppTranslationsForm):
 
 class PushAppTranslationsForm(AppTranslationsForm):
     form_action = 'push'
+    target_lang = forms.ChoiceField(label=gettext_lazy("Translated Language"),
+                                    choices=([(None, gettext_lazy('Select Translated Language'))]
+                                             + langcodes.get_all_langs_for_select()),
+                                    required=True,
+                                    )
 
     def form_fields(self):
         form_fields = super(PushAppTranslationsForm, self).form_fields()
@@ -262,6 +264,11 @@ class PushAppTranslationsForm(AppTranslationsForm):
 
 class PullAppTranslationsForm(AppTranslationsForm):
     form_action = 'pull'
+    target_lang = forms.ChoiceField(label=gettext_lazy("Translated Language"),
+                                    choices=([(None, gettext_lazy('Select Translated Language'))]
+                                             + langcodes.get_all_langs_for_select()),
+                                    required=True,
+                                    )
     lock_translations = forms.BooleanField(
         label=gettext_lazy("Lock translations for resources that are being pulled"),
         help_text=gettext_lazy("Please note that this will lock the resource for all languages"),
@@ -284,6 +291,7 @@ class BackUpAppTranslationsForm(AppTranslationsForm):
 
 class DeleteAppTranslationsForm(AppTranslationsForm):
     form_action = 'delete'
+    app_id = forms.ChoiceField(label=gettext_lazy("Application"), choices=(), required=False)
 
     def form_fields(self):
         return [

--- a/corehq/apps/translations/integrations/transifex/views.py
+++ b/corehq/apps/translations/integrations/transifex/views.py
@@ -357,11 +357,9 @@ class AppTranslations(BaseTranslationsView):
     def page_context(self):
         context = super(AppTranslations, self).page_context
         if context['transifex_details_available']:
-            context['create_form'] = AppTranslationsForm.form_for('create')(self.domain)
-            context['update_form'] = AppTranslationsForm.form_for('update')(self.domain)
+            context['create_update_form'] = AppTranslationsForm.form_for('create_update')(self.domain)
             context['push_form'] = AppTranslationsForm.form_for('push')(self.domain)
             context['pull_form'] = AppTranslationsForm.form_for('pull')(self.domain)
-            context['backup_form'] = AppTranslationsForm.form_for('backup')(self.domain)
             if self.request.user.is_staff:
                 context['delete_form'] = AppTranslationsForm.form_for('delete')(self.domain)
         form_action = self.request.POST.get('action')
@@ -378,7 +376,9 @@ class AppTranslations(BaseTranslationsView):
         return Transifex(domain, form_data['app_id'], source_language_code, transifex_project_slug,
                          form_data['version'],
                          use_version_postfix='yes' in form_data['use_version_postfix'],
-                         update_resource=(form_data['action'] == 'update'))
+                         # the 'yes in' part is kind of unnecessary here...
+                         update_resource=('update_existing_resource' in form_data
+                                          and 'yes' in form_data['update_existing_resource']))
 
     def perform_push_request(self, request, form_data):
         if form_data['target_lang']:
@@ -416,16 +416,14 @@ class AppTranslations(BaseTranslationsView):
                 messages.error(request, _('Resources yet to be completely translated for all languages. '
                                           'Hence, the request for locking resources can not be performed.'))
                 return False
-        pull_translation_files_from_transifex.delay(request.domain, form_data, request.user.email)
-        messages.success(request, _('Successfully enqueued request to pull for translations. '
-                                    'You should receive an email shortly.'))
-        return True
 
-    def perform_backup_request(self, request, form_data):
-        if not self.ensure_resources_present(request):
-            return False
-        backup_project_from_transifex.delay(request.domain, form_data, request.user.email)
-        messages.success(request, _('Successfully enqueued request to take backup.'))
+        if 'yes' in form_data['pull_all_source_files_and_translations']:
+            backup_project_from_transifex.delay(request.domain, form_data, request.user.email)
+            messages.success(request, _('Successfully enqueued request to take backup.'))
+        else:
+            pull_translation_files_from_transifex.delay(request.domain, form_data, request.user.email)
+            messages.success(request, _('Successfully enqueued request to pull for translations. '
+                                        'You should receive an email shortly.'))
         return True
 
     def perform_delete_request(self, request, form_data):
@@ -446,12 +444,10 @@ class AppTranslations(BaseTranslationsView):
             messages.error(request, _('Source lang selected not available for the project'))
             return False
         else:
-            if form_data['action'] in ['create', 'update', 'push']:
+            if form_data['action'] in ['create_update', 'push']:
                 return self.perform_push_request(request, form_data)
             elif form_data['action'] == 'pull':
                 return self.perform_pull_request(request, form_data)
-            elif form_data['action'] == 'backup':
-                return self.perform_backup_request(request, form_data)
             elif form_data['action'] == 'delete':
                 return self.perform_delete_request(request, form_data)
 

--- a/corehq/apps/translations/integrations/transifex/views.py
+++ b/corehq/apps/translations/integrations/transifex/views.py
@@ -438,7 +438,7 @@ class AppTranslations(BaseTranslationsView):
             messages.error(request, _('Source lang selected not available for the project'))
             return False
         else:
-            if form_data['action'] in ['create_update', 'push']:
+            if form_data['action'] in ['create_or_update', 'push']:
                 return self.perform_push_request(request, form_data)
             elif form_data['action'] == 'pull':
                 return self.perform_pull_request(request, form_data)
@@ -468,7 +468,7 @@ class CreateUpdateTranslations(AppTranslations):
     def page_context(self):
         context = super(CreateUpdateTranslations, self).page_context
         if context['transifex_details_available']:
-            context['trans_form'] = AppTranslationsForm.form_for('create_update')(self.domain)
+            context['trans_form'] = AppTranslationsForm.form_for('create_or_update')(self.domain)
             context['page_action'] = 'create_update'
         return context
 

--- a/corehq/apps/translations/integrations/transifex/views.py
+++ b/corehq/apps/translations/integrations/transifex/views.py
@@ -356,12 +356,6 @@ class AppTranslations(BaseTranslationsView):
     @property
     def page_context(self):
         context = super(AppTranslations, self).page_context
-        if context['transifex_details_available']:
-            context['create_update_form'] = AppTranslationsForm.form_for('create_update')(self.domain)
-            context['push_form'] = AppTranslationsForm.form_for('push')(self.domain)
-            context['pull_form'] = AppTranslationsForm.form_for('pull')(self.domain)
-            if self.request.user.is_staff:
-                context['delete_form'] = AppTranslationsForm.form_for('delete')(self.domain)
         form_action = self.request.POST.get('action')
         if form_action:
             context[form_action + '_form'] = self.translations_form
@@ -376,7 +370,6 @@ class AppTranslations(BaseTranslationsView):
         return Transifex(domain, form_data['app_id'], source_language_code, transifex_project_slug,
                          form_data['version'],
                          use_version_postfix='yes' in form_data['use_version_postfix'],
-                         # the 'yes in' part is kind of unnecessary here...
                          update_resource=('update_existing_resource' in form_data
                                           and 'yes' in form_data['update_existing_resource']))
 
@@ -462,6 +455,58 @@ class AppTranslations(BaseTranslationsView):
                 except ResourceMissing as e:
                     messages.error(request, e)
         return self.get(request, *args, **kwargs)
+
+
+class CreateUpdateTranslations(AppTranslations):
+    page_title = gettext_lazy('Create or Update Translations')
+    urlname = 'create_update_translations'
+
+    @property
+    def page_context(self):
+        context = super(CreateUpdateTranslations, self).page_context
+        if context['transifex_details_available']:
+            context['trans_form'] = AppTranslationsForm.form_for('create_update')(self.domain)
+            context['page_action'] = 'create_update'
+        return context
+
+
+class PushTranslations(AppTranslations):
+    page_title = gettext_lazy('Push Translations')
+    urlname = 'push_translations'
+
+    @property
+    def page_context(self):
+        context = super(PushTranslations, self).page_context
+        if context['transifex_details_available']:
+            context['trans_form'] = AppTranslationsForm.form_for('push')(self.domain)
+            context['page_action'] = 'push'
+        return context
+
+
+class PullTranslations(AppTranslations):
+    page_title = gettext_lazy('Pull Translations')
+    urlname = 'pull_translations'
+
+    @property
+    def page_context(self):
+        context = super(PullTranslations, self).page_context
+        if context['transifex_details_available']:
+            context['trans_form'] = AppTranslationsForm.form_for('pull')(self.domain)
+            context['page_action'] = 'pull'
+        return context
+
+
+class DeleteTranslations(AppTranslations):
+    page_title = gettext_lazy('Delete Translations')
+    urlname = 'delete_translations'
+
+    @property
+    def page_context(self):
+        context = super(DeleteTranslations, self).page_context
+        if context['transifex_details_available']:
+            context['trans_form'] = AppTranslationsForm.form_for('delete')(self.domain)
+            context['page_action'] = 'delete'
+        return context
 
 
 class DownloadTranslations(BaseTranslationsView):

--- a/corehq/apps/translations/tasks.py
+++ b/corehq/apps/translations/tasks.py
@@ -66,7 +66,8 @@ def push_translation_files_to_transifex(domain, data, email):
                                   data.get('transifex_project_slug'),
                                   data.get('version'),
                                   use_version_postfix='yes' in data['use_version_postfix'],
-                                  update_resource=(data['action'] == 'update')
+                                  update_resource=('update_existing_resource' in data
+                                                   and 'yes' in data['update_existing_resource'])
                                   ).send_translation_files()
     data['language'] = data.get('target_lang') or data.get('source_lang')
     if upload_status:

--- a/corehq/apps/translations/templates/app_translations.html
+++ b/corehq/apps/translations/templates/app_translations.html
@@ -66,8 +66,7 @@
             <legend>{% trans "Delete Project Resources" %}</legend>
             <p>
               {% blocktrans %}
-                Delete all resources for the project. (This may be a bug - I think it's only supposed to delete
-                resources that come from the selected application). Use caution!
+                Delete all resources for the selected project. Use caution!
               {% endblocktrans %}
             </p>
             </br>

--- a/corehq/apps/translations/templates/app_translations.html
+++ b/corehq/apps/translations/templates/app_translations.html
@@ -11,44 +11,28 @@
 
   {% if not transifex_details_available %}
     <p class="text-error">
-            <span class="label label-danger">
-                {% trans 'Transifex integration not set for this domain' %}
-            </span>
+      <span class="label label-danger">
+          {% trans 'Transifex integration not set for this domain' %}
+      </span>
     </p>
   {% else %}
-    <ul class="nav nav-tabs sticky-tabs" style="margin-bottom: 10px;">
-      <li><a data-toggle="tab" href="#create-update-trans-form" id="create-tab">{% trans "Create or Update" %}</a></li>
-      <li><a data-toggle="tab" href="#push-trans-form" id="push-tab">{% trans "Push" %}</a></li>
-      <li><a data-toggle="tab" href="#pull-trans-form" id="pull-tab">{% trans "Pull" %}</a></li>
-      <li><a data-toggle="tab" href="#del-trans-form" id="delete-tab">{% trans "Delete" %}</a></li>
-    </ul>
-    <div class="tab-content">
-      <div id="create-update-trans-form" class="tab-pane">
-        <form class="form form-horizontal" name="product" method="post">
+    <div>
+      <form class="form form-horizontal" name="product" method="post">
+        {% if page_action == 'create_update' %}
           <legend>{% trans "Set Up or Update Resource" %}</legend>
           <p>
             {% blocktrans %}
               Create a new resource or update an existing one in Transifex.
             {% endblocktrans %}
           </p>
-          </br>
-          {% crispy create_update_form %}
-        </form>
-      </div>
-      <div id="push-trans-form" class="tab-pane">
-        <form class="form form-horizontal" name="product" method="post">
+        {% elif page_action == 'push' %}
           <legend>{% trans "Push Target Language" %}</legend>
           <p>
             {% blocktrans %}
               Push translations for a target language to Transifex.
             {% endblocktrans %}
           </p>
-          </br>
-          {% crispy push_form %}
-        </form>
-      </div>
-      <div id="pull-trans-form" class="tab-pane">
-        <form class="form form-horizontal" name="product" method="post">
+        {% elif page_action == 'pull' %}
           <legend>{% trans "Pull App Translations" %}</legend>
           <p>
             {% blocktrans %}
@@ -56,26 +40,17 @@
               If you choose to pull all source files and translations, it will be emailed to you as a zip file.
             {% endblocktrans %}
           </p>
-          </br>
-          {% crispy pull_form %}
-        </form>
-      </div>
-      <div id="del-trans-form" class="tab-pane">
-        {% if delete_form %}
-          <form class="form form-horizontal" name="product" method="post">
-            <legend>{% trans "Delete Project Resources" %}</legend>
+        {% elif page_action == 'delete' %}
+          <legend>{% trans "Delete Project Resources" %}</legend>
             <p>
               {% blocktrans %}
                 Delete all resources for the selected project. Use caution!
               {% endblocktrans %}
             </p>
-            </br>
-            {% crispy delete_form %}
-          </form>
-        {% else %}
-          <b>{% trans "Action permitted to only users with staff access" %}</b>
         {% endif %}
-      </div>
+        </br>
+        {% crispy trans_form %}
+      </form>
     </div>
   {% endif %}
 {% endblock %}

--- a/corehq/apps/translations/templates/app_translations.html
+++ b/corehq/apps/translations/templates/app_translations.html
@@ -17,48 +17,60 @@
     </p>
   {% else %}
     <ul class="nav nav-tabs sticky-tabs" style="margin-bottom: 10px;">
-      <li><a data-toggle="tab" href="#create-trans-form" id="create-tab">{% trans "Create" %}</a></li>
-      <li><a data-toggle="tab" href="#update-trans-form" id="update-tab">{% trans "Update" %}</a></li>
+      <li><a data-toggle="tab" href="#create-update-trans-form" id="create-tab">{% trans "Create or Update" %}</a></li>
       <li><a data-toggle="tab" href="#push-trans-form" id="push-tab">{% trans "Push" %}</a></li>
       <li><a data-toggle="tab" href="#pull-trans-form" id="pull-tab">{% trans "Pull" %}</a></li>
-      <li><a data-toggle="tab" href="#backup-trans-form" id="backup-tab">{% trans "BackUp" %}</a></li>
       <li><a data-toggle="tab" href="#del-trans-form" id="delete-tab">{% trans "Delete" %}</a></li>
     </ul>
     <div class="tab-content">
-      <div id="create-trans-form" class="tab-pane">
+      <div id="create-update-trans-form" class="tab-pane">
         <form class="form form-horizontal" name="product" method="post">
-          <legend>{% trans "Set Up New Project" %}</legend>
-          {% crispy create_form %}
-        </form>
-      </div>
-      <div id="update-trans-form" class="tab-pane">
-        <form class="form form-horizontal" name="product" method="post">
-          <legend>{% trans "Update Source Files" %}</legend>
-          {% crispy update_form %}
+          <legend>{% trans "Set Up or Update Resource" %}</legend>
+          <p>
+            {% blocktrans %}
+              Create a new resource or update an existing one in Transifex.
+            {% endblocktrans %}
+          </p>
+          </br>
+          {% crispy create_update_form %}
         </form>
       </div>
       <div id="push-trans-form" class="tab-pane">
         <form class="form form-horizontal" name="product" method="post">
           <legend>{% trans "Push Target Language" %}</legend>
+          <p>
+            {% blocktrans %}
+              Push translations for a target language to Transifex.
+            {% endblocktrans %}
+          </p>
+          </br>
           {% crispy push_form %}
         </form>
       </div>
       <div id="pull-trans-form" class="tab-pane">
         <form class="form form-horizontal" name="product" method="post">
           <legend>{% trans "Pull App Translations" %}</legend>
+          <p>
+            {% blocktrans %}
+              Pull all translations for a selected language, which will be emailed to you as an Excel file.
+              If you choose to pull all source files and translations, it will be emailed to you as a zip file.
+            {% endblocktrans %}
+          </p>
+          </br>
           {% crispy pull_form %}
-        </form>
-      </div>
-      <div id="backup-trans-form" class="tab-pane">
-        <form class="form form-horizontal" name="product" method="post">
-          <legend>{% trans "BackUp Translations" %}</legend>
-          {% crispy backup_form %}
         </form>
       </div>
       <div id="del-trans-form" class="tab-pane">
         {% if delete_form %}
           <form class="form form-horizontal" name="product" method="post">
-            <legend>{% trans "Delete Project" %}</legend>
+            <legend>{% trans "Delete Project Resources" %}</legend>
+            <p>
+              {% blocktrans %}
+                Delete all resources for the project. (This may be a bug - I think it's only supposed to delete
+                resources that come from the selected application). Use caution!
+              {% endblocktrans %}
+            </p>
+            </br>
             {% crispy delete_form %}
           </form>
         {% else %}

--- a/corehq/apps/translations/templates/app_translations.html
+++ b/corehq/apps/translations/templates/app_translations.html
@@ -37,7 +37,13 @@
           <p>
             {% blocktrans %}
               Pull all translations for a selected language, which will be emailed to you as an Excel file.
-              If you choose to pull all source files and translations, it will be emailed to you as a zip file.
+            {% endblocktrans %}
+          </p>
+        {% elif page_action == 'backup' %}
+          <legend>{% trans "Backup App Translations" %}</legend>
+          <p>
+            {% blocktrans %}
+              Pull all translations for all languages in the project, which will be emailed to you as a zip file.
             {% endblocktrans %}
           </p>
         {% elif page_action == 'delete' %}

--- a/corehq/apps/translations/urls.py
+++ b/corehq/apps/translations/urls.py
@@ -1,12 +1,15 @@
 from django.urls import re_path as url
 
 from corehq.apps.translations.integrations.transifex.views import (
-    AppTranslations,
     BlacklistTranslations,
+    CreateUpdateTranslations,
     ConvertTranslations,
+    DeleteTranslations,
     DownloadTranslations,
     MigrateTransifexProject,
     PullResource,
+    PushTranslations,
+    PullTranslations,
     delete_translation_blacklist,
 )
 
@@ -19,8 +22,14 @@ urlpatterns = [
         name=BlacklistTranslations.urlname),
     url(r'^blacklist_translations/delete/(?P<pk>[0-9]+)/$', delete_translation_blacklist,
         name='delete_translation_blacklist'),
-    url(r'^translations/apps/', AppTranslations.as_view(),
-        name='app_translations'),
+    url(r'^translations/create_update', CreateUpdateTranslations.as_view(),
+        name='create_update_translations'),
+    url(r'^translations/push', PushTranslations.as_view(),
+        name='push_translations'),
+    url(r'^translations/pull', PullTranslations.as_view(),
+        name='pull_translations'),
+    url(r'^translations/delete', DeleteTranslations.as_view(),
+        name='delete_translations'),
     url(r'^dl/', DownloadTranslations.as_view(),
         name='download_translations'),
     url(r'^migrate/$', MigrateTransifexProject.as_view(),

--- a/corehq/apps/translations/urls.py
+++ b/corehq/apps/translations/urls.py
@@ -1,6 +1,7 @@
 from django.urls import re_path as url
 
 from corehq.apps.translations.integrations.transifex.views import (
+    BackupTranslations,
     BlacklistTranslations,
     CreateUpdateTranslations,
     ConvertTranslations,
@@ -28,6 +29,8 @@ urlpatterns = [
         name='push_translations'),
     url(r'^translations/pull', PullTranslations.as_view(),
         name='pull_translations'),
+    url(r'^translations/backup', BackupTranslations.as_view(),
+        name='backup_translations'),
     url(r'^translations/delete', DeleteTranslations.as_view(),
         name='delete_translations'),
     url(r'^dl/', DownloadTranslations.as_view(),

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1839,8 +1839,16 @@ class TranslationsTab(UITab):
             if toggles.APP_TRANSLATIONS_WITH_TRANSIFEX.enabled_for_request(self._request):
                 items.append((_('Translations'), [
                     {
-                        'url': reverse('app_translations', args=[self.domain]),
-                        'title': _('Manage App Translations')
+                        'url': reverse('create_update_translations', args=[self.domain]),
+                        'title': _('Create or Update Translations')
+                    },
+                    {
+                        'url': reverse('push_translations', args=[self.domain]),
+                        'title': _('Push Translations')
+                    },
+                    {
+                        'url': reverse('pull_translations', args=[self.domain]),
+                        'title': _('Pull Translations')
                     },
                     {
                         'url': reverse('pull_resource', args=[self.domain]),
@@ -1859,6 +1867,12 @@ class TranslationsTab(UITab):
                         'title': _('Migrate Project')
                     },
                 ]))
+        if self._request.user.is_staff:
+            items.append((_('Translations'), [
+                {'url': reverse('delete_translations', args=[self.domain]),
+                 'title': 'Delete Translations'
+                 }
+            ]))
         return items
 
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1851,6 +1851,10 @@ class TranslationsTab(UITab):
                         'title': _('Pull Translations')
                     },
                     {
+                        'url': reverse('backup_translations', args=[self.domain]),
+                        'title': _('Backup Translations')
+                    },
+                    {
                         'url': reverse('pull_resource', args=[self.domain]),
                         'title': _('Pull Resource')
                     },


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR makes minor UI adjustments for both clarity of use and so that certain elements like drop down menus can function again. These are all the visible changes I made:

- Broke up Manage App Translations tabs into their own separate pages on the sidebar (pictured below)
- Merged Create and Update tabs into one singular page (with an option to Update resources instead of create them)
- Removed excess fields from the Delete resources from project page

The new sidebar:
<img width="224" alt="Screen Shot 2024-05-08 at 9 07 56 AM" src="https://github.com/dimagi/commcare-hq/assets/33491742/01bae4d5-7e03-481b-884f-ab04b9d7ef52">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4460)
[Main Transifex API upgrade epic](https://dimagi.atlassian.net/browse/USH-4258)

Like I described above, this was mostly refactoring. The one notable technical detail that drove splitting the tabs into separate pages was that because all the drop down menus on that page was using the same id (all inherited from `AppTranslationsForm`) only the last tab to have the element actually had it working. 

Like I said, mostly refactoring. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[app_trans_with_transifex](https://staging.commcarehq.org/hq/flags/edit/app_trans_with_transifex/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Pretty safe, it's only UI changes.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

[QA Epic](https://dimagi.atlassian.net/browse/QA-5954)

This already passed QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
