### PR TITLE
Disable mobile endpoints

### DIFF
--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -19,7 +19,7 @@ from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.decorators import (
-    check_redirect,
+    check_access_and_redirect,
     safe_cached_download,
     safe_download,
 )
@@ -56,7 +56,7 @@ def _get_build_profile_id(request):
 
 
 @safe_download
-@check_redirect
+@check_access_and_redirect
 def download_odk_profile(request, domain, app_id):
     """
     See ApplicationBase.create_profile
@@ -75,7 +75,7 @@ def download_odk_profile(request, domain, app_id):
 
 
 @safe_download
-@check_redirect
+@check_access_and_redirect
 def download_odk_media_profile(request, domain, app_id):
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
@@ -89,7 +89,7 @@ def download_odk_media_profile(request, domain, app_id):
     )
 
 
-@check_redirect
+@check_access_and_redirect
 @safe_cached_download
 def download_suite(request, domain, app_id):
     """
@@ -104,7 +104,7 @@ def download_suite(request, domain, app_id):
     )
 
 
-@check_redirect
+@check_access_and_redirect
 @safe_cached_download
 def download_media_suite(request, domain, app_id):
     """
@@ -119,7 +119,7 @@ def download_media_suite(request, domain, app_id):
     )
 
 
-@check_redirect
+@check_access_and_redirect
 @safe_cached_download
 def download_app_strings(request, domain, app_id, lang):
     """
@@ -133,7 +133,7 @@ def download_app_strings(request, domain, app_id, lang):
     )
 
 
-@check_redirect
+@check_access_and_redirect
 @safe_cached_download
 def download_xform(request, domain, app_id, module_id, form_id):
     """
@@ -172,7 +172,7 @@ class DownloadCCZ(DownloadMultimediaZip):
         super(DownloadCCZ, self).check_before_zipping()
 
 
-@check_redirect
+@check_access_and_redirect
 @safe_cached_download
 def download_file(request, domain, app_id, path):
     download_target_version = request.GET.get('download_target_version') == 'true'
@@ -281,7 +281,7 @@ def download_file(request, domain, app_id, path):
 
 
 @safe_download
-@check_redirect
+@check_access_and_redirect
 def download_profile(request, domain, app_id):
     """
     See ApplicationBase.create_profile
@@ -299,7 +299,7 @@ def download_profile(request, domain, app_id):
 
 
 @safe_download
-@check_redirect
+@check_access_and_redirect
 def download_media_profile(request, domain, app_id):
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
@@ -312,7 +312,7 @@ def download_media_profile(request, domain, app_id):
     )
 
 
-@check_redirect
+@check_access_and_redirect
 @safe_cached_download
 def download_practice_user_restore(request, domain, app_id):
     if not request.app.copy_of:

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -53,6 +53,7 @@ from corehq.apps.sso.utils.view_helpers import (
 from corehq.apps.users.models import CouchUser
 from corehq.toggles import (
     DATA_MIGRATION,
+    DISABLE_MOBILE_ENDPOINTS,
     IS_CONTRACTOR,
     TWO_FACTOR_SUPERUSER_ROLLOUT,
 )
@@ -670,7 +671,10 @@ cls_require_superuser_or_contractor = cls_to_view(additional_decorator=require_s
 
 def check_domain_migration(view_func):
     def wrapped_view(request, domain, *args, **kwargs):
-        if DATA_MIGRATION.enabled(domain):
+        if (
+            DATA_MIGRATION.enabled(domain)
+            or DISABLE_MOBILE_ENDPOINTS.enabled(domain)
+        ):
             auth_logger.info(
                 "Request rejected domain=%s reason=%s request=%s",
                 domain, "flag:migration", request.path

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -669,7 +669,7 @@ cls_require_superusers = cls_to_view(additional_decorator=require_superuser)
 cls_require_superuser_or_contractor = cls_to_view(additional_decorator=require_superuser_or_contractor)
 
 
-def check_domain_migration(view_func):
+def check_domain_mobile_access(view_func):
     def wrapped_view(request, domain, *args, **kwargs):
         if (
             DATA_MIGRATION.enabled(domain)

--- a/corehq/apps/domain/tests/test_redirect_url.py
+++ b/corehq/apps/domain/tests/test_redirect_url.py
@@ -157,6 +157,27 @@ class TestCheckDomainMigration(TestCase):
             r"^<\?xml version='1.0' encoding='UTF-8'\?>"
         )
 
+    @flag_enabled('DISABLE_MOBILE_ENDPOINTS')
+    def test_disable_endpoints_blocks_updates(self):
+        response = self._download_odk_media_profile()
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
+            response.content.decode('utf-8'),
+            'Service Temporarily Unavailable'
+        )
+
+    @flag_enabled('DISABLE_MOBILE_ENDPOINTS')
+    def test_redirect_overrides_disable(self):
+        with _set_redirect_url():
+            response = self._download_odk_media_profile()
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(
+                response.url,
+                f'https://example.com/a/{DOMAIN}/apps/download/{self.app._id}'
+                '/media_profile.ccpr?latest=true'
+                f'&username=user%40{DOMAIN}.commcarehq.org'
+            )
+
     def _download_odk_media_profile(self):
         return self.client.get(reverse(
             'download_odk_media_profile',

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -48,7 +48,7 @@ from corehq.apps.case_search.exceptions import CaseSearchUserError
 from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY, CASE_SEARCH_TAGS_MAPPING
 from corehq.apps.case_search.utils import get_case_search_results_from_request
 from corehq.apps.domain.auth import formplayer_auth
-from corehq.apps.domain.decorators import check_domain_migration
+from corehq.apps.domain.decorators import check_domain_mobile_access
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.permissions import (
     location_safe,
@@ -88,7 +88,7 @@ PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 @location_safe
 @handle_401_response
 @mobile_auth_or_formplayer
-@check_domain_migration
+@check_domain_mobile_access
 def restore(request, domain, app_id=None):
     """
     We override restore because we have to supply our own
@@ -106,7 +106,7 @@ def restore(request, domain, app_id=None):
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
-@check_domain_migration
+@check_domain_mobile_access
 @toggles.SYNC_SEARCH_CASE_CLAIM.required_decorator()
 def search(request, domain):
     return app_aware_search(request, domain, None)
@@ -116,7 +116,7 @@ def search(request, domain):
 @location_safe_bypass
 @csrf_exempt
 @mobile_auth
-@check_domain_migration
+@check_domain_mobile_access
 @toggles.SYNC_SEARCH_CASE_CLAIM.required_decorator()
 def app_aware_search(request, domain, app_id):
     """
@@ -171,7 +171,7 @@ def _log_search_timing(start_time, request_dict, domain, app_id):
 @csrf_exempt
 @require_POST
 @mobile_auth
-@check_domain_migration
+@check_domain_mobile_access
 @toggles.SYNC_SEARCH_CASE_CLAIM.required_decorator()
 def claim(request, domain):
     """

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -184,6 +184,13 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
         message = "Service Temporarily Unavailable"
         self.assertIn(message, res.content.decode('utf-8'))
 
+    @flag_enabled('DISABLE_MOBILE_ENDPOINTS')
+    def test_disable_mobile_endpoints(self):
+        file, res = self._submit('simple_form.xml')
+        self.assertEqual(503, res.status_code)
+        message = "Service Temporarily Unavailable"
+        self.assertIn(message, res.content.decode('utf-8'))
+
     def test_error_saving_normal_form(self):
         sql_patch = patch(
             'corehq.form_processor.backends.sql.processor.FormProcessorSQL.save_processed_models',

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -29,7 +29,7 @@ from corehq.apps.domain.auth import (
 )
 from corehq.apps.domain.decorators import (
     api_auth,
-    check_domain_migration,
+    check_domain_mobile_access,
     login_or_basic_ex,
     login_or_digest_ex,
     login_or_api_key_ex,
@@ -231,7 +231,7 @@ def _record_metrics(tags, submission_type, response, timer=None, xform=None):
 @require_permission(HqPermissions.edit_data)
 @require_permission(HqPermissions.access_api)
 @require_POST
-@check_domain_migration
+@check_domain_mobile_access
 @set_request_duration_reporting_threshold(60)
 def post_api(request, domain):
     return _process_form(
@@ -248,7 +248,7 @@ def post_api(request, domain):
 @location_safe
 @csrf_exempt
 @require_POST
-@check_domain_migration
+@check_domain_mobile_access
 @set_request_duration_reporting_threshold(60)
 def post(request, domain, app_id=None):
     try:
@@ -401,7 +401,7 @@ def _secure_post_api_key(request, domain, app_id=None):
 @location_safe
 @csrf_exempt
 @require_POST
-@check_domain_migration
+@check_domain_mobile_access
 @set_request_duration_reporting_threshold(60)
 def secure_post(request, domain, app_id=None):
     authtype_map = {

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1644,6 +1644,21 @@ DATA_MIGRATION = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+
+DISABLE_MOBILE_ENDPOINTS = StaticToggle(
+    'disable_mobile_endpoints',
+    'Disable mobile endpoints for form submissions and restores',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+    description=(
+        "This flag disables endpoints used by CommCare Mobile to submit forms "
+        "and sync cases, etc. It does NOT block web access. It does NOT "
+        "prevent data changes by case edits, data forwarding, etc. To do "
+        "that, use the DATA_MIGRATION feature flag."
+    )
+)
+
+
 EMWF_WORKER_ACTIVITY_REPORT = StaticToggle(
     'emwf_worker_activity_report',
     'Make the Worker Activity Report use the Groups or Users or Locations filter',


### PR DESCRIPTION
## Product Description

Adds a new feature flag to disable mobile endpoints, without blocking web user access to a project space. This is useful for domains that want to block form submissions, but need web access during a long-running data migration.

## Technical Summary

Implements a subset of the DATA_MIGRATION feature flag. Adds the DISABLE_MOBILE_ENDPOINTS feature flag and uses it only for the view decorator that protects mobile endpoints.

Mobile endpoints:

| View | View Name |
| ---- | --------- |
| corehq.apps.ota.views.restore | ota_restore |
| corehq.apps.ota.views.search | remote_search |
| corehq.apps.ota.views.app_aware_search | app_aware_remote_search |
| corehq.apps.ota.views.claim | claim_case |
| corehq.apps.receiverwrapper.views.post_api | receiver_post_api |
| corehq.apps.receiverwrapper.views.post | receiver_post |
| corehq.apps.receiverwrapper.views.secure_post | receiver_secure_post |
| corehq.apps.app_manager.views.download_* | download_* |

## Feature Flag

DISABLE_MOBILE_ENDPOINTS

## Safety Assurance

### Safety story

* Small change already explored and tested for PR https://github.com/dimagi/commcare-hq/pull/34461. 
* To be tested on Staging.

### Automated test coverage

Includes test

### QA Plan

TBD


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
