### PR TITLE
Fix case exports order columns for deprecated groups

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -235,7 +235,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                             'caseType': element.caseType,
                             'name': element.name,
                             'label': element.label() || element.name,
-                            'index': index,
+                            'index': group.toBeDeprecated() ? 0 : index,
                             'data_type': element.dataType(),
                             'group': group.toBeDeprecated() ? "" : group.name(),
                             'description': element.description(),

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -66,7 +66,8 @@ def data_dictionary_json(request, domain, case_type_name=None):
         queryset = queryset.filter(is_deprecated=False)
     queryset = queryset.prefetch_related(
         Prefetch('groups', queryset=CasePropertyGroup.objects.order_by('index')),
-        Prefetch('properties', queryset=CaseProperty.objects.order_by('group_id', 'index')),
+        # order by pk for properties with same index, likely for automatically added properties
+        Prefetch('properties', queryset=CaseProperty.objects.order_by('group_id', 'index', 'pk')),
         Prefetch('properties__allowed_values', queryset=CasePropertyAllowedValue.objects.order_by('allowed_value'))
     )
     if toggles.FHIR_INTEGRATION.enabled(domain):

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -131,7 +131,7 @@ def data_dictionary_json(request, domain, case_type_name=None):
                 "properties": grouped_properties.get(group.id, [])
             })
 
-        # Aggregate properties that dont have a group
+        # Aggregate properties that don't have a group
         p["groups"].append({
             "name": "",
             "properties": grouped_properties.get(None, [])

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -2413,7 +2413,8 @@ class CaseExportDataSchema(ExportDataSchema):
             CaseProperty.objects
                 .filter(**filter_kwargs)
                 .select_related('case_type').select_related('group')
-                .order_by('group__index', 'index')
+                # order by pk for properties with same index, likely for automatically added properties
+                .order_by('group__index', 'index', 'pk')
                 .values_list('name', flat=True)
         ):
             case_properties_indices[case_property_name] = case_property_index


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Minor follow up to https://github.com/dimagi/commcare-hq/pull/34502 to correct ordering on case export columns based on data dictionary for deprecated case property group.

This only effects projects with access to Data Dictionary.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3674

Some context,
So when a case property group is deprecated, the case properties in that group are removed from that group by setting their group to be blank. In the UI, the properties are not moved to the "No Group" section until there is a page reload after save.
In such a case when data dictionary is saved, we were retaining the index of case properties as it was on the group that was deprecated. An "index" stores the index of the case property in its group to maintain the order of case properties.
This would cause "index" on these case properties to be faulty until next save was done, which would then correctly set the index.

So, this PR changes the index to the default value of 0 for case properties belonging to case property group getting deprecated on save.
Additionally, to make ordering of case properties with the same index, additionally ordering by their primary key, to make their order predictable and same for both case exports and data dictionary. It would not be very rare for two case properties to have the same index like set in the case above or for case properties that getting automatically added to Data dictionary. Only a save on Data Dictionary would set the index on the case properties.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. Blast radius is limited to Data dictionary view or new case exports for projects with access to data dictionary. The additional indexing with pk is not expected to cause any performance issues.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-6489

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
