### PR TITLE
Added use_bootstrap5 to HQFormHelper

### DIFF
--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -33,6 +33,7 @@ class HQFormHelper(FormHelper):
         if use_bootstrap5:
             self.label_class = CSS_LABEL_CLASS_BOOTSTRAP5
             self.field_class = CSS_FIELD_CLASS_BOOTSTRAP5
+            self.use_bootstrap5 = use_bootstrap5
 
         if 'autocomplete' not in self.attrs:
             self.attrs.update({


### PR DESCRIPTION
## Technical Summary
Templates in crispy forms [like this](https://github.com/dimagi/crispy-bootstrap3to5/blob/f8b70d6bba1d6df7510561222ed04d430be19cbc/crispy_bootstrap3to5/templates/bootstrap3to5/field.html#L1) depend on the `use_bootstrap5` context variable. This is typically available courtesy of [this context processor](https://github.com/dimagi/commcare-hq/blob/7d9a6397c4b4351cc7718e68041efbaaedcdc9f0/corehq/util/context_processors.py#L311-L314). However, it is not always available to these crispy form fields - I assume they're being rendered using a simpler context, not the full `RequestContext`. This is resulting in the B3 versions of fields being rendered on B5 pages.

Happily, you can add arbitrary attributes to `FormHelper` and they'll be passed along when the form is rendered: https://django-crispy-forms.readthedocs.io/en/latest/form_helper.html#custom-helper-attributes

@biyeun This is the solution to the issue we paired on the other day.

## Safety Assurance

### Safety story
Little to no risk here.

### Automated test coverage

not of this specific logic

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
