### PR TITLE
"Bootstrap 5 Migration - Marked 'custom_data_fields' as complete"

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -54,9 +54,6 @@
   "corehq.tabs": {
     "in_progress": true
   },
-  "custom_user_fields": {
-    "in_progress": true
-  },
   "ota": {
     "is_complete": true
   },

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -95,5 +95,8 @@
   },
   "enterprise": {
     "is_complete": true
+  },
+  "custom_data_fields": {
+    "is_complete": true
   }
 }


### PR DESCRIPTION
## Technical Summary
Realized just after merging https://github.com/dimagi/commcare-hq/pull/34519/ that I didn't mark it complete.

Also, it's `custom_data_fields` not `custom_user_fields`, I don't know how that got in there but the"in progress" config wasn't doing anything anyway.

## Safety Assurance

### Safety story
Only affects config for internal engineering tools.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
