### PR TITLE
[B5] web apps: updated input groups

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/bootstrap5/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/bootstrap5/list.html
@@ -26,13 +26,11 @@
                class="form-control"
                placeholder="Search"
                id="searchText">
-        <div class="input-group-btn">  {# todo B5: css:input-group-btn #}
-          <button class="btn btn-outline-primary"
-                  type="button"
-                  id="case-list-search-button">
-            <i class="fa fa-search" aria-hidden="true"></i>
-          </button>
-        </div>
+        <button class="btn btn-outline-primary"
+                type="button"
+                id="case-list-search-button">
+          <i class="fa fa-search" aria-hidden="true"></i>
+        </button>
       </div>
     </div>
     <% } %>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap5/entry_date.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap5/entry_date.html
@@ -2,6 +2,6 @@
   <div class="input-group">
     <input type="text" class="form-control"
       data-bind="attr: {id: entryId, 'aria-required': $parent.required() ? 'true' : 'false'}"/>
-    <span class="input-group-addon"><i class="fa-solid fa-calendar-days"></i></span>  {# todo B5: css:input-group-addon #}
+    <span class="input-group-text"><i class="fa-solid fa-calendar-days"></i></span>
   </div>
 </script>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap5/entry_datetime.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap5/entry_datetime.html
@@ -1,6 +1,6 @@
 <script type="text/html" id="datetime-entry-ko-template">
   <div class="input-group">
     <input type="text" class="form-control" data-bind="attr: { id: entryId, 'aria-required': $parent.required() ? 'true' : 'false' }"/>
-    <span class="input-group-addon"><i class="fcc fcc-fd-datetime"></i></span>  {# todo B5: css:input-group-addon #}
+    <span class="input-group-text"><i class="fcc fcc-fd-datetime"></i></span>
   </div>
 </script>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap5/entry_ethiopian_date.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap5/entry_ethiopian_date.html
@@ -1,6 +1,6 @@
 <script type="text/html" id="ethiopian-date-entry-ko-template">
   <div class="input-group">
     <input type="text" class="form-control" autocomplete="off" data-bind="attr: { id: entryId, 'aria-required': $parent.required() ? 'true' : 'false' }"/>
-    <span class="input-group-addon"><i class="fa-solid fa-calendar-days"></i></span>  {# todo B5: css:input-group-addon #}
+    <span class="input-group-text"><i class="fa-solid fa-calendar-days"></i></span>
   </div>
 </script>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap5/entry_time.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap5/entry_time.html
@@ -1,6 +1,6 @@
 <script type="text/html" id="time-entry-ko-template">
   <div class="input-group">
     <input type="text" class="form-control" data-bind="attr: { id: entryId, 'aria-required': $parent.required() ? 'true' : 'false' }"/>
-    <span class="input-group-addon"><i class="fa-regular fa-clock"></i></span>  {# todo B5: css:input-group-addon #}
+    <span class="input-group-text"><i class="fa-regular fa-clock"></i></span>
   </div>
 </script>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users/bootstrap5/restore_as.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users/bootstrap5/restore_as.html
@@ -13,11 +13,9 @@
           class="js-user-query form-control"
           value="<%- query %>"
           placeholder="{% trans_html_attr "Filter workers" %}" />
-        <div class="input-group-btn">  {# todo B5: css:input-group-btn #}
           <button class="btn btn-outline-primary" type="submit">
             <i class="fa fa-search" aria-hidden="true"></i>
           </button>
-        </div>
       </div>
     </form>
     <table class="table module-table">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/case_list/list.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/case_list/list.html.diff.txt
@@ -23,18 +23,26 @@
      </div>
      <% } %>
  
-@@ -26,8 +26,8 @@
+@@ -26,13 +26,11 @@
                 class="form-control"
                 placeholder="Search"
                 id="searchText">
 -        <div class="input-group-btn">
 -          <button class="btn btn-default"
-+        <div class="input-group-btn">  {# todo B5: css:input-group-btn #}
-+          <button class="btn btn-outline-primary"
-                   type="button"
-                   id="case-list-search-button">
-             <i class="fa fa-search" aria-hidden="true"></i>
-@@ -41,30 +41,30 @@
+-                  type="button"
+-                  id="case-list-search-button">
+-            <i class="fa fa-search" aria-hidden="true"></i>
+-          </button>
+-        </div>
++        <button class="btn btn-outline-primary"
++                type="button"
++                id="case-list-search-button">
++          <i class="fa fa-search" aria-hidden="true"></i>
++        </button>
+       </div>
+     </div>
+     <% } %>
+@@ -41,30 +39,30 @@
           class="row row-no-gutters">
        <% if (showMap) { %>
          <div id="module-case-list-map"
@@ -70,7 +78,7 @@
              </div>
            <% }) %>
          <% } %>
-@@ -73,7 +73,7 @@
+@@ -73,7 +71,7 @@
  
      <% if (!hasNoItems) { %>
        {% block pagination_templates %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/form_entry/entry_date.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/form_entry/entry_date.html.diff.txt
@@ -5,6 +5,6 @@
      <input type="text" class="form-control"
        data-bind="attr: {id: entryId, 'aria-required': $parent.required() ? 'true' : 'false'}"/>
 -    <span class="input-group-addon"><i class="fa-solid fa-calendar-days"></i></span>
-+    <span class="input-group-addon"><i class="fa-solid fa-calendar-days"></i></span>  {# todo B5: css:input-group-addon #}
++    <span class="input-group-text"><i class="fa-solid fa-calendar-days"></i></span>
    </div>
  </script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/form_entry/entry_datetime.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/form_entry/entry_datetime.html.diff.txt
@@ -5,6 +5,6 @@
    <div class="input-group">
      <input type="text" class="form-control" data-bind="attr: { id: entryId, 'aria-required': $parent.required() ? 'true' : 'false' }"/>
 -    <span class="input-group-addon"><i class="fcc fcc-fd-datetime"></i></span>
-+    <span class="input-group-addon"><i class="fcc fcc-fd-datetime"></i></span>  {# todo B5: css:input-group-addon #}
++    <span class="input-group-text"><i class="fcc fcc-fd-datetime"></i></span>
    </div>
  </script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/form_entry/entry_ethiopian_date.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/form_entry/entry_ethiopian_date.html.diff.txt
@@ -5,6 +5,6 @@
    <div class="input-group">
      <input type="text" class="form-control" autocomplete="off" data-bind="attr: { id: entryId, 'aria-required': $parent.required() ? 'true' : 'false' }"/>
 -    <span class="input-group-addon"><i class="fa-solid fa-calendar-days"></i></span>
-+    <span class="input-group-addon"><i class="fa-solid fa-calendar-days"></i></span>  {# todo B5: css:input-group-addon #}
++    <span class="input-group-text"><i class="fa-solid fa-calendar-days"></i></span>
    </div>
  </script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/form_entry/entry_time.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/form_entry/entry_time.html.diff.txt
@@ -5,6 +5,6 @@
    <div class="input-group">
      <input type="text" class="form-control" data-bind="attr: { id: entryId, 'aria-required': $parent.required() ? 'true' : 'false' }"/>
 -    <span class="input-group-addon"><i class="fa-regular fa-clock"></i></span>
-+    <span class="input-group-addon"><i class="fa-regular fa-clock"></i></span>  {# todo B5: css:input-group-addon #}
++    <span class="input-group-text"><i class="fa-regular fa-clock"></i></span>
    </div>
  </script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/users/restore_as.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/users/restore_as.html.diff.txt
@@ -9,18 +9,20 @@
        <h1 class="page-title">{% trans "Log in as user" %}</h1>
      </div>
      <form class="module-search-container js-user-search">
-@@ -13,8 +13,8 @@
+@@ -13,11 +13,9 @@
            class="js-user-query form-control"
            value="<%- query %>"
            placeholder="{% trans_html_attr "Filter workers" %}" />
 -        <div class="input-group-btn">
 -          <button class="btn btn-default" type="submit">
-+        <div class="input-group-btn">  {# todo B5: css:input-group-btn #}
 +          <button class="btn btn-outline-primary" type="submit">
              <i class="fa fa-search" aria-hidden="true"></i>
            </button>
-         </div>
-@@ -26,7 +26,7 @@
+-        </div>
+       </div>
+     </form>
+     <table class="table module-table">
+@@ -26,7 +24,7 @@
      </table>
      <% if (endPage) { %>
        {% block pagination_templates %}


### PR DESCRIPTION
## Technical Summary
Easy one.

https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/utils/bootstrap/changes_guide/input-group-btn.md

https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/utils/bootstrap/changes_guide/input-group-addon.md

## Safety Assurance

### Safety story
No risk, these templates aren't used in prod.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
