### PR TITLE
Catch exception in case of missing ds table

### DIFF
--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -217,8 +217,7 @@ class IndicatorSqlAdapter(IndicatorAdapter):
         except ProgrammingError as e:
             if not self.table_exists:
                 return
-            else:
-                raise e
+            raise e
 
         register_data_source_row_change(
             domain=self.config.domain,

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -211,8 +211,11 @@ class IndicatorSqlAdapter(IndicatorAdapter):
         table = self.get_table()
         doc_ids = [doc['_id'] for doc in docs]
         delete = table.delete(table.c.doc_id.in_(doc_ids))
-        with self.session_context() as session:
-            session.execute(delete)
+        try:
+            with self.session_context() as session:
+                session.execute(delete)
+        except ProgrammingError:
+            return
 
         register_data_source_row_change(
             domain=self.config.domain,

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -214,8 +214,11 @@ class IndicatorSqlAdapter(IndicatorAdapter):
         try:
             with self.session_context() as session:
                 session.execute(delete)
-        except ProgrammingError:
-            return
+        except ProgrammingError as e:
+            if not self.table_exists:
+                return
+            else:
+                raise e
 
         register_data_source_row_change(
             domain=self.config.domain,

--- a/corehq/apps/userreports/tests/test_adapters.py
+++ b/corehq/apps/userreports/tests/test_adapters.py
@@ -8,15 +8,6 @@ from corehq.apps.userreports.app_manager.helpers import clean_table_name
 
 class TestIndicatorSqlAdapter(SimpleTestCase):
 
-    def setUp(self):
-        super().setUp()
-        config = self._create_data_source_config("domain")
-        self.adapter = IndicatorSqlAdapter(config)
-
-    def tearDown(self):
-        self.adapter.drop_table()
-        super().tearDown()
-
     @staticmethod
     def _create_data_source_config(domain):
         indicator = {
@@ -39,17 +30,23 @@ class TestIndicatorSqlAdapter(SimpleTestCase):
 
     @patch("corehq.apps.userreports.sql.adapter.register_data_source_row_change")
     def test_bulk_delete_table_dont_exist(self, register_data_source_row_change_mock):
-        docs = [{'_id': '1'}]
-        self.assertFalse(self.adapter.table_exists)
+        config = self._create_data_source_config("test-domain")
+        adapter = IndicatorSqlAdapter(config)
 
-        self.adapter.bulk_delete(docs)
+        docs = [{'_id': '1'}]
+        self.assertFalse(adapter.table_exists)
+
+        adapter.bulk_delete(docs)
         register_data_source_row_change_mock.assert_not_called()
 
     @patch("corehq.apps.userreports.sql.adapter.register_data_source_row_change")
     def test_bulk_delete_table_exists(self, register_data_source_row_change_mock):
-        docs = [{'_id': '1'}]
-        self.adapter.build_table()
-        self.assertTrue(self.adapter.table_exists)
+        config = self._create_data_source_config("test-domain2")
+        adapter = IndicatorSqlAdapter(config)
 
-        self.adapter.bulk_delete(docs)
+        docs = [{'_id': '1'}]
+        adapter.build_table()
+        self.assertTrue(adapter.table_exists)
+
+        adapter.bulk_delete(docs)
         register_data_source_row_change_mock.assert_called()

--- a/corehq/apps/userreports/tests/test_adapters.py
+++ b/corehq/apps/userreports/tests/test_adapters.py
@@ -1,0 +1,55 @@
+from django.test import SimpleTestCase
+from unittest.mock import patch
+
+from corehq.apps.userreports.sql.adapter import IndicatorSqlAdapter
+from corehq.apps.userreports.models import DataSourceConfiguration
+from corehq.apps.userreports.app_manager.helpers import clean_table_name
+
+
+class TestIndicatorSqlAdapter(SimpleTestCase):
+
+    def setUp(self):
+        super().setUp()
+        config = self._create_data_source_config("domain")
+        self.adapter = IndicatorSqlAdapter(config)
+
+    def tearDown(self):
+        self.adapter.drop_table()
+        super().tearDown()
+
+    @staticmethod
+    def _create_data_source_config(domain):
+        indicator = {
+            "type": "expression",
+            "expression": {
+                "type": "property_name",
+                "property_name": 'name'
+            },
+            "column_id": 'name',
+            "display_name": 'name',
+            "datatype": "string"
+        }
+        return DataSourceConfiguration(
+            domain=domain,
+            display_name='foo',
+            referenced_doc_type='CommCareCase',
+            table_id=clean_table_name('domain', 'test-table'),
+            configured_indicators=[indicator],
+        )
+
+    @patch("corehq.apps.userreports.sql.adapter.register_data_source_row_change")
+    def test_bulk_delete_table_dont_exist(self, register_data_source_row_change_mock):
+        docs = [{'_id': '1'}]
+        self.assertFalse(self.adapter.table_exists)
+
+        self.adapter.bulk_delete(docs)
+        register_data_source_row_change_mock.assert_not_called()
+
+    @patch("corehq.apps.userreports.sql.adapter.register_data_source_row_change")
+    def test_bulk_delete_table_exists(self, register_data_source_row_change_mock):
+        docs = [{'_id': '1'}]
+        self.adapter.build_table()
+        self.assertTrue(self.adapter.table_exists)
+
+        self.adapter.bulk_delete(docs)
+        register_data_source_row_change_mock.assert_called()

--- a/corehq/apps/userreports/tests/test_adapters.py
+++ b/corehq/apps/userreports/tests/test_adapters.py
@@ -1,4 +1,4 @@
-from django.test import SimpleTestCase
+from django.test import TestCase
 from unittest.mock import patch
 
 from corehq.apps.userreports.sql.adapter import IndicatorSqlAdapter
@@ -6,7 +6,7 @@ from corehq.apps.userreports.models import DataSourceConfiguration
 from corehq.apps.userreports.app_manager.helpers import clean_table_name
 
 
-class TestIndicatorSqlAdapter(SimpleTestCase):
+class TestIndicatorSqlAdapter(TestCase):
 
     @staticmethod
     def _create_data_source_config(domain):


### PR DESCRIPTION
Replaces [this PR](https://github.com/dimagi/commcare-hq/pull/34562), but with the difference being that we're catching the exception instead of checking whether or not the table exists.

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3671)

An error was [picked up](https://dimagi.sentry.io/issues/3318283172/events/73d62d1d1c0d4b649883ae6d71ec5ef3/) by sentry in which a case made changes to a UCR that does not exist. This PR is simply to catch the error when the table does not exist and return, since no further work is necessary.

That said, I don't think this addresses the real problem, i.e. why the case change is propagated for this config which is supposedly deleted. This issue is to be investigated further, but this PR change will at least silence the error.

## Feature Flag
UCRs

## Safety Assurance

### Safety story
--

### Automated test coverage
No tests, don't think it's necessary for such a simple change.

### QA Plan
No QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
