### PR TITLE
Catch missing SQLLocation

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -672,7 +672,11 @@ def get_latest_app_release_by_location(domain, location_id, app_id):
     Child location's setting takes precedence over parent
     """
     from corehq.apps.app_manager.models import AppReleaseByLocation
-    location = SQLLocation.active_objects.get(location_id=location_id)
+
+    try:
+        location = SQLLocation.active_objects.get(location_id=location_id)
+    except SQLLocation.DoesNotExist:
+        return None
     location_and_ancestor_ids = location.get_ancestors(include_self=True).values_list(
         'location_id', flat=True).reverse()
     # get all active enabled releases and order by version desc to get one with the highest version in the end


### PR DESCRIPTION
## Technical Summary

Resolves [this Sentry error](https://dimagi.sentry.io/issues/5325954212/?project=136860).

This function is used in two places. Both places already check whether it returned `None`.

(One of those places is the `clean()` method on a model, and that seems fine. But the other place fetches the latest enabled build for a user based on their location. So this error means that there is a user out there assigned to a location that doesn't exist. I will follow up.)

## Safety Assurance

### Safety story

Catches an uncaught exception, and returns a valid return value instead.

### Automated test coverage

Not covered by automated tests.

### QA Plan

QA not planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
