### PR TITLE
[B5] enterprise

### DIFF
--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -54,6 +54,7 @@ from corehq.apps.domain.forms import (
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.models import Alert
 from corehq.apps.hqwebapp.signals import clear_login_attempts
 from corehq.apps.locations.permissions import location_safe
@@ -524,6 +525,7 @@ class RecoveryMeasuresHistory(BaseAdminProjectSettingsView):
         }
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 class ManageDomainMobileWorkersView(ManageMobileWorkersMixin, BaseAdminProjectSettingsView):
     page_title = gettext_lazy("Manage Mobile Workers")
     template_name = 'enterprise/manage_mobile_workers.html'

--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
 from django.urls import reverse
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
@@ -19,13 +20,21 @@ class EnterpriseSettingsForm(forms.Form):
     restrict_domain_creation = forms.BooleanField(
         label=gettext_lazy("Restrict Project Space Creation"),
         required=False,
-        help_text=gettext_lazy("Do not allow current web users, other than enterprise admins, "
-                               "to create new project spaces."),
+        widget=BootstrapCheckboxInput(
+            inline_label=gettext_lazy(
+                "Do not allow current web users, other than enterprise admins, "
+                "to create new project spaces."
+            ),
+        ),
     )
     restrict_signup = forms.BooleanField(
         label=gettext_lazy("Restrict User Signups"),
         required=False,
-        help_text=gettext_lazy("<span data-bind='html: restrictSignupHelp'></span>"),
+        widget=BootstrapCheckboxInput(
+            inline_label=mark_safe(gettext_lazy(
+                "<span data-bind='html: restrictSignupHelp'></span>"
+            )),
+        ),
     )
     restrict_signup_message = forms.CharField(
         label="Signup Restriction Message",
@@ -125,10 +134,8 @@ class EnterpriseSettingsForm(forms.Form):
         super(EnterpriseSettingsForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper(self)
         self.helper.form_id = 'enterprise-settings-form'
-        self.helper.form_class = 'form-horizontal'
         self.helper.form_action = reverse("edit_enterprise_settings", args=[self.domain])
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper.label_class = 'form-label'
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 _("Edit Enterprise Settings"),
@@ -170,12 +177,10 @@ class EnterpriseSettingsForm(forms.Form):
             )
 
         self.helper.layout.append(
-            hqcrispy.FormActions(
-                StrictButton(
-                    _("Update Enterprise Settings"),
-                    type="submit",
-                    css_class='btn-primary',
-                )
+            StrictButton(
+                _("Update Enterprise Settings"),
+                type="submit",
+                css_class='btn-primary',
             )
         )
 

--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -10,7 +10,6 @@ from crispy_forms.bootstrap import PrependedText, StrictButton
 from crispy_forms.helper import FormHelper
 
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
 from corehq.apps.export.models.export_settings import ExportFileType
 from corehq.privileges import DEFAULT_EXPORT_SETTINGS
@@ -289,9 +288,7 @@ class EnterpriseManageMobileWorkersForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper(self)
         self.helper.form_id = 'emw-settings-form'
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper.label_class = 'form-label'
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 _("Manage Mobile Workers"),
@@ -301,12 +298,10 @@ class EnterpriseManageMobileWorkersForm(forms.Form):
                 ),
                 PrependedText('allow_custom_deactivation', ''),
             ),
-            hqcrispy.FormActions(
-                StrictButton(
-                    _("Update Settings"),
-                    type="submit",
-                    css_class='btn-primary',
-                )
+            StrictButton(
+                _("Update Settings"),
+                type="submit",
+                css_class='btn-primary',
             )
         )
 

--- a/corehq/apps/enterprise/static/enterprise/js/enterprise_dashboard.js
+++ b/corehq/apps/enterprise/static/enterprise/js/enterprise_dashboard.js
@@ -1,9 +1,9 @@
 hqDefine("enterprise/js/enterprise_dashboard", [
     'jquery',
     'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/bootstrap3/alert_user',
+    'hqwebapp/js/bootstrap5/alert_user',
     'analytix/js/kissmetrix',
-    'hqwebapp/js/bootstrap3/hq.helpers',
+    'hqwebapp/js/bootstrap5/hq.helpers',
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/enterprise/templates/enterprise/enterprise_dashboard.html
+++ b/corehq/apps/enterprise/templates/enterprise/enterprise_dashboard.html
@@ -1,10 +1,10 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
 
 {% block page_title %}{{ account.name }}{% endblock %}
 
-{% requirejs_main 'enterprise/js/enterprise_dashboard' %}
+{% requirejs_main_b5 'enterprise/js/enterprise_dashboard' %}
 
 {% block page_content %}
   {% registerurl "enterprise_dashboard_email" domain "---" %}
@@ -12,13 +12,13 @@
 
   <div class="row">
     {% for report in reports %}
-      <div class="col-sm-6 col-md-6 col-lg-3">
-        <div class="panel panel-default text-center report-panel" data-slug="{{ report.slug }}">
-          <div class="panel-heading">
-            <h3 class="panel-title">{{ report.title }}</h3>
+      <div class="col-md-6 col-lg-6 col-xl-3">
+        <div class="card card-default text-center report-panel" data-slug="{{ report.slug }}">  {# todo B5: css:panel #}
+          <div class="card-header">
+            <h3 class="card-title">{{ report.title }}</h3>
             <small>{{ report.subtitle|default:"&nbsp;" }}</small>
           </div>
-          <div class="panel-body">
+          <div class="card-body">
             <h1 class="total">
               <i class="fa fa-spin fa-spinner"></i>
             </h1>

--- a/corehq/apps/enterprise/templates/enterprise/enterprise_dashboard.html
+++ b/corehq/apps/enterprise/templates/enterprise/enterprise_dashboard.html
@@ -13,20 +13,20 @@
   <div class="row">
     {% for report in reports %}
       <div class="col-md-6 col-lg-6 col-xl-3">
-        <div class="card card-default text-center report-panel" data-slug="{{ report.slug }}">  {# todo B5: css:panel #}
+        <div class="card text-center report-panel mb-3" data-slug="{{ report.slug }}">
           <div class="card-header">
-            <h3 class="card-title">{{ report.title }}</h3>
-            <small>{{ report.subtitle|default:"&nbsp;" }}</small>
+            <div class="fs-4">{{ report.title }}</div>
+            <div class="fs-6">{{ report.subtitle|default:"&nbsp;" }}</div>
           </div>
           <div class="card-body">
-            <h1 class="total">
+            <h1 class="card-text total">
               <i class="fa fa-spin fa-spinner"></i>
             </h1>
             <br>
-            <a class="btn btn-primary btn-lg">
+            <button class="btn btn-primary btn-lg">
               <i class="fa fa-envelope"></i>
               {% trans "Email Report" %}
-            </a>
+            </button>
           </div>
         </div>
       </div>

--- a/corehq/apps/enterprise/templates/enterprise/enterprise_permissions.html
+++ b/corehq/apps/enterprise/templates/enterprise/enterprise_permissions.html
@@ -1,9 +1,9 @@
-{% extends 'hqwebapp/bootstrap3/base_section.html' %}
+{% extends 'hqwebapp/bootstrap5/base_section.html' %}
 {% load crispy_forms_tags %}
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "hqwebapp/js/bootstrap3/widgets" %}
+{% requirejs_main_b5 "hqwebapp/js/bootstrap5/widgets" %}
 
 {% block page_content %}
   <p class="lead">
@@ -20,9 +20,9 @@
   </p>
 
   {% if is_enabled %}
-    <form class="pull-right" method="POST" action="{% url "disable_enterprise_permissions" domain %}">
+    <form class="float-end" method="POST" action="{% url "disable_enterprise_permissions" domain %}">
       {% csrf_token %}
-      <button class="btn btn-danger" type="submit">
+      <button class="btn btn-outline-danger" type="submit">
         <i class="fa fa-ban"></i>
         {% trans "Disable Enterprise Permissions" %}
       </button>
@@ -38,7 +38,7 @@
   <form method="POST" action="{% url "update_enterprise_permissions_source_domain" domain %}">
     {% csrf_token %}
     <div class="row">
-      <div class="col-sm-3">
+      <div class="col-md-3">
         <select name="source_domain" class="hqwebapp-select2">
           {% if not source_domain %}
             <option value="">{% trans "Select the controlling project space" %}</option>
@@ -48,8 +48,8 @@
           {% endfor %}
         </select>
       </div>
-      <div class="col-sm-3">
-        <button class="btn btn-default" type="submit">
+      <div class="col-md-3">
+        <button class="btn btn-outline-primary" type="submit">
           {% trans "Update" %}
         </button>
       </div>
@@ -58,7 +58,7 @@
 
   <br>
   <div class="row">
-    <div class="col-sm-6">
+    <div class="col-md-6">
       <p class="help-block">
         {% if source_domain %}
           {% blocktrans trimmed %}
@@ -72,7 +72,7 @@
       </p>
       {% include "enterprise/partials/enterprise_permissions_table.html" with DOMAINS=controlled_domains ACTION_ENABLE=False %}
     </div>
-    <div class="col-sm-6">
+    <div class="col-md-6">
       <p class="help-block">
         {% if source_domain %}
           {% blocktrans trimmed %}

--- a/corehq/apps/enterprise/templates/enterprise/enterprise_settings.html
+++ b/corehq/apps/enterprise/templates/enterprise/enterprise_settings.html
@@ -8,5 +8,5 @@
   {% initial_page_data 'accounts_email' accounts_email %}
   {% initial_page_data 'restricted_domains' account.enterprise_restricted_signup_domains %}
   {% initial_page_data 'restrict_signup' restrict_signup %}
-  {% crispy settings_form %}  {# todo B5: check crispy #}
+  {% crispy settings_form %}
 {% endblock %}

--- a/corehq/apps/enterprise/templates/enterprise/enterprise_settings.html
+++ b/corehq/apps/enterprise/templates/enterprise/enterprise_settings.html
@@ -1,12 +1,12 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'enterprise/js/enterprise_settings' %}
+{% requirejs_main_b5 'enterprise/js/enterprise_settings' %}
 
 {% block page_content %}
   {% initial_page_data 'accounts_email' accounts_email %}
   {% initial_page_data 'restricted_domains' account.enterprise_restricted_signup_domains %}
   {% initial_page_data 'restrict_signup' restrict_signup %}
-  {% crispy settings_form %}
+  {% crispy settings_form %}  {# todo B5: check crispy #}
 {% endblock %}

--- a/corehq/apps/enterprise/templates/enterprise/manage_mobile_workers.html
+++ b/corehq/apps/enterprise/templates/enterprise/manage_mobile_workers.html
@@ -4,5 +4,5 @@
 {% load i18n %}
 
 {% block page_content %}
-  {% crispy edit_emw_settings_form %}  {# todo B5: check crispy #}
+  {% crispy edit_emw_settings_form %}
 {% endblock %}

--- a/corehq/apps/enterprise/templates/enterprise/manage_mobile_workers.html
+++ b/corehq/apps/enterprise/templates/enterprise/manage_mobile_workers.html
@@ -1,8 +1,8 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {% load i18n %}
 
 {% block page_content %}
-  {% crispy edit_emw_settings_form %}
+  {% crispy edit_emw_settings_form %}  {# todo B5: check crispy #}
 {% endblock %}

--- a/corehq/apps/enterprise/templates/enterprise/partials/enterprise_permissions_table.html
+++ b/corehq/apps/enterprise/templates/enterprise/partials/enterprise_permissions_table.html
@@ -5,10 +5,10 @@
     <tbody>
       {% for domain_name in DOMAINS %}
         <tr>
-          <td class="col-sm-10">
+          <td class="col-md-10">
             {{ domain_name }}
           </td>
-          <td class="col-sm-2">
+          <td class="col-md-2">
             <form class="form form-horizontal disable-on-submit"
                   {% if ACTION_ENABLE %}
                     action="{% url 'add_enterprise_permissions_domain' domain domain_name %}"
@@ -18,7 +18,7 @@
                   method="POST">
               {% csrf_token %}
               <input type="hidden" name="target_domain" value="{{ domain_name }}"/>
-              <button type="submit" class="btn btn-default">
+              <button type="submit" class="btn btn-outline-primary">
                 {% if ACTION_ENABLE %}
                   <i class="fa fa-rocket"></i> {% trans "Enable" %}
                 {% else %}

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -57,6 +57,7 @@ from corehq.apps.users.decorators import require_can_edit_or_view_web_users
 from corehq.const import USER_DATE_FORMAT
 
 
+@use_bootstrap5
 @always_allow_project_access
 @require_enterprise_admin
 @login_and_domain_required

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -50,6 +50,7 @@ from corehq.apps.enterprise.tasks import email_enterprise_report
 
 from corehq.apps.export.utils import get_default_export_settings_if_available
 
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.users.decorators import require_can_edit_or_view_web_users
 
@@ -337,6 +338,7 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
 # with other views in this area. They also require superuser access because these views
 # used to be in another part of HQ, where they were limited to superusers, and we don't
 # want them to be visible to any external users until we're ready to GA this feature.
+@use_bootstrap5
 @require_can_edit_or_view_web_users
 @require_superuser
 @require_enterprise_admin

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -447,6 +447,7 @@ def update_enterprise_permissions_source_domain(request, domain):
     return HttpResponseRedirect(redirect)
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 class ManageEnterpriseMobileWorkersView(ManageMobileWorkersMixin, BaseEnterpriseAdminView):
     page_title = gettext_lazy("Manage Mobile Workers")
     template_name = 'enterprise/manage_mobile_workers.html'

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -120,6 +120,7 @@ def enterprise_dashboard_email(request, domain, slug):
     return JsonResponse({'message': message})
 
 
+@use_bootstrap5
 @require_enterprise_admin
 @login_and_domain_required
 def enterprise_settings(request, domain):

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -105,7 +105,7 @@
         <div id="message-alerts"
              class="ko-template"
              data-bind="foreach: {data: alerts, beforeRemove: fadeOut}">
-          <div class="alert alert-dismissible fade show" data-bind="css: {true: alert_class}">
+          <div class="alert alert-dismissible fade show" data-bind="attr: {class: alert_class}">
             <span data-bind="html: message"></span>
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans_html_attr "Close" %}"></button>
           </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
@@ -146,7 +146,7 @@
 -          <div data-bind="attr: {'class': alert_class}">
 -            <a class="close"
 -               data-dismiss="alert" href="#">&times;</a>
-+          <div class="alert alert-dismissible fade show" data-bind="css: {true: alert_class}">
++          <div class="alert alert-dismissible fade show" data-bind="attr: {class: alert_class}">
              <span data-bind="html: message"></span>
 +            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans_html_attr "Close" %}"></button>
            </div>

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -86,5 +86,8 @@
   },
   "reports_core": {
     "in_progress": true
+  },
+  "enterprise": {
+    "is_complete": true
   }
 }


### PR DESCRIPTION
## Product Description
Reviewers don't need to look closely at the initial automated commits.

| before    | after |
| -------- | ------- |
| ![Screenshot 2024-05-13 at 8 43 45 PM](https://github.com/dimagi/commcare-hq/assets/1486591/807e58a8-0f75-4069-be8f-818cf1026dfe)  | ![Screenshot 2024-05-13 at 8 39 54 PM](https://github.com/dimagi/commcare-hq/assets/1486591/8709ba4d-8811-4110-b038-8499d7a6634a)    |
| ![Screenshot 2024-05-13 at 8 43 55 PM](https://github.com/dimagi/commcare-hq/assets/1486591/91877ca2-021a-4ddb-b685-60c271440196)  | ![Screenshot 2024-05-13 at 8 41 58 PM](https://github.com/dimagi/commcare-hq/assets/1486591/14527aaf-ec99-4db9-afa2-c6d5dbc291eb)    |
| ![Screenshot 2024-05-13 at 8 59 27 PM](https://github.com/dimagi/commcare-hq/assets/1486591/35ffbc68-b360-4426-a49e-bf8acea82998)  | ![Screenshot 2024-05-13 at 8 42 29 PM](https://github.com/dimagi/commcare-hq/assets/1486591/66e9f6fb-a1bf-4576-ab4e-ff973405b4d0)    |
| ![Screenshot 2024-05-13 at 8 44 03 PM](https://github.com/dimagi/commcare-hq/assets/1486591/457c3c2e-474b-4341-9692-aa3fb5e777cc)  | ![Screenshot 2024-05-13 at 8 42 10 PM](https://github.com/dimagi/commcare-hq/assets/1486591/0d961ce0-aa45-4fc4-adfb-9b7ee9e03e48)    |

## Safety Assurance

### Safety story
This was a simple one with little interactivity. I tested locally:
* Emailing enterprise dashboard reports
* The little bit of interactivity on the settings page (checking restricting signups adds a text box to input a message0
* Enterprise permissions page (adding/removing domains, enabling/disabling permissions)

### Automated test coverage

Not much if any.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
