### PR TITLE
Resize app preview properly for tablet view on page load

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -39,7 +39,7 @@ hqDefine('app_manager/js/preview_app', [
     module.DATA = {
         OPEN: 'preview-isopen',
         POSITION: 'position',
-        TABLET: 'preview-tablet',
+        TABLET: 'preview-tablet',   // also referenced in cloudcare/js/preview_app/preview_app
     };
 
     _private.isFormdesigner = false;

--- a/corehq/apps/cloudcare/static/cloudcare/js/preview_app/preview_app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/preview_app/preview_app.js
@@ -14,6 +14,12 @@ hqDefine('cloudcare/js/preview_app/preview_app', [
         });
 
         FormplayerFrontend.start(options);
+
+        if (localStorage.getItem("preview-tablet")) {
+            FormplayerFrontend.trigger('view:tablet');
+        } else {
+            FormplayerFrontend.trigger('view:phone');
+        }
     };
 
     return {


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-15524

## Technical Summary
Probably introduced by the [requirejs migration](https://github.com/dimagi/commcare-hq/pull/34271). As explained in ticket:

> This width is controlled via the .preview-tablet-mode .scrollable-container selector ([here](https://github.com/dimagi/commcare-hq/blob/81c2b6ab65890e664d105da20ea4a64baf3465ba/corehq/apps/hqwebapp/static/preview_app/less/preview_app/scrollable.less#L18-L23)). This class is applied to the outer js-appmanager-preview div, but that doesn’t matter, because it’s outside the iframe, so the styles don’t get inherited. It needs to also be applied to the body tag within the iframe. This happens via the view:tablet handler [here](https://github.com/dimagi/commcare-hq/blob/81c2b6ab65890e664d105da20ea4a64baf3465ba/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js#L572-L574). This event does get triggered on page load, [here](https://github.com/dimagi/commcare-hq/blob/81c2b6ab65890e664d105da20ea4a64baf3465ba/corehq/apps/app_manager/static/app_manager/js/preview_app.js#L83). However, if web apps / app preview javascript hasn’t fully loaded at that point, the handler hasn’t been created yet, so preview-tablet-mode doesn't get applied to the iframe body, and the display is squashed.

I don't like that formplayer js now knows about data that's conceptually part of app manager, but I do like that this is simple. The best alternative is probably to have app preview to signal to app manager when it's finished loading, but the app manager / app preview relationship is currently structured so that app manager sends instructions to app preview, not the other way around.

## Safety Assurance

### Safety story
Risk is pretty minor here, the change is quite targeted. Tested locally.

### Automated test coverage

No

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
