### PR TITLE
Add Tableau Config to Invite (Backend)

### DIFF
--- a/corehq/apps/reports/tests/test_tableau_api_util.py
+++ b/corehq/apps/reports/tests/test_tableau_api_util.py
@@ -10,6 +10,7 @@ from corehq.apps.reports.models import (
 from corehq.apps.reports.util import (
     TableauGroupTuple,
     get_all_tableau_groups,
+    get_tableau_groups_by_ids,
     get_tableau_groups_for_user,
     get_matching_tableau_users_from_other_domains,
     add_tableau_user,
@@ -72,6 +73,18 @@ class TestTableauAPIUtil(TestTableauAPISession):
         self.assertEqual(len(group_tuples), 3)
         self.assertEqual(group_tuples[0].name, 'group1')
         self.assertEqual(group_tuples[2].id, 'zx39n')
+
+    @mock.patch('corehq.apps.reports.models.requests.request')
+    def test_get_tableau_groups_by_ids(self, mock_request):
+        mock_request.side_effect = _mock_create_session_responses(self) + [
+            self.tableau_instance.query_groups_response()
+        ]
+
+        interested_group_ids = ["1a2b3", "zx39n"]
+        group_tuples = get_tableau_groups_by_ids(interested_group_ids, self.domain)
+        self.assertEqual(len(group_tuples), 2)
+        self.assertEqual(group_tuples[0].name, 'group1')
+        self.assertEqual(group_tuples[1].name, 'group3')
 
     @mock.patch('corehq.apps.reports.models.requests.request')
     def test_get_tableau_groups_for_user(self, mock_request):

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import math
+from typing import List
 import warnings
 from collections import defaultdict, namedtuple
 from datetime import datetime
@@ -437,7 +438,7 @@ def tableau_username(HQ_username):
     return 'HQ/' + HQ_username
 
 
-def _group_json_to_tuples(group_json):
+def _group_json_to_tuples(group_json) -> TableauGroupTuple:
     group_tuples = [TableauGroupTuple(group_dict['name'], group_dict['id']) for group_dict in group_json]
     # Remove default Tableau group and HQ group:
     group_tuples_without_defaults = []
@@ -480,6 +481,14 @@ def _notify_tableau_exception(e, domain):
     notify_exception(None, str(e), details={
         'domain': domain
     })
+
+
+def get_tableau_groups_by_ids(interested_group_ids: List, domain: str,
+                            session: TableauAPISession = None) -> TableauGroupTuple:
+    session = session or TableauAPISession.create_session_for_domain(domain)
+    group_json = session.query_groups()
+    filtered_group_json = [group for group in group_json if group['id'] in interested_group_ids]
+    return _group_json_to_tuples(filtered_group_json)
 
 
 def get_matching_tableau_users_from_other_domains(user):

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -577,11 +577,12 @@ def _delete_user_remote(session, deleted_user_id):
 
 
 @atomic
-def update_tableau_user(domain, username, role=None, groups: List[TableauGroupTuple] = [], session=None):
+def update_tableau_user(domain, username, role=None, groups: List[TableauGroupTuple] = None, session=None):
     '''
     Update the TableauUser object to have the given role and new group details. The `groups` arg should be a list
     of TableauGroupTuples.
     '''
+    groups = groups or []
     session = session or TableauAPISession.create_session_for_domain(domain)
     user = TableauUser.objects.filter(
         server=session.tableau_connected_app.server

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -577,7 +577,7 @@ def _delete_user_remote(session, deleted_user_id):
 
 
 @atomic
-def update_tableau_user(domain, username, role=None, groups=[], session=None):
+def update_tableau_user(domain, username, role=None, groups: List[TableauGroupTuple] = [], session=None):
     '''
     Update the TableauUser object to have the given role and new group details. The `groups` arg should be a list
     of TableauGroupTuples.

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -534,8 +534,6 @@ class _AuthorizableMixin(IsMemberOfMixin):
                         tableau_role=None, tableau_group_ids=None):
         if assigned_location_ids is None:
             assigned_location_ids = []
-        if tableau_group_ids is None:
-            tableau_group_ids = []
         domain_obj = Domain.get_by_name(domain)
         self.add_domain_membership(domain=domain)
         self.set_role(domain, role)
@@ -549,6 +547,8 @@ class _AuthorizableMixin(IsMemberOfMixin):
             user_data = self.get_user_data(domain_obj.name)
             user_data.update({}, profile_id=profile.id)
         if TABLEAU_USER_SYNCING.enabled(domain) and (tableau_role or tableau_group_ids):
+            if tableau_group_ids is None:
+                tableau_group_ids = []
             from corehq.apps.reports.util import get_tableau_groups_by_ids, update_tableau_user
             update_tableau_user(domain=domain, username=self.username,
                     role=tableau_role, groups=get_tableau_groups_by_ids(tableau_group_ids, domain))

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -548,7 +548,7 @@ class _AuthorizableMixin(IsMemberOfMixin):
         if domain_has_privilege(domain_obj.name, privileges.APP_USER_PROFILES) and profile:
             user_data = self.get_user_data(domain_obj.name)
             user_data.update({}, profile_id=profile.id)
-        if tableau_role or tableau_group_ids:
+        if TABLEAU_USER_SYNCING.enabled(domain) and (tableau_role or tableau_group_ids):
             from corehq.apps.reports.util import get_tableau_groups_by_ids, update_tableau_user
             update_tableau_user(domain=domain, username=self.username,
                     role=tableau_role, groups=get_tableau_groups_by_ids(tableau_group_ids, domain))

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -267,18 +267,6 @@ class TestCommCareUserRoles(BaseCommCareUserTestSetup):
         self.assertIsNotNone(role)
         self.assertEqual(role.get_qualified_id(), expected.get_qualified_id())
 
-    def _create_user(self, username, role_id=None):
-        user = self.user_class.create(
-            domain=self.domain,
-            username=username,
-            password='***',
-            created_by=None,
-            created_via=None,
-            role_id=role_id
-        )
-        self.addCleanup(user.delete, None, None)
-        return user
-
 
 class TestWebUserRoles(TestCommCareUserRoles):
     user_class = WebUser


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
no user facing changes

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4451)
Related to model change [PR](https://github.com/dimagi/commcare-hq/pull/34445)
This PR implements the backend changes needed to configure a web user with a "Tableau Role" and "Tableau Groups" via web user invite workflow. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[Tableau User Syncing](https://www.commcarehq.org/hq/flags/edit/tableau_user_syncing/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I locally tested that 
- when invitations contain values in both "tableau_role" and "tableau_groups," they successfully create or update the associated TableauUser object for the respective web user, ensuring that the TableauUser possesses these specified properties.
- If the web user already exists within domain2 (along with its corresponding TableauUser object), accepting an invitation to domain1 will result in the update of the Tableau Role and Tableau Groups for that web user across both domain1 and domain2.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I added test:
-  That the new tableau util `get_tableau_groups_by_ids`  returns the correct tableau group names
-  That `add_web_user` calls correctly calls the functions needed to add the tableau role and groups to the web user

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA. QA will be done when the UI portion is complete for full feature testing.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
