### PR TITLE
Gevent doesn't guarantee ordering when calculating ES adapter doc counts

### DIFF
--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -164,7 +164,7 @@ class ESSyncUtil:
         self.perform_cleanup(adapter)
 
         def get_doc_count(_adapter):
-            return {_adapter.index_name: _adapter.count}
+            return {_adapter.index_name: _adapter.count()}
 
         greenlets = gevent.joinall([
             gevent.spawn(get_doc_count, adapter.primary),

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -161,17 +161,23 @@ class ESSyncUtil:
         """
         es_manager.index_refresh(adapter.primary.index_name)
         es_manager.index_refresh(adapter.secondary.index_name)
-
         self.perform_cleanup(adapter)
 
-        greenlets = gevent.joinall([
-            gevent.spawn(adapter.count, {}),
-            gevent.spawn(adapter.secondary.count, {})
-        ])
-        primary_count, secondary_count = [g.get() for g in greenlets]
+        def get_doc_count(_adapter):
+            return {_adapter.index_name: _adapter.count}
 
-        print(f"\nDoc Count In Old Index '{adapter.primary.index_name}' - {primary_count}")
-        print(f"\nDoc Count In New Index '{adapter.secondary.index_name}' - {secondary_count}\n\n")
+        greenlets = gevent.joinall([
+            gevent.spawn(get_doc_count, adapter.primary),
+            gevent.spawn(get_doc_count, adapter.secondary)
+        ])
+        counts = {}
+        for greenlet in greenlets:
+            counts.update(greenlet.get())
+
+        print(f"\nDoc Count In Old Index '{adapter.primary.index_name}' - {counts[adapter.primary.index_name]}")
+        print(
+            f"\nDoc Count In New Index '{adapter.secondary.index_name}' - {counts[adapter.secondary.index_name]}\n"
+        )
 
     def display_backfill_subindex_doc_counts_for_domain(self, source_adapter, destination_adapter, domain):
         if not destination_adapter.parent_index_cname:

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -164,7 +164,7 @@ class ESSyncUtil:
         self.perform_cleanup(adapter)
 
         def get_doc_count(_adapter):
-            return {_adapter.index_name: _adapter.count()}
+            return {_adapter.index_name: _adapter.count({})}
 
         greenlets = gevent.joinall([
             gevent.spawn(get_doc_count, adapter.primary),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
~It doesn't seem necessary to use gevent here anyway, and based on the output of this command, it looks like the order of results returned isn't guaranteed (which makes sense).~

It is useful to use gevent so that the counts for both indices are calculated at roughly the same time. Otherwise writes can result in surprisingly different counts between the two indices.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
