### PR TITLE
Removed custom styling from mocha base template

### DIFF
--- a/corehq/apps/mocha/templates/mocha/base.html
+++ b/corehq/apps/mocha/templates/mocha/base.html
@@ -11,14 +11,6 @@
     <!-- Mocha and test-only dependencies -->
     <link href="{% static 'mocha/mocha.css' %}" type="text/css" rel="stylesheet"/>
 
-    <style type="text/css">
-      /* Override bootstrap's .progress styles for the Mocha progress widget. */
-      #mocha-stats .progress {
-        height: auto;
-        background-color: transparent;
-        box-shadow: none;
-      }
-    </style>
     <script>
       window.USE_BOOTSTRAP5 = {{ use_bootstrap5|BOOL }};
     </script>


### PR DESCRIPTION
## Technical Summary
This is the only bootstrap-related code in the mocha app, and it doesn't seem necessary - maybe leftover from B2? The progress indicator still displays fine without it, in both B3 and B5 tests.

## Safety Assurance

### Safety story
Only affects test output formatting.

### Automated test coverage

It's a test.

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
