### PR TITLE
[B5] groups

### DIFF
--- a/corehq/apps/groups/static/groups/js/all_groups.js
+++ b/corehq/apps/groups/static/groups/js/all_groups.js
@@ -1,11 +1,13 @@
 hqDefine("groups/js/all_groups", [
     'jquery',
     'analytix/js/google',
+    'es6!hqwebapp/js/bootstrap5_loader',
     // Just importing main.py so the post-link function is accessible, function parameter not needed
     'hqwebapp/js/bootstrap5/main',
 ], function (
     $,
-    googleAnalytics
+    googleAnalytics,
+    bootstrap
 ) {
     $(function () {
         var $createGroupForm = $("#create_group_form");
@@ -16,8 +18,8 @@ hqDefine("groups/js/all_groups", [
             return false;
         });
 
-        $('.js-case-sharing-alert').popover({  /* todo B5: plugin:popover */
-            trigger: 'hover',
+        $('.js-case-sharing-alert').each(function (i, el) {
+            new bootstrap.Popover(el);
         });
     });
 });

--- a/corehq/apps/groups/static/groups/js/all_groups.js
+++ b/corehq/apps/groups/static/groups/js/all_groups.js
@@ -2,7 +2,7 @@ hqDefine("groups/js/all_groups", [
     'jquery',
     'analytix/js/google',
     // Just importing main.py so the post-link function is accessible, function parameter not needed
-    'hqwebapp/js/bootstrap3/main',
+    'hqwebapp/js/bootstrap5/main',
 ], function (
     $,
     googleAnalytics
@@ -16,7 +16,7 @@ hqDefine("groups/js/all_groups", [
             return false;
         });
 
-        $('.js-case-sharing-alert').popover({
+        $('.js-case-sharing-alert').popover({  /* todo B5: plugin:popover */
             trigger: 'hover',
         });
     });

--- a/corehq/apps/groups/static/groups/js/all_groups.js
+++ b/corehq/apps/groups/static/groups/js/all_groups.js
@@ -1,3 +1,4 @@
+"use strict";
 hqDefine("groups/js/all_groups", [
     'jquery',
     'analytix/js/google',

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -3,9 +3,9 @@ hqDefine("groups/js/group_members", [
     "underscore",
     "analytix/js/google",
     "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list",
+    "hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-list",
     "hqwebapp/js/select_2_ajax_widget",     // "Group Membership" select2
-    "hqwebapp/js/bootstrap3/components.ko",            // select toggle for "Edit Setings" popup
+    "hqwebapp/js/bootstrap5/components.ko",            // select toggle for "Edit Setings" popup
 ], function (
     $,
     _,
@@ -14,7 +14,7 @@ hqDefine("groups/js/group_members", [
     uiMapList
 ) {
     $(function () {
-        $('.verify-button').tooltip();
+        $('.verify-button').tooltip();  /* todo B5: plugin:tooltip */
         // custom data
         var customDataEditor = uiMapList.new(initialPageData.get("group_id"), gettext("Edit Group Information"));
         customDataEditor.val(initialPageData.get("group_metadata"));
@@ -79,7 +79,7 @@ hqDefine("groups/js/group_members", [
                 $(id).find(':button').enableButton();
                 $('#save-alert').removeClass('alert-danger alert-success alert-info').addClass(alertClass);
                 $('#save-alert').html(message).show();
-                $('#editGroupSettings').modal('hide');
+                $('#editGroupSettings').modal('hide');  /* todo B5: plugin:modal */
 
                 if (_.isFunction(additionalCallback)) {
                     additionalCallback();

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -2,6 +2,7 @@ hqDefine("groups/js/group_members", [
     "jquery",
     "underscore",
     "analytix/js/google",
+    "es6!hqwebapp/js/bootstrap5_loader",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap5/alert_user",
     "hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-list",
@@ -11,6 +12,7 @@ hqDefine("groups/js/group_members", [
     $,
     _,
     googleAnalytics,
+    bootstrap,
     initialPageData,
     alertUser,
     uiMapList
@@ -76,7 +78,7 @@ hqDefine("groups/js/group_members", [
                 }
                 $(id).find(':button').enableButton();
                 alertUser.alert_user(message, isSuccess ? 'success' : 'danger');
-                $('#editGroupSettings').modal('hide');  /* todo B5: plugin:modal */
+                bootstrap.Modal.getOrCreateInstance(document.getElementById('editGroupSettings')).hide();
 
                 if (_.isFunction(additionalCallback)) {
                     additionalCallback();

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -3,6 +3,7 @@ hqDefine("groups/js/group_members", [
     "underscore",
     "analytix/js/google",
     "hqwebapp/js/initial_page_data",
+    "hqwebapp/js/bootstrap5/alert_user",
     "hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-list",
     "hqwebapp/js/select_2_ajax_widget",     // "Group Membership" select2
     "hqwebapp/js/bootstrap5/components.ko",            // select toggle for "Edit Setings" popup
@@ -11,6 +12,7 @@ hqDefine("groups/js/group_members", [
     _,
     googleAnalytics,
     initialPageData,
+    alertUser,
     uiMapList
 ) {
     $(function () {
@@ -65,18 +67,15 @@ hqDefine("groups/js/group_members", [
 
         function outcome(isSuccess, name, id, gaEventLabel, additionalCallback) {
             return function () {
-                var alertClass, message;
+                var message;
                 if (isSuccess) {
-                    alertClass = 'alert-success';
                     message = gettext('Successfully saved ') + name.toLowerCase() + '.';
                     unsavedChanges[name] = false;
                 } else {
-                    alertClass = 'alert-danger';
                     message = gettext('Failed to save ') + name.toLowerCase() + '.';
                 }
                 $(id).find(':button').enableButton();
-                $('#save-alert').removeClass('alert-danger alert-success alert-info').addClass(alertClass);
-                $('#save-alert').html(message).show();
+                alertUser.alert_user(message, isSuccess ? 'success' : 'danger');
                 $('#editGroupSettings').modal('hide');  /* todo B5: plugin:modal */
 
                 if (_.isFunction(additionalCallback)) {
@@ -99,11 +98,11 @@ hqDefine("groups/js/group_members", [
             $('#edit_membership').submit(function () {
                 var _showMembershipUpdating = function () {
                         $('#edit_membership').fadeOut();
-                        $('#membership_updating').fadeIn();
+                        $('#membership_updating').removeClass("d-none");
                     },
                     _hideMembershipUpdating = function () {
                         $('#edit_membership').fadeIn();
-                        $('#membership_updating').fadeOut();
+                        $('#membership_updating').addClass("d-none");
                     };
                 _showMembershipUpdating();
                 $(this).find(':button').prop('disabled', true);

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -1,3 +1,4 @@
+"use strict";
 hqDefine("groups/js/group_members", [
     "jquery",
     "underscore",
@@ -54,7 +55,7 @@ hqDefine("groups/js/group_members", [
             var ret = gettext("The following changes will not be saved: ");
 
             for (var key in unsavedChanges) {
-                if (unsavedChanges.hasOwnProperty(key) && unsavedChanges[key]) {
+                if (_.has(unsavedChanges, key) && unsavedChanges[key]) {
                     ret += "\n" + key;
                     someUnsavedChanges = true;
                 }

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -14,8 +14,6 @@ hqDefine("groups/js/group_members", [
     uiMapList
 ) {
     $(function () {
-        $('.verify-button').tooltip();  /* todo B5: plugin:tooltip */
-        // custom data
         var customDataEditor = uiMapList.new(initialPageData.get("group_id"), gettext("Edit Group Information"));
         customDataEditor.val(initialPageData.get("group_metadata"));
         customDataEditor.on("change", function () {

--- a/corehq/apps/groups/templates/groups/all_groups.html
+++ b/corehq/apps/groups/templates/groups/all_groups.html
@@ -38,24 +38,7 @@
       </li>
     </ul>
 
-    {% if not request.is_view_only %}
-      <form method="post" action="{% url "add_group" domain %}" id="create_group_form">
-        {% csrf_token %}
-        <div class="row">
-          <div class="col-md-4">
-            <input type="text" placeholder="{% trans "Group Name" %}" id="id_group_name" name="group_name" class="form-control" />
-          </div>
-          <div class="col">
-            <button class="btn btn-primary" type="submit">
-              <i class="fa fa-plus"></i>
-              {% trans "Add Group" %}
-            </button>
-          </div>
-        </div>
-      </form>
-    {% endif %}
-
-    <div class="card card-default mt-3">
+    <div class="card card-default mb-3">
       <div class="card-body">
         <h3 class="card-title">{% trans "Project Groups" %}</h3>
         {% if all_groups %}
@@ -130,6 +113,23 @@
         {% endif %}
       </div>
     </div>
+
+    {% if not request.is_view_only %}
+      <form method="post" action="{% url "add_group" domain %}" id="create_group_form">
+        {% csrf_token %}
+        <div class="row">
+          <div class="col-md-4">
+            <input type="text" placeholder="{% trans "Group Name" %}" id="id_group_name" name="group_name" class="form-control" />
+          </div>
+          <div class="col">
+            <button class="btn btn-primary" type="submit">
+              <i class="fa fa-plus"></i>
+              {% trans "Add Group" %}
+            </button>
+          </div>
+        </div>
+      </form>
+    {% endif %}
   {% endif %}
 {% endblock %}
 

--- a/corehq/apps/groups/templates/groups/all_groups.html
+++ b/corehq/apps/groups/templates/groups/all_groups.html
@@ -82,14 +82,16 @@
                 </td>
                 <td class="text-center">
                   {% if group.case_sharing %}
-                    <i class="fa fa-check"></i>
                     {% if not is_case_sharing_enabled %}
                       <span class="js-case-sharing-alert badge text-bg-warning"
-                            title="{% trans_html_attr 'Limited Access' %}"
-                            data-content="{% trans_html_attr 'Your subscription was downgraded after creating this group. Group membership will not be editable until case sharing is disabled.' %}">
+                            data-bs-toggle="popover"
+                            data-bs-trigger="hover focus"
+                            data-bs-content="{% trans_html_attr 'Your subscription was downgraded after creating this group. Group membership will not be editable until case sharing is disabled.' %}">
                         <i class="fa fa-warning"></i>
                         {% trans "Limited Access" %}
                       </span>
+                    {% else %}
+                      <i class="fa fa-check"></i>
                     {% endif %}
                   {% endif %}
                 </td>

--- a/corehq/apps/groups/templates/groups/all_groups.html
+++ b/corehq/apps/groups/templates/groups/all_groups.html
@@ -37,27 +37,32 @@
         {% include 'groups/partials/case_sharing_upgrade_notice.html' %}
       </li>
     </ul>
+
     {% if not request.is_view_only %}
-      <form class="card well-sm form-inline" method="post" action="{% url "add_group" domain %}" id="create_group_form">  {# todo B5: css:form-inline, css:well #}
+      <form method="post" action="{% url "add_group" domain %}" id="create_group_form">
         {% csrf_token %}
-        <input type="text" placeholder="{% trans "Group Name" %}" id="id_group_name" name="group_name" class="form-control" />
-        <button class="btn btn-primary" type="submit">
-          <i class="fa fa-plus"></i>
-          {% trans "Add Group" %}
-        </button>
+        <div class="row">
+          <div class="col-md-4">
+            <input type="text" placeholder="{% trans "Group Name" %}" id="id_group_name" name="group_name" class="form-control" />
+          </div>
+          <div class="col">
+            <button class="btn btn-primary" type="submit">
+              <i class="fa fa-plus"></i>
+              {% trans "Add Group" %}
+            </button>
+          </div>
+        </div>
       </form>
     {% endif %}
 
-    <div class="card card-default">  {# todo B5: css:panel #}
-      <div class="card-header">
-        <h3 class="card-title">{% trans "Project Groups" %}</h3>
-      </div>
+    <div class="card card-default mt-3">
       <div class="card-body">
+        <h3 class="card-title">{% trans "Project Groups" %}</h3>
         {% if all_groups %}
           <table class="table table-striped">
             <thead>
             <th>{% trans "Group Name" %}</th>
-            <th>
+            <th class="text-center">
               {% trans "Reporting Group" %}
               <span class="hq-help-template"
                     data-title="{% trans 'Reporting Groups' %}"
@@ -66,10 +71,10 @@
                                     data.{% endblocktrans %}{% if not request.is_view_only %}
                                     {% blocktrans %}You can remove this group from reports by
                                     editing this group's settings.{% endblocktrans %}{% endif %}">
-                            </span>
+              </span>
             </th>
-            <th>
-              {% trans "Case Sharing Groups" %}
+            <th class="text-center">
+              {% trans "Case Sharing Group" %}
               <span class="hq-help-template"
                     data-title="{% trans 'Case Sharing Groups' %}"
                     data-content="{% blocktrans %}
@@ -78,7 +83,7 @@
                                     {% if not request.is_view_only %}
                                     {% blocktrans %} You can change this by editing this
                                     group's settings.{% endblocktrans %}{% endif %}">
-                            </span>
+              </span>
             </th>
             </thead>
             <tbody>
@@ -89,10 +94,10 @@
                     {{ group.display_name }}
                   </a>
                 </td>
-                <td>
+                <td class="text-center">
                   {% if group.reporting %}<i class="fa fa-check"></i>{% endif %}
                 </td>
-                <td>
+                <td class="text-center">
                   {% if group.case_sharing %}
                     <i class="fa fa-check"></i>
                     {% if not is_case_sharing_enabled %}

--- a/corehq/apps/groups/templates/groups/all_groups.html
+++ b/corehq/apps/groups/templates/groups/all_groups.html
@@ -1,7 +1,7 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
-{% requirejs_main "groups/js/all_groups" %}
+{% requirejs_main_b5 "groups/js/all_groups" %}
 
 {% block page_title %}
   {% trans "Groups" %}
@@ -38,7 +38,7 @@
       </li>
     </ul>
     {% if not request.is_view_only %}
-      <form class="well well-sm form-inline" method="post" action="{% url "add_group" domain %}" id="create_group_form">
+      <form class="card well-sm form-inline" method="post" action="{% url "add_group" domain %}" id="create_group_form">  {# todo B5: css:form-inline, css:well #}
         {% csrf_token %}
         <input type="text" placeholder="{% trans "Group Name" %}" id="id_group_name" name="group_name" class="form-control" />
         <button class="btn btn-primary" type="submit">
@@ -48,11 +48,11 @@
       </form>
     {% endif %}
 
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">{% trans "Project Groups" %}</h3>
+    <div class="card card-default">  {# todo B5: css:panel #}
+      <div class="card-header">
+        <h3 class="card-title">{% trans "Project Groups" %}</h3>
       </div>
-      <div class="panel-body">
+      <div class="card-body">
         {% if all_groups %}
           <table class="table table-striped">
             <thead>
@@ -96,7 +96,7 @@
                   {% if group.case_sharing %}
                     <i class="fa fa-check"></i>
                     {% if not is_case_sharing_enabled %}
-                      <span class="js-case-sharing-alert label label-warning"
+                      <span class="js-case-sharing-alert badge text-bg-warning"
                             title="{% trans_html_attr 'Limited Access' %}"
                             data-content="{% trans_html_attr 'Your subscription was downgraded after creating this group. Group membership will not be editable until case sharing is disabled.' %}">
                         <i class="fa fa-warning"></i>

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -1,4 +1,4 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
@@ -11,7 +11,7 @@
   </style>
 {% endblock %}
 
-{% requirejs_main "groups/js/group_members" %}
+{% requirejs_main_b5 "groups/js/group_members" %}
 
 {% block page_title %}
   {% if request.is_view_only %}
@@ -53,20 +53,20 @@
       <div class="btn-toolbar">
         {% if show_disable_case_sharing %}
           <a href="#disableCaseSharing"
-             class="btn btn-default"
-             data-toggle="modal">
+             class="btn btn-outline-primary"
+             data-bs-toggle="modal">
             <i class="fa fa-pencil"></i>
             {% trans "Change group type to Reporting Group" %}
           </a>
         {% else %}
           <a href="#editGroupSettings"
-             class="btn btn-default"
-             data-toggle="modal">
+             class="btn btn-outline-primary"
+             data-bs-toggle="modal">
             <i class="fa fa-pencil"></i>
             {% trans "Edit Settings" %}
           </a>
         {% endif %}
-        <a class="btn btn-danger pull-right" style="margin-right: 45px;" data-toggle="modal" href="#delete_group_modal">
+        <a class="btn btn-outline-danger float-end" style="margin-right: 45px;" data-bs-toggle="modal" href="#delete_group_modal">  {# todo B5: inline style #}
           <i class="fa fa-remove"></i>
           {% blocktrans with group.name as group_name %}
             Delete Group "{{group_name}}"
@@ -75,7 +75,7 @@
 
         {% if bulk_sms_verification_enabled %}
           <form id="initiate-verification-workflow"
-                class="form-inline"
+                class="form-inline"  {# todo B5: css:form-inline #}
                 method="post"
                 action="{% url "bulk_sms_verification" domain group.get_id %}">
             {% csrf_token %}
@@ -83,7 +83,7 @@
                     type="submit"
                     data-html="true"
                     data-title="<div class='alert alert-warning'><i class='fa-solid fa-triangle-exclamation'></i> <strong>{% trans 'SMS charges will incur.' %}</strong></div>{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
-                    class="btn btn-default verify-button">
+                    class="btn btn-outline-primary verify-button">
               <i class="fa fa-signal"></i> {% trans 'Verify Phone Numbers' %}
             </button>
             <span class="hq-help-template"
@@ -104,14 +104,14 @@
       <hr />
     {% endif %}
 
-    <ul class="nav nav-tabs sticky-tabs" role="tablist" style="margin-bottom: 20px;">
+    <ul class="nav nav-tabs sticky-tabs" role="tablist" style="margin-bottom: 20px;">  {# todo B5: css:nav, inline style #}
       <li role="presentation">
-        <a href="#membership-tab" aria-controls="home" role="tab" data-toggle="tab">
+        <a href="#membership-tab" aria-controls="home" role="tab" data-bs-toggle="tab">
           {% trans "Group Membership" %}
         </a>
       </li>
       <li role="presentation">
-        <a href="#groupdata-tab" aria-controls="profile" role="tab" data-toggle="tab">
+        <a href="#groupdata-tab" aria-controls="profile" role="tab" data-bs-toggle="tab">
           {% trans "Group Data" %}
         </a>
       </li>
@@ -120,17 +120,17 @@
     <!-- Tab panes -->
     <div class="tab-content">
       <div role="tabpanel" class="tab-pane" id="membership-tab">
-        <div class="panel-body">
+        <div class="card-body">
           {% if request.is_view_only or not can_edit_group_membership or show_disable_case_sharing %}
             <div class="form form-horizontal">
               <legend>
                 {% trans "View Group Membership" %}
               </legend>
-              <div class="form-group">
-                <label class="control-label col-xs-12 col-sm-4 col-md-4 col-lg-2">
+              <div class="form-group">  {# todo B5: css:form-group #}
+                <label class="form-label col-sm-12 col-md-4 col-lg-4 col-xl-2">
                   {% trans "Group Membership" %}
                 </label>
-                <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6 controls-text">
+                <div class="col-sm-12 col-md-8 col-lg-8 col-xl-6 controls-text">
                   {% if not group_members %}
                     {% blocktrans %}
                       No Mobile Workers are currently assigned to this group.
@@ -157,8 +157,8 @@
             {% include "groups/partials/edit_group_disabled_case_sharing.html" %}
           {% else %}
             <div class="row">
-              <div class="col-sm-12">
-                <div class="alert alert-info" id="membership_updating" style="display: none">
+              <div class="col-md-12">
+                <div class="alert alert-info" id="membership_updating" style="display: none">  {# todo B5: inline style #}
                   <p class="lead">
                     <i class="fa fa-spinner fa-spin"></i> {% trans 'Updating Group Membership, please wait...' %}
                   </p>
@@ -167,7 +167,7 @@
                 <form class="form-horizontal disable-on-submit"
                       id="edit_membership"
                       action="{% url "update_group_membership" domain group.get_id %}" method='post'>
-                  {% crispy group_membership_form %}
+                  {% crispy group_membership_form %}  {# todo B5: check crispy #}
                 </form>
 
               </div>
@@ -176,17 +176,17 @@
         </div>
       </div>
       <div role="tabpanel" class="tab-pane" id="groupdata-tab">
-        <div class="panel-body">
+        <div class="card-body">
           {% if request.is_view_only or show_disable_case_sharing %}
             <div class="form form-horizontal">
               <legend>
                 {% trans "View Group Data" %}
               </legend>
-              <div class="form-group">
-                <label class="control-label col-xs-12 col-sm-4 col-md-4 col-lg-2">
+              <div class="form-group">  {# todo B5: css:form-group #}
+                <label class="form-label col-sm-12 col-md-4 col-lg-4 col-xl-2">
                   {% trans "Group Data" %}
                 </label>
-                <div class="controls-text col-xs-12 col-sm-8 col-md-8 col-lg-6">
+                <div class="controls-text col-sm-12 col-md-8 col-lg-8 col-xl-6">
                   {% if not group.metadata %}
                     {% trans "No Data Provided" %}
                   {% else %}
@@ -209,17 +209,17 @@
               {% csrf_token %}
               <fieldset>
                 <legend>{% trans "Edit Group Data" %}</legend>
-                <div class="form-group">
-                  <label class="control-label col-sm-2">
+                <div class="form-group">  {# todo B5: css:form-group #}
+                  <label class="form-label col-md-2">
                     {% trans "Group Data" %}
                   </label>
-                  <div class="col-sm-9">
+                  <div class="col-md-9">
                     <div id="group-data-ui-editor"></div>
                   </div>
                 </div>
                 <input name="group-data" id="group-data" type="hidden" value="{% html_attr group.metadata %}">
                 <div class="form-actions">
-                  <div class="col-sm-9 col-sm-offset-2">
+                  <div class="col-md-9 offset-md-2">
                     <button type="submit" class="btn btn-primary">{% trans "Update Group Data" %}</button>
                   </div>
                 </div>
@@ -239,8 +239,8 @@
     <div id="delete_group_modal" class="modal fade">
       <div class="modal-dialog">
         <div class="modal-content">
-          <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <div class="modal-header">  {# todo B5: css:modal-header #}
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>  {# todo B5: css:close #}
             <h4 class="modal-title">
               {% blocktrans with group.name as group_name %}
                 Delete Group "{{group_name}}"?
@@ -257,8 +257,8 @@
               </p>
             </div>
             <div class="modal-footer">
-              <a href="#" data-dismiss="modal" class="btn btn-default">{% trans 'Cancel' %}</a>
-              <button class="btn btn-danger disable-on-submit" type="submit">
+              <a href="#" data-bs-dismiss="modal" class="btn btn-outline-primary">{% trans 'Cancel' %}</a>
+              <button class="btn btn-outline-danger disable-on-submit" type="submit">
                 <i class="fa fa-remove"></i>
                 {% trans 'Delete' %}
               </button>
@@ -271,8 +271,8 @@
     <div class="modal fade" id="editGroupSettings">
       <div class="modal-dialog">
         <div class="modal-content">
-          <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <div class="modal-header">  {# todo B5: css:modal-header #}
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>  {# todo B5: css:close #}
             <h4 class="modal-title">
               {% blocktrans with group.name as group_name %}
                 Edit Settings for Group "{{ group_name }}"
@@ -282,15 +282,15 @@
           <form id="edit-group-settings" class="form form-horizontal" method="post" action="{% url "edit_group" domain group.get_id %}">
             {% csrf_token %}
             <div class="modal-body">
-              <div class="form-group">
-                <label class="control-label col-sm-3" for="group-name-input">{% trans "Group Name" %}</label>
-                <div class="col-sm-9">
+              <div class="form-group">  {# todo B5: css:form-group #}
+                <label class="form-label col-md-3" for="group-name-input">{% trans "Group Name" %}</label>
+                <div class="col-md-9">
                   <input type="text" value="{{ group.name }}" class="form-control" name="name" id="group-name-input" />
                 </div>
               </div>
-              <div class="form-group">
-                <label class="control-label col-sm-3" for="group-case-sharing-input">{% trans "Case Sharing" %}</label>
-                <div class="col-sm-9">
+              <div class="form-group">  {# todo B5: css:form-group #}
+                <label class="form-label col-md-3" for="group-case-sharing-input">{% trans "Case Sharing" %}</label>
+                <div class="col-md-9">
                   <select-toggle params="name: 'case_sharing',
                                          id: 'group-case-sharing-input',
                                          options: [
@@ -315,9 +315,9 @@
                   </div>
                 </div>
               </div>
-              <div class="form-group">
-                <label class="control-label col-sm-3" for="group-reporting-input">{% trans "Reporting" %}</label>
-                <div class="col-sm-6">
+              <div class="form-group">  {# todo B5: css:form-group #}
+                <label class="form-label col-md-3" for="group-reporting-input">{% trans "Reporting" %}</label>
+                <div class="col-md-6">
                   <select-toggle params="name: 'reporting',
                                                        id: 'group-reporting-input',
                                                        options: [{
@@ -333,7 +333,7 @@
               </div>
             </div>
             <div class="modal-footer">
-              <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
+              <a href="#" class="btn btn-outline-primary" data-bs-dismiss="modal">{% trans "Cancel" %}</a>
               <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
             </div>
           </form>
@@ -347,8 +347,8 @@
          id="disableCaseSharing">
       <div class="modal-dialog">
         <div class="modal-content">
-          <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <div class="modal-header">  {# todo B5: css:modal-header #}
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>  {# todo B5: css:close #}
             <h4 class="modal-title">
               {% blocktrans with group.name as group_name %}
                 Change Group Type for "{{ group_name }}" to Reporting Group
@@ -377,7 +377,7 @@
               </p>
             </div>
             <div class="modal-footer">
-              <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
+              <a href="#" class="btn btn-outline-primary" data-bs-dismiss="modal">{% trans "Cancel" %}</a>
               <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
             </div>
           </form>

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -19,7 +19,7 @@
   {% else %}
     {% trans "Editing Group" %}
   {% endif %}
-  "{{ group.name }}"{% if group.case_sharing %} ({% trans 'Case Sharing' %}){% endif %} ({% blocktrans count num_users=num_users %}{{ num_users }} member{% plural %}{{ num_users }} members{% endblocktrans %})
+  "{{ group.name }}"{% if group.case_sharing %} ({% trans 'Case Sharing' %}){% endif %}
 {% endblock %}
 
 {% block page_content %}
@@ -105,6 +105,7 @@
       <li role="presentation" class="nav-item">
         <a href="#membership-tab" aria-controls="home" role="tab" data-bs-toggle="tab" class="nav-link">
           {% trans "Group Membership" %}
+          <span class="badge bg-secondary">{{ num_users }}</span>
         </a>
       </li>
       <li role="presentation" class="nav-item">

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -209,13 +209,13 @@
     <div id="delete_group_modal" class="modal fade">
       <div class="modal-dialog">
         <div class="modal-content">
-          <div class="modal-header">  {# todo B5: css:modal-header #}
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>  {# todo B5: css:close #}
+          <div class="modal-header">
             <h4 class="modal-title">
               {% blocktrans with group.name as group_name %}
                 Delete Group "{{group_name}}"?
               {% endblocktrans %}
             </h4>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans_html_attr "Close" %}"></button>
           </div>
           <form name="delete_group" action="{% url "delete_group" domain group.get_id %}" method="post">
             {% csrf_token %}
@@ -241,65 +241,59 @@
     <div class="modal fade" id="editGroupSettings">
       <div class="modal-dialog">
         <div class="modal-content">
-          <div class="modal-header">  {# todo B5: css:modal-header #}
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>  {# todo B5: css:close #}
+          <div class="modal-header">
             <h4 class="modal-title">
               {% blocktrans with group.name as group_name %}
                 Edit Settings for Group "{{ group_name }}"
               {% endblocktrans %}
             </h4>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans_html_attr "Close" %}"></button>
           </div>
           <form id="edit-group-settings" class="form form-horizontal" method="post" action="{% url "edit_group" domain group.get_id %}">
             {% csrf_token %}
             <div class="modal-body">
-              <div class="form-group">  {# todo B5: css:form-group #}
-                <label class="form-label col-md-3" for="group-name-input">{% trans "Group Name" %}</label>
-                <div class="col-md-9">
-                  <input type="text" value="{{ group.name }}" class="form-control" name="name" id="group-name-input" />
+              <div class="mb-3">
+                <label class="form-label" for="group-name-input">{% trans "Group Name" %}</label>
+                <input type="text" value="{{ group.name }}" class="form-control" name="name" id="group-name-input" />
+              </div>
+              <div class="mb-3">
+                <label class="form-label" for="group-case-sharing-input">{% trans "Case Sharing" %}</label>
+                <select-toggle params="name: 'case_sharing',
+                                       id: 'group-case-sharing-input',
+                                       options: [
+                                         {
+                                           id: 'true',
+                                           text: '{% trans_html_attr 'On' %}',
+                                         },
+                                         {
+                                           id: 'false',
+                                           text: '{% trans_html_attr 'Off' %}',
+                                         },
+                                       ],
+                                       {% if not is_case_sharing_enabled %}disabled: true,{% endif %}
+                                       value: '{% if group.case_sharing %}true{% else %}false{% endif %}'"></select-toggle>
+                <p class="help-block">{% trans "Determines whether users within this group will share cases with each other." %}</p>
+                {% include 'groups/partials/case_sharing_upgrade_notice.html' %}
+                <div id="group-case-sharing-warning" hidden="true">
+                  <p class="help-block alert alert-warning">
+                    {% trans 'Warning: Case sharing will not work until enabled under application settings. Read more here: ' %}
+                    <a href="https://help.commcarehq.org/display/commcarepublic/Case+Sharing" target="_blank">Case Sharing</a>
+                  </p>
                 </div>
               </div>
-              <div class="form-group">  {# todo B5: css:form-group #}
-                <label class="form-label col-md-3" for="group-case-sharing-input">{% trans "Case Sharing" %}</label>
-                <div class="col-md-9">
-                  <select-toggle params="name: 'case_sharing',
-                                         id: 'group-case-sharing-input',
-                                         options: [
-                                           {
-                                             id: 'true',
-                                             text: '{% trans_html_attr 'On' %}',
-                                           },
-                                           {
-                                             id: 'false',
-                                             text: '{% trans_html_attr 'Off' %}',
-                                           },
-                                         ],
-                                         {% if not is_case_sharing_enabled %}disabled: true,{% endif %}
-                                         value: '{% if group.case_sharing %}true{% else %}false{% endif %}'"></select-toggle>
-                  <p class="help-block">{% trans "Determines whether users within this group will share cases with each other." %}</p>
-                  {% include 'groups/partials/case_sharing_upgrade_notice.html' %}
-                  <div id="group-case-sharing-warning" hidden="true">
-                    <p class="help-block alert alert-warning">
-                      {% trans 'Warning: Case sharing will not work until enabled under application settings. Read more here: ' %}
-                      <a href="https://help.commcarehq.org/display/commcarepublic/Case+Sharing" target="_blank">Case Sharing</a>
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div class="form-group">  {# todo B5: css:form-group #}
-                <label class="form-label col-md-3" for="group-reporting-input">{% trans "Reporting" %}</label>
-                <div class="col-md-6">
-                  <select-toggle params="name: 'reporting',
-                                                       id: 'group-reporting-input',
-                                                       options: [{
-                                                                    id: 'true',
-                                                                    text: '{% trans_html_attr 'On' %}',
-                                                                }, {
-                                                                    id: 'false',
-                                                                    text: '{% trans_html_attr 'Off' %}',
-                                                                }],
-                                                       value: '{% if group.reporting %}true{% else %}false{% endif %}'"></select-toggle>
-                  <p class="help-block">{% trans "Indicate whether this group's name should appear in the group filter for reports." %}</p>
-                </div>
+              <div class="mb-3">
+                <label class="form-label" for="group-reporting-input">{% trans "Reporting" %}</label>
+                <select-toggle params="name: 'reporting',
+                                       id: 'group-reporting-input',
+                                       options: [{
+                                           id: 'true',
+                                           text: '{% trans_html_attr 'On' %}',
+                                         }, {
+                                           id: 'false',
+                                           text: '{% trans_html_attr 'Off' %}',
+                                         }],
+                                       value: '{% if group.reporting %}true{% else %}false{% endif %}'"></select-toggle>
+                <p class="help-block">{% trans "Indicate whether this group's name should appear in the group filter for reports." %}</p>
               </div>
             </div>
             <div class="modal-footer">
@@ -317,13 +311,13 @@
          id="disableCaseSharing">
       <div class="modal-dialog">
         <div class="modal-content">
-          <div class="modal-header">  {# todo B5: css:modal-header #}
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>  {# todo B5: css:close #}
+          <div class="modal-header">
             <h4 class="modal-title">
               {% blocktrans with group.name as group_name %}
                 Change Group Type for "{{ group_name }}" to Reporting Group
               {% endblocktrans %}
             </h4>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans_html_attr "Close" %}"></button>
           </div>
           <form id="edit-group-settings"
                 class="form form-horizontal"

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -81,8 +81,6 @@
             {% csrf_token %}
             <button id="submit-verification"
                     type="submit"
-                    data-html="true"
-                    data-title="<div class='alert alert-warning'><i class='fa-solid fa-triangle-exclamation'></i> <strong>{% trans 'SMS charges will incur.' %}</strong></div>{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
                     class="btn btn-outline-primary verify-button">
               <i class="fa fa-signal"></i> {% trans 'Verify Phone Numbers' %}
             </button>
@@ -91,7 +89,8 @@
                   data-html="true"
                   data-content="{% blocktrans %}
                         For all active mobile workers in this group, and for each phone number, this will
-                        initiate an SMS verification workflow. If the phone number is already verified or
+                        initiate an SMS verification workflow. When a user replies to the SMS< their phone
+                        number will be verified.<br><br>If the phone number is already verified or
                         if the phone number is already in use by another contact in the system, nothing
                         will happen. If the phone number is pending verification, the verification SMS
                         will be resent.

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -101,17 +101,16 @@
           {% endblocktrans %}
         </a>
       </div>
-      <hr />
     {% endif %}
 
-    <ul class="nav nav-tabs sticky-tabs" role="tablist" style="margin-bottom: 20px;">  {# todo B5: css:nav, inline style #}
-      <li role="presentation">
-        <a href="#membership-tab" aria-controls="home" role="tab" data-bs-toggle="tab">
+    <ul class="nav nav-tabs sticky-tabs mt-5 mb-3" role="tablist">
+      <li role="presentation" class="nav-item">
+        <a href="#membership-tab" aria-controls="home" role="tab" data-bs-toggle="tab" class="nav-link">
           {% trans "Group Membership" %}
         </a>
       </li>
-      <li role="presentation">
-        <a href="#groupdata-tab" aria-controls="profile" role="tab" data-bs-toggle="tab">
+      <li role="presentation" class="nav-item">
+        <a href="#groupdata-tab" aria-controls="profile" role="tab" data-bs-toggle="tab" class="nav-link">
           {% trans "Group Data" %}
         </a>
       </li>

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -66,16 +66,10 @@
             {% trans "Edit Settings" %}
           </a>
         {% endif %}
-        <a class="btn btn-outline-danger float-end" style="margin-right: 45px;" data-bs-toggle="modal" href="#delete_group_modal">  {# todo B5: inline style #}
-          <i class="fa fa-remove"></i>
-          {% blocktrans with group.name as group_name %}
-            Delete Group "{{group_name}}"
-          {% endblocktrans %}
-        </a>
 
         {% if bulk_sms_verification_enabled %}
           <form id="initiate-verification-workflow"
-                class="form-inline"  {# todo B5: css:form-inline #}
+                class="mx-3"
                 method="post"
                 action="{% url "bulk_sms_verification" domain group.get_id %}">
             {% csrf_token %}
@@ -99,6 +93,13 @@
                 </span>
           </form>
         {% endif %}
+
+        <a class="btn btn-outline-danger ms-auto" data-bs-toggle="modal" href="#delete_group_modal">
+          <i class="fa fa-remove"></i>
+          {% blocktrans with group.name as group_name %}
+            Delete Group "{{group_name}}"
+          {% endblocktrans %}
+        </a>
       </div>
       <hr />
     {% endif %}

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -27,8 +27,6 @@
   {% initial_page_data "group_metadata" group.metadata %}
   {% initial_page_data "domain_uses_case_sharing" domain_uses_case_sharing %}
   {% initial_page_data "show_disable_case_sharing" show_disable_case_sharing %}
-  <p id="save-alert" class="alert" hidden="hidden">
-  </p>
   {% if group.is_deleted %}
     <div class="alert alert-info">
       {% blocktrans%}
@@ -145,7 +143,7 @@
           {% else %}
             <div class="row">
               <div class="col-md-12">
-                <div class="alert alert-info" id="membership_updating" style="display: none">  {# todo B5: inline style #}
+                <div class="alert alert-info d-none" id="membership_updating">
                   <p class="lead">
                     <i class="fa fa-spinner fa-spin"></i> {% trans 'Updating Group Membership, please wait...' %}
                   </p>

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -121,29 +121,17 @@
       <div role="tabpanel" class="tab-pane" id="membership-tab">
         <div class="card-body">
           {% if request.is_view_only or not can_edit_group_membership or show_disable_case_sharing %}
-            <div class="form form-horizontal">
-              <legend>
-                {% trans "View Group Membership" %}
-              </legend>
-              <div class="form-group">  {# todo B5: css:form-group #}
-                <label class="form-label col-sm-12 col-md-4 col-lg-4 col-xl-2">
-                  {% trans "Group Membership" %}
-                </label>
-                <div class="col-sm-12 col-md-8 col-lg-8 col-xl-6 controls-text">
-                  {% if not group_members %}
-                    {% blocktrans %}
-                      No Mobile Workers are currently assigned to this group.
-                    {% endblocktrans %}
-                  {% else %}
-                    <ul>
-                      {% for member in group_members %}
-                        <li>{{ member.username_in_report }}</li>
-                      {% endfor %}
-                    </ul>
-                  {% endif %}
-                </div>
-              </div>
-            </div>
+            {% if not group_members %}
+              {% blocktrans %}
+                <p>No Mobile Workers are currently assigned to this group.</p>
+              {% endblocktrans %}
+            {% else %}
+              <ul>
+                {% for member in group_members %}
+                  <li>{{ member.username_in_report }}</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
             {% if not can_edit_group_membership %}
               <div class="alert alert-info">
                 {% blocktrans %}
@@ -163,10 +151,10 @@
                   </p>
                 </div>
 
-                <form class="form-horizontal disable-on-submit"
+                <form class="disable-on-submit"
                       id="edit_membership"
                       action="{% url "update_group_membership" domain group.get_id %}" method='post'>
-                  {% crispy group_membership_form %}  {# todo B5: check crispy #}
+                  {% crispy group_membership_form %}
                 </form>
 
               </div>
@@ -177,38 +165,26 @@
       <div role="tabpanel" class="tab-pane" id="groupdata-tab">
         <div class="card-body">
           {% if request.is_view_only or show_disable_case_sharing %}
-            <div class="form form-horizontal">
-              <legend>
-                {% trans "View Group Data" %}
-              </legend>
-              <div class="form-group">  {# todo B5: css:form-group #}
-                <label class="form-label col-sm-12 col-md-4 col-lg-4 col-xl-2">
-                  {% trans "Group Data" %}
-                </label>
-                <div class="controls-text col-sm-12 col-md-8 col-lg-8 col-xl-6">
-                  {% if not group.metadata %}
-                    {% trans "No Data Provided" %}
-                  {% else %}
-                    <ul>
-                      {% for key, val in group.metadata.items %}
-                        <li>
-                          <strong>{{ key }}</strong>
-                          &rarr;
-                          {{ val }}
-                        </li>
-                      {% endfor %}
-                    </ul>
-                  {% endif %}
-                </div>
-              </div>
+              {% if not group.metadata %}
+                {% trans "No Data Provided" %}
+              {% else %}
+                <ul>
+                  {% for key, val in group.metadata.items %}
+                    <li>
+                      <strong>{{ key }}</strong>
+                      &rarr;
+                      {{ val }}
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
               {% include "groups/partials/edit_group_disabled_case_sharing.html" %}
             </div>
           {% else %}
             <form id="group-data-form" class="form-horizontal disable-on-submit" name="group-data-form" method="post" action="{% url "update_group_data" domain group.get_id %}">
               {% csrf_token %}
               <fieldset>
-                <legend>{% trans "Edit Group Data" %}</legend>
-                <div class="form-group">  {# todo B5: css:form-group #}
+                <div class="mb-3">
                   <label class="form-label col-md-2">
                     {% trans "Group Data" %}
                   </label>
@@ -217,12 +193,9 @@
                   </div>
                 </div>
                 <input name="group-data" id="group-data" type="hidden" value="{% html_attr group.metadata %}">
-                <div class="form-actions">
-                  <div class="col-md-9 offset-md-2">
-                    <button type="submit" class="btn btn-primary">{% trans "Update Group Data" %}</button>
-                  </div>
+                <div class="mb-3">
+                  <button type="submit" class="btn btn-primary">{% trans "Update Group Data" %}</button>
                 </div>
-
               </fieldset>
             </form>
           {% endif %}

--- a/corehq/apps/groups/templates/groups/partials/case_sharing_upgrade_notice.html
+++ b/corehq/apps/groups/templates/groups/partials/case_sharing_upgrade_notice.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% if not is_case_sharing_enabled %}
-  <div class="well well-sm">
+  <div class="card well-sm">  {# todo B5: css:well #}
     <i class="fa fa-info-circle"></i>
     {% blocktrans %}
       Case Sharing Groups are not available on your subscription. This feature

--- a/corehq/apps/groups/templates/groups/partials/case_sharing_upgrade_notice.html
+++ b/corehq/apps/groups/templates/groups/partials/case_sharing_upgrade_notice.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% if not is_case_sharing_enabled %}
-  <div class="card well-sm">  {# todo B5: css:well #}
+  <div class="alert alert-info">
     <i class="fa fa-info-circle"></i>
     {% blocktrans %}
       Case Sharing Groups are not available on your subscription. This feature

--- a/corehq/apps/groups/templates/groups/partials/edit_group_disabled_case_sharing.html
+++ b/corehq/apps/groups/templates/groups/partials/edit_group_disabled_case_sharing.html
@@ -8,7 +8,7 @@
         This is a <strong>Case Sharing Group</strong>. You subscription no longer supports
         Case Sharing Groups. Editing this group will be disabled until you either upgrade to our Pro plan or
         <a href="#disableCaseSharing"
-           data-toggle="modal">change the group type to <strong>Reporting Group</strong> only</a>.
+           data-bs-toggle="modal">change the group type to <strong>Reporting Group</strong> only</a>.
       {% endblocktrans %}
     </p>
     <p>

--- a/corehq/apps/groups/templates/groups/partials/edit_group_disabled_case_sharing.html
+++ b/corehq/apps/groups/templates/groups/partials/edit_group_disabled_case_sharing.html
@@ -7,7 +7,7 @@
       {% blocktrans %}
         This is a <strong>Case Sharing Group</strong>. You subscription no longer supports
         Case Sharing Groups. Editing this group will be disabled until you either upgrade to our Pro plan or
-        <a href="#disableCaseSharing"
+        <a href="#" data-bs-target="#disableCaseSharing"
            data-bs-toggle="modal">change the group type to <strong>Reporting Group</strong> only</a>.
       {% endblocktrans %}
     </p>

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -72,6 +72,9 @@
   "casexml": {
     "is_complete": true
   },
+  "groups": {
+    "is_complete": true
+  },
   "programs": {
     "is_complete": true
   },

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1020,27 +1020,17 @@ class GroupMembershipForm(forms.Form):
     )
 
     def __init__(self, group_api_url, *args, **kwargs):
-        submit_label = kwargs.pop('submit_label', "Update")
-        fieldset_title = kwargs.pop(
-            'fieldset_title', gettext_lazy("Edit Group Membership"))
-
         super(GroupMembershipForm, self).__init__(*args, **kwargs)
         self.fields['selected_ids'].widget.set_url(group_api_url)
 
         self.helper = FormHelper()
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper.label_class = 'form-label'
         self.helper.form_tag = False
 
         self.helper.layout = crispy.Layout(
-            crispy.Fieldset(
-                fieldset_title,
-                'selected_ids',
-            ),
-            hqcrispy.FormActions(
-                crispy.ButtonHolder(
-                    Submit('submit', submit_label)
-                )
+            crispy.Field('selected_ids'),
+            crispy.ButtonHolder(
+                Submit('submit', _('Update'))
             )
         )
 

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -142,8 +142,8 @@ class BaseGroupsView(BaseUserSettingsView):
                 self.request, privileges.CASE_SHARING_GROUPS
             ),
             'needs_to_downgrade_locations': (
-                users_have_locations(self.domain) and
-                not has_privilege(self.request, privileges.LOCATIONS)
+                users_have_locations(self.domain)
+                and not has_privilege(self.request, privileges.LOCATIONS)
             ),
         })
         return context
@@ -215,12 +215,12 @@ class EditGroupMembersView(BaseGroupsView):
     @property
     def page_context(self):
         domain_has_reminders_or_keywords = (
-            domain_has_reminders(self.domain) or
-            Keyword.domain_has_keywords(self.domain)
+            domain_has_reminders(self.domain)
+            or Keyword.domain_has_keywords(self.domain)
         )
         bulk_sms_verification_enabled = (
-            domain_has_reminders_or_keywords and
-            domain_has_privilege(self.domain, privileges.INBOUND_SMS)
+            domain_has_reminders_or_keywords
+            and domain_has_privilege(self.domain, privileges.INBOUND_SMS)
         )
         return {
             'group': self.group,

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -149,6 +149,7 @@ class BaseGroupsView(BaseUserSettingsView):
         return context
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 class GroupsListView(BaseGroupsView):
     template_name = "groups/all_groups.html"
     page_title = gettext_noop("Groups")

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -16,7 +16,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.es.users import UserES
 from corehq.apps.groups.models import Group
-from corehq.apps.hqwebapp.decorators import use_multiselect
+from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_multiselect
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.reports.filters.api import MobileWorkersOptionsView
 from corehq.apps.reports.util import get_simplified_users
@@ -155,6 +155,7 @@ class GroupsListView(BaseGroupsView):
     urlname = 'all_groups'
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 class EditGroupMembersView(BaseGroupsView):
     urlname = 'group_members'
     page_title = gettext_noop("Edit Group")


### PR DESCRIPTION
## Product Description
| before | after |
| ------ | ----- |
| ![Screenshot 2024-05-14 at 10 26 29 AM](https://github.com/dimagi/commcare-hq/assets/1486591/8490c9f8-9fbf-4309-a14b-fee39e2b9c2c) | ![Screenshot 2024-05-14 at 10 25 06 AM](https://github.com/dimagi/commcare-hq/assets/1486591/b6a5568d-721d-418c-9bb5-b493073a1bed) |
| ![Screenshot 2024-05-14 at 10 26 58 AM](https://github.com/dimagi/commcare-hq/assets/1486591/5f100af4-bb00-4e0f-b98c-d31b7c840892) | ![Screenshot 2024-05-14 at 10 25 14 AM](https://github.com/dimagi/commcare-hq/assets/1486591/cb23f586-9b3f-4be3-bbcd-2138f77fc9c3) |
| ![Screenshot 2024-05-14 at 10 26 50 AM](https://github.com/dimagi/commcare-hq/assets/1486591/283c9dbe-9333-4c4c-8446-d99506759656) | ![Screenshot 2024-05-14 at 10 25 22 AM](https://github.com/dimagi/commcare-hq/assets/1486591/8d75aaf9-479a-460c-82f1-3b71b52dad02) |
| ![Screenshot 2024-05-14 at 10 20 06 AM](https://github.com/dimagi/commcare-hq/assets/1486591/ab6368e2-0bfc-4c0a-963c-77f8d1226418) | ![Screenshot 2024-05-14 at 10 22 50 AM](https://github.com/dimagi/commcare-hq/assets/1486591/87d0e682-9e0f-46f9-9091-a9ba9ea626fa) |
| ![Screenshot 2024-05-14 at 10 19 58 AM](https://github.com/dimagi/commcare-hq/assets/1486591/241eae95-3607-489f-a54d-4a59ab1b783e) | ![Screenshot 2024-05-14 at 10 22 22 AM](https://github.com/dimagi/commcare-hq/assets/1486591/5ffed067-a360-4e72-8242-a1a45e6fb7f7) |

## Safety Assurance

### Safety story
This is largely markup changes, with some javascript show/hide logic. No new javascript widgets. I think local testing is sufficient here. I've tested adding/editing/deleting groups, members, and data, verified the popups still show, tested the view-only content, and tested out the warnings that show if you don't have access to case sharing.

### Automated test coverage

little if any

### QA Plan
Not requesting QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
