### PR TITLE
Allow location-restricted to bulk upload/download users

### DIFF
--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -15,7 +15,6 @@ from corehq.apps.users.models import HqPermissions
 from corehq.apps.users.views import BaseUserSettingsView
 from corehq.util.jqueryrmi import JSONResponseMixin, allow_remote_invocation
 from corehq.apps.users.dbaccessors import (
-    get_all_commcare_users_by_domain,
     get_mobile_users_by_filters
 )
 from .exceptions import AttendeeTrackedException

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -287,6 +287,17 @@ def user_can_access_any_location_id(domain, user, location_ids):
             .exists())
 
 
+def user_can_change_locations(domain, couch_user, current_loc_ids, loc_ids_being_assigned):
+    from corehq.apps.locations.models import SQLLocation
+    locs_accessible_to_user = set(SQLLocation.objects.accessible_to_user(
+        domain, couch_user).values_list('location_id', flat=True))
+    # symmetric_difference = XOR, represents the locations that are being added/removed. All of these locations
+    # must be accessible to user
+    problem_location_ids = (set(current_loc_ids).symmetric_difference(set(loc_ids_being_assigned))
+                            - locs_accessible_to_user)
+    return list(problem_location_ids)
+
+
 def user_can_access_other_user(domain, user, other_user):
     if user.has_permission(domain, 'access_all_locations'):
         return True

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -35,10 +35,6 @@ from corehq.apps.user_importer.exceptions import UserUploadError
 from corehq.apps.user_importer.helpers import (
     spec_value_to_boolean_or_none,
 )
-from corehq.apps.user_importer.validation import (
-    get_user_import_validators,
-    is_password,
-)
 from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.account_confirmation import (
     send_account_confirmation_if_necessary,
@@ -419,6 +415,7 @@ class BaseUserRow:
 class CCUserRow(BaseUserRow):
 
     def process(self):
+        from corehq.apps.user_importer.validation import is_password
         if not self._process_column_values():
             return False
 
@@ -493,6 +490,7 @@ class CCUserRow(BaseUserRow):
         return True
 
     def _parse_password(self):
+        from corehq.apps.user_importer.validation import is_password
         if self.row.get('password'):
             password = str(self.row.get('password'))
         elif self.column_values["send_confirmation_sms"]:
@@ -562,6 +560,7 @@ class CCUserRow(BaseUserRow):
         )
 
     def _process_simple_fields(self):
+        from corehq.apps.user_importer.validation import is_password
         cv = self.column_values
         # process password
         if cv["user_id"] and is_password(cv["password"]):
@@ -941,6 +940,7 @@ class DomainInfo:
     @property
     @memoized
     def validators(self):
+        from corehq.apps.user_importer.validation import get_user_import_validators
         roles_by_name = list(self.roles_by_name)
         domain_user_specs = [
             spec

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -843,7 +843,7 @@ class WebImporter:
 
     @memoized
     def domain_info(self, domain):
-        return DomainInfo(self, domain, is_web_upload=self.is_web_upload)
+        return DomainInfo(self, domain, is_web_upload=self.is_web_upload, upload_user=self.upload_user)
 
     def run(self):
         ret = {"errors": [], "rows": []}
@@ -877,10 +877,11 @@ class CCImporter(WebImporter):
 
 class DomainInfo:
 
-    def __init__(self, importer, domain, is_web_upload):
+    def __init__(self, importer, domain, is_web_upload, upload_user=None):
         self.importer = importer
         self.domain = domain
         self.is_web_upload = is_web_upload
+        self.upload_user = upload_user
 
     @property
     @memoized
@@ -957,6 +958,8 @@ class DomainInfo:
             allowed_roles=roles_by_name,
             profiles_by_name=self.profiles_by_name,
             upload_domain=self.importer.upload_domain,
+            upload_user=self.upload_user,
+            location_cache=self.location_cache
         )
 
 

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -324,7 +324,6 @@ class TestLocationAccessValidator(LocationHierarchyTestCase):
         cls.upload_user.set_location(cls.domain, cls.locations['Middlesex'])
         restrict_user_by_location(cls.domain, cls.upload_user)
         cls.editable_user = WebUser.create(cls.domain, 'editable-user', 'password', None, None)
-        # cls.upload_user.reset_locations(cls.domain, [cls.locations['Middlesex'].location_id])
         cls.validator = LocationAccessValidator(cls.domain, cls.upload_user,
                                                 SiteCodeToLocationCache(cls.domain), True)
 
@@ -334,7 +333,6 @@ class TestLocationAccessValidator(LocationHierarchyTestCase):
                      'location_code': [self.locations['Middlesex'].site_code,
                                        self.locations['Cambridge'].site_code]}
         validation_result = self.validator.validate_spec(user_spec)
-        print(validation_result)
         assert validation_result is None
 
     def testCantEditWebUser(self):

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -12,9 +12,15 @@ from dimagi.utils.parsing import string_to_boolean
 
 from corehq.apps.domain.forms import clean_password
 from corehq.apps.enterprise.models import EnterprisePermissions
+from corehq.apps.locations.models import SQLLocation
+from corehq.apps.locations.permissions import user_can_access_other_user, user_can_change_locations
 from corehq.apps.user_importer.exceptions import UserUploadError
 from corehq.apps.users.forms import get_mobile_worker_max_username_length
+from corehq.apps.users.models import CouchUser, Invitation
 from corehq.apps.users.util import normalize_username, raw_username
+from corehq.apps.users.views.utils import (
+    user_can_access_invite
+)
 from corehq.util.workbook_json.excel import (
     StringTypeRequiredError,
     enforce_string_type,
@@ -37,6 +43,7 @@ def get_user_import_validators(domain_obj, all_specs, is_web_user_import, allowe
         ExistingUserValidator(domain, all_specs),
         TargetDomainValidator(upload_domain),
         ProfileValidator(domain, list(profiles_by_name)),
+        LocationAccessValidator(domain, upload_user, location_cache, is_web_user_import)
     ]
     if is_web_user_import:
         return validators + [RequiredWebFieldsValidator(domain), DuplicateValidator(domain, 'email', all_specs),
@@ -382,3 +389,52 @@ class ConfirmationSmsValidator(ImportValidator):
                 if error_values:
                     errors_formatted = ' and '.join(error_values)
                     return self.error_existing_user.format(self.confirmation_sms_header, errors_formatted)
+
+
+class LocationAccessValidator(ImportValidator):
+    error_message_user_access = _("Based on your locations do not have permission to edit this user or user "
+                                  "invitation")
+    error_message_location_access = _("You do not have permission to assign or remove these locations: {}")
+
+    def __init__(self, domain, upload_user, location_cache, is_web_user_import):
+        super().__init__(domain)
+        self.upload_user = upload_user
+        self.location_cache = location_cache
+        self.is_web_user_import = is_web_user_import
+
+    def validate_spec(self, spec):
+        from corehq.apps.user_importer.importer import find_location_id
+        # 1. Get current locations for user or user invitation and ensure user can edit it
+        username = spec.get('username')
+        current_locs = []
+        if self.is_web_user_import:
+            editable_user = CouchUser.get_by_username(username, strict=True)
+            if not editable_user:
+                try:
+                    invitation = Invitation.objects.get(domain=self.domain, email=username, is_accepted=False)
+                    if not user_can_access_invite(self.domain, self.upload_user, invitation):
+                        return self.error_message_user_access.format(invitation.email)
+                    current_locs = invitation.assigned_locations.all()
+                except Invitation.DoesNotExist:
+                    pass
+        else:
+            if 'username' in spec:
+                editable_user = CouchUser.get_by_username(username, strict=True)
+            elif 'user_id' in spec:
+                editable_user = CouchUser.get_by_user_id(spec.get('user_id'))
+        if editable_user:
+            if not user_can_access_other_user(self.domain, self.upload_user, editable_user):
+                return self.error_message_user_access.format(editable_user.username)
+            current_locs = editable_user.get_location_ids(self.domain)
+
+        # 2. Ensure the user is only adding the user to/removing from *new locations* that they have permission
+        # to access.
+        if 'location_code' in spec:
+            location_codes = spec['location_code']
+            locs_being_assigned = find_location_id(location_codes, self.location_cache)
+            problem_location_ids = user_can_change_locations(self.domain, self.upload_user,
+                                                            current_locs, locs_being_assigned)
+            if problem_location_ids:
+                return self.error_message_location_access.format(
+                    ', '.join(SQLLocation.objects.filter(
+                        location_id__in=problem_location_ids).values_list('site_code', flat=True)))

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -407,6 +407,7 @@ class LocationAccessValidator(ImportValidator):
         # 1. Get current locations for user or user invitation and ensure user can edit it
         username = spec.get('username')
         current_locs = []
+        editable_user = None
         if self.is_web_user_import:
             try:
                 invitation = Invitation.objects.get(domain=self.domain, email=username, is_accepted=False)
@@ -416,7 +417,7 @@ class LocationAccessValidator(ImportValidator):
             except Invitation.DoesNotExist:
                 editable_user = CouchUser.get_by_username(username, strict=True)
         else:
-            if 'username' in spec:
+            if username:
                 editable_user = CouchUser.get_by_username(username, strict=True)
             elif 'user_id' in spec:
                 editable_user = CouchUser.get_by_user_id(spec.get('user_id'))

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -408,15 +408,13 @@ class LocationAccessValidator(ImportValidator):
         username = spec.get('username')
         current_locs = []
         if self.is_web_user_import:
-            editable_user = CouchUser.get_by_username(username, strict=True)
-            if not editable_user:
-                try:
-                    invitation = Invitation.objects.get(domain=self.domain, email=username, is_accepted=False)
-                    if not user_can_access_invite(self.domain, self.upload_user, invitation):
-                        return self.error_message_user_access.format(invitation.email)
-                    current_locs = invitation.assigned_locations.all()
-                except Invitation.DoesNotExist:
-                    pass
+            try:
+                invitation = Invitation.objects.get(domain=self.domain, email=username, is_accepted=False)
+                if not user_can_access_invite(self.domain, self.upload_user, invitation):
+                    return self.error_message_user_access.format(invitation.email)
+                current_locs = invitation.assigned_locations.all()
+            except Invitation.DoesNotExist:
+                editable_user = CouchUser.get_by_username(username, strict=True)
         else:
             if 'username' in spec:
                 editable_user = CouchUser.get_by_username(username, strict=True)

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -22,7 +22,7 @@ from corehq.util.workbook_json.excel import (
 
 
 def get_user_import_validators(domain_obj, all_specs, is_web_user_import, allowed_groups=None, allowed_roles=None,
-                               profiles_by_name=None, upload_domain=None):
+                               profiles_by_name=None, upload_domain=None, upload_user=None, location_cache=None):
     domain = domain_obj.name
     validate_passwords = domain_obj.strong_mobile_passwords
     noop = NoopValidator(domain)

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -428,7 +428,8 @@ class LocationAccessValidator(ImportValidator):
         # 2. Ensure the user is only adding the user to/removing from *new locations* that they have permission
         # to access.
         if 'location_code' in spec:
-            location_codes = spec['location_code']
+            location_codes = (spec['location_code'] if isinstance(spec['location_code'], list)
+                              else [spec['location_code']])
             locs_being_assigned = find_location_id(location_codes, self.location_cache)
             problem_location_ids = user_can_change_locations(self.domain, self.upload_user,
                                                             current_locs, locs_being_assigned)

--- a/corehq/apps/users/dbaccessors.py
+++ b/corehq/apps/users/dbaccessors.py
@@ -193,6 +193,10 @@ def _get_invitations_by_filters(domain, user_filters, count_only=False):
         filters["role"] = role.get_qualified_id()
 
     invitations = Invitation.by_domain(domain, **filters)
+    if 'web_user_assigned_location_ids' in user_filters.keys():
+        locations_accessible_to_user = SQLLocation.objects.get_locations_and_children(
+            user_filters['web_user_assigned_location_ids'])
+        invitations = invitations.filter(assigned_locations__in=locations_accessible_to_user)
     if count_only:
         return invitations.count()
     return invitations

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1757,11 +1757,17 @@ class UserFilterForm(forms.Form):
             return False
         return None
 
+    def clean_location_id(self):
+        location_id = self.cleaned_data['location_id']
+        if location_id and not user_can_access_location_id(self.domain, self.couch_user, location_id):
+            raise forms.ValidationError("You do not have access to that location.")
+        return location_id
+
     def clean(self):
         data = self.cleaned_data
         user = self.couch_user
 
-        if not user.has_permission(self.domain, 'access_all_locations') and not data.get('location_id'):
+        if not data.get('location_id') and not user.has_permission(self.domain, 'access_all_locations'):
             # Add (web) user assigned_location_ids so as to
             # 1) reflect all locations user is assigned to ('All' option)
             # 2) restrict user access

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -58,7 +58,7 @@
           </a>
 
           {% if not request.is_view_only %}
-            {% if can_bulk_edit_users and can_access_all_locations %}
+            {% if can_bulk_edit_users %}
               <a id="bulk_upload" class="btn btn-default" href="{% url "upload_commcare_users" domain %}">
                 <i class="fa-solid fa-cloud-arrow-up"></i> {% trans "Bulk Upload" %}
               </a>

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -27,16 +27,14 @@
       </a>
       {% endif %}
 
-      {% if user_can_access_all_locations %}
-        <a id="bulk_download" class="btn btn-info" href="{{ bulk_download_url }}">
-          <i class="fa-solid fa-cloud-arrow-down"></i> {% trans "Download Web Users" %}
-        </a>
+      <a id="bulk_download" class="btn btn-info" href="{{ bulk_download_url }}">
+        <i class="fa-solid fa-cloud-arrow-down"></i> {% trans "Download Web Users" %}
+      </a>
 
-        {% if not request.is_view_only %}
-        <a id="bulk_upload" class="btn btn-default" href="{% url "upload_web_users" domain %}">
-          <i class="fa-solid fa-cloud-arrow-up"></i> {% trans "Upload Web Users" %}
-        </a>
-        {% endif %}
+      {% if not request.is_view_only %}
+      <a id="bulk_upload" class="btn btn-default" href="{% url "upload_web_users" domain %}">
+        <i class="fa-solid fa-cloud-arrow-up"></i> {% trans "Upload Web Users" %}
+      </a>
       {% endif %}
     </div>
   </p>

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1276,6 +1276,7 @@ class BaseUploadUser(BaseUserSettingsView):
             )
 
 
+@location_safe
 class UploadWebUsers(BaseUploadUser):
     template_name = 'hqwebapp/bootstrap3/bulk_upload.html'
     urlname = 'upload_web_users'
@@ -1299,6 +1300,7 @@ class UploadWebUsers(BaseUploadUser):
         return super(UploadWebUsers, self).post(request, *args, **kwargs)
 
 
+@location_safe
 class WebUserUploadStatusView(BaseManageWebUserView):
     urlname = 'web_user_upload_status'
     page_title = gettext_noop('Web User Upload Status')
@@ -1339,6 +1341,7 @@ class UserUploadJobPollView(BaseUserSettingsView):
         return render(request, 'users/mobile/partials/user_upload_status.html', context)
 
 
+@location_safe
 class WebUserUploadJobPollView(UserUploadJobPollView, BaseManageWebUserView):
     urlname = "web_user_upload_job_poll"
     on_complete_long = 'Web Worker upload has finished'

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -585,8 +585,6 @@ class ListWebUsersView(BaseRoleAccessView):
             'admins': WebUser.get_admins_by_domain(self.domain),
             'domain_object': self.domain_object,
             'bulk_download_url': bulk_download_url,
-            'user_can_access_all_locations': self.request.couch_user.has_permission(
-                self.domain, 'access_all_locations'),
             'from_address': settings.DEFAULT_FROM_EMAIL
         }
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -592,12 +592,14 @@ class ListWebUsersView(BaseRoleAccessView):
 
 
 @require_can_edit_or_view_web_users
+@location_safe
 def download_web_users(request, domain):
     track_workflow(request.couch_user.get_email(), 'Bulk download web users selected')
     from corehq.apps.users.views.mobile.users import download_users
     return download_users(request, domain, user_type=WEB_USER_TYPE)
 
 
+@location_safe
 class DownloadWebUsersStatusView(BaseUserSettingsView):
     urlname = 'download_web_users_status'
     page_title = gettext_noop('Download Web Users Status')

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1104,6 +1104,7 @@ def get_user_upload_context(domain, request_params, download_url, adjective, plu
     return context
 
 
+@location_safe
 class UploadCommCareUsers(BaseUploadUser):
     template_name = 'hqwebapp/bootstrap3/bulk_upload.html'
     urlname = 'upload_commcare_users'
@@ -1125,6 +1126,7 @@ class UploadCommCareUsers(BaseUploadUser):
         return super(UploadCommCareUsers, self).post(request, *args, **kwargs)
 
 
+@location_safe
 class UserUploadStatusView(BaseManageCommCareUserView):
     urlname = 'user_upload_status'
     page_title = gettext_noop('Mobile Worker Upload Status')
@@ -1147,6 +1149,7 @@ class UserUploadStatusView(BaseManageCommCareUserView):
         return reverse(self.urlname, args=self.args, kwargs=self.kwargs)
 
 
+@location_safe
 class CommcareUserUploadJobPollView(UserUploadJobPollView):
     urlname = "commcare_user_upload_job_poll"
     on_complete_long = 'Mobile Worker upload has finished'

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1229,6 +1229,7 @@ class FilteredCommCareUserDownload(FilteredUserDownload, BaseManageCommCareUserV
         return super().get(request, domain, *args, **kwargs)
 
 
+@location_safe
 @method_decorator([require_can_use_filtered_user_download], name='dispatch')
 class FilteredWebUserDownload(FilteredUserDownload, BaseManageWebUserView):
     page_title = gettext_noop('Filter and Download Users')
@@ -1462,6 +1463,7 @@ def count_commcare_users(request, domain):
 
 @require_can_edit_web_users
 @require_can_use_filtered_user_download
+@location_safe
 def count_web_users(request, domain):
     return _count_users(request, domain, WEB_USER_TYPE)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

JIRA: [USH-4397](https://dimagi.atlassian.net/browse/USH-4397?atlOrigin=eyJpIjoiZmU1NWQ4MmRkYmMwNGRiOGIyMzNkZWNkZDA5YTJlZDEiLCJwIjoiaiJ9).

In #34518, we allowed location-restricted users to edit other web users. This PR allows them to edit other web users (and mobile workers) via bulk upload.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Bulk download for web users, as far as I could tell, was actually already restricted based on the user's location (i.e. already location-safe). See [here](https://github.com/dimagi/commcare-hq/blob/3d28f5e041f94ee6fd0eabd2eff1695a99bb8bb3/corehq/apps/users/dbaccessors.py#L102-L114). This user ES query is used to filter the users that show up in download, and as you can see there the query is filtered by the web user's location IDs.

Bulk upload wasn't, however, so this PR:

1. Makes sure the uploading user has access to each of the user's they are trying to edit
2. Only adds/removes locations they have access to 


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Automated tests do a decent job I think
- Gonna QA this

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added some for validation

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

[Here](https://dimagi.atlassian.net/browse/QA-6515)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4397]: https://dimagi.atlassian.net/browse/USH-4397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ