### PR TITLE
Add index_name to case search config

### DIFF
--- a/corehq/apps/case_search/migrations/0014_casesearchconfig_index_name.py
+++ b/corehq/apps/case_search/migrations/0014_casesearchconfig_index_name.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("case_search", "0013_casesearchconfig_fuzzy_prefix_length"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="casesearchconfig",
+            name="index_name",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Name or alias of alternative index to use for case search",
+                max_length=256,
+            ),
+        ),
+    ]

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -293,6 +293,8 @@ class CaseSearchConfig(models.Model):
     fuzzy_prefix_length = models.SmallIntegerField(blank=True, null=True, validators=[
         MinValueValidator(0), MaxValueValidator(10),
     ])
+    index_name = models.CharField(max_length=256, blank=True, default='', help_text=(
+        "Name or alias of alternative index to use for case search"))
 
     objects = GetOrNoneManager()
 

--- a/migrations.lock
+++ b/migrations.lock
@@ -229,6 +229,7 @@ case_search
  0011_domainsnotincasesearchindex
  0012_casesearchconfig_sync_cases_on_form_entry
  0013_casesearchconfig_fuzzy_prefix_length
+ 0014_casesearchconfig_index_name
 cleanup
  0001_convert_change_feed_checkpoint_to_sql
  0002_convert_mc_checkpoint_to_sql


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Not in use yet - I'm separating the model change from the code for safety.  This field will be used to allow for dynamically configuring an alternative elasticsearch index to use for case search on a per-domain basis.

Editable in the Django admin:

![image](https://github.com/dimagi/commcare-hq/assets/2367539/28925e1f-cf36-428a-be4b-99216c3158d7)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

Migration does nothing

### Rollback instructions

This PR cannot be easily reverted.  You could rollback the migration and then revert without too much trouble, I suppose.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
