### PR TITLE
Use alternative elasticsearch index in case search

### DIFF
--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -29,11 +29,15 @@ class SearchFilterContext:
     domain: Union[str, List[str]]  # query domain
     fuzzy: bool = False
     request_domain: str = None
+    helper: Union[
+        'corehq.apps.case_search.utils.QueryHelper',
+        'corehq.apps.case_search.utils.RegistryQueryHelper',
+    ] = None
     profiler: 'corehq.apps.case_search.utils.CaseSearchProfiler' = None
     config: 'corehq.apps.case_search.models.CaseSearchConfig' = None
 
     def __post_init__(self):
-        from corehq.apps.case_search.utils import CaseSearchProfiler
+        from corehq.apps.case_search.utils import QueryHelper
         from corehq.apps.case_search.models import CaseSearchConfig
         if self.request_domain is None:
             if isinstance(self.domain, str):
@@ -42,8 +46,9 @@ class SearchFilterContext:
                 self.request_domain = self.domain[0]
             else:
                 raise ValueError("When domain is a list with more than one item, request_domain cannot be None.")
-        if self.profiler is None:
-            self.profiler = CaseSearchProfiler()
+        if self.helper is None:
+            self.helper = QueryHelper(self.request_domain)
+        self.profiler = self.helper.profiler
         if self.config is None:
             self.config = CaseSearchConfig(domain=self.request_domain)
 

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -33,16 +33,12 @@ class SearchFilterContext:
         'corehq.apps.case_search.utils.RegistryQueryHelper',
     ] = None
     profiler: 'corehq.apps.case_search.utils.CaseSearchProfiler' = None
-    config: 'corehq.apps.case_search.models.CaseSearchConfig' = None
 
     def __post_init__(self):
         from corehq.apps.case_search.utils import QueryHelper
-        from corehq.apps.case_search.models import CaseSearchConfig
         if self.helper is None:
             self.helper = QueryHelper(self.domain)
         self.profiler = self.helper.profiler
-        if self.config is None:
-            self.config = CaseSearchConfig(domain=self.domain)
 
 
 def print_ast(node):

--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Union, List
+from typing import Union
 
 from django.utils.translation import gettext as _
 from eulxml.xpath import parse as parse_xpath
@@ -26,9 +26,8 @@ from corehq.apps.case_search.xpath_functions.comparison import property_comparis
 
 @dataclass
 class SearchFilterContext:
-    domain: Union[str, List[str]]  # query domain
+    domain: str
     fuzzy: bool = False
-    request_domain: str = None
     helper: Union[
         'corehq.apps.case_search.utils.QueryHelper',
         'corehq.apps.case_search.utils.RegistryQueryHelper',
@@ -39,18 +38,11 @@ class SearchFilterContext:
     def __post_init__(self):
         from corehq.apps.case_search.utils import QueryHelper
         from corehq.apps.case_search.models import CaseSearchConfig
-        if self.request_domain is None:
-            if isinstance(self.domain, str):
-                self.request_domain = self.domain
-            elif len(self.domain) == 1:
-                self.request_domain = self.domain[0]
-            else:
-                raise ValueError("When domain is a list with more than one item, request_domain cannot be None.")
         if self.helper is None:
-            self.helper = QueryHelper(self.request_domain)
+            self.helper = QueryHelper(self.domain)
         self.profiler = self.helper.profiler
         if self.config is None:
-            self.config = CaseSearchConfig(domain=self.request_domain)
+            self.config = CaseSearchConfig(domain=self.domain)
 
 
 def print_ast(node):

--- a/corehq/apps/case_search/tests/test_case_search_es_queries.py
+++ b/corehq/apps/case_search/tests/test_case_search_es_queries.py
@@ -20,8 +20,8 @@ DOMAIN = 'mighty-search'
 @es_test
 class CaseSearchTests(ElasticTestMixin, TestCase):
     def setUp(self):
-        super(CaseSearchTests, self).setUp()
-        self.config, created = CaseSearchConfig.objects.get_or_create(pk=DOMAIN, enabled=True)
+        super().setUp()
+        self.config, _ = CaseSearchConfig.objects.get_or_create(pk=DOMAIN, enabled=True)
 
     def test_add_blacklisted_ids(self):
         criteria = {

--- a/corehq/apps/case_search/tests/test_case_search_es_queries.py
+++ b/corehq/apps/case_search/tests/test_case_search_es_queries.py
@@ -25,7 +25,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
             "query": {
                 "bool": {
                     "filter": [
-                        {'terms': {'domain.exact': [DOMAIN]}},
+                        {'term': {'domain.exact': DOMAIN}},
                         {"terms": {"type.exact": ["case_type"]}},
                         {"term": {"closed": False}},
                         {
@@ -107,7 +107,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
             "query": {
                 "bool": {
                     "filter": [
-                        {'terms': {'domain.exact': [DOMAIN]}},
+                        {'term': {'domain.exact': DOMAIN}},
                         {"terms": {"type.exact": ["case_type"]}},
                         {"term": {"closed": False}},
                         {"match_all": {}}
@@ -261,7 +261,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
             "query": {
                 "bool": {
                     "filter": [
-                        {"terms": {"domain.exact": [DOMAIN]}},
+                        {"term": {"domain.exact": DOMAIN}},
                         {"terms": {"type.exact": ["case_type"]}},
                         {"term": {"closed": False}},
                         {"term": {"name.exact": "Frodo Baggins"}},
@@ -310,7 +310,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
             "query": {
                 "bool": {
                     "filter": [
-                        {'terms': {'domain.exact': [DOMAIN]}},
+                        {'term': {'domain.exact': DOMAIN}},
                         {"terms": {"type.exact": ["case_type"]}},
                         {"term": {"closed": False}},
                         {"match_all": {}}
@@ -375,7 +375,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
             "query": {
                 "bool": {
                     "filter": [
-                        {"terms": {"domain.exact": [DOMAIN]}},
+                        {"term": {"domain.exact": DOMAIN}},
                         {"terms": {"type.exact": ["case_type"]}},
                         {"term": {"closed": False}},
                         {"match_all": {}}

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -18,17 +18,16 @@ from corehq.apps.case_search.models import (
     criteria_dict_to_criteria_list,
 )
 from corehq.apps.case_search.utils import (
+    QueryHelper,
+    RegistryQueryHelper,
     _get_helper,
+    get_and_tag_related_cases,
     get_case_search_results,
     get_primary_case_search_results,
-    get_and_tag_related_cases,
 )
 from corehq.apps.domain.shortcuts import create_user
-from corehq.apps.es.case_search import case_search_adapter
-from corehq.apps.es.tests.utils import (
-    case_search_es_setup,
-    es_test,
-)
+from corehq.apps.es.case_search import CaseSearchES, case_search_adapter
+from corehq.apps.es.tests.utils import case_search_es_setup, es_test
 from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.registry.tests.utils import (
     Grant,
@@ -342,20 +341,15 @@ class TestCaseSearchRegistryPermissions(TestCase):
         ).slug
 
     def test_user_without_permission_cannot_access_all_domains(self):
-        domains = self._get_registry_visible_domains(HqPermissions(view_data_registry_contents=False))
-        self.assertEqual(domains, {self.domain})
+        helper = self._get_query_helper(HqPermissions(view_data_registry_contents=False))
+        self.assertIsInstance(helper, QueryHelper)
 
     def test_user_with_permission_can_access_all_domains(self):
-        domains = self._get_registry_visible_domains(HqPermissions(view_data_registry_contents=True))
-        self.assertEqual(domains, {self.domain, "A", "B"})
+        helper = self._get_query_helper(HqPermissions(view_data_registry_contents=True))
+        self.assertIsInstance(helper, RegistryQueryHelper)
+        self.assertCountEqual(helper._registry_helper.visible_domains, [self.domain, "A", "B"])
 
-    def _get_registry_visible_domains(self, permissions):
+    def _get_query_helper(self, permissions):
         mock_role = mock.Mock(permissions=permissions)
         mock_user = mock.Mock(get_role=mock.Mock(return_value=mock_role))
-        helper = _get_helper(
-                mock_user,
-                self.domain,
-                ["herb"],
-                self.registry_slug,
-            )
-        return set(helper.query_domains)
+        return _get_helper(mock_user, self.domain, ["herb"], self.registry_slug)

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -311,8 +311,8 @@ class TestCaseSearchRegistry(TestCase):
     def test_primary_cases_not_included_with_related_cases(self):
         with patch_get_app_cached:
             registry_helper = _get_helper(None, self.domain_1, ["creative_work"], self.registry_slug)
-            primary_cases = get_primary_case_search_results(registry_helper, self.domain_1, ["creative_work"],
-                                                            [SearchCriteria("name", "Jane Eyre")])
+            primary_cases = get_primary_case_search_results(
+                registry_helper, ["creative_work"], [SearchCriteria("name", "Jane Eyre")])
             related_cases = registry_helper.get_all_related_live_cases(primary_cases)
 
             self.assertItemsEqual([

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -21,12 +21,11 @@ from corehq.apps.case_search.utils import (
     QueryHelper,
     RegistryQueryHelper,
     _get_helper,
-    get_and_tag_related_cases,
     get_case_search_results,
     get_primary_case_search_results,
 )
 from corehq.apps.domain.shortcuts import create_user
-from corehq.apps.es.case_search import CaseSearchES, case_search_adapter
+from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.tests.utils import case_search_es_setup, es_test
 from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.registry.tests.utils import (
@@ -320,6 +319,7 @@ class TestCaseSearchRegistry(TestCase):
                 (case.name, case.type, case.domain)
                 for case in related_cases
             ])
+
 
 class TestCaseSearchRegistryPermissions(TestCase):
     @classmethod

--- a/corehq/apps/case_search/tests/test_get_related_cases.py
+++ b/corehq/apps/case_search/tests/test_get_related_cases.py
@@ -13,7 +13,7 @@ from corehq.apps.app_manager.models import (
 from corehq.apps.case_search.const import IS_RELATED_CASE
 from corehq.apps.case_search.utils import (
     _get_all_related_cases,
-    _QueryHelper,
+    QueryHelper,
     get_and_tag_related_cases,
     get_child_case_results,
     get_path_related_cases_results,
@@ -152,7 +152,7 @@ class TestGetRelatedCases(BaseCaseSearchTest):
         def get_related_cases_helper(include_all_related_cases):
             with patch("corehq.apps.case_search.utils.get_app_context",
                        return_value=({"parent", "parent/parent"}, {"c", "d"})):
-                return get_and_tag_related_cases(_QueryHelper(self.domain), None, {"c"}, source_cases, None,
+                return get_and_tag_related_cases(QueryHelper(self.domain), None, {"c"}, source_cases, None,
                     include_all_related_cases)
 
         partial_related_cases = get_related_cases_helper(include_all_related_cases=False)
@@ -203,7 +203,7 @@ class TestGetRelatedCases(BaseCaseSearchTest):
         with patch("corehq.apps.case_search.utils.get_app_context",
                    return_value=({"parent"}, {"c"})):
             include_all_related_cases = False
-            partial_related_cases = get_and_tag_related_cases(_QueryHelper(self.domain), None, {"a"}, source_cases,
+            partial_related_cases = get_and_tag_related_cases(QueryHelper(self.domain), None, {"a"}, source_cases,
                 'custom_related_case_id', include_all_related_cases)
 
         EXPECTED_PARTIAL_RELATED_CASES = (source_cases_related["EXPANDED_CASE_ID"]
@@ -237,10 +237,10 @@ class TestGetRelatedCases(BaseCaseSearchTest):
         CHILD_CASE_TYPE_FILTER = {'b'}
         WITH_FILTER_RESULT_CHILD_CASE_ID = {'b1'}
 
-        result_cases = get_child_case_results(_QueryHelper(self.domain), SOURCE_CASE_ID)
+        result_cases = get_child_case_results(QueryHelper(self.domain), SOURCE_CASE_ID)
         self._assert_case_ids(RESULT_CHILD_CASE_ID, result_cases)
 
-        result_cases = get_child_case_results(_QueryHelper(self.domain), SOURCE_CASE_ID, CHILD_CASE_TYPE_FILTER)
+        result_cases = get_child_case_results(QueryHelper(self.domain), SOURCE_CASE_ID, CHILD_CASE_TYPE_FILTER)
         self._assert_case_ids(WITH_FILTER_RESULT_CHILD_CASE_ID, result_cases)
 
     def test__get_all_related_cases(self):
@@ -285,7 +285,7 @@ class TestGetRelatedCases(BaseCaseSearchTest):
         }
 
         EXPECTED_ALL_RELATED_CASES = set().union(*source_cases_related.values())
-        all_related_cases = _get_all_related_cases(_QueryHelper(self.domain), source_cases)
+        all_related_cases = _get_all_related_cases(QueryHelper(self.domain), source_cases)
         self._assert_case_ids(EXPECTED_ALL_RELATED_CASES, all_related_cases)
 
     def test_get_related_cases_result(self):
@@ -323,7 +323,7 @@ class TestGetRelatedCases(BaseCaseSearchTest):
         def get_related_cases_result_helper(include_all_related_cases):
             with patch("corehq.apps.case_search.utils.get_app_context",
                     return_value=({"parent"}, {"c"})):
-                return get_related_cases_result(_QueryHelper(self.domain), 'app_id', {'teacher'},
+                return get_related_cases_result(QueryHelper(self.domain), 'app_id', {'teacher'},
                     source_cases, include_all_related_cases)
 
         EXPECTED_PARTIAL_RELATED_CASES = (source_cases_related["PATH_RELATED_CASE_ID"]
@@ -336,7 +336,7 @@ class TestGetRelatedCases(BaseCaseSearchTest):
         self._assert_case_ids(EXPECTED_ALL_RELATED_CASES, all_related_cases)
 
     def _assert_related_case_ids(self, cases, paths, expected_case_ids):
-        results = get_path_related_cases_results(_QueryHelper(self.domain), cases, paths)
+        results = get_path_related_cases_results(QueryHelper(self.domain), cases, paths)
         self._assert_case_ids(expected_case_ids, results)
 
     def _assert_case_ids(self, expected_case_ids, result_cases):

--- a/corehq/apps/case_search/tests/utils.py
+++ b/corehq/apps/case_search/tests/utils.py
@@ -1,12 +1,12 @@
 from corehq.apps.case_search.models import criteria_dict_to_criteria_list
 from corehq.apps.case_search.utils import (
-    CaseSearchProfiler,
     CaseSearchQueryBuilder,
+    QueryHelper,
 )
 
 
 def get_case_search_query(domain, case_types, criteria_dict, commcare_sort=None):
     """Helper function for tests"""
     criteria = criteria_dict_to_criteria_list(criteria_dict)
-    builder = CaseSearchQueryBuilder(domain, case_types, CaseSearchProfiler())
+    builder = CaseSearchQueryBuilder(QueryHelper(domain), case_types)
     return builder.build_query(criteria, commcare_sort=commcare_sort)

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -202,7 +202,7 @@ class QueryHelper:
         self.profiler = CaseSearchProfiler()
 
     def get_base_queryset(self):
-        return CaseSearchES().domain(self.domain)
+        return CaseSearchES(index=self.config.index_name or None).domain(self.domain)
 
     def wrap_case(self, es_hit, include_score=False):
         return wrap_case_search_hit(es_hit, include_score=include_score)

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -9,6 +9,9 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
 from casexml.apps.case.fixtures import CaseDBFixture
+from casexml.apps.phone.data_providers.case.livequery import (
+    get_all_related_live_cases,
+)
 from dimagi.utils.logging import notify_exception
 
 from corehq import toggles
@@ -199,9 +202,6 @@ class QueryHelper:
         return wrap_case_search_hit(es_hit, include_score=include_score)
 
     def get_all_related_live_cases(self, initial_cases):
-        from casexml.apps.phone.data_providers.case.livequery import (
-            get_all_related_live_cases,
-        )
         case_ids = {case.case_id for case in initial_cases}
         return get_all_related_live_cases(self.domain, case_ids)
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -245,7 +245,6 @@ class CaseSearchQueryBuilder:
         self.request_domain = helper.domain
         self.case_types = case_types
         self.helper = helper
-        self.profiler = helper.profiler
         self.query_domains = helper.query_domains
 
     @cached_property
@@ -322,8 +321,8 @@ class CaseSearchQueryBuilder:
 
     def _build_filter_from_xpath(self, xpath, fuzzy=False):
         context = SearchFilterContext(self.query_domains, fuzzy, self.request_domain,
-                                      self.profiler, self.config)
-        with self.profiler.timing_context('_build_filter_from_xpath'):
+                                      self.helper, self.config)
+        with self.helper.profiler.timing_context('_build_filter_from_xpath'):
             return build_filter_from_xpath(xpath, context=context)
 
     def _get_daterange_query(self, criteria):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -184,7 +184,7 @@ def get_primary_case_search_results(helper, case_types, criteria, commcare_sort=
 
 
 def _get_helper(couch_user, domain, case_types, registry_slug):
-    helper = _QueryHelper(domain)
+    helper = QueryHelper(domain)
     if registry_slug:
         try:
             registry_helper = DataRegistryHelper(domain, registry_slug=registry_slug)
@@ -192,11 +192,11 @@ def _get_helper(couch_user, domain, case_types, registry_slug):
         except (RegistryNotFound, RegistryAccessException):
             pass
         else:
-            helper = _RegistryQueryHelper(domain, couch_user, registry_helper)
+            helper = RegistryQueryHelper(domain, couch_user, registry_helper)
     return helper
 
 
-class _QueryHelper:
+class QueryHelper:
     def __init__(self, domain):
         self.domain = domain
         self.query_domains = [self.domain]
@@ -216,7 +216,7 @@ class _QueryHelper:
         return get_all_related_live_cases(self.domain, case_ids)
 
 
-class _RegistryQueryHelper:
+class RegistryQueryHelper:
     def __init__(self, domain, couch_user, registry_helper):
         self.domain = domain
         self.couch_user = couch_user

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -216,24 +216,23 @@ class QueryHelper:
         return get_all_related_live_cases(self.domain, case_ids)
 
 
-class RegistryQueryHelper:
+class RegistryQueryHelper(QueryHelper):
     def __init__(self, domain, couch_user, registry_helper):
-        self.domain = domain
-        self.couch_user = couch_user
-        self.registry_helper = registry_helper
-        self.query_domains = self.registry_helper.visible_domains
-        self.profiler = CaseSearchProfiler()
+        super().__init__(domain)
+        self._couch_user = couch_user
+        self._registry_helper = registry_helper
+        self.query_domains = self._registry_helper.visible_domains
 
     def get_base_queryset(self):
         return CaseSearchES().domain(self.query_domains)
 
     def wrap_case(self, es_hit, include_score=False):
-        case = wrap_case_search_hit(es_hit, include_score=include_score)
+        case = super().wrap_case(es_hit, include_score)
         case.case_json[COMMCARE_PROJECT] = case.domain
         return case
 
     def get_all_related_live_cases(self, initial_cases):
-        all_cases = self.registry_helper.get_multi_domain_case_hierarchy(self.couch_user, initial_cases)
+        all_cases = self._registry_helper.get_multi_domain_case_hierarchy(self._couch_user, initial_cases)
         initial_case_ids = {case.case_id for case in initial_cases}
         return list(case for case in all_cases if case.case_id not in initial_case_ids)
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -145,7 +145,7 @@ def get_case_search_results(domain, case_types, criteria,
     if profiler:
         helper.profiler = profiler
 
-    cases = get_primary_case_search_results(helper, domain, case_types, criteria, commcare_sort)
+    cases = get_primary_case_search_results(helper, case_types, criteria, commcare_sort)
     helper.profiler.primary_count = len(cases)
     if app_id:
         related_cases = get_and_tag_related_cases(helper, app_id, case_types, cases,
@@ -156,8 +156,8 @@ def get_case_search_results(domain, case_types, criteria,
 
 
 @time_function()
-def get_primary_case_search_results(helper, domain, case_types, criteria, commcare_sort=None):
-    builder = CaseSearchQueryBuilder(domain, case_types, helper.profiler, helper.query_domains)
+def get_primary_case_search_results(helper, case_types, criteria, commcare_sort=None):
+    builder = CaseSearchQueryBuilder(helper, case_types)
     try:
         with helper.profiler.timing_context('build_query'):
             search_es = builder.build_query(criteria, commcare_sort)
@@ -241,11 +241,12 @@ class _RegistryQueryHelper:
 class CaseSearchQueryBuilder:
     """Compiles the case search object for the view"""
 
-    def __init__(self, domain, case_types, profiler, query_domains=None):
-        self.request_domain = domain
+    def __init__(self, helper, case_types):
+        self.request_domain = helper.domain
         self.case_types = case_types
-        self.profiler = profiler
-        self.query_domains = [domain] if query_domains is None else query_domains
+        self.helper = helper
+        self.profiler = helper.profiler
+        self.query_domains = helper.query_domains
 
     @cached_property
     def config(self):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -165,19 +165,10 @@ def get_primary_case_search_results(helper, case_types, criteria, commcare_sort=
         raise CaseSearchUserError(_('Search has too many results. Please try a more specific search.'))
     except CaseFilterError as e:
         # This is an app building error, notify so we can track
-        notify_exception(None, str(e), details=dict(
-            exception_type=type(e),
-        ))
+        notify_exception(None, str(e), details={'exception_type': type(e)})
         raise CaseSearchUserError(str(e))
 
-    try:
-        results = helper.profiler.run_query('main', search_es)
-    except Exception as e:
-        notify_exception(None, str(e), details=dict(
-            exception_type=type(e),
-        ))
-        raise
-
+    results = helper.profiler.run_query('main', search_es)
     with helper.profiler.timing_context('wrap_cases'):
         cases = [helper.wrap_case(hit, include_score=True) for hit in results.raw_hits]
     return cases

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -279,8 +279,7 @@ class CaseSearchQueryBuilder:
         max_results = CASE_SEARCH_MAX_RESULTS
         if toggles.INCREASED_MAX_SEARCH_RESULTS.enabled(self.request_domain):
             max_results = 1500
-        return (CaseSearchES()
-                .domain(self.query_domains)
+        return (self.helper.get_base_queryset()
                 .case_type(self.case_types)
                 .is_closed(False)
                 .size(max_results))

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -208,20 +208,12 @@ class QueryHelper:
     @cached_property
     def config(self):
         try:
-            config = (CaseSearchConfig.objects
-                      .prefetch_related('fuzzy_properties')
-                      .prefetch_related('ignore_patterns')
-                      .get(domain=self.domain))
-        except CaseSearchConfig.DoesNotExist as e:
-            from corehq.util.soft_assert import soft_assert
-            _soft_assert = soft_assert(
-                to="{}@{}.com".format('frener', 'dimagi'),
-                notify_admins=False, send_to_ops=False
-            )
-            msg = f"Someone in domain: {self.domain} tried accessing case search without a config"
-            _soft_assert(False, msg, e)
-            config = CaseSearchConfig(domain=self.domain)
-        return config
+            return (CaseSearchConfig.objects
+                    .prefetch_related('fuzzy_properties')
+                    .prefetch_related('ignore_patterns')
+                    .get(domain=self.domain))
+        except CaseSearchConfig.DoesNotExist:
+            return CaseSearchConfig(domain=self.domain)
 
 
 class RegistryQueryHelper(QueryHelper):

--- a/corehq/apps/case_search/xpath_functions/ancestor_functions.py
+++ b/corehq/apps/case_search/xpath_functions/ancestor_functions.py
@@ -7,7 +7,7 @@ from corehq.apps.case_search.dsl_utils import unwrap_value
 from corehq.apps.case_search.exceptions import CaseFilterError, TooManyRelatedCasesError
 from corehq.apps.case_search.xpath_functions.utils import confirm_args_count
 from corehq.apps.case_search.const import MAX_RELATED_CASES
-from corehq.apps.es.case_search import CaseSearchES, reverse_index_case_query
+from corehq.apps.es.case_search import reverse_index_case_query
 from corehq.toggles import NO_SCROLL_IN_CASE_SEARCH
 
 
@@ -102,7 +102,7 @@ def _is_ancestor_path_expression(node):
 def _child_case_lookup(context, case_ids, identifier):
     """returns a list of all case_ids who have parents `case_id` with the relationship `identifier`
     """
-    es_query = CaseSearchES().domain(context.domain).get_child_cases(case_ids, identifier)
+    es_query = context.helper.get_base_queryset().get_child_cases(case_ids, identifier)
     context.profiler.add_query('_child_case_lookup', es_query)
     if _should_scroll(context):
         return es_query.scroll_ids()
@@ -159,8 +159,7 @@ def _get_case_ids_from_ast_filter(context, filter_node):
     else:
         from corehq.apps.case_search.filter_dsl import build_filter_from_ast
         es_filter = build_filter_from_ast(filter_node, context)
-
-        es_query = CaseSearchES().domain(context.domain).filter(es_filter)
+        es_query = context.helper.get_base_queryset().filter(es_filter)
         context.profiler.add_query('_get_case_ids_from_ast_filter', es_query)
         if es_query.count() > MAX_RELATED_CASES:
             new_query = serialize(filter_node)

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -40,9 +40,9 @@ def property_comparison_query(context, case_property_name_raw, op, value_raw, no
     if meta_property := INDEXED_METADATA_BY_KEY.get(case_property_name):
         if meta_property.is_datetime:
             return _create_system_datetime_query(
-                context.request_domain, meta_property, op, value, node,
+                context.domain, meta_property, op, value, node,
             )
-        if (CASE_SEARCH_INDEXED_METADATA.enabled(context.request_domain)
+        if (CASE_SEARCH_INDEXED_METADATA.enabled(context.domain)
                 and op in [EQ, NEQ] and not context.fuzzy):  # We can filter better at the top level
             return _create_system_query(meta_property, op, value)
     return _create_query(context, case_property_name, op, value, node)

--- a/corehq/apps/case_search/xpath_functions/query_functions.py
+++ b/corehq/apps/case_search/xpath_functions/query_functions.py
@@ -93,7 +93,7 @@ def fuzzy_match(node, context):
     value = unwrap_value(node.args[1], context)
 
     return case_property_query(property_name, value, fuzzy=True,
-                               fuzzy_prefix_length=context.config.fuzzy_prefix_length)
+                               fuzzy_prefix_length=context.helper.config.fuzzy_prefix_length)
 
 
 def _property_name_to_string(value, node):

--- a/corehq/apps/case_search/xpath_functions/subcase_functions.py
+++ b/corehq/apps/case_search/xpath_functions/subcase_functions.py
@@ -11,7 +11,7 @@ from eulxml.xpath.ast import (
 
 from corehq.apps.case_search.const import MAX_RELATED_CASES
 from corehq.apps.case_search.exceptions import XPathFunctionException
-from corehq.apps.es import CaseSearchES, filters, queries
+from corehq.apps.es import filters, queries
 
 
 @dataclass
@@ -100,7 +100,7 @@ def _run_subcase_query(subcase_query, context):
         subcase_filter = filters.match_all()
 
     es_query = (
-        CaseSearchES().domain(context.domain)
+        context.helper.get_base_queryset()
         .nested(
             'indices',
             queries.filtered(

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1026,17 +1026,6 @@ USH_CASE_CLAIM_UPDATES = StaticToggle(
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
 )
 
-NO_SCROLL_IN_CASE_SEARCH = StaticToggle(
-    'no_scroll_in_case_search',
-    "Do not use scroll queries in case search elasticsearch queries",
-    TAG_INTERNAL,
-    namespaces=[NAMESPACE_DOMAIN],
-    description="""
-    This toggle replaces scroll queries in case search ancestor functions with
-    normal search queries.
-    """
-)
-
 GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
     "geocoder_my_location_button",
     "USH: Add button to geocoder to populate search with the user's current location",


### PR DESCRIPTION
## Product Description
No user-facing changes

## Technical Summary
This PR releases the scroll IDs change fully.  That felt small enough to include here, since it was a blocker for some of the cleanup I included.  Aside from that, this PR should have no changes at all unless the `index_name` field is configured for a project.

Case search has a series of state objects that get passed around in various places - `helper`, `profiler`, `CaseSearchQueryBuilder`, `CaseSearchConfig`, and `SearchFilterContext`.  These each have somewhat different purposes and scopes, though they also overlap.  Since we needed access to a shared base queryset everywhere that makes queries, I decided to extend the scope of `helper`, so now it goes basically everywhere.  Since helper already has access to the profiler object, we no longer need to pass that around, and I similarly raised `config` up to helper.  I don't love assembling multiple layers of this kind of thing to be able to call basic-ish functions, but I didn't see a much better approach.

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
