### PR TITLE
Web apps UI: Fixed unclosed div for repeat group children

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap3/repeat_juncture.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap3/repeat_juncture.html
@@ -12,7 +12,7 @@
         <span class="ix" data-bind="text: ixInfo($data)"></span>
       </div>
       <div class="panel-body">
-        <div class="children" data-bind="template: { name: childTemplate, foreach: $data.children }"/>
+        <div class="children" data-bind="template: { name: childTemplate, foreach: $data.children }"></div>
         <div class="alert alert-info empty" data-bind="visible: !children().length">
           {% trans "This repeatable group is empty" %}
         </div>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap5/repeat_juncture.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/bootstrap5/repeat_juncture.html
@@ -12,7 +12,7 @@
         <span class="ix" data-bind="text: ixInfo($data)"></span>
       </div>
       <div class="card-body">
-        <div class="children" data-bind="template: { name: childTemplate, foreach: $data.children }"/>
+        <div class="children" data-bind="template: { name: childTemplate, foreach: $data.children }"></div>
         <div class="alert alert-info empty" data-bind="visible: !children().length">
           {% trans "This repeatable group is empty" %}
         </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/form_entry/repeat_juncture.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/form_entry/repeat_juncture.html.diff.txt
@@ -16,7 +16,7 @@
        </div>
 -      <div class="panel-body">
 +      <div class="card-body">
-         <div class="children" data-bind="template: { name: childTemplate, foreach: $data.children }"/>
+         <div class="children" data-bind="template: { name: childTemplate, foreach: $data.children }"></div>
          <div class="alert alert-info empty" data-bind="visible: !children().length">
            {% trans "This repeatable group is empty" %}
          </div>


### PR DESCRIPTION
## Product Description
before: weird gap around the footer, where the "Add new repeat" button is
![Screenshot 2024-05-15 at 11 30 41 AM](https://github.com/dimagi/commcare-hq/assets/1486591/38b80f51-d1b0-41da-9eaf-2e0595504e99)
![Screenshot 2024-05-15 at 11 30 47 AM](https://github.com/dimagi/commcare-hq/assets/1486591/f3ac8244-98b9-404b-9a27-4ac47a236919)

after: no gap, and it turns out there's an info message for empty repeat groups

![Screenshot 2024-05-15 at 11 30 12 AM](https://github.com/dimagi/commcare-hq/assets/1486591/d2082225-50a2-45d6-abe5-4c5b8c819c75)
![Screenshot 2024-05-15 at 11 30 22 AM](https://github.com/dimagi/commcare-hq/assets/1486591/5684a4a5-c091-4d33-92a3-770dbeb24001)

## Safety Assurance

### Safety story
This is a web apps UI change, should only affect user-controlled repeat groups.

### Automated test coverage

no

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
