### PR TITLE
Handle scenario when Entra Application have Group as member

### DIFF
--- a/corehq/apps/sso/exceptions.py
+++ b/corehq/apps/sso/exceptions.py
@@ -30,3 +30,12 @@ class EntraVerificationFailed(Exception):
 
     def __str__(self):
         return f"EntraVerificationFailed({self.error}, {self.message})"
+
+
+class EntraUnsupportedType(Exception):
+    def __init__(self, message):
+        super().__init__(f"{message}")
+        self.message = message
+
+    def __str__(self):
+        return f"EntraUnsupportedTypeReceived({self.message})"

--- a/corehq/apps/sso/exceptions.py
+++ b/corehq/apps/sso/exceptions.py
@@ -34,7 +34,7 @@ class EntraVerificationFailed(Exception):
 
 class EntraUnsupportedType(Exception):
     def __init__(self, message):
-        super().__init__(f"{message}")
+        super().__init__(message)
         self.message = message
 
     def __str__(self):

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -1,13 +1,14 @@
 import json
 import requests
 
-from corehq.apps.sso.exceptions import EntraVerificationFailed
+from corehq.apps.sso.exceptions import EntraVerificationFailed, EntraUnsupportedType
 
 
 class MSGraphIssue:
     HTTP_ERROR = "http_error"
     VERIFICATION_ERROR = "verification_error"
     EMPTY_ERROR = "empty_error"
+    UNSUPPORTED_ERROR = "unsupported_error"
     OTHER_ERROR = "other_error"
 
 
@@ -118,10 +119,8 @@ def get_all_user_ids_in_app(token, app_id):
         elif assignment["principalType"] == "Group":
             group_queue.append(assignment["principalId"])
         else:
-            # Service Principal represents an application
-            # Which make the query too complicated
-            raise NotImplementedError("ServicePrincipal members are not supported. "
-                                      "Please include only Users or Groups as members of this SSO application.")
+            raise EntraUnsupportedType("Nested applications (ServicePrincipal members) are not supported. "
+                                       "Please include only Users or Groups as members of this SSO application")
 
     for group_id in group_queue:
         members_data = get_group_members(group_id, token)

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -120,7 +120,7 @@ def get_all_user_ids_in_app(token, app_id):
         else:
             # Service Principal represents an application
             # Which make the query too complicated
-            raise NotImplementedError("The application have Service Principal member")
+            raise NotImplementedError("ServicePrincipal members are not supported. Please include only Users or Groups as members of this SSO application.")
 
     for group_id in group_queue:
         members_data = get_group_members(group_id, token)

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -122,14 +122,13 @@ def get_all_user_ids_in_app(token, app_id):
             # Which make the query too complicated
             raise NotImplementedError("The application have Service Principal member")
 
-    while group_queue:
-        group_id = group_queue.pop(0)
+    for group_id in group_queue:
         members_data = get_group_members(group_id, token)
         for member in members_data.get("value", []):
+            # Only direct user in the group will have access to the application
+            # Nested group won't have access to the application
             if member["@odata.type"] == MSOdataType.USER:
                 user_ids.add(member["id"])
-            elif member["@odata.type"] == MSOdataType.GROUP:
-                group_queue.append(member["id"])
 
     return user_ids
 

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -120,7 +120,8 @@ def get_all_user_ids_in_app(token, app_id):
         else:
             # Service Principal represents an application
             # Which make the query too complicated
-            raise NotImplementedError("ServicePrincipal members are not supported. Please include only Users or Groups as members of this SSO application.")
+            raise NotImplementedError("ServicePrincipal members are not supported. "
+                                      "Please include only Users or Groups as members of this SSO application.")
 
     for group_id in group_queue:
         members_data = get_group_members(group_id, token)

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -33,7 +33,7 @@ def get_all_members_of_the_idp_from_entra(idp):
         response.raise_for_status()  # Raises an error for bad status
         assignments = response.json()
 
-        # microsoft.graph.appRoleAssignment's property doesn't  userPrincipalName
+        # microsoft.graph.appRoleAssignment's property doesn't have userPrincipalName
         # Property principalType can either be User, Group or ServicePrincipal
         principal_ids = {assignment["principalId"] for assignment in assignments["value"]
                          if assignment["principalType"] == "User"}

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -13,17 +13,7 @@ class MSGraphIssue:
 
 def get_all_members_of_the_idp_from_entra(idp):
     import msal
-    authority_base_url = "https://login.microsoftonline.com/"
-    authority = f"{authority_base_url}{idp.api_host}"
-
-    config = {
-        "authority": authority,
-        "client_id": idp.api_id,
-        "scope": ["https://graph.microsoft.com/.default"],
-        "secret": idp.api_secret,
-        "endpoint": f"https://graph.microsoft.com/v1.0/servicePrincipals(appId='{idp.api_id}')/"
-                    "appRoleAssignedTo?$select=principalId, principalType"
-    }
+    config = configure_idp(idp)
 
     # Create a preferably long-lived app instance which maintains a token cache.
     app = msal.ConfidentialClientApplication(
@@ -81,3 +71,17 @@ def get_all_members_of_the_idp_from_entra(idp):
     else:
         raise EntraVerificationFailed(result.get('error', {}),
                                       result.get('error_description', 'No error description provided'))
+
+
+def configure_idp(idp):
+    authority_base_url = "https://login.microsoftonline.com/"
+    authority = f"{authority_base_url}{idp.api_host}"
+
+    return {
+        "authority": authority,
+        "client_id": idp.api_id,
+        "scope": ["https://graph.microsoft.com/.default"],
+        "secret": idp.api_secret,
+        "endpoint": f"https://graph.microsoft.com/v1.0/servicePrincipals(appId='{idp.api_id}')/"
+                    "appRoleAssignedTo?$select=principalId, principalType"
+    }

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -34,6 +34,9 @@ def get_all_members_of_the_idp_from_entra(idp):
     # microsoft.graph.appRoleAssignment's property doesn't have userPrincipalName
     user_principal_ids = get_all_user_ids_in_app(token, config["client_id"])
 
+    if len(user_principal_ids) == 0:
+        return []
+
     user_principal_names = get_user_principal_names(user_principal_ids, token)
 
     return user_principal_names

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -14,6 +14,11 @@ class MSGraphIssue:
 class MSOdataType:
     USER = "#microsoft.graph.user"
     GROUP = "#microsoft.graph.group"
+
+
+ENDPOINT_BASE_URL = "https://graph.microsoft.com/v1.0"
+
+
 def get_all_members_of_the_idp_from_entra(idp):
     import msal
     config = configure_idp(idp)
@@ -59,7 +64,7 @@ def get_user_principal_names(user_ids, token):
     }
     # Send batch request
     batch_response = requests.post(
-        'https://graph.microsoft.com/v1.0/$batch',
+        f'{ENDPOINT_BASE_URL}/$batch',
         headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'},
         data=json.dumps(batch_payload)
     )
@@ -90,7 +95,7 @@ def get_access_token(app, config):
 
 
 def get_all_user_ids_in_app(token, app_id):
-    endpoint = (f"https://graph.microsoft.com/v1.0/servicePrincipals(appId='{app_id}')/"
+    endpoint = (f"{ENDPOINT_BASE_URL}/servicePrincipals(appId='{app_id}')/"
                f"appRoleAssignedTo?$select=principalId, principalType")
     # Calling graph using the access token
     response = requests.get(
@@ -127,7 +132,7 @@ def get_all_user_ids_in_app(token, app_id):
 
 
 def get_group_members(group_id, token):
-    endpoint = f"https://graph.microsoft.com/v1.0/groups/{group_id}/members?$select=id"
+    endpoint = f"{ENDPOINT_BASE_URL}/groups/{group_id}/members?$select=id"
     headers = {'Authorization': 'Bearer ' + token}
     response = requests.get(endpoint, headers=headers)
     response.raise_for_status()


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15528

When get all roles from an entra application, Microsoft Graph can return `User`, `Group`, `ServicePrincipal`. We don't handle the `ServicePrincipal` for now, because it means another entra application, which is too complicated for now.

This PR add the support for `Group`. It will query all members of the group, and add all users in that group to the `user_ids` set. We won't consider members in the nested group, because Microsoft explicitly said: "When you assign a group to an application, only users directly in the group will have access. The assignment does not cascade to nested groups."

Review by commit 🐡 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging.
I've tested 4 scenarios:
1. The enterprise application only have individual members
2. The enterprise application only have groups
3. The enterprise application have both individual members and groups
4. The enterprise application have no group and no individual member

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA ... ? 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
